### PR TITLE
feat(satellites): Add ReSpeaker 2-Mic HAT V2 provisioning support

### DIFF
--- a/src/satellite/provisioning/README.md
+++ b/src/satellite/provisioning/README.md
@@ -4,10 +4,11 @@ Ansible playbook for provisioning Raspberry Pi Zero 2 W satellites with ReSpeake
 
 ## Supported Hardware
 
-| HAT | LEDs | SPI | Power Pin | ALSA Card |
-|-----|------|-----|-----------|-----------|
-| ReSpeaker 2-Mic HAT | 3 | 0:0 | — | `seeed2micvoicec` |
-| ReSpeaker 4-Mic Array | 12 | 0:1 | GPIO 5 | `seeed4micvoicec` |
+| HAT | `hat_type` | LEDs | SPI | Power Pin | ALSA Card |
+|-----|-----------|------|-----|-----------|-----------|
+| ReSpeaker 2-Mic HAT V1 (WM8960) | `2mic` | 3 | 0:0 | — | `seeed2micvoicec` |
+| ReSpeaker 2-Mic HAT V2 (TLV320AIC3104) | `2mic-v2` | 3 | 0:0 | — | `seeed2micvoicec` |
+| ReSpeaker 4-Mic Array | `4mic` | 12 | 0:1 | GPIO 5 | `seeed4micvoicec` |
 
 ## Prerequisites
 
@@ -72,7 +73,7 @@ ansible-playbook -i inventory.yml provision.yml --limit satellite-fitnessraum --
 
 | Variable | Description | 2-mic default | 4-mic default |
 |----------|-------------|---------------|---------------|
-| `hat_type` | `"2mic"` or `"4mic"` | `"2mic"` | `"4mic"` |
+| `hat_type` | `"2mic"`, `"2mic-v2"`, or `"4mic"` | `"2mic"` | `"4mic"` |
 | `satellite_id` | Unique satellite ID | — | — |
 | `satellite_room` | Room name | — | — |
 | `led_num` | Number of APA102 LEDs | `3` | `12` |

--- a/src/satellite/provisioning/group_vars/satellites.yml
+++ b/src/satellite/provisioning/group_vars/satellites.yml
@@ -86,6 +86,9 @@ ble_rssi_threshold: -80
 # openwakeword installed separately with --no-deps for Python 3.13+ compat
 openwakeword_package: "openwakeword"
 
+# 2-Mic V2 driver repo (TLV320AIC3104 codec)
+seeed_dtoverlays_repo: "https://github.com/Seeed-Studio/seeed-linux-dtoverlays.git"
+
 # Model URLs
 oww_base_url: "https://github.com/dscripka/openWakeWord/releases/download/v0.6.0"
 oww_models:

--- a/src/satellite/provisioning/host_vars/satellite-kinderbad.yml
+++ b/src/satellite/provisioning/host_vars/satellite-kinderbad.yml
@@ -1,0 +1,21 @@
+---
+# ReSpeaker 2-Mic HAT configuration
+
+hat_type: "2mic-v2"
+satellite_id: "sat-kinderbad"
+satellite_room: "Kinderbad"
+
+# Audio (stereo with beamforming)
+audio_device: "capture"
+audio_playback_device: "plughw:0,0"
+audio_channels: 2
+beamforming_enabled: true
+beamforming_mic_spacing: 0.058
+
+# LEDs (2-Mic HAT: 3 LEDs on SPI 0:0, no power pin)
+led_num: 3
+led_spi_device: 0
+led_power_pin: null
+
+# 2-mic overlay variant: "simple" or "full"
+overlay_variant: "simple"

--- a/src/satellite/provisioning/inventory.yml
+++ b/src/satellite/provisioning/inventory.yml
@@ -9,3 +9,6 @@ all:
         satellite-fitnessraum:
           ansible_host: satellite-fitnessraum.local
           ansible_user: evdb
+        satellite-kinderbad:
+          ansible_host: satellite-kinderbad.local
+          ansible_user: evdb

--- a/src/satellite/provisioning/provision.yml
+++ b/src/satellite/provisioning/provision.yml
@@ -2,7 +2,7 @@
 # Renfield Satellite Provisioning Playbook
 #
 # Provisions a Raspberry Pi Zero 2 W as a Renfield voice satellite.
-# Supports both ReSpeaker 2-Mic HAT and 4-Mic Array via hat_type variable.
+# Supports ReSpeaker 2-Mic HAT (V1 + V2) and 4-Mic Array via hat_type variable.
 #
 # Usage:
 #   ansible-playbook -i inventory.yml provision.yml --limit satellite-fitnessraum -v
