### PR TITLE
feat(chat): Document upload in chat — Phase 1 (#101)

### DIFF
--- a/src/backend/alembic/versions/v5w6x7y8z9a0_add_chat_uploads.py
+++ b/src/backend/alembic/versions/v5w6x7y8z9a0_add_chat_uploads.py
@@ -1,0 +1,38 @@
+"""add chat_uploads table
+
+Revision ID: v5w6x7y8z9a0
+Revises: u4v5w6x7y8z9
+Create Date: 2026-02-09
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'v5w6x7y8z9a0'
+down_revision: Union[str, None] = 'u4v5w6x7y8z9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'chat_uploads',
+        sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('session_id', sa.String(128), nullable=False, index=True),
+        sa.Column('document_id', sa.Integer(), sa.ForeignKey('documents.id'), nullable=True),
+        sa.Column('filename', sa.String(255), nullable=False),
+        sa.Column('file_type', sa.String(50), nullable=True),
+        sa.Column('file_size', sa.Integer(), nullable=True),
+        sa.Column('file_hash', sa.String(64), nullable=True, index=True),
+        sa.Column('extracted_text', sa.Text(), nullable=True),
+        sa.Column('status', sa.String(50), server_default='processing', nullable=True, index=True),
+        sa.Column('error_message', sa.Text(), nullable=True),
+        sa.Column('knowledge_base_id', sa.Integer(), sa.ForeignKey('knowledge_bases.id'), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('chat_uploads')

--- a/src/backend/api/routes/chat_upload.py
+++ b/src/backend/api/routes/chat_upload.py
@@ -1,0 +1,125 @@
+"""
+Chat Upload API Routes
+
+Upload documents directly in chat for quick text extraction.
+No RAG indexing — just extract text and store metadata.
+"""
+import hashlib
+import os
+import uuid
+from pathlib import Path
+
+import aiofiles
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from loguru import logger
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import UPLOAD_STATUS_COMPLETED, UPLOAD_STATUS_FAILED, ChatUpload
+from services.database import get_db
+from services.document_processor import DocumentProcessor
+from utils.config import settings
+
+from .chat_upload_schemas import ChatUploadResponse
+
+router = APIRouter()
+
+_document_processor: DocumentProcessor | None = None
+
+
+def _get_processor() -> DocumentProcessor:
+    global _document_processor
+    if _document_processor is None:
+        _document_processor = DocumentProcessor()
+    return _document_processor
+
+
+@router.post("/upload", response_model=ChatUploadResponse)
+async def upload_chat_document(
+    file: UploadFile = File(...),
+    session_id: str = Form(...),
+    knowledge_base_id: int | None = Form(None),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Upload a document in chat for quick text extraction.
+
+    Returns extracted text preview and metadata.
+    No RAG indexing or chunking — just raw text extraction.
+    """
+    # Validate file extension
+    filename = file.filename or "unknown"
+    ext = Path(filename).suffix.lower().lstrip('.')
+    if ext not in settings.allowed_extensions_list:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported file format: .{ext}",
+        )
+
+    # Read file content
+    content = await file.read()
+
+    # Validate file size
+    max_bytes = settings.max_file_size_mb * 1024 * 1024
+    if len(content) > max_bytes:
+        raise HTTPException(
+            status_code=400,
+            detail=f"File too large (max. {settings.max_file_size_mb}MB)",
+        )
+
+    # Compute SHA256 hash
+    file_hash = hashlib.sha256(content).hexdigest()
+
+    # Save file to upload dir
+    upload_dir = Path(settings.upload_dir)
+    upload_dir.mkdir(parents=True, exist_ok=True)
+
+    safe_name = os.path.basename(filename.replace("\x00", ""))
+    unique_filename = f"{uuid.uuid4().hex}_{safe_name}"
+    file_path = upload_dir / unique_filename
+
+    try:
+        async with aiofiles.open(file_path, 'wb') as f:
+            await f.write(content)
+    except Exception as e:
+        logger.error(f"Chat upload: Datei speichern fehlgeschlagen: {e}")
+        raise HTTPException(status_code=500, detail="File save failed")
+
+    # Extract text
+    extracted_text = None
+    status = UPLOAD_STATUS_COMPLETED
+    error_message = None
+
+    try:
+        processor = _get_processor()
+        extracted_text = await processor.extract_text_only(str(file_path))
+    except Exception as e:
+        logger.error(f"Chat upload: Text-Extraktion fehlgeschlagen: {e}")
+        status = UPLOAD_STATUS_FAILED
+        error_message = str(e)
+
+    # Create DB entry
+    upload = ChatUpload(
+        session_id=session_id,
+        filename=safe_name,
+        file_type=ext,
+        file_size=len(content),
+        file_hash=file_hash,
+        extracted_text=extracted_text,
+        status=status,
+        error_message=error_message,
+        knowledge_base_id=knowledge_base_id,
+    )
+    db.add(upload)
+    await db.commit()
+    await db.refresh(upload)
+
+    return ChatUploadResponse(
+        id=upload.id,
+        filename=upload.filename,
+        file_type=upload.file_type,
+        file_size=upload.file_size,
+        status=upload.status,
+        text_preview=extracted_text[:500] if extracted_text else None,
+        error_message=upload.error_message,
+        created_at=upload.created_at.isoformat() if upload.created_at else "",
+    )

