### PR TITLE
fix(rag): Hybrid search broken + KG quality issues from document ingest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,7 @@ services:
       - ./pytest.ini:/pytest.ini
       - ./config/mcp_servers.yaml:/app/config/mcp_servers.yaml:ro  # MCP server configuration
       - ./config/agent_roles.yaml:/app/config/agent_roles.yaml:ro  # Agent role definitions
+      - ./config/kg_scopes.yaml:/app/config/kg_scopes.yaml:ro      # Knowledge Graph scope definitions
       - ./config/mail_accounts.yaml:/config/mail_accounts.yaml:ro  # Email MCP account config
       - ./config/calendar_accounts.yaml:/config/calendar_accounts.yaml:ro  # Calendar MCP account config
       - ./data/wakeword-models:/app/wakeword-models:ro  # TFLite models for satellite download
@@ -159,6 +160,7 @@ services:
       - ./pytest.ini:/pytest.ini
       - ./config/mcp_servers.yaml:/app/config/mcp_servers.yaml:ro  # MCP server configuration
       - ./config/agent_roles.yaml:/app/config/agent_roles.yaml:ro  # Agent role definitions
+      - ./config/kg_scopes.yaml:/app/config/kg_scopes.yaml:ro      # Knowledge Graph scope definitions
       - ./config/mail_accounts.yaml:/config/mail_accounts.yaml:ro  # Email MCP account config
       - ./config/calendar_accounts.yaml:/config/calendar_accounts.yaml:ro  # Calendar MCP account config
       - ./data/wakeword-models:/app/wakeword-models:ro  # TFLite models for satellite download

--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -4,6 +4,7 @@ Datenbank Models
 from datetime import UTC, datetime
 
 from sqlalchemy import JSON, Boolean, Column, DateTime, Float, ForeignKey, Index, Integer, String, Text
+from sqlalchemy.dialects.postgresql import TSVECTOR
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 
@@ -470,8 +471,8 @@ class DocumentChunk(Base):
     section_title = Column(String(512), nullable=True)
     chunk_type = Column(String(50), default="paragraph")  # paragraph, table, code, formula, etc.
 
-    # Full-text search vector (populated during ingestion, actual type TSVECTOR via migration)
-    search_vector = Column(Text, nullable=True)
+    # Full-text search vector (populated during ingestion via to_tsvector())
+    search_vector = Column(TSVECTOR, nullable=True)
 
     # Additional Metadata (JSON für Flexibilität)
     chunk_metadata = Column(JSON, nullable=True)  # Umbenannt von 'metadata' (SQLAlchemy reserved)

--- a/src/backend/services/document_processor.py
+++ b/src/backend/services/document_processor.py
@@ -146,6 +146,16 @@ class DocumentProcessor:
             logger.error(f"Konvertierungsfehler: {e}")
             return None
 
+    @staticmethod
+    def _strip_upload_hash(name: str) -> str:
+        """Remove the 32-char hex upload hash prefix added by the upload handler.
+
+        Uploaded files are stored as ``<sha256[:32]>_<original_name>``.
+        This strips that prefix so titles and filenames are human-readable.
+        """
+        import re
+        return re.sub(r'^[a-f0-9]{32}_', '', name)
+
     def _extract_metadata(self, doc, file_path: str) -> dict[str, Any]:
         """Extrahiert Dokument-Metadaten"""
         path = Path(file_path)
@@ -161,9 +171,9 @@ class DocumentProcessor:
         # Docling-Metadaten
         try:
             if hasattr(doc, 'name') and doc.name:
-                metadata["title"] = doc.name
+                metadata["title"] = self._strip_upload_hash(doc.name)
             else:
-                metadata["title"] = path.stem
+                metadata["title"] = self._strip_upload_hash(path.stem)
 
             if hasattr(doc, 'origin') and doc.origin:
                 if hasattr(doc.origin, 'author'):


### PR DESCRIPTION
## Summary

Fixes 4 bugs discovered during real-world document ingest testing (Hetzner PDF invoice):

- **Critical: All RAG searches returned 500** — `search_vector` column was `text` instead of `tsvector` due to ORM/migration mismatch
- **KG hallucinations** — Table chunks sent to KG hook produced wrong entities (wrong bank names, phantom persons)
- **Document title showed SHA hash prefix** — `d7b340677...._Hetzner_2026-01-22.pdf` instead of `Hetzner_2026-01-22.pdf`
- **`kg_scopes.yaml` not mounted** — Missing Docker volume mount caused WARNING on every startup

## Root Causes & Fixes

### 1. `search_vector`: `text` → `tsvector` (`models/database.py`)
The SQLAlchemy model declared `Column(Text)`. asyncpg typed NULLs as `character varying`, which PostgreSQL rejects for a `tsvector` column. The migration's `ADD COLUMN IF NOT EXISTS` silently skipped when the column pre-existed as `text`.
- Changed to `Column(TSVECTOR)` from `sqlalchemy.dialects.postgresql`
- Migration updated with idempotent `ALTER COLUMN TYPE` fallback for existing installs

### 2. KG table chunk filtering (`rag_service.py`)
Docling flattens tables to `field = value. field = value.` — useless noise for the LLM that causes hallucinations. Now filters `chunk_type in {"table", "code", "formula"}` before KG hook.

### 3. Hash-prefix stripping in title (`document_processor.py`)
Added `_strip_upload_hash()` that removes the `[a-f0-9]{32}_` upload prefix from `doc.name` and `path.stem`.

### 4. `docker-compose.yml` volume mount
Added `./config/kg_scopes.yaml:/app/config/kg_scopes.yaml:ro` to both backend service definitions.

## Test plan

- [x] Uploaded Hetzner PDF invoice to production KB "xidra"
- [x] RAG search: 4/5 test queries return correct chunks (up from 0/5 with 500 error)
- [x] Document title: `Hetzner_2026-01-22_086000645845` (no hash prefix)
- [x] KG: No table-driven hallucinations; `Gunzenhausen` and `Hetzner` correctly extracted
- [x] kg_scopes.yaml: Scopes API returns family/public scopes without WARNING in logs

## Production hotfix applied
The DB column type was fixed manually on production via:
```sql
ALTER TABLE document_chunks ALTER COLUMN search_vector TYPE tsvector USING search_vector::tsvector;
CREATE INDEX IF NOT EXISTS idx_document_chunks_search_vector ON document_chunks USING gin(search_vector);
```

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)