### PR TITLE
feat(notifications): Add privacy-aware TTS delivery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,7 +287,12 @@ Room-level presence detection using BLE scanning from satellites. Satellites sca
 
 **API:** `GET /api/presence/rooms` (all rooms with occupants), `GET /api/presence/user/{id}` (user location + alone?), `POST /api/presence/devices` (admin: register BLE device). MAC whitelist pushed to satellites after registration.
 
-**Privacy:** `is_user_alone_in_room(user_id)` enables privacy-aware TTS decisions (e.g. confidential calendar reminders only when user is alone). Disabled by default (`PRESENCE_ENABLED=false`).
+**Privacy-Aware TTS Delivery:** Notifications carry `privacy` and `target_user_id` metadata. The privacy gate (`services/notification_privacy.py`) checks room occupancy before allowing TTS:
+- `public` — TTS always plays
+- `personal` — TTS only when all room occupants have household roles (`PRESENCE_HOUSEHOLD_ROLES`)
+- `confidential` — TTS only when the target user is completely alone in the room
+
+When `PRESENCE_ENABLED=false`, only `public` notifications get TTS. Web notifications are always delivered regardless of privacy level. Calendar MCP derives privacy from `visibility: owner` → `confidential`, `visibility: shared` → `personal`.
 
 ### Device Management
 
@@ -398,6 +403,7 @@ All configuration via `.env`, loaded by `src/backend/utils/config.py` (Pydantic 
 - `PRESENCE_ENABLED` — BLE-based room-level presence detection (default: `false`, opt-in)
 - `PRESENCE_STALE_TIMEOUT` — Seconds before user marked absent (default: `120`)
 - `PRESENCE_HYSTERESIS_SCANS` — Consecutive scans before room change (default: `2`)
+- `PRESENCE_HOUSEHOLD_ROLES` — Comma-separated role names considered household members for privacy TTS (default: `"Admin,Familie"`)
 - `METRICS_ENABLED` — Prometheus `/metrics` endpoint (default: `false`, opt-in)
 - `PLUGIN_MODULE` — Hook-based extension entry point (default: `""`, e.g. `"renfield_twin.hooks:register"`)
 

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -322,6 +322,7 @@ Siehe `docs/PROACTIVE_SCHEDULING_TEMPLATES.md` für fertige Templates.
 PRESENCE_ENABLED=false
 PRESENCE_STALE_TIMEOUT=120               # Sekunden bis Benutzer als abwesend markiert
 PRESENCE_HYSTERESIS_SCANS=2              # Aufeinanderfolgende Scans vor Raumwechsel
+PRESENCE_HOUSEHOLD_ROLES="Admin,Familie" # Rollen die als Haushaltsmitglieder gelten (für Privacy-TTS)
 ```
 
 **Satellite-Konfiguration** (in `satellite.yaml`):

--- a/src/backend/alembic/versions/c3d4e5f6g7h9_add_notification_privacy.py
+++ b/src/backend/alembic/versions/c3d4e5f6g7h9_add_notification_privacy.py
@@ -1,0 +1,31 @@
+"""add notification privacy columns
+
+Revision ID: c3d4e5f6g7h9
+Revises: b2c3d4e5f6g8
+Create Date: 2026-02-13 18:00:00.000000
+
+Privacy-aware TTS delivery: privacy level and target_user_id on notifications.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c3d4e5f6g7h9'
+down_revision: Union[str, None] = 'b2c3d4e5f6g8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('notifications', sa.Column('privacy', sa.String(20), server_default='public'))
+    op.add_column('notifications', sa.Column('target_user_id', sa.Integer(), sa.ForeignKey('users.id'), nullable=True))
+    op.create_index('ix_notifications_target_user_id', 'notifications', ['target_user_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_notifications_target_user_id', table_name='notifications')
+    op.drop_column('notifications', 'target_user_id')
+    op.drop_column('notifications', 'privacy')

--- a/src/backend/api/routes/notifications.py
+++ b/src/backend/api/routes/notifications.py
@@ -112,6 +112,8 @@ async def receive_webhook(
             tts=body.tts,
             data=body.data,
             enrich=body.enrich,
+            privacy=body.privacy,
+            target_user_id=body.target_user_id,
         )
         return WebhookResponse(**result)
     except ValueError as e:

--- a/src/backend/api/routes/notifications_schemas.py
+++ b/src/backend/api/routes/notifications_schemas.py
@@ -7,6 +7,9 @@ from pydantic import BaseModel, Field, field_validator
 VALID_URGENCIES = {"critical", "info", "low", "auto"}
 
 
+VALID_PRIVACY_LEVELS = {"public", "personal", "confidential"}
+
+
 class WebhookRequest(BaseModel):
     """Incoming webhook payload from HA automation."""
     event_type: str = Field(..., min_length=1, max_length=100)
@@ -17,12 +20,21 @@ class WebhookRequest(BaseModel):
     tts: bool | None = None
     data: dict | None = None
     enrich: bool = False
+    privacy: str = Field(default="public", max_length=20)
+    target_user_id: int | None = None
 
     @field_validator("urgency")
     @classmethod
     def validate_urgency(cls, v: str) -> str:
         if v not in VALID_URGENCIES:
             raise ValueError(f"urgency must be one of {VALID_URGENCIES}")
+        return v
+
+    @field_validator("privacy")
+    @classmethod
+    def validate_privacy(cls, v: str) -> str:
+        if v not in VALID_PRIVACY_LEVELS:
+            raise ValueError(f"privacy must be one of {VALID_PRIVACY_LEVELS}")
         return v
 
 

--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -806,8 +806,13 @@ class Notification(Base):
     original_message = Column(Text, nullable=True)
     urgency_auto = Column(Boolean, default=False)
 
+    # Privacy-aware TTS delivery
+    privacy = Column(String(20), default="public")
+    target_user_id = Column(Integer, ForeignKey("users.id"), nullable=True, index=True)
+
     # Relationships
     room = relationship("Room", foreign_keys=[room_id])
+    target_user = relationship("User", foreign_keys=[target_user_id])
 
 
 class NotificationSuppression(Base):

--- a/src/backend/services/notification_poller.py
+++ b/src/backend/services/notification_poller.py
@@ -187,6 +187,8 @@ class NotificationPollerService:
                     tts=notification.get("tts", True),
                     data=notification.get("data"),
                     source=f"mcp_poll:{server_name}",
+                    privacy=notification.get("privacy", "public"),
+                    target_user_id=notification.get("target_user_id"),
                 )
                 logger.info(
                     "Notification delivered from '%s': %s",

--- a/src/backend/services/notification_privacy.py
+++ b/src/backend/services/notification_privacy.py
@@ -1,0 +1,88 @@
+"""
+Privacy-aware TTS gating for notifications.
+
+Determines whether a notification should be played via TTS based on
+its privacy level and room occupancy from the BLE presence system.
+
+Privacy levels:
+  - public: always play TTS
+  - personal: play only when all room occupants are household members
+  - confidential: play only when the target user is completely alone
+"""
+
+from loguru import logger
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from utils.config import settings
+
+
+async def should_play_tts(
+    privacy: str,
+    target_user_id: int | None,
+    room_id: int | None,
+    db: AsyncSession,
+) -> bool:
+    """
+    Decide whether TTS should play for a notification.
+
+    Args:
+        privacy: Privacy level ("public", "personal", "confidential").
+        target_user_id: The user this notification is intended for (if any).
+        room_id: The room where TTS would play (if known).
+        db: Database session for querying user roles.
+
+    Returns:
+        True if TTS is allowed, False if it should be suppressed.
+    """
+    if privacy == "public":
+        return True
+
+    if not settings.presence_enabled:
+        logger.debug("Presence disabled — suppressing non-public TTS (privacy=%s)", privacy)
+        return False
+
+    from services.presence_service import get_presence_service
+    presence = get_presence_service()
+
+    if privacy == "confidential":
+        if target_user_id is None:
+            return False
+        alone = presence.is_user_alone_in_room(target_user_id)
+        if alone is None:
+            # User not tracked by BLE — fail-safe: don't play
+            return False
+        return alone
+
+    if privacy == "personal":
+        if room_id is None:
+            return False
+        occupants = presence.get_room_occupants(room_id)
+        if not occupants:
+            return False
+
+        occupant_ids = [o.user_id for o in occupants]
+        return await _all_household_members(occupant_ids, db)
+
+    # Unknown privacy level — fail-safe
+    logger.warning("Unknown privacy level '%s' — suppressing TTS", privacy)
+    return False
+
+
+async def _all_household_members(user_ids: list[int], db: AsyncSession) -> bool:
+    """Check whether all given user IDs belong to household roles."""
+    from models.database import User
+
+    household_roles = {r.strip() for r in settings.presence_household_roles.split(",") if r.strip()}
+
+    result = await db.execute(
+        select(User).options(selectinload(User.role)).where(User.id.in_(user_ids))
+    )
+    users = result.scalars().all()
+
+    if len(users) != len(user_ids):
+        # Some user IDs not found in DB — fail-safe
+        return False
+
+    return all(u.role and u.role.name in household_roles for u in users)

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -291,6 +291,7 @@ class Settings(BaseSettings):
     presence_enabled: bool = False                      # Master-Switch for BLE presence detection
     presence_stale_timeout: int = 120                   # Seconds before user marked absent
     presence_hysteresis_scans: int = 2                  # Consecutive scans before room change
+    presence_household_roles: str = "Admin,Familie"        # Roles considered household members for privacy TTS
 
     # Notification Polling (generic MCP server polling)
     notification_poller_enabled: bool = False           # Master-Switch for MCP notification polling

--- a/tests/backend/test_notification_privacy.py
+++ b/tests/backend/test_notification_privacy.py
@@ -1,0 +1,248 @@
+"""
+Tests for privacy-aware TTS gating (should_play_tts).
+
+Tests cover all privacy levels, presence states, and edge cases.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.notification_privacy import should_play_tts
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_user(user_id: int, role_name: str):
+    """Create a mock User with a Role."""
+    role = MagicMock()
+    role.name = role_name
+    user = MagicMock()
+    user.id = user_id
+    user.role = role
+    return user
+
+
+def _make_presence(user_id: int, room_id: int | None = 1, room_name: str | None = "Wohnzimmer"):
+    """Create a mock UserPresence."""
+    p = MagicMock()
+    p.user_id = user_id
+    p.room_id = room_id
+    p.room_name = room_name
+    return p
+
+
+def _mock_db_returning_users(users: list):
+    """Create an AsyncSession mock that returns the given users from a select query."""
+    db = AsyncMock()
+    result_mock = MagicMock()
+    scalars_mock = MagicMock()
+    scalars_mock.all.return_value = users
+    result_mock.scalars.return_value = scalars_mock
+    db.execute = AsyncMock(return_value=result_mock)
+    return db
+
+
+PATCH_SETTINGS = "services.notification_privacy.settings"
+PATCH_PRESENCE = "services.presence_service.get_presence_service"
+
+
+# ---------------------------------------------------------------------------
+# Public
+# ---------------------------------------------------------------------------
+
+class TestPublicPrivacy:
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_public_always_allowed(self):
+        """Public notifications always get TTS."""
+        db = AsyncMock()
+        result = await should_play_tts("public", None, None, db)
+        assert result is True
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_public_allowed_even_without_presence(self):
+        """Public TTS works regardless of presence system state."""
+        db = AsyncMock()
+        with patch(PATCH_SETTINGS) as mock_settings:
+            mock_settings.presence_enabled = False
+            result = await should_play_tts("public", None, None, db)
+            assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Confidential
+# ---------------------------------------------------------------------------
+
+class TestConfidentialPrivacy:
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_confidential_user_alone(self):
+        """Confidential TTS plays when target user is alone in their room."""
+        presence = MagicMock()
+        presence.is_user_alone_in_room.return_value = True
+
+        db = AsyncMock()
+        with patch(PATCH_SETTINGS) as mock_settings, \
+             patch(PATCH_PRESENCE, return_value=presence):
+            mock_settings.presence_enabled = True
+            result = await should_play_tts("confidential", 1, 10, db)
+            assert result is True
+            presence.is_user_alone_in_room.assert_called_once_with(1)
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_confidential_user_not_alone(self):
+        """Confidential TTS suppressed when others are in the room."""
+        presence = MagicMock()
+        presence.is_user_alone_in_room.return_value = False
+
+        db = AsyncMock()
+        with patch(PATCH_SETTINGS) as mock_settings, \
+             patch(PATCH_PRESENCE, return_value=presence):
+            mock_settings.presence_enabled = True
+            result = await should_play_tts("confidential", 1, 10, db)
+            assert result is False
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_confidential_user_not_tracked(self):
+        """Confidential TTS suppressed when user is not tracked (conservative)."""
+        presence = MagicMock()
+        presence.is_user_alone_in_room.return_value = None  # not tracked
+
+        db = AsyncMock()
+        with patch(PATCH_SETTINGS) as mock_settings, \
+             patch(PATCH_PRESENCE, return_value=presence):
+            mock_settings.presence_enabled = True
+            result = await should_play_tts("confidential", 1, 10, db)
+            assert result is False
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_confidential_no_target_user(self):
+        """Confidential TTS suppressed when no target_user_id specified."""
+        db = AsyncMock()
+        with patch(PATCH_SETTINGS) as mock_settings, \
+             patch(PATCH_PRESENCE):
+            mock_settings.presence_enabled = True
+            result = await should_play_tts("confidential", None, 10, db)
+            assert result is False
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_confidential_user_wrong_room(self):
+        """Confidential: user not alone in their room — TTS suppressed."""
+        presence = MagicMock()
+        presence.is_user_alone_in_room.return_value = False
+
+        db = AsyncMock()
+        with patch(PATCH_SETTINGS) as mock_settings, \
+             patch(PATCH_PRESENCE, return_value=presence):
+            mock_settings.presence_enabled = True
+            result = await should_play_tts("confidential", 1, 10, db)
+            assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Personal
+# ---------------------------------------------------------------------------
+
+class TestPersonalPrivacy:
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_personal_all_household(self):
+        """Personal TTS plays when all room occupants are household members."""
+        presence = MagicMock()
+        presence.get_room_occupants.return_value = [
+            _make_presence(1), _make_presence(2),
+        ]
+
+        users = [_make_user(1, "Admin"), _make_user(2, "Familie")]
+        db = _mock_db_returning_users(users)
+
+        with patch(PATCH_SETTINGS) as mock_settings, \
+             patch(PATCH_PRESENCE, return_value=presence):
+            mock_settings.presence_enabled = True
+            mock_settings.presence_household_roles = "Admin,Familie"
+            result = await should_play_tts("personal", None, 10, db)
+            assert result is True
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_personal_non_household_occupant(self):
+        """Personal TTS suppressed when a non-household member is in the room."""
+        presence = MagicMock()
+        presence.get_room_occupants.return_value = [
+            _make_presence(1), _make_presence(3),
+        ]
+
+        users = [_make_user(1, "Familie"), _make_user(3, "Gast")]
+        db = _mock_db_returning_users(users)
+
+        with patch(PATCH_SETTINGS) as mock_settings, \
+             patch(PATCH_PRESENCE, return_value=presence):
+            mock_settings.presence_enabled = True
+            mock_settings.presence_household_roles = "Admin,Familie"
+            result = await should_play_tts("personal", None, 10, db)
+            assert result is False
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_personal_no_occupants(self):
+        """Personal TTS suppressed when room has no occupants (conservative)."""
+        presence = MagicMock()
+        presence.get_room_occupants.return_value = []
+
+        db = AsyncMock()
+        with patch(PATCH_SETTINGS) as mock_settings, \
+             patch(PATCH_PRESENCE, return_value=presence):
+            mock_settings.presence_enabled = True
+            result = await should_play_tts("personal", None, 10, db)
+            assert result is False
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_personal_no_room(self):
+        """Personal TTS suppressed when no room_id is provided."""
+        db = AsyncMock()
+        with patch(PATCH_SETTINGS) as mock_settings, \
+             patch(PATCH_PRESENCE):
+            mock_settings.presence_enabled = True
+            result = await should_play_tts("personal", None, None, db)
+            assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Presence Disabled
+# ---------------------------------------------------------------------------
+
+class TestPresenceDisabled:
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_presence_disabled_blocks_nonpublic(self):
+        """When presence is disabled, non-public notifications don't get TTS."""
+        db = AsyncMock()
+        with patch(PATCH_SETTINGS) as mock_settings:
+            mock_settings.presence_enabled = False
+            assert await should_play_tts("personal", None, 10, db) is False
+            assert await should_play_tts("confidential", 1, 10, db) is False
+
+
+# ---------------------------------------------------------------------------
+# Unknown Privacy Level
+# ---------------------------------------------------------------------------
+
+class TestUnknownPrivacy:
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_unknown_privacy_level_denied(self):
+        """Unknown privacy levels are denied (fail-safe)."""
+        db = AsyncMock()
+        with patch(PATCH_SETTINGS) as mock_settings, \
+             patch(PATCH_PRESENCE):
+            mock_settings.presence_enabled = True
+            result = await should_play_tts("secret", None, 10, db)
+            assert result is False


### PR DESCRIPTION
## Summary
- Gate TTS playback based on notification `privacy` level and room occupancy from BLE presence system
- Three privacy levels: `public` (always), `personal` (household only), `confidential` (user alone)
- New `notification_privacy.py` service with `should_play_tts()` gate function
- DB migration adds `privacy` + `target_user_id` columns to notifications table
- New `PRESENCE_HOUSEHOLD_ROLES` config (default: `"Admin,Familie"`)
- Graceful degradation: `PRESENCE_ENABLED=false` → only public gets TTS; web notifications always delivered

## Changes
- **Backend**: `notification_privacy.py` (new), `notification_service.py`, `notification_poller.py`, `notifications_schemas.py`, `notifications.py`, `database.py`, `config.py`
- **Migration**: `c3d4e5f6g7h9_add_notification_privacy.py`
- **Tests**: 19 new tests (13 privacy gate + 2 poller forwarding + 4 integration)
- **Docs**: CLAUDE.md, ENVIRONMENT_VARIABLES.md

## Test plan
- [x] 13 privacy gate tests pass (all privacy levels, edge cases, fail-safe)
- [x] 2 notification poller forwarding tests pass
- [x] 4 notification integration tests pass (model, schema validation, TTS suppression)
- [x] 16 existing presence tests pass (no regression)
- [x] 62 existing notification tests pass (no regression)
- [x] Lint clean (`ruff check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)