### PR TITLE
feat(satellite): ReSpeaker 4-Mic Array support and VAD improvements

### DIFF
--- a/docs/AUDIO_CAPTURE_4MIC.md
+++ b/docs/AUDIO_CAPTURE_4MIC.md
@@ -1,0 +1,195 @@
+# ReSpeaker 4-Mic Array: Native Audio Capture Plan
+
+## Status: Phase 1 Active, Phase 2 Planned
+
+## Background
+
+The ReSpeaker 4-Mic Array uses the AC108 quad-channel ADC codec. Hardware constraints:
+
+| Property | Value |
+|----------|-------|
+| **Format** | S32_LE only (no S16_LE at hardware level) |
+| **Channels** | 4 (one per microphone) |
+| **ADC resolution** | ~24-bit in 32-bit container |
+| **Sample rates** | 8-48 kHz |
+| **Driver** | HinTak/seeed-voicecard (DKMS) |
+| **ALSA card** | `seeed4micvoicec` |
+
+### Critical: AC108 Kernel Crash Triggers
+
+1. **dsnoop/dmix on capture device** — AC108 is capture-only. Using dmix/dsnoop in `.asoundrc` crashes the kernel driver immediately.
+2. **Opening raw hw device with wrong format** — Opening `hw:seeed4micvoicec` with S16_LE/1ch triggers `ac108_set_clock` crash (I2S SYNC error). The device only accepts S32_LE/4ch.
+
+---
+
+## Phase 1: ALSA plughw Downconversion (Current)
+
+Uses ALSA `plughw:` plugin layer to handle format/channel conversion in C:
+
+```
+AC108 hw device (S32_LE/4ch)
+  → plughw: (format conversion S32→S16, channel mix 4→1)
+    → Application gets S16_LE/1ch
+```
+
+### Configuration
+
+**`.asoundrc`** (no dsnoop/dmix!):
+```
+pcm.capture {
+    type plug
+    slave.pcm "plughw:seeed4micvoicec"
+}
+```
+
+**`satellite.yaml`**:
+```yaml
+audio:
+  device: "capture"        # Matches ALSA plugin name, NOT raw hw device
+  channels: 1
+  beamforming:
+    enabled: false
+```
+
+**PyAudio device matching**: The satellite's `capture.py` searches PyAudio device names by substring. ALSA plugin devices like `"capture"` appear as `"capture: - (default)"` in PyAudio. The raw hw device appears as `"seeed-4mic-voicecard: ..."`. Using `"capture"` ensures PyAudio routes through `plughw:` which handles format conversion safely.
+
+### Pros
+- Simple, works with existing code unchanged
+- Format conversion in optimized C (ALSA)
+- Minimal CPU overhead
+
+### Cons
+- Loses 4-channel information (averages all mics without spatial processing)
+- No beamforming possible (needs multi-channel data)
+- 16-bit truncation (marginal loss for speech)
+
+---
+
+## Phase 2: Native S32_LE/4ch Capture (Planned)
+
+Captures at AC108's native format, converts in Python, enables 4-channel beamforming.
+
+```
+AC108 hw device (S32_LE/4ch)
+  → PyAudio paInt32/4ch (raw capture)
+    → NumPy: deinterleave to (1280, 4)
+      → S32→S16 conversion (right-shift 16 bits)
+        → 4-channel DAS beamforming → mono S16_LE
+          → Downstream pipeline (wake word, VAD, WebSocket)
+```
+
+### Changes Required
+
+#### 1. `config.py` — Add format_bits support
+```python
+@dataclass
+class AudioConfig:
+    format_bits: int = 16        # 16 or 32
+    channels: int = 1            # 1 (mono) or 4 (native 4-mic)
+    native_channels: int = 4     # Hardware channel count for conversion
+```
+
+#### 2. `capture.py` — Native format capture + conversion
+```python
+# In _start_pyaudio():
+if self.format_bits == 32:
+    pa_format = pyaudio.paInt32
+else:
+    pa_format = pyaudio.paInt16
+
+self._stream = self._pyaudio.open(
+    format=pa_format,
+    channels=self.native_channels,  # 4 for AC108
+    rate=self.sample_rate,
+    input=True,
+    ...
+)
+
+# In _pyaudio_capture_loop():
+if self.format_bits == 32 and self.native_channels > 1:
+    # S32_LE interleaved 4ch → deinterleave
+    raw = np.frombuffer(audio_bytes, dtype=np.int32)
+    multichannel = raw.reshape(-1, self.native_channels)  # (1280, 4)
+
+    # Apply 4-channel beamforming
+    if self._beamformer:
+        mono_int32 = self._beamformer.process_multichannel(multichannel)
+    else:
+        # Simple average if no beamformer
+        mono_int32 = multichannel.mean(axis=1).astype(np.int32)
+
+    # S32 → S16 (right-shift 16 bits, upper bits contain signal)
+    mono_int16 = (mono_int32 >> 16).astype(np.int16)
+    audio_bytes = mono_int16.tobytes()
+```
+
+#### 3. `beamformer.py` — 4-mic circular array DAS
+
+The ReSpeaker 4-Mic Array has microphones in a roughly square layout. Mic positions (approximate, need calibration on actual board):
+
+```
+      Mic 0 (top)
+       ●
+      / \
+Mic 3 ●   ● Mic 1
+      \ /
+       ●
+      Mic 2 (bottom)
+```
+
+New class: `BeamformerDAS4Mic`
+- Takes 4-channel input `(samples, 4)`
+- Computes per-channel delays based on steering angle and mic geometry
+- Aligns all 4 channels and sums (constructive interference)
+- Returns mono output
+
+#### 4. Ansible host_vars — Update for native capture
+```yaml
+# satellite-fitnessraum.yml
+audio_device: "seeed-4mic"      # Raw hw device name in PyAudio
+audio_channels: 4               # Native 4 channels
+audio_format_bits: 32           # S32_LE
+beamforming_enabled: true       # Enable 4-channel beamforming
+```
+
+### Performance Budget (Pi Zero 2 W)
+
+| Component | CPU per 80ms chunk | Notes |
+|-----------|-------------------|-------|
+| `np.frombuffer` + reshape | ~0.05ms | Creates views, no copy |
+| 4-channel DAS beamforming | ~1-3ms | Estimated from 2ch (~0.5-1ms) |
+| `>> 16` + `astype(int16)` | ~0.1ms | Vectorized shift |
+| **Total** | **~1.5-3.5ms** | **~2-4% CPU on one core** |
+
+### Data Rate Impact
+
+| Stage | Bytes/chunk | Bytes/sec |
+|-------|-------------|-----------|
+| Raw capture (S32_LE/4ch) | 20,480 | 256 KB/s |
+| After conversion (S16_LE/1ch) | 2,560 | 32 KB/s |
+| WebSocket (base64) | 3,414 | 43 KB/s |
+
+Convert as early as possible to minimize memory pressure on the 512MB Pi Zero 2 W.
+
+### Memory Impact
+
+With `MAX_AUDIO_BUFFER_CHUNKS = 500`:
+- Raw buffer: 500 x 20,480 = **10 MB** (before conversion)
+- After conversion: 500 x 2,560 = **1.3 MB**
+
+Strategy: Convert in capture loop before buffering, so downstream only sees S16_LE/1ch.
+
+---
+
+## Downstream Consumer Requirements
+
+All downstream consumers expect **S16_LE mono at 16kHz**. No changes needed downstream if conversion happens in `capture.py`:
+
+| Consumer | Expected Input | File |
+|----------|---------------|------|
+| OpenWakeWord | `np.int16` mono | `wakeword/detector.py` |
+| Silero VAD | `np.int16` mono → float | `audio/vad.py` |
+| WebRTC VAD | Raw PCM bytes, 16-bit mono | `audio/vad.py` |
+| AudioPreprocessor | `np.int16` mono | `audio/preprocessor.py` |
+| WebSocket streaming | Raw PCM bytes (base64) | `network/websocket_client.py` |
+| Server-side Whisper STT | Mono audio | Backend |

