### PR TITLE
fix(kb): Restore vector indexes, user_id in KG extraction, prompt fixes (#175)

### DIFF
--- a/src/backend/alembic/versions/cce1984705df_resize_embedding_vectors_768_to_2560.py
+++ b/src/backend/alembic/versions/cce1984705df_resize_embedding_vectors_768_to_2560.py
@@ -34,6 +34,18 @@ def upgrade() -> None:
         op.execute(f"UPDATE {table} SET embedding = NULL WHERE embedding IS NOT NULL")
         op.execute(f"ALTER TABLE {table} ALTER COLUMN embedding TYPE vector(2560)")
 
+    # Note: ALTER COLUMN TYPE automatically drops any vector index (ivfflat/hnsw)
+    # on the affected column. Recreate an HNSW index for document_chunks so that
+    # dense vector search doesn't fall back to a full table scan.
+    # Both regular HNSW and IVFFlat have a 2000-dim limit; use halfvec cast
+    # (pgvector 0.8.0+ supports HNSW via halfvec for up to 4096 dimensions).
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_document_chunks_embedding_hnsw
+        ON document_chunks
+        USING hnsw ((embedding::halfvec(2560)) halfvec_cosine_ops)
+        WITH (m = 16, ef_construction = 64)
+    """)
+
 
 def downgrade() -> None:
     for table in TABLES:

--- a/src/backend/alembic/versions/p1q2r3s4t5u6_fix_kb_performance_indexes.py
+++ b/src/backend/alembic/versions/p1q2r3s4t5u6_fix_kb_performance_indexes.py
@@ -1,0 +1,58 @@
+"""Fix KB performance: HNSW vector indexes and composite lookup index
+
+Revision ID: p1q2r3s4t5u6
+Revises: ab4bb605dc07
+Create Date: 2026-02-17
+
+The embedding resize migration (cce1984705df) dropped the HNSW index on
+document_chunks.embedding via ALTER COLUMN TYPE but never recreated it,
+causing a full table scan on every dense vector search. This migration
+restores all missing performance indexes for the KB and Knowledge Graph.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'p1q2r3s4t5u6'
+down_revision: Union[str, None] = 'ab4bb605dc07'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # --- HNSW vector index on document_chunks.embedding ---
+    # Lost when cce1984705df resized the column from vector(768) to vector(2560).
+    # Both HNSW and IVFFlat have a 2000-dim limit for regular vector type.
+    # pgvector 0.8.0+ supports HNSW via halfvec cast for up to 4096 dimensions.
+    # Uses IF NOT EXISTS — safe to run on instances where the index already exists.
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_document_chunks_embedding_hnsw
+        ON document_chunks
+        USING hnsw ((embedding::halfvec(2560)) halfvec_cosine_ops)
+        WITH (m = 16, ef_construction = 64)
+    """)
+
+    # --- HNSW vector index on kg_entities.embedding ---
+    # Entity similarity search for deduplication and context retrieval.
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_kg_entities_embedding_hnsw
+        ON kg_entities
+        USING hnsw ((embedding::halfvec(2560)) halfvec_cosine_ops)
+        WITH (m = 16, ef_construction = 64)
+    """)
+
+    # --- Composite index for context window expansion ---
+    # RAGService fetches adjacent chunks by (document_id, chunk_index ±N).
+    # Without this index, every context window expansion is a full doc scan.
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_document_chunks_doc_chunk
+        ON document_chunks (document_id, chunk_index)
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_document_chunks_embedding_hnsw")
+    op.execute("DROP INDEX IF EXISTS idx_kg_entities_embedding_hnsw")
+    op.execute("DROP INDEX IF EXISTS idx_document_chunks_doc_chunk")

