### PR TITLE
fix(mcp): Enable correct HA tools — replace non-existent HassGetState/HassSetValue (#101)

### DIFF
--- a/config/mcp_servers.yaml
+++ b/config/mcp_servers.yaml
@@ -241,13 +241,15 @@ servers:
     auth_token_env: HOME_ASSISTANT_TOKEN
     enabled: "${HA_MCP_ENABLED:-false}"
     refresh_interval: 600
-    example_intent: mcp.homeassistant.HassTurnOn
+    example_intent: mcp.homeassistant.GetLiveContext
     prompt_tools:
       - HassTurnOn
       - HassTurnOff
-      - HassGetState
-      - HassSetValue
       - HassLightSet
+      - GetLiveContext
+      - HassSetPosition
+      - HassMediaSearchAndPlay
+      - HassSetVolume
     examples:
       de:
         - "Schalte das Licht im Wohnzimmer ein"

--- a/src/backend/config/mcp_servers.yaml
+++ b/src/backend/config/mcp_servers.yaml
@@ -194,13 +194,15 @@ servers:
     auth_token_env: HOME_ASSISTANT_TOKEN
     enabled: "${HA_MCP_ENABLED:-false}"
     refresh_interval: 600
-    example_intent: mcp.homeassistant.HassTurnOn
+    example_intent: mcp.homeassistant.GetLiveContext
     prompt_tools:
       - HassTurnOn
       - HassTurnOff
-      - HassGetState
-      - HassSetValue
       - HassLightSet
+      - GetLiveContext
+      - HassSetPosition
+      - HassMediaSearchAndPlay
+      - HassSetVolume
     examples:
       de:
         - "Schalte das Licht im Wohnzimmer ein"

--- a/src/backend/prompts/agent.yaml
+++ b/src/backend/prompts/agent.yaml
@@ -83,7 +83,7 @@ de:
     - "Deckenlicht Kueche aus" → HassTurnOff mit {{"name": "Deckenlicht Kueche"}}
     - Wenn kein Raum im Befehl UND kein Raum-Kontext → nutze nur "domain" ohne "area"
     - Fuer Helligkeiten/Farben: Nutze HassLightSet mit "area"+"domain" oder "name"
-    - Fuer Sensorwerte: Nutze HassGetState mit "name" und optional "area"
+    - Fuer Sensorwerte: Nutze GetLiveContext mit "name" und optional "area"
     - Uebergib NIEMALS "device_class"
     - Die finale Antwort muss natuerlich und auf Deutsch sein
     - Antworte NUR mit JSON
@@ -431,7 +431,7 @@ en:
     - "Kitchen ceiling light off" → HassTurnOff with {{"name": "Kitchen Ceiling Light"}}
     - If no room in command AND no room context → use only "domain" without "area"
     - For brightness/colors: Use HassLightSet with "area"+"domain" or "name"
-    - For sensor values: Use HassGetState with "name" and optionally "area"
+    - For sensor values: Use GetLiveContext with "name" and optionally "area"
     - NEVER pass "device_class"
     - The final answer must be natural and in English
     - Reply ONLY with JSON


### PR DESCRIPTION
## Summary

- HA MCP server exposes 21 tools, but `prompt_tools` referenced `HassGetState` and `HassSetValue` which **don't exist** in HA's built-in MCP server
- Only 3/5 configured tools matched (HassTurnOn, HassTurnOff, HassLightSet) — no tool for reading sensor values
- Queries like "Wie warm ist es im Wohnzimmer?" failed: agent correctly reported "kein passendes Tool fehlt"
- Now enables **7 actual tools**: HassTurnOn, HassTurnOff, HassLightSet, GetLiveContext, HassSetPosition, HassMediaSearchAndPlay, HassSetVolume
- Updates agent prompt to reference `GetLiveContext` instead of `HassGetState`

## Test plan

- [ ] Deploy to production, verify `homeassistant connected: 7/21 tools (filtered)`
- [ ] Ask "Wie warm ist es im Wohnzimmer?" — should return actual temperature
- [ ] Ask "Schalte das Licht ein" — still works (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)