--- a/docs/TECHNICAL_DEBT.md
+++ b/docs/TECHNICAL_DEBT.md
@@ -321,6 +321,14 @@ Nur eine zentrale ErrorBoundary, keine Feature-spezifischen.
 
 ## Satellite
 
+### ✅ Behoben
+
+#### ~~Native S32_LE/4ch Audio Capture für 4-Mic Array~~ ✅ (RESOLVED 2026-02-09)
+
+`arecord` subprocess captures 4ch/S32_LE natively. Python converts to mono S16_LE (channel 1, right-shift 16). PyAudio cannot be used due to kernel crash with onnxruntime. RMS VAD replaces Silero for reliable end-of-speech detection under CPU load. See `src/satellite/TECHNICAL_DEBT.md` for details.
+
+---
+
 ### ~~🟡 Mittel~~ → ✅ Behoben/Dokumentiert
 
 #### ~~1. Bare Except Clauses (22)~~ ✅ Behoben

--- a/src/satellite/config/satellite.yaml
+++ b/src/satellite/config/satellite.yaml
@@ -43,13 +43,16 @@ wakeword:
   #   - "nevermind"
 
 # Voice Activity Detection (for end-of-speech)
+# Note: On Pi Zero 2 W with 4-mic HAT, use "rms" backend — Silero VAD's ONNX
+# inference competes with openwakeword for CPU and produces unreliable results.
+# RMS is essentially free and directly measures audio volume.
 vad:
   backend: "silero"           # "rms" (simple), "webrtc" (fast), or "silero" (ML-based, best)
-  silence_duration_ms: 1200   # How long silence to end recording
+  silence_threshold: 500      # RMS threshold (for "rms" backend)
+  silence_duration_ms: 2000   # How long silence to end recording (ms)
+  min_listening_seconds: 5.0  # Grace period before silence detection starts
   max_recording_seconds: 20   # Maximum recording length
   silero_threshold: 0.5       # Silero VAD threshold 0-1 (higher = stricter)
-  # Settings for other backends (uncomment if switching backend):
-  # silence_threshold: 350    # RMS threshold (for "rms" backend only)
   # webrtc_aggressiveness: 2  # WebRTC aggressiveness 0-3 (for "webrtc" backend only)
 
 # LED settings (ReSpeaker HAT)

--- a/src/satellite/provisioning/README.md
+++ b/src/satellite/provisioning/README.md
@@ -1,0 +1,108 @@
+# Renfield Satellite Provisioning
+
+Ansible playbook for provisioning Raspberry Pi Zero 2 W satellites with ReSpeaker audio HATs.
+
+## Supported Hardware
+
+| HAT | LEDs | SPI | Power Pin | ALSA Card |
+|-----|------|-----|-----------|-----------|
+| ReSpeaker 2-Mic HAT | 3 | 0:0 | — | `seeed2micvoicec` |
+| ReSpeaker 4-Mic Array | 12 | 0:1 | GPIO 5 | `seeed4micvoicec` |
+
+## Prerequisites
+
+On your **control machine** (Mac/Linux):
+
+```bash
+pip install ansible
+```
+
+On the **Pi** (fresh Raspberry Pi OS image):
+- SSH enabled, user configured
+- Network connected (Wi-Fi or Ethernet)
+- SPI and I2C enabled in `raspi-config`
+
+## Quick Start
+
+Provision a single satellite:
+
+```bash
+cd src/satellite/provisioning
+ansible-playbook -i inventory.yml provision.yml --limit satellite-fitnessraum -v
+```
+
+Provision all satellites:
+
+```bash
+ansible-playbook -i inventory.yml provision.yml -v
+```
+
+## Tags
+
+Run individual phases:
+
+```bash
+# Just update the config
+ansible-playbook -i inventory.yml provision.yml --limit satellite-fitnessraum --tags config
+
+# Just redeploy code
+ansible-playbook -i inventory.yml provision.yml --limit satellite-fitnessraum --tags app
+
+# Just update models
+ansible-playbook -i inventory.yml provision.yml --limit satellite-fitnessraum --tags models
+```
+
+Available tags: `system`, `boot`, `driver`, `python`, `app`, `config`, `models`, `service`
+
+## Dry Run
+
+Preview changes without applying:
+
+```bash
+ansible-playbook -i inventory.yml provision.yml --limit satellite-fitnessraum --check -v
+```
+
+## Adding a New Satellite
+
+1. Add the host to `inventory.yml`
+2. Create `host_vars/<hostname>.yml` with HAT-specific settings
+3. Run the playbook
+
+## Host Variables
+
+| Variable | Description | 2-mic default | 4-mic default |
+|----------|-------------|---------------|---------------|
+| `hat_type` | `"2mic"` or `"4mic"` | `"2mic"` | `"4mic"` |
+| `satellite_id` | Unique satellite ID | — | — |
+| `satellite_room` | Room name | — | — |
+| `led_num` | Number of APA102 LEDs | `3` | `12` |
+| `led_spi_device` | SPI device number | `0` | `1` |
+| `led_power_pin` | GPIO for LED power | `null` | `5` |
+| `audio_device` | ALSA capture device | `"capture"` | `"default"` |
+| `audio_playback_device` | ALSA playback device | `"plughw:0,0"` | `"default"` |
+| `audio_channels` | Recording channels | `2` | `1` |
+| `beamforming_enabled` | Delay-and-Sum beamforming | `true` | `false` |
+
+## Safety Notes
+
+- The playbook uses `systemctl start`, not `restart` — safe for first provisioning
+- Each step is idempotent — safe to re-run
+- Driver installation triggers a reboot (handled automatically)
+- For code-only updates, use `--tags app` to skip hardware steps
+
+## Verification
+
+After provisioning, check:
+
+```bash
+# Sound card detected?
+ssh satellite-fitnessraum.local "cat /proc/asound/cards"
+
+# Service running?
+ssh satellite-fitnessraum.local "sudo journalctl -u renfield-satellite -n 30"
+
+# Expected log lines:
+#   LED power enabled on GPIO5       (4-mic only)
+#   SPI opened: bus 0, device 1      (4-mic only)
+#   Connected to server
+```

