### PR TITLE
feat(calendar): Google Calendar integration via n8n MCP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,10 @@ HOME_ASSISTANT_URL=http://homeassistant.local:8123
 # N8N_API_URL=http://n8n.local:5678       # Used by n8n-mcp stdio subprocess
 # N8N_API_KEY=your_n8n_api_key            # n8n → Settings → API → Create API Key
 
+# Google Calendar (via n8n MCP Server Trigger)
+# CALENDAR_ENABLED=false
+# CALENDAR_MCP_URL=http://n8n:5678/mcp/calendar/sse
+
 # Email MCP (IMAP/SMTP via renfield-mcp-mail)
 # EMAIL_MCP_ENABLED=false
 # MAIL_ACCOUNTS_CONFIG=/config/mail_accounts.yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,7 +369,7 @@ All configuration via `.env`, loaded by `src/backend/utils/config.py` (Pydantic 
 - `RAG_HYBRID_ENABLED` — Enable Hybrid Search: Dense + BM25 via RRF (default: `true`)
 - `RAG_CONTEXT_WINDOW` — Adjacent chunks per direction for context expansion (default: `1`)
 - `MCP_ENABLED` — Master switch for MCP server integration (default: `false`)
-- Per-server toggles: `WEATHER_ENABLED`, `SEARCH_ENABLED`, `NEWS_ENABLED`, `JELLYFIN_ENABLED`, `N8N_MCP_ENABLED`, `HA_MCP_ENABLED`, `PAPERLESS_ENABLED`, `EMAIL_MCP_ENABLED`
+- Per-server toggles: `WEATHER_ENABLED`, `SEARCH_ENABLED`, `NEWS_ENABLED`, `JELLYFIN_ENABLED`, `N8N_MCP_ENABLED`, `HA_MCP_ENABLED`, `PAPERLESS_ENABLED`, `EMAIL_MCP_ENABLED`, `CALENDAR_ENABLED`
 - `MEMORY_CONTRADICTION_RESOLUTION` — LLM-based contradiction detection for memories (default: `false`, opt-in)
 - `METRICS_ENABLED` — Prometheus `/metrics` endpoint (default: `false`, opt-in)
 - `PLUGIN_MODULE` — Hook-based extension entry point (default: `""`, e.g. `"renfield_twin.hooks:register"`)

--- a/config/mcp_servers.yaml
+++ b/config/mcp_servers.yaml
@@ -232,6 +232,29 @@ servers:
         - "Search emails from Amazon"
         - "Send an email to max@example.com"
 
+  # --- Google Calendar MCP Server (via n8n) ---
+  # Uses n8n MCP Server Trigger workflow as calendar bridge.
+  # Requires: n8n "Calendar MCP Server" workflow active
+  - name: calendar
+    transport: sse
+    url: "${CALENDAR_MCP_URL:-http://n8n:5678/mcp/calendar/sse}"
+    enabled: "${CALENDAR_ENABLED:-false}"
+    refresh_interval: 300
+    example_intent: mcp.calendar.SearchEvent
+    prompt_tools:
+      - SearchEvent
+      - CreateEvent
+    examples:
+      de:
+        - "Was steht heute in meinem Kalender?"
+        - "Erstelle einen Termin morgen um 14 Uhr: Zahnarzt"
+        - "Bin ich morgen Nachmittag frei?"
+        - "Wann ist mein nächster Termin?"
+      en:
+        - "What's on my calendar today?"
+        - "Create an appointment tomorrow at 2 PM: Dentist"
+        - "Am I free tomorrow afternoon?"
+
   # --- Home Assistant MCP Server ---
   # Uses HA's built-in MCP server at /api/mcp
   # Requires: MCP Server integration enabled in HA

