### PR TITLE
fix(deploy): Missing prod volumes, aiosmtplib dep & email error detail (#101)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -106,10 +106,16 @@ services:
       - mail_regfish_password
     volumes:
       - ./src/backend:/app
+      - ./src/satellite:/app/satellite  # For OTA update package building
       - ./tests:/tests
       - ./pytest.ini:/pytest.ini
+      - ./config/mcp_servers.yaml:/app/config/mcp_servers.yaml:ro
+      - ./config/agent_roles.yaml:/app/config/agent_roles.yaml:ro
+      - ./config/mail_accounts.yaml:/config/mail_accounts.yaml:ro
+      - ./data/wakeword-models:/app/wakeword-models:ro
       - whisper_models:/root/.cache/whisper
       - piper_models:/root/.local/share/piper
+      - huggingface_cache:/root/.cache/huggingface
       - rag_uploads:/app/data/uploads
     depends_on:
       postgres:
@@ -157,10 +163,16 @@ services:
       - mail_regfish_password
     volumes:
       - ./src/backend:/app
+      - ./src/satellite:/app/satellite
       - ./tests:/tests
       - ./pytest.ini:/pytest.ini
+      - ./config/mcp_servers.yaml:/app/config/mcp_servers.yaml:ro
+      - ./config/agent_roles.yaml:/app/config/agent_roles.yaml:ro
+      - ./config/mail_accounts.yaml:/config/mail_accounts.yaml:ro
+      - ./data/wakeword-models:/app/wakeword-models:ro
       - whisper_models:/root/.cache/whisper
       - piper_models:/root/.local/share/piper
+      - huggingface_cache:/root/.cache/huggingface
       - rag_uploads:/app/data/uploads
     depends_on:
       postgres:
@@ -240,6 +252,7 @@ volumes:
   ollama_data:
   whisper_models:
   piper_models:
+  huggingface_cache:
   rag_uploads:
 
 secrets:

--- a/src/backend/api/routes/chat_upload.py
+++ b/src/backend/api/routes/chat_upload.py
@@ -355,7 +355,11 @@ async def forward_via_email(
         raise HTTPException(status_code=502, detail=f"Email forwarding failed: {e}")
 
     if not mcp_result or not mcp_result.get("success"):
-        raise HTTPException(status_code=502, detail="Email forwarding failed")
+        logger.error(f"Email forward MCP result: {mcp_result}")
+        detail = "Email forwarding failed"
+        if mcp_result and mcp_result.get("message"):
+            detail = f"Email forwarding failed: {mcp_result['message']}"
+        raise HTTPException(status_code=502, detail=detail)
 
     return EmailForwardResponse(
         success=True,

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -75,6 +75,7 @@ jsonschema>=4.21.0            # JSON Schema validation for MCP tool inputs
 renfield-mcp-weather @ https://github.com/ebongard/renfield_mcp_weather/archive/refs/heads/main.tar.gz
 renfield-mcp-paperless @ https://github.com/ebongard/renfield-mcp-paperless/archive/refs/heads/main.tar.gz
 renfield-mcp-mail @ https://github.com/ebongard/renfield-mcp-mail/archive/refs/heads/main.tar.gz
+aiosmtplib>=3.0                  # Required by renfield-mcp-mail (not auto-resolved from archive installs)
 renfield-mcp-jellyfin @ https://github.com/ebongard/renfield-mcp-jellyfin/archive/refs/heads/main.tar.gz
 
 # Monitoring & Logging


### PR DESCRIPTION
## Summary
- **Missing volume mounts** in `docker-compose.prod.yml`: `mail_accounts.yaml`, `mcp_servers.yaml`, `agent_roles.yaml`, `satellite`, `wakeword-models`, `huggingface_cache` — synced with `docker-compose.yml`
- **aiosmtplib missing**: `renfield-mcp-mail` declares it as a dependency but pip doesn't resolve it from archive installs. Added explicitly to `requirements.txt`.
- **Email error logging**: Forward failures now log the MCP result and include the error message in the 502 response detail.

## Test plan
- [x] E2E browser test: 11/11 passed on production
- [x] Email forward returns 200 (was 502 due to missing `aiosmtplib` + missing `account`)
- [x] KB list endpoint returns 200 (was 500 due to MissingGreenlet)
- [x] Auto-index creates "Chat Uploads" KB with documents
- [x] Quick actions menu opens downward, fully visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)