--- a/src/satellite/provisioning/group_vars/satellites.yml
+++ b/src/satellite/provisioning/group_vars/satellites.yml
@@ -1,0 +1,88 @@
+---
+# Common defaults for all Renfield satellites
+
+# Connection
+ansible_python_interpreter: /usr/bin/python3
+
+# Application paths
+satellite_base_dir: /opt/renfield-satellite
+satellite_venv: "{{ satellite_base_dir }}/venv"
+satellite_config_dir: "{{ satellite_base_dir }}/config"
+satellite_models_dir: "{{ satellite_base_dir }}/models"
+satellite_code_dir: "{{ satellite_base_dir }}/renfield_satellite"
+
+# Source paths (relative to playbook)
+source_code_dir: "../renfield_satellite"
+source_hardware_dir: "../hardware"
+
+# Server connection
+server_url: "wss://renfield.local/ws/satellite"
+server_auto_discover: true
+server_auth_enabled: false
+server_verify_tls: false
+
+# Wake word
+wakeword_model: "alexa"
+wakeword_threshold: 0.5
+
+# VAD
+vad_backend: "silero"
+vad_silence_duration_ms: 1200
+vad_max_recording_seconds: 20
+vad_silero_threshold: 0.5
+
+# LED
+led_brightness: 20
+
+# Button
+button_gpio_pin: 17
+
+# Language
+satellite_language: "de"
+
+# System packages needed on all satellites
+satellite_system_packages:
+  - python3-pip
+  - python3-venv
+  - python3-dev
+  - portaudio19-dev
+  - libasound2-dev
+  - libasound2-plugins
+  - libopenblas0
+  - libmpv-dev
+  - mpv
+  - libsamplerate0
+  - swig
+  - liblgpio-dev
+  - git
+  - device-tree-compiler
+
+# Python packages (installed in venv)
+satellite_python_packages:
+  - onnxruntime
+  - pyaudio
+  - numpy
+  - websockets
+  - python-mpv
+  - spidev
+  - lgpio
+  - gpiozero
+  - pyyaml
+  - zeroconf
+  - webrtcvad
+  - psutil
+  - scikit-learn
+  - noisereduce
+  - aiohttp
+  - requests
+
+# openwakeword installed separately with --no-deps for Python 3.13+ compat
+openwakeword_package: "openwakeword"
+
+# Model URLs
+oww_base_url: "https://github.com/dscripka/openWakeWord/releases/download/v0.6.0"
+oww_models:
+  - melspectrogram.onnx
+  - embedding_model.onnx
+silero_vad_url: "https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx"
+alexa_model_url: "{{ oww_base_url }}/alexa_v0.1.onnx"

--- a/src/satellite/provisioning/host_vars/satellite-fitnessraum.yml
+++ b/src/satellite/provisioning/host_vars/satellite-fitnessraum.yml
@@ -1,0 +1,22 @@
+---
+# ReSpeaker 4-Mic Array configuration
+
+hat_type: "4mic"
+satellite_id: "sat-fitnessraum"
+satellite_room: "Fitnessraum"
+
+# Audio: ALSA plughw handles S32_LE/4ch → S16_LE/1ch conversion in kernel space.
+# "capture" matches the ALSA plugin device in /etc/asound.conf.
+# Native S32_LE/4ch capture is blocked by AC108 driver kernel panic — see TECHNICAL_DEBT.md
+audio_device: "capture"
+audio_playback_device: "plughw:vc4hdmi"
+audio_channels: 1
+beamforming_enabled: false
+
+# LEDs (4-Mic Array: 12 LEDs on SPI 0:1, GPIO5 power)
+led_num: 12
+led_spi_device: 1
+led_power_pin: 5
+
+# Driver
+seeed_voicecard_branch: "v6.12"

--- a/src/satellite/provisioning/host_vars/satellite-wohnzimmer.yml
+++ b/src/satellite/provisioning/host_vars/satellite-wohnzimmer.yml
@@ -1,0 +1,21 @@
+---
+# ReSpeaker 2-Mic HAT configuration
+
+hat_type: "2mic"
+satellite_id: "sat-wohnzimmer"
+satellite_room: "Wohnzimmer"
+
+# Audio (stereo with beamforming)
+audio_device: "capture"
+audio_playback_device: "plughw:0,0"
+audio_channels: 2
+beamforming_enabled: true
+beamforming_mic_spacing: 0.058
+
+# LEDs (2-Mic HAT: 3 LEDs on SPI 0:0, no power pin)
+led_num: 3
+led_spi_device: 0
+led_power_pin: null
+
+# 2-mic overlay variant: "simple" or "full"
+overlay_variant: "simple"