--- a/src/backend/api/routes/knowledge.py
+++ b/src/backend/api/routes/knowledge.py
@@ -272,7 +272,8 @@ async def upload_document(
             str(file_path),
             knowledge_base_id=knowledge_base_id,
             filename=file.filename,
-            file_hash=file_hash
+            file_hash=file_hash,
+            user_id=user.id if user else None
         )
 
         return DocumentResponse(

--- a/src/backend/prompts/knowledge_graph.yaml
+++ b/src/backend/prompts/knowledge_graph.yaml
@@ -58,6 +58,9 @@ de:
     IGNORIERE:
     - Formatierung, Seitenzahlen, Inhaltsverzeichnisse
     - Generische/unbenannte Verweise
+    - Bankverbindungen, IBANs, BICs, Kontonummern (z.B. "IBAN DE12...", "BIC DEUTDEMM")
+    - Steueridentifikationsnummern, Umsatzsteuer-IDs
+    - Generische Fusszeilentexte ("Gerichtsstand", "Handelsregister", "Registergericht")
 
     Text:
     {text}
@@ -124,6 +127,9 @@ en:
     IGNORE:
     - Formatting, page numbers, tables of contents
     - Generic/unnamed references
+    - Bank details, IBANs, BICs, account numbers (e.g. "IBAN DE12...", "BIC DEUTDEMM")
+    - Tax IDs, VAT numbers
+    - Generic footer text ("jurisdiction", "commercial register", "court of registry")
 
     Text:
     {text}

--- a/src/backend/services/rag_service.py
+++ b/src/backend/services/rag_service.py
@@ -92,7 +92,8 @@ class RAGService:
         file_path: str,
         knowledge_base_id: int | None = None,
         filename: str | None = None,
-        file_hash: str | None = None
+        file_hash: str | None = None,
+        user_id: int | None = None
     ) -> Document:
         """
         Verarbeitet und indexiert ein Dokument.
@@ -216,7 +217,7 @@ class RAGService:
                     "post_document_ingest",
                     chunks=kg_chunks,
                     document_id=doc.id,
-                    user_id=None,
+                    user_id=user_id,
                 ))
 
             logger.info(f"Dokument indexiert: ID={doc.id}, Chunks={chunk_count}")


### PR DESCRIPTION
## Summary

Fixes remaining KB quality and performance issues found after PR #174.

- **Fix A**: HNSW vector index was lost after embedding resize (768→2560). PostgreSQL auto-drops indexes on `ALTER COLUMN TYPE`. The resize migration `cce1984705df` never recreated them. New migration `p1q2r3s4t5u6` restores them for production; `cce1984705df` now also recreates after resize for fresh installs.
- **Fix B**: `ingest_document()` never received `user_id`, causing all KG entities extracted from uploaded documents to have `user_id=NULL`. Now threaded from upload route → `ingest_document()` → KG hook.
- **Fix C**: Composite index `(document_id, chunk_index)` missing — context window expansion (adjacent chunk lookup) was doing a full table scan per document. Added in new migration.
- **Fix F**: KG document extraction prompt was producing hallucinated bank/institution entities from IBAN/BIC footer rows. Added IBAN, BIC, tax IDs, footer text to IGNORIERE/IGNORE section.

**Technical note**: pgvector 0.8.0+ supports HNSW via `halfvec` cast for vectors >2000 dimensions — this is required for our 2560-dim embeddings (both HNSW and IVFFlat have a 2000-dim hard limit on the raw `vector` type).

## Test plan

- [ ] Run `alembic upgrade head` on a fresh instance — all indexes exist, no errors
- [ ] Upload a document while authenticated — check `kg_entities.user_id` is not NULL
- [ ] RAG search returns results with reasonable scores
- [ ] KG entities no longer include IBAN/BIC/bank names from document footers
- [ ] `pg_indexes` shows `idx_document_chunks_embedding_hnsw`, `idx_kg_entities_embedding_hnsw`, `idx_document_chunks_doc_chunk`

🤖 Generated with [Claude Code](https://claude.com/claude-code)