--- a/config/n8n-workflows/calendar-mcp-server.json
+++ b/config/n8n-workflows/calendar-mcp-server.json
@@ -1,0 +1,139 @@
+{
+  "name": "Calendar MCP Server",
+  "meta": {
+    "templateId": 3569,
+    "description": "MCP Server for Google Calendar — exposes SearchEvent, CreateEvent, UpdateEvent, DeleteEvent as MCP tools. Used by Renfield as calendar bridge via SSE transport.",
+    "notes": "Credential ID 'hsXFmEfCRMaamQeR' and calendar ID are instance-specific. Update after import."
+  },
+  "nodes": [
+    {
+      "id": "ec4aa55d-c6ee-4990-9c51-6ee1892600dd",
+      "name": "Google Calendar MCP",
+      "type": "@n8n/n8n-nodes-langchain.mcpTrigger",
+      "position": [400, 60],
+      "parameters": {
+        "path": "calendar"
+      },
+      "typeVersion": 1
+    },
+    {
+      "id": "42800020-7ed3-4419-9847-d2a751aa3071",
+      "name": "SearchEvent",
+      "type": "n8n-nodes-base.googleCalendarTool",
+      "position": [400, 260],
+      "parameters": {
+        "operation": "getAll",
+        "calendar": {
+          "__rl": true,
+          "mode": "id",
+          "value": "8hgqtcsiej7sucgg50ub3v1uss@group.calendar.google.com"
+        },
+        "timeMin": "={{ /*n8n-auto-generated-fromAI-override*/ $fromAI('After', ``, 'string') }}",
+        "timeMax": "={{ /*n8n-auto-generated-fromAI-override*/ $fromAI('Before', ``, 'string') }}",
+        "limit": "={{ /*n8n-auto-generated-fromAI-override*/ $fromAI('Limit', ``, 'number') }}",
+        "options": {}
+      },
+      "typeVersion": 1.3,
+      "credentials": {
+        "googleCalendarOAuth2Api": {
+          "id": "hsXFmEfCRMaamQeR",
+          "name": "Google Calendar account"
+        }
+      }
+    },
+    {
+      "id": "5d2bce57-f77d-4fd1-9342-d81107a6009d",
+      "name": "CreateEvent",
+      "type": "n8n-nodes-base.googleCalendarTool",
+      "position": [520, 260],
+      "parameters": {
+        "calendar": {
+          "__rl": true,
+          "mode": "id",
+          "value": "8hgqtcsiej7sucgg50ub3v1uss@group.calendar.google.com"
+        },
+        "start": "={{ /*n8n-auto-generated-fromAI-override*/ $fromAI('Start', ``, 'string') }}",
+        "end": "={{ /*n8n-auto-generated-fromAI-override*/ $fromAI('End', ``, 'string') }}",
+        "additionalFields": {
+          "summary": "={{ $fromAI(\"event_title\", \"The event title\", \"string\") }}",
+          "description": "={{ $fromAI(\"event_description\", \"The event description\", \"string\") }}"
+        }
+      },
+      "typeVersion": 1.3,
+      "credentials": {
+        "googleCalendarOAuth2Api": {
+          "id": "hsXFmEfCRMaamQeR",
+          "name": "Google Calendar account"
+        }
+      }
+    },
+    {
+      "id": "dbebec9c-fecc-4154-ba77-cfbb519ba40a",
+      "name": "UpdateEvent",
+      "type": "n8n-nodes-base.googleCalendarTool",
+      "position": [640, 260],
+      "parameters": {
+        "operation": "update",
+        "calendar": {
+          "__rl": true,
+          "mode": "id",
+          "value": "8hgqtcsiej7sucgg50ub3v1uss@group.calendar.google.com"
+        },
+        "eventId": "={{ /*n8n-auto-generated-fromAI-override*/ $fromAI('Event_ID', ``, 'string') }}",
+        "updateFields": {
+          "start": "={{ /*n8n-auto-generated-fromAI-override*/ $fromAI('Start', ``, 'string') }}",
+          "end": "={{ /*n8n-auto-generated-fromAI-override*/ $fromAI('End', ``, 'string') }}",
+          "summary": "={{ $fromAI(\"event_title\", \"The event title\", \"string\") }}",
+          "description": "={{ $fromAI(\"event_description\", \"The event description\", \"string\") }}"
+        }
+      },
+      "typeVersion": 1.3,
+      "credentials": {
+        "googleCalendarOAuth2Api": {
+          "id": "hsXFmEfCRMaamQeR",
+          "name": "Google Calendar account"
+        }
+      }
+    },
+    {
+      "id": "24ef1fd5-29dc-4208-a33b-5337307d01e0",
+      "name": "DeleteEvent",
+      "type": "n8n-nodes-base.googleCalendarTool",
+      "position": [760, 260],
+      "parameters": {
+        "operation": "delete",
+        "calendar": {
+          "__rl": true,
+          "mode": "id",
+          "value": "8hgqtcsiej7sucgg50ub3v1uss@group.calendar.google.com"
+        },
+        "eventId": "={{ /*n8n-auto-generated-fromAI-override*/ $fromAI('Event_ID', ``, 'string') }}",
+        "options": {}
+      },
+      "typeVersion": 1.3,
+      "credentials": {
+        "googleCalendarOAuth2Api": {
+          "id": "hsXFmEfCRMaamQeR",
+          "name": "Google Calendar account"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "SearchEvent": {
+      "ai_tool": [[{"node": "Google Calendar MCP", "type": "ai_tool", "index": 0}]]
+    },
+    "CreateEvent": {
+      "ai_tool": [[{"node": "Google Calendar MCP", "type": "ai_tool", "index": 0}]]
+    },
+    "UpdateEvent": {
+      "ai_tool": [[{"node": "Google Calendar MCP", "type": "ai_tool", "index": 0}]]
+    },
+    "DeleteEvent": {
+      "ai_tool": [[{"node": "Google Calendar MCP", "type": "ai_tool", "index": 0}]]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -741,6 +741,9 @@ PAPERLESS_ENABLED=true
 
 # Email (IMAP/SMTP)
 EMAIL_MCP_ENABLED=true
+
+# Calendar (Google Calendar via n8n)
+CALENDAR_ENABLED=true
 ```
 
 **Defaults:** Alle `false`
@@ -772,6 +775,9 @@ SEARXNG_API_URL=http://cuda.local:3002
 
 # Paperless-NGX URL
 PAPERLESS_API_URL=http://paperless.local:8000
+
+# Calendar MCP URL (n8n MCP Server Trigger)
+CALENDAR_MCP_URL=http://n8n:5678/mcp/calendar/sse
 ```
 
 **Hinweis:** In Produktion werden Secrets über Docker Compose File-Based Secrets bereitgestellt und von `mcp_client.py` automatisch in `os.environ` injiziert. Siehe `docs/SECRETS_MANAGEMENT.md`.

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -47,6 +47,7 @@ class Settings(BaseSettings):
     weather_enabled: bool = False
     news_enabled: bool = False
     search_enabled: bool = False
+    calendar_enabled: bool = False
 
     # Sprache
     default_language: str = "de"


### PR DESCRIPTION
## Summary

- Add Google Calendar integration using n8n MCP Server Trigger as bridge
- Calendar queries ("Was steht heute an?") and event management (create, update, delete) via existing MCP infrastructure
- No backend code changes — fully configuration-driven

## Changes

- **n8n Workflow** (`config/n8n-workflows/calendar-mcp-server.json`): MCP Trigger + 4 Google Calendar Tool nodes (SearchEvent, CreateEvent, UpdateEvent, DeleteEvent), exported for reproducibility
- **MCP Config** (`config/mcp_servers.yaml`): New `calendar` server entry (SSE transport, bilingual examples)
- **Settings** (`src/backend/utils/config.py`): `calendar_enabled: bool = False`
- **Docs**: `.env.example`, `ENVIRONMENT_VARIABLES.md`, `CLAUDE.md` updated

## Test plan

- [ ] n8n Workflow active, MCP Trigger on `/mcp/calendar`
- [ ] Backend logs: "MCP server 'calendar' connected, X tools discovered"
- [ ] Intent recognition: "Was steht heute an?" → `mcp.calendar.*`
- [ ] End-to-End: Chat lists calendar events
- [ ] 149 MCP/permissions/intent tests pass with no regressions

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)