--- a/src/satellite/provisioning/inventory.yml
+++ b/src/satellite/provisioning/inventory.yml
@@ -1,0 +1,11 @@
+---
+all:
+  children:
+    satellites:
+      hosts:
+        satellite-wohnzimmer:
+          ansible_host: satellite-wohnzimmer.local
+          ansible_user: evdb
+        satellite-fitnessraum:
+          ansible_host: satellite-fitnessraum.local
+          ansible_user: evdb

--- a/src/satellite/provisioning/provision.yml
+++ b/src/satellite/provisioning/provision.yml
@@ -1,0 +1,382 @@
+---
+# Renfield Satellite Provisioning Playbook
+#
+# Provisions a Raspberry Pi Zero 2 W as a Renfield voice satellite.
+# Supports both ReSpeaker 2-Mic HAT and 4-Mic Array via hat_type variable.
+#
+# Usage:
+#   ansible-playbook -i inventory.yml provision.yml --limit satellite-fitnessraum -v
+#
+# Tags:
+#   system, boot, driver, python, app, config, models, service
+#
+# Run a single phase:
+#   ansible-playbook -i inventory.yml provision.yml --limit satellite-fitnessraum --tags config
+#
+# Dry run:
+#   ansible-playbook -i inventory.yml provision.yml --limit satellite-fitnessraum --check
+
+- name: Provision Renfield Satellite
+  hosts: satellites
+  become: true
+
+  handlers:
+    - name: reboot after driver install
+      ansible.builtin.reboot:
+        reboot_timeout: 120
+        msg: "Rebooting after audio driver installation"
+
+    - name: reload systemd
+      ansible.builtin.systemd:
+        daemon_reload: true
+
+  tasks:
+    # =========================================================================
+    # SYSTEM — System preparation
+    # =========================================================================
+
+    - name: Install system packages
+      tags: [system]
+      ansible.builtin.apt:
+        name: "{{ satellite_system_packages }}"
+        state: present
+        update_cache: true
+        cache_valid_time: 3600
+
+    - name: Add user to hardware groups
+      tags: [system]
+      ansible.builtin.user:
+        name: "{{ ansible_user }}"
+        groups: audio,spi,gpio,i2c
+        append: true
+
+    - name: Create satellite directories
+      tags: [system]
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: "0755"
+      loop:
+        - "{{ satellite_base_dir }}"
+        - "{{ satellite_config_dir }}"
+        - "{{ satellite_models_dir }}"
+        - "{{ satellite_code_dir }}"
+
+    # =========================================================================
+    # BOOT — Boot configuration (config.txt)
+    # =========================================================================
+
+    - name: Enable I2S
+      tags: [boot]
+      ansible.builtin.lineinfile:
+        path: /boot/firmware/config.txt
+        regexp: '^#?\s*dtparam=i2s'
+        line: "dtparam=i2s=on"
+        state: present
+
+    - name: Enable SPI
+      tags: [boot]
+      ansible.builtin.lineinfile:
+        path: /boot/firmware/config.txt
+        regexp: '^#?\s*dtparam=spi'
+        line: "dtparam=spi=on"
+        state: present
+
+    - name: Enable I2C
+      tags: [boot]
+      ansible.builtin.lineinfile:
+        path: /boot/firmware/config.txt
+        regexp: '^#?\s*dtparam=i2c_arm'
+        line: "dtparam=i2c_arm=on"
+        state: present
+
+    - name: Remove w1-gpio overlay (GPIO4 conflict with audio HATs)
+      tags: [boot]
+      ansible.builtin.lineinfile:
+        path: /boot/firmware/config.txt
+        regexp: '^dtoverlay=w1-gpio'
+        state: absent
+
+    # =========================================================================
+    # DRIVER — Audio driver installation
+    # =========================================================================
+
+    # --- 4-Mic Array: seeed-voicecard driver ---
+
+    - name: Clone seeed-voicecard for 4-mic HAT
+      tags: [driver]
+      when: hat_type == "4mic"
+      ansible.builtin.git:
+        repo: https://github.com/HinTak/seeed-voicecard.git
+        dest: /tmp/seeed-voicecard
+        version: "{{ seeed_voicecard_branch }}"
+        force: true
+
+    - name: Install seeed-voicecard driver (4-mic)
+      tags: [driver]
+      when: hat_type == "4mic"
+      ansible.builtin.shell: |
+        cd /tmp/seeed-voicecard && bash install.sh
+      args:
+        creates: /boot/firmware/overlays/seeed-4mic-voicecard.dtbo
+      notify: reboot after driver install
+
+    - name: Ensure 4-mic overlay in config.txt
+      tags: [driver]
+      when: hat_type == "4mic"
+      ansible.builtin.lineinfile:
+        path: /boot/firmware/config.txt
+        line: "dtoverlay=seeed-4mic-voicecard"
+        state: present
+      notify: reboot after driver install
+
+    # --- 2-Mic HAT: custom GPCLK overlay ---
+
+    - name: Copy 2-mic overlay sources to Pi
+      tags: [driver]
+      when: hat_type == "2mic"
+      ansible.builtin.synchronize:
+        src: "{{ playbook_dir }}/../hardware/"
+        dest: /tmp/renfield-overlay/
+        recursive: true
+
+    - name: Install 2-mic overlay
+      tags: [driver]
+      when: hat_type == "2mic"
+      ansible.builtin.shell: |
+        cd /tmp/renfield-overlay && bash install-overlay.sh {{ overlay_variant | default('simple') }}
+      args:
+        creates: "/boot/firmware/overlays/seeed-2mic-gpclk-{{ overlay_variant | default('simple') }}.dtbo"
+      notify: reboot after driver install
+
+    # --- Flush handlers (reboot if driver was installed) ---
+
+    - name: Reboot now if driver was installed
+      tags: [driver]
+      ansible.builtin.meta: flush_handlers
+
+    - name: Wait for sound card after reboot
+      tags: [driver]
+      ansible.builtin.wait_for:
+        path: /proc/asound/cards
+        search_regex: "seeed"
+        timeout: 30
+      register: soundcard_check
+      ignore_errors: true
+
+    - name: Show detected sound cards
+      tags: [driver]
+      ansible.builtin.command: cat /proc/asound/cards
+      register: asound_cards
+      changed_when: false
+
+    - name: Display sound cards
+      tags: [driver]
+      ansible.builtin.debug:
+        var: asound_cards.stdout_lines
+
+    # =========================================================================
+    # PYTHON — Python virtual environment
+    # =========================================================================
+
+    - name: Create Python venv
+      tags: [python]
+      become_user: "{{ ansible_user }}"
+      ansible.builtin.command:
+        cmd: python3 -m venv {{ satellite_venv }}
+        creates: "{{ satellite_venv }}/bin/python"
+
+    - name: Upgrade pip
+      tags: [python]
+      become_user: "{{ ansible_user }}"
+      ansible.builtin.pip:
+        name: pip
+        state: latest
+        virtualenv: "{{ satellite_venv }}"
+
+    - name: Install Python packages
+      tags: [python]
+      become_user: "{{ ansible_user }}"
+      ansible.builtin.pip:
+        name: "{{ satellite_python_packages }}"
+        virtualenv: "{{ satellite_venv }}"
+
+    - name: Install openwakeword (--no-deps for Python 3.13+ compat)
+      tags: [python]
+      become_user: "{{ ansible_user }}"
+      ansible.builtin.pip:
+        name: "{{ openwakeword_package }}"
+        virtualenv: "{{ satellite_venv }}"
+        extra_args: "--no-deps"
+
+    # =========================================================================
+    # APP — Deploy application code
+    # =========================================================================
+
+    - name: Deploy satellite code via rsync
+      tags: [app]
+      ansible.builtin.synchronize:
+        src: "{{ playbook_dir }}/../renfield_satellite/"
+        dest: "{{ satellite_code_dir }}/"
+        recursive: true
+        delete: true
+        rsync_opts:
+          - "--exclude=__pycache__"
+          - "--exclude=*.pyc"
+          - "--exclude=.pytest_cache"
+
+    - name: Set code ownership
+      tags: [app]
+      ansible.builtin.file:
+        path: "{{ satellite_code_dir }}"
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        recurse: true
+
+    # =========================================================================
+    # CONFIG — Configuration files
+    # =========================================================================
+
+    - name: Deploy satellite.yaml
+      tags: [config]
+      ansible.builtin.template:
+        src: satellite.yaml.j2
+        dest: "{{ satellite_config_dir }}/satellite.yaml"
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: "0644"
+
+    - name: Deploy ALSA config (system-wide)
+      tags: [config]
+      ansible.builtin.template:
+        src: "asoundrc-{{ hat_type }}.j2"
+        dest: /etc/asound.conf
+        owner: root
+        group: root
+        mode: "0644"
+
+    - name: Disable WiFi power save (Pi Zero 2 W firmware bug)
+      tags: [config]
+      ansible.builtin.copy:
+        content: "options brcmfmac roamoff=1\noptions 8192cu rtw_power_mgnt=0 rtw_enusbss=0\n"
+        dest: /etc/modprobe.d/wifi-powersave.conf
+        mode: "0644"
+
+    - name: Add WiFi power save disable to rc.local
+      tags: [config]
+      ansible.builtin.lineinfile:
+        path: /etc/rc.local
+        line: "iw dev wlan0 set power_save off || true"
+        insertbefore: "^exit 0"
+        create: true
+        mode: "0755"
+
+    # =========================================================================
+    # MODELS — Wake word and VAD models
+    # =========================================================================
+
+    - name: Download openWakeWord base models
+      tags: [models]
+      become_user: "{{ ansible_user }}"
+      ansible.builtin.get_url:
+        url: "{{ oww_base_url }}/{{ item }}"
+        dest: "{{ satellite_models_dir }}/{{ item }}"
+        mode: "0644"
+      loop: "{{ oww_models }}"
+
+    - name: Download Alexa wake word model
+      tags: [models]
+      become_user: "{{ ansible_user }}"
+      ansible.builtin.get_url:
+        url: "{{ alexa_model_url }}"
+        dest: "{{ satellite_models_dir }}/alexa_v0.1.onnx"
+        mode: "0644"
+
+    - name: Download Silero VAD model
+      tags: [models]
+      become_user: "{{ ansible_user }}"
+      ansible.builtin.get_url:
+        url: "{{ silero_vad_url }}"
+        dest: "{{ satellite_models_dir }}/silero_vad.onnx"
+        mode: "0644"
+
+    - name: Find openwakeword models directory in venv
+      tags: [models]
+      ansible.builtin.find:
+        paths: "{{ satellite_venv }}/lib"
+        patterns: "openwakeword"
+        file_type: directory
+        recurse: true
+      register: oww_dirs
+
+    - name: Copy models to openwakeword package directory
+      tags: [models]
+      when: oww_dirs.files | length > 0
+      ansible.builtin.copy:
+        src: "{{ satellite_models_dir }}/{{ item }}"
+        dest: "{{ oww_dirs.files[0].path }}/resources/models/{{ item }}"
+        remote_src: true
+        owner: "{{ ansible_user }}"
+        mode: "0644"
+      loop:
+        - melspectrogram.onnx
+        - embedding_model.onnx
+        - alexa_v0.1.onnx
+
+    # =========================================================================
+    # SERVICE — Systemd service
+    # =========================================================================
+
+    - name: Deploy systemd service file
+      tags: [service]
+      ansible.builtin.template:
+        src: renfield-satellite.service.j2
+        dest: /etc/systemd/system/renfield-satellite.service
+        mode: "0644"
+      notify: reload systemd
+
+    - name: Flush handlers (reload systemd)
+      tags: [service]
+      ansible.builtin.meta: flush_handlers
+
+    - name: Enable renfield-satellite service
+      tags: [service]
+      ansible.builtin.systemd:
+        name: renfield-satellite
+        enabled: true
+
+    - name: Start renfield-satellite service
+      tags: [service]
+      ansible.builtin.systemd:
+        name: renfield-satellite
+        state: started
+
+    # =========================================================================
+    # VERIFY — Post-provisioning checks
+    # =========================================================================
+
+    - name: Check service status
+      tags: [service]
+      ansible.builtin.command: systemctl status renfield-satellite --no-pager
+      register: service_status
+      changed_when: false
+      ignore_errors: true
+
+    - name: Display service status
+      tags: [service]
+      ansible.builtin.debug:
+        var: service_status.stdout_lines
+
+    - name: Show provisioning summary
+      tags: [always]
+      ansible.builtin.debug:
+        msg: |
+          Satellite provisioned successfully!
+          - Host: {{ inventory_hostname }}
+          - HAT: {{ hat_type }}
+          - ID: {{ satellite_id }}
+          - Room: {{ satellite_room }}
+          - LEDs: {{ led_num }} on SPI 0:{{ led_spi_device }}
+          - Server: {{ server_url }}

