### PR TITLE
docs(readme): Add presence detection to EN/DE READMEs

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -22,6 +22,7 @@ Unterstützung oder Billigung durch solche Dritte.
 - **Konversations-Gedächtnis** — Langzeit-Erinnerungen (Präferenzen, Fakten, Anweisungen) mit Widerspruchserkennung
 - **Intent Feedback Learning** — Lernt aus Korrekturen und verbessert Intent-Erkennung über semantisches Matching
 - **Spracheingabe & -ausgabe** — Whisper STT und Piper TTS, Sprechererkennung mit SpeechBrain
+- **Präsenzerkennung** — BLE-Scanning, Sprechererkennung und Web-Auth verfolgen, wer sich in welchem Raum befindet
 
 ### Integrationen (8 MCP-Server)
 | Server | Beschreibung | Transport | Aktivierung |
@@ -51,6 +52,20 @@ Unterstützung oder Billigung durch solche Dritte.
 - **Wake-Word-Erkennung** — Lokales OpenWakeWord, zentrale Verwaltung
 - **Audio-Output-Routing** — TTS-Ausgabe auf optimales Gerät im Raum
 - **IP-basierte Raumerkennung** — Automatischer Raum-Kontext für Befehle
+
+### Präsenzerkennung
+
+Raumbasierte Präsenzerkennung aus drei Quellen:
+
+| Quelle | Auslöser | Latenz |
+|--------|----------|--------|
+| BLE-Scanning | Satellit erkennt Telefon/Uhr via Bluetooth | ~30s (Hysterese) |
+| Voice Presence | Sprechererkennung identifiziert Nutzer | Sofort |
+| Web Auth | Authentifizierter Nutzer mit Raumzuweisung | Sofort |
+
+- **Privacy-aware TTS** — Benachrichtigungen respektieren Raumbelegung (public / personal / confidential)
+- **Automation-Hooks** — `enter_room`, `leave_room`, `first_arrived`, `last_left` Events feuern Webhooks für n8n / Home Assistant
+- **Presence Dashboard** — Echtzeit-Raumbelegung im Admin-UI
 
 ### Sicherheit & Zugriffskontrolle
 - **RPBAC** — Role-Permission Based Access Control mit JWT (optional)
@@ -253,6 +268,9 @@ PROACTIVE_REMINDERS_ENABLED=false # Erinnerungen (opt-in)
 
 # Authentifizierung
 AUTH_ENABLED=false                # RPBAC (opt-in)
+
+# Präsenzerkennung
+PRESENCE_ENABLED=false           # Raum-Präsenzerkennung (opt-in)
 
 # Monitoring
 METRICS_ENABLED=false             # Prometheus /metrics (opt-in)

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@
 - **Conversational memory** — long-term recall of preferences, facts, and instructions with contradiction detection
 - **Intent feedback learning** — learns from corrections via semantic matching
 - **Voice I/O** — Whisper STT + Piper TTS + SpeechBrain speaker recognition
+- **Presence detection** — BLE scanning, voice recognition, and web auth track who's in which room
 
 ### Integrations (8 MCP Servers)
 
@@ -94,6 +95,20 @@
 - Local wake word detection (OpenWakeWord)
 - Audio output routing to best device per room
 - IP-based room context detection
+
+### Presence Detection
+
+Multi-source room-level presence tracking:
+
+| Source | Trigger | Latency |
+|--------|---------|---------|
+| BLE Scanning | Satellite detects phone/watch via Bluetooth | ~30s (hysteresis) |
+| Voice Presence | Speaker recognition identifies user | Instant |
+| Web Auth | Authenticated user on room-assigned device | Instant |
+
+- **Privacy-aware TTS** — notifications respect room occupancy (public / personal / confidential)
+- **Automation hooks** — `enter_room`, `leave_room`, `first_arrived`, `last_left` events fire webhooks for n8n / Home Assistant
+- **Presence dashboard** — real-time room occupancy in the admin UI
 
 ### Security & Access Control
 - Role-permission based access control (RPBAC) with JWT
@@ -148,6 +163,7 @@ AGENT_ENABLED=false               # ReAct agent loop (opt-in)
 MEMORY_ENABLED=false              # long-term memory (opt-in)
 AUTH_ENABLED=false                 # RPBAC auth (opt-in)
 MCP_ENABLED=true                  # master switch for integrations
+PRESENCE_ENABLED=false            # room presence detection (opt-in)
 METRICS_ENABLED=false             # Prometheus /metrics (opt-in)
 ```
 


### PR DESCRIPTION
## Summary
- Add **Presence Detection** section to both README.md and README.de.md with multi-source table (BLE scanning, voice recognition, web auth)
- Highlight privacy-aware TTS, automation hooks, and presence dashboard
- Add presence to Core features bullet list in both languages
- Add `PRESENCE_ENABLED` to key settings sections

## Context
Follows PRs #145-#151 which implemented the full presence detection stack (BLE, triangulation, hooks, voice/auth sources, dashboard, documentation).

## Test plan
- [x] Documentation-only, no code impact
- [x] Markdown renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)