### PR TITLE
feat(knowledge-graph): Extract entities from documents and chat uploads

### DIFF
--- a/src/backend/api/lifecycle.py
+++ b/src/backend/api/lifecycle.py
@@ -513,6 +513,7 @@ async def lifespan(app: "FastAPI"):
     # Knowledge Graph hooks
     if settings.knowledge_graph_enabled:
         from services.knowledge_graph_service import (
+            kg_post_document_ingest_hook,
             kg_post_message_hook,
             kg_retrieve_context_hook,
         )
@@ -520,6 +521,7 @@ async def lifespan(app: "FastAPI"):
 
         register_hook("post_message", kg_post_message_hook)
         register_hook("retrieve_context", kg_retrieve_context_hook)
+        register_hook("post_document_ingest", kg_post_document_ingest_hook)
         logger.info("✅ Knowledge Graph hooks registered")
 
     # Plugin / Hook System

--- a/src/backend/prompts/knowledge_graph.yaml
+++ b/src/backend/prompts/knowledge_graph.yaml
@@ -36,6 +36,35 @@ de:
       "relations": [{{"subject": "...", "predicate": "...", "object": "...", "confidence": 0.8}}]
     }}
 
+  document_extraction_prompt: |
+    Analysiere den folgenden Textabschnitt aus einem Dokument und extrahiere benannte Entitaeten und ihre Beziehungen.
+
+    ENTITAETEN extrahieren:
+    - Personen (Name, Spitzname)
+    - Orte (Staedte, Laender, Gebaeude)
+    - Organisationen (Firmen, Vereine)
+    - Dinge (Haustiere, Geraete, Fahrzeuge)
+    - Ereignisse (Urlaube, Termine, Feiern)
+    - Konzepte (Hobbys, Berufe, Faecher)
+
+    RELATIONEN extrahieren:
+    - Beziehungen zwischen Entitaeten ("wohnt_in", "arbeitet_bei", "mag", "besitzt", "kennt", "ist_verheiratet_mit")
+    - Nur Relationen die EXPLIZIT im Text erwaehnt werden
+    - confidence: 0.5-1.0 (wie sicher ist die Relation)
+
+    IGNORIERE:
+    - Formatierung, Seitenzahlen, Inhaltsverzeichnisse
+    - Generische/unbenannte Verweise
+
+    Text:
+    {text}
+
+    Antworte als JSON-Objekt (leere Arrays wenn nichts relevant):
+    {{
+      "entities": [{{"name": "...", "type": "person|place|organization|thing|event|concept", "description": "..."}}],
+      "relations": [{{"subject": "...", "predicate": "...", "object": "...", "confidence": 0.8}}]
+    }}
+
 en:
   extraction_system: "You extract entities and relations from dialogs. Reply ONLY with a JSON object."
 
@@ -63,6 +92,35 @@ en:
     Dialog:
     User: {user_message}
     Assistant: {assistant_response}
+
+    Reply as JSON object (empty arrays if nothing relevant):
+    {{
+      "entities": [{{"name": "...", "type": "person|place|organization|thing|event|concept", "description": "..."}}],
+      "relations": [{{"subject": "...", "predicate": "...", "object": "...", "confidence": 0.8}}]
+    }}
+
+  document_extraction_prompt: |
+    Analyze the following text passage from a document and extract named entities and their relationships.
+
+    EXTRACT entities:
+    - People (names, nicknames)
+    - Places (cities, countries, buildings)
+    - Organizations (companies, clubs)
+    - Things (pets, devices, vehicles)
+    - Events (vacations, appointments, celebrations)
+    - Concepts (hobbies, professions, subjects)
+
+    EXTRACT relations:
+    - Relationships between entities ("lives_in", "works_at", "likes", "owns", "knows", "married_to")
+    - Only relations EXPLICITLY mentioned in the text
+    - confidence: 0.5-1.0 (how certain is the relation)
+
+    IGNORE:
+    - Formatting, page numbers, tables of contents
+    - Generic/unnamed references
+
+    Text:
+    {text}
 
     Reply as JSON object (empty arrays if nothing relevant):
     {{

--- a/src/backend/services/rag_service.py
+++ b/src/backend/services/rag_service.py
@@ -200,6 +200,17 @@ class RAGService:
 
             await self.db.refresh(doc)
 
+            # Fire KG extraction hook (fire-and-forget)
+            chunk_texts = [co.content for co in chunk_objects if co.content]
+            if chunk_texts:
+                from utils.hooks import run_hooks
+                _task = asyncio.create_task(run_hooks(  # noqa: RUF006
+                    "post_document_ingest",
+                    chunks=chunk_texts,
+                    document_id=doc.id,
+                    user_id=None,
+                ))
+
             logger.info(f"Dokument indexiert: ID={doc.id}, Chunks={chunk_count}")
             return doc
 

--- a/src/backend/utils/hooks.py
+++ b/src/backend/utils/hooks.py
@@ -18,6 +18,7 @@ HOOK_EVENTS: frozenset[str] = frozenset({
     "register_routes",
     "register_tools",
     "post_message",
+    "post_document_ingest",
     "retrieve_context",
     "presence_enter_room",
     "presence_leave_room",


### PR DESCRIPTION
## Summary
- Add `post_document_ingest` hook event that fires after RAG document ingest and chat-upload text extraction
- New `extract_from_text()` and `extract_from_chunks()` methods on `KnowledgeGraphService` for free-text KG extraction
- Bilingual `document_extraction_prompt` (DE/EN) adapted for document text (ignores formatting/ToC, no user/assistant pair)
- Fire-and-forget background execution — never blocks upload response
- 9 new tests covering text extraction, chunk iteration, and hook function

Closes #156

## Test plan
- [x] `python3 -m pytest tests/backend/test_knowledge_graph_service.py -v` — 44 tests pass
- [x] `ruff check` — all changed files clean
- [ ] RAG upload: document → backend logs show `KG: Extracted N entities from document`
- [ ] Chat upload: file → KG extracts entities from extracted_text
- [ ] `/admin/knowledge-graph` shows entities from uploaded documents

🤖 Generated with [Claude Code](https://claude.com/claude-code)