### PR TITLE
fix(rag): NULL chat_uploads FK before deleting document (#101)

### DIFF
--- a/src/backend/services/rag_service.py
+++ b/src/backend/services/rag_service.py
@@ -687,6 +687,12 @@ class RAGService:
         except Exception as e:
             logger.warning(f"Konnte Datei nicht löschen: {e}")
 
+        # Lösche FK-Referenzen aus chat_uploads
+        await self.db.execute(
+            text("UPDATE chat_uploads SET document_id = NULL WHERE document_id = :doc_id"),
+            {"doc_id": document_id}
+        )
+
         # Lösche zuerst die Chunks (explizit, falls CASCADE nicht greift)
         chunk_stmt = delete(DocumentChunk).where(DocumentChunk.document_id == document_id)
         await self.db.execute(chunk_stmt)


### PR DESCRIPTION
## Summary
- Deleting a document that was auto-indexed from a chat upload failed with `ForeignKeyViolationError` because `chat_uploads.document_id` references `documents.id` without CASCADE
- Fix: NULL out `chat_uploads.document_id` before deleting the document in `RAGService.delete_document()`
- Added unit test covering the FK cleanup scenario

## Test plan
- [x] `ruff check` passes
- [x] Unit test `TestDeleteDocumentFKCleanup::test_delete_document_nulls_chat_upload_fk` passes
- [ ] E2E: Upload doc via chat → auto-index → delete from KB → should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)