### PR TITLE
fix(mcp): Pass SEARXNG_INSTANCES env to stdio subprocess (#101)

### DIFF
--- a/config/mcp_servers.yaml
+++ b/config/mcp_servers.yaml
@@ -60,6 +60,8 @@ servers:
     refresh_interval: 300
     example_intent: mcp.search.web_search
     # No prompt_tools filter — search has only 1 tool
+    env:
+      SEARXNG_INSTANCES: "${SEARXNG_INSTANCES:-http://localhost:8080}"
     examples:
       de:
         - "Suche im Web nach Python Tutorials"


### PR DESCRIPTION
## Summary
- SearXNG web search returned no results because the MCP stdio subprocess didn't receive the `SEARXNG_INSTANCES` env var
- `mcp_client.py` uses an env whitelist for stdio subprocesses — `SEARXNG_INSTANCES` was filtered out
- The SearXNG MCP server fell back to its default `http://localhost:8080`, which is unreachable inside the Docker container
- Fix: Add `env: { SEARXNG_INSTANCES }` to the search server config in `mcp_servers.yaml`

## Test plan
- [x] SearXNG reachable from container via `curl http://cuda.local:3002/search?q=test&format=json`
- [x] WebSocket search query "Was läuft im Kino in Neuss am kommenden Wochenende?" returns UCI Kinowelt results
- [x] No more `ECONNREFUSED localhost:8080` in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)