### PR TITLE
fix(security,perf): Critical security hardening and performance hotfixes

### DIFF
--- a/src/backend/alembic/versions/t3u4v5w6x7y8_add_must_change_password.py
+++ b/src/backend/alembic/versions/t3u4v5w6x7y8_add_must_change_password.py
@@ -1,0 +1,27 @@
+"""add must_change_password to users
+
+Revision ID: t3u4v5w6x7y8
+Revises: s2t3u4v5w6x7
+Create Date: 2026-02-06
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 't3u4v5w6x7y8'
+down_revision: Union[str, None] = 's2t3u4v5w6x7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'users',
+        sa.Column('must_change_password', sa.Boolean(), nullable=False, server_default='false')
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('users', 'must_change_password')

--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -306,10 +306,7 @@ async def _stream_rag_response(
                     )
 
                     if search_results:
-                        rag_context = await rag_service.get_context(
-                            query=content,
-                            knowledge_base_id=knowledge_base_id
-                        )
+                        rag_context = rag_service.format_context_from_results(search_results)
                         session_state.update_rag_context(
                             context=rag_context,
                             results=search_results,

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -41,9 +41,10 @@ from api.routes import homeassistant as ha_routes
 from api.routes import mcp as mcp_routes
 from api.routes import settings as settings_routes
 from api.websocket import chat_router, device_router, satellite_router
+from models.database import User
 from models.permissions import Permission
 from services.api_rate_limiter import setup_rate_limiter
-from services.auth_service import require_permission
+from services.auth_service import get_current_user, require_permission
 from services.database import AsyncSessionLocal
 from services.device_manager import get_device_manager
 from services.ollama_service import OllamaService
@@ -315,7 +316,8 @@ async def liveness_check():
 @app.post("/api/ws/token")
 async def create_ws_token(
     device_id: str = None,
-    device_type: str = None
+    device_type: str = None,
+    current_user: User | None = Depends(get_current_user),
 ):
     """
     Generate a WebSocket authentication token.

--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -596,6 +596,7 @@ class User(Base):
 
     # Account status
     is_active = Column(Boolean, default=True, nullable=False)
+    must_change_password = Column(Boolean, default=False, nullable=False, server_default="false")
 
     # User preferences
     preferred_language = Column(String(10), default="de", nullable=False)

--- a/src/backend/services/rag_service.py
+++ b/src/backend/services/rag_service.py
@@ -609,6 +609,23 @@ class RAGService:
 
         return "\n\n---\n\n".join(context_parts)
 
+    def format_context_from_results(self, results: list[dict]) -> str:
+        """Format pre-fetched search results into context string without re-searching."""
+        if not results:
+            return ""
+        context_parts = []
+        for i, result in enumerate(results, 1):
+            chunk = result["chunk"]
+            doc = result["document"]
+            source_info = f"[Quelle {i}: {doc['filename']}"
+            if chunk.get("page_number"):
+                source_info += f", Seite {chunk['page_number']}"
+            if chunk.get("section_title"):
+                source_info += f", {chunk['section_title']}"
+            source_info += "]"
+            context_parts.append(f"{source_info}\n{chunk['content']}")
+        return "\n\n---\n\n".join(context_parts)
+
     # ==========================================================================
     # Document Management
     # ==========================================================================

