### PR TITLE
feat(chat): Multi-file upload, progress bars, email forwarding & cleanup TTL (#101)

### DIFF
--- a/src/backend/api/routes/chat_upload_schemas.py
+++ b/src/backend/api/routes/chat_upload_schemas.py
@@ -31,3 +31,21 @@ class PaperlessResponse(BaseModel):
     success: bool
     paperless_task_id: str | None = None
     message: str
+
+
+class EmailForwardRequest(BaseModel):
+    to: str
+    subject: str | None = None
+    body: str | None = None
+
+
+class EmailForwardResponse(BaseModel):
+    success: bool
+    message: str
+
+
+class CleanupResponse(BaseModel):
+    success: bool
+    deleted_count: int
+    deleted_files: int
+    message: str

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -166,6 +166,8 @@ class Settings(BaseSettings):
     chat_upload_max_context_chars: int = Field(default=50000, ge=1000, le=200000)
     chat_upload_auto_index: bool = False
     chat_upload_default_kb_name: str = "Chat Uploads"
+    chat_upload_retention_days: int = Field(default=30, ge=1, le=365)
+    chat_upload_cleanup_enabled: bool = False
 
     # Monitoring
     metrics_enabled: bool = False  # Enable Prometheus /metrics endpoint

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -134,7 +134,15 @@
     "indexingFailed": "Fehler beim Hinzufügen",
     "paperlessSuccess": "An Paperless gesendet",
     "paperlessFailed": "Senden an Paperless fehlgeschlagen",
-    "alreadyIndexed": "Bereits indexiert"
+    "alreadyIndexed": "Bereits indexiert",
+    "sendViaEmail": "Per E-Mail senden",
+    "emailDialogTitle": "Dokument per E-Mail senden",
+    "emailTo": "Empfänger",
+    "emailSubject": "Betreff",
+    "emailBody": "Nachricht (optional)",
+    "emailSend": "Senden",
+    "emailSuccess": "Per E-Mail gesendet",
+    "emailFailed": "E-Mail-Versand fehlgeschlagen"
   },
   "voice": {
     "startRecording": "Sprachaufnahme starten",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -134,7 +134,15 @@
     "indexingFailed": "Failed to add to Knowledge Base",
     "paperlessSuccess": "Sent to Paperless",
     "paperlessFailed": "Failed to send to Paperless",
-    "alreadyIndexed": "Already indexed"
+    "alreadyIndexed": "Already indexed",
+    "sendViaEmail": "Send via Email",
+    "emailDialogTitle": "Send Document via Email",
+    "emailTo": "Recipient",
+    "emailSubject": "Subject",
+    "emailBody": "Message (optional)",
+    "emailSend": "Send",
+    "emailSuccess": "Sent via Email",
+    "emailFailed": "Failed to send email"
   },
   "voice": {
     "startRecording": "Start voice recording",

--- a/src/frontend/src/pages/ChatPage/AttachmentQuickActions.jsx
+++ b/src/frontend/src/pages/ChatPage/AttachmentQuickActions.jsx
@@ -1,12 +1,13 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { MoreVertical, BookOpen, Send, FileSearch, Loader } from 'lucide-react';
+import { MoreVertical, BookOpen, Send, FileSearch, Mail, Loader } from 'lucide-react';
 import apiClient from '../../utils/axios';
 
 export default function AttachmentQuickActions({
   attachment,
   onIndexToKb,
   onSendToPaperless,
+  onSendViaEmail,
   onSummarize,
   actionLoading,
 }) {
@@ -69,6 +70,12 @@ export default function AttachmentQuickActions({
     e.stopPropagation();
     setOpen(false);
     onSendToPaperless(attachment.id);
+  };
+
+  const handleEmail = (e) => {
+    e.stopPropagation();
+    setOpen(false);
+    onSendViaEmail?.(attachment.id);
   };
 
   const handleSummarize = (e) => {
@@ -137,6 +144,15 @@ export default function AttachmentQuickActions({
           >
             <Send className="w-3.5 h-3.5 flex-shrink-0" aria-hidden="true" />
             {t('chat.sendToPaperless')}
+          </button>
+
+          {/* Send via Email */}
+          <button
+            onClick={handleEmail}
+            className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-left hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+          >
+            <Mail className="w-3.5 h-3.5 flex-shrink-0" aria-hidden="true" />
+            {t('chat.sendViaEmail')}
           </button>
 
           {/* Summarize */}

--- a/src/frontend/src/pages/ChatPage/ChatMessages.jsx
+++ b/src/frontend/src/pages/ChatPage/ChatMessages.jsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Volume2, Loader, FileText, AlertCircle, CheckCircle } from 'lucide-react';
 import IntentCorrectionButton from '../../components/IntentCorrectionButton';
 import AttachmentQuickActions from './AttachmentQuickActions';
+import EmailForwardDialog from './EmailForwardDialog';
 import { useChatContext } from './context/ChatContext';
 
 export default function ChatMessages() {
@@ -10,6 +11,7 @@ export default function ChatMessages() {
   const {
     messages, loading, historyLoading, speakText, handleFeedbackSubmit,
     actionLoading, actionResult, indexToKb, sendToPaperless, handleSummarize,
+    handleSendViaEmail, emailDialog, confirmSendViaEmail, cancelEmailDialog,
   } = useChatContext();
   const messagesEndRef = useRef(null);
 
@@ -91,6 +93,7 @@ export default function ChatMessages() {
                       attachment={att}
                       onIndexToKb={indexToKb}
                       onSendToPaperless={sendToPaperless}
+                      onSendViaEmail={handleSendViaEmail}
                       onSummarize={handleSummarize}
                       actionLoading={actionLoading}
                     />
@@ -147,10 +150,24 @@ export default function ChatMessages() {
           role="status"
         >
           {actionResult.success
-            ? (actionResult.type === 'indexing' ? t('chat.indexingSuccess') : t('chat.paperlessSuccess'))
-            : (actionResult.type === 'indexing' ? t('chat.indexingFailed') : t('chat.paperlessFailed'))
+            ? (actionResult.type === 'indexing' ? t('chat.indexingSuccess')
+              : actionResult.type === 'email' ? t('chat.emailSuccess')
+              : t('chat.paperlessSuccess'))
+            : (actionResult.type === 'indexing' ? t('chat.indexingFailed')
+              : actionResult.type === 'email' ? t('chat.emailFailed')
+              : t('chat.paperlessFailed'))
           }
         </div>
+      )}
+
+      {/* Email Forward Dialog */}
+      {emailDialog && (
+        <EmailForwardDialog
+          open={!!emailDialog}
+          filename={emailDialog.filename}
+          onConfirm={confirmSendViaEmail}
+          onCancel={cancelEmailDialog}
+        />
       )}
 
       {/* Scroll anchor */}

--- a/src/frontend/src/pages/ChatPage/EmailForwardDialog.jsx
+++ b/src/frontend/src/pages/ChatPage/EmailForwardDialog.jsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Mail } from 'lucide-react';
+import Modal from '../../components/Modal';
+
+export default function EmailForwardDialog({ open, filename, onConfirm, onCancel }) {
+  const { t } = useTranslation();
+  const [to, setTo] = useState('');
+  const [subject, setSubject] = useState(`Document: ${filename || ''}`);
+  const [body, setBody] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!to.trim()) return;
+    onConfirm(to.trim(), subject.trim(), body.trim());
+    setTo('');
+    setSubject('');
+    setBody('');
+  };
+
+  return (
+    <Modal isOpen={open} onClose={onCancel}>
+      <form onSubmit={handleSubmit}>
+        <div className="flex items-center gap-2 mb-4">
+          <div className="w-10 h-10 rounded-full bg-primary-100 dark:bg-primary-900/30 flex items-center justify-center">
+            <Mail className="w-5 h-5 text-primary-600 dark:text-primary-400" aria-hidden="true" />
+          </div>
+          <h2 className="text-lg font-bold text-gray-900 dark:text-white">
+            {t('chat.emailDialogTitle')}
+          </h2>
+        </div>
+
+        <div className="space-y-3 mb-4">
+          <div>
+            <label htmlFor="email-to" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              {t('chat.emailTo')} *
+            </label>
+            <input
+              id="email-to"
+              type="email"
+              required
+              value={to}
+              onChange={(e) => setTo(e.target.value)}
+              className="input w-full"
+              placeholder="user@example.com"
+              autoFocus
+            />
+          </div>
+
+          <div>
+            <label htmlFor="email-subject" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              {t('chat.emailSubject')}
+            </label>
+            <input
+              id="email-subject"
+              type="text"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              className="input w-full"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="email-body" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              {t('chat.emailBody')}
+            </label>
+            <textarea
+              id="email-body"
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              className="input w-full h-20 resize-none"
+              rows={3}
+            />
+          </div>
+        </div>
+
+        <div className="flex space-x-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 btn btn-secondary"
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            type="submit"
+            disabled={!to.trim()}
+            className="flex-1 btn btn-primary disabled:opacity-50"
+          >
+            {t('chat.emailSend')}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/src/frontend/src/pages/ChatPage/hooks/useDocumentUpload.js
+++ b/src/frontend/src/pages/ChatPage/hooks/useDocumentUpload.js
@@ -1,12 +1,20 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import apiClient from '../../../utils/axios';
 
 export function useDocumentUpload() {
-  const [uploading, setUploading] = useState(false);
+  const [uploadStates, setUploadStates] = useState({});
   const [uploadError, setUploadError] = useState(null);
+  const keyCounter = useRef(0);
+
+  const uploading = Object.values(uploadStates).some(s => s.uploading);
 
   const uploadDocument = useCallback(async (file, sessionId) => {
-    setUploading(true);
+    const fileKey = `upload-${keyCounter.current++}`;
+
+    setUploadStates(prev => ({
+      ...prev,
+      [fileKey]: { progress: 0, uploading: true, error: null, name: file.name },
+    }));
     setUploadError(null);
 
     try {
@@ -16,17 +24,55 @@ export function useDocumentUpload() {
 
       const response = await apiClient.post('/api/chat/upload', formData, {
         headers: { 'Content-Type': 'multipart/form-data' },
+        onUploadProgress: (progressEvent) => {
+          const percent = progressEvent.total
+            ? Math.round((progressEvent.loaded * 100) / progressEvent.total)
+            : 0;
+          setUploadStates(prev => ({
+            ...prev,
+            [fileKey]: { ...prev[fileKey], progress: percent },
+          }));
+        },
+      });
+
+      // Remove from upload states on success
+      setUploadStates(prev => {
+        const next = { ...prev };
+        delete next[fileKey];
+        return next;
       });
 
       return response.data;
     } catch (error) {
       const message = error.response?.data?.detail || error.message;
       setUploadError(message);
+      setUploadStates(prev => ({
+        ...prev,
+        [fileKey]: { ...prev[fileKey], uploading: false, error: message },
+      }));
       return null;
-    } finally {
-      setUploading(false);
     }
   }, []);
 
-  return { uploading, uploadError, uploadDocument };
+  const uploadDocuments = useCallback(async (files, sessionId) => {
+    const results = [];
+    for (const file of files) {
+      const result = await uploadDocument(file, sessionId);
+      results.push(result);
+    }
+    return results;
+  }, [uploadDocument]);
+
+  const clearError = useCallback((fileKey) => {
+    if (fileKey) {
+      setUploadStates(prev => {
+        const next = { ...prev };
+        delete next[fileKey];
+        return next;
+      });
+    }
+    setUploadError(null);
+  }, []);
+
+  return { uploading, uploadError, uploadDocument, uploadDocuments, uploadStates, clearError };
 }

--- a/src/frontend/src/pages/ChatPage/hooks/useQuickActions.js
+++ b/src/frontend/src/pages/ChatPage/hooks/useQuickActions.js
@@ -57,9 +57,38 @@ export function useQuickActions() {
     }
   }, []);
 
+  const sendViaEmail = useCallback(async (uploadId, to, subject, body) => {
+    setActionLoading(prev => ({ ...prev, [uploadId]: 'email' }));
+    try {
+      const response = await apiClient.post(`/api/chat/upload/${uploadId}/email`, {
+        to,
+        subject,
+        body,
+      });
+      setActionResult({
+        type: 'email',
+        success: true,
+        message: response.data.message,
+      });
+    } catch (error) {
+      const detail = error.response?.data?.detail || 'Unknown error';
+      setActionResult({
+        type: 'email',
+        success: false,
+        message: detail,
+      });
+    } finally {
+      setActionLoading(prev => {
+        const next = { ...prev };
+        delete next[uploadId];
+        return next;
+      });
+    }
+  }, []);
+
   const clearResult = useCallback(() => {
     setActionResult(null);
   }, []);
 
-  return { actionLoading, actionResult, clearResult, indexToKb, sendToPaperless };
+  return { actionLoading, actionResult, clearResult, indexToKb, sendToPaperless, sendViaEmail };
 }

--- a/tests/frontend/react/pages/ChatUpload.test.jsx
+++ b/tests/frontend/react/pages/ChatUpload.test.jsx
@@ -247,6 +247,188 @@ describe('Chat Upload', () => {
     localStorage.removeItem('renfield_current_session');
   });
 
+  it('allows multiple file selection', async () => {
+    renderWithProviders(<ChatPage />);
+
+    await waitFor(() => {
+      const fileInput = document.querySelector('input[type="file"]');
+      expect(fileInput).toBeTruthy();
+      expect(fileInput.hasAttribute('multiple')).toBe(true);
+    });
+  });
+
+  it('shows upload progress indicators', async () => {
+    // Create a delayed upload response to catch the progress state
+    let resolveUpload;
+    const uploadPromise = new Promise(resolve => { resolveUpload = resolve; });
+
+    server.use(
+      http.post(`${BASE_URL}/api/chat/upload`, async () => {
+        await uploadPromise;
+        return HttpResponse.json({
+          id: 1,
+          filename: 'report.pdf',
+          file_type: 'pdf',
+          file_size: 12345,
+          status: 'completed',
+          text_preview: 'text',
+          error_message: null,
+          created_at: '2026-02-10T12:00:00',
+        });
+      })
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<ChatPage />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Datei anhängen')).toBeInTheDocument();
+    });
+
+    const fileInput = document.querySelector('input[type="file"]');
+    const file = new File(['test content'], 'progress-test.pdf', { type: 'application/pdf' });
+
+    await user.upload(fileInput, file);
+
+    // The progress bar should be rendered (role="progressbar")
+    await waitFor(() => {
+      const progressBar = document.querySelector('[role="progressbar"]');
+      expect(progressBar).toBeTruthy();
+    }, { timeout: 3000 });
+
+    // Resolve the upload so it completes
+    resolveUpload();
+
+    // After resolution, the progress bar should disappear
+    await waitFor(() => {
+      expect(screen.getByText(/progress-test\.pdf/)).toBeInTheDocument();
+    }, { timeout: 5000 });
+  });
+
+  it('renders email quick action in menu', async () => {
+    const sessionId = 'session-email-action';
+    server.use(
+      http.get(`${BASE_URL}/api/chat/conversations`, () => {
+        return HttpResponse.json({
+          conversations: [{
+            session_id: sessionId,
+            preview: 'Check doc',
+            message_count: 1,
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          }],
+          total: 1,
+        });
+      }),
+      http.get(`${BASE_URL}/api/chat/history/${sessionId}`, () => {
+        return HttpResponse.json({
+          messages: [
+            {
+              role: 'user',
+              content: 'Check this doc',
+              timestamp: new Date().toISOString(),
+              metadata: { attachment_ids: [20] },
+              attachments: [
+                { id: 20, filename: 'invoice.pdf', file_type: 'pdf', file_size: 3000, status: 'completed' },
+              ],
+            },
+          ],
+        });
+      })
+    );
+
+    localStorage.setItem('renfield_current_session', sessionId);
+    const user = userEvent.setup();
+    renderWithProviders(<ChatPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/invoice\.pdf/)).toBeInTheDocument();
+    }, { timeout: 5000 });
+
+    const quickActionBtn = screen.getByLabelText('Schnellaktionen');
+    await user.click(quickActionBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText('Per E-Mail senden')).toBeInTheDocument();
+    });
+
+    localStorage.removeItem('renfield_current_session');
+  });
+
+  it('shows email success toast', async () => {
+    const sessionId = 'session-email-toast';
+    server.use(
+      http.get(`${BASE_URL}/api/chat/conversations`, () => {
+        return HttpResponse.json({
+          conversations: [{
+            session_id: sessionId,
+            preview: 'Check doc',
+            message_count: 1,
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          }],
+          total: 1,
+        });
+      }),
+      http.get(`${BASE_URL}/api/chat/history/${sessionId}`, () => {
+        return HttpResponse.json({
+          messages: [
+            {
+              role: 'user',
+              content: 'Check this doc',
+              timestamp: new Date().toISOString(),
+              metadata: { attachment_ids: [30] },
+              attachments: [
+                { id: 30, filename: 'memo.pdf', file_type: 'pdf', file_size: 2000, status: 'completed' },
+              ],
+            },
+          ],
+        });
+      }),
+      http.post(`${BASE_URL}/api/chat/upload/30/email`, () => {
+        return HttpResponse.json({
+          success: true,
+          message: 'Sent to test@example.com',
+        });
+      })
+    );
+
+    localStorage.setItem('renfield_current_session', sessionId);
+    const user = userEvent.setup();
+    renderWithProviders(<ChatPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/memo\.pdf/)).toBeInTheDocument();
+    }, { timeout: 5000 });
+
+    // Open quick actions menu
+    const quickActionBtn = screen.getByLabelText('Schnellaktionen');
+    await user.click(quickActionBtn);
+
+    // Click "Per E-Mail senden"
+    await waitFor(() => {
+      expect(screen.getByText('Per E-Mail senden')).toBeInTheDocument();
+    });
+    await user.click(screen.getByText('Per E-Mail senden'));
+
+    // Email dialog should appear
+    await waitFor(() => {
+      expect(screen.getByText('Dokument per E-Mail senden')).toBeInTheDocument();
+    });
+
+    // Fill in email address and submit
+    const emailInput = screen.getByPlaceholderText('user@example.com');
+    await user.type(emailInput, 'test@example.com');
+    await user.click(screen.getByText('Senden'));
+
+    // Success toast should appear
+    await waitFor(() => {
+      expect(screen.getByText('Per E-Mail gesendet')).toBeInTheDocument();
+    }, { timeout: 5000 });
+
+    localStorage.removeItem('renfield_current_session');
+  });
+
   it('shows attachment chip after successful upload', async () => {
     server.use(
       http.post(`${BASE_URL}/api/chat/upload`, () => {


### PR DESCRIPTION
## Summary
- **Multi-file upload** — file picker + drag-drop accept multiple files, uploaded sequentially to existing endpoint
- **Progress bars** — per-file upload progress via axios `onUploadProgress` with visual indicator
- **Email forwarding** — new quick action to forward uploads via Email MCP (`send_email` with base64 attachment)
- **Cleanup TTL** — background task (hourly, opt-in) + `DELETE /api/chat/upload/cleanup` endpoint to delete old non-indexed uploads
- **EmailForwardDialog** — modal with recipient, subject, body fields; i18n DE/EN

## Test plan
- [ ] 9 new backend tests: `TestChatUploadEmail` (4) + `TestChatUploadCleanup` (5)
- [ ] 4 new frontend tests: multi-file, progress, email action, email toast
- [ ] UI: Drop 3 files → progress bars shown → all chips appear
- [ ] UI: Click 3-dot → "Per E-Mail senden" → enter email → send → success toast
- [ ] Manual: `curl -X DELETE .../api/chat/upload/cleanup?days=1` → old uploads deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)