### PR TITLE
fix(kg): Pass missing isOpen prop to edit entity Modal

### DIFF
--- a/src/frontend/src/pages/KnowledgeGraphPage.jsx
+++ b/src/frontend/src/pages/KnowledgeGraphPage.jsx
@@ -712,7 +712,7 @@ export default function KnowledgeGraphPage() {
 
       {/* Edit Modal */}
       {showEditModal && (
-        <Modal onClose={() => setShowEditModal(false)} title={t('common.edit')}>
+        <Modal isOpen={showEditModal} onClose={() => setShowEditModal(false)} title={t('common.edit')}>
           <div className="space-y-4">
             <div>
               <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">


### PR DESCRIPTION
## Summary
- Adds missing `isOpen={showEditModal}` prop to the `<Modal>` in `KnowledgeGraphPage.jsx`
- Without it, the Modal's `if (!isOpen) return null` guard prevented the edit dialog from ever rendering

Closes #164

## Test plan
- [x] 300/301 frontend tests pass (1 pre-existing failure in IntegrationsPage)
- [ ] Open /admin/knowledge-graph, click edit (pencil) on an entity — modal should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)