--- a/src/satellite/provisioning/templates/asoundrc-2mic.j2
+++ b/src/satellite/provisioning/templates/asoundrc-2mic.j2
@@ -1,0 +1,54 @@
+# Renfield Satellite — ALSA Configuration for ReSpeaker 2-Mics Pi HAT
+# Managed by Ansible — do not edit manually
+
+defaults.pcm.rate_converter "samplerate"
+
+pcm.!default {
+    type asym
+    playback.pcm "playback"
+    capture.pcm "capture"
+}
+
+pcm.playback {
+    type plug
+    slave.pcm "dmixed"
+}
+
+pcm.capture {
+    type plug
+    slave.pcm "array"
+}
+
+pcm.dmixed {
+    type dmix
+    slave.pcm "hw:seeed2micvoicec"
+    ipc_key 555555
+}
+
+# Stereo microphone array (for beamforming)
+pcm.array {
+    type dsnoop
+    slave {
+        pcm "hw:seeed2micvoicec"
+        channels 2
+    }
+    ipc_key 666666
+}
+
+# Mono capture (single channel, downmixed)
+pcm.mono {
+    type plug
+    slave {
+        pcm "array"
+        channels 1
+    }
+}
+
+# 16kHz stereo capture (for beamforming with openwakeword)
+pcm.array16k {
+    type rate
+    slave {
+        pcm "array"
+        rate 16000
+    }
+}

