### PR TITLE
chore(satellite): Bump to v1.1.0 and fix OTA SSL

### DIFF
--- a/src/satellite/renfield_satellite/__init__.py
+++ b/src/satellite/renfield_satellite/__init__.py
@@ -5,7 +5,7 @@ A headless voice assistant satellite for the Renfield ecosystem.
 Designed for Raspberry Pi Zero 2 W with ReSpeaker 2-Mics Pi HAT.
 """
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 __author__ = "Renfield Team"
 
 # Lazy imports to allow CLI tools to run without all dependencies


### PR DESCRIPTION
## Summary
- Bump satellite version `1.0.0` → `1.1.0` (includes BLE presence scanning, voice presence support)
- Fix OTA update download failing with `SSL: CERTIFICATE_VERIFY_FAILED` on self-signed certs by using an unverified SSL context for local network downloads

## Test plan
- [x] Both satellites (Fitnessraum + Wohnzimmer) deployed and running v1.1.0
- [x] Satellites connected and reporting correct version via `/api/satellites`

🤖 Generated with [Claude Code](https://claude.com/claude-code)