### PR TITLE
fix(frontend): Replace native confirm() with styled ConfirmDialog

### DIFF
--- a/src/frontend/src/components/RoomOutputSettings.jsx
+++ b/src/frontend/src/components/RoomOutputSettings.jsx
@@ -1,9 +1,11 @@
 import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   Volume2, Plus, Trash2, Loader, ChevronDown, ChevronUp,
   GripVertical, Power, PowerOff, Speaker, Radio, Monitor
 } from 'lucide-react';
 import apiClient from '../utils/axios';
+import { useConfirmDialog } from './ConfirmDialog';
 
 // Output device type icons
 const OUTPUT_TYPE_ICONS = {
@@ -22,6 +24,8 @@ const OUTPUT_TYPE_ICONS = {
  * - Drag-and-drop reordering (simplified: up/down buttons)
  */
 export default function RoomOutputSettings({ roomId, roomName }) {
+  const { t } = useTranslation();
+  const { confirm, ConfirmDialogComponent } = useConfirmDialog();
   // State
   const [expanded, setExpanded] = useState(false);
   const [outputDevices, setOutputDevices] = useState([]);
@@ -123,7 +127,12 @@ export default function RoomOutputSettings({ roomId, roomName }) {
   };
 
   const deleteOutputDevice = async (deviceId) => {
-    if (!confirm('Ausgabegeraet wirklich entfernen?')) return;
+    const confirmed = await confirm({
+      title: t('rooms.removeOutputDevice'),
+      message: t('rooms.removeOutputDeviceConfirm'),
+      variant: 'danger',
+    });
+    if (!confirmed) return;
 
     try {
       await apiClient.delete(`/api/rooms/output-devices/${deviceId}`);
@@ -316,6 +325,8 @@ export default function RoomOutputSettings({ roomId, roomName }) {
           </button>
         </div>
       )}
+
+      {ConfirmDialogComponent}
 
       {/* Add Device Modal */}
       {showAddModal && (

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -242,7 +242,9 @@
     "haAreasCount": "Home Assistant Areas ({{count}})",
     "haNotConnected": "Keine HA Areas gefunden. Ist Home Assistant verbunden?",
     "deleteDevice": "Gerät entfernen?",
-    "deleteDeviceConfirm": "Möchtest du \"{{name}}\" wirklich entfernen?"
+    "deleteDeviceConfirm": "Möchtest du \"{{name}}\" wirklich entfernen?",
+    "removeOutputDevice": "Ausgabegerät entfernen",
+    "removeOutputDeviceConfirm": "Ausgabegerät wirklich entfernen?"
   },
   "speakers": {
     "title": "Sprechererkennung",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -242,7 +242,9 @@
     "haAreasCount": "Home Assistant Areas ({{count}})",
     "haNotConnected": "No HA areas found. Is Home Assistant connected?",
     "deleteDevice": "Delete device?",
-    "deleteDeviceConfirm": "Do you really want to remove \"{{name}}\"?"
+    "deleteDeviceConfirm": "Do you really want to remove \"{{name}}\"?",
+    "removeOutputDevice": "Remove output device",
+    "removeOutputDeviceConfirm": "Really remove this output device?"
   },
   "speakers": {
     "title": "Speaker Recognition",

--- a/src/frontend/src/pages/KnowledgePage.jsx
+++ b/src/frontend/src/pages/KnowledgePage.jsx
@@ -19,9 +19,11 @@ import {
   AlertCircle
 } from 'lucide-react';
 import apiClient from '../utils/axios';
+import { useConfirmDialog } from '../components/ConfirmDialog';
 
 export default function KnowledgePage() {
   const { t } = useTranslation();
+  const { confirm, ConfirmDialogComponent } = useConfirmDialog();
   // State
   const [documents, setDocuments] = useState([]);
   const [knowledgeBases, setKnowledgeBases] = useState([]);
@@ -123,7 +125,12 @@ export default function KnowledgePage() {
 
   // Delete document
   const handleDeleteDocument = async (id, filename) => {
-    if (!confirm(t('knowledge.deleteDocument', { filename }))) return;
+    const confirmed = await confirm({
+      title: t('common.delete'),
+      message: t('knowledge.deleteDocument', { filename }),
+      variant: 'danger',
+    });
+    if (!confirmed) return;
 
     try {
       await apiClient.delete(`/api/knowledge/documents/${id}`);
@@ -188,7 +195,12 @@ export default function KnowledgePage() {
 
   // Delete Knowledge Base
   const handleDeleteKnowledgeBase = async (id, name) => {
-    if (!confirm(t('knowledge.deleteKnowledgeBaseConfirm', { name }))) return;
+    const confirmed = await confirm({
+      title: t('knowledge.deleteKnowledgeBase'),
+      message: t('knowledge.deleteKnowledgeBaseConfirm', { name }),
+      variant: 'danger',
+    });
+    if (!confirmed) return;
 
     try {
       await apiClient.delete(`/api/knowledge/bases/${id}`);
@@ -562,6 +574,8 @@ export default function KnowledgePage() {
           ))
         )}
       </div>
+
+      {ConfirmDialogComponent}
 
       {/* New Knowledge Base Modal */}
       {showNewKbModal && (


### PR DESCRIPTION
## Summary
- Replace native `window.confirm()` with accessible `useConfirmDialog()` hook in KnowledgePage (KB delete + document delete) and RoomOutputSettings (output device delete)
- Add i18n keys for output device removal confirmation (`rooms.removeOutputDevice`, `rooms.removeOutputDeviceConfirm`)
- Consistent UX across all admin pages — 6 pages already used the styled dialog, these 2 were the last holdouts

## Test plan
- [x] Playwright E2E test: styled ConfirmDialog appears on KB delete (not native confirm)
- [x] Cancel dismisses dialog, KB preserved
- [x] Confirm deletes KB successfully
- [x] ESLint: no new errors (only pre-existing warnings)
- [x] Deployed and verified on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)