### PR TITLE
fix(knowledge): MissingGreenlet crash in KB list endpoint (#101)

### DIFF
--- a/src/backend/api/routes/knowledge.py
+++ b/src/backend/api/routes/knowledge.py
@@ -589,7 +589,7 @@ async def list_knowledge_bases(
             is_public=kb.is_public if hasattr(kb, 'is_public') else False,
             owner_id=kb.owner_id if hasattr(kb, 'owner_id') else None,
             owner_username=owner_username,
-            document_count=getattr(kb, '_document_count', len(kb.documents) if kb.documents else 0),
+            document_count=getattr(kb, '_document_count', 0),
             created_at=kb.created_at.isoformat() if kb.created_at else "",
             updated_at=kb.updated_at.isoformat() if kb.updated_at else "",
             permission=perm


### PR DESCRIPTION
## Summary
- `GET /api/knowledge/bases` crashed with `MissingGreenlet` because the `document_count` fallback accessed `kb.documents` — a lazy-loaded relationship — inside an async context
- The `_document_count` transient attribute is always set by `rag_service.list_knowledge_bases()`, so the fallback to `0` is safe
- Found during E2E testing of the chat upload bugfixes

## Test plan
- [x] `curl -sk https://renfield.local/api/knowledge/bases` returns 200 with correct `document_count`
- [x] E2E browser test: Auto-Index KB check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)