### PR TITLE
feat(presence): Add voice/auth-based presence detection

### DIFF
--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -557,6 +557,20 @@ async def websocket_endpoint(
                 except Exception as e:
                     logger.warning(f"⚠️ Failed to load user permissions: {e}")
 
+            # Register voice/auth presence if user is authenticated in a known room
+            if (user_id and settings.presence_enabled
+                    and room_context and room_context.get("room_id")):
+                try:
+                    from services.presence_service import get_presence_service
+                    presence_svc = get_presence_service()
+                    await presence_svc.register_voice_presence(
+                        user_id=int(user_id),
+                        room_id=room_context["room_id"],
+                        room_name=room_context.get("room_name"),
+                    )
+                except Exception as e:
+                    logger.warning(f"⚠️ Auth presence update failed: {e}")
+
             # Retrieve memory context (long-term user knowledge)
             memory_context = await _retrieve_memory_context(
                 content, user_id=user_id, lang=ollama.default_lang


### PR DESCRIPTION
## Summary
- Add `register_voice_presence()` to PresenceService — bypasses BLE hysteresis for certain presence signals (voice/auth)
- Satellite handler: recognized speaker triggers voice presence update (lookup gate widened to work with `presence_enabled` even without `auth_enabled`)
- Chat handler: authenticated user with room-assigned device triggers auth-based presence update
- 6 new unit tests covering all voice presence scenarios (enter, same-room refresh, room change, first_arrived, last_left, hysteresis bypass)

Closes #143

## Test plan
- [x] 38/38 presence tests pass (32 existing + 6 new)
- [x] Lint clean (ruff)
- [ ] Manual: satellite speaker recognized → room updated in presence API
- [ ] Manual: web client with room context → presence updated on message send

🤖 Generated with [Claude Code](https://claude.com/claude-code)