### PR TITLE
fix(presence): Add status endpoint and fix empty-state UX

### DIFF
--- a/src/backend/api/routes/presence.py
+++ b/src/backend/api/routes/presence.py
@@ -54,6 +54,19 @@ class BLEDeviceCreate(BaseModel):
     device_type: str = Field(default="phone", max_length=50)
 
 
+# --- Status ---
+
+
+class PresenceStatusResponse(BaseModel):
+    enabled: bool
+
+
+@router.get("/status", response_model=PresenceStatusResponse)
+async def get_presence_status():
+    """Check whether presence detection is enabled."""
+    return PresenceStatusResponse(enabled=settings.presence_enabled)
+
+
 # --- Room occupancy ---
 
 @router.get("/rooms", response_model=list[RoomOccupancyResponse])

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -646,10 +646,11 @@
   },
   "presence": {
     "title": "Anwesenheit",
-    "subtitle": "Wer ist wo \u2014 BLE-basierte Raumpr\u00e4senz",
+    "subtitle": "Wer ist wo \u2014 Raumpr\u00e4senz via BLE, Sprache und Web",
     "roomOccupancy": "Raumbelegung",
     "noData": "Keine Pr\u00e4senzdaten verf\u00fcgbar",
     "presenceDisabled": "Pr\u00e4senzerkennung ist deaktiviert (PRESENCE_ENABLED=false)",
+    "noOccupants": "Keine Anwesenden erkannt \u2014 Pr\u00e4senz wird aktualisiert wenn Satelliten BLE-Ger\u00e4te scannen oder Sprecher erkennen",
     "trackedUsers": "Erfasste Personen",
     "occupiedRooms": "Belegte R\u00e4ume",
     "confidence": "Konfidenz",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -646,10 +646,11 @@
   },
   "presence": {
     "title": "Presence",
-    "subtitle": "Who is where \u2014 BLE-based room presence",
+    "subtitle": "Who is where \u2014 room presence via BLE, voice, and web",
     "roomOccupancy": "Room Occupancy",
     "noData": "No presence data available",
     "presenceDisabled": "Presence detection is disabled (PRESENCE_ENABLED=false)",
+    "noOccupants": "No occupants detected — presence updates when satellites scan BLE devices or recognize speakers",
     "trackedUsers": "Tracked Users",
     "occupiedRooms": "Occupied Rooms",
     "confidence": "Confidence",

--- a/src/frontend/src/pages/PresencePage.jsx
+++ b/src/frontend/src/pages/PresencePage.jsx
@@ -257,6 +257,7 @@ export default function PresencePage() {
   const [error, setError] = useState(null);
   const [autoRefresh, setAutoRefresh] = useState(true);
   const [showAddDevice, setShowAddDevice] = useState(false);
+  const [presenceEnabled, setPresenceEnabled] = useState(null);
 
   const refreshIntervalRef = useRef(null);
 
@@ -297,6 +298,9 @@ export default function PresencePage() {
     loadPresence();
     loadDevices();
     loadUsers();
+    apiClient.get('/api/presence/status')
+      .then(res => setPresenceEnabled(res.data?.enabled ?? false))
+      .catch(() => setPresenceEnabled(false));
   }, [loadPresence, loadDevices, loadUsers]);
 
   // Auto-refresh presence data
@@ -435,7 +439,9 @@ export default function PresencePage() {
             {t('presence.noData')}
           </h3>
           <p className="text-gray-500 dark:text-gray-400">
-            {t('presence.presenceDisabled')}
+            {presenceEnabled === false
+              ? t('presence.presenceDisabled')
+              : t('presence.noOccupants')}
           </p>
         </div>
       ) : (


### PR DESCRIPTION
## Summary
- Add `/api/presence/status` backend endpoint that returns whether presence detection is enabled
- Frontend now fetches actual status and shows different messages for disabled vs enabled-but-empty
- Updated i18n strings (EN/DE) with new `noOccupants` key and updated subtitle ("via BLE, voice, and web")

Fixes the misleading "Presence detection is disabled" message that appeared whenever no occupants were detected, even when presence was actually enabled.

## Test plan
- [x] Deployed to production and verified via Playwright screenshot test
- [x] Desktop, tablet, and mobile viewports tested
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)