### PR TITLE
fix(agent): Fix router misclassification & resolve short tool names (#101)

### DIFF
--- a/config/agent_roles.yaml
+++ b/config/agent_roles.yaml
@@ -15,8 +15,8 @@
 roles:
   smart_home:
     description:
-      de: "Smart Home: Licht, Schalter, Sensoren, Heizung, Szenen steuern (NICHT Musik/Medien abspielen)"
-      en: "Smart home: control lights, switches, sensors, heating, scenes (NOT playing music/media)"
+      de: "Smart Home: Licht, Schalter, Sensoren, Heizung, Szenen steuern, Temperatur/Luftfeuchte in Raeumen abfragen (NICHT Musik/Medien, NICHT Aussenwetter)"
+      en: "Smart home: control lights, switches, sensors, heating, scenes, query temperature/humidity in rooms (NOT music/media, NOT outdoor weather)"
     mcp_servers: [homeassistant]
     internal_tools: [internal.resolve_room_player, internal.play_in_room]
     max_steps: 4
@@ -25,8 +25,8 @@ roles:
 
   research:
     description:
-      de: "Recherche: Websuche, Nachrichten, Wetterdaten"
-      en: "Research: web search, news, weather data"
+      de: "Recherche: Websuche, Nachrichten, Aussenwetter/Wettervorhersage (NICHT Raumtemperatur)"
+      en: "Research: web search, news, outdoor weather/forecast (NOT room temperature)"
     mcp_servers: [search, news, weather]
     max_steps: 6
     prompt_key: agent_prompt_research

--- a/src/backend/prompts/router.yaml
+++ b/src/backend/prompts/router.yaml
@@ -14,6 +14,10 @@ de:
     KATEGORIEN:
     {role_descriptions}
 
+    WICHTIG: Wenn nach Temperatur, Luftfeuchte oder Sensorwerten in einem RAUM gefragt wird
+    (z.B. Kueche, Wohnzimmer, Buero, Schlafzimmer), ist das IMMER smart_home (nicht research).
+    research ist NUR fuer Aussenwetter und Wettervorhersagen.
+
     Antworte NUR mit JSON: {{"role": "<kategorie>", "reason": "..."}}
 
   # Conversation history context template
@@ -33,6 +37,10 @@ en:
 
     CATEGORIES:
     {role_descriptions}
+
+    IMPORTANT: When asking about temperature, humidity or sensor values in a ROOM
+    (e.g. kitchen, living room, office, bedroom), this is ALWAYS smart_home (not research).
+    research is ONLY for outdoor weather and weather forecasts.
 
     Reply ONLY with JSON: {{"role": "<category>", "reason": "..."}}
 

--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -694,8 +694,9 @@ class AgentService:
                 )
                 return
 
-            # Validate tool name
-            if not self.tool_registry.is_valid_tool(action):
+            # Validate and resolve tool name (supports short names from small LLMs)
+            resolved = self.tool_registry.resolve_tool_name(action)
+            if not resolved:
                 logger.warning(f"⚠️ Agent step {step_num}: Invalid tool '{action}'")
                 error_content = f"Unknown tool: {action}" if lang == "en" else f"Unbekanntes Tool: {action}"
                 error_step = AgentStep(
@@ -708,6 +709,9 @@ class AgentService:
                 yield error_step
                 # Continue loop — LLM will see the error in history
                 continue
+            if resolved != action:
+                logger.info(f"🔧 Agent step {step_num}: Resolved '{action}' → '{resolved}'")
+                action = resolved
 
             parameters = parsed.get("parameters", {})
             reason = parsed.get("reason", "")


### PR DESCRIPTION
## Summary

- **Router misclassification:** "Wie warm ist es in der Küche?" was classified as `research` (weather) instead of `smart_home` (sensor). Clarified role descriptions and added disambiguation rule to router prompt
- **Short tool name resolution:** Small LLMs (qwen3:8b) emit `GetLiveContext` instead of `mcp.homeassistant.GetLiveContext`. Added `resolve_tool_name()` with unambiguous suffix-match fallback

## Changes

| File | Change |
|------|--------|
| `config/agent_roles.yaml` | `smart_home` mentions "Temperatur in Räumen", `research` says "Außenwetter" |
| `src/backend/prompts/router.yaml` | Disambiguation rule: room temp → smart_home, outdoor weather → research |
| `src/backend/services/agent_tools.py` | `resolve_tool_name()` with suffix-match fallback |
| `src/backend/services/agent_service.py` | Use `resolve_tool_name()` before validation |
| `tests/backend/test_agent_tools.py` | 5 tests for resolve (exact, short, ambiguous, unknown, is_valid) |

## Test plan

- [x] 5 unit tests pass for `resolve_tool_name()`
- [x] "Wie warm ist es in der Küche?" → `smart_home` (was: `research`)
- [x] "Wie warm ist es im Wohnzimmer?" → `smart_home` (unchanged)
- [x] `GetLiveContext` → resolved to `mcp.homeassistant.GetLiveContext`
- [x] Deployed and verified on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)