@@ -149,6 +149,36 @@
         cd /tmp/renfield-overlay && bash install-overlay.sh {{ overlay_variant | default('simple') }}
       args:
         creates: "/boot/firmware/overlays/seeed-2mic-gpclk-{{ overlay_variant | default('simple') }}.dtbo"
+      notify: reboot after driver install
+
+    # --- 2-Mic HAT V2: seeed-linux-dtoverlays (TLV320AIC3104) ---
+
+    - name: Clone seeed-linux-dtoverlays for 2-mic-v2 HAT
+      tags: [driver]
+      when: hat_type == "2mic-v2"
+      ansible.builtin.git:
+        repo: "{{ seeed_dtoverlays_repo }}"
+        dest: /tmp/seeed-linux-dtoverlays
+        depth: 1
+        force: true
+
+    - name: Compile respeaker-2mic-v2_0 overlay
+      tags: [driver]
+      when: hat_type == "2mic-v2"
+      ansible.builtin.shell: |
+        cd /tmp/seeed-linux-dtoverlays && make overlays/rpi/respeaker-2mic-v2_0-overlay.dtbo
+        cp overlays/rpi/respeaker-2mic-v2_0-overlay.dtbo /boot/firmware/overlays/respeaker-2mic-v2_0.dtbo
+      args:
+        creates: /boot/firmware/overlays/respeaker-2mic-v2_0.dtbo
+      notify: reboot after driver install
+
+    - name: Ensure 2-mic-v2 overlay in config.txt
+      tags: [driver]
+      when: hat_type == "2mic-v2"
+      ansible.builtin.lineinfile:
+        path: /boot/firmware/config.txt
+        line: "dtoverlay=respeaker-2mic-v2_0"
+        state: present
       notify: reboot after driver install
 
     # --- Flush handlers (reboot if driver was installed) ---

--- a/src/satellite/provisioning/templates/asoundrc-2mic-v2.j2
+++ b/src/satellite/provisioning/templates/asoundrc-2mic-v2.j2
@@ -1,0 +1,55 @@
+# Renfield Satellite — ALSA Configuration for ReSpeaker 2-Mics Pi HAT V2
+# Managed by Ansible — do not edit manually
+# V2 uses TLV320AIC3104 codec but same ALSA card name as V1
+
+defaults.pcm.rate_converter "samplerate"
+
+pcm.!default {
+    type asym
+    playback.pcm "playback"
+    capture.pcm "capture"
+}
+
+pcm.playback {
+    type plug
+    slave.pcm "dmixed"
+}
+
+pcm.capture {
+    type plug
+    slave.pcm "array"
+}
+
+pcm.dmixed {
+    type dmix
+    slave.pcm "hw:seeed2micvoicec"
+    ipc_key 555555
+}
+
+# Stereo microphone array (for beamforming)
+pcm.array {
+    type dsnoop
+    slave {
+        pcm "hw:seeed2micvoicec"
+        channels 2
+    }
+    ipc_key 666666
+}
+
+# Mono capture (single channel, downmixed)
+pcm.mono {
+    type plug
+    slave {
+        pcm "array"
+        channels 1
+    }
+}
+
+# 16kHz stereo capture (for beamforming with openwakeword)
+pcm.array16k {
+    type rate
+    slave {
+        pcm "array"
+        rate 16000
+    }
+}


### PR DESCRIPTION
## Summary
- Add `hat_type: "2mic-v2"` support to Ansible provisioning for the ReSpeaker 2-Mic HAT V2.0 (TLV320AIC3104 codec)
- V2 uses `seeed-linux-dtoverlays` repo instead of the custom GPCLK overlay used by V1
- Add `satellite-kinderbad` host config and inventory entry (already manually provisioned)

## Changes
- **`provision.yml`** — 3 new driver tasks: clone repo, compile overlay, add to config.txt
- **`host_vars/satellite-kinderbad.yml`** — New host with `hat_type: "2mic-v2"`
- **`inventory.yml`** — Add satellite-kinderbad entry
- **`templates/asoundrc-2mic-v2.j2`** — ALSA config (same card name as V1)
- **`group_vars/satellites.yml`** — `seeed_dtoverlays_repo` default
- **`README.md`** — Updated hardware table with V1/V2 distinction

## Test plan
- [x] YAML syntax validated on all modified files
- [x] satellite-kinderbad already running with V2 HAT (manually provisioned)
- [ ] Dry-run: `ansible-playbook -i inventory.yml provision.yml --limit satellite-kinderbad --check -v`

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)