### PR TITLE
fix(rag): Migrate embedding vectors 768→2560 for qwen3-embedding (#101)

### DIFF
--- a/src/backend/alembic/versions/cce1984705df_resize_embedding_vectors_768_to_2560.py
+++ b/src/backend/alembic/versions/cce1984705df_resize_embedding_vectors_768_to_2560.py
@@ -1,0 +1,41 @@
+"""resize_embedding_vectors_768_to_2560
+
+Revision ID: cce1984705df
+Revises: w6x7y8z9a0b1
+Create Date: 2026-02-10 13:34:52.595443
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'cce1984705df'
+down_revision: Union[str, None] = 'w6x7y8z9a0b1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# All tables with embedding Vector columns
+TABLES = [
+    "document_chunks",
+    "intent_corrections",
+    "notifications",
+    "notification_suppressions",
+    "conversation_memories",
+]
+
+
+def upgrade() -> None:
+    # Resize all embedding columns from vector(768) to vector(2560).
+    # Existing embeddings become invalid and must be re-generated via /admin/reembed.
+    for table in TABLES:
+        # Drop old data — dimensions are incompatible, re-embed is required anyway
+        op.execute(f"UPDATE {table} SET embedding = NULL WHERE embedding IS NOT NULL")
+        op.execute(f"ALTER TABLE {table} ALTER COLUMN embedding TYPE vector(2560)")
+
+
+def downgrade() -> None:
+    for table in TABLES:
+        op.execute(f"UPDATE {table} SET embedding = NULL WHERE embedding IS NOT NULL")
+        op.execute(f"ALTER TABLE {table} ALTER COLUMN embedding TYPE vector(768)")


### PR DESCRIPTION
## Summary
- Embedding model was changed to `qwen3-embedding:4b` (2560 dims) but pgvector columns remained at 768 dims
- All document indexing silently failed with `expected 768 dimensions, not 2560`
- Alembic migration resizes all 5 embedding Vector columns and NULLs incompatible data
- After migration: `EMBEDDING_DIMENSION=2560` in `.env` + `/admin/reembed` required

## Test plan
- [x] Migration runs successfully on production
- [x] Documents reindex with 2560-dim embeddings (status: completed)
- [x] `/admin/reembed` re-embeds notifications (3 processed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)