### PR TITLE
fix(security,perf,tests): Auth enforcement, query optimization, and critical test coverage (#73)

### DIFF
--- a/src/backend/api/routes/users.py
+++ b/src/backend/api/routes/users.py
@@ -32,6 +32,11 @@ from services.database import get_db
 router = APIRouter()
 
 
+def _escape_like(value: str) -> str:
+    """Escape LIKE special characters to prevent wildcard injection."""
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 # =============================================================================
 # Request/Response Models
 # =============================================================================
@@ -114,9 +119,10 @@ async def list_users(
 
     # Apply filters
     if search:
+        safe_search = _escape_like(search)
         query = query.where(
-            User.username.ilike(f"%{search}%") |
-            User.email.ilike(f"%{search}%")
+            User.username.ilike(f"%{safe_search}%") |
+            User.email.ilike(f"%{safe_search}%")
         )
     if role_id:
         query = query.where(User.role_id == role_id)

--- a/src/backend/api/websocket/satellite_handler.py
+++ b/src/backend/api/websocket/satellite_handler.py
@@ -10,6 +10,7 @@ This module handles:
 - OTA update progress tracking
 """
 
+import asyncio
 from datetime import date
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
@@ -301,7 +302,7 @@ async def satellite_websocket(
                 # Transcribe with Whisper (with speaker recognition)
                 try:
                     whisper = get_whisper_service()
-                    whisper.load_model()  # No-op if already loaded
+                    await asyncio.to_thread(whisper.load_model)  # No-op if already loaded
 
                     # Create WAV file with proper header
                     import io

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -94,7 +94,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         # In production, this should be more restrictive
         response.headers["Content-Security-Policy"] = (
             "default-src 'self'; "
-            "script-src 'self' 'unsafe-inline' 'unsafe-eval'; "
+            "script-src 'self' 'unsafe-inline'; "
             "style-src 'self' 'unsafe-inline'; "
             "img-src 'self' data: blob:; "
             "font-src 'self' data:; "
@@ -116,7 +116,7 @@ _cors_origins = (
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_cors_origins,
-    allow_credentials=True,
+    allow_credentials=settings.cors_origins != "*",
     allow_methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
     allow_headers=["Authorization", "Content-Type", "X-Request-ID"],
 )

--- a/src/backend/services/task_queue.py
+++ b/src/backend/services/task_queue.py
@@ -1,25 +1,25 @@
 """
-Task Queue Service mit Redis
+Task Queue Service mit Redis (async)
 """
 import json
 
-import redis
+import redis.asyncio as aioredis
 from loguru import logger
 
 from utils.config import settings
 
 
 class TaskQueue:
-    """Simple Task Queue mit Redis"""
+    """Async Task Queue mit Redis"""
 
     def __init__(self):
-        self.redis_client = redis.from_url(settings.redis_url, decode_responses=True)
+        self.redis_client = aioredis.from_url(settings.redis_url, decode_responses=True)
         self.queue_name = "renfield:tasks"
 
     async def enqueue(self, task_type: str, parameters: dict) -> str:
         """Task in Queue einreihen"""
         try:
-            task_id = f"task:{task_type}:{self.redis_client.incr('task:counter')}"
+            task_id = f"task:{task_type}:{await self.redis_client.incr('task:counter')}"
 
             task_data = {
                 "id": task_id,
@@ -29,50 +29,54 @@ class TaskQueue:
             }
 
             # In Redis speichern
-            self.redis_client.lpush(self.queue_name, json.dumps(task_data))
-            self.redis_client.set(task_id, json.dumps(task_data))
+            await self.redis_client.lpush(self.queue_name, json.dumps(task_data))
+            await self.redis_client.set(task_id, json.dumps(task_data))
 
-            logger.info(f"✅ Task {task_id} eingefügt")
+            logger.info(f"Task {task_id} eingefuegt")
             return task_id
         except Exception as e:
-            logger.error(f"❌ Enqueue Fehler: {e}")
+            logger.error(f"Enqueue Fehler: {e}")
             raise
 
-    def dequeue(self) -> dict | None:
-        """Nächsten Task aus Queue holen"""
+    async def dequeue(self) -> dict | None:
+        """Naechsten Task aus Queue holen"""
         try:
-            task_json = self.redis_client.rpop(self.queue_name)
+            task_json = await self.redis_client.rpop(self.queue_name)
             if task_json:
                 return json.loads(task_json)
             return None
         except Exception as e:
-            logger.error(f"❌ Dequeue Fehler: {e}")
+            logger.error(f"Dequeue Fehler: {e}")
             return None
 
-    def get_task_status(self, task_id: str) -> dict | None:
+    async def get_task_status(self, task_id: str) -> dict | None:
         """Task-Status abrufen"""
         try:
-            task_json = self.redis_client.get(task_id)
+            task_json = await self.redis_client.get(task_id)
             if task_json:
                 return json.loads(task_json)
             return None
         except Exception as e:
-            logger.error(f"❌ Get Status Fehler: {e}")
+            logger.error(f"Get Status Fehler: {e}")
             return None
 
-    def update_task_status(self, task_id: str, status: str, result: dict | None = None):
+    async def update_task_status(self, task_id: str, status: str, result: dict | None = None):
         """Task-Status aktualisieren"""
         try:
-            task = self.get_task_status(task_id)
+            task = await self.get_task_status(task_id)
             if task:
                 task["status"] = status
                 if result:
                     task["result"] = result
-                self.redis_client.set(task_id, json.dumps(task))
-                logger.info(f"✅ Task {task_id} Status: {status}")
+                await self.redis_client.set(task_id, json.dumps(task))
+                logger.info(f"Task {task_id} Status: {status}")
         except Exception as e:
-            logger.error(f"❌ Update Status Fehler: {e}")
+            logger.error(f"Update Status Fehler: {e}")
 
-    def queue_length(self) -> int:
+    async def queue_length(self) -> int:
         """Anzahl der Tasks in Queue"""
-        return self.redis_client.llen(self.queue_name)
+        return await self.redis_client.llen(self.queue_name)
+
+    async def close(self):
+        """Close Redis connection gracefully."""
+        await self.redis_client.close()

--- a/tests/backend/test_api_rate_limiter.py
+++ b/tests/backend/test_api_rate_limiter.py
@@ -1,0 +1,238 @@
+"""
+Tests for API Rate Limiter
+
+Tests cover:
+- get_client_ip() extraction from various request scenarios
+- rate_limit_exceeded_handler response format
+- setup_rate_limiter() configuration
+- limit decorator functions
+- is_plugin_enabled helper
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+_missing_stubs = [
+    "asyncpg", "whisper", "piper", "piper.voice",
+    "speechbrain", "speechbrain.inference", "speechbrain.inference.speaker",
+    "openwakeword", "openwakeword.model",
+    "slowapi", "slowapi.errors", "slowapi.middleware", "slowapi.util",
+]
+for _mod in _missing_stubs:
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+# slowapi stubs need specific attributes
+sys.modules["slowapi"].Limiter = MagicMock
+sys.modules["slowapi.errors"].RateLimitExceeded = type("RateLimitExceeded", (Exception,), {})
+sys.modules["slowapi.middleware"].SlowAPIMiddleware = MagicMock
+sys.modules["slowapi.util"].get_remote_address = MagicMock(return_value="127.0.0.1")
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from services.api_rate_limiter import (
+    get_client_ip,
+    limit_custom,
+    rate_limit_exceeded_handler,
+    setup_rate_limiter,
+)
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+def _make_request(headers: dict | None = None, client_host: str = "10.0.0.1") -> MagicMock:
+    """Create a mock Request with optional headers and client info."""
+    req = MagicMock(spec=Request)
+    req.headers = headers or {}
+    req.url = MagicMock()
+    req.url.path = "/api/test"
+    # slowapi's get_remote_address reads request.client.host
+    req.client = MagicMock()
+    req.client.host = client_host
+    return req
+
+
+# =============================================================================
+# get_client_ip tests
+# =============================================================================
+
+class TestGetClientIp:
+    """Tests for the get_client_ip function."""
+
+    @pytest.mark.unit
+    def test_x_forwarded_for_single_ip(self):
+        """Should extract IP from X-Forwarded-For header."""
+        request = _make_request(headers={"X-Forwarded-For": "203.0.113.50"})
+        assert get_client_ip(request) == "203.0.113.50"
+
+    @pytest.mark.unit
+    def test_x_forwarded_for_multiple_ips(self):
+        """Should take first IP from X-Forwarded-For chain."""
+        request = _make_request(
+            headers={"X-Forwarded-For": "203.0.113.50, 70.41.3.18, 150.172.238.178"}
+        )
+        assert get_client_ip(request) == "203.0.113.50"
+
+    @pytest.mark.unit
+    def test_x_forwarded_for_with_spaces(self):
+        """Should strip whitespace from X-Forwarded-For value."""
+        request = _make_request(headers={"X-Forwarded-For": "  203.0.113.50 , 10.0.0.1"})
+        assert get_client_ip(request) == "203.0.113.50"
+
+    @pytest.mark.unit
+    def test_x_real_ip_header(self):
+        """Should use X-Real-IP when X-Forwarded-For is absent."""
+        request = _make_request(headers={"X-Real-IP": "198.51.100.1"})
+        assert get_client_ip(request) == "198.51.100.1"
+
+    @pytest.mark.unit
+    def test_x_forwarded_for_takes_priority_over_x_real_ip(self):
+        """X-Forwarded-For should have priority over X-Real-IP."""
+        request = _make_request(headers={
+            "X-Forwarded-For": "203.0.113.50",
+            "X-Real-IP": "198.51.100.1",
+        })
+        assert get_client_ip(request) == "203.0.113.50"
+
+    @pytest.mark.unit
+    def test_fallback_to_remote_address(self):
+        """Should fall back to direct client IP when no proxy headers."""
+        request = _make_request(client_host="192.168.1.42")
+        with patch("services.api_rate_limiter.get_remote_address", return_value="192.168.1.42"):
+            ip = get_client_ip(request)
+        assert ip == "192.168.1.42"
+
+    @pytest.mark.unit
+    def test_empty_forwarded_for_uses_real_ip(self):
+        """Empty X-Forwarded-For should fall through to X-Real-IP."""
+        # An empty string is falsy, so it should skip to X-Real-IP
+        request = _make_request(headers={"X-Forwarded-For": "", "X-Real-IP": "10.20.30.40"})
+        assert get_client_ip(request) == "10.20.30.40"
+
+
+# =============================================================================
+# rate_limit_exceeded_handler tests
+# =============================================================================
+
+class TestRateLimitExceededHandler:
+    """Tests for the rate limit exceeded handler."""
+
+    @pytest.mark.unit
+    def test_returns_429_status(self):
+        """Handler should return 429 status code."""
+        request = _make_request(client_host="10.0.0.1")
+        exc = MagicMock()
+        exc.retry_after = 30
+        exc.detail = "5 per minute"
+
+        with patch("services.api_rate_limiter.get_client_ip", return_value="10.0.0.1"):
+            response = rate_limit_exceeded_handler(request, exc)
+
+        assert isinstance(response, JSONResponse)
+        assert response.status_code == 429
+
+    @pytest.mark.unit
+    def test_response_body_contains_error_fields(self):
+        """Response body should contain error, message, retry_after, detail."""
+        request = _make_request()
+        exc = MagicMock()
+        exc.retry_after = 60
+        exc.detail = "100 per minute"
+
+        with patch("services.api_rate_limiter.get_client_ip", return_value="127.0.0.1"):
+            response = rate_limit_exceeded_handler(request, exc)
+
+        assert response.body is not None
+        import json
+        body = json.loads(response.body)
+        assert body["error"] == "rate_limit_exceeded"
+        assert body["retry_after"] == 60
+        assert "60" in body["message"]
+        assert body["detail"] == "100 per minute"
+
+    @pytest.mark.unit
+    def test_retry_after_header_set(self):
+        """Response should include Retry-After header."""
+        request = _make_request()
+        exc = MagicMock()
+        exc.retry_after = 45
+        exc.detail = "10 per minute"
+
+        with patch("services.api_rate_limiter.get_client_ip", return_value="127.0.0.1"):
+            response = rate_limit_exceeded_handler(request, exc)
+
+        assert response.headers.get("retry-after") == "45"
+
+    @pytest.mark.unit
+    def test_handler_defaults_retry_after_when_missing(self):
+        """Should default retry_after to 60 when exc has no retry_after."""
+        request = _make_request()
+        exc = MagicMock(spec=[])  # no attributes at all
+
+        with patch("services.api_rate_limiter.get_client_ip", return_value="127.0.0.1"):
+            response = rate_limit_exceeded_handler(request, exc)
+
+        import json
+        body = json.loads(response.body)
+        assert body["retry_after"] == 60
+
+
+# =============================================================================
+# setup_rate_limiter tests
+# =============================================================================
+
+class TestSetupRateLimiter:
+    """Tests for the setup_rate_limiter function."""
+
+    @pytest.mark.unit
+    def test_disabled_does_not_add_middleware(self):
+        """When rate limiting is disabled, no middleware should be added."""
+        app = MagicMock(spec=FastAPI)
+        with patch("services.api_rate_limiter.settings") as mock_settings:
+            mock_settings.api_rate_limit_enabled = False
+            setup_rate_limiter(app)
+
+        app.add_middleware.assert_not_called()
+        app.add_exception_handler.assert_not_called()
+
+    @pytest.mark.unit
+    def test_enabled_adds_middleware_and_handler(self):
+        """When enabled, should add middleware and exception handler."""
+        app = MagicMock(spec=FastAPI)
+        app.state = MagicMock()
+        with patch("services.api_rate_limiter.settings") as mock_settings:
+            mock_settings.api_rate_limit_enabled = True
+            mock_settings.api_rate_limit_default = "100/minute"
+            setup_rate_limiter(app)
+
+        app.add_middleware.assert_called_once()
+        app.add_exception_handler.assert_called_once()
+
+    @pytest.mark.unit
+    def test_enabled_sets_limiter_on_app_state(self):
+        """When enabled, limiter should be set on app.state."""
+        app = MagicMock(spec=FastAPI)
+        app.state = MagicMock()
+        with patch("services.api_rate_limiter.settings") as mock_settings:
+            mock_settings.api_rate_limit_enabled = True
+            mock_settings.api_rate_limit_default = "100/minute"
+            setup_rate_limiter(app)
+
+        assert app.state.limiter is not None
+
+
+# =============================================================================
+# Decorator tests
+# =============================================================================
+
+class TestLimitDecorators:
+    """Tests for the rate limit decorator functions."""
+
+    @pytest.mark.unit
+    def test_limit_custom_returns_decorator(self):
+        """limit_custom should return a callable decorator."""
+        decorator = limit_custom("5/minute")
+        assert callable(decorator)

--- a/tests/backend/test_audio_output_service.py
+++ b/tests/backend/test_audio_output_service.py
@@ -1,0 +1,381 @@
+"""Tests for AudioOutputService.
+
+Tests TTS audio delivery to Renfield devices (WebSocket) and
+Home Assistant media players (HA service calls), caching, and cleanup.
+"""
+import sys
+import time
+from unittest.mock import MagicMock
+
+# Pre-mock modules not available in test environment
+_missing_stubs = [
+    "asyncpg", "whisper", "piper", "piper.voice", "speechbrain",
+    "speechbrain.inference", "speechbrain.inference.speaker",
+    "openwakeword", "openwakeword.model",
+]
+for _mod in _missing_stubs:
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services.audio_output_service import AudioOutputService, get_audio_output_service
+
+
+def _make_output_device(
+    *,
+    renfield_device_id=None,
+    ha_entity_id=None,
+    tts_volume=0.5,
+):
+    """Create a mock RoomOutputDevice."""
+    dev = MagicMock()
+    dev.renfield_device_id = renfield_device_id
+    dev.ha_entity_id = ha_entity_id
+    dev.tts_volume = tts_volume
+    dev.is_renfield_device = renfield_device_id is not None
+    return dev
+
+
+@pytest.fixture
+def mock_ha_client():
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_settings():
+    s = MagicMock()
+    s.advertise_host = "renfield.local"
+    s.advertise_port = 8000
+    s.backend_internal_url = "http://backend:8000"
+    return s
+
+
+@pytest.fixture
+def service(mock_ha_client, mock_settings, tmp_path):
+    with patch("services.audio_output_service.HomeAssistantClient", return_value=mock_ha_client), \
+         patch("services.audio_output_service.settings", mock_settings):
+        svc = AudioOutputService()
+        # Use tmp_path for cache to avoid filesystem side effects
+        svc.TTS_CACHE_DIR = tmp_path
+    return svc
+
+
+# ============================================================================
+# Play on Renfield Device Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestPlayOnRenfieldDevice:
+
+    @pytest.mark.asyncio
+    async def test_play_on_connected_device(self, service):
+        """Audio is sent to a connected Renfield device."""
+        mock_device = MagicMock()
+        mock_device.capabilities.has_speaker = True
+
+        mock_dm = MagicMock()
+        mock_dm.get_device.return_value = mock_device
+        mock_dm.send_tts_audio = AsyncMock()
+
+        with patch("services.audio_output_service.get_device_manager", return_value=mock_dm):
+            result = await service._play_on_renfield_device(
+                audio_bytes=b"fake-audio",
+                device_id="sat-kitchen",
+                session_id="sess-1",
+            )
+
+        assert result is True
+        mock_dm.send_tts_audio.assert_called_once_with(
+            session_id="sess-1",
+            audio_bytes=b"fake-audio",
+            is_final=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_play_on_disconnected_device(self, service):
+        """Returns False when device is not connected."""
+        mock_dm = MagicMock()
+        mock_dm.get_device.return_value = None
+
+        with patch("services.audio_output_service.get_device_manager", return_value=mock_dm):
+            result = await service._play_on_renfield_device(
+                audio_bytes=b"audio", device_id="sat-gone", session_id="sess-1"
+            )
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_play_on_device_without_speaker(self, service):
+        """Returns False when device has no speaker."""
+        mock_device = MagicMock()
+        mock_device.capabilities.has_speaker = False
+
+        mock_dm = MagicMock()
+        mock_dm.get_device.return_value = mock_device
+
+        with patch("services.audio_output_service.get_device_manager", return_value=mock_dm):
+            result = await service._play_on_renfield_device(
+                audio_bytes=b"audio", device_id="sat-nospeaker", session_id="sess-1"
+            )
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_play_on_device_send_error(self, service):
+        """Returns False when WebSocket send raises."""
+        mock_device = MagicMock()
+        mock_device.capabilities.has_speaker = True
+
+        mock_dm = MagicMock()
+        mock_dm.get_device.return_value = mock_device
+        mock_dm.send_tts_audio = AsyncMock(side_effect=Exception("WS closed"))
+
+        with patch("services.audio_output_service.get_device_manager", return_value=mock_dm):
+            result = await service._play_on_renfield_device(
+                audio_bytes=b"audio", device_id="sat-err", session_id="sess-1"
+            )
+
+        assert result is False
+
+
+# ============================================================================
+# Play on HA Media Player Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestPlayOnHAMediaPlayer:
+
+    @pytest.mark.asyncio
+    async def test_play_on_ha_player_success(self, service, mock_ha_client):
+        """Successful playback on HA media player."""
+        mock_ha_client.get_state = AsyncMock(
+            return_value={"attributes": {"volume_level": 0.3}}
+        )
+        mock_ha_client.call_service = AsyncMock(return_value=True)
+
+        device = _make_output_device(ha_entity_id="media_player.living", tts_volume=0.5)
+        result = await service.play_audio(
+            audio_bytes=b"wav-data",
+            output_device=device,
+            session_id="sess-1",
+        )
+
+        assert result is True
+        # Volume was changed, so call_service should be called for volume_set + play_media
+        assert mock_ha_client.call_service.call_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_play_on_ha_player_no_volume_change(self, service, mock_ha_client):
+        """No volume_set call when volume already matches tts_volume."""
+        mock_ha_client.get_state = AsyncMock(
+            return_value={"attributes": {"volume_level": 0.5}}
+        )
+        mock_ha_client.call_service = AsyncMock(return_value=True)
+
+        result = await service._play_on_ha_media_player(
+            audio_bytes=b"wav-data",
+            entity_id="media_player.living",
+            tts_volume=0.5,
+            session_id="sess-1",
+        )
+
+        assert result is True
+        # Only play_media should be called, not volume_set
+        calls = mock_ha_client.call_service.call_args_list
+        services_called = [c.kwargs.get("service") or c[1].get("service", c[0][1] if len(c[0]) > 1 else None) for c in calls]
+        assert "volume_set" not in services_called
+
+    @pytest.mark.asyncio
+    async def test_play_on_ha_player_null_volume(self, service, mock_ha_client):
+        """No volume adjustment when tts_volume is None."""
+        mock_ha_client.call_service = AsyncMock(return_value=True)
+
+        result = await service._play_on_ha_media_player(
+            audio_bytes=b"wav-data",
+            entity_id="media_player.living",
+            tts_volume=None,
+            session_id="sess-1",
+        )
+
+        assert result is True
+        # get_state should not be called when tts_volume is None
+        mock_ha_client.get_state.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_play_on_ha_player_failure(self, service, mock_ha_client):
+        """Returns False when HA service call fails."""
+        mock_ha_client.call_service = AsyncMock(side_effect=Exception("HA unreachable"))
+
+        result = await service._play_on_ha_media_player(
+            audio_bytes=b"wav-data",
+            entity_id="media_player.dead",
+            tts_volume=None,
+            session_id="sess-1",
+        )
+
+        assert result is False
+
+
+# ============================================================================
+# play_audio Dispatch Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestPlayAudioDispatch:
+
+    @pytest.mark.asyncio
+    async def test_dispatches_to_renfield(self, service):
+        """play_audio routes to _play_on_renfield_device for Renfield devices."""
+        service._play_on_renfield_device = AsyncMock(return_value=True)
+        device = _make_output_device(renfield_device_id="sat-1")
+
+        result = await service.play_audio(b"audio", device, "sess-1")
+
+        assert result is True
+        service._play_on_renfield_device.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_dispatches_to_ha(self, service):
+        """play_audio routes to _play_on_ha_media_player for HA devices."""
+        service._play_on_ha_media_player = AsyncMock(return_value=True)
+        device = _make_output_device(ha_entity_id="media_player.test")
+
+        result = await service.play_audio(b"audio", device, "sess-1")
+
+        assert result is True
+        service._play_on_ha_media_player.assert_called_once()
+
+
+# ============================================================================
+# Cache Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestTTSCache:
+
+    def test_get_cached_audio_existing_file(self, service, tmp_path):
+        """get_cached_audio returns bytes for existing file."""
+        audio_id = "tts_test_abc123"
+        audio_file = tmp_path / f"{audio_id}.wav"
+        audio_file.write_bytes(b"cached-wav-data")
+
+        result = service.get_cached_audio(audio_id)
+
+        assert result == b"cached-wav-data"
+
+    def test_get_cached_audio_missing_file(self, service):
+        """get_cached_audio returns None for missing file."""
+        result = service.get_cached_audio("nonexistent_id")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_cleanup_removes_old_files(self, service, tmp_path):
+        """Old cache files are removed during cleanup."""
+        old_file = tmp_path / "tts_old_file.wav"
+        old_file.write_bytes(b"old-data")
+
+        # Make file appear old by setting last_cleanup to 0 and file mtime far in past
+        import os
+        old_time = time.time() - 999
+        os.utime(old_file, (old_time, old_time))
+
+        service._last_cleanup = 0
+        service.CACHE_CLEANUP_INTERVAL = 0  # Always run
+        service.CACHE_MAX_AGE = 60  # 1 minute
+
+        await service._cleanup_old_cache_files()
+
+        assert not old_file.exists()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_skipped_if_recent(self, service, tmp_path):
+        """Cleanup is skipped if run recently."""
+        old_file = tmp_path / "tts_should_remain.wav"
+        old_file.write_bytes(b"data")
+
+        import os
+        old_time = time.time() - 999
+        os.utime(old_file, (old_time, old_time))
+
+        service._last_cleanup = time.time()  # Just ran
+        service.CACHE_CLEANUP_INTERVAL = 9999
+
+        await service._cleanup_old_cache_files()
+
+        assert old_file.exists()  # Should NOT have been cleaned up
+
+
+# ============================================================================
+# Backend URL Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestBackendURL:
+
+    def test_url_with_advertise_host(self):
+        """Uses advertise_host when set."""
+        mock_s = MagicMock()
+        mock_s.advertise_host = "renfield.local"
+        mock_s.advertise_port = 8000
+
+        with patch("services.audio_output_service.settings", mock_s), \
+             patch("services.audio_output_service.HomeAssistantClient"):
+            svc = AudioOutputService()
+            url = svc._get_backend_url()
+
+        assert url == "http://renfield.local:8000"
+
+    def test_url_falls_back_to_internal(self):
+        """Falls back to backend_internal_url when advertise_host is None."""
+        mock_s = MagicMock()
+        mock_s.advertise_host = None
+        mock_s.backend_internal_url = "http://backend:8000"
+
+        with patch("services.audio_output_service.settings", mock_s), \
+             patch("services.audio_output_service.HomeAssistantClient"):
+            svc = AudioOutputService()
+            url = svc._get_backend_url()
+
+        assert url == "http://backend:8000"
+
+
+# ============================================================================
+# Singleton Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestSingleton:
+
+    def test_get_audio_output_service_returns_instance(self):
+        """get_audio_output_service returns an AudioOutputService."""
+        import services.audio_output_service as mod
+        # Reset singleton
+        mod._audio_output_service = None
+
+        with patch("services.audio_output_service.HomeAssistantClient"), \
+             patch("services.audio_output_service.settings") as mock_s:
+            mock_s.advertise_host = None
+            mock_s.backend_internal_url = "http://backend:8000"
+            svc = get_audio_output_service()
+
+        assert isinstance(svc, AudioOutputService)
+        # Reset to avoid leaking state
+        mod._audio_output_service = None
+
+    def test_get_audio_output_service_returns_same_instance(self):
+        """Repeated calls return the same singleton instance."""
+        import services.audio_output_service as mod
+        mod._audio_output_service = None
+
+        with patch("services.audio_output_service.HomeAssistantClient"), \
+             patch("services.audio_output_service.settings") as mock_s:
+            mock_s.advertise_host = None
+            mock_s.backend_internal_url = "http://backend:8000"
+            svc1 = get_audio_output_service()
+            svc2 = get_audio_output_service()
+
+        assert svc1 is svc2
+        mod._audio_output_service = None

--- a/tests/backend/test_document_processor.py
+++ b/tests/backend/test_document_processor.py
@@ -1,0 +1,368 @@
+"""Tests for DocumentProcessor.
+
+Tests document processing, metadata extraction, chunk creation,
+format support, and fallback text splitting.
+"""
+import sys
+from unittest.mock import MagicMock
+
+# Pre-mock modules not available in test environment
+_missing_stubs = [
+    "asyncpg", "whisper", "piper", "piper.voice", "speechbrain",
+    "speechbrain.inference", "speechbrain.inference.speaker",
+    "openwakeword", "openwakeword.model",
+    "docling", "docling.document_converter", "docling.chunking",
+]
+for _mod in _missing_stubs:
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from unittest.mock import patch
+
+import pytest
+
+from services.document_processor import DocumentProcessor
+
+
+def _make_mock_settings(rag_chunk_size=512, rag_chunk_overlap=50):
+    s = MagicMock()
+    s.rag_chunk_size = rag_chunk_size
+    s.rag_chunk_overlap = rag_chunk_overlap
+    return s
+
+
+@pytest.fixture
+def mock_settings():
+    return _make_mock_settings()
+
+
+@pytest.fixture
+def processor():
+    return DocumentProcessor()
+
+
+# ============================================================================
+# Initialization Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestDocumentProcessorInit:
+
+    def test_init_not_initialized(self, processor):
+        assert processor._initialized is False
+        assert processor._converter is None
+        assert processor._chunker is None
+
+    def test_ensure_initialized_sets_flag(self, processor):
+        """After initialization, _initialized is True."""
+        mock_converter_cls = MagicMock()
+        mock_chunker_cls = MagicMock()
+
+        with patch("services.document_processor.settings") as mock_s:
+            mock_s.rag_chunk_size = 512
+            with patch.dict(sys.modules, {
+                "docling.document_converter": MagicMock(DocumentConverter=mock_converter_cls),
+                "docling.chunking": MagicMock(HybridChunker=mock_chunker_cls),
+            }):
+                processor._ensure_initialized()
+
+        assert processor._initialized is True
+        assert processor._converter is not None
+        assert processor._chunker is not None
+
+    def test_ensure_initialized_only_once(self, processor):
+        """Repeated calls do not re-initialize."""
+        processor._initialized = True
+        processor._converter = MagicMock()
+        processor._chunker = MagicMock()
+
+        original_converter = processor._converter
+        processor._ensure_initialized()
+
+        assert processor._converter is original_converter
+
+
+# ============================================================================
+# Format Support Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestFormatSupport:
+
+    def test_supported_formats_include_pdf(self, processor):
+        assert "pdf" in processor.get_supported_formats()
+
+    def test_supported_formats_include_docx(self, processor):
+        assert "docx" in processor.get_supported_formats()
+
+    def test_supported_formats_include_txt(self, processor):
+        assert "txt" in processor.get_supported_formats()
+
+    def test_supported_formats_include_md(self, processor):
+        assert "md" in processor.get_supported_formats()
+
+    def test_supported_formats_include_images(self, processor):
+        formats = processor.get_supported_formats()
+        assert "png" in formats
+        assert "jpg" in formats
+        assert "jpeg" in formats
+
+    def test_is_supported_pdf(self, processor):
+        assert processor.is_supported("document.pdf") is True
+
+    def test_is_supported_docx(self, processor):
+        assert processor.is_supported("report.docx") is True
+
+    def test_is_supported_txt(self, processor):
+        assert processor.is_supported("notes.txt") is True
+
+    def test_is_supported_unsupported_format(self, processor):
+        assert processor.is_supported("video.mp4") is False
+
+    def test_is_supported_case_insensitive(self, processor):
+        assert processor.is_supported("FILE.PDF") is True
+
+    def test_is_supported_no_extension(self, processor):
+        assert processor.is_supported("noextension") is False
+
+
+# ============================================================================
+# Metadata Extraction Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestMetadataExtraction:
+
+    def test_extract_metadata_basic_fields(self, processor, tmp_path):
+        """Basic metadata includes filename, file_type, file_size, processed_at."""
+        test_file = tmp_path / "test.pdf"
+        test_file.write_bytes(b"fake pdf content")
+
+        mock_doc = MagicMock()
+        mock_doc.name = "Test Document"
+        mock_doc.origin = None
+        mock_doc.pages = None
+
+        metadata = processor._extract_metadata(mock_doc, str(test_file))
+
+        assert metadata["filename"] == "test.pdf"
+        assert metadata["file_type"] == "pdf"
+        assert metadata["file_size"] > 0
+        assert "processed_at" in metadata
+        assert metadata["title"] == "Test Document"
+
+    def test_extract_metadata_uses_stem_when_no_doc_name(self, processor, tmp_path):
+        """Falls back to filename stem when doc has no name."""
+        test_file = tmp_path / "my_report.docx"
+        test_file.write_bytes(b"content")
+
+        mock_doc = MagicMock()
+        mock_doc.name = None
+        mock_doc.origin = None
+        mock_doc.pages = None
+
+        metadata = processor._extract_metadata(mock_doc, str(test_file))
+
+        assert metadata["title"] == "my_report"
+
+    def test_extract_metadata_with_author(self, processor, tmp_path):
+        """Author is extracted from doc.origin."""
+        test_file = tmp_path / "test.pdf"
+        test_file.write_bytes(b"content")
+
+        mock_doc = MagicMock()
+        mock_doc.name = "Test"
+        mock_doc.origin = MagicMock()
+        mock_doc.origin.author = "John Doe"
+        mock_doc.pages = None
+
+        metadata = processor._extract_metadata(mock_doc, str(test_file))
+
+        assert metadata["author"] == "John Doe"
+
+    def test_extract_metadata_with_page_count(self, processor, tmp_path):
+        """Page count extracted from doc.pages."""
+        test_file = tmp_path / "test.pdf"
+        test_file.write_bytes(b"content")
+
+        mock_doc = MagicMock()
+        mock_doc.name = "Test"
+        mock_doc.origin = None
+        mock_doc.pages = [MagicMock(), MagicMock(), MagicMock()]
+
+        metadata = processor._extract_metadata(mock_doc, str(test_file))
+
+        assert metadata["page_count"] == 3
+
+
+# ============================================================================
+# Chunk Creation Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestChunkCreation:
+
+    def test_create_chunks_returns_list(self, processor):
+        """Chunks are returned as a list of dicts."""
+        mock_chunk = MagicMock()
+        mock_chunk.text = "Sample text content"
+        mock_chunk.meta = MagicMock()
+        mock_chunk.meta.headings = ["Chapter 1"]
+        mock_chunk.meta.doc_items = []
+
+        processor._chunker = MagicMock()
+        processor._chunker.chunk.return_value = [mock_chunk]
+
+        chunks = processor._create_chunks(MagicMock())
+
+        assert len(chunks) == 1
+        assert chunks[0]["text"] == "Sample text content"
+        assert chunks[0]["chunk_index"] == 0
+        assert "metadata" in chunks[0]
+
+    def test_create_chunks_extracts_headings(self, processor):
+        mock_chunk = MagicMock()
+        mock_chunk.text = "Content"
+        mock_chunk.meta.headings = ["Introduction", "Background"]
+        mock_chunk.meta.doc_items = []
+
+        processor._chunker = MagicMock()
+        processor._chunker.chunk.return_value = [mock_chunk]
+
+        chunks = processor._create_chunks(MagicMock())
+
+        assert chunks[0]["metadata"]["headings"] == ["Introduction", "Background"]
+
+    def test_create_chunks_fallback_on_error(self, processor):
+        """Falls back to simple_chunk when chunking fails."""
+        mock_doc = MagicMock()
+        mock_doc.export_to_text.return_value = "Hello world. This is a test."
+
+        processor._chunker = MagicMock()
+        processor._chunker.chunk.side_effect = Exception("chunking error")
+
+        with patch("services.document_processor.settings") as mock_s:
+            mock_s.rag_chunk_size = 512
+            mock_s.rag_chunk_overlap = 50
+            chunks = processor._create_chunks(mock_doc)
+
+        assert len(chunks) >= 1
+        assert chunks[0]["text"] == "Hello world. This is a test."
+
+    def test_get_headings_no_meta(self, processor):
+        mock_chunk = MagicMock(spec=[])  # No attributes
+        assert processor._get_headings(mock_chunk) == []
+
+    def test_get_chunk_type_default_paragraph(self, processor):
+        mock_chunk = MagicMock(spec=[])
+        assert processor._get_chunk_type(mock_chunk) == "paragraph"
+
+    def test_get_page_number_none_when_no_prov(self, processor):
+        mock_chunk = MagicMock(spec=[])
+        assert processor._get_page_number(mock_chunk) is None
+
+
+# ============================================================================
+# Simple Chunk Fallback Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestSimpleChunk:
+
+    def test_simple_chunk_splits_text(self, processor):
+        """Simple chunking splits long text into pieces."""
+        with patch("services.document_processor.settings") as mock_s:
+            mock_s.rag_chunk_size = 10  # ~40 chars per chunk
+            mock_s.rag_chunk_overlap = 2  # ~8 chars overlap
+
+            text = "A" * 100  # 100 chars
+            chunks = processor._simple_chunk(text)
+
+        assert len(chunks) > 1
+        for chunk in chunks:
+            assert chunk["text"]
+            assert "chunk_index" in chunk
+            assert chunk["metadata"]["chunk_type"] == "paragraph"
+
+    def test_simple_chunk_empty_text(self, processor):
+        with patch("services.document_processor.settings") as mock_s:
+            mock_s.rag_chunk_size = 512
+            mock_s.rag_chunk_overlap = 50
+            chunks = processor._simple_chunk("")
+
+        assert chunks == []
+
+    def test_simple_chunk_short_text(self, processor):
+        """Short text results in a single chunk."""
+        with patch("services.document_processor.settings") as mock_s:
+            mock_s.rag_chunk_size = 512
+            mock_s.rag_chunk_overlap = 50
+            chunks = processor._simple_chunk("Short text.")
+
+        assert len(chunks) == 1
+        assert chunks[0]["text"] == "Short text."
+        assert chunks[0]["chunk_index"] == 0
+
+    def test_simple_chunk_breaks_at_sentence(self, processor):
+        """Prefers to break at sentence boundaries."""
+        with patch("services.document_processor.settings") as mock_s:
+            mock_s.rag_chunk_size = 10  # ~40 chars
+            mock_s.rag_chunk_overlap = 2
+
+            text = "First sentence. Second sentence. Third sentence."
+            chunks = processor._simple_chunk(text)
+
+        # First chunk should end at a period
+        assert chunks[0]["text"].endswith(".")
+
+
+# ============================================================================
+# Process Document Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestProcessDocument:
+
+    @pytest.mark.asyncio
+    async def test_process_nonexistent_file(self, processor):
+        """Non-existent file returns failed status."""
+        processor._initialized = True
+        processor._converter = MagicMock()
+        processor._chunker = MagicMock()
+
+        result = await processor.process_document("/nonexistent/file.pdf")
+
+        assert result["status"] == "failed"
+        assert "nicht gefunden" in result["error"]
+        assert result["chunks"] == []
+
+    @pytest.mark.asyncio
+    async def test_process_document_conversion_failure(self, processor, tmp_path):
+        """Failed conversion returns failed status."""
+        test_file = tmp_path / "bad.pdf"
+        test_file.write_bytes(b"not a real pdf")
+
+        processor._initialized = True
+        processor._converter = MagicMock()
+        processor._converter.convert.return_value = None
+        processor._chunker = MagicMock()
+
+        # Mock _convert_document directly since it's called via executor
+        processor._convert_document = MagicMock(return_value=None)
+
+        result = await processor.process_document(str(test_file))
+
+        assert result["status"] == "failed"
+
+    @pytest.mark.asyncio
+    async def test_process_document_exception(self, processor, tmp_path):
+        """Exception during processing returns failed status."""
+        test_file = tmp_path / "error.pdf"
+        test_file.write_bytes(b"content")
+
+        processor._ensure_initialized = MagicMock(side_effect=RuntimeError("Docling crash"))
+
+        result = await processor.process_document(str(test_file))
+
+        assert result["status"] == "failed"
+        assert "Docling crash" in result["error"]

--- a/tests/backend/test_intents_api.py
+++ b/tests/backend/test_intents_api.py
@@ -1,0 +1,222 @@
+"""
+Tests for Intent Registry API Routes
+
+Tests cover:
+- GET /api/intents/status
+- GET /api/intents/prompt
+- GET /api/intents/check/{intent_name}
+- GET /api/intents/integrations/summary
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+_missing_stubs = [
+    "asyncpg", "whisper", "piper", "piper.voice",
+    "speechbrain", "speechbrain.inference", "speechbrain.inference.speaker",
+    "openwakeword", "openwakeword.model",
+    "redis", "redis.asyncio",
+    "slowapi", "slowapi.errors", "slowapi.middleware", "slowapi.util",
+    "jose", "passlib", "passlib.context",
+]
+for _mod in _missing_stubs:
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from api.routes.intents import router as intents_router
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+def _create_test_app():
+    """Create a minimal FastAPI app with the intents router."""
+    app = FastAPI()
+    app.include_router(intents_router, prefix="/api/intents")
+    return app
+
+
+@pytest.fixture
+async def intents_client():
+    """Async HTTP client for intents API tests — no auth required."""
+    app = _create_test_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+# =============================================================================
+# GET /api/intents/status
+# =============================================================================
+
+class TestIntentStatus:
+    """Tests for the /status endpoint."""
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_status_returns_200(self, intents_client):
+        """Endpoint should return 200."""
+        resp = await intents_client.get("/api/intents/status")
+        assert resp.status_code == 200
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_status_contains_expected_fields(self, intents_client):
+        """Response should contain all expected top-level fields."""
+        resp = await intents_client.get("/api/intents/status")
+        data = resp.json()
+        assert "total_intents" in data
+        assert "enabled_integrations" in data
+        assert "disabled_integrations" in data
+        assert "integrations" in data
+        assert "plugins" in data
+        assert "mcp_tools" in data
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_status_integrations_structure(self, intents_client):
+        """Each integration should have name, title, enabled, intents."""
+        resp = await intents_client.get("/api/intents/status")
+        data = resp.json()
+        for integration in data["integrations"]:
+            assert "name" in integration
+            assert "title" in integration
+            assert "enabled" in integration
+            assert "intent_count" in integration
+            assert "intents" in integration
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_status_lang_en(self, intents_client):
+        """Should accept lang=en query parameter."""
+        resp = await intents_client.get("/api/intents/status?lang=en")
+        assert resp.status_code == 200
+        data = resp.json()
+        # The general integration is always enabled
+        general = next(
+            (i for i in data["integrations"] if i["name"] == "general"),
+            None,
+        )
+        assert general is not None
+        assert general["enabled"] is True
+
+
+# =============================================================================
+# GET /api/intents/prompt
+# =============================================================================
+
+class TestIntentPrompt:
+    """Tests for the /prompt endpoint."""
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_prompt_returns_200(self, intents_client):
+        """Endpoint should return 200."""
+        resp = await intents_client.get("/api/intents/prompt")
+        assert resp.status_code == 200
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_prompt_contains_expected_fields(self, intents_client):
+        """Response should contain language, intent_types, examples."""
+        resp = await intents_client.get("/api/intents/prompt")
+        data = resp.json()
+        assert "language" in data
+        assert "intent_types" in data
+        assert "examples" in data
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_prompt_default_language_is_de(self, intents_client):
+        """Default language should be 'de'."""
+        resp = await intents_client.get("/api/intents/prompt")
+        assert resp.json()["language"] == "de"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_prompt_lang_en(self, intents_client):
+        """Should return English prompt when lang=en."""
+        resp = await intents_client.get("/api/intents/prompt?lang=en")
+        assert resp.json()["language"] == "en"
+
+
+# =============================================================================
+# GET /api/intents/check/{intent_name}
+# =============================================================================
+
+class TestCheckIntent:
+    """Tests for the /check/{intent_name} endpoint."""
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_check_existing_intent(self, intents_client):
+        """Should return available=True for a known intent."""
+        resp = await intents_client.get("/api/intents/check/general.conversation")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["intent"] == "general.conversation"
+        assert data["available"] is True
+        assert data["definition"] is not None
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_check_nonexistent_intent(self, intents_client):
+        """Should return available=False for an unknown intent."""
+        resp = await intents_client.get("/api/intents/check/nonexistent.intent")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["intent"] == "nonexistent.intent"
+        assert data["available"] is False
+        assert data["definition"] is None
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_check_intent_definition_structure(self, intents_client):
+        """Known intent definition should have name, description_de, description_en, parameters."""
+        resp = await intents_client.get("/api/intents/check/general.conversation")
+        definition = resp.json()["definition"]
+        assert "name" in definition
+        assert "description_de" in definition
+        assert "description_en" in definition
+        assert "parameters" in definition
+
+
+# =============================================================================
+# GET /api/intents/integrations/summary
+# =============================================================================
+
+class TestIntegrationsSummary:
+    """Tests for the /integrations/summary endpoint."""
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_summary_returns_200(self, intents_client):
+        """Should return 200."""
+        resp = await intents_client.get("/api/intents/integrations/summary")
+        assert resp.status_code == 200
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_summary_structure(self, intents_client):
+        """Should have enabled, disabled, plugins_enabled, mcp_enabled."""
+        resp = await intents_client.get("/api/intents/integrations/summary")
+        data = resp.json()
+        assert "enabled" in data
+        assert "disabled" in data
+        assert "plugins_enabled" in data
+        assert "mcp_enabled" in data
+        assert isinstance(data["enabled"], list)
+        assert isinstance(data["disabled"], list)
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_summary_general_is_always_enabled(self, intents_client):
+        """The 'general' integration should always appear in enabled list."""
+        resp = await intents_client.get("/api/intents/integrations/summary")
+        data = resp.json()
+        enabled_names = [e["name"] for e in data["enabled"]]
+        assert "general" in enabled_names

--- a/tests/backend/test_output_routing_service.py
+++ b/tests/backend/test_output_routing_service.py
@@ -1,0 +1,429 @@
+"""Tests for OutputRoutingService.
+
+Tests routing logic, device availability checks, priority ordering,
+and fallback behavior.
+"""
+import sys
+from unittest.mock import MagicMock
+
+# Pre-mock modules not available in test environment
+_missing_stubs = [
+    "asyncpg", "whisper", "piper", "piper.voice", "speechbrain",
+    "speechbrain.inference", "speechbrain.inference.speaker",
+    "openwakeword", "openwakeword.model",
+]
+for _mod in _missing_stubs:
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services.output_routing_service import (
+    DeviceAvailability,
+    OutputDecision,
+    OutputRoutingService,
+)
+
+
+def _make_output_device(
+    *,
+    renfield_device_id=None,
+    ha_entity_id=None,
+    priority=1,
+    allow_interruption=False,
+    is_enabled=True,
+    device_name="Test Device",
+    output_type="audio",
+    tts_volume=0.5,
+):
+    """Create a mock RoomOutputDevice."""
+    dev = MagicMock()
+    dev.renfield_device_id = renfield_device_id
+    dev.ha_entity_id = ha_entity_id
+    dev.priority = priority
+    dev.allow_interruption = allow_interruption
+    dev.is_enabled = is_enabled
+    dev.device_name = device_name
+    dev.output_type = output_type
+    dev.tts_volume = tts_volume
+    dev.is_renfield_device = renfield_device_id is not None
+    dev.target_id = renfield_device_id or ha_entity_id or ""
+    return dev
+
+
+@pytest.fixture
+def mock_db_session():
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_ha_client():
+    return AsyncMock()
+
+
+@pytest.fixture
+def service(mock_db_session, mock_ha_client):
+    with patch("services.output_routing_service.HomeAssistantClient", return_value=mock_ha_client):
+        svc = OutputRoutingService(mock_db_session)
+    return svc
+
+
+# ============================================================================
+# Routing Logic Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestOutputRoutingDecisions:
+    """Tests for the core routing decision logic."""
+
+    @pytest.mark.asyncio
+    async def test_no_devices_configured_returns_fallback(self, service):
+        """When no output devices exist, fallback to input device."""
+        service._get_output_devices = AsyncMock(return_value=[])
+
+        result = await service.get_audio_output_for_room(room_id=1, input_device_id="sat-kitchen")
+
+        assert isinstance(result, OutputDecision)
+        assert result.fallback_to_input is True
+        assert result.target_id == "sat-kitchen"
+        assert result.target_type == "renfield"
+        assert result.reason == "no_output_devices_configured"
+
+    @pytest.mark.asyncio
+    async def test_no_devices_configured_no_input_device(self, service):
+        """When no output devices and no input device, target_id is empty."""
+        service._get_output_devices = AsyncMock(return_value=[])
+
+        result = await service.get_audio_output_for_room(room_id=1, input_device_id=None)
+
+        assert result.fallback_to_input is True
+        assert result.target_id == ""
+
+    @pytest.mark.asyncio
+    async def test_available_device_selected(self, service):
+        """First available device in priority order is selected."""
+        dev = _make_output_device(ha_entity_id="media_player.living_room", priority=1)
+        service._get_output_devices = AsyncMock(return_value=[dev])
+        service._check_device_availability = AsyncMock(return_value=DeviceAvailability.AVAILABLE)
+
+        result = await service.get_audio_output_for_room(room_id=1)
+
+        assert result.fallback_to_input is False
+        assert result.target_id == "media_player.living_room"
+        assert result.target_type == "homeassistant"
+        assert result.reason == "device_available"
+        assert result.availability == DeviceAvailability.AVAILABLE
+
+    @pytest.mark.asyncio
+    async def test_renfield_device_type_detected(self, service):
+        """Renfield devices get target_type='renfield'."""
+        dev = _make_output_device(renfield_device_id="sat-kitchen", priority=1)
+        service._get_output_devices = AsyncMock(return_value=[dev])
+        service._check_device_availability = AsyncMock(return_value=DeviceAvailability.AVAILABLE)
+
+        result = await service.get_audio_output_for_room(room_id=1)
+
+        assert result.target_type == "renfield"
+        assert result.target_id == "sat-kitchen"
+
+    @pytest.mark.asyncio
+    async def test_busy_device_with_interruption_allowed(self, service):
+        """Busy device is selected when allow_interruption=True."""
+        dev = _make_output_device(
+            ha_entity_id="media_player.bedroom",
+            allow_interruption=True,
+        )
+        service._get_output_devices = AsyncMock(return_value=[dev])
+        service._check_device_availability = AsyncMock(return_value=DeviceAvailability.BUSY)
+
+        result = await service.get_audio_output_for_room(room_id=1)
+
+        assert result.fallback_to_input is False
+        assert result.reason == "device_busy_allowing_interruption"
+        assert result.availability == DeviceAvailability.BUSY
+
+    @pytest.mark.asyncio
+    async def test_busy_device_without_interruption_skipped(self, service):
+        """Busy device is skipped when allow_interruption=False."""
+        dev = _make_output_device(
+            ha_entity_id="media_player.bedroom",
+            allow_interruption=False,
+        )
+        service._get_output_devices = AsyncMock(return_value=[dev])
+        service._check_device_availability = AsyncMock(return_value=DeviceAvailability.BUSY)
+
+        result = await service.get_audio_output_for_room(room_id=1)
+
+        assert result.fallback_to_input is True
+        assert result.reason == "all_devices_unavailable"
+
+    @pytest.mark.asyncio
+    async def test_off_device_skipped(self, service):
+        """OFF device is skipped."""
+        dev = _make_output_device(ha_entity_id="media_player.off_device")
+        service._get_output_devices = AsyncMock(return_value=[dev])
+        service._check_device_availability = AsyncMock(return_value=DeviceAvailability.OFF)
+
+        result = await service.get_audio_output_for_room(room_id=1)
+
+        assert result.fallback_to_input is True
+        assert result.reason == "all_devices_unavailable"
+
+    @pytest.mark.asyncio
+    async def test_unavailable_device_skipped(self, service):
+        """UNAVAILABLE device is skipped."""
+        dev = _make_output_device(ha_entity_id="media_player.dead")
+        service._get_output_devices = AsyncMock(return_value=[dev])
+        service._check_device_availability = AsyncMock(return_value=DeviceAvailability.UNAVAILABLE)
+
+        result = await service.get_audio_output_for_room(room_id=1)
+
+        assert result.fallback_to_input is True
+
+    @pytest.mark.asyncio
+    async def test_priority_ordering_first_available_wins(self, service):
+        """Among multiple devices, first available by priority wins."""
+        dev1 = _make_output_device(ha_entity_id="media_player.priority1", priority=1)
+        dev2 = _make_output_device(ha_entity_id="media_player.priority2", priority=2)
+        service._get_output_devices = AsyncMock(return_value=[dev1, dev2])
+
+        async def availability_side_effect(device):
+            if device.ha_entity_id == "media_player.priority1":
+                return DeviceAvailability.OFF
+            return DeviceAvailability.AVAILABLE
+
+        service._check_device_availability = AsyncMock(side_effect=availability_side_effect)
+
+        result = await service.get_audio_output_for_room(room_id=1)
+
+        assert result.target_id == "media_player.priority2"
+        assert result.reason == "device_available"
+
+    @pytest.mark.asyncio
+    async def test_disabled_device_skipped(self, service):
+        """Disabled devices are skipped entirely."""
+        dev = _make_output_device(ha_entity_id="media_player.disabled", is_enabled=False)
+        service._get_output_devices = AsyncMock(return_value=[dev])
+        # _check_device_availability should NOT be called for disabled devices
+        service._check_device_availability = AsyncMock(return_value=DeviceAvailability.AVAILABLE)
+
+        result = await service.get_audio_output_for_room(room_id=1)
+
+        assert result.fallback_to_input is True
+        service._check_device_availability.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_visual_output_uses_correct_type(self, service):
+        """get_visual_output_for_room passes correct output_type."""
+        service._get_output_devices = AsyncMock(return_value=[])
+
+        await service.get_visual_output_for_room(room_id=1)
+
+        service._get_output_devices.assert_called_once_with(1, "visual")
+
+
+# ============================================================================
+# Device Availability Check Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestDeviceAvailabilityChecks:
+    """Tests for device availability detection."""
+
+    @pytest.mark.asyncio
+    async def test_ha_device_idle_is_available(self, service):
+        service.ha_client.get_state = AsyncMock(return_value={"state": "idle"})
+        result = await service._check_ha_device_availability("media_player.test")
+        assert result == DeviceAvailability.AVAILABLE
+
+    @pytest.mark.asyncio
+    async def test_ha_device_paused_is_available(self, service):
+        service.ha_client.get_state = AsyncMock(return_value={"state": "paused"})
+        result = await service._check_ha_device_availability("media_player.test")
+        assert result == DeviceAvailability.AVAILABLE
+
+    @pytest.mark.asyncio
+    async def test_ha_device_standby_is_available(self, service):
+        service.ha_client.get_state = AsyncMock(return_value={"state": "standby"})
+        result = await service._check_ha_device_availability("media_player.test")
+        assert result == DeviceAvailability.AVAILABLE
+
+    @pytest.mark.asyncio
+    async def test_ha_device_on_is_available(self, service):
+        service.ha_client.get_state = AsyncMock(return_value={"state": "on"})
+        result = await service._check_ha_device_availability("media_player.test")
+        assert result == DeviceAvailability.AVAILABLE
+
+    @pytest.mark.asyncio
+    async def test_ha_device_playing_is_busy(self, service):
+        service.ha_client.get_state = AsyncMock(return_value={"state": "playing"})
+        result = await service._check_ha_device_availability("media_player.test")
+        assert result == DeviceAvailability.BUSY
+
+    @pytest.mark.asyncio
+    async def test_ha_device_buffering_is_busy(self, service):
+        service.ha_client.get_state = AsyncMock(return_value={"state": "buffering"})
+        result = await service._check_ha_device_availability("media_player.test")
+        assert result == DeviceAvailability.BUSY
+
+    @pytest.mark.asyncio
+    async def test_ha_device_off_is_off(self, service):
+        service.ha_client.get_state = AsyncMock(return_value={"state": "off"})
+        result = await service._check_ha_device_availability("media_player.test")
+        assert result == DeviceAvailability.OFF
+
+    @pytest.mark.asyncio
+    async def test_ha_device_unknown_is_unavailable(self, service):
+        service.ha_client.get_state = AsyncMock(return_value={"state": "unknown"})
+        result = await service._check_ha_device_availability("media_player.test")
+        assert result == DeviceAvailability.UNAVAILABLE
+
+    @pytest.mark.asyncio
+    async def test_ha_device_no_state_is_unavailable(self, service):
+        service.ha_client.get_state = AsyncMock(return_value=None)
+        result = await service._check_ha_device_availability("media_player.test")
+        assert result == DeviceAvailability.UNAVAILABLE
+
+    @pytest.mark.asyncio
+    async def test_ha_device_error_is_unavailable(self, service):
+        service.ha_client.get_state = AsyncMock(side_effect=Exception("Connection refused"))
+        result = await service._check_ha_device_availability("media_player.test")
+        assert result == DeviceAvailability.UNAVAILABLE
+
+    @pytest.mark.asyncio
+    async def test_renfield_device_idle_is_available(self, service):
+        from services.device_manager import DeviceState
+        mock_device = MagicMock()
+        mock_device.capabilities.has_speaker = True
+        mock_device.state = DeviceState.IDLE
+
+        mock_dm = MagicMock()
+        mock_dm.get_device.return_value = mock_device
+
+        with patch("services.device_manager.get_device_manager", return_value=mock_dm):
+            result = await service._check_renfield_device_availability("sat-kitchen")
+
+        assert result == DeviceAvailability.AVAILABLE
+
+    @pytest.mark.asyncio
+    async def test_renfield_device_speaking_is_busy(self, service):
+        from services.device_manager import DeviceState
+        mock_device = MagicMock()
+        mock_device.capabilities.has_speaker = True
+        mock_device.state = DeviceState.SPEAKING
+
+        mock_dm = MagicMock()
+        mock_dm.get_device.return_value = mock_device
+
+        with patch("services.device_manager.get_device_manager", return_value=mock_dm):
+            result = await service._check_renfield_device_availability("sat-kitchen")
+
+        assert result == DeviceAvailability.BUSY
+
+    @pytest.mark.asyncio
+    async def test_renfield_device_not_connected_is_unavailable(self, service):
+        mock_dm = MagicMock()
+        mock_dm.get_device.return_value = None
+
+        with patch("services.device_manager.get_device_manager", return_value=mock_dm):
+            result = await service._check_renfield_device_availability("sat-kitchen")
+
+        assert result == DeviceAvailability.UNAVAILABLE
+
+    @pytest.mark.asyncio
+    async def test_renfield_device_no_speaker_is_unavailable(self, service):
+        mock_device = MagicMock()
+        mock_device.capabilities.has_speaker = False
+
+        mock_dm = MagicMock()
+        mock_dm.get_device.return_value = mock_device
+
+        with patch("services.device_manager.get_device_manager", return_value=mock_dm):
+            result = await service._check_renfield_device_availability("sat-kitchen")
+
+        assert result == DeviceAvailability.UNAVAILABLE
+
+    @pytest.mark.asyncio
+    async def test_check_device_dispatches_to_renfield(self, service):
+        """_check_device_availability routes to renfield checker for renfield devices."""
+        dev = _make_output_device(renfield_device_id="sat-1")
+        service._check_renfield_device_availability = AsyncMock(return_value=DeviceAvailability.AVAILABLE)
+
+        result = await service._check_device_availability(dev)
+
+        assert result == DeviceAvailability.AVAILABLE
+        service._check_renfield_device_availability.assert_called_once_with("sat-1")
+
+    @pytest.mark.asyncio
+    async def test_check_device_dispatches_to_ha(self, service):
+        """_check_device_availability routes to HA checker for HA devices."""
+        dev = _make_output_device(ha_entity_id="media_player.test")
+        service._check_ha_device_availability = AsyncMock(return_value=DeviceAvailability.BUSY)
+
+        result = await service._check_device_availability(dev)
+
+        assert result == DeviceAvailability.BUSY
+        service._check_ha_device_availability.assert_called_once_with("media_player.test")
+
+
+# ============================================================================
+# CRUD Operation Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestCRUDOperations:
+    """Tests for add/update/delete output device operations."""
+
+    @pytest.mark.asyncio
+    async def test_add_device_requires_either_renfield_or_ha(self, service):
+        """Must provide either renfield_device_id or ha_entity_id."""
+        with pytest.raises(ValueError, match="Either renfield_device_id or ha_entity_id"):
+            await service.add_output_device(room_id=1, output_type="audio")
+
+    @pytest.mark.asyncio
+    async def test_add_device_rejects_both_renfield_and_ha(self, service):
+        """Cannot provide both renfield_device_id and ha_entity_id."""
+        with pytest.raises(ValueError, match="Only one of"):
+            await service.add_output_device(
+                room_id=1,
+                output_type="audio",
+                renfield_device_id="sat-1",
+                ha_entity_id="media_player.test",
+            )
+
+    @pytest.mark.asyncio
+    async def test_get_available_ha_media_players_error_returns_empty(self, service):
+        """HA errors return empty list instead of raising."""
+        service.ha_client.get_entities_by_domain = AsyncMock(side_effect=Exception("HA offline"))
+
+        result = await service.get_available_ha_media_players()
+
+        assert result == []
+
+
+# ============================================================================
+# Model Enum Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestEnumsAndDataclasses:
+
+    def test_device_availability_values(self):
+        assert DeviceAvailability.AVAILABLE == "available"
+        assert DeviceAvailability.BUSY == "busy"
+        assert DeviceAvailability.OFF == "off"
+        assert DeviceAvailability.UNAVAILABLE == "unavailable"
+
+    def test_output_decision_fields(self):
+        decision = OutputDecision(
+            output_device=None,
+            target_id="sat-1",
+            target_type="renfield",
+            availability=DeviceAvailability.AVAILABLE,
+            fallback_to_input=True,
+            reason="test",
+        )
+        assert decision.target_id == "sat-1"
+        assert decision.fallback_to_input is True

--- a/tests/backend/test_piper_service.py
+++ b/tests/backend/test_piper_service.py
@@ -1,0 +1,269 @@
+"""Tests for PiperService.
+
+Tests TTS initialization, voice selection, synthesis methods,
+and availability checks.
+"""
+import sys
+from unittest.mock import MagicMock
+
+# Pre-mock modules not available in test environment
+_missing_stubs = [
+    "asyncpg", "whisper", "piper", "piper.voice", "speechbrain",
+    "speechbrain.inference", "speechbrain.inference.speaker",
+    "openwakeword", "openwakeword.model",
+]
+for _mod in _missing_stubs:
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services.piper_service import PiperService
+
+
+def _make_mock_settings(
+    piper_voice="de_DE-thorsten-high",
+    piper_voice_map=None,
+    default_language="de",
+):
+    s = MagicMock()
+    s.piper_voice = piper_voice
+    s.piper_voice_map = piper_voice_map or {"de": "de_DE-thorsten-high", "en": "en_US-amy-medium"}
+    s.default_language = default_language
+    return s
+
+
+@pytest.fixture
+def mock_settings():
+    return _make_mock_settings()
+
+
+@pytest.fixture
+def service(mock_settings):
+    with patch("services.piper_service.settings", mock_settings), \
+         patch("services.piper_service.subprocess") as mock_subprocess:
+        # Simulate piper being available
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_subprocess.run.return_value = mock_result
+        svc = PiperService()
+    return svc
+
+
+@pytest.fixture
+def service_unavailable(mock_settings):
+    with patch("services.piper_service.settings", mock_settings), \
+         patch("services.piper_service.subprocess") as mock_subprocess:
+        # Simulate piper NOT being available
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_subprocess.run.return_value = mock_result
+        svc = PiperService()
+    return svc
+
+
+# ============================================================================
+# Initialization Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestPiperServiceInit:
+
+    def test_init_with_piper_available(self, service):
+        """Service is available when piper binary exists."""
+        assert service.available is True
+
+    def test_init_with_piper_unavailable(self, service_unavailable):
+        """Service is not available when piper binary missing."""
+        assert service_unavailable.available is False
+
+    def test_init_sets_voice_map(self, service):
+        """Voice map is loaded from settings."""
+        assert service.voice_map == {"de": "de_DE-thorsten-high", "en": "en_US-amy-medium"}
+
+    def test_init_sets_default_voice(self, service):
+        """Default voice is loaded from settings."""
+        assert service.default_voice == "de_DE-thorsten-high"
+
+    def test_init_sets_default_language(self, service):
+        assert service.default_language == "de"
+
+    def test_check_piper_handles_exception(self):
+        """Graceful handling when subprocess.run raises."""
+        mock_s = _make_mock_settings()
+        with patch("services.piper_service.settings", mock_s), \
+             patch("services.piper_service.subprocess") as mock_sub:
+            mock_sub.run.side_effect = FileNotFoundError("which not found")
+            svc = PiperService()
+        assert svc.available is False
+
+
+# ============================================================================
+# Voice Selection Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestVoiceSelection:
+
+    def test_get_voice_for_german(self, service):
+        assert service._get_voice_for_language("de") == "de_DE-thorsten-high"
+
+    def test_get_voice_for_english(self, service):
+        assert service._get_voice_for_language("en") == "en_US-amy-medium"
+
+    def test_get_voice_for_unknown_language_falls_back(self, service):
+        """Unknown language falls back to default voice."""
+        result = service._get_voice_for_language("fr")
+        assert result == "de_DE-thorsten-high"  # Falls back to default_voice
+
+    def test_get_voice_for_none_uses_default_language(self, service):
+        """None language uses default_language setting."""
+        result = service._get_voice_for_language(None)
+        assert result == "de_DE-thorsten-high"  # de is default_language
+
+    def test_get_voice_case_insensitive(self, service):
+        """Language lookup is case-insensitive."""
+        result = service._get_voice_for_language("DE")
+        assert result == "de_DE-thorsten-high"
+
+    def test_get_model_path(self, service):
+        """Model path follows expected convention."""
+        path = service._get_model_path("de_DE-thorsten-high")
+        assert path == "/usr/share/piper/voices/de_DE-thorsten-high.onnx"
+
+
+# ============================================================================
+# Synthesis Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestSynthesis:
+
+    @pytest.mark.asyncio
+    async def test_synthesize_to_file_success(self, service, tmp_path):
+        """Successful synthesis writes file and returns True."""
+        output_path = str(tmp_path / "output.wav")
+
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate.return_value = (b"", b"")
+
+        with patch("services.piper_service.subprocess.Popen", return_value=mock_proc) as mock_popen:
+            result = await service.synthesize_to_file("Hallo Welt", output_path)
+
+        assert result is True
+        mock_popen.assert_called_once()
+        # Verify command includes model and output_file
+        call_args = mock_popen.call_args[0][0]
+        assert "piper" in call_args
+        assert "--model" in call_args
+        assert "--output_file" in call_args
+
+    @pytest.mark.asyncio
+    async def test_synthesize_to_file_failure(self, service, tmp_path):
+        """Failed synthesis returns False."""
+        output_path = str(tmp_path / "output.wav")
+
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.communicate.return_value = (b"", b"Error: model not found")
+
+        with patch("services.piper_service.subprocess.Popen", return_value=mock_proc):
+            result = await service.synthesize_to_file("Hallo", output_path)
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_synthesize_to_file_exception(self, service, tmp_path):
+        """Exception during synthesis returns False."""
+        output_path = str(tmp_path / "output.wav")
+
+        with patch("services.piper_service.subprocess.Popen", side_effect=OSError("spawn failed")):
+            result = await service.synthesize_to_file("Hallo", output_path)
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_synthesize_to_file_when_unavailable(self, service_unavailable, tmp_path):
+        """Returns False immediately when piper is not available."""
+        result = await service_unavailable.synthesize_to_file("Hello", str(tmp_path / "out.wav"))
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_synthesize_to_file_uses_correct_voice_for_language(self, service, tmp_path):
+        """Correct voice model is used based on language parameter."""
+        output_path = str(tmp_path / "output.wav")
+
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate.return_value = (b"", b"")
+
+        with patch("services.piper_service.subprocess.Popen", return_value=mock_proc) as mock_popen:
+            await service.synthesize_to_file("Hello world", output_path, language="en")
+
+        call_args = mock_popen.call_args[0][0]
+        # Should use en_US-amy-medium model
+        assert "/usr/share/piper/voices/en_US-amy-medium.onnx" in call_args
+
+    @pytest.mark.asyncio
+    async def test_synthesize_to_bytes_success(self, service, tmp_path):
+        """synthesize_to_bytes returns audio bytes on success."""
+        fake_wav = b"RIFF\x00\x00\x00\x00WAVEfmt "
+
+        with patch.object(service, "synthesize_to_file", new_callable=AsyncMock) as mock_synth:
+            # Simulate synthesize_to_file writing content
+            async def write_and_return(text, path, language=None):
+                from pathlib import Path
+                Path(path).write_bytes(fake_wav)
+                return True
+            mock_synth.side_effect = write_and_return
+
+            result = await service.synthesize_to_bytes("Hallo")
+
+        assert result == fake_wav
+
+    @pytest.mark.asyncio
+    async def test_synthesize_to_bytes_failure_returns_empty(self, service):
+        """synthesize_to_bytes returns empty bytes on failure."""
+        with patch.object(service, "synthesize_to_file", new_callable=AsyncMock, return_value=False):
+            result = await service.synthesize_to_bytes("Hallo")
+
+        assert result == b""
+
+    @pytest.mark.asyncio
+    async def test_synthesize_to_bytes_when_unavailable(self, service_unavailable):
+        """Returns empty bytes when piper unavailable."""
+        result = await service_unavailable.synthesize_to_bytes("Hello")
+        assert result == b""
+
+    @pytest.mark.asyncio
+    async def test_synthesize_sends_text_via_stdin(self, service, tmp_path):
+        """Text is passed to piper via stdin."""
+        output_path = str(tmp_path / "output.wav")
+
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate.return_value = (b"", b"")
+
+        with patch("services.piper_service.subprocess.Popen", return_value=mock_proc):
+            await service.synthesize_to_file("Hallo Welt", output_path)
+
+        mock_proc.communicate.assert_called_once_with(input=b"Hallo Welt")
+
+
+# ============================================================================
+# ensure_model_downloaded Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestEnsureModelDownloaded:
+
+    def test_noop_when_available(self, service):
+        """Does nothing when piper is available (piper auto-downloads)."""
+        service.ensure_model_downloaded()  # Should not raise
+
+    def test_noop_when_unavailable(self, service_unavailable):
+        """Does nothing when piper is unavailable."""
+        service_unavailable.ensure_model_downloaded()  # Should not raise

--- a/tests/backend/test_preferences_api.py
+++ b/tests/backend/test_preferences_api.py
@@ -1,0 +1,261 @@
+"""
+Tests for User Preferences API Routes
+
+Tests cover:
+- GET /api/preferences (all preferences)
+- GET /api/preferences/language
+- PUT /api/preferences/language
+- Auth-dependent behavior (authenticated vs anonymous)
+- Language validation
+"""
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+_missing_stubs = [
+    "asyncpg", "whisper", "piper", "piper.voice",
+    "speechbrain", "speechbrain.inference", "speechbrain.inference.speaker",
+    "openwakeword", "openwakeword.model",
+    "redis", "redis.asyncio",
+    "slowapi", "slowapi.errors", "slowapi.middleware", "slowapi.util",
+    "jose", "passlib", "passlib.context",
+]
+for _mod in _missing_stubs:
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from api.routes.preferences import router as preferences_router
+from services.auth_service import get_current_user, get_optional_user
+from services.database import get_db
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+def _make_mock_user(preferred_language: str = "de", username: str = "testuser"):
+    """Create a mock User with required attributes."""
+    user = MagicMock()
+    user.preferred_language = preferred_language
+    user.username = username
+    return user
+
+
+def _create_test_app(
+    user=None,
+    optional_user=None,
+    db_session=None,
+):
+    """Create a minimal FastAPI app with the preferences router and overrides."""
+    app = FastAPI()
+    app.include_router(preferences_router, prefix="/api/preferences")
+
+    if db_session is None:
+        db_session = AsyncMock()
+
+    async def _override_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_db
+
+    if optional_user is not None:
+        app.dependency_overrides[get_optional_user] = lambda: optional_user
+
+    if user is not None:
+        app.dependency_overrides[get_current_user] = lambda: user
+
+    return app
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+@pytest.fixture
+def mock_db_session():
+    """Mock async database session."""
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+    return session
+
+
+# =============================================================================
+# GET /api/preferences/language
+# =============================================================================
+
+class TestGetLanguagePreference:
+    """Tests for the GET /language endpoint."""
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_authenticated_user_returns_stored_language(self, mock_db_session):
+        """Authenticated user should get their stored preference."""
+        user = _make_mock_user(preferred_language="en")
+        app = _create_test_app(optional_user=user, db_session=mock_db_session)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/api/preferences/language")
+        assert resp.status_code == 200
+        assert resp.json()["language"] == "en"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_anonymous_user_returns_default_language(self, mock_db_session):
+        """Anonymous user should get the default language from settings."""
+        app = _create_test_app(optional_user=None, db_session=mock_db_session)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/api/preferences/language")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "language" in data
+        assert len(data["language"]) >= 2
+
+
+# =============================================================================
+# PUT /api/preferences/language
+# =============================================================================
+
+class TestSetLanguagePreference:
+    """Tests for the PUT /language endpoint."""
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_set_valid_language(self, mock_db_session):
+        """Should update language for authenticated user."""
+        user = _make_mock_user(preferred_language="de")
+
+        async def fake_refresh(obj):
+            obj.preferred_language = "en"
+
+        mock_db_session.refresh = fake_refresh
+
+        app = _create_test_app(user=user, optional_user=user, db_session=mock_db_session)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            with patch("api.routes.preferences.settings") as mock_settings:
+                mock_settings.supported_languages_list = ["de", "en"]
+                resp = await client.put(
+                    "/api/preferences/language",
+                    json={"language": "en"},
+                )
+        assert resp.status_code == 200
+        assert resp.json()["language"] == "en"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_set_unsupported_language_returns_400(self, mock_db_session):
+        """Should reject unsupported language codes."""
+        user = _make_mock_user()
+        app = _create_test_app(user=user, optional_user=user, db_session=mock_db_session)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            with patch("api.routes.preferences.settings") as mock_settings:
+                mock_settings.supported_languages_list = ["de", "en"]
+                resp = await client.put(
+                    "/api/preferences/language",
+                    json={"language": "xx"},
+                )
+        assert resp.status_code == 400
+        assert "Unsupported language" in resp.json()["detail"]
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_unauthenticated_user_returns_401(self, mock_db_session):
+        """Should return 401 for unauthenticated users (get_current_user returns None)."""
+        app = _create_test_app(user=None, db_session=mock_db_session)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.put(
+                "/api/preferences/language",
+                json={"language": "en"},
+            )
+        assert resp.status_code == 401
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_language_too_short_validation(self, mock_db_session):
+        """Language code shorter than 2 chars should fail validation."""
+        user = _make_mock_user()
+        app = _create_test_app(user=user, optional_user=user, db_session=mock_db_session)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.put(
+                "/api/preferences/language",
+                json={"language": "x"},
+            )
+        assert resp.status_code == 422  # Pydantic validation
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_language_too_long_validation(self, mock_db_session):
+        """Language code longer than 10 chars should fail validation."""
+        user = _make_mock_user()
+        app = _create_test_app(user=user, optional_user=user, db_session=mock_db_session)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.put(
+                "/api/preferences/language",
+                json={"language": "x" * 11},
+            )
+        assert resp.status_code == 422  # Pydantic validation
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_missing_language_field_returns_422(self, mock_db_session):
+        """Missing language field should fail validation."""
+        user = _make_mock_user()
+        app = _create_test_app(user=user, optional_user=user, db_session=mock_db_session)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.put(
+                "/api/preferences/language",
+                json={},
+            )
+        assert resp.status_code == 422
+
+
+# =============================================================================
+# GET /api/preferences
+# =============================================================================
+
+class TestGetAllPreferences:
+    """Tests for the GET /api/preferences endpoint."""
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_authenticated_returns_user_prefs(self, mock_db_session):
+        """Should return user's preferences plus supported languages."""
+        user = _make_mock_user(preferred_language="en")
+        app = _create_test_app(optional_user=user, db_session=mock_db_session)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            with patch("api.routes.preferences.settings") as mock_settings:
+                mock_settings.default_language = "de"
+                mock_settings.supported_languages_list = ["de", "en"]
+                resp = await client.get("/api/preferences")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["language"] == "en"
+        assert "supported_languages" in data
+        assert isinstance(data["supported_languages"], list)
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_anonymous_returns_default_prefs(self, mock_db_session):
+        """Anonymous user should get defaults."""
+        app = _create_test_app(optional_user=None, db_session=mock_db_session)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            with patch("api.routes.preferences.settings") as mock_settings:
+                mock_settings.default_language = "de"
+                mock_settings.supported_languages_list = ["de", "en"]
+                resp = await client.get("/api/preferences")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["language"] == "de"

--- a/tests/backend/test_task_queue.py
+++ b/tests/backend/test_task_queue.py
@@ -1,0 +1,272 @@
+"""Tests for async TaskQueue service.
+
+Tests enqueue, dequeue, status tracking, queue length, and error handling
+against the async Redis-backed implementation.
+"""
+import json
+import sys
+from unittest.mock import MagicMock
+
+# Pre-mock modules not available in test environment
+_missing_stubs = [
+    "asyncpg", "whisper", "piper", "piper.voice", "speechbrain",
+    "speechbrain.inference", "speechbrain.inference.speaker",
+    "openwakeword", "openwakeword.model",
+    "redis", "redis.asyncio",
+]
+for _mod in _missing_stubs:
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services.task_queue import TaskQueue
+
+
+@pytest.fixture
+def mock_redis():
+    """Create a mock async Redis client."""
+    client = AsyncMock()
+    client.incr = AsyncMock(return_value=1)
+    client.lpush = AsyncMock()
+    client.rpop = AsyncMock(return_value=None)
+    client.get = AsyncMock(return_value=None)
+    client.set = AsyncMock()
+    client.llen = AsyncMock(return_value=0)
+    client.close = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def queue(mock_redis):
+    with patch("services.task_queue.aioredis") as mock_aioredis:
+        mock_aioredis.from_url.return_value = mock_redis
+        with patch("services.task_queue.settings") as mock_s:
+            mock_s.redis_url = "redis://localhost:6379"
+            q = TaskQueue()
+    return q
+
+
+# ============================================================================
+# Initialization Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestTaskQueueInit:
+
+    def test_queue_name(self, queue):
+        assert queue.queue_name == "renfield:tasks"
+
+    def test_redis_client_created(self, queue):
+        assert queue.redis_client is not None
+
+
+# ============================================================================
+# Enqueue Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestEnqueue:
+
+    @pytest.mark.asyncio
+    async def test_enqueue_returns_task_id(self, queue, mock_redis):
+        """Enqueue returns a unique task ID."""
+        task_id = await queue.enqueue("process_document", {"file": "test.pdf"})
+
+        assert task_id == "task:process_document:1"
+        mock_redis.incr.assert_called_once_with("task:counter")
+
+    @pytest.mark.asyncio
+    async def test_enqueue_pushes_to_list(self, queue, mock_redis):
+        """Task is pushed to the Redis list."""
+        await queue.enqueue("process_document", {"file": "test.pdf"})
+
+        mock_redis.lpush.assert_called_once()
+        call_args = mock_redis.lpush.call_args[0]
+        assert call_args[0] == "renfield:tasks"
+        task_data = json.loads(call_args[1])
+        assert task_data["type"] == "process_document"
+        assert task_data["status"] == "queued"
+        assert task_data["parameters"] == {"file": "test.pdf"}
+
+    @pytest.mark.asyncio
+    async def test_enqueue_stores_task_by_id(self, queue, mock_redis):
+        """Task is also stored by its ID for status lookups."""
+        await queue.enqueue("embed", {"doc_id": 42})
+
+        # set should be called with the task ID as key
+        mock_redis.set.assert_called_once()
+        call_args = mock_redis.set.call_args[0]
+        assert call_args[0] == "task:embed:1"
+        task_data = json.loads(call_args[1])
+        assert task_data["id"] == "task:embed:1"
+
+    @pytest.mark.asyncio
+    async def test_enqueue_increments_counter(self, queue, mock_redis):
+        """Each enqueue increments the counter."""
+        mock_redis.incr = AsyncMock(side_effect=[1, 2, 3])
+
+        id1 = await queue.enqueue("a", {})
+        id2 = await queue.enqueue("b", {})
+        id3 = await queue.enqueue("c", {})
+
+        assert id1 == "task:a:1"
+        assert id2 == "task:b:2"
+        assert id3 == "task:c:3"
+
+    @pytest.mark.asyncio
+    async def test_enqueue_raises_on_redis_error(self, queue, mock_redis):
+        """Redis errors propagate from enqueue."""
+        mock_redis.incr = AsyncMock(side_effect=Exception("Connection refused"))
+
+        with pytest.raises(Exception, match="Connection refused"):
+            await queue.enqueue("task", {})
+
+
+# ============================================================================
+# Dequeue Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestDequeue:
+
+    @pytest.mark.asyncio
+    async def test_dequeue_returns_task(self, queue, mock_redis):
+        """Dequeue returns a task dict when queue is non-empty."""
+        task_data = {"id": "task:test:1", "type": "test", "parameters": {}, "status": "queued"}
+        mock_redis.rpop = AsyncMock(return_value=json.dumps(task_data))
+
+        result = await queue.dequeue()
+
+        assert result == task_data
+        mock_redis.rpop.assert_called_once_with("renfield:tasks")
+
+    @pytest.mark.asyncio
+    async def test_dequeue_returns_none_when_empty(self, queue, mock_redis):
+        """Dequeue returns None when queue is empty."""
+        mock_redis.rpop = AsyncMock(return_value=None)
+
+        result = await queue.dequeue()
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_dequeue_returns_none_on_error(self, queue, mock_redis):
+        """Redis errors return None instead of raising."""
+        mock_redis.rpop = AsyncMock(side_effect=Exception("timeout"))
+
+        result = await queue.dequeue()
+
+        assert result is None
+
+
+# ============================================================================
+# Task Status Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestTaskStatus:
+
+    @pytest.mark.asyncio
+    async def test_get_task_status_returns_data(self, queue, mock_redis):
+        """Get status returns task data when task exists."""
+        task_data = {"id": "task:test:1", "type": "test", "status": "queued"}
+        mock_redis.get = AsyncMock(return_value=json.dumps(task_data))
+
+        result = await queue.get_task_status("task:test:1")
+
+        assert result == task_data
+
+    @pytest.mark.asyncio
+    async def test_get_task_status_returns_none_for_unknown(self, queue, mock_redis):
+        """Returns None for unknown task IDs."""
+        mock_redis.get = AsyncMock(return_value=None)
+
+        result = await queue.get_task_status("task:nonexistent:99")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_task_status_returns_none_on_error(self, queue, mock_redis):
+        """Redis errors return None."""
+        mock_redis.get = AsyncMock(side_effect=Exception("connection lost"))
+
+        result = await queue.get_task_status("task:test:1")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_update_task_status(self, queue, mock_redis):
+        """Task status is updated in Redis."""
+        existing = {"id": "task:test:1", "type": "test", "status": "queued"}
+        mock_redis.get = AsyncMock(return_value=json.dumps(existing))
+
+        await queue.update_task_status("task:test:1", "processing")
+
+        mock_redis.set.assert_called_once()
+        updated = json.loads(mock_redis.set.call_args[0][1])
+        assert updated["status"] == "processing"
+
+    @pytest.mark.asyncio
+    async def test_update_task_status_with_result(self, queue, mock_redis):
+        """Task status update includes result data."""
+        existing = {"id": "task:test:1", "type": "test", "status": "processing"}
+        mock_redis.get = AsyncMock(return_value=json.dumps(existing))
+
+        await queue.update_task_status(
+            "task:test:1", "completed", result={"chunks": 5}
+        )
+
+        updated = json.loads(mock_redis.set.call_args[0][1])
+        assert updated["status"] == "completed"
+        assert updated["result"] == {"chunks": 5}
+
+    @pytest.mark.asyncio
+    async def test_update_nonexistent_task_is_noop(self, queue, mock_redis):
+        """Updating a non-existent task does nothing."""
+        mock_redis.get = AsyncMock(return_value=None)
+
+        await queue.update_task_status("task:missing:99", "completed")
+
+        mock_redis.set.assert_not_called()
+
+
+# ============================================================================
+# Queue Length Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestQueueLength:
+
+    @pytest.mark.asyncio
+    async def test_queue_length_empty(self, queue, mock_redis):
+        mock_redis.llen = AsyncMock(return_value=0)
+
+        length = await queue.queue_length()
+
+        assert length == 0
+        mock_redis.llen.assert_called_once_with("renfield:tasks")
+
+    @pytest.mark.asyncio
+    async def test_queue_length_with_items(self, queue, mock_redis):
+        mock_redis.llen = AsyncMock(return_value=5)
+
+        length = await queue.queue_length()
+
+        assert length == 5
+
+
+# ============================================================================
+# Close Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestClose:
+
+    @pytest.mark.asyncio
+    async def test_close_closes_redis(self, queue, mock_redis):
+        await queue.close()
+
+        mock_redis.close.assert_called_once()

--- a/tests/backend/test_whisper_service_unit.py
+++ b/tests/backend/test_whisper_service_unit.py
@@ -1,0 +1,393 @@
+"""Tests for WhisperService.
+
+Tests model loading, transcription, language detection, audio format handling,
+preprocessing, and transcribe_bytes.
+"""
+import sys
+from unittest.mock import MagicMock
+
+# Pre-mock modules not available in test environment
+_missing_stubs = [
+    "asyncpg", "whisper", "piper", "piper.voice", "speechbrain",
+    "speechbrain.inference", "speechbrain.inference.speaker",
+    "openwakeword", "openwakeword.model",
+    "librosa", "soundfile",
+]
+for _mod in _missing_stubs:
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services.whisper_service import WhisperService
+
+
+def _make_mock_settings(
+    whisper_model="base",
+    default_language="de",
+    whisper_initial_prompt=None,
+    whisper_preprocess_enabled=False,
+    whisper_preprocess_noise_reduce=True,
+    whisper_preprocess_normalize=True,
+    whisper_preprocess_target_db=-20.0,
+    speaker_recognition_enabled=False,
+):
+    s = MagicMock()
+    s.whisper_model = whisper_model
+    s.default_language = default_language
+    s.whisper_initial_prompt = whisper_initial_prompt
+    s.whisper_preprocess_enabled = whisper_preprocess_enabled
+    s.whisper_preprocess_noise_reduce = whisper_preprocess_noise_reduce
+    s.whisper_preprocess_normalize = whisper_preprocess_normalize
+    s.whisper_preprocess_target_db = whisper_preprocess_target_db
+    s.speaker_recognition_enabled = speaker_recognition_enabled
+    return s
+
+
+@pytest.fixture
+def mock_settings():
+    return _make_mock_settings()
+
+
+@pytest.fixture
+def service(mock_settings):
+    with patch("services.whisper_service.settings", mock_settings), \
+         patch("services.whisper_service.AudioPreprocessor"):
+        svc = WhisperService()
+    return svc
+
+
+# ============================================================================
+# Initialization Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestWhisperServiceInit:
+
+    def test_init_sets_model_size(self, service):
+        assert service.model_size == "base"
+
+    def test_init_model_not_loaded_yet(self, service):
+        assert service.model is None
+
+    def test_init_sets_language(self, service):
+        assert service.language == "de"
+
+    def test_init_with_initial_prompt(self):
+        mock_s = _make_mock_settings(whisper_initial_prompt="Renfield Transkription")
+        with patch("services.whisper_service.settings", mock_s), \
+             patch("services.whisper_service.AudioPreprocessor"):
+            svc = WhisperService()
+        assert svc.initial_prompt == "Renfield Transkription"
+
+    def test_init_without_initial_prompt(self, service):
+        assert service.initial_prompt is None
+
+    def test_init_preprocessing_disabled_by_default(self, service):
+        assert service.preprocess_enabled is False
+
+
+# ============================================================================
+# Model Loading Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestModelLoading:
+
+    def test_load_model_calls_whisper(self, service):
+        mock_model = MagicMock()
+        with patch("services.whisper_service.whisper") as mock_whisper:
+            mock_whisper.load_model.return_value = mock_model
+            service.load_model()
+
+        assert service.model is mock_model
+        mock_whisper.load_model.assert_called_once_with("base")
+
+    def test_load_model_only_once(self, service):
+        mock_model = MagicMock()
+        with patch("services.whisper_service.whisper") as mock_whisper:
+            mock_whisper.load_model.return_value = mock_model
+            service.load_model()
+            service.load_model()  # Second call should be noop
+
+        mock_whisper.load_model.assert_called_once()
+
+    def test_load_model_raises_on_error(self, service):
+        with patch("services.whisper_service.whisper") as mock_whisper:
+            mock_whisper.load_model.side_effect = RuntimeError("CUDA OOM")
+            with pytest.raises(RuntimeError, match="CUDA OOM"):
+                service.load_model()
+
+
+# ============================================================================
+# Transcription Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestTranscription:
+
+    @pytest.mark.asyncio
+    async def test_transcribe_file_success(self, service):
+        """Successful transcription returns text."""
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = {"text": "  Hallo Welt  "}
+        service.model = mock_model
+
+        result = await service.transcribe_file("/tmp/test.wav")
+
+        assert result == "Hallo Welt"
+        mock_model.transcribe.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_transcribe_file_auto_loads_model(self, service):
+        """Model is loaded on first transcription if not yet loaded."""
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = {"text": "Test"}
+
+        with patch("services.whisper_service.whisper") as mock_whisper:
+            mock_whisper.load_model.return_value = mock_model
+            result = await service.transcribe_file("/tmp/test.wav")
+
+        assert result == "Test"
+        mock_whisper.load_model.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_transcribe_file_uses_default_language(self, service):
+        """Uses default language when none specified."""
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = {"text": "Hallo"}
+        service.model = mock_model
+
+        await service.transcribe_file("/tmp/test.wav")
+
+        call_kwargs = mock_model.transcribe.call_args
+        assert call_kwargs[1]["language"] == "de"
+
+    @pytest.mark.asyncio
+    async def test_transcribe_file_uses_explicit_language(self, service):
+        """Uses explicitly provided language."""
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = {"text": "Hello"}
+        service.model = mock_model
+
+        await service.transcribe_file("/tmp/test.wav", language="en")
+
+        call_kwargs = mock_model.transcribe.call_args
+        assert call_kwargs[1]["language"] == "en"
+
+    @pytest.mark.asyncio
+    async def test_transcribe_file_includes_initial_prompt(self):
+        """Initial prompt is passed to whisper when configured."""
+        mock_s = _make_mock_settings(whisper_initial_prompt="Smart Home commands")
+        with patch("services.whisper_service.settings", mock_s), \
+             patch("services.whisper_service.AudioPreprocessor"):
+            svc = WhisperService()
+
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = {"text": "Turn on lights"}
+        svc.model = mock_model
+
+        await svc.transcribe_file("/tmp/test.wav")
+
+        call_kwargs = mock_model.transcribe.call_args
+        assert call_kwargs[1]["initial_prompt"] == "Smart Home commands"
+
+    @pytest.mark.asyncio
+    async def test_transcribe_file_error_returns_empty(self, service):
+        """Transcription error returns empty string."""
+        mock_model = MagicMock()
+        mock_model.transcribe.side_effect = RuntimeError("decode error")
+        service.model = mock_model
+
+        result = await service.transcribe_file("/tmp/test.wav")
+
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_transcribe_file_sets_fp16_false(self, service):
+        """fp16 is set to False for CPU compatibility."""
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = {"text": "Test"}
+        service.model = mock_model
+
+        await service.transcribe_file("/tmp/test.wav")
+
+        call_kwargs = mock_model.transcribe.call_args
+        assert call_kwargs[1]["fp16"] is False
+
+    @pytest.mark.asyncio
+    async def test_transcribe_file_sets_beam_params(self, service):
+        """Beam search parameters are set for accuracy."""
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = {"text": "Test"}
+        service.model = mock_model
+
+        await service.transcribe_file("/tmp/test.wav")
+
+        call_kwargs = mock_model.transcribe.call_args
+        assert call_kwargs[1]["beam_size"] == 5
+        assert call_kwargs[1]["best_of"] == 5
+
+
+# ============================================================================
+# Transcribe Bytes Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestTranscribeBytes:
+
+    @pytest.mark.asyncio
+    async def test_transcribe_bytes_writes_temp_file(self, service):
+        """Bytes are written to a temp file and transcribed."""
+        service.transcribe_file = AsyncMock(return_value="Transcribed text")
+
+        result = await service.transcribe_bytes(b"fake-audio-data", filename="recording.wav")
+
+        assert result == "Transcribed text"
+        # transcribe_file was called with a temp path
+        call_args = service.transcribe_file.call_args[0]
+        assert call_args[0].endswith(".wav")
+
+    @pytest.mark.asyncio
+    async def test_transcribe_bytes_preserves_extension(self, service):
+        """File extension from filename is preserved."""
+        service.transcribe_file = AsyncMock(return_value="Text")
+
+        await service.transcribe_bytes(b"data", filename="audio.mp3")
+
+        call_args = service.transcribe_file.call_args[0]
+        assert call_args[0].endswith(".mp3")
+
+    @pytest.mark.asyncio
+    async def test_transcribe_bytes_passes_language(self, service):
+        """Language is forwarded to transcribe_file."""
+        service.transcribe_file = AsyncMock(return_value="Text")
+
+        await service.transcribe_bytes(b"data", language="en")
+
+        call_kwargs = service.transcribe_file.call_args[1]
+        assert call_kwargs["language"] == "en"
+
+    @pytest.mark.asyncio
+    async def test_transcribe_bytes_cleans_up_temp_file(self, service, tmp_path):
+        """Temp file is cleaned up even on error."""
+        service.transcribe_file = AsyncMock(side_effect=Exception("fail"))
+
+        # Should not raise (temp file cleanup happens in finally)
+        with pytest.raises(Exception):  # noqa: B017
+            await service.transcribe_bytes(b"data")
+
+
+# ============================================================================
+# Preprocessing Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestPreprocessing:
+
+    @pytest.mark.asyncio
+    async def test_preprocessing_skipped_when_disabled(self, service):
+        """Preprocessing is not called when disabled."""
+        service.preprocess_enabled = False
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = {"text": "Test"}
+        service.model = mock_model
+
+        await service.transcribe_file("/tmp/test.wav")
+
+        # Original path is used directly
+        mock_model.transcribe.assert_called_once()
+        assert mock_model.transcribe.call_args[0][0] == "/tmp/test.wav"
+
+    @pytest.mark.asyncio
+    async def test_preprocessing_used_when_enabled(self, service):
+        """Preprocessed file is used when preprocessing is enabled."""
+        service.preprocess_enabled = True
+        service._preprocess_audio = MagicMock(return_value="/tmp/preprocessed.wav")
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = {"text": "Test"}
+        service.model = mock_model
+
+        await service.transcribe_file("/tmp/test.wav")
+
+        # Preprocessed path is used
+        mock_model.transcribe.assert_called_once()
+        assert mock_model.transcribe.call_args[0][0] == "/tmp/preprocessed.wav"
+
+    @pytest.mark.asyncio
+    async def test_preprocessing_failure_uses_original(self, service):
+        """Falls back to original when preprocessing fails."""
+        service.preprocess_enabled = True
+        service._preprocess_audio = MagicMock(return_value=None)
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = {"text": "Test"}
+        service.model = mock_model
+
+        await service.transcribe_file("/tmp/test.wav")
+
+        assert mock_model.transcribe.call_args[0][0] == "/tmp/test.wav"
+
+
+# ============================================================================
+# Transcribe with Speaker Tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestTranscribeWithSpeaker:
+
+    @pytest.mark.asyncio
+    async def test_returns_text_and_speaker_info(self, service):
+        """Returns dict with text and speaker fields."""
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = {"text": "Hello"}
+        service.model = mock_model
+
+        result = await service.transcribe_with_speaker("/tmp/test.wav")
+
+        assert result["text"] == "Hello"
+        assert result["speaker_id"] is None
+        assert result["speaker_name"] is None
+        assert result["speaker_confidence"] == 0.0
+        assert result["is_new_speaker"] is False
+
+    @pytest.mark.asyncio
+    async def test_transcription_error_returns_empty(self, service):
+        """Transcription failure returns empty text with speaker defaults."""
+        mock_model = MagicMock()
+        mock_model.transcribe.side_effect = RuntimeError("fail")
+        service.model = mock_model
+
+        result = await service.transcribe_with_speaker("/tmp/test.wav")
+
+        assert result["text"] == ""
+        assert result["speaker_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_skips_speaker_when_disabled(self, service):
+        """Speaker recognition skipped when disabled in settings."""
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = {"text": "Test"}
+        service.model = mock_model
+
+        # speaker_recognition_enabled defaults to False in our mock
+        result = await service.transcribe_with_speaker("/tmp/test.wav", db_session=MagicMock())
+
+        assert result["speaker_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_skips_speaker_when_no_db_session(self, service):
+        """Speaker recognition skipped when no db_session provided."""
+        mock_s = _make_mock_settings(speaker_recognition_enabled=True)
+        with patch("services.whisper_service.settings", mock_s), \
+             patch("services.whisper_service.AudioPreprocessor"):
+            svc = WhisperService()
+
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = {"text": "Test"}
+        svc.model = mock_model
+
+        result = await svc.transcribe_with_speaker("/tmp/test.wav", db_session=None)
+
+        assert result["speaker_id"] is None


### PR DESCRIPTION
## Summary

- **Security**: Escape ILIKE wildcards in user search, add auth/ownership checks to all knowledge endpoints, remove `unsafe-eval` from CSP, fix CORS credentials with wildcard origins
- **Performance**: Batch N+1 context window queries into single SQL, convert TaskQueue to async Redis, parallel document embeddings via `asyncio.gather` + `Semaphore(5)`, wrap `whisper.load_model` in `asyncio.to_thread`
- **Tests**: 190 new tests across 9 new test files covering output_routing_service, audio_output_service, piper_service, whisper_service, document_processor, task_queue, api_rate_limiter, preferences API, intents API

## Test plan

- [x] All 190 new tests pass locally
- [x] All existing tests pass (pre-existing Docker-only failures excluded)
- [x] Ruff lint clean on all modified and new files
- [ ] Deploy to renfield.local, verify chat works
- [ ] Verify user search with `%` and `_` chars doesn't leak data
- [ ] Verify knowledge endpoints enforce auth when AUTH_ENABLED=true

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)