### PR TITLE
fix(chat): Auto-index, quick actions menu & email account param (#101)

### DIFF
--- a/src/backend/api/routes/chat_upload.py
+++ b/src/backend/api/routes/chat_upload.py
@@ -339,6 +339,7 @@ async def forward_via_email(
         mcp_result = await manager.execute_tool(
             "mcp.email.send_email",
             {
+                "account": settings.chat_upload_email_account,
                 "to": email_request.to,
                 "subject": subject,
                 "body": body,

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -164,10 +164,11 @@ class Settings(BaseSettings):
     max_file_size_mb: int = Field(default=50, ge=1, le=500)
     allowed_extensions: str = "pdf,docx,doc,txt,md,html,pptx,xlsx,png,jpg,jpeg"  # Comma-separated
     chat_upload_max_context_chars: int = Field(default=50000, ge=1000, le=200000)
-    chat_upload_auto_index: bool = False
+    chat_upload_auto_index: bool = True
     chat_upload_default_kb_name: str = "Chat Uploads"
     chat_upload_retention_days: int = Field(default=30, ge=1, le=365)
     chat_upload_cleanup_enabled: bool = False
+    chat_upload_email_account: str = "regfish"
 
     # Monitoring
     metrics_enabled: bool = False  # Enable Prometheus /metrics endpoint

--- a/src/frontend/src/pages/ChatPage/AttachmentQuickActions.jsx
+++ b/src/frontend/src/pages/ChatPage/AttachmentQuickActions.jsx
@@ -101,7 +101,7 @@ export default function AttachmentQuickActions({
       )}
 
       {open && (
-        <div className="absolute bottom-full right-0 mb-1 w-48 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg z-50 py-1">
+        <div className="absolute top-full right-0 mt-1 w-48 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg z-50 py-1">
           {/* Add to KB */}
           <button
             onClick={handleAddToKb}

--- a/tests/backend/test_chat_upload.py
+++ b/tests/backend/test_chat_upload.py
@@ -740,6 +740,7 @@ class TestChatUploadEmail:
             mock_manager.execute_tool.assert_called_once()
             call_args = mock_manager.execute_tool.call_args
             assert call_args[0][0] == "mcp.email.send_email"
+            assert call_args[0][1]["account"] == "regfish"
             assert call_args[0][1]["to"] == "user@example.com"
             assert call_args[0][1]["subject"] == "Document: report.pdf"
             assert len(call_args[0][1]["attachments"]) == 1


### PR DESCRIPTION
## Summary
- **Auto-Index default → True**: `chat_upload_auto_index` was `False`, so uploaded documents were never indexed into the KB. The entire Phase-5 WS notification infrastructure depends on this being enabled.
- **Quick Actions menu clipping**: Dropdown opened upward (`bottom-full`) and got clipped by parent `overflow-y-auto`. Changed to open downward (`top-full`) where there's always space.
- **Email forward 502**: MCP `send_email` requires `account` as a mandatory parameter. Added `chat_upload_email_account` config setting (default: `regfish`) and pass it in the `execute_tool` call.

## Test plan
- [ ] `ruff check` passes on changed backend files
- [ ] `test_email_success` asserts `account == "regfish"` in MCP call
- [ ] E2E: Upload a document → verify it auto-indexes into KB
- [ ] E2E: Quick actions menu visible without clipping
- [ ] E2E: Email forward returns 200 instead of 502

🤖 Generated with [Claude Code](https://claude.com/claude-code)