--- a/tests/backend/test_chat_stream.py
+++ b/tests/backend/test_chat_stream.py
@@ -1,0 +1,377 @@
+"""Tests for OllamaService streaming methods.
+
+Tests chat_stream() and chat_stream_with_rag() with mocked ollama client.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.ollama_service import OllamaService
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+def _make_chunk(content: str):
+    """Create a mock ollama chat chunk with Pydantic-style attributes."""
+    chunk = MagicMock()
+    chunk.message = MagicMock()
+    chunk.message.content = content
+    return chunk
+
+
+def _make_empty_chunk():
+    """Create a chunk with no content (e.g. final chunk)."""
+    chunk = MagicMock()
+    chunk.message = MagicMock()
+    chunk.message.content = ""
+    return chunk
+
+
+def _make_none_message_chunk():
+    """Create a chunk with message=None."""
+    chunk = MagicMock()
+    chunk.message = None
+    return chunk
+
+
+async def _async_iter(items):
+    """Helper to create an async iterable from a list."""
+    for item in items:
+        yield item
+
+
+# ============================================================================
+# chat_stream Tests
+# ============================================================================
+
+@pytest.mark.backend
+class TestChatStream:
+    """Tests for OllamaService.chat_stream()."""
+
+    @patch("services.ollama_service.get_default_client")
+    @patch("services.ollama_service.settings")
+    @patch("services.ollama_service.llm_circuit_breaker")
+    async def test_basic_streaming(self, mock_cb, mock_settings, mock_get_client):
+        mock_cb.allow_request.return_value = True
+        mock_settings.ollama_model = "test-model"
+        mock_settings.ollama_chat_model = "test-model"
+        mock_settings.ollama_rag_model = "test-model"
+        mock_settings.ollama_embed_model = "test-embed"
+        mock_settings.ollama_intent_model = "test-model"
+        mock_settings.ollama_num_ctx = 4096
+        mock_settings.default_language = "de"
+
+        client = AsyncMock()
+        chunks = [_make_chunk("Hello "), _make_chunk("world")]
+        client.chat.return_value = _async_iter(chunks)
+        mock_get_client.return_value = client
+
+        service = OllamaService()
+        collected = []
+        async for chunk in service.chat_stream("Test message"):
+            collected.append(chunk)
+
+        assert collected == ["Hello ", "world"]
+        mock_cb.record_success.assert_called_once()
+
+    @patch("services.ollama_service.get_default_client")
+    @patch("services.ollama_service.settings")
+    @patch("services.ollama_service.llm_circuit_breaker")
+    async def test_streaming_skips_empty_chunks(self, mock_cb, mock_settings, mock_get_client):
+        mock_cb.allow_request.return_value = True
+        mock_settings.ollama_model = "test-model"
+        mock_settings.ollama_chat_model = "test-model"
+        mock_settings.ollama_rag_model = "test-model"
+        mock_settings.ollama_embed_model = "test-embed"
+        mock_settings.ollama_intent_model = "test-model"
+        mock_settings.ollama_num_ctx = 4096
+        mock_settings.default_language = "de"
+
+        client = AsyncMock()
+        chunks = [_make_chunk("data"), _make_empty_chunk(), _make_none_message_chunk()]
+        client.chat.return_value = _async_iter(chunks)
+        mock_get_client.return_value = client
+
+        service = OllamaService()
+        collected = []
+        async for chunk in service.chat_stream("msg"):
+            collected.append(chunk)
+
+        assert collected == ["data"]
+
+    @patch("services.ollama_service.get_default_client")
+    @patch("services.ollama_service.settings")
+    @patch("services.ollama_service.llm_circuit_breaker")
+    async def test_streaming_with_history(self, mock_cb, mock_settings, mock_get_client):
+        mock_cb.allow_request.return_value = True
+        mock_settings.ollama_model = "test-model"
+        mock_settings.ollama_chat_model = "test-model"
+        mock_settings.ollama_rag_model = "test-model"
+        mock_settings.ollama_embed_model = "test-embed"
+        mock_settings.ollama_intent_model = "test-model"
+        mock_settings.ollama_num_ctx = 4096
+        mock_settings.default_language = "de"
+
+        client = AsyncMock()
+        chunks = [_make_chunk("response")]
+        client.chat.return_value = _async_iter(chunks)
+        mock_get_client.return_value = client
+
+        service = OllamaService()
+        history = [
+            {"role": "user", "content": "prev msg"},
+            {"role": "assistant", "content": "prev response"},
+        ]
+        collected = []
+        async for chunk in service.chat_stream("new msg", history=history):
+            collected.append(chunk)
+
+        assert collected == ["response"]
+        # Verify messages passed to client include history
+        call_kwargs = client.chat.call_args
+        messages = call_kwargs.kwargs.get("messages") or call_kwargs[1].get("messages")
+        # system + 2 history + user = 4
+        assert len(messages) == 4
+
+    @patch("services.ollama_service.get_default_client")
+    @patch("services.ollama_service.settings")
+    @patch("services.ollama_service.llm_circuit_breaker")
+    async def test_circuit_breaker_open(self, mock_cb, mock_settings, mock_get_client):
+        mock_cb.allow_request.return_value = False
+        mock_settings.ollama_model = "test-model"
+        mock_settings.ollama_chat_model = "test-model"
+        mock_settings.ollama_rag_model = "test-model"
+        mock_settings.ollama_embed_model = "test-embed"
+        mock_settings.ollama_intent_model = "test-model"
+        mock_settings.ollama_num_ctx = 4096
+        mock_settings.default_language = "de"
+        mock_get_client.return_value = AsyncMock()
+
+        service = OllamaService()
+        collected = []
+        async for chunk in service.chat_stream("msg"):
+            collected.append(chunk)
+
+        # Should yield a single error message
+        assert len(collected) == 1
+        assert collected[0]  # Non-empty fallback
+
+    @patch("services.ollama_service.get_default_client")
+    @patch("services.ollama_service.settings")
+    @patch("services.ollama_service.llm_circuit_breaker")
+    async def test_streaming_error_handling(self, mock_cb, mock_settings, mock_get_client):
+        mock_cb.allow_request.return_value = True
+        mock_settings.ollama_model = "test-model"
+        mock_settings.ollama_chat_model = "test-model"
+        mock_settings.ollama_rag_model = "test-model"
+        mock_settings.ollama_embed_model = "test-embed"
+        mock_settings.ollama_intent_model = "test-model"
+        mock_settings.ollama_num_ctx = 4096
+        mock_settings.default_language = "de"
+
+        client = AsyncMock()
+        client.chat.side_effect = Exception("Connection failed")
+        mock_get_client.return_value = client
+
+        service = OllamaService()
+        collected = []
+        async for chunk in service.chat_stream("msg"):
+            collected.append(chunk)
+
+        assert len(collected) == 1
+        mock_cb.record_failure.assert_called_once()
+
+    @patch("services.ollama_service.get_default_client")
+    @patch("services.ollama_service.settings")
+    @patch("services.ollama_service.llm_circuit_breaker")
+    async def test_streaming_with_memory_context(self, mock_cb, mock_settings, mock_get_client):
+        mock_cb.allow_request.return_value = True
+        mock_settings.ollama_model = "test-model"
+        mock_settings.ollama_chat_model = "test-model"
+        mock_settings.ollama_rag_model = "test-model"
+        mock_settings.ollama_embed_model = "test-embed"
+        mock_settings.ollama_intent_model = "test-model"
+        mock_settings.ollama_num_ctx = 4096
+        mock_settings.default_language = "de"
+
+        client = AsyncMock()
+        chunks = [_make_chunk("ok")]
+        client.chat.return_value = _async_iter(chunks)
+        mock_get_client.return_value = client
+
+        service = OllamaService()
+        collected = []
+        async for chunk in service.chat_stream("msg", memory_context="User likes coffee"):
+            collected.append(chunk)
+
+        assert collected == ["ok"]
+        # System prompt should include memory context
+        call_kwargs = client.chat.call_args
+        messages = call_kwargs.kwargs.get("messages") or call_kwargs[1].get("messages")
+        system_content = messages[0]["content"]
+        assert "User likes coffee" in system_content
+
+
+# ============================================================================
+# chat_stream_with_rag Tests
+# ============================================================================
+
+@pytest.mark.backend
+class TestChatStreamWithRag:
+    """Tests for OllamaService.chat_stream_with_rag()."""
+
+    @patch("services.ollama_service.get_default_client")
+    @patch("services.ollama_service.settings")
+    async def test_rag_streaming(self, mock_settings, mock_get_client):
+        mock_settings.ollama_model = "test-model"
+        mock_settings.ollama_chat_model = "chat-model"
+        mock_settings.ollama_rag_model = "rag-model"
+        mock_settings.ollama_embed_model = "test-embed"
+        mock_settings.ollama_intent_model = "test-model"
+        mock_settings.ollama_num_ctx = 4096
+        mock_settings.default_language = "de"
+
+        client = AsyncMock()
+        chunks = [_make_chunk("Based on "), _make_chunk("the docs")]
+        client.chat.return_value = _async_iter(chunks)
+        mock_get_client.return_value = client
+
+        service = OllamaService()
+        collected = []
+        async for chunk in service.chat_stream_with_rag("What is X?", rag_context="X is a thing"):
+            collected.append(chunk)
+
+        assert collected == ["Based on ", "the docs"]
+        # Should use rag_model when context is provided
+        call_kwargs = client.chat.call_args
+        model_used = call_kwargs.kwargs.get("model") or call_kwargs[1].get("model")
+        assert model_used == "rag-model"
+
+    @patch("services.ollama_service.get_default_client")
+    @patch("services.ollama_service.settings")
+    async def test_rag_streaming_no_context_uses_chat_model(self, mock_settings, mock_get_client):
+        mock_settings.ollama_model = "test-model"
+        mock_settings.ollama_chat_model = "chat-model"
+        mock_settings.ollama_rag_model = "rag-model"
+        mock_settings.ollama_embed_model = "test-embed"
+        mock_settings.ollama_intent_model = "test-model"
+        mock_settings.ollama_num_ctx = 4096
+        mock_settings.default_language = "de"
+
+        client = AsyncMock()
+        chunks = [_make_chunk("plain")]
+        client.chat.return_value = _async_iter(chunks)
+        mock_get_client.return_value = client
+
+        service = OllamaService()
+        collected = []
+        async for chunk in service.chat_stream_with_rag("What?", rag_context=None):
+            collected.append(chunk)
+
+        assert collected == ["plain"]
+        call_kwargs = client.chat.call_args
+        model_used = call_kwargs.kwargs.get("model") or call_kwargs[1].get("model")
+        assert model_used == "chat-model"
+
+    @patch("services.ollama_service.get_default_client")
+    @patch("services.ollama_service.settings")
+    async def test_rag_streaming_includes_context_in_prompt(self, mock_settings, mock_get_client):
+        mock_settings.ollama_model = "test-model"
+        mock_settings.ollama_chat_model = "chat-model"
+        mock_settings.ollama_rag_model = "rag-model"
+        mock_settings.ollama_embed_model = "test-embed"
+        mock_settings.ollama_intent_model = "test-model"
+        mock_settings.ollama_num_ctx = 4096
+        mock_settings.default_language = "de"
+
+        client = AsyncMock()
+        chunks = [_make_chunk("answer")]
+        client.chat.return_value = _async_iter(chunks)
+        mock_get_client.return_value = client
+
+        service = OllamaService()
+        async for _ in service.chat_stream_with_rag("Q?", rag_context="The document says XYZ"):
+            pass
+
+        call_kwargs = client.chat.call_args
+        messages = call_kwargs.kwargs.get("messages") or call_kwargs[1].get("messages")
+        system_content = messages[0]["content"]
+        assert "The document says XYZ" in system_content
+
+    @patch("services.ollama_service.get_default_client")
+    @patch("services.ollama_service.settings")
+    async def test_rag_streaming_with_history(self, mock_settings, mock_get_client):
+        mock_settings.ollama_model = "test-model"
+        mock_settings.ollama_chat_model = "chat-model"
+        mock_settings.ollama_rag_model = "rag-model"
+        mock_settings.ollama_embed_model = "test-embed"
+        mock_settings.ollama_intent_model = "test-model"
+        mock_settings.ollama_num_ctx = 4096
+        mock_settings.default_language = "de"
+
+        client = AsyncMock()
+        chunks = [_make_chunk("ok")]
+        client.chat.return_value = _async_iter(chunks)
+        mock_get_client.return_value = client
+
+        service = OllamaService()
+        history = [{"role": "user", "content": "prev"}]
+        async for _ in service.chat_stream_with_rag("Q?", rag_context="ctx", history=history):
+            pass
+
+        call_kwargs = client.chat.call_args
+        messages = call_kwargs.kwargs.get("messages") or call_kwargs[1].get("messages")
+        # system + 1 history + user = 3
+        assert len(messages) == 3
+
+    @patch("services.ollama_service.get_default_client")
+    @patch("services.ollama_service.settings")
+    async def test_rag_streaming_error_yields_fallback(self, mock_settings, mock_get_client):
+        mock_settings.ollama_model = "test-model"
+        mock_settings.ollama_chat_model = "chat-model"
+        mock_settings.ollama_rag_model = "rag-model"
+        mock_settings.ollama_embed_model = "test-embed"
+        mock_settings.ollama_intent_model = "test-model"
+        mock_settings.ollama_num_ctx = 4096
+        mock_settings.default_language = "de"
+
+        client = AsyncMock()
+        client.chat.side_effect = Exception("LLM down")
+        mock_get_client.return_value = client
+
+        service = OllamaService()
+        collected = []
+        async for chunk in service.chat_stream_with_rag("Q?", rag_context="ctx"):
+            collected.append(chunk)
+
+        assert len(collected) == 1
+        # Should contain error info
+
+    @patch("services.ollama_service.get_default_client")
+    @patch("services.ollama_service.settings")
+    async def test_rag_streaming_with_memory_context(self, mock_settings, mock_get_client):
+        mock_settings.ollama_model = "test-model"
+        mock_settings.ollama_chat_model = "chat-model"
+        mock_settings.ollama_rag_model = "rag-model"
+        mock_settings.ollama_embed_model = "test-embed"
+        mock_settings.ollama_intent_model = "test-model"
+        mock_settings.ollama_num_ctx = 4096
+        mock_settings.default_language = "de"
+
+        client = AsyncMock()
+        chunks = [_make_chunk("ok")]
+        client.chat.return_value = _async_iter(chunks)
+        mock_get_client.return_value = client
+
+        service = OllamaService()
+        async for _ in service.chat_stream_with_rag(
+            "Q?", rag_context="doc ctx", memory_context="User prefers German"
+        ):
+            pass
+
+        call_kwargs = client.chat.call_args
+        messages = call_kwargs.kwargs.get("messages") or call_kwargs[1].get("messages")
+        system_content = messages[0]["content"]
+        assert "User prefers German" in system_content
+        assert "doc ctx" in system_content

--- a/tests/backend/test_conversation_service.py
+++ b/tests/backend/test_conversation_service.py
@@ -1,0 +1,381 @@
+"""Tests for Conversation persistence and management.
+
+Tests ConversationService CRUD operations using the database fixtures from conftest.
+"""
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import Conversation, Message
+from services.conversation_service import ConversationService
+
+# ============================================================================
+# ConversationService.save_message Tests
+# ============================================================================
+
+@pytest.mark.backend
+@pytest.mark.database
+class TestSaveMessage:
+    """Tests for ConversationService.save_message()."""
+
+    async def test_save_message_creates_conversation(self, db_session: AsyncSession):
+        service = ConversationService(db_session)
+        msg = await service.save_message("new-session-1", "user", "Hello")
+
+        assert msg.id is not None
+        assert msg.role == "user"
+        assert msg.content == "Hello"
+
+        # Verify conversation was created
+        result = await db_session.execute(
+            select(Conversation).where(Conversation.session_id == "new-session-1")
+        )
+        conv = result.scalar_one()
+        assert conv is not None
+        assert conv.session_id == "new-session-1"
+
+    async def test_save_message_reuses_existing_conversation(self, db_session: AsyncSession):
+        service = ConversationService(db_session)
+        await service.save_message("session-reuse", "user", "First")
+        await service.save_message("session-reuse", "assistant", "Response")
+
+        # Should only have one conversation
+        result = await db_session.execute(
+            select(Conversation).where(Conversation.session_id == "session-reuse")
+        )
+        conversations = result.scalars().all()
+        assert len(conversations) == 1
+
+        # Should have two messages
+        conv = conversations[0]
+        result = await db_session.execute(
+            select(Message).where(Message.conversation_id == conv.id)
+        )
+        messages = result.scalars().all()
+        assert len(messages) == 2
+
+    async def test_save_message_with_metadata(self, db_session: AsyncSession):
+        service = ConversationService(db_session)
+        metadata = {"intent": "homeassistant.turn_on", "confidence": 0.95}
+        msg = await service.save_message("session-meta", "assistant", "Done", metadata=metadata)
+        assert msg.message_metadata == metadata
+
+    async def test_save_message_updates_conversation_timestamp(self, db_session: AsyncSession):
+        service = ConversationService(db_session)
+        await service.save_message("session-ts", "user", "First")
+
+        result = await db_session.execute(
+            select(Conversation).where(Conversation.session_id == "session-ts")
+        )
+        conv = result.scalar_one()
+        first_updated = conv.updated_at
+
+        await service.save_message("session-ts", "user", "Second")
+        await db_session.refresh(conv)
+        # updated_at should be >= first (may be same if fast enough)
+        assert conv.updated_at >= first_updated
+
+
+# ============================================================================
+# ConversationService.load_context Tests
+# ============================================================================
+
+@pytest.mark.backend
+@pytest.mark.database
+class TestLoadContext:
+    """Tests for ConversationService.load_context()."""
+
+    async def test_load_context_empty_session(self, db_session: AsyncSession):
+        service = ConversationService(db_session)
+        result = await service.load_context("nonexistent-session")
+        assert result == []
+
+    async def test_load_context_returns_messages(self, db_session: AsyncSession):
+        service = ConversationService(db_session)
+        await service.save_message("ctx-session", "user", "Hello")
+        await service.save_message("ctx-session", "assistant", "Hi there")
+        await service.save_message("ctx-session", "user", "How are you?")
+
+        context = await service.load_context("ctx-session")
+        assert len(context) == 3
+        assert context[0]["role"] == "user"
+        assert context[0]["content"] == "Hello"
+        assert context[-1]["role"] == "user"
+        assert context[-1]["content"] == "How are you?"
+
+    async def test_load_context_respects_max_messages(self, db_session: AsyncSession):
+        service = ConversationService(db_session)
+        for i in range(10):
+            await service.save_message("ctx-limit", "user", f"Message {i}")
+
+        context = await service.load_context("ctx-limit", max_messages=3)
+        assert len(context) == 3
+        # Should be the 3 most recent, in chronological order
+        assert context[0]["content"] == "Message 7"
+        assert context[-1]["content"] == "Message 9"
+
+    async def test_load_context_with_fixture_conversation(
+        self, db_session: AsyncSession, test_conversation: Conversation, test_message: Message
+    ):
+        service = ConversationService(db_session)
+        context = await service.load_context(test_conversation.session_id)
+        assert len(context) == 1
+        assert context[0]["content"] == test_message.content
+
+
+# ============================================================================
+# ConversationService.get_summary Tests
+# ============================================================================
+
+@pytest.mark.backend
+@pytest.mark.database
+class TestGetSummary:
+    """Tests for ConversationService.get_summary()."""
+
+    async def test_summary_nonexistent(self, db_session: AsyncSession):
+        service = ConversationService(db_session)
+        result = await service.get_summary("no-such-session")
+        assert result is None
+
+    async def test_summary_fields(self, db_session: AsyncSession):
+        service = ConversationService(db_session)
+        await service.save_message("summary-session", "user", "First message")
+        await service.save_message("summary-session", "assistant", "Last message")
+
+        summary = await service.get_summary("summary-session")
+        assert summary is not None
+        assert summary["session_id"] == "summary-session"
+        assert summary["message_count"] == 2
+        assert summary["first_message"] == "First message"
+        assert summary["last_message"] == "Last message"
+        assert "created_at" in summary
+        assert "updated_at" in summary
+
+
+# ============================================================================
+# ConversationService.delete Tests
+# ============================================================================
+
+@pytest.mark.backend
+@pytest.mark.database
+class TestDelete:
+    """Tests for ConversationService.delete()."""
+
+    async def test_delete_existing_conversation(self, db_session: AsyncSession):
+        service = ConversationService(db_session)
+        await service.save_message("del-session", "user", "to delete")
+        await service.save_message("del-session", "assistant", "response")
+
+        result = await service.delete("del-session")
+        assert result is True
+
+        # Conversation should be gone
+        db_result = await db_session.execute(
+            select(Conversation).where(Conversation.session_id == "del-session")
+        )
+        assert db_result.scalar_one_or_none() is None
+
+    async def test_delete_nonexistent_returns_false(self, db_session: AsyncSession):
+        service = ConversationService(db_session)
+        result = await service.delete("no-such-session")
+        assert result is False
+
+    async def test_delete_cascades_to_messages(self, db_session: AsyncSession):
+        service = ConversationService(db_session)
+        await service.save_message("cascade-session", "user", "msg1")
+        await service.save_message("cascade-session", "assistant", "msg2")
+
+        # Get conversation id first
+        db_result = await db_session.execute(
+            select(Conversation).where(Conversation.session_id == "cascade-session")
+        )
+        conv = db_result.scalar_one()
+        conv_id = conv.id
+
+        await service.delete("cascade-session")
+
+        # Messages should be gone too (cascade)
+        msg_result = await db_session.execute(
+            select(Message).where(Message.conversation_id == conv_id)
+        )
+        assert msg_result.scalars().all() == []
+
+
+# ============================================================================
+# ConversationService.list_all Tests
+# ============================================================================
+
+@pytest.mark.backend
+@pytest.mark.database
+class TestListAll:
+    """Tests for ConversationService.list_all()."""
+
+    async def test_list_empty(self, db_session: AsyncSession):
+        service = ConversationService(db_session)
+        result = await service.list_all()
+        assert result == []
+
+    async def test_list_with_conversations(self, db_session: AsyncSession):
+        service = ConversationService(db_session)
+        await service.save_message("list-1", "user", "First conv")
+        await service.save_message("list-2", "user", "Second conv")
+
+        result = await service.list_all()
+        assert len(result) == 2
+        # Each entry should have expected fields
+        for entry in result:
+            assert "session_id" in entry
+            assert "created_at" in entry
+            assert "updated_at" in entry
+            assert "message_count" in entry
+            assert "preview" in entry
+
+    async def test_list_with_pagination(self, db_session: AsyncSession):
+        service = ConversationService(db_session)
+        for i in range(5):
+            await service.save_message(f"page-{i}", "user", f"Conv {i}")
+
+        page1 = await service.list_all(limit=2, offset=0)
+        assert len(page1) == 2
+
+        page2 = await service.list_all(limit=2, offset=2)
+        assert len(page2) == 2
+
+        page3 = await service.list_all(limit=2, offset=4)
+        assert len(page3) == 1
+
+    async def test_list_ordered_by_updated_at_desc(self, db_session: AsyncSession):
+        service = ConversationService(db_session)
+        await service.save_message("older", "user", "Old")
+        await service.save_message("newer", "user", "New")
+
+        result = await service.list_all()
+        # Most recently updated first
+        assert result[0]["session_id"] == "newer"
+        assert result[1]["session_id"] == "older"
+
+
+# ============================================================================
+# ConversationService.search Tests
+# ============================================================================
+
+@pytest.mark.backend
+@pytest.mark.database
+class TestSearch:
+    """Tests for ConversationService.search()."""
+
+    async def test_search_no_results(self, db_session: AsyncSession):
+        service = ConversationService(db_session)
+        await service.save_message("s1", "user", "Hello world")
+        result = await service.search("nonexistent-xyz")
+        assert result == []
+
+    async def test_search_finds_matching_messages(self, db_session: AsyncSession):
+        service = ConversationService(db_session)
+        await service.save_message("s1", "user", "Schalte das Licht ein")
+        await service.save_message("s2", "user", "Wie wird das Wetter")
+        await service.save_message("s3", "user", "Mach das Licht aus")
+
+        result = await service.search("Licht")
+        assert len(result) == 2
+        session_ids = [r["session_id"] for r in result]
+        assert "s1" in session_ids
+        assert "s3" in session_ids
+
+    async def test_search_case_insensitive(self, db_session: AsyncSession):
+        service = ConversationService(db_session)
+        await service.save_message("ci", "user", "UPPERCASE Test")
+        result = await service.search("uppercase")
+        assert len(result) == 1
+
+    async def test_search_groups_by_conversation(self, db_session: AsyncSession):
+        service = ConversationService(db_session)
+        await service.save_message("group", "user", "keyword here")
+        await service.save_message("group", "assistant", "also keyword")
+
+        result = await service.search("keyword")
+        assert len(result) == 1
+        assert len(result[0]["matching_messages"]) == 2
+
+    async def test_search_respects_limit(self, db_session: AsyncSession):
+        service = ConversationService(db_session)
+        for i in range(10):
+            await service.save_message(f"limit-{i}", "user", f"common term {i}")
+
+        result = await service.search("common term", limit=3)
+        # limit applies to messages, so we get at most 3 message matches
+        total_messages = sum(len(r["matching_messages"]) for r in result)
+        assert total_messages <= 3
+
+
+# ============================================================================
+# Database Model Tests
+# ============================================================================
+
+@pytest.mark.backend
+@pytest.mark.database
+class TestConversationModel:
+    """Tests for the Conversation and Message models."""
+
+    async def test_conversation_creation(self, db_session: AsyncSession):
+        conv = Conversation(session_id="model-test-1")
+        db_session.add(conv)
+        await db_session.commit()
+        await db_session.refresh(conv)
+
+        assert conv.id is not None
+        assert conv.session_id == "model-test-1"
+        assert conv.created_at is not None
+        assert conv.updated_at is not None
+
+    async def test_message_creation(self, db_session: AsyncSession):
+        conv = Conversation(session_id="model-msg-test")
+        db_session.add(conv)
+        await db_session.commit()
+        await db_session.refresh(conv)
+
+        msg = Message(
+            conversation_id=conv.id,
+            role="user",
+            content="Test content",
+            message_metadata={"key": "value"},
+        )
+        db_session.add(msg)
+        await db_session.commit()
+        await db_session.refresh(msg)
+
+        assert msg.id is not None
+        assert msg.conversation_id == conv.id
+        assert msg.role == "user"
+        assert msg.content == "Test content"
+        assert msg.message_metadata == {"key": "value"}
+        assert msg.timestamp is not None
+
+    async def test_conversation_unique_session_id(self, db_session: AsyncSession):
+        from sqlalchemy.exc import IntegrityError
+
+        conv1 = Conversation(session_id="unique-test")
+        db_session.add(conv1)
+        await db_session.commit()
+
+        conv2 = Conversation(session_id="unique-test")
+        db_session.add(conv2)
+        with pytest.raises(IntegrityError):
+            await db_session.commit()
+
+    async def test_message_ordering(self, db_session: AsyncSession):
+        service = ConversationService(db_session)
+        await service.save_message("order-test", "user", "First")
+        await service.save_message("order-test", "assistant", "Second")
+        await service.save_message("order-test", "user", "Third")
+
+        context = await service.load_context("order-test")
+        assert [m["content"] for m in context] == ["First", "Second", "Third"]
+
+    async def test_conversation_with_fixture(self, test_conversation: Conversation, test_message: Message):
+        """Test using conftest fixtures."""
+        assert test_conversation.session_id == "test-session-123"
+        assert test_message.conversation_id == test_conversation.id
+        assert test_message.role == "user"
+        assert test_message.content == "Schalte das Licht ein"

--- a/tests/backend/test_ws_chat_integration.py
+++ b/tests/backend/test_ws_chat_integration.py
@@ -1,0 +1,490 @@
+"""Tests for WebSocket chat handler integration.
+
+Tests ConversationSessionState, _stream_rag_response, is_followup_question,
+and helper functions from chat_handler and shared modules.
+
+NOTE: Imports from api.websocket trigger services.database which needs asyncpg.
+We mock asyncpg in sys.modules before importing to allow local test execution.
+"""
+import sys
+from unittest.mock import MagicMock
+
+# Pre-mock modules that are not installed locally but are imported transitively
+# by the api.websocket package (asyncpg, whisper, piper, speechbrain, etc.).
+_missing_stubs = [
+    "asyncpg", "whisper", "piper", "piper.voice", "speechbrain",
+    "speechbrain.inference", "speechbrain.inference.speaker",
+    "openwakeword", "openwakeword.model",
+]
+for _mod in _missing_stubs:
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from time import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# ============================================================================
+# ConversationSessionState Tests
+# ============================================================================
+
+@pytest.mark.backend
+class TestConversationSessionState:
+    """Tests for ConversationSessionState dataclass."""
+
+    def _get_class(self):
+        from api.websocket.shared import ConversationSessionState
+        return ConversationSessionState
+
+    def test_init_defaults(self):
+        cls = self._get_class()
+        state = cls()
+        assert state.conversation_history == []
+        assert state.history_loaded is False
+        assert state.db_session_id is None
+        assert state.last_rag_context is None
+        assert state.last_query is None
+        assert state.last_intent is None
+        assert state.last_action_result is None
+        assert state.last_entities == []
+
+    def test_add_to_history(self):
+        cls = self._get_class()
+        state = cls()
+        state.add_to_history("user", "Hello")
+        state.add_to_history("assistant", "Hi there")
+        assert len(state.conversation_history) == 2
+        assert state.conversation_history[0] == {"role": "user", "content": "Hello"}
+        assert state.conversation_history[1] == {"role": "assistant", "content": "Hi there"}
+
+    def test_add_to_history_truncates_at_max(self):
+        cls = self._get_class()
+        state = cls()
+        state.MAX_HISTORY_MESSAGES = 4
+        for i in range(6):
+            state.add_to_history("user", f"msg {i}")
+        assert len(state.conversation_history) == 4
+        # Should keep the most recent 4
+        assert state.conversation_history[0]["content"] == "msg 2"
+        assert state.conversation_history[-1]["content"] == "msg 5"
+
+    def test_rag_context_valid_when_fresh(self):
+        cls = self._get_class()
+        state = cls()
+        state.update_rag_context("some context", [{"id": 1}], "query", kb_id=1)
+        assert state.is_rag_context_valid() is True
+
+    def test_rag_context_invalid_when_empty(self):
+        cls = self._get_class()
+        state = cls()
+        assert state.is_rag_context_valid() is False
+
+    def test_rag_context_invalid_when_expired(self):
+        cls = self._get_class()
+        state = cls()
+        state.last_rag_context = "old context"
+        state.last_rag_timestamp = time() - 600  # 10 minutes ago
+        assert state.is_rag_context_valid() is False
+
+    def test_update_rag_context(self):
+        cls = self._get_class()
+        state = cls()
+        results = [{"id": 1, "score": 0.9}]
+        state.update_rag_context("doc content", results, "my query", kb_id=42)
+        assert state.last_rag_context == "doc content"
+        assert state.last_rag_results == results
+        assert state.last_query == "my query"
+        assert state.knowledge_base_id == 42
+        assert state.last_rag_timestamp > 0
+
+    def test_update_action_context(self):
+        cls = self._get_class()
+        state = cls()
+        intent = {"intent": "homeassistant.turn_on", "parameters": {"entity_id": "light.kitchen"}}
+        result = {"success": True}
+        state.update_action_context(intent, result)
+        assert state.last_intent == intent
+        assert state.last_action_result == result
+        assert state.last_entities == ["light.kitchen"]
+
+    def test_update_action_context_no_entity(self):
+        cls = self._get_class()
+        state = cls()
+        intent = {"intent": "general.conversation", "parameters": {}}
+        result = {"success": True}
+        state.update_action_context(intent, result)
+        assert state.last_entities == []
+
+    def test_clear_rag(self):
+        cls = self._get_class()
+        state = cls()
+        state.update_rag_context("ctx", [{"id": 1}], "q", kb_id=1)
+        state.clear_rag()
+        assert state.last_rag_context is None
+        assert state.last_rag_results is None
+        assert state.last_query is None
+        assert state.last_rag_timestamp == 0
+        assert state.knowledge_base_id is None
+
+    def test_clear_all(self):
+        cls = self._get_class()
+        state = cls()
+        state.add_to_history("user", "msg")
+        state.history_loaded = True
+        state.update_rag_context("ctx", [], "q")
+        state.update_action_context({"intent": "x", "parameters": {"entity_id": "e"}}, {})
+        state.clear_all()
+        assert state.conversation_history == []
+        assert state.history_loaded is False
+        assert state.last_rag_context is None
+        assert state.last_intent is None
+        assert state.last_entities == []
+
+
+# ============================================================================
+# is_followup_question Tests
+# ============================================================================
+
+@pytest.mark.backend
+class TestIsFollowupQuestion:
+    """Tests for is_followup_question helper."""
+
+    def _get_func(self):
+        from api.websocket.shared import is_followup_question
+        return is_followup_question
+
+    def test_short_query_is_followup(self):
+        assert self._get_func()("was ist das") is True
+
+    def test_very_short_query_is_followup(self):
+        assert self._get_func()("ja") is True
+
+    def test_demonstrative_pronoun_is_followup(self):
+        assert self._get_func()("Kannst du das nochmal erklären bitte") is True
+
+    def test_continuation_word_is_followup(self):
+        assert self._get_func()("Zeig mir noch mehr davon") is True
+
+    def test_conjunction_start_is_followup(self):
+        assert self._get_func()("und was passiert dann mit dem Licht") is True
+
+    def test_prepositional_pronoun_is_followup(self):
+        assert self._get_func()("Erzähl mir mehr darüber bitte jetzt") is True
+
+    def test_detail_request_is_followup(self):
+        assert self._get_func()("Kannst du genauer beschreiben wie das funktioniert") is True
+
+    def test_independent_long_query_not_followup(self):
+        # No pronouns, no continuation words, long enough
+        assert self._get_func()("Wie wird morgen Nachmittag in Berlin Wetter sein") is False
+
+    def test_topic_overlap_is_followup(self):
+        fn = self._get_func()
+        prev = "Wie wird das Wetter morgen"
+        assert fn("Wie wird das Wetter morgen Nachmittag", prev) is True
+
+    def test_completely_different_topic_not_followup(self):
+        fn = self._get_func()
+        prev = "Schalte das Licht ein"
+        assert fn("Erstelle eine Einkaufsliste fuer morgen Abend bitte", prev) is False
+
+
+# ============================================================================
+# _parse_mcp_raw_data Tests
+# ============================================================================
+
+@pytest.mark.backend
+class TestParseMcpRawData:
+    """Tests for _parse_mcp_raw_data helper."""
+
+    def _get_func(self):
+        from api.websocket.chat_handler import _parse_mcp_raw_data
+        return _parse_mcp_raw_data
+
+    def test_valid_mcp_format(self):
+        fn = self._get_func()
+        data = [{"type": "text", "text": '{"results": [1, 2, 3]}'}]
+        result = fn(data)
+        assert result == {"results": [1, 2, 3]}
+
+    def test_none_input(self):
+        assert self._get_func()(None) is None
+
+    def test_empty_list(self):
+        assert self._get_func()([]) is None
+
+    def test_non_mcp_format(self):
+        data = [{"foo": "bar"}]
+        assert self._get_func()(data) is None
+
+    def test_non_json_text_long(self):
+        fn = self._get_func()
+        data = [{"type": "text", "text": "a" * 100}]
+        result = fn(data)
+        assert result is not None
+        assert "text_summary" in result
+
+    def test_non_json_text_short(self):
+        fn = self._get_func()
+        data = [{"type": "text", "text": "short"}]
+        result = fn(data)
+        assert result is None
+
+
+# ============================================================================
+# _build_agent_action_result Tests
+# ============================================================================
+
+@pytest.mark.backend
+class TestBuildAgentActionResult:
+    """Tests for _build_agent_action_result helper."""
+
+    def _get_func(self):
+        from api.websocket.chat_handler import _build_agent_action_result
+        return _build_agent_action_result
+
+    def test_empty_results(self):
+        assert self._get_func()([]) is None
+
+    def test_single_result(self):
+        fn = self._get_func()
+        tool_results = [("search_docs", {"results": [1, 2]})]
+        result = fn(tool_results)
+        assert result["success"] is True
+        assert result["data"] == {"results": [1, 2]}
+        assert result["_agent_intent"] == "search_docs"
+
+    def test_prefers_search_over_send(self):
+        fn = self._get_func()
+        tool_results = [
+            ("send_email", {"sent": True}),
+            ("search_documents", {"results": ["doc1"]}),
+        ]
+        result = fn(tool_results)
+        assert result["_agent_intent"] == "search_documents"
+
+    def test_none_data_skipped(self):
+        fn = self._get_func()
+        tool_results = [("tool1", None), ("tool2", {"ok": True})]
+        result = fn(tool_results)
+        assert result["_agent_intent"] == "tool2"
+
+
+# ============================================================================
+# _build_action_summary Tests
+# ============================================================================
+
+@pytest.mark.backend
+class TestBuildActionSummary:
+    """Tests for _build_action_summary helper."""
+
+    def _get_func(self):
+        from api.websocket.chat_handler import _build_action_summary
+        return _build_action_summary
+
+    def test_no_data(self):
+        fn = self._get_func()
+        intent = {"intent": "test"}
+        result = fn(intent, {"success": True, "data": None})
+        assert result == ""
+
+    def test_dict_with_results_list(self):
+        fn = self._get_func()
+        intent = {"intent": "mcp.search"}
+        action_result = {
+            "success": True,
+            "data": {"results": [{"id": 1, "title": "Doc A"}]}
+        }
+        summary = fn(intent, action_result)
+        assert "mcp.search" in summary
+        assert "id=1" in summary
+        assert "title=Doc A" in summary
+
+    def test_simple_dict(self):
+        fn = self._get_func()
+        intent = {"intent": "mcp.weather"}
+        action_result = {"success": True, "data": {"temp": 20, "city": "Berlin"}}
+        summary = fn(intent, action_result)
+        assert "mcp.weather" in summary
+
+    def test_list_items(self):
+        fn = self._get_func()
+        intent = {"intent": "mcp.list"}
+        items = [{"id": i, "name": f"item{i}"} for i in range(3)]
+        summary = fn(intent, {"success": True, "data": items})
+        assert "3 Ergebnisse" in summary
+        assert "id=0" in summary
+
+    def test_max_chars_truncation(self):
+        fn = self._get_func()
+        intent = {"intent": "test"}
+        data = {"key": "x" * 5000}
+        summary = fn(intent, {"success": True, "data": data}, max_chars=200)
+        # max_chars limits the JSON portion; intent prefix is added separately
+        assert len(summary) < 5000
+
+    def test_none_intent(self):
+        fn = self._get_func()
+        summary = fn(None, {"success": True, "data": {"foo": 1}})
+        assert summary != ""
+
+
+# ============================================================================
+# _stream_rag_response Tests
+# ============================================================================
+
+@pytest.mark.backend
+class TestStreamRagResponse:
+    """Tests for _stream_rag_response function."""
+
+    async def _make_async_gen(self, chunks):
+        """Helper to create an async generator from a list of chunks."""
+        for chunk in chunks:
+            yield chunk
+
+    @patch("api.websocket.chat_handler.settings")
+    async def test_rag_disabled_falls_back_to_plain_chat(self, mock_settings):
+        from api.websocket.chat_handler import _stream_rag_response
+        from api.websocket.shared import ConversationSessionState
+
+        mock_settings.rag_enabled = False
+
+        ollama = AsyncMock()
+        ollama.chat_stream = MagicMock(return_value=self._make_async_gen(["Hello ", "world"]))
+
+        ws = AsyncMock()
+        session_state = ConversationSessionState()
+
+        result = await _stream_rag_response(
+            "test query", None, ollama, session_state, ws
+        )
+        assert result == "Hello world"
+        # Should have sent stream messages
+        assert ws.send_json.call_count == 2
+
+    @patch("api.websocket.chat_handler.settings")
+    @patch("api.websocket.chat_handler.AsyncSessionLocal")
+    async def test_rag_no_results_falls_back(self, mock_session_local, mock_settings):
+        from api.websocket.chat_handler import _stream_rag_response
+        from api.websocket.shared import ConversationSessionState
+
+        mock_settings.rag_enabled = True
+
+        # Mock RAG service returning no results
+        mock_rag = AsyncMock()
+        mock_rag.search.return_value = []
+
+        mock_db = AsyncMock()
+        mock_session_local.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_session_local.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        ollama = AsyncMock()
+        ollama.chat_stream = MagicMock(return_value=self._make_async_gen(["fallback"]))
+
+        ws = AsyncMock()
+        session_state = ConversationSessionState()
+
+        with patch("services.rag_service.RAGService", return_value=mock_rag):
+            result = await _stream_rag_response(
+                "test query", 1, ollama, session_state, ws
+            )
+
+        assert result == "fallback"
+        # Should have sent rag_context with has_context=False
+        rag_ctx_calls = [
+            c for c in ws.send_json.call_args_list
+            if c.args[0].get("type") == "rag_context"
+        ]
+        assert len(rag_ctx_calls) == 1
+        assert rag_ctx_calls[0].args[0]["has_context"] is False
+
+    @patch("api.websocket.chat_handler.settings")
+    @patch("api.websocket.chat_handler.AsyncSessionLocal")
+    async def test_rag_with_results_streams_rag_response(self, mock_session_local, mock_settings):
+        from api.websocket.chat_handler import _stream_rag_response
+        from api.websocket.shared import ConversationSessionState
+
+        mock_settings.rag_enabled = True
+
+        mock_rag = AsyncMock()
+        mock_rag.search.return_value = [{"chunk": {"id": 1, "content": "doc text", "page_number": None, "section_title": None}, "document": {"filename": "test.pdf"}, "similarity": 0.9}]
+        mock_rag.format_context_from_results = MagicMock(return_value="Document context here")
+
+        mock_db = AsyncMock()
+        mock_session_local.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_session_local.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        ollama = AsyncMock()
+        ollama.chat_stream_with_rag = MagicMock(
+            return_value=self._make_async_gen(["RAG ", "answer"])
+        )
+
+        ws = AsyncMock()
+        session_state = ConversationSessionState()
+
+        with patch("services.rag_service.RAGService", return_value=mock_rag):
+            result = await _stream_rag_response(
+                "test query", 1, ollama, session_state, ws
+            )
+
+        assert result == "RAG answer"
+        # Should have sent rag_context with has_context=True
+        rag_ctx_calls = [
+            c for c in ws.send_json.call_args_list
+            if c.args[0].get("type") == "rag_context"
+        ]
+        assert len(rag_ctx_calls) == 1
+        assert rag_ctx_calls[0].args[0]["has_context"] is True
+        # History should be updated
+        assert len(session_state.conversation_history) == 2
+
+    @patch("api.websocket.chat_handler.settings")
+    async def test_rag_followup_uses_cached_context(self, mock_settings):
+        from api.websocket.chat_handler import _stream_rag_response
+        from api.websocket.shared import ConversationSessionState
+
+        mock_settings.rag_enabled = True
+
+        ollama = AsyncMock()
+        ollama.chat_stream_with_rag = MagicMock(
+            return_value=self._make_async_gen(["cached ", "answer"])
+        )
+
+        ws = AsyncMock()
+        session_state = ConversationSessionState()
+        # Pre-populate RAG cache
+        session_state.update_rag_context("cached doc context", [{"id": 1}], "original query", kb_id=1)
+
+        # Short follow-up query that will be detected as follow-up
+        result = await _stream_rag_response(
+            "und dann?", 1, ollama, session_state, ws
+        )
+
+        assert result == "cached answer"
+
+    @patch("api.websocket.chat_handler.settings")
+    async def test_rag_exception_falls_back_to_plain(self, mock_settings):
+        from api.websocket.chat_handler import _stream_rag_response
+        from api.websocket.shared import ConversationSessionState
+
+        mock_settings.rag_enabled = True
+
+        ollama = AsyncMock()
+        ollama.chat_stream = MagicMock(return_value=self._make_async_gen(["error ", "fallback"]))
+
+        ws = AsyncMock()
+        session_state = ConversationSessionState()
+
+        # Patch RAGService import to raise
+        with patch("services.rag_service.RAGService", side_effect=Exception("RAG broken")), \
+             patch("api.websocket.chat_handler.AsyncSessionLocal") as mock_sl:
+                mock_db = AsyncMock()
+                mock_sl.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+                mock_sl.return_value.__aexit__ = AsyncMock(return_value=False)
+
+                result = await _stream_rag_response(
+                    "test", 1, ollama, session_state, ws
+                )
+
+        assert result == "error fallback"


### PR DESCRIPTION
## Summary

Phase 1 of the 55-finding fix plan. Addresses 9 CRITICAL + 2 related HIGH findings.

### Security (Findings 1, 2, 3, 11)
- Refuse startup when `AUTH_ENABLED=true` with default `SECRET_KEY`
- Generate random admin password on first startup, log once; add `must_change_password` DB field + migration
- Gate `/api/ws/token` behind auth when `AUTH_ENABLED=true`
- Add auth + ownership checks to all chat endpoints (history, delete, list, search, stats, cleanup)

### Performance (Findings 4, 5, 6, 37)
- HA client singleton with shared `httpx.AsyncClient` + connection pooling (20 conn)
- Frigate client singleton with shared `httpx.AsyncClient` + connection pooling (10 conn)
- Fix RAG double-search: new `format_context_from_results()` skips redundant vector search
- Close HTTP client singletons on graceful shutdown

### Tests (Findings 7, 8, 9) — 81 new tests
- `test_ws_chat_integration.py` — 42 tests (session state, follow-up detection, RAG streaming, helpers)
- `test_chat_stream.py` — 12 tests (OllamaService streaming, RAG streaming, error handling)
- `test_conversation_service.py` — 27 tests (CRUD, search, pagination, cleanup)

## Test plan
- [x] All 81 new tests pass
- [x] All 1031 pre-existing tests still pass (no regressions)
- [x] Ruff lint clean
- [ ] Browser E2E: chat still works via WebSocket
- [ ] Deploy to renfield.local, verify startup check blocks with default key + AUTH_ENABLED
- [ ] Verify HA integration still works with singleton client

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)