--- a/src/satellite/provisioning/templates/asoundrc-4mic.j2
+++ b/src/satellite/provisioning/templates/asoundrc-4mic.j2
@@ -1,0 +1,21 @@
+# Renfield Satellite — ALSA Configuration for ReSpeaker 4-Mic Array
+# NOTE: Do NOT use dsnoop or dmix on the AC108 — they crash the kernel driver.
+# Use plughw: for format/rate conversion instead.
+
+defaults.pcm.rate_converter "samplerate"
+
+pcm.!default {
+    type asym
+    playback.pcm "playback"
+    capture.pcm "capture"
+}
+
+pcm.playback {
+    type plug
+    slave.pcm "plughw:vc4hdmi"
+}
+
+pcm.capture {
+    type plug
+    slave.pcm "plughw:seeed4micvoicec"
+}

--- a/src/satellite/provisioning/templates/renfield-satellite.service.j2
+++ b/src/satellite/provisioning/templates/renfield-satellite.service.j2
@@ -1,0 +1,33 @@
+# Renfield Satellite Voice Assistant
+# Managed by Ansible — do not edit manually
+
+[Unit]
+Description=Renfield Satellite Voice Assistant
+After=network-online.target sound.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{ ansible_user }}
+Group=audio
+WorkingDirectory={{ satellite_base_dir }}
+ExecStart={{ satellite_venv }}/bin/python -m renfield_satellite config/satellite.yaml
+Restart=always
+RestartSec=5
+Environment=PYTHONUNBUFFERED=1
+Environment=HOME=/home/{{ ansible_user }}
+
+# Allow access to hardware
+SupplementaryGroups=spi gpio i2c
+
+# Resource limits (Pi Zero 2 W has 512MB RAM)
+# AC108 4-mic driver needs headroom — memory pressure triggers vmalloc kernel crash
+MemoryMax=450M
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=renfield-satellite
+
+[Install]
+WantedBy=multi-user.target

--- a/src/satellite/provisioning/templates/satellite.yaml.j2
+++ b/src/satellite/provisioning/templates/satellite.yaml.j2
@@ -1,0 +1,54 @@
+# Renfield Satellite Configuration
+# Managed by Ansible — do not edit manually
+
+satellite:
+  id: "{{ satellite_id }}"
+  room: "{{ satellite_room }}"
+  language: "{{ satellite_language }}"
+
+server:
+  url: "{{ server_url }}"
+  auto_discover: {{ server_auto_discover | lower }}
+  discovery_timeout: 10
+  reconnect_interval: 5
+  heartbeat_interval: 30
+  auth_enabled: {{ server_auth_enabled | lower }}
+  verify_tls: {{ server_verify_tls | lower }}
+
+audio:
+  sample_rate: 16000
+  chunk_size: 1280
+  channels: {{ audio_channels }}
+  device: "{{ audio_device }}"
+  playback_device: "{{ audio_playback_device }}"
+  beamforming:
+    enabled: {{ beamforming_enabled | lower }}
+{%- if beamforming_enabled %}
+    mic_spacing: {{ beamforming_mic_spacing }}
+    steering_angle: 0.0
+{%- endif %}
+
+wakeword:
+  model: "{{ wakeword_model }}"
+  threshold: {{ wakeword_threshold }}
+  models_path: "{{ satellite_models_dir }}"
+  refractory_seconds: 2.0
+
+vad:
+  backend: "{{ vad_backend }}"
+  silence_duration_ms: {{ vad_silence_duration_ms }}
+  max_recording_seconds: {{ vad_max_recording_seconds }}
+  silero_threshold: {{ vad_silero_threshold }}
+
+led:
+  brightness: {{ led_brightness }}
+  num_leds: {{ led_num }}
+  spi_bus: 0
+  spi_device: {{ led_spi_device }}
+{%- if led_power_pin is not none %}
+  led_power_pin: {{ led_power_pin }}
+{%- endif %}
+
+button:
+  gpio_pin: {{ button_gpio_pin }}
+  debounce_ms: 50

--- a/src/satellite/renfield_satellite/config.py
+++ b/src/satellite/renfield_satellite/config.py
@@ -52,7 +52,7 @@ class AudioConfig:
     sample_rate: int = 16000
     chunk_size: int = 1280  # 80ms at 16kHz
     channels: int = 1
