### PR TITLE
feat(chat): WS notifications & OCR image upload (#101)

### DIFF
--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -162,7 +162,7 @@ class Settings(BaseSettings):
     # Document Upload
     upload_dir: str = "/app/data/uploads"
     max_file_size_mb: int = Field(default=50, ge=1, le=500)
-    allowed_extensions: str = "pdf,docx,doc,txt,md,html,pptx,xlsx"  # Comma-separated
+    allowed_extensions: str = "pdf,docx,doc,txt,md,html,pptx,xlsx,png,jpg,jpeg"  # Comma-separated
     chat_upload_max_context_chars: int = Field(default=50000, ge=1000, le=200000)
     chat_upload_auto_index: bool = False
     chat_upload_default_kb_name: str = "Chat Uploads"

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -142,7 +142,9 @@
     "emailBody": "Nachricht (optional)",
     "emailSend": "Senden",
     "emailSuccess": "Per E-Mail gesendet",
-    "emailFailed": "E-Mail-Versand fehlgeschlagen"
+    "emailFailed": "E-Mail-Versand fehlgeschlagen",
+    "documentIndexing": "Wird indexiert...",
+    "documentIndexed": "In Wissensdatenbank indexiert"
   },
   "voice": {
     "startRecording": "Sprachaufnahme starten",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -142,7 +142,9 @@
     "emailBody": "Message (optional)",
     "emailSend": "Send",
     "emailSuccess": "Sent via Email",
-    "emailFailed": "Failed to send email"
+    "emailFailed": "Failed to send email",
+    "documentIndexing": "Indexing to KB...",
+    "documentIndexed": "Indexed to KB"
   },
   "voice": {
     "startRecording": "Start voice recording",

--- a/src/frontend/src/pages/ChatPage/ChatInput.jsx
+++ b/src/frontend/src/pages/ChatPage/ChatInput.jsx
@@ -235,7 +235,7 @@ export default function ChatInput() {
           ref={fileInputRef}
           type="file"
           className="hidden"
-          accept=".pdf,.docx,.doc,.txt,.md,.html,.pptx,.xlsx"
+          accept=".pdf,.docx,.doc,.txt,.md,.html,.pptx,.xlsx,.png,.jpg,.jpeg"
           onChange={handleFileChange}
           multiple
         />

--- a/src/frontend/src/pages/ChatPage/ChatMessages.jsx
+++ b/src/frontend/src/pages/ChatPage/ChatMessages.jsx
@@ -85,9 +85,13 @@ export default function ChatMessages() {
                         })
                       </span>
                     )}
-                    {att.status === 'completed'
-                      ? <CheckCircle className="w-3 h-3 flex-shrink-0" aria-hidden="true" />
-                      : <AlertCircle className="w-3 h-3 flex-shrink-0" aria-hidden="true" />
+                    {att.indexing
+                      ? <Loader className="w-3 h-3 flex-shrink-0 animate-spin" aria-hidden="true" title={t('chat.documentIndexing')} />
+                      : att.indexed
+                        ? <span className="inline-flex items-center px-1 rounded text-[9px] font-semibold bg-green-200 text-green-900 dark:bg-green-800 dark:text-green-100" title={t('chat.documentIndexed')}>KB</span>
+                        : att.status === 'completed'
+                          ? <CheckCircle className="w-3 h-3 flex-shrink-0" aria-hidden="true" />
+                          : <AlertCircle className="w-3 h-3 flex-shrink-0" aria-hidden="true" />
                     }
                     <AttachmentQuickActions
                       attachment={att}

--- a/src/frontend/src/pages/ChatPage/hooks/useChatWebSocket.js
+++ b/src/frontend/src/pages/ChatPage/hooks/useChatWebSocket.js
@@ -19,6 +19,9 @@ export function useChatWebSocket({
   onAction,
   onRagContext,
   onIntentFeedbackRequest,
+  onDocumentProcessing,
+  onDocumentReady,
+  onDocumentError,
 } = {}) {
   const [wsConnected, setWsConnected] = useState(false);
   const wsRef = useRef(null);
@@ -60,6 +63,15 @@ export function useChatWebSocket({
         // Proaktives Feedback vom Backend
         debug.log('Intent feedback request:', data.detected_intent);
         onIntentFeedbackRequest?.(data);
+      } else if (data.type === 'document_processing') {
+        debug.log('Document processing:', data.filename);
+        onDocumentProcessing?.(data);
+      } else if (data.type === 'document_ready') {
+        debug.log('Document ready:', data.filename, 'doc_id:', data.document_id);
+        onDocumentReady?.(data);
+      } else if (data.type === 'document_error') {
+        debug.log('Document error:', data.filename, data.error);
+        onDocumentError?.(data);
       }
     };
 
@@ -75,7 +87,7 @@ export function useChatWebSocket({
     };
 
     wsRef.current = ws;
-  }, [onStreamChunk, onStreamDone, onAction, onRagContext, onIntentFeedbackRequest]);
+  }, [onStreamChunk, onStreamDone, onAction, onRagContext, onIntentFeedbackRequest, onDocumentProcessing, onDocumentReady, onDocumentError]);
 
   // Connect on mount, cleanup on unmount
   useEffect(() => {

--- a/tests/frontend/react/pages/ChatUpload.test.jsx
+++ b/tests/frontend/react/pages/ChatUpload.test.jsx
@@ -139,6 +139,19 @@ describe('Chat Upload', () => {
     });
   });
 
+  it('accepts image file types', async () => {
+    renderWithProviders(<ChatPage />);
+
+    await waitFor(() => {
+      const fileInput = document.querySelector('input[type="file"]');
+      expect(fileInput).toBeTruthy();
+      const accept = fileInput.getAttribute('accept');
+      expect(accept).toContain('.png');
+      expect(accept).toContain('.jpg');
+      expect(accept).toContain('.jpeg');
+    });
+  });
+
   it('renders attachment chips from loaded history', async () => {
     // Mock a conversation with attachments in history
     const sessionId = 'session-with-attachments';


### PR DESCRIPTION
## Summary
- **WebSocket notifications** for background RAG indexing: `document_processing`, `document_ready`, `document_error` messages pushed to connected chat sessions in real-time
- **OCR image upload support**: PNG/JPG/JPEG added to allowed extensions, file input accept attribute, and email MIME types
- **Connection registry** in `shared.py` with auto-cleanup of dead connections
- **Frontend indicators**: spinning loader during indexing, green "KB" badge when indexed
- **i18n**: German + English translations for indexing status

Closes the remaining gaps from #101 (Chat Document Upload).

## Test plan
- [x] 5 unit tests for WS connection registry (register, unregister, notify, unknown session, dead connection)
- [x] 2 backend tests for PNG/JPG upload acceptance
- [x] 1 frontend test for image file type acceptance in file input
- [x] `ruff check` passes on all changed backend files
- [x] All 7 backend unit tests pass
- [x] All 11 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)