### PR TITLE
feat(kg): Add YAML-based scope system for shared Knowledge Graph entities

### DIFF
--- a/config/kg_scopes.yaml
+++ b/config/kg_scopes.yaml
@@ -1,0 +1,24 @@
+# Knowledge Graph Scopes — Define which roles can access each scope
+# The "personal" scope is hardcoded and always exists (owner-only)
+
+scopes:
+  # Family household scope
+  - name: family
+    label_de: Familie
+    label_en: Family
+    description_de: Sichtbar für Familienmitglieder
+    description_en: Visible to family members
+    roles:
+      - Admin
+      - Familie
+
+  # Public scope
+  - name: public
+    label_de: Öffentlich
+    label_en: Public
+    description_de: Sichtbar für alle Benutzer
+    description_en: Visible to all users
+    roles:
+      - Admin
+      - Familie
+      - Gast

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -746,6 +746,54 @@ FRIGATE_URL=http://frigate.local:5000
 
 ---
 
+## Knowledge Graph
+
+Das Knowledge Graph-System extrahiert Entitäten und Relationen aus Konversationen und Dokumenten.
+
+### System-Kontrolle
+
+```bash
+# Knowledge Graph aktivieren
+KNOWLEDGE_GRAPH_ENABLED=false
+```
+
+**Default:** `false`
+
+### Konfiguration
+
+```bash
+# Modell für KG-Extraktion (leer = Standard-Modell verwenden)
+KG_EXTRACTION_MODEL=
+
+# Schwellenwert für Entity-Deduplizierung (Embedding-Ähnlichkeit)
+KG_SIMILARITY_THRESHOLD=0.92
+
+# Schwellenwert für Kontext-Retrieval (Embedding-Ähnlichkeit)
+KG_RETRIEVAL_THRESHOLD=0.70
+
+# Max. persönliche Entitäten pro Benutzer (custom scopes zählen nicht)
+KG_MAX_ENTITIES_PER_USER=5000
+
+# Max. Triples im LLM-Kontext
+KG_MAX_CONTEXT_TRIPLES=15
+```
+
+### Entity-Scoping
+
+Entitäten können verschiedene Sichtbarkeits-Scopes haben:
+
+- **`personal`** (built-in): Nur für den Besitzer sichtbar (Standard)
+- **Custom Scopes**: Definiert in `config/kg_scopes.yaml` mit rollenbasierter Zugriffskontrolle
+  - Beispiele: `family` (sichtbar für Familie-Rolle), `public` (für alle sichtbar)
+  - Jeder Scope definiert, welche Rollen darauf zugreifen können
+  - Erweiterbar: Neue Scopes können per YAML hinzugefügt werden ohne Code-Änderungen
+
+**Entity-Auflösung:** Custom Scopes werden vor Erstellung neuer persönlicher Entitäten geprüft → verhindert Duplikate.
+
+**Limit-Verhalten:** Nur `personal` Entitäten zählen zum `KG_MAX_ENTITIES_PER_USER` Limit. Family/Public Entitäten verbrauchen kein Benutzer-Kontingent.
+
+---
+
 ## MCP Server Configuration
 
 MCP (Model Context Protocol) Server stellen externe Tools für den Agent Loop bereit. Konfiguration in `config/mcp_servers.yaml`.

--- a/src/backend/alembic/versions/ab4bb605dc07_add_scope_to_kg_entities.py
+++ b/src/backend/alembic/versions/ab4bb605dc07_add_scope_to_kg_entities.py
@@ -1,0 +1,36 @@
+"""Add scope to kg_entities
+
+Revision ID: ab4bb605dc07
+Revises: g7h8i9j0k1l3
+Create Date: 2026-02-16 10:24:13.437035
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'ab4bb605dc07'
+down_revision: Union[str, None] = 'g7h8i9j0k1l3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add scope column to kg_entities with default value 'personal'
+    op.add_column('kg_entities', sa.Column('scope', sa.String(length=50), nullable=False, server_default='personal'))
+
+    # Create indexes
+    op.create_index(op.f('ix_kg_entities_scope'), 'kg_entities', ['scope'], unique=False)
+    op.create_index('ix_kg_entities_scope_active', 'kg_entities', ['scope', 'is_active'], unique=False)
+
+
+def downgrade() -> None:
+    # Drop indexes
+    op.drop_index('ix_kg_entities_scope_active', table_name='kg_entities')
+    op.drop_index(op.f('ix_kg_entities_scope'), table_name='kg_entities')
+
+    # Drop column
+    op.drop_column('kg_entities', 'scope')

--- a/src/backend/api/routes/knowledge_graph_schemas.py
+++ b/src/backend/api/routes/knowledge_graph_schemas.py
@@ -3,6 +3,23 @@
 from pydantic import BaseModel, Field
 
 
+class ScopeInfo(BaseModel):
+    """Scope information."""
+    name: str           # e.g., "personal", "family", "public"
+    label: str          # Localized label (e.g., "Familie", "Family")
+    description: str    # Localized description
+
+
+class ScopesListResponse(BaseModel):
+    """List of available scopes."""
+    scopes: list[ScopeInfo]
+
+
+class EntityScopeUpdate(BaseModel):
+    """Update entity scope."""
+    scope: str  # e.g., "personal", "family", "public", or any custom scope from YAML
+
+
 class EntityResponse(BaseModel):
     id: int
     name: str
@@ -11,6 +28,7 @@ class EntityResponse(BaseModel):
     mention_count: int = 1
     first_seen_at: str = ""
     last_seen_at: str = ""
+    scope: str = "personal"  # New field
 
 
 class EntityUpdate(BaseModel):

--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -945,6 +945,9 @@ MEMORY_CHANGED_BY_RESOLUTION = "contradiction_resolution"
 # Entity Type Constants
 KG_ENTITY_TYPES = ["person", "place", "organization", "thing", "event", "concept"]
 
+# Knowledge Graph Scope Constants
+KG_SCOPE_PERSONAL = "personal"  # Built-in scope, always exists (owner-only)
+
 
 class KGEntity(Base):
     """Named entity extracted from conversations for the Knowledge Graph."""
@@ -963,9 +966,12 @@ class KGEntity(Base):
     first_seen_at = Column(DateTime, default=_utcnow)
     last_seen_at = Column(DateTime, default=_utcnow)
     is_active = Column(Boolean, default=True, index=True)
+    # Scope references either "personal" or a scope name from kg_scopes.yaml
+    scope = Column(String(50), default=KG_SCOPE_PERSONAL, nullable=False, index=True)
 
     __table_args__ = (
         Index('ix_kg_entities_user_active', 'user_id', 'is_active'),
+        Index('ix_kg_entities_scope_active', 'scope', 'is_active'),
     )
 
     user = relationship("User", foreign_keys=[user_id])

--- a/src/backend/services/kg_scope_loader.py
+++ b/src/backend/services/kg_scope_loader.py
@@ -1,0 +1,160 @@
+"""
+Knowledge Graph Scope Loader — Load scope definitions from YAML config.
+"""
+import yaml
+from pathlib import Path
+from loguru import logger
+from models.database import KG_SCOPE_PERSONAL
+
+
+class KGScopeLoader:
+    """Loads and validates KG scope definitions from YAML."""
+
+    def __init__(self, config_path: str = "config/kg_scopes.yaml"):
+        self.config_path = Path(config_path)
+        self._scopes = {}
+        self.load()
+
+    def load(self):
+        """Load scopes from YAML file."""
+        if not self.config_path.exists():
+            logger.warning(f"KG scopes file not found: {self.config_path}, using defaults")
+            self._load_defaults()
+            return
+
+        try:
+            with open(self.config_path, 'r', encoding='utf-8') as f:
+                data = yaml.safe_load(f)
+
+            scopes_list = data.get('scopes', [])
+            for scope_def in scopes_list:
+                name = scope_def.get('name')
+                if not name:
+                    logger.warning("KG scope missing 'name', skipping")
+                    continue
+
+                self._scopes[name] = {
+                    'label_de': scope_def.get('label_de', name),
+                    'label_en': scope_def.get('label_en', name),
+                    'description_de': scope_def.get('description_de', ''),
+                    'description_en': scope_def.get('description_en', ''),
+                    'roles': scope_def.get('roles', []),
+                }
+
+            logger.info(f"Loaded {len(self._scopes)} KG scopes from {self.config_path}")
+        except Exception as e:
+            logger.error(f"Failed to load KG scopes: {e}")
+            self._load_defaults()
+
+    def _load_defaults(self):
+        """Load default scopes if YAML fails."""
+        self._scopes = {
+            'family': {
+                'label_de': 'Familie',
+                'label_en': 'Family',
+                'description_de': 'Sichtbar für Familienmitglieder',
+                'description_en': 'Visible to family members',
+                'roles': ['Admin', 'Familie'],
+            },
+            'public': {
+                'label_de': 'Öffentlich',
+                'label_en': 'Public',
+                'description_de': 'Sichtbar für alle Benutzer',
+                'description_en': 'Visible to all users',
+                'roles': ['Admin', 'Familie', 'Gast'],
+            },
+        }
+
+    def get_all_scopes(self, lang: str = 'de') -> list[dict]:
+        """
+        Get all available scopes including 'personal'.
+
+        Returns:
+            [
+                {'name': 'personal', 'label': 'Persönlich', 'description': '...'},
+                {'name': 'family', 'label': 'Familie', 'description': '...'},
+                ...
+            ]
+        """
+        label_key = f'label_{lang}'
+        desc_key = f'description_{lang}'
+
+        # Built-in personal scope
+        result = [{
+            'name': KG_SCOPE_PERSONAL,
+            'label': 'Persönlich' if lang == 'de' else 'Personal',
+            'description': 'Nur für den Besitzer sichtbar' if lang == 'de' else 'Visible only to owner',
+        }]
+
+        # Custom scopes from YAML
+        for name, scope_def in self._scopes.items():
+            result.append({
+                'name': name,
+                'label': scope_def.get(label_key, name),
+                'description': scope_def.get(desc_key, ''),
+            })
+
+        return result
+
+    def is_valid_scope(self, scope: str) -> bool:
+        """Check if a scope name is valid."""
+        return scope == KG_SCOPE_PERSONAL or scope in self._scopes
+
+    def can_access_scope(self, scope: str, user_role: str | None) -> bool:
+        """
+        Check if a user with the given role can access entities with this scope.
+
+        Args:
+            scope: Scope name (e.g., 'family', 'public')
+            user_role: User's role name (e.g., 'Familie', 'Gast')
+
+        Returns:
+            True if user can access this scope
+        """
+        if scope == KG_SCOPE_PERSONAL:
+            # Personal scope is owner-only, checked separately
+            return True
+
+        scope_def = self._scopes.get(scope)
+        if not scope_def:
+            logger.warning(f"Unknown scope: {scope}")
+            return False
+
+        if user_role is None:
+            # Unauthenticated users cannot access custom scopes
+            return False
+
+        return user_role in scope_def.get('roles', [])
+
+    def get_accessible_scopes(self, user_role: str | None, include_personal: bool = True) -> list[str]:
+        """
+        Get list of scope names accessible to a user.
+
+        Args:
+            user_role: User's role name
+            include_personal: Whether to include 'personal' in the list
+
+        Returns:
+            ['personal', 'family', 'public'] (example)
+        """
+        result = []
+        if include_personal:
+            result.append(KG_SCOPE_PERSONAL)
+
+        for name, scope_def in self._scopes.items():
+            if user_role and user_role in scope_def.get('roles', []):
+                result.append(name)
+
+        return result
+
+
+# Singleton instance
+_scope_loader = None
+
+
+def get_scope_loader() -> KGScopeLoader:
+    """Get the global scope loader instance."""
+    global _scope_loader
+    if _scope_loader is None:
+        _scope_loader = KGScopeLoader()
+    return _scope_loader

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -824,6 +824,12 @@
     "organization": "Organisation",
     "thing": "Sache",
     "event": "Ereignis",
-    "concept": "Konzept"
+    "concept": "Konzept",
+    "personal": "Persönlich",
+    "family": "Familie",
+    "public": "Öffentlich",
+    "scopeFilter": "Sichtbarkeit",
+    "changeScope": "Sichtbarkeit ändern",
+    "scopeUpdated": "{{name}} ist jetzt {{scope}}"
   }
 }

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -824,6 +824,12 @@
     "organization": "Organization",
     "thing": "Thing",
     "event": "Event",
-    "concept": "Concept"
+    "concept": "Concept",
+    "personal": "Personal",
+    "family": "Family",
+    "public": "Public",
+    "scopeFilter": "Scope",
+    "changeScope": "Change scope",
+    "scopeUpdated": "{{name}} is now {{scope}}"
   }
 }


### PR DESCRIPTION
## Summary
- Add flexible YAML-based scope system (`config/kg_scopes.yaml`) for Knowledge Graph entities with role-based access control
- Support custom scopes (e.g., `family`, `public`) beyond the built-in `personal` scope, each with configurable role access
- Entity resolution now checks accessible custom scopes before creating new personal entities to prevent duplication
- Admin UI for changing entity scope via `/admin/knowledge-graph`
- Alembic migration adds `scope` column to KG entities

## Test plan
- [ ] Verify `config/kg_scopes.yaml` is loaded correctly on startup
- [ ] Test entity creation with different scopes (personal, family, public)
- [ ] Verify role-based access: users only see entities in scopes their role grants
- [ ] Test entity resolution prioritizes custom scopes over creating duplicates
- [ ] Verify admin UI scope selector works in Knowledge Graph page
- [ ] Run existing KG tests to confirm no regressions
- [ ] Test migration applies cleanly (`alembic upgrade head`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)