### PR TITLE
feat(presence): Add automation hooks and webhook dispatcher (#143)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,10 @@ Minimal async hook system for the Open-Core plugin architecture. External packag
 | `register_tools` | `registry` (AgentToolRegistry) | Add custom agent tools |
 | `post_message` | `user_msg`, `assistant_msg`, `user_id`, `session_id` | Post-processing (e.g. graph extraction) |
 | `retrieve_context` | `query`, `user_id`, `lang` | Inject additional LLM context (return `str`) |
+| `presence_enter_room` | `user_id`, `user_name`, `room_id`, `room_name`, `confidence` | User entered a room |
+| `presence_leave_room` | `user_id`, `user_name`, `room_id`, `room_name` | User left a room |
+| `presence_first_arrived` | `user_id`, `user_name`, `room_id`, `room_name` | First user detected (house was empty) |
+| `presence_last_left` | `room_id`, `room_name` | Last occupant left a room |
 
 **Insertion Points:**
 
@@ -405,6 +409,8 @@ All configuration via `.env`, loaded by `src/backend/utils/config.py` (Pydantic 
 - `PRESENCE_HYSTERESIS_SCANS` — Consecutive scans before room change (default: `2`)
 - `PRESENCE_RSSI_THRESHOLD` — RSSI threshold in dBm; signals weaker than this are ignored for room assignment (default: `-80`)
 - `PRESENCE_HOUSEHOLD_ROLES` — Comma-separated role names considered household members for privacy TTS (default: `"Admin,Familie"`)
+- `PRESENCE_WEBHOOK_URL` — URL to POST presence events to (empty = disabled). Supports n8n webhook triggers (default: `""`)
+- `PRESENCE_WEBHOOK_SECRET` — Shared secret sent as X-Webhook-Secret header for webhook authentication (default: `""`)
 - `METRICS_ENABLED` — Prometheus `/metrics` endpoint (default: `false`, opt-in)
 - `PLUGIN_MODULE` — Hook-based extension entry point (default: `""`, e.g. `"renfield_twin.hooks:register"`)
 

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -324,6 +324,10 @@ PRESENCE_STALE_TIMEOUT=120               # Sekunden bis Benutzer als abwesend ma
 PRESENCE_HYSTERESIS_SCANS=2              # Aufeinanderfolgende Scans vor Raumwechsel
 PRESENCE_RSSI_THRESHOLD=-80              # dBm, schwächere Signale werden für Raumzuweisung ignoriert
 PRESENCE_HOUSEHOLD_ROLES="Admin,Familie" # Rollen die als Haushaltsmitglieder gelten (für Privacy-TTS)
+
+# Presence Webhooks (Automation-Hooks)
+PRESENCE_WEBHOOK_URL=""                  # URL für Presence-Events (leer = deaktiviert). Unterstützt n8n Webhook-Trigger
+PRESENCE_WEBHOOK_SECRET=""               # Shared Secret als X-Webhook-Secret Header für Webhook-Authentifizierung
 ```
 
 **Satellite-Konfiguration** (in `satellite.yaml`):

--- a/src/backend/api/lifecycle.py
+++ b/src/backend/api/lifecycle.py
@@ -458,6 +458,12 @@ async def lifespan(app: "FastAPI"):
     # Zeroconf for satellite discovery
     zeroconf_service = await _init_zeroconf(app)
 
+    # Presence webhooks
+    if settings.presence_enabled:
+        from services.presence_webhook import register_presence_webhooks
+
+        register_presence_webhooks()
+
     # Plugin / Hook System
     await _load_plugin_module()
     from utils.hooks import run_hooks

--- a/src/backend/api/websocket/satellite_handler.py
+++ b/src/backend/api/websocket/satellite_handler.py
@@ -561,7 +561,7 @@ Gib eine kurze, natürliche Antwort. KEIN JSON, nur Text."""
 
                     from services.presence_service import get_presence_service
                     presence_svc = get_presence_service()
-                    presence_svc.process_ble_report(
+                    await presence_svc.process_ble_report(
                         satellite_id=satellite_id,
                         room_id=ble_room_id,
                         devices=ble_devices,

--- a/src/backend/services/presence_webhook.py
+++ b/src/backend/services/presence_webhook.py
@@ -1,0 +1,47 @@
+"""Presence webhook dispatcher — forwards presence events to external URL (e.g. n8n)."""
+
+import httpx
+from loguru import logger
+
+from utils.config import settings
+from utils.hooks import register_hook
+
+_client: httpx.AsyncClient | None = None
+
+
+async def _dispatch(event: str, **kwargs):
+    """POST event to webhook URL. Fire-and-forget with error logging."""
+    global _client
+    if not _client:
+        _client = httpx.AsyncClient(timeout=10.0)
+
+    headers = {"Content-Type": "application/json"}
+    if settings.presence_webhook_secret:
+        headers["X-Webhook-Secret"] = settings.presence_webhook_secret
+
+    payload = {"event": event, **kwargs}
+    try:
+        resp = await _client.post(settings.presence_webhook_url, json=payload, headers=headers)
+        resp.raise_for_status()
+        logger.debug(f"Presence webhook: {event} → {resp.status_code}")
+    except Exception:
+        logger.opt(exception=True).warning(f"Presence webhook failed for {event}")
+
+
+def register_presence_webhooks():
+    """Register hook handlers for all presence events."""
+    if not settings.presence_webhook_url:
+        return
+
+    for event in (
+        "presence_enter_room",
+        "presence_leave_room",
+        "presence_first_arrived",
+        "presence_last_left",
+    ):
+        async def handler(ev=event, **kwargs):
+            await _dispatch(ev, **kwargs)
+
+        register_hook(event, handler)
+
+    logger.info(f"Presence webhooks registered → {settings.presence_webhook_url}")

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -293,6 +293,8 @@ class Settings(BaseSettings):
     presence_hysteresis_scans: int = 2                  # Consecutive scans before room change
     presence_rssi_threshold: int = -80                     # dBm, signals weaker than this are ignored
     presence_household_roles: str = "Admin,Familie"        # Roles considered household members for privacy TTS
+    presence_webhook_url: str = ""                           # URL to POST presence events (empty = disabled)
+    presence_webhook_secret: str = ""                        # Shared secret for webhook auth (X-Webhook-Secret header)
 
     # Notification Polling (generic MCP server polling)
     notification_poller_enabled: bool = False           # Master-Switch for MCP notification polling

--- a/src/backend/utils/hooks.py
+++ b/src/backend/utils/hooks.py
@@ -19,6 +19,10 @@ HOOK_EVENTS: frozenset[str] = frozenset({
     "register_tools",
     "post_message",
     "retrieve_context",
+    "presence_enter_room",
+    "presence_leave_room",
+    "presence_first_arrived",
+    "presence_last_left",
 })
 
 HookFn = Callable[..., Coroutine[Any, Any, Any]]

--- a/tests/backend/test_presence_webhook.py
+++ b/tests/backend/test_presence_webhook.py
@@ -1,0 +1,105 @@
+"""
+Tests for presence webhook dispatcher.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.unit
+class TestPresenceWebhook:
+    @pytest.mark.asyncio
+    async def test_dispatch_posts_to_url(self):
+        """Webhook POSTs event payload to configured URL."""
+        mock_settings = type("S", (), {
+            "presence_webhook_url": "http://n8n.local/webhook/presence",
+            "presence_webhook_secret": "",
+        })()
+
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = lambda: None
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch("services.presence_webhook.settings", mock_settings):
+            import services.presence_webhook as mod
+            mod._client = mock_client
+
+            await mod._dispatch("presence_enter_room", user_id=1, room_id=10)
+
+        mock_client.post.assert_called_once()
+        call_args = mock_client.post.call_args
+        assert call_args[0][0] == "http://n8n.local/webhook/presence"
+        payload = call_args[1]["json"]
+        assert payload["event"] == "presence_enter_room"
+        assert payload["user_id"] == 1
+        assert payload["room_id"] == 10
+
+        # Cleanup
+        mod._client = None
+
+    @pytest.mark.asyncio
+    async def test_dispatch_includes_secret_header(self):
+        """When secret configured, X-Webhook-Secret header is sent."""
+        mock_settings = type("S", (), {
+            "presence_webhook_url": "http://n8n.local/webhook/presence",
+            "presence_webhook_secret": "my-secret-token",
+        })()
+
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = lambda: None
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch("services.presence_webhook.settings", mock_settings):
+            import services.presence_webhook as mod
+            mod._client = mock_client
+
+            await mod._dispatch("presence_leave_room", user_id=1, room_id=10)
+
+        call_args = mock_client.post.call_args
+        headers = call_args[1]["headers"]
+        assert headers["X-Webhook-Secret"] == "my-secret-token"
+
+        # Cleanup
+        mod._client = None
+
+    @pytest.mark.asyncio
+    async def test_dispatch_error_logged_not_raised(self):
+        """Network error doesn't propagate (fire-and-forget)."""
+        mock_settings = type("S", (), {
+            "presence_webhook_url": "http://n8n.local/webhook/presence",
+            "presence_webhook_secret": "",
+        })()
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=Exception("Connection refused"))
+
+        with patch("services.presence_webhook.settings", mock_settings):
+            import services.presence_webhook as mod
+            mod._client = mock_client
+
+            # Should not raise
+            await mod._dispatch("presence_enter_room", user_id=1, room_id=10)
+
+        # Cleanup
+        mod._client = None
+
+    def test_register_skipped_when_no_url(self):
+        """No URL configured → no hooks registered."""
+        mock_settings = type("S", (), {
+            "presence_webhook_url": "",
+            "presence_webhook_secret": "",
+        })()
+
+        with patch("services.presence_webhook.settings", mock_settings), \
+             patch("services.presence_webhook.register_hook") as mock_register:
+            import services.presence_webhook as mod
+            mod.register_presence_webhooks()
+
+        mock_register.assert_not_called()


### PR DESCRIPTION
## Summary

- **Hook events:** `presence_enter_room`, `presence_leave_room`, `presence_first_arrived`, `presence_last_left` — fired on room transitions and stale cleanup
- **Webhook dispatcher:** New `presence_webhook.py` service POSTs events to configurable URL (e.g. n8n webhook trigger) with optional `X-Webhook-Secret` header
- **Async migration:** `process_ble_report()` is now async to bridge sync room-assignment logic with the async hook system
- **Config:** `PRESENCE_WEBHOOK_URL` and `PRESENCE_WEBHOOK_SECRET` environment variables

## Test plan

- [x] 8 new hook tests verify enter/leave/first_arrived/last_left fire correctly
- [x] 4 new webhook tests verify POST payload, secret header, error resilience, and no-op when URL empty
- [x] All 24 existing presence tests updated to async and still pass
- [x] 10 existing API presence tests updated and pass (fixture fix for `_rssi_threshold`)
- [x] Lint clean (`ruff check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)