-    format_bits: int = 16
+    use_arecord: bool = False  # Use arecord subprocess (required for AC108 4-mic + onnxruntime)
     device: str = "plughw:1,0"  # ReSpeaker default
     playback_device: str = "plughw:1,0"
     beamforming: BeamformingConfig = field(default_factory=BeamformingConfig)
@@ -88,6 +88,7 @@ class LEDConfig:
     spi_bus: int = 0
     spi_device: int = 0
     num_leds: int = 3
+    led_power_pin: Optional[int] = None  # GPIO pin to enable LED power (4-mic HAT: 5)
 
 
 @dataclass
@@ -170,6 +171,7 @@ def load_config(config_path: Optional[str] = None) -> Config:
         config.audio.sample_rate = aud.get("sample_rate", config.audio.sample_rate)
         config.audio.chunk_size = aud.get("chunk_size", config.audio.chunk_size)
         config.audio.channels = aud.get("channels", config.audio.channels)
+        config.audio.use_arecord = aud.get("use_arecord", config.audio.use_arecord)
         config.audio.device = aud.get("device", config.audio.device)
         config.audio.playback_device = aud.get("playback_device", config.audio.playback_device)
 
@@ -206,6 +208,7 @@ def load_config(config_path: Optional[str] = None) -> Config:
         config.led.num_leds = led.get("num_leds", config.led.num_leds)
         config.led.spi_bus = led.get("spi_bus", config.led.spi_bus)
         config.led.spi_device = led.get("spi_device", config.led.spi_device)
+        config.led.led_power_pin = led.get("led_power_pin", config.led.led_power_pin)
 
     if "button" in config_data:
         btn = config_data["button"]

--- a/tests/satellite/test_config_loading.py
+++ b/tests/satellite/test_config_loading.py
@@ -67,13 +67,12 @@ class TestConfigDefaults:
 
     @pytest.mark.satellite
     def test_default_audio_values(self):
-        """Default audio config has 16kHz, 1280 chunk, mono, 16-bit."""
+        """Default audio config has 16kHz, 1280 chunk, mono."""
         config = load_config("/tmp/nonexistent_renfield_config_12345.yaml")
 
         assert config.audio.sample_rate == 16000
         assert config.audio.chunk_size == 1280
         assert config.audio.channels == 1
-        assert config.audio.format_bits == 16
 
     @pytest.mark.satellite
     def test_default_vad_values(self):
@@ -211,9 +210,35 @@ button:
         assert config.led.spi_bus == 1
         assert config.led.spi_device == 1
         assert config.led.num_leds == 6
+        assert config.led.led_power_pin is None  # Not set in YAML
 
         # Button section
         assert config.button.gpio_pin == 27
+
+    @pytest.mark.satellite
+    def test_led_power_pin_parsed_from_yaml(self, tmp_path):
+        """led_power_pin is parsed from YAML config (4-mic HAT uses GPIO5)."""
+        yaml_content = """\
+led:
+  num_leds: 12
+  spi_bus: 0
+  spi_device: 1
+  led_power_pin: 5
+"""
+        config_file = tmp_path / "4mic.yaml"
+        config_file.write_text(yaml_content)
+
+        config = load_config(str(config_file))
+
+        assert config.led.num_leds == 12
+        assert config.led.spi_device == 1
+        assert config.led.led_power_pin == 5
+
+    @pytest.mark.satellite
+    def test_led_power_pin_defaults_to_none(self):
+        """led_power_pin defaults to None when not specified."""
+        config = load_config("/tmp/nonexistent_renfield_config_12345.yaml")
+        assert config.led.led_power_pin is None
 
     @pytest.mark.satellite
     def test_partial_yaml_only_satellite_section(self, tmp_path):

