### PR TITLE
feat(rooms): Add delete button for offline devices (#128)

### DIFF
--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -238,7 +238,9 @@
     "exportResult": "Export: {{exported}} neu erstellt, {{linked}} verknüpft",
     "syncResult": "Sync: {{imported}} importiert, {{exported}} exportiert",
     "haAreasCount": "Home Assistant Areas ({{count}})",
-    "haNotConnected": "Keine HA Areas gefunden. Ist Home Assistant verbunden?"
+    "haNotConnected": "Keine HA Areas gefunden. Ist Home Assistant verbunden?",
+    "deleteDevice": "Gerät entfernen?",
+    "deleteDeviceConfirm": "Möchtest du \"{{name}}\" wirklich entfernen?"
   },
   "speakers": {
     "title": "Sprechererkennung",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -238,7 +238,9 @@
     "exportResult": "Export: {{exported}} created, {{linked}} linked",
     "syncResult": "Sync: {{imported}} imported, {{exported}} exported",
     "haAreasCount": "Home Assistant Areas ({{count}})",
-    "haNotConnected": "No HA areas found. Is Home Assistant connected?"
+    "haNotConnected": "No HA areas found. Is Home Assistant connected?",
+    "deleteDevice": "Delete device?",
+    "deleteDeviceConfirm": "Do you really want to remove \"{{name}}\"?"
   },
   "speakers": {
     "title": "Speaker Recognition",

--- a/src/frontend/src/pages/RoomsPage.jsx
+++ b/src/frontend/src/pages/RoomsPage.jsx
@@ -255,6 +255,26 @@ export default function RoomsPage() {
     }
   };
 
+  const deleteDevice = async (device) => {
+    const confirmed = await confirm({
+      title: t('rooms.deleteDevice'),
+      message: t('rooms.deleteDeviceConfirm', { name: device.device_name || device.device_id }),
+      confirmLabel: t('common.delete'),
+      cancelLabel: t('common.cancel'),
+      variant: 'danger',
+    });
+
+    if (!confirmed) return;
+
+    try {
+      await apiClient.delete(`/api/rooms/devices/${device.device_id}`);
+      loadRooms();
+    } catch (err) {
+      console.error('Failed to delete device:', err);
+      setError(t('common.error'));
+    }
+  };
+
   const openEditModal = (room) => {
     setSelectedRoom(room);
     setEditRoomName(room.name);
@@ -431,6 +451,15 @@ export default function RoomsPage() {
                             <span className={device.is_online ? 'text-green-600 dark:text-green-400' : 'text-gray-500'}>
                               {device.is_online ? t('common.online') : t('common.offline')}
                             </span>
+                            {!device.is_online && (
+                              <button
+                                onClick={() => deleteDevice(device)}
+                                className="p-0.5 rounded hover:bg-red-100 dark:hover:bg-red-600/20 text-red-400 hover:text-red-600 dark:hover:text-red-400"
+                                aria-label={t('rooms.deleteDevice')}
+                              >
+                                <Trash2 className="w-3 h-3" aria-hidden="true" />
+                              </button>
+                            )}
                           </div>
                         </div>
                       );


### PR DESCRIPTION
## Summary
- Add trash icon button for **offline** devices in room management cards
- Confirm dialog before deletion (reuses existing `useConfirmDialog` pattern)
- Calls existing `DELETE /api/rooms/devices/{device_id}` endpoint
- i18n keys added for DE + EN

## Test plan
- [ ] Open Rooms page, verify offline devices show a red trash icon
- [ ] Online devices should NOT show the trash icon
- [ ] Click trash → confirm dialog appears with device name
- [ ] After confirming, device disappears from the list
- [ ] Cancel closes dialog without side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)