--- a/src/backend/api/routes/chat_upload_schemas.py
+++ b/src/backend/api/routes/chat_upload_schemas.py
@@ -1,0 +1,15 @@
+"""
+Pydantic schemas for Chat Upload API.
+"""
+from pydantic import BaseModel
+
+
+class ChatUploadResponse(BaseModel):
+    id: int
+    filename: str
+    file_type: str | None
+    file_size: int | None
+    status: str
+    text_preview: str | None
+    error_message: str | None
+    created_at: str

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -22,6 +22,7 @@ from api.routes import (
     auth,
     camera,
     chat,
+    chat_upload,
     feedback,
     intents,
     knowledge,
@@ -132,6 +133,7 @@ app.include_router(auth.router, prefix="/api/auth", tags=["Authentication"])
 app.include_router(roles.router, prefix="/api/roles", tags=["Roles"])
 app.include_router(users.router, prefix="/api/users", tags=["Users"])
 app.include_router(chat.router, prefix="/api/chat", tags=["Chat"])
+app.include_router(chat_upload.router, prefix="/api/chat", tags=["Chat Upload"])
 app.include_router(tasks.router, prefix="/api/tasks", tags=["Tasks"])
 app.include_router(voice.router, prefix="/api/voice", tags=["Voice"])
 app.include_router(camera.router, prefix="/api/camera", tags=["Camera"])

--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -487,6 +487,36 @@ class DocumentChunk(Base):
     # USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);
 
 
+# =============================================================================
+# Chat Upload Model
+# =============================================================================
+
+# Upload Status Constants
+UPLOAD_STATUS_PROCESSING = "processing"
+UPLOAD_STATUS_COMPLETED = "completed"
+UPLOAD_STATUS_FAILED = "failed"
+
+UPLOAD_STATUSES = [UPLOAD_STATUS_PROCESSING, UPLOAD_STATUS_COMPLETED, UPLOAD_STATUS_FAILED]
+
+
+class ChatUpload(Base):
+    """Dokument-Upload direkt im Chat (ohne RAG-Indexierung)"""
+    __tablename__ = "chat_uploads"
+
+    id = Column(Integer, primary_key=True, index=True)
+    session_id = Column(String(128), nullable=False, index=True)
+    document_id = Column(Integer, ForeignKey("documents.id"), nullable=True)
+    filename = Column(String(255), nullable=False)
+    file_type = Column(String(50))
+    file_size = Column(Integer)
+    file_hash = Column(String(64), nullable=True, index=True)
+    extracted_text = Column(Text, nullable=True)
+    status = Column(String(50), default=UPLOAD_STATUS_PROCESSING, index=True)
+    error_message = Column(Text, nullable=True)
+    knowledge_base_id = Column(Integer, ForeignKey("knowledge_bases.id"), nullable=True)
+    created_at = Column(DateTime, default=_utcnow)
+
+
 # Document Processing Status Constants
 DOC_STATUS_PENDING = "pending"
 DOC_STATUS_PROCESSING = "processing"

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -114,7 +114,15 @@
     "thisWeek": "Diese Woche",
     "older": "Älter",
     "processingMessage": "Bitte warten, Nachricht wird verarbeitet",
-    "thinkingStatus": "Renfield denkt nach..."
+    "thinkingStatus": "Renfield denkt nach...",
+    "attachFile": "Datei anhängen",
+    "uploading": "Wird hochgeladen...",
+    "uploadSuccess": "Hochgeladen",
+    "uploadFailed": "Upload fehlgeschlagen",
+    "unsupportedFormat": "Dateiformat nicht unterstützt",
+    "fileTooLarge": "Datei zu groß (max. {{size}}MB)",
+    "removeAttachment": "Anhang entfernen",
+    "documentUploaded": "Dokument hochgeladen: {{filename}}"
   },
   "voice": {
     "startRecording": "Sprachaufnahme starten",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -114,7 +114,15 @@
     "thisWeek": "This Week",
     "older": "Older",
     "processingMessage": "Please wait, processing message",
-    "thinkingStatus": "Renfield is thinking..."
+    "thinkingStatus": "Renfield is thinking...",
+    "attachFile": "Attach file",
+    "uploading": "Uploading...",
+    "uploadSuccess": "Uploaded",
+    "uploadFailed": "Upload failed",
+    "unsupportedFormat": "Unsupported file format",
+    "fileTooLarge": "File too large (max. {{size}}MB)",
+    "removeAttachment": "Remove attachment",
+    "documentUploaded": "Document uploaded: {{filename}}"
   },
   "voice": {
     "startRecording": "Start voice recording",

--- a/src/frontend/src/pages/ChatPage/ChatMessages.jsx
+++ b/src/frontend/src/pages/ChatPage/ChatMessages.jsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Volume2, Loader } from 'lucide-react';
+import { Volume2, Loader, FileText, AlertCircle, CheckCircle } from 'lucide-react';
 import IntentCorrectionButton from '../../components/IntentCorrectionButton';
 import { useChatContext } from './context/ChatContext';
 
@@ -56,6 +56,37 @@ export default function ChatMessages() {
             }`}
           >
             <p className="whitespace-pre-wrap">{message.content}</p>
+
+            {/* Attachment chips */}
+            {message.attachments && message.attachments.length > 0 && (
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {message.attachments.map(att => (
+                  <div
+                    key={att.id}
+                    className={`flex items-center space-x-1 px-2 py-1 rounded text-xs ${
+                      att.status === 'completed'
+                        ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
+                        : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'
+                    }`}
+                  >
+                    <FileText className="w-3 h-3 flex-shrink-0" aria-hidden="true" />
+                    <span className="truncate max-w-[140px]">{att.filename}</span>
+                    {att.file_size && (
+                      <span className="text-[10px] opacity-70">
+                        ({att.file_size < 1024 * 1024
+                          ? `${Math.round(att.file_size / 1024)} KB`
+                          : `${(att.file_size / (1024 * 1024)).toFixed(1)} MB`
+                        })
+                      </span>
+                    )}
+                    {att.status === 'completed'
+                      ? <CheckCircle className="w-3 h-3 flex-shrink-0" aria-hidden="true" />
+                      : <AlertCircle className="w-3 h-3 flex-shrink-0" aria-hidden="true" />
+                    }
+                  </div>
+                ))}
+              </div>
+            )}
 
             {/* TTS Button for assistant messages */}
             {message.role === 'assistant' && !message.streaming && speakText && (

--- a/src/frontend/src/pages/ChatPage/hooks/index.js
+++ b/src/frontend/src/pages/ChatPage/hooks/index.js
@@ -1,2 +1,3 @@
 export { useChatWebSocket } from './useChatWebSocket';
 export { useAudioRecording } from './useAudioRecording';
+export { useDocumentUpload } from './useDocumentUpload';

--- a/src/frontend/src/pages/ChatPage/hooks/useDocumentUpload.js
+++ b/src/frontend/src/pages/ChatPage/hooks/useDocumentUpload.js
@@ -1,0 +1,32 @@
+import { useState, useCallback } from 'react';
+import apiClient from '../../../utils/axios';
+
+export function useDocumentUpload() {
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState(null);
+
+  const uploadDocument = useCallback(async (file, sessionId) => {
+    setUploading(true);
+    setUploadError(null);
+
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      formData.append('session_id', sessionId);
+
+      const response = await apiClient.post('/api/chat/upload', formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+
+      return response.data;
+    } catch (error) {
+      const message = error.response?.data?.detail || error.message;
+      setUploadError(message);
+      return null;
+    } finally {
+      setUploading(false);
+    }
+  }, []);
+
+  return { uploading, uploadError, uploadDocument };
+}

--- a/tests/backend/test_chat_upload.py
+++ b/tests/backend/test_chat_upload.py
@@ -1,0 +1,208 @@
+"""
+Tests for Chat Upload API
+
+Tests:
+- File upload with text extraction
+- Invalid format rejection
+- File size limit
+- Missing session_id validation
+- DB entry creation
+- Duplicate uploads allowed (no 409)
+"""
+import io
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import ChatUpload
+
+# ============================================================================
+# API Tests
+# ============================================================================
+
+class TestChatUploadAPI:
+    """Tests for POST /api/chat/upload"""
+
+    @pytest.mark.backend
+    async def test_upload_txt_file(self, async_client: AsyncClient):
+        """TXT upload returns 200 with text_preview"""
+        content = b"Hello, this is a test document with some content."
+        files = {"file": ("test.txt", io.BytesIO(content), "text/plain")}
+        data = {"session_id": "test-session-123"}
+
+        with patch("api.routes.chat_upload._get_processor") as mock_proc:
+            processor = AsyncMock()
+            processor.extract_text_only = AsyncMock(return_value="Hello, this is a test document with some content.")
+            mock_proc.return_value = processor
+
+            response = await async_client.post("/api/chat/upload", files=files, data=data)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["filename"] == "test.txt"
+        assert body["file_type"] == "txt"
+        assert body["status"] == "completed"
+        assert body["text_preview"] is not None
+        assert "Hello" in body["text_preview"]
+
+    @pytest.mark.backend
+    async def test_upload_invalid_format(self, async_client: AsyncClient):
+        """.exe files are rejected with 400"""
+        content = b"MZ\x00\x00"
+        files = {"file": ("malware.exe", io.BytesIO(content), "application/octet-stream")}
+        data = {"session_id": "test-session-123"}
+
+        response = await async_client.post("/api/chat/upload", files=files, data=data)
+
+        assert response.status_code == 400
+        assert "Unsupported" in response.json()["detail"]
+
+    @pytest.mark.backend
+    async def test_upload_too_large(self, async_client: AsyncClient):
+        """Files exceeding max size are rejected with 400"""
+        with patch("api.routes.chat_upload.settings") as mock_settings:
+            mock_settings.max_file_size_mb = 1
+            mock_settings.allowed_extensions_list = ["txt"]
+            mock_settings.upload_dir = "/tmp/renfield-test-uploads"
+
+            # 2MB content exceeds 1MB limit
+            content = b"x" * (2 * 1024 * 1024)
+            files = {"file": ("big.txt", io.BytesIO(content), "text/plain")}
+            data = {"session_id": "test-session-123"}
+
+            response = await async_client.post("/api/chat/upload", files=files, data=data)
+
+        assert response.status_code == 400
+        assert "too large" in response.json()["detail"]
+
+    @pytest.mark.backend
+    async def test_upload_missing_session_id(self, async_client: AsyncClient):
+        """Missing session_id returns 422"""
+        content = b"test content"
+        files = {"file": ("test.txt", io.BytesIO(content), "text/plain")}
+
+        response = await async_client.post("/api/chat/upload", files=files)
+
+        assert response.status_code == 422
+
+    @pytest.mark.backend
+    async def test_upload_creates_db_entry(self, async_client: AsyncClient, db_session: AsyncSession):
+        """Upload creates a ChatUpload entry in the database"""
+        content = b"DB test content"
+        files = {"file": ("db_test.txt", io.BytesIO(content), "text/plain")}
+        data = {"session_id": "db-test-session"}
+
+        with patch("api.routes.chat_upload._get_processor") as mock_proc:
+            processor = AsyncMock()
+            processor.extract_text_only = AsyncMock(return_value="DB test content")
+            mock_proc.return_value = processor
+
+            response = await async_client.post("/api/chat/upload", files=files, data=data)
+
+        assert response.status_code == 200
+
+        # Verify DB entry via response ID
+        upload_id = response.json()["id"]
+        result = await db_session.execute(
+            select(ChatUpload).where(ChatUpload.id == upload_id)
+        )
+        upload = result.scalar_one_or_none()
+        assert upload is not None
+        assert upload.session_id == "db-test-session"
+        assert upload.filename == "db_test.txt"
+
+    @pytest.mark.backend
+    async def test_upload_duplicate_allowed(self, async_client: AsyncClient):
+        """Same file can be uploaded twice in chat (no 409 like KB)"""
+        content = b"duplicate test content"
+
+        with patch("api.routes.chat_upload._get_processor") as mock_proc:
+            processor = AsyncMock()
+            processor.extract_text_only = AsyncMock(return_value="duplicate test content")
+            mock_proc.return_value = processor
+
+            for _ in range(2):
+                files = {"file": ("dup.txt", io.BytesIO(content), "text/plain")}
+                data = {"session_id": "dup-session"}
+                response = await async_client.post("/api/chat/upload", files=files, data=data)
+                assert response.status_code == 200
+
+    @pytest.mark.backend
+    async def test_upload_pdf_format_accepted(self, async_client: AsyncClient):
+        """PDF extension is accepted"""
+        content = b"%PDF-1.4 fake pdf content"
+        files = {"file": ("report.pdf", io.BytesIO(content), "application/pdf")}
+        data = {"session_id": "pdf-session"}
+
+        with patch("api.routes.chat_upload._get_processor") as mock_proc:
+            processor = AsyncMock()
+            processor.extract_text_only = AsyncMock(return_value="Extracted PDF text")
+            mock_proc.return_value = processor
+
+            response = await async_client.post("/api/chat/upload", files=files, data=data)
+
+        assert response.status_code == 200
+        assert response.json()["file_type"] == "pdf"
+
+    @pytest.mark.backend
+    async def test_upload_extraction_failure(self, async_client: AsyncClient):
+        """When text extraction fails, status is 'failed' but HTTP 200"""
+        content = b"some content"
+        files = {"file": ("broken.txt", io.BytesIO(content), "text/plain")}
+        data = {"session_id": "fail-session"}
+
+        with patch("api.routes.chat_upload._get_processor") as mock_proc:
+            processor = AsyncMock()
+            processor.extract_text_only = AsyncMock(side_effect=RuntimeError("Docling crash"))
+            mock_proc.return_value = processor
+
+            response = await async_client.post("/api/chat/upload", files=files, data=data)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "failed"
+        assert body["error_message"] is not None
+
+
+# ============================================================================
+# Model Tests
+# ============================================================================
+
+class TestChatUploadModel:
+    """Tests for ChatUpload database model"""
+
+    @pytest.mark.database
+    async def test_create_chat_upload(self, db_session: AsyncSession):
+        """ChatUpload can be created and retrieved"""
+        upload = ChatUpload(
+            session_id="model-test-session",
+            filename="test.pdf",
+            file_type="pdf",
+            file_size=12345,
+            file_hash="abc123",
+            extracted_text="Some extracted text",
+            status="completed",
+        )
+        db_session.add(upload)
+        await db_session.commit()
+        await db_session.refresh(upload)
+
+        assert upload.id is not None
+        assert upload.session_id == "model-test-session"
+        assert upload.created_at is not None
+
+    @pytest.mark.database
+    async def test_chat_upload_default_status(self, db_session: AsyncSession):
+        """Default status is 'processing'"""
+        upload = ChatUpload(
+            session_id="default-status-test",
+            filename="test.txt",
+        )
+        db_session.add(upload)
+        await db_session.commit()
+        await db_session.refresh(upload)
+
+        assert upload.status == "processing"

--- a/tests/frontend/react/pages/ChatUpload.test.jsx
+++ b/tests/frontend/react/pages/ChatUpload.test.jsx
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { server } from '../mocks/server.js';
+import { BASE_URL } from '../mocks/handlers.js';
+import ChatPage from '../../../../src/frontend/src/pages/ChatPage';
+import { renderWithProviders } from '../test-utils.jsx';
+
+// Mock useWakeWord hook
+vi.mock('../../../../src/frontend/src/hooks/useWakeWord', () => ({
+  useWakeWord: () => ({
+    isEnabled: false,
+    isListening: false,
+    isLoading: false,
+    isReady: false,
+    isAvailable: false,
+    lastDetection: null,
+    error: null,
+    settings: { keyword: 'hey_jarvis', threshold: 0.5 },
+    enable: vi.fn(),
+    disable: vi.fn(),
+    toggle: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    setKeyword: vi.fn(),
+    setThreshold: vi.fn(),
+    availableKeywords: [{ id: 'hey_jarvis', label: 'Hey Jarvis' }]
+  })
+}));
+
+// Mock WAKEWORD_CONFIG
+vi.mock('../../../../src/frontend/src/config/wakeword', () => ({
+  WAKEWORD_CONFIG: {
+    activationDelayMs: 100
+  }
+}));
+
+// Mock navigator.mediaDevices
+const mockGetUserMedia = vi.fn();
+Object.defineProperty(global.navigator, 'mediaDevices', {
+  value: { getUserMedia: mockGetUserMedia },
+  writable: true,
+  configurable: true
+});
+
+// Mock AudioContext
+global.AudioContext = vi.fn().mockImplementation(() => ({
+  state: 'running',
+  resume: vi.fn().mockResolvedValue(undefined),
+  close: vi.fn().mockResolvedValue(undefined),
+  createMediaStreamSource: vi.fn().mockReturnValue({ connect: vi.fn() }),
+  createAnalyser: vi.fn().mockReturnValue({
+    fftSize: 512,
+    frequencyBinCount: 256,
+    smoothingTimeConstant: 0.3,
+    getByteFrequencyData: vi.fn()
+  }),
+  createBufferSource: vi.fn().mockReturnValue({
+    buffer: null,
+    connect: vi.fn(),
+    start: vi.fn(),
+    onended: null
+  }),
+  decodeAudioData: vi.fn().mockResolvedValue({ duration: 1.0 }),
+  destination: {}
+}));
+global.webkitAudioContext = global.AudioContext;
+
+// Mock MediaRecorder
+global.MediaRecorder = vi.fn().mockImplementation(() => ({
+  start: vi.fn(),
+  stop: vi.fn(),
+  ondataavailable: null,
+  onstop: null
+}));
+
+// Mock WebSocket
+class MockWebSocket {
+  constructor(url) {
+    this.url = url;
+    this.readyState = 1;
+    this.OPEN = 1;
+    setTimeout(() => { if (this.onopen) this.onopen({}); }, 10);
+  }
+  send() {}
+  close() { if (this.onclose) this.onclose({}); }
+}
+global.WebSocket = MockWebSocket;
+
+// Mock scrollIntoView
+Element.prototype.scrollIntoView = vi.fn();
+
+describe('Chat Upload', () => {
+  beforeEach(() => {
+    server.resetHandlers();
+    server.use(
+      http.get(`${BASE_URL}/api/knowledge/bases`, () => {
+        return HttpResponse.json([]);
+      })
+    );
+    mockGetUserMedia.mockResolvedValue({
+      getTracks: () => [{ stop: vi.fn() }]
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the upload button', async () => {
+    renderWithProviders(<ChatPage />);
+
+    await waitFor(() => {
+      const attachButton = screen.getByLabelText('Datei anhängen');
+      expect(attachButton).toBeInTheDocument();
+    });
+  });
+
+  it('has a hidden file input', async () => {
+    renderWithProviders(<ChatPage />);
+
+    await waitFor(() => {
+      const fileInput = document.querySelector('input[type="file"]');
+      expect(fileInput).toBeTruthy();
+      expect(fileInput.className).toContain('hidden');
+    });
+  });
+
+  it('accepts correct file types', async () => {
+    renderWithProviders(<ChatPage />);
+
+    await waitFor(() => {
+      const fileInput = document.querySelector('input[type="file"]');
+      expect(fileInput).toBeTruthy();
+      expect(fileInput.getAttribute('accept')).toContain('.pdf');
+      expect(fileInput.getAttribute('accept')).toContain('.txt');
+      expect(fileInput.getAttribute('accept')).toContain('.docx');
+    });
+  });
+
+  it('shows upload confirmation message after successful upload', async () => {
+    server.use(
+      http.post(`${BASE_URL}/api/chat/upload`, () => {
+        return HttpResponse.json({
+          id: 1,
+          filename: 'report.pdf',
+          file_type: 'pdf',
+          file_size: 12345,
+          status: 'completed',
+          text_preview: 'Extracted text from the report...',
+          error_message: null,
+          created_at: '2026-02-09T12:00:00',
+        });
+      })
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<ChatPage />);
+
+    // Wait for page to render
+    await waitFor(() => {
+      expect(screen.getByLabelText('Datei anhängen')).toBeInTheDocument();
+    });
+
+    // Simulate file selection
+    const fileInput = document.querySelector('input[type="file"]');
+    const file = new File(['test content'], 'report.pdf', { type: 'application/pdf' });
+
+    await user.upload(fileInput, file);
+
+    // The upload confirmation message should appear (i18n key: chat.documentUploaded)
+    await waitFor(() => {
+      expect(screen.getByText(/Dokument hochgeladen.*report\.pdf/)).toBeInTheDocument();
+    }, { timeout: 5000 });
+  });
+});


### PR DESCRIPTION
## Summary

- **Upload button** (paperclip icon) in chat input between text field and mic button
- **Backend endpoint** `POST /api/chat/upload` with format/size validation and quick text extraction via Docling
- **ChatUpload DB model** + Alembic migration for `chat_uploads` table
- **Attachment rendering** in chat message bubbles with status chips (green/red)
- **i18n** translations (DE/EN) for all upload-related strings

Phase 1 scope: Upload + text extraction + display only. No WebSocket context injection, no background RAG indexing, no drag & drop (Phase 2-4).

## Test plan

- [x] Backend model tests pass (2/2)
- [x] Backend API tests written (8 tests, require Docker for asyncpg)
- [x] Frontend tests pass (4/4)
- [x] Existing ChatPage tests pass (10/10, no regressions)
- [x] Ruff lint clean
- [ ] Manual test: upload TXT/PDF in chat UI
- [ ] Verify Alembic migration runs on production DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)