### PR TITLE
feat(calendar): Add calendar visibility config and MCP permissions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,11 +324,13 @@ servers:
 **User-ID Propagation:** `user_id` flows through the entire execution chain for per-user filtering:
 - `chat_handler.py` → extracts `user_id` from JWT auth
 - `satellite_handler.py` → extracts `user_id` from Speaker→User FK lookup
-- `ActionExecutor.execute(intent_data, user_permissions=..., user_id=...)` → injects `_user_id` into MCP tool parameters
+- `ActionExecutor.execute(intent_data, user_permissions=..., user_id=...)` → injects `user_id` into MCP tool parameters
 - `AgentService.run(..., user_id=...)` → passes through to executor
 - `MCPManager.execute_tool(..., user_id=...)` → debug logging with user context
 
-MCP servers receive `_user_id` in their tool parameters and can use it for per-user filtering (e.g. calendar visibility). When `user_id` is `None` (no auth / unauthenticated), `_user_id` is not injected.
+MCP servers receive `user_id` in their tool parameters and can use it for per-user filtering (e.g. calendar visibility). When `user_id` is `None` (no auth / unauthenticated), `user_id` is not injected.
+
+**Calendar Visibility:** Per-user calendar filtering via `visibility`/`owner_id` fields in `config/calendar_accounts.yaml`. `visibility: shared` (default) = all users see it. `visibility: owner` + `owner_id: N` = only user N sees it. `user_id=None` (no auth / notification poller) = all calendars visible. Filtering happens in the calendar MCP server, not in Renfield backend. See `docs/ACCESS_CONTROL.md`.
 
 **Key files:** `models/permissions.py`, `services/auth_service.py`, `api/routes/auth.py`, `api/routes/roles.py`, `services/mcp_client.py`
 

--- a/config/calendar_accounts.yaml
+++ b/config/calendar_accounts.yaml
@@ -11,9 +11,12 @@
 calendars:
   # --- Exchange 2019 (Firmenkalender) ---
   # Direct EWS endpoint (no Autodiscover, no Microsoft 365)
+  # visibility: owner — only the owner (user_id 1) sees this calendar
   - name: work
     label: "Firmenkalender"
     type: ews
+    visibility: owner
+    owner_id: 1
     ews_url: "https://exchange2019.ionos.eu/EWS/Exchange.asmx"
     username_env: CALENDAR_WORK_USERNAME
     password_env: CALENDAR_WORK_PASSWORD
@@ -21,9 +24,11 @@ calendars:
   # --- Google Calendar (Familienkalender) ---
   # OAuth2 Desktop Flow — initial auth required once:
   #   docker exec -it renfield-backend python -m renfield_mcp_calendar --auth google
+  # visibility: shared (default) — all users see this calendar
   - name: family
     label: "Familienkalender"
     type: google
+    visibility: shared
     calendar_id: "primary"
     credentials_file: "/config/google_calendar_credentials.json"
     token_file: "/data/calendar/google_calendar_token.json"

--- a/config/mcp_servers.yaml
+++ b/config/mcp_servers.yaml
@@ -253,6 +253,17 @@ servers:
       - list_calendars
       - list_events
       - create_event
+    permissions:
+      - mcp.calendar.read
+      - mcp.calendar.manage
+    tool_permissions:
+      list_calendars: mcp.calendar.read
+      list_events: mcp.calendar.read
+      get_event: mcp.calendar.read
+      get_pending_notifications: mcp.calendar.read
+      create_event: mcp.calendar.manage
+      update_event: mcp.calendar.manage
+      delete_event: mcp.calendar.manage
     notifications:
       enabled: "${NOTIFICATION_POLLER_ENABLED:-false}"
       poll_interval: 900           # 15 minutes

--- a/src/backend/services/action_executor.py
+++ b/src/backend/services/action_executor.py
@@ -32,7 +32,7 @@ class ActionExecutor:
             }
             user_permissions: User's permission strings for MCP access control.
                 None means no auth / allow all (backwards-compatible).
-            user_id: Authenticated user ID. Passed to MCP tools as _user_id
+            user_id: Authenticated user ID. Passed to MCP tools as user_id
                 for per-user filtering (e.g. calendar visibility).
 
         Returns:
@@ -69,7 +69,7 @@ class ActionExecutor:
         if self.mcp_manager and intent.startswith("mcp."):
             logger.info(f"🔌 Executing MCP tool: {intent}")
             if user_id is not None:
-                parameters["_user_id"] = user_id
+                parameters["user_id"] = user_id
             return await self.mcp_manager.execute_tool(
                 intent, parameters, user_permissions=user_permissions,
                 user_id=user_id,

--- a/tests/backend/test_action_executor.py
+++ b/tests/backend/test_action_executor.py
@@ -303,16 +303,16 @@ class TestActionExecutorUserIdPropagation:
 
         await action_executor.execute(intent_data, user_id=42)
 
-        # Verify _user_id was injected into the parameters
+        # Verify user_id was injected into the parameters
         call_args = action_executor.mcp_manager.execute_tool.call_args
         params = call_args.args[1]  # second positional arg = arguments
-        assert params["_user_id"] == 42
+        assert params["user_id"] == 42
         assert params["calendar"] == "work"
         assert call_args.kwargs["user_id"] == 42
 
     @pytest.mark.unit
     async def test_no_user_id_means_no_injection(self, action_executor):
-        """Without user_id, _user_id is NOT added to parameters."""
+        """Without user_id, user_id is NOT added to parameters."""
         action_executor.mcp_manager.execute_tool.return_value = {
             "success": True,
             "message": "OK",
@@ -329,7 +329,7 @@ class TestActionExecutorUserIdPropagation:
 
         call_args = action_executor.mcp_manager.execute_tool.call_args
         params = call_args.args[1]
-        assert "_user_id" not in params
+        assert "user_id" not in params
 
     @pytest.mark.unit
     async def test_user_id_none_means_no_injection(self, action_executor):
@@ -350,7 +350,7 @@ class TestActionExecutorUserIdPropagation:
 
         call_args = action_executor.mcp_manager.execute_tool.call_args
         params = call_args.args[1]
-        assert "_user_id" not in params
+        assert "user_id" not in params
 
     @pytest.mark.unit
     async def test_user_id_not_injected_for_non_mcp(self):


### PR DESCRIPTION
## Summary
- Add `visibility: owner` + `owner_id: 1` to work calendar, `visibility: shared` to family calendar in `calendar_accounts.yaml`
- Add `permissions` and `tool_permissions` to calendar server in `mcp_servers.yaml` (read/manage split)
- Rename `_user_id` injection key to `user_id` in `ActionExecutor` (FastMCP rejects `_` prefix parameters)
- Document calendar visibility in `ACCESS_CONTROL.md` and `CLAUDE.md`

## Test plan
- [x] All 4 `TestActionExecutorUserIdPropagation` tests pass with renamed key
- [x] Calendar MCP server PR (renfield-mcp-calendar) tested separately with 56/56 passing
- [x] YAML configs valid
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)