--- a/tests/satellite/test_led_controller.py
+++ b/tests/satellite/test_led_controller.py
@@ -1,0 +1,185 @@
+"""
+LED Controller Tests
+
+Tests for renfield_satellite.hardware.led.LEDController:
+- GPIO power pin initialization and cleanup
+- SPI end frame format
+- Constructor parameters
+- Dual-HAT compatibility (2-mic vs 4-mic)
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch, PropertyMock
+
+
+class TestLEDControllerInit:
+    """Tests for LEDController constructor and parameters."""
+
+    @pytest.mark.satellite
+    def test_default_parameters(self):
+        """LEDController defaults: 3 LEDs, SPI 0:0, no power pin."""
+        from renfield_satellite.hardware.led import LEDController
+
+        ctrl = LEDController()
+        assert ctrl.num_leds == 3
+        assert ctrl.spi_bus == 0
+        assert ctrl.spi_device == 0
+        assert ctrl.brightness == 20
+        assert ctrl.led_power_pin is None
+        assert ctrl._power is None
+
+    @pytest.mark.satellite
+    def test_4mic_hat_parameters(self):
+        """LEDController accepts 4-mic HAT config: 12 LEDs, SPI 0:1, GPIO5."""
+        from renfield_satellite.hardware.led import LEDController
+
+        ctrl = LEDController(
+            num_leds=12,
+            spi_bus=0,
+            spi_device=1,
+            brightness=25,
+            led_power_pin=5,
+        )
+        assert ctrl.num_leds == 12
+        assert ctrl.spi_device == 1
+        assert ctrl.led_power_pin == 5
+
+    @pytest.mark.satellite
+    def test_brightness_clamped_to_31(self):
+        """Brightness values above 31 are clamped."""
+        from renfield_satellite.hardware.led import LEDController
+
+        ctrl = LEDController(brightness=50)
+        assert ctrl.brightness == 31
+
+
+class TestLEDPowerPin:
+    """Tests for GPIO power pin enable/disable logic."""
+
+    @pytest.mark.satellite
+    @patch("renfield_satellite.hardware.led.SPI_AVAILABLE", True)
+    @patch("renfield_satellite.hardware.led.GPIO_AVAILABLE", True)
+    @patch("renfield_satellite.hardware.led.spidev")
+    @patch("renfield_satellite.hardware.led.GpioLED")
+    def test_open_enables_gpio_power(self, mock_gpio_led_cls, mock_spidev):
+        """open() enables GPIO power pin before SPI init when led_power_pin is set."""
+        from renfield_satellite.hardware.led import LEDController
+
+        mock_power = MagicMock()
+        mock_gpio_led_cls.return_value = mock_power
+
+        mock_spi = MagicMock()
+        mock_spidev.SpiDev.return_value = mock_spi
+
+        ctrl = LEDController(num_leds=12, spi_device=1, led_power_pin=5)
+        result = ctrl.open()
+
+        assert result is True
+        mock_gpio_led_cls.assert_called_once_with(5)
+        mock_power.on.assert_called_once()
+        assert ctrl._power is mock_power
+
+    @pytest.mark.satellite
+    @patch("renfield_satellite.hardware.led.SPI_AVAILABLE", True)
+    @patch("renfield_satellite.hardware.led.GPIO_AVAILABLE", True)
+    @patch("renfield_satellite.hardware.led.spidev")
+    @patch("renfield_satellite.hardware.led.GpioLED")
+    def test_no_gpio_when_power_pin_is_none(self, mock_gpio_led_cls, mock_spidev):
+        """open() skips GPIO when led_power_pin is None (2-mic HAT)."""
+        from renfield_satellite.hardware.led import LEDController
+
+        mock_spi = MagicMock()
+        mock_spidev.SpiDev.return_value = mock_spi
+
+        ctrl = LEDController(num_leds=3)
+        result = ctrl.open()
+
+        assert result is True
+        mock_gpio_led_cls.assert_not_called()
+        assert ctrl._power is None
+
+    @pytest.mark.satellite
+    @patch("renfield_satellite.hardware.led.SPI_AVAILABLE", True)
+    @patch("renfield_satellite.hardware.led.GPIO_AVAILABLE", False)
+    @patch("renfield_satellite.hardware.led.spidev")
+    def test_warning_when_gpiozero_not_installed(self, mock_spidev, capsys):
+        """open() prints warning when gpiozero is missing but power pin is set."""
+        from renfield_satellite.hardware.led import LEDController
+
+        mock_spi = MagicMock()
+        mock_spidev.SpiDev.return_value = mock_spi
+
+        ctrl = LEDController(num_leds=12, led_power_pin=5)
+        result = ctrl.open()
+
+        assert result is True
+        captured = capsys.readouterr()
+        assert "gpiozero not installed" in captured.out
+        assert "GPIO5" in captured.out
+
+    @pytest.mark.satellite
+    @patch("renfield_satellite.hardware.led.SPI_AVAILABLE", True)
+    @patch("renfield_satellite.hardware.led.GPIO_AVAILABLE", True)
+    @patch("renfield_satellite.hardware.led.spidev")
+    @patch("renfield_satellite.hardware.led.GpioLED")
+    def test_close_disables_gpio_power(self, mock_gpio_led_cls, mock_spidev):
+        """close() turns off and closes GPIO power pin."""
+        from renfield_satellite.hardware.led import LEDController
+
+        mock_power = MagicMock()
+        mock_gpio_led_cls.return_value = mock_power
+
+        mock_spi = MagicMock()
+        mock_spidev.SpiDev.return_value = mock_spi
+
+        ctrl = LEDController(num_leds=12, led_power_pin=5)
+        ctrl.open()
+        ctrl.close()
+
+        mock_power.off.assert_called_once()
+        mock_power.close.assert_called_once()
+        assert ctrl._power is None
+
+    @pytest.mark.satellite
+    @patch("renfield_satellite.hardware.led.SPI_AVAILABLE", True)
+    @patch("renfield_satellite.hardware.led.spidev")
+    def test_close_without_power_pin(self, mock_spidev):
+        """close() works cleanly when no power pin is configured."""
+        from renfield_satellite.hardware.led import LEDController
+
+        mock_spi = MagicMock()
+        mock_spidev.SpiDev.return_value = mock_spi
+
+        ctrl = LEDController(num_leds=3)
+        ctrl.open()
+        ctrl.close()  # Should not raise
+
+
+class TestEndFrame:
+    """Tests for APA102 end frame format."""
+
+    @pytest.mark.satellite
+    @patch("renfield_satellite.hardware.led.SPI_AVAILABLE", True)
+    @patch("renfield_satellite.hardware.led.spidev")
+    def test_end_frame_uses_zero_bytes(self, mock_spidev):
+        """_write() uses 0x00 end frame bytes (matching 4-mic HAT reference driver)."""
+        from renfield_satellite.hardware.led import LEDController, Color
+
+        mock_spi = MagicMock()
+        mock_spidev.SpiDev.return_value = mock_spi
+
+        ctrl = LEDController(num_leds=3)
+        ctrl.open()
+        ctrl.set_all(Color(255, 0, 0))
+
+        # Get the data written to SPI
+        written_data = mock_spi.writebytes.call_args[0][0]
+
+        # End frame should be 0x00 bytes, not 0xFF
+        # Start frame: 4 bytes of 0x00
+        # LED data: 3 * 4 = 12 bytes
+        # End frame: at least 4 bytes of 0x00
+        end_frame_start = 4 + (3 * 4)  # After start frame + LED data
+        end_frame = written_data[end_frame_start:]
+        assert all(b == 0x00 for b in end_frame)
+        assert len(end_frame) >= 4


### PR DESCRIPTION
## Summary

- Add full ReSpeaker 4-Mic Array (AC108) support on Pi Zero 2 W with `arecord` subprocess isolation (prevents PyAudio + onnxruntime kernel crash)
- Fix VAD end-of-speech detection: chunk-counting instead of wall-clock time, RMS backend for 4-mic HAT
- Skip redundant stop-word inference when no stop words configured (halves per-chunk CPU)
- Ansible provisioning playbook for both 2-mic and 4-mic satellite HATs
- Updated docs (README, TECHNICAL_DEBT) with 4-mic setup instructions and architecture notes

## Test plan

- [x] Satellite boots, connects to server, detects wake word "alexa"
- [x] Full sentence "Sende eine Email an evdb at x-idra.de" captured without cutoff
- [x] TTS audio plays back through speaker
- [x] Stable under systemd for 20+ minutes
- [x] Unit tests pass (`test_config_loading.py`, `test_led_controller.py`)

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)