### PR TITLE
feat(wakeword): Activate Hey Renfield as default wake word

### DIFF
--- a/src/backend/services/wakeword_config_manager.py
+++ b/src/backend/services/wakeword_config_manager.py
@@ -31,6 +31,11 @@ from utils.config import settings
 # Available wake word keywords with their metadata
 AVAILABLE_KEYWORDS = [
     {
+        "id": "hey_renfield",
+        "label": "Hey Renfield",
+        "description": "Custom trained wake word (ONNX)"
+    },
+    {
         "id": "alexa",
         "label": "Alexa",
         "description": "Pre-trained wake word (32-bit ONNX, recommended)"

--- a/src/backend/services/wakeword_service.py
+++ b/src/backend/services/wakeword_service.py
@@ -33,6 +33,7 @@ class WakeWordService:
 
     # Available wake word models
     AVAILABLE_KEYWORDS = [
+        "hey_renfield",
         "hey_jarvis",
         "alexa",
         "hey_mycroft",

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -95,7 +95,7 @@ class Settings(BaseSettings):
 
     # Wake Word Detection
     wake_word_enabled: bool = False  # Disabled by default (opt-in)
-    wake_word_default: str = "alexa"  # Default wake word for satellites (alexa has 32-bit ONNX model)
+    wake_word_default: str = "hey_renfield"  # Default wake word
     wake_word_threshold: float = 0.5
     wake_word_cooldown_ms: int = 2000
 

--- a/src/frontend/src/config/wakeword.ts
+++ b/src/frontend/src/config/wakeword.ts
@@ -61,6 +61,12 @@ export const WAKEWORD_CONFIG: WakeWordConfigType = {
   // Add custom trained models here (e.g., hey_renfield.onnx)
   availableKeywords: [
     {
+      id: 'hey_renfield',
+      label: 'Hey Renfield',
+      model: 'hey_renfield.onnx',
+      description: 'Custom trained wake word'
+    },
+    {
       id: 'hey_jarvis',
       label: 'Hey Jarvis',
       model: 'hey_jarvis_v0.1.onnx',
@@ -78,19 +84,12 @@ export const WAKEWORD_CONFIG: WakeWordConfigType = {
       model: 'hey_mycroft_v0.1.onnx',
       description: 'Pre-trained wake word'
     },
-    // Uncomment after training custom model:
-    // {
-    //   id: 'hey_renfield',
-    //   label: 'Hey Renfield',
-    //   model: 'hey_renfield.onnx',
-    //   description: 'Custom trained wake word'
-    // },
   ],
 
   // Default settings
   defaults: {
     enabled: false,           // Disabled by default (opt-in for privacy)
-    keyword: 'hey_jarvis',    // Default wake word
+    keyword: 'hey_renfield',  // Default wake word
     threshold: 0.5,           // Detection sensitivity (0.0 - 1.0)
     cooldownMs: 2000,         // Minimum ms between detections
     audioFeedback: true,      // Play sound on detection

--- a/src/satellite/provisioning/group_vars/satellites.yml
+++ b/src/satellite/provisioning/group_vars/satellites.yml
@@ -22,7 +22,7 @@ server_auth_enabled: false
 server_verify_tls: false
 
 # Wake word
-wakeword_model: "alexa"
+wakeword_model: "hey_renfield"
 wakeword_threshold: 0.5
 
 # VAD


### PR DESCRIPTION
## Summary

- Register `hey_renfield` as available keyword in backend config manager and wakeword service
- Change default wake word from `alexa` to `hey_renfield` (backend, frontend, satellite provisioning)
- Add ONNX model support to backend download endpoint (was hardcoded to `.tflite`)
- Update satellite model downloader to read file extension from `Content-Disposition` header

## Notes

The `hey_renfield.onnx` model file (206KB) must be placed in `data/wakeword-models/` manually on the server — it is not tracked in git. Satellites auto-download it on reconnect via WebSocket config push + HTTP download.

## Test plan

- [ ] `ruff check` passes on changed backend files
- [ ] `pytest -k wakeword` — 55 unit tests pass
- [ ] `curl /api/settings/wakeword/models` returns `hey_renfield` with `available: true`
- [ ] Frontend build succeeds
- [ ] Satellite reconnects and downloads `hey_renfield.onnx` automatically

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)