### PR TITLE
feat(chat): Inject uploaded document text as LLM context (#104)

### DIFF
--- a/src/backend/models/websocket_messages.py
+++ b/src/backend/models/websocket_messages.py
@@ -187,6 +187,8 @@ class WSChatMessage(BaseModel):
     # RAG options
     use_rag: bool = Field(default=False, description="Enable RAG context for this query")
     knowledge_base_id: int | None = Field(None, description="Specific knowledge base to search")
+    # Document upload context
+    attachment_ids: list[int] | None = Field(None, description="IDs of uploaded documents to include as context")
 
 
 # =============================================================================

--- a/src/backend/prompts/agent.yaml
+++ b/src/backend/prompts/agent.yaml
@@ -4,7 +4,7 @@
 
 de:
   # Main agent prompt template
-  # Available variables: {message}, {conv_context}, {memory_context}, {tools_prompt}, {tool_corrections}, {history_prompt}, {step_directive}
+  # Available variables: {message}, {conv_context}, {memory_context}, {document_context}, {tools_prompt}, {tool_corrections}, {history_prompt}, {step_directive}
   agent_prompt: |
     Du bist ein Agent, der komplexe Aufgaben Schritt für Schritt löst.
 
@@ -19,6 +19,8 @@ de:
     {conv_context}
 
     {memory_context}
+
+    {document_context}
 
     ANTWORT-FORMAT: Antworte mit GENAU EINEM JSON-Objekt.
 
@@ -61,6 +63,8 @@ de:
 
     {memory_context}
 
+    {document_context}
+
     ANTWORT-FORMAT: Antworte mit GENAU EINEM JSON-Objekt.
 
     Tool aufrufen:
@@ -102,6 +106,8 @@ de:
 
     {memory_context}
 
+    {document_context}
+
     ANTWORT-FORMAT: Antworte mit GENAU EINEM JSON-Objekt.
 
     Tool aufrufen:
@@ -137,6 +143,8 @@ de:
     {conv_context}
 
     {memory_context}
+
+    {document_context}
 
     ANTWORT-FORMAT: Antworte mit GENAU EINEM JSON-Objekt.
 
@@ -177,6 +185,8 @@ de:
     {conv_context}
 
     {memory_context}
+
+    {document_context}
 
     ANTWORT-FORMAT: Antworte mit GENAU EINEM JSON-Objekt.
 
@@ -220,6 +230,8 @@ de:
     {conv_context}
 
     {memory_context}
+
+    {document_context}
 
     ANTWORT-FORMAT: Antworte mit GENAU EINEM JSON-Objekt.
 
@@ -340,7 +352,7 @@ de:
 
 en:
   # Main agent prompt template
-  # Available variables: {message}, {conv_context}, {memory_context}, {tools_prompt}, {tool_corrections}, {history_prompt}, {step_directive}
+  # Available variables: {message}, {conv_context}, {memory_context}, {document_context}, {tools_prompt}, {tool_corrections}, {history_prompt}, {step_directive}
   agent_prompt: |
     You are an agent that solves complex tasks step by step.
 
@@ -355,6 +367,8 @@ en:
     {conv_context}
 
     {memory_context}
+
+    {document_context}
 
     RESPONSE FORMAT: Reply with EXACTLY ONE JSON object.
 
@@ -397,6 +411,8 @@ en:
 
     {memory_context}
 
+    {document_context}
+
     RESPONSE FORMAT: Reply with EXACTLY ONE JSON object.
 
     Call a tool:
@@ -438,6 +454,8 @@ en:
 
     {memory_context}
 
+    {document_context}
+
     RESPONSE FORMAT: Reply with EXACTLY ONE JSON object.
 
     Call a tool:
@@ -473,6 +491,8 @@ en:
     {conv_context}
 
     {memory_context}
+
+    {document_context}
 
     RESPONSE FORMAT: Reply with EXACTLY ONE JSON object.
 
@@ -513,6 +533,8 @@ en:
     {conv_context}
 
     {memory_context}
+
+    {document_context}
 
     RESPONSE FORMAT: Reply with EXACTLY ONE JSON object.
 
@@ -556,6 +578,8 @@ en:
     {conv_context}
 
     {memory_context}
+
+    {document_context}
 
     RESPONSE FORMAT: Reply with EXACTLY ONE JSON object.
 

--- a/src/backend/prompts/chat.yaml
+++ b/src/backend/prompts/chat.yaml
@@ -48,6 +48,20 @@ de:
     Nutze diese Erinnerungen um personalisierter zu antworten.
     Widerspreche ihnen nicht, es sei denn der Benutzer korrigiert dich explizit.
 
+  document_context_section: |
+    HOCHGELADENES DOKUMENT ({filename}, {file_size}):
+    {document_text}
+
+    WICHTIG: Der Benutzer hat dieses Dokument hochgeladen. Beantworte Fragen basierend auf dem Dokumentinhalt. Zitiere relevante Stellen wenn moeglich.
+
+  document_context_multi_section: |
+    HOCHGELADENE DOKUMENTE ({count} Dateien):
+    {documents}
+
+    WICHTIG: Der Benutzer hat diese Dokumente hochgeladen. Beantworte Fragen basierend auf den Dokumentinhalten. Zitiere relevante Stellen und nenne das jeweilige Dokument.
+
+  document_separator: "--- DOKUMENT: {filename} ({file_size}) ---\n{document_text}"
+
   error_fallback: "Entschuldigung, es gab einen Fehler: {error}"
   error_service_unavailable: "Der Dienst ist vorübergehend nicht verfügbar. Bitte versuche es später erneut."
 
@@ -96,6 +110,20 @@ en:
 
     Use these memories to give personalized responses.
     Don't contradict them unless the user explicitly corrects you.
+
+  document_context_section: |
+    UPLOADED DOCUMENT ({filename}, {file_size}):
+    {document_text}
+
+    IMPORTANT: The user has uploaded this document. Answer questions based on the document content. Cite relevant passages when possible.
+
+  document_context_multi_section: |
+    UPLOADED DOCUMENTS ({count} files):
+    {documents}
+
+    IMPORTANT: The user has uploaded these documents. Answer questions based on the document contents. Cite relevant passages and name the respective document.
+
+  document_separator: "--- DOCUMENT: {filename} ({file_size}) ---\n{document_text}"
 
   error_fallback: "Sorry, there was an error: {error}"
   error_service_unavailable: "The service is temporarily unavailable. Please try again later."

--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -397,6 +397,7 @@ class AgentService:
         room_context: dict | None = None,
         lang: str = "de",
         memory_context: str = "",
+        document_context: str = "",
     ) -> str:
         """Build the prompt for the Agent LLM call."""
         tools_prompt = self.tool_registry.build_tools_prompt()
@@ -454,6 +455,7 @@ class AgentService:
             room_context=room_context_str,
             conv_context=conv_context,
             memory_context=memory_context,
+            document_context=document_context,
             tools_prompt=tools_prompt,
             tool_corrections=tool_corrections,
             history_prompt=history_prompt,
@@ -469,6 +471,7 @@ class AgentService:
                 room_context=room_context_str,
                 conv_context=conv_context,
                 memory_context=memory_context,
+                document_context=document_context,
                 tools_prompt=tools_prompt,
                 tool_corrections=tool_corrections,
                 history_prompt=history_prompt,
@@ -486,6 +489,7 @@ class AgentService:
         room_context: dict | None = None,
         lang: str | None = None,
         memory_context: str = "",
+        document_context: str = "",
     ) -> AsyncGenerator[AgentStep, None]:
         """
         Run the Agent Loop. Yields AgentStep objects for real-time feedback.
@@ -498,6 +502,7 @@ class AgentService:
             room_context: Optional room context for HA entity resolution
             lang: Language for prompts and responses (de/en). None = default_lang
             memory_context: Formatted memory section for the agent prompt
+            document_context: Formatted document section for the agent prompt
         """
         # Use ollama's default language if not specified
         lang = lang or ollama.default_lang
@@ -545,7 +550,7 @@ class AgentService:
                 return
 
             # Build prompt with all available tools (32k context fits all tools)
-            prompt = await self._build_agent_prompt(message, context, conversation_history, room_context=room_context, lang=lang, memory_context=memory_context)
+            prompt = await self._build_agent_prompt(message, context, conversation_history, room_context=room_context, lang=lang, memory_context=memory_context, document_context=document_context)
             logger.info(f"🤖 Agent step {step_num} prompt ({len(prompt)} chars, {total_tools} tools)")
 
             # Check circuit breaker before LLM call

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -163,6 +163,7 @@ class Settings(BaseSettings):
     upload_dir: str = "/app/data/uploads"
     max_file_size_mb: int = Field(default=50, ge=1, le=500)
     allowed_extensions: str = "pdf,docx,doc,txt,md,html,pptx,xlsx"  # Comma-separated
+    chat_upload_max_context_chars: int = Field(default=50000, ge=1000, le=200000)
 
     # Monitoring
     metrics_enabled: bool = False  # Enable Prometheus /metrics endpoint

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -122,7 +122,8 @@
     "unsupportedFormat": "Dateiformat nicht unterstützt",
     "fileTooLarge": "Datei zu groß (max. {{size}}MB)",
     "removeAttachment": "Anhang entfernen",
-    "documentUploaded": "Dokument hochgeladen: {{filename}}"
+    "documentUploaded": "Dokument hochgeladen: {{filename}}",
+    "documentAttached": "{{count}} Dokument(e) angehängt"
   },
   "voice": {
     "startRecording": "Sprachaufnahme starten",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -122,7 +122,8 @@
     "unsupportedFormat": "Unsupported file format",
     "fileTooLarge": "File too large (max. {{size}}MB)",
     "removeAttachment": "Remove attachment",
-    "documentUploaded": "Document uploaded: {{filename}}"
+    "documentUploaded": "Document uploaded: {{filename}}",
+    "documentAttached": "{{count}} document(s) attached"
   },
   "voice": {
     "startRecording": "Start voice recording",

--- a/tests/frontend/react/pages/ChatUpload.test.jsx
+++ b/tests/frontend/react/pages/ChatUpload.test.jsx
@@ -139,7 +139,7 @@ describe('Chat Upload', () => {
     });
   });
 
-  it('shows upload confirmation message after successful upload', async () => {
+  it('shows attachment chip after successful upload', async () => {
     server.use(
       http.post(`${BASE_URL}/api/chat/upload`, () => {
         return HttpResponse.json({
@@ -169,9 +169,9 @@ describe('Chat Upload', () => {
 
     await user.upload(fileInput, file);
 
-    // The upload confirmation message should appear (i18n key: chat.documentUploaded)
+    // The attachment chip should appear (shows filename)
     await waitFor(() => {
-      expect(screen.getByText(/Dokument hochgeladen.*report\.pdf/)).toBeInTheDocument();
+      expect(screen.getByText(/report\.pdf/)).toBeInTheDocument();
     }, { timeout: 5000 });
   });
 });


### PR DESCRIPTION
## Summary
- **Phase 2** of chat document upload: extracted text from uploaded documents is now injected into the LLM system prompt, enabling the assistant to answer questions about uploaded document content
- Adds `attachment_ids` field to WebSocket messages, document context prompt templates (DE/EN), and threads `document_context` through all LLM call paths (chat, RAG, agent)
- Frontend sends `attachment_ids` with the message and clears attachment chips after sending

## Changes
| File | Change |
|------|--------|
| `websocket_messages.py` | `attachment_ids` field on WSChatMessage |
| `config.py` | `chat_upload_max_context_chars` setting (50k default) |
| `chat.yaml` | Document context prompt templates (DE/EN) |
| `agent.yaml` | `{document_context}` placeholder in all 12 agent prompts |
| `ollama_service.py` | `document_context` param on chat_stream, chat_stream_with_rag, _build_rag_system_prompt |
| `agent_service.py` | `document_context` param on run(), _build_agent_prompt() |
| `chat_handler.py` | `_fetch_document_context()` helper, wiring through all 9 LLM call sites |
| `ChatContext.jsx` | Send attachment_ids, clear chips after send |
| `de.json` / `en.json` | `chat.documentAttached` i18n key |
| `test_chat_upload.py` | 8 new tests for context injection |
| `ChatUpload.test.jsx` | Updated for new upload flow |

## Test plan
- [x] `ruff check` — all checks passed
- [x] Backend unit/database tests — 4/4 passed
- [x] Frontend Vitest — 4/4 passed
- [ ] Full backend test suite in Docker (needs asyncpg)
- [ ] Browser UI test: upload file → ask question → LLM answers based on document

🤖 Generated with [Claude Code](https://claude.com/claude-code)