### PR TITLE
feat(config): Add edition/feature flag system (community vs pro)

### DIFF
--- a/src/backend/api/routes/auth.py
+++ b/src/backend/api/routes/auth.py
@@ -92,6 +92,7 @@ class AuthStatusResponse(BaseModel):
     allow_registration: bool
     authenticated: bool
     user: UserResponse | None = None
+    features: dict[str, bool] = {}
 
 
 # =============================================================================
@@ -354,7 +355,8 @@ async def get_auth_status(
         auth_enabled=settings.auth_enabled,
         allow_registration=settings.allow_registration,
         authenticated=user is not None,
-        user=user_response
+        user=user_response,
+        features=settings.features
     )
 
 

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -137,10 +137,13 @@ app.include_router(chat.router, prefix="/api/chat", tags=["Chat"])
 app.include_router(chat_upload.router, prefix="/api/chat", tags=["Chat Upload"])
 app.include_router(tasks.router, prefix="/api/tasks", tags=["Tasks"])
 app.include_router(voice.router, prefix="/api/voice", tags=["Voice"])
-app.include_router(camera.router, prefix="/api/camera", tags=["Camera"])
-app.include_router(ha_routes.router, prefix="/api/homeassistant", tags=["Home Assistant"])
+if settings.features["cameras"]:
+    app.include_router(camera.router, prefix="/api/camera", tags=["Camera"])
+if settings.features["smart_home"]:
+    app.include_router(ha_routes.router, prefix="/api/homeassistant", tags=["Home Assistant"])
 app.include_router(settings_routes.router, prefix="/api/settings", tags=["Settings"])
-app.include_router(satellites.router, prefix="/api/satellites", tags=["Satellites"])
+if settings.features["satellites"]:
+    app.include_router(satellites.router, prefix="/api/satellites", tags=["Satellites"])
 app.include_router(speakers.router, prefix="/api/speakers", tags=["Speakers"])
 app.include_router(rooms.router, prefix="/api/rooms", tags=["Rooms"])
 app.include_router(knowledge.router, prefix="/api/knowledge", tags=["Knowledge"])
@@ -155,7 +158,8 @@ app.include_router(kg_routes.router, prefix="/api/knowledge-graph", tags=["Knowl
 
 # WebSocket Routers
 app.include_router(chat_router, tags=["WebSocket Chat"])
-app.include_router(satellite_router, tags=["WebSocket Satellite"])
+if settings.features["satellites"]:
+    app.include_router(satellite_router, tags=["WebSocket Satellite"])
 app.include_router(device_router, tags=["WebSocket Device"])
 
 

--- a/src/frontend/src/App.jsx
+++ b/src/frontend/src/App.jsx
@@ -7,7 +7,7 @@ import ChatPage from './pages/ChatPage';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import { DeviceProvider } from './context/DeviceContext';
-import { AuthProvider } from './context/AuthContext';
+import { AuthProvider, useAuth } from './context/AuthContext';
 import { ThemeProvider } from './context/ThemeContext';
 import LoadingSpinner from './components/LoadingSpinner';
 
@@ -28,6 +28,104 @@ const IntentsPage = lazy(() => import('./pages/IntentsPage'));
 const PresencePage = lazy(() => import('./pages/PresencePage'));
 const KnowledgeGraphPage = lazy(() => import('./pages/KnowledgeGraphPage'));
 
+function AppRoutes() {
+  const { isFeatureEnabled } = useAuth();
+
+  return (
+    <Routes>
+      {/* Public routes without layout */}
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/register" element={<RegisterPage />} />
+
+      {/* Routes with layout */}
+      <Route path="/*" element={
+        <Layout>
+          <Routes>
+            <Route path="/" element={<ChatPage />} />
+            <Route path="/chat" element={<Navigate to="/" replace />} />
+            <Route path="/tasks" element={<TasksPage />} />
+            {isFeatureEnabled('cameras') && (
+              <Route path="/camera" element={
+                <ProtectedRoute permission={['cam.view', 'cam.full']} requireAny>
+                  <CameraPage />
+                </ProtectedRoute>
+              } />
+            )}
+            {isFeatureEnabled('smart_home') && (
+              <Route path="/homeassistant" element={
+                <ProtectedRoute permission={['ha.read', 'ha.control', 'ha.full']} requireAny>
+                  <HomeAssistantPage />
+                </ProtectedRoute>
+              } />
+            )}
+            <Route path="/speakers" element={
+              <ProtectedRoute permission={['speakers.own', 'speakers.all']} requireAny>
+                <SpeakersPage />
+              </ProtectedRoute>
+            } />
+            <Route path="/rooms" element={
+              <ProtectedRoute permission={['rooms.read', 'rooms.manage']} requireAny>
+                <RoomsPage />
+              </ProtectedRoute>
+            } />
+            <Route path="/knowledge" element={
+              <ProtectedRoute permission={['kb.own', 'kb.shared', 'kb.all']} requireAny>
+                <KnowledgePage />
+              </ProtectedRoute>
+            } />
+            <Route path="/memory" element={<MemoryPage />} />
+            {/* Redirect old /plugins route to new integrations page */}
+            <Route path="/plugins" element={<Navigate to="/admin/integrations" replace />} />
+            {/* Admin routes */}
+            <Route path="/admin/users" element={
+              <AdminRoute>
+                <UsersPage />
+              </AdminRoute>
+            } />
+            <Route path="/admin/roles" element={
+              <AdminRoute>
+                <RolesPage />
+              </AdminRoute>
+            } />
+            <Route path="/admin/settings" element={
+              <AdminRoute>
+                <SettingsPage />
+              </AdminRoute>
+            } />
+            {isFeatureEnabled('satellites') && (
+              <Route path="/admin/satellites" element={
+                <AdminRoute>
+                  <SatellitesPage />
+                </AdminRoute>
+              } />
+            )}
+            <Route path="/admin/integrations" element={
+              <AdminRoute>
+                <IntegrationsPage />
+              </AdminRoute>
+            } />
+            <Route path="/admin/intents" element={
+              <AdminRoute>
+                <IntentsPage />
+              </AdminRoute>
+            } />
+            <Route path="/admin/presence" element={
+              <AdminRoute>
+                <PresencePage />
+              </AdminRoute>
+            } />
+            <Route path="/admin/knowledge-graph" element={
+              <AdminRoute>
+                <KnowledgeGraphPage />
+              </AdminRoute>
+            } />
+          </Routes>
+        </Layout>
+      } />
+    </Routes>
+  );
+}
+
 function App() {
   return (
     <ErrorBoundary>
@@ -35,91 +133,7 @@ function App() {
         <AuthProvider>
           <DeviceProvider>
           <Suspense fallback={<LoadingSpinner />}>
-          <Routes>
-            {/* Public routes without layout */}
-            <Route path="/login" element={<LoginPage />} />
-            <Route path="/register" element={<RegisterPage />} />
-
-            {/* Routes with layout */}
-            <Route path="/*" element={
-              <Layout>
-                <Routes>
-                  <Route path="/" element={<ChatPage />} />
-                  <Route path="/chat" element={<Navigate to="/" replace />} />
-                  <Route path="/tasks" element={<TasksPage />} />
-                  <Route path="/camera" element={
-                    <ProtectedRoute permission={['cam.view', 'cam.full']} requireAny>
-                      <CameraPage />
-                    </ProtectedRoute>
-                  } />
-                  <Route path="/homeassistant" element={
-                    <ProtectedRoute permission={['ha.read', 'ha.control', 'ha.full']} requireAny>
-                      <HomeAssistantPage />
-                    </ProtectedRoute>
-                  } />
-                  <Route path="/speakers" element={
-                    <ProtectedRoute permission={['speakers.own', 'speakers.all']} requireAny>
-                      <SpeakersPage />
-                    </ProtectedRoute>
-                  } />
-                  <Route path="/rooms" element={
-                    <ProtectedRoute permission={['rooms.read', 'rooms.manage']} requireAny>
-                      <RoomsPage />
-                    </ProtectedRoute>
-                  } />
-                  <Route path="/knowledge" element={
-                    <ProtectedRoute permission={['kb.own', 'kb.shared', 'kb.all']} requireAny>
-                      <KnowledgePage />
-                    </ProtectedRoute>
-                  } />
-                  <Route path="/memory" element={<MemoryPage />} />
-                  {/* Redirect old /plugins route to new integrations page */}
-                  <Route path="/plugins" element={<Navigate to="/admin/integrations" replace />} />
-                  {/* Admin routes */}
-                  <Route path="/admin/users" element={
-                    <AdminRoute>
-                      <UsersPage />
-                    </AdminRoute>
-                  } />
-                  <Route path="/admin/roles" element={
-                    <AdminRoute>
-                      <RolesPage />
-                    </AdminRoute>
-                  } />
-                  <Route path="/admin/settings" element={
-                    <AdminRoute>
-                      <SettingsPage />
-                    </AdminRoute>
-                  } />
-                  <Route path="/admin/satellites" element={
-                    <AdminRoute>
-                      <SatellitesPage />
-                    </AdminRoute>
-                  } />
-                  <Route path="/admin/integrations" element={
-                    <AdminRoute>
-                      <IntegrationsPage />
-                    </AdminRoute>
-                  } />
-                  <Route path="/admin/intents" element={
-                    <AdminRoute>
-                      <IntentsPage />
-                    </AdminRoute>
-                  } />
-                  <Route path="/admin/presence" element={
-                    <AdminRoute>
-                      <PresencePage />
-                    </AdminRoute>
-                  } />
-                  <Route path="/admin/knowledge-graph" element={
-                    <AdminRoute>
-                      <KnowledgeGraphPage />
-                    </AdminRoute>
-                  } />
-                </Routes>
-              </Layout>
-            } />
-          </Routes>
+            <AppRoutes />
           </Suspense>
           </DeviceProvider>
         </AuthProvider>

--- a/src/frontend/src/components/Layout.jsx
+++ b/src/frontend/src/components/Layout.jsx
@@ -36,19 +36,19 @@ const mainNavigationConfig = [
   { nameKey: 'nav.knowledge', href: '/knowledge', icon: BookOpen, permission: ['kb.own', 'kb.shared', 'kb.all'] },
   { nameKey: 'nav.memory', href: '/memory', icon: Brain },
   { nameKey: 'nav.tasks', href: '/tasks', icon: CheckSquare },
-  { nameKey: 'nav.cameras', href: '/camera', icon: Camera, permission: ['cam.view', 'cam.full'] },
+  { nameKey: 'nav.cameras', href: '/camera', icon: Camera, permission: ['cam.view', 'cam.full'], feature: 'cameras' },
 ];
 
 // Admin navigation with translation keys
 const adminNavigationConfig = [
   { nameKey: 'nav.rooms', href: '/rooms', icon: DoorOpen, permission: ['rooms.read', 'rooms.manage'] },
   { nameKey: 'nav.speakers', href: '/speakers', icon: Users, permission: ['speakers.own', 'speakers.all'] },
-  { nameKey: 'nav.smarthome', href: '/homeassistant', icon: Lightbulb, permission: ['ha.read', 'ha.control', 'ha.full'] },
+  { nameKey: 'nav.smarthome', href: '/homeassistant', icon: Lightbulb, permission: ['ha.read', 'ha.control', 'ha.full'], feature: 'smart_home' },
   { nameKey: 'nav.integrations', href: '/admin/integrations', icon: Blocks, permission: ['admin', 'plugins.use', 'plugins.manage'] },
   { nameKey: 'nav.intents', href: '/admin/intents', icon: Zap, permission: ['admin'] },
   { nameKey: 'nav.users', href: '/admin/users', icon: UserCog, permission: ['admin'] },
   { nameKey: 'nav.roles', href: '/admin/roles', icon: Shield, permission: ['admin'] },
-  { nameKey: 'nav.satellites', href: '/admin/satellites', icon: Satellite, permission: ['admin'] },
+  { nameKey: 'nav.satellites', href: '/admin/satellites', icon: Satellite, permission: ['admin'], feature: 'satellites' },
   { nameKey: 'nav.presence', href: '/admin/presence', icon: MapPin, permission: ['admin'] },
   { nameKey: 'nav.knowledgeGraph', href: '/admin/knowledge-graph', icon: Brain, permission: ['admin'] },
   { nameKey: 'nav.settings', href: '/admin/settings', icon: Settings, permission: ['admin'] },
@@ -70,7 +70,7 @@ export default function Layout({ children }) {
   const firstFocusableRef = useRef(null);
 
   // Auth context
-  const { user, isAuthenticated, authEnabled, logout, hasAnyPermission, loading: authLoading } = useAuth();
+  const { user, isAuthenticated, authEnabled, logout, hasAnyPermission, isFeatureEnabled, loading: authLoading } = useAuth();
 
   // Translate navigation items
   const mainNavigation = mainNavigationConfig.map(item => ({
@@ -83,11 +83,14 @@ export default function Layout({ children }) {
     name: t(item.nameKey)
   }));
 
-  // Filter navigation items based on permissions
+  // Filter navigation items based on features and permissions
   const filterNavItems = (items) => {
-    if (!authEnabled) return items; // Show all if auth disabled
     return items.filter(item => {
-      if (!item.permission) return true; // No permission required
+      // Feature flag check first
+      if (item.feature && !isFeatureEnabled(item.feature)) return false;
+      // Permission check
+      if (!authEnabled) return true;
+      if (!item.permission) return true;
       return hasAnyPermission(item.permission);
     });
   };

--- a/src/frontend/src/components/RoomOutputSettings.jsx
+++ b/src/frontend/src/components/RoomOutputSettings.jsx
@@ -6,6 +6,7 @@ import {
 } from 'lucide-react';
 import apiClient from '../utils/axios';
 import { useConfirmDialog } from './ConfirmDialog';
+import { useAuth } from '../context/AuthContext';
 
 // Output device type icons
 const OUTPUT_TYPE_ICONS = {
@@ -26,6 +27,8 @@ const OUTPUT_TYPE_ICONS = {
 export default function RoomOutputSettings({ roomId, roomName }) {
   const { t } = useTranslation();
   const { confirm, ConfirmDialogComponent } = useConfirmDialog();
+  const { isFeatureEnabled } = useAuth();
+  const showHA = isFeatureEnabled('smart_home');
   // State
   const [expanded, setExpanded] = useState(false);
   const [outputDevices, setOutputDevices] = useState([]);
@@ -36,7 +39,7 @@ export default function RoomOutputSettings({ roomId, roomName }) {
   const [error, setError] = useState(null);
 
   // Add form state
-  const [selectedType, setSelectedType] = useState('homeassistant'); // 'renfield' or 'homeassistant'
+  const [selectedType, setSelectedType] = useState(showHA ? 'homeassistant' : 'renfield'); // 'renfield' or 'homeassistant'
   const [selectedDevice, setSelectedDevice] = useState('');
   const [allowInterruption, setAllowInterruption] = useState(false);
   const [ttsVolume, setTtsVolume] = useState(50);
@@ -76,7 +79,7 @@ export default function RoomOutputSettings({ roomId, roomName }) {
 
   const openAddModal = () => {
     loadAvailableOutputs();
-    setSelectedType('homeassistant');
+    setSelectedType(showHA ? 'homeassistant' : 'renfield');
     setSelectedDevice('');
     setAllowInterruption(false);
     setTtsVolume(50);
@@ -186,11 +189,12 @@ export default function RoomOutputSettings({ roomId, roomName }) {
       return availableOutputs.renfield_devices.filter(
         d => !configuredRenfieldIds.has(d.device_id)
       );
-    } else {
+    } else if (showHA) {
       return availableOutputs.ha_media_players.filter(
         d => !configuredHAIds.has(d.entity_id)
       );
     }
+    return [];
   };
 
   return (
@@ -340,20 +344,22 @@ export default function RoomOutputSettings({ roomId, roomName }) {
               <div>
                 <label className="block text-sm text-gray-400 mb-2">Geraetetyp:</label>
                 <div className="flex space-x-2">
-                  <button
-                    onClick={() => {
-                      setSelectedType('homeassistant');
-                      setSelectedDevice('');
-                    }}
-                    className={`flex-1 p-3 rounded-lg border ${
-                      selectedType === 'homeassistant'
-                        ? 'border-blue-500 bg-blue-500/20'
-                        : 'border-gray-700 bg-gray-800'
-                    }`}
-                  >
-                    <Speaker className="w-5 h-5 mx-auto mb-1 text-blue-400" />
-                    <span className="text-sm text-gray-300">HA Media Player</span>
-                  </button>
+                  {showHA && (
+                    <button
+                      onClick={() => {
+                        setSelectedType('homeassistant');
+                        setSelectedDevice('');
+                      }}
+                      className={`flex-1 p-3 rounded-lg border ${
+                        selectedType === 'homeassistant'
+                          ? 'border-blue-500 bg-blue-500/20'
+                          : 'border-gray-700 bg-gray-800'
+                      }`}
+                    >
+                      <Speaker className="w-5 h-5 mx-auto mb-1 text-blue-400" />
+                      <span className="text-sm text-gray-300">HA Media Player</span>
+                    </button>
+                  )}
                   <button
                     onClick={() => {
                       setSelectedType('renfield');

--- a/src/frontend/src/pages/RolesPage.jsx
+++ b/src/frontend/src/pages/RolesPage.jsx
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react';
 
 // Permission categories for better organization
+// Categories with a 'feature' key are only shown when that feature is enabled
 const PERMISSION_CATEGORIES = {
   'Knowledge Bases': {
     description: 'Access to knowledge base documents',
@@ -22,11 +23,13 @@ const PERMISSION_CATEGORIES = {
   },
   'Home Assistant': {
     description: 'Smart home device control',
-    permissions: ['ha.none', 'ha.read', 'ha.control', 'ha.full']
+    permissions: ['ha.none', 'ha.read', 'ha.control', 'ha.full'],
+    feature: 'smart_home'
   },
   'Cameras': {
     description: 'Camera and video access',
-    permissions: ['cam.none', 'cam.view', 'cam.full']
+    permissions: ['cam.none', 'cam.view', 'cam.full'],
+    feature: 'cameras'
   },
   'Conversations': {
     description: 'Chat history access',
@@ -70,7 +73,7 @@ const PERMISSION_DESCRIPTIONS = {
 
 export default function RolesPage() {
   const { t } = useTranslation();
-  const { getAccessToken } = useAuth();
+  const { getAccessToken, isFeatureEnabled } = useAuth();
   const { confirm, ConfirmDialogComponent } = useConfirmDialog();
 
   const [roles, setRoles] = useState([]);
@@ -455,7 +458,9 @@ export default function RolesPage() {
             </div>
 
             <div className="space-y-2 max-h-96 overflow-y-auto pr-2">
-              {Object.entries(PERMISSION_CATEGORIES).map(([category, { description, permissions }]) => {
+              {Object.entries(PERMISSION_CATEGORIES).filter(([, { feature }]) =>
+                !feature || isFeatureEnabled(feature)
+              ).map(([category, { description, permissions }]) => {
                 const isExpanded = expandedCategories[category];
                 const selectedCount = getCategoryPermissionCount(category, formData.permissions);
 

--- a/tests/backend/test_feature_flags.py
+++ b/tests/backend/test_feature_flags.py
@@ -1,0 +1,190 @@
+"""
+Tests for Edition & Feature Flag System
+
+Tests cover:
+- Edition presets (community, pro)
+- Feature flag overrides
+- /api/auth/status includes features
+- Route guards (conditional mounting)
+"""
+
+from utils.config import Settings
+
+# ============================================================================
+# Edition Preset Tests
+# ============================================================================
+
+class TestEditionPresets:
+    """Test that edition presets set correct defaults."""
+
+    def test_community_edition_enables_all(self):
+        """Community (home) edition enables all features by default."""
+        s = Settings(renfield_edition="community", _env_file=None)
+        assert s.features == {
+            "smart_home": True,
+            "cameras": True,
+            "satellites": True,
+        }
+
+    def test_pro_edition_disables_home_features(self):
+        """Pro (business) edition disables smart home features by default."""
+        s = Settings(renfield_edition="pro", _env_file=None)
+        assert s.features == {
+            "smart_home": False,
+            "cameras": False,
+            "satellites": False,
+        }
+
+    def test_unknown_edition_falls_back_to_pro(self):
+        """Unknown edition name falls back to pro defaults."""
+        s = Settings(renfield_edition="enterprise", _env_file=None)
+        assert s.features == {
+            "smart_home": False,
+            "cameras": False,
+            "satellites": False,
+        }
+
+    def test_default_edition_is_community(self):
+        """Default edition is community."""
+        s = Settings(_env_file=None)
+        assert s.renfield_edition == "community"
+        assert s.features["smart_home"] is True
+
+
+# ============================================================================
+# Feature Flag Override Tests
+# ============================================================================
+
+class TestFeatureOverrides:
+    """Test that explicit feature flags override edition presets."""
+
+    def test_override_enables_on_pro(self):
+        """Explicit True overrides pro's default False."""
+        s = Settings(
+            renfield_edition="pro",
+            feature_cameras=True,
+            _env_file=None,
+        )
+        assert s.features["cameras"] is True
+        # Others still follow pro defaults
+        assert s.features["smart_home"] is False
+        assert s.features["satellites"] is False
+
+    def test_override_disables_on_community(self):
+        """Explicit False overrides community's default True."""
+        s = Settings(
+            renfield_edition="community",
+            feature_smart_home=False,
+            _env_file=None,
+        )
+        assert s.features["smart_home"] is False
+        # Others still follow community defaults
+        assert s.features["cameras"] is True
+        assert s.features["satellites"] is True
+
+    def test_multiple_overrides(self):
+        """Multiple overrides work independently."""
+        s = Settings(
+            renfield_edition="pro",
+            feature_smart_home=True,
+            feature_cameras=True,
+            feature_satellites=True,
+            _env_file=None,
+        )
+        assert s.features == {
+            "smart_home": True,
+            "cameras": True,
+            "satellites": True,
+        }
+
+    def test_none_means_use_default(self):
+        """None (not set) means use edition default."""
+        s = Settings(
+            renfield_edition="community",
+            feature_smart_home=None,
+            _env_file=None,
+        )
+        assert s.features["smart_home"] is True
+
+
+# ============================================================================
+# Auth Status Endpoint Tests
+# ============================================================================
+
+class TestAuthStatusFeatures:
+    """Test that features are correctly resolved for API responses."""
+
+    def test_community_features_for_status(self):
+        """Community edition features dict is correct for auth status."""
+        s = Settings(renfield_edition="community", _env_file=None)
+        features = s.features
+        assert features == {
+            "smart_home": True,
+            "cameras": True,
+            "satellites": True,
+        }
+
+    def test_pro_features_for_status(self):
+        """Pro edition features dict is correct for auth status."""
+        s = Settings(renfield_edition="pro", _env_file=None)
+        features = s.features
+        assert features == {
+            "smart_home": False,
+            "cameras": False,
+            "satellites": False,
+        }
+
+    def test_override_in_features_for_status(self):
+        """Override in pro edition shows in features dict."""
+        s = Settings(renfield_edition="pro", feature_cameras=True, _env_file=None)
+        features = s.features
+        assert features["cameras"] is True
+        assert features["smart_home"] is False
+
+
+# ============================================================================
+# Route Guard Tests
+# ============================================================================
+
+class TestRouteGuards:
+    """Test that routes are conditionally mounted based on feature flags."""
+
+    def test_camera_route_not_mounted_when_disabled(self):
+        """Camera routes should not be mounted when cameras feature is disabled."""
+        s = Settings(renfield_edition="pro", _env_file=None)
+        assert s.features["cameras"] is False
+
+    def test_ha_route_not_mounted_when_disabled(self):
+        """HA routes should not be mounted when smart_home feature is disabled."""
+        s = Settings(renfield_edition="pro", _env_file=None)
+        assert s.features["smart_home"] is False
+
+    def test_satellite_route_not_mounted_when_disabled(self):
+        """Satellite routes should not be mounted when satellites feature is disabled."""
+        s = Settings(renfield_edition="pro", _env_file=None)
+        assert s.features["satellites"] is False
+
+    def test_all_routes_mounted_when_community(self):
+        """All feature routes should be mounted in community edition."""
+        s = Settings(renfield_edition="community", _env_file=None)
+        assert all(s.features.values())
+
+
+# ============================================================================
+# Features Property Consistency Tests
+# ============================================================================
+
+class TestFeaturesPropertyConsistency:
+    """Test that features property is always consistent."""
+
+    def test_features_returns_all_keys(self):
+        """Features dict always contains all three keys."""
+        for edition in ["community", "pro", "enterprise"]:
+            s = Settings(renfield_edition=edition, _env_file=None)
+            assert set(s.features.keys()) == {"smart_home", "cameras", "satellites"}
+
+    def test_features_values_are_bool(self):
+        """All feature values are booleans."""
+        s = Settings(_env_file=None)
+        for key, value in s.features.items():
+            assert isinstance(value, bool), f"{key} should be bool, got {type(value)}"

--- a/tests/frontend/react/components/FeatureFlags.test.jsx
+++ b/tests/frontend/react/components/FeatureFlags.test.jsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import Layout from '../../../../src/frontend/src/components/Layout';
+import { renderWithRouter } from '../test-utils.jsx';
+import { useAuth } from '../../../../src/frontend/src/context/AuthContext';
+
+// Mock AuthContext
+vi.mock('../../../../src/frontend/src/context/AuthContext', () => ({
+  useAuth: vi.fn(),
+}));
+
+// Mock DeviceStatus to avoid unrelated side effects
+vi.mock('../../../../src/frontend/src/components/DeviceStatus', () => ({
+  default: () => <div data-testid="device-status">Device Status</div>,
+}));
+
+// Mock NotificationToast
+vi.mock('../../../../src/frontend/src/components/NotificationToast', () => ({
+  default: () => null,
+}));
+
+// Mock ThemeContext
+vi.mock('../../../../src/frontend/src/context/ThemeContext', () => ({
+  useTheme: () => ({ theme: 'light', isDark: false, setTheme: vi.fn(), toggleTheme: vi.fn() }),
+  ThemeProvider: ({ children }) => children,
+}));
+
+// Base auth mock with all features enabled (community edition)
+const communityAuth = {
+  user: { username: 'admin', role: 'Admin', permissions: ['admin'] },
+  isAuthenticated: true,
+  authEnabled: true,
+  allowRegistration: false,
+  loading: false,
+  logout: vi.fn(),
+  hasPermission: () => true,
+  hasAnyPermission: () => true,
+  isAdmin: () => true,
+  getAccessToken: () => 'mock-token',
+  features: { smart_home: true, cameras: true, satellites: true },
+  isFeatureEnabled: () => true,
+};
+
+// Pro edition - all home features disabled
+const proAuth = {
+  ...communityAuth,
+  features: { smart_home: false, cameras: false, satellites: false },
+  isFeatureEnabled: () => false,
+};
+
+describe('Layout feature flags', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows camera nav item when cameras feature is enabled', () => {
+    useAuth.mockReturnValue(communityAuth);
+    renderWithRouter(
+      <Layout><div>content</div></Layout>,
+    );
+    expect(screen.getByText('Kameras')).toBeInTheDocument();
+  });
+
+  it('hides camera nav item when cameras feature is disabled', () => {
+    useAuth.mockReturnValue({
+      ...communityAuth,
+      features: { smart_home: true, cameras: false, satellites: true },
+      isFeatureEnabled: (f) => f !== 'cameras',
+    });
+    renderWithRouter(
+      <Layout><div>content</div></Layout>,
+    );
+    expect(screen.queryByText('Kameras')).not.toBeInTheDocument();
+    // Chat should still be visible
+    expect(screen.getByText('Chat')).toBeInTheDocument();
+  });
+
+  it('hides smart home nav item when smart_home feature is disabled', () => {
+    useAuth.mockReturnValue({
+      ...communityAuth,
+      features: { smart_home: false, cameras: true, satellites: true },
+      isFeatureEnabled: (f) => f !== 'smart_home',
+    });
+    renderWithRouter(
+      <Layout><div>content</div></Layout>,
+    );
+    expect(screen.queryByText('Smart Home')).not.toBeInTheDocument();
+  });
+
+  it('hides satellites nav item when satellites feature is disabled', () => {
+    useAuth.mockReturnValue({
+      ...communityAuth,
+      features: { smart_home: true, cameras: true, satellites: false },
+      isFeatureEnabled: (f) => f !== 'satellites',
+    });
+    renderWithRouter(
+      <Layout><div>content</div></Layout>,
+    );
+    expect(screen.queryByText('Satellites')).not.toBeInTheDocument();
+  });
+
+  it('hides all home features in pro edition', () => {
+    useAuth.mockReturnValue(proAuth);
+    renderWithRouter(
+      <Layout><div>content</div></Layout>,
+    );
+    expect(screen.queryByText('Kameras')).not.toBeInTheDocument();
+    expect(screen.queryByText('Smart Home')).not.toBeInTheDocument();
+    expect(screen.queryByText('Satellites')).not.toBeInTheDocument();
+    // Core features still visible
+    expect(screen.getByText('Chat')).toBeInTheDocument();
+  });
+
+  it('shows all nav items in community edition', () => {
+    useAuth.mockReturnValue(communityAuth);
+    renderWithRouter(
+      <Layout><div>content</div></Layout>,
+    );
+    expect(screen.getByText('Chat')).toBeInTheDocument();
+    expect(screen.getByText('Kameras')).toBeInTheDocument();
+  });
+});

--- a/tests/frontend/react/pages/RolesPage.test.jsx
+++ b/tests/frontend/react/pages/RolesPage.test.jsx
@@ -18,6 +18,7 @@ const adminAuthMock = {
   getAccessToken: () => 'mock-token',
   hasPermission: () => true,
   hasAnyPermission: () => true,
+  isFeatureEnabled: () => true,
   isAuthenticated: true,
   authEnabled: true,
   loading: false,

--- a/tests/frontend/react/test-utils.jsx
+++ b/tests/frontend/react/test-utils.jsx
@@ -17,6 +17,8 @@ const defaultMockAuth = {
   authEnabled: true,
   allowRegistration: false,
   loading: false,
+  features: { smart_home: true, cameras: true, satellites: true },
+  isFeatureEnabled: (feature) => true,
   login: async () => {},
   logout: () => {},
   register: async () => {},


### PR DESCRIPTION
## Summary
- Add `RENFIELD_EDITION` env var (`community`/`pro`) with edition presets for smart_home, cameras, and satellites features
- Individual `FEATURE_SMART_HOME`, `FEATURE_CAMERAS`, `FEATURE_SATELLITES` env vars override edition defaults
- Backend conditionally mounts REST routes and WebSocket endpoints based on feature flags
- Frontend hides nav items, routes, permission groups, and HA media player tab when features disabled

## Test plan
- [x] Backend: 17 unit tests for edition presets, overrides, consistency (`test_feature_flags.py`)
- [x] Frontend: 6 tests for Layout nav filtering by feature flags (`FeatureFlags.test.jsx`)
- [x] Existing tests pass (300/301, 1 pre-existing failure unrelated)
- [ ] Manual: Set `RENFIELD_EDITION=pro`, verify Camera/HA/Satellites hidden in UI and API returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)