### PR TITLE
fix(frontend): Handle paginated /api/users in PresencePage

### DIFF
--- a/src/frontend/src/pages/PresencePage.jsx
+++ b/src/frontend/src/pages/PresencePage.jsx
@@ -285,7 +285,8 @@ export default function PresencePage() {
   const loadUsers = useCallback(async () => {
     try {
       const response = await apiClient.get('/api/users');
-      setUsers(response.data || []);
+      const data = response.data;
+      setUsers(Array.isArray(data) ? data : data?.users || []);
     } catch {
       // Non-critical
     }


### PR DESCRIPTION
## Summary
- `/api/users` returns `{users: [...], total, page}` (paginated), but PresencePage set `users` state directly from `response.data`, causing `.map()` to crash on an object
- Fix: extract the `users` array from the paginated response with `Array.isArray(data) ? data : data?.users || []`

Closes #143

## Test plan
- [x] Verified on production: page now renders correctly with stats, empty states, and Add Device button
- [x] Desktop and mobile screenshots confirm correct layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)