### PR TITLE
feat(kg): KG quality improvement — entity filter, prompt hardening, cleanup API

### DIFF
--- a/src/backend/api/routes/knowledge_graph_schemas.py
+++ b/src/backend/api/routes/knowledge_graph_schemas.py
@@ -91,3 +91,47 @@ class KGStatsResponse(BaseModel):
     entity_count: int = 0
     relation_count: int = 0
     entity_types: dict[str, int] = Field(default_factory=dict)
+
+
+# =============================================================================
+# Cleanup Schemas
+# =============================================================================
+
+class InvalidEntitySample(BaseModel):
+    id: int
+    name: str
+    entity_type: str
+
+
+class CleanupInvalidResponse(BaseModel):
+    dry_run: bool
+    total_scanned: int
+    invalid_count: int
+    orphaned_relations: int
+    samples: list[InvalidEntitySample] = Field(default_factory=list)
+
+
+class DuplicateEntityInfo(BaseModel):
+    id: int
+    name: str
+    mention_count: int
+    entity_type: str
+
+
+class DuplicateCluster(BaseModel):
+    canonical: DuplicateEntityInfo
+    duplicates: list[DuplicateEntityInfo]
+    cluster_size: int
+    entity_type: str
+
+
+class DuplicateClustersResponse(BaseModel):
+    clusters: list[DuplicateCluster]
+    total_clusters: int
+
+
+class MergeDuplicatesResponse(BaseModel):
+    dry_run: bool
+    clusters_found: int
+    entities_merged: int
+    clusters: list[dict] = Field(default_factory=list)

--- a/src/backend/prompts/knowledge_graph.yaml
+++ b/src/backend/prompts/knowledge_graph.yaml
@@ -3,17 +3,17 @@
 # entities and relations from conversation exchanges.
 
 de:
-  extraction_system: "Du extrahierst Entitaeten und Relationen aus Dialogen. Antworte NUR mit einem JSON-Objekt."
+  extraction_system: "Du extrahierst Entitaeten und Relationen aus Dialogen. Antworte NUR mit einem JSON-Objekt. Keine Nummern, IDs, URLs oder OCR-Artefakte als Entitaeten."
 
   extraction_prompt: |
     Analysiere den folgenden Dialog und extrahiere benannte Entitaeten und ihre Beziehungen.
 
-    ENTITAETEN extrahieren:
-    - Personen (Name, Spitzname)
-    - Orte (Staedte, Laender, Gebaeude)
-    - Organisationen (Firmen, Vereine)
-    - Dinge (Haustiere, Geraete, Fahrzeuge)
-    - Ereignisse (Urlaube, Termine, Feiern)
+    Nur KONKRETE, BENANNTE Entitaeten extrahieren — mit echtem Namen oder Titel:
+    - Personen (vollstaendiger Name oder Spitzname, NICHT generische Rollen)
+    - Orte (Staedte, Laender, Gebaeude — mit konkretem Namen)
+    - Organisationen (Firmen, Vereine — mit konkretem Namen)
+    - Dinge (Haustiere, Geraete, Fahrzeuge — mit konkretem Namen)
+    - Ereignisse (Urlaube, Termine, Feiern — mit konkretem Namen)
     - Konzepte (Hobbys, Berufe, Faecher)
 
     RELATIONEN extrahieren:
@@ -21,10 +21,14 @@ de:
     - Nur Relationen die EXPLIZIT im Dialog erwaehnt werden
     - confidence: 0.5-1.0 (wie sicher ist die Relation)
 
-    IGNORIERE:
+    IGNORIERE (NIEMALS als Entitaet extrahieren):
     - Einmalige Befehle ("Schalte das Licht ein")
     - Smalltalk ohne benannte Entitaeten
     - Informationen die der Assistent gegeben hat (nur Fakten VOM Benutzer)
+    - Generische Rollen OHNE konkreten Namen ("Kunde", "Sachbearbeiter", "Vermittler", "Berater", "Bediener")
+    - Nummern, IDs, Referenzcodes, Vertragsnummern, Aktenzeichen
+    - URLs, E-Mail-Adressen, Telefonnummern
+    - Datumsangaben als Entitaeten (nur in Beschreibungen verwenden)
 
     Dialog:
     User: {user_message}
@@ -39,12 +43,12 @@ de:
   document_extraction_prompt: |
     Analysiere den folgenden Textabschnitt aus einem Dokument und extrahiere benannte Entitaeten und ihre Beziehungen.
 
-    ENTITAETEN extrahieren:
-    - Personen (Name, Spitzname)
-    - Orte (Staedte, Laender, Gebaeude)
-    - Organisationen (Firmen, Vereine, Behoerden)
-    - Dinge (Haustiere, Geraete, Fahrzeuge)
-    - Ereignisse (Urlaube, Termine, Feiern)
+    Nur KONKRETE, BENANNTE Entitaeten mit echtem Namen extrahieren:
+    - Personen (vollstaendiger Name, NICHT generische Rollen wie "Kunde" oder "Sachbearbeiter")
+    - Orte (Staedte, Laender, Gebaeude — mit konkretem Namen)
+    - Organisationen (Firmen, Vereine, Behoerden — mit konkretem Namen)
+    - Dinge (Haustiere, Geraete, Fahrzeuge — mit konkretem Namen)
+    - Ereignisse (Urlaube, Termine, Feiern — mit konkretem Namen)
     - Konzepte (Hobbys, Berufe, Faecher)
 
     RELATIONEN extrahieren:
@@ -55,12 +59,18 @@ de:
     - Auch IMPLIZITE Relationen aus der Dokumentstruktur extrahieren (z.B. Firma im Briefkopf + Person in der Anrede = "sendet_an")
     - confidence: 0.5-1.0 (wie sicher ist die Relation)
 
-    IGNORIERE:
+    IGNORIERE (NIEMALS als Entitaet extrahieren):
     - Formatierung, Seitenzahlen, Inhaltsverzeichnisse
     - Generische/unbenannte Verweise
+    - OCR-Artefakte: Woerter mit ungewoehnlichen Leerzeichen ("F R E S E N"), unleserliche Fragmente, verstümmelte Woerter
     - Bankverbindungen, IBANs, BICs, Kontonummern (z.B. "IBAN DE12...", "BIC DEUTDEMM")
-    - Steueridentifikationsnummern, Umsatzsteuer-IDs
+    - Steueridentifikationsnummern, Umsatzsteuer-IDs (z.B. "DE811127597")
     - Generische Fusszeilentexte ("Gerichtsstand", "Handelsregister", "Registergericht")
+    - URLs, E-Mail-Adressen, Telefonnummern, Faxnummern
+    - Reine Nummern, Referenzcodes, Vertragsnummern, Aktenzeichen, Kundennummern
+    - Datumsangaben als Entitaeten (nur in Beschreibungen verwenden)
+    - Generische Rollen OHNE konkreten Namen ("Kunde", "Vermittler", "Sachbearbeiter", "Bediener", "Berater", "Vollziehungsbeamter")
+    - Nummerierte Rollen ("Bediener 2", "Sachbearbeiter 3")
 
     Text:
     {text}
@@ -72,17 +82,17 @@ de:
     }}
 
 en:
-  extraction_system: "You extract entities and relations from dialogs. Reply ONLY with a JSON object."
+  extraction_system: "You extract entities and relations from dialogs. Reply ONLY with a JSON object. No numbers, IDs, URLs, or OCR artifacts as entities."
 
   extraction_prompt: |
     Analyze the following dialog and extract named entities and their relationships.
 
-    EXTRACT entities:
-    - People (names, nicknames)
-    - Places (cities, countries, buildings)
-    - Organizations (companies, clubs)
-    - Things (pets, devices, vehicles)
-    - Events (vacations, appointments, celebrations)
+    Only extract CONCRETE, NAMED entities — with real names or titles:
+    - People (full names or nicknames, NOT generic roles)
+    - Places (cities, countries, buildings — with concrete names)
+    - Organizations (companies, clubs — with concrete names)
+    - Things (pets, devices, vehicles — with concrete names)
+    - Events (vacations, appointments, celebrations — with concrete names)
     - Concepts (hobbies, professions, subjects)
 
     EXTRACT relations:
@@ -90,10 +100,14 @@ en:
     - Only relations EXPLICITLY mentioned in the dialog
     - confidence: 0.5-1.0 (how certain is the relation)
 
-    IGNORE:
+    IGNORE (NEVER extract as entity):
     - One-time commands ("Turn on the light")
     - Smalltalk without named entities
     - Information given BY the assistant (only facts FROM the user)
+    - Generic roles WITHOUT concrete names ("customer", "clerk", "agent", "operator")
+    - Numbers, IDs, reference codes, contract numbers, file numbers
+    - URLs, email addresses, phone numbers
+    - Dates as entities (use only in descriptions)
 
     Dialog:
     User: {user_message}
@@ -108,12 +122,12 @@ en:
   document_extraction_prompt: |
     Analyze the following text passage from a document and extract named entities and their relationships.
 
-    EXTRACT entities:
-    - People (names, nicknames)
-    - Places (cities, countries, buildings)
-    - Organizations (companies, clubs, authorities)
-    - Things (pets, devices, vehicles)
-    - Events (vacations, appointments, celebrations)
+    Only extract CONCRETE, NAMED entities with real names:
+    - People (full names, NOT generic roles like "customer" or "clerk")
+    - Places (cities, countries, buildings — with concrete names)
+    - Organizations (companies, clubs, authorities — with concrete names)
+    - Things (pets, devices, vehicles — with concrete names)
+    - Events (vacations, appointments, celebrations — with concrete names)
     - Concepts (hobbies, professions, subjects)
 
     EXTRACT relations:
@@ -124,12 +138,18 @@ en:
     - Also extract IMPLIED relations from document structure (e.g. company in letterhead + person in salutation = "sends_to")
     - confidence: 0.5-1.0 (how certain is the relation)
 
-    IGNORE:
+    IGNORE (NEVER extract as entity):
     - Formatting, page numbers, tables of contents
     - Generic/unnamed references
+    - OCR artifacts: words with unusual spacing ("F R E S E N"), illegible fragments, garbled words
     - Bank details, IBANs, BICs, account numbers (e.g. "IBAN DE12...", "BIC DEUTDEMM")
-    - Tax IDs, VAT numbers
+    - Tax IDs, VAT numbers (e.g. "DE811127597")
     - Generic footer text ("jurisdiction", "commercial register", "court of registry")
+    - URLs, email addresses, phone numbers, fax numbers
+    - Pure numbers, reference codes, contract numbers, file numbers, customer IDs
+    - Dates as entities (use only in descriptions)
+    - Generic roles WITHOUT concrete names ("customer", "agent", "clerk", "operator", "advisor")
+    - Numbered roles ("Operator 2", "Clerk 3")
 
     Text:
     {text}

--- a/src/backend/services/kg_cleanup_service.py
+++ b/src/backend/services/kg_cleanup_service.py
@@ -1,0 +1,263 @@
+"""
+Knowledge Graph Cleanup Service — Bulk operations for data quality.
+
+Provides admin-only operations to scan and clean up invalid entities,
+find duplicate clusters via embedding similarity, and auto-merge them.
+All destructive operations support dry_run mode.
+"""
+from loguru import logger
+from sqlalchemy import func, select, text, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import KGEntity, KGRelation
+from services.knowledge_graph_service import KnowledgeGraphService
+from utils.config import settings
+
+
+class KGCleanupService:
+    """Bulk cleanup operations for the knowledge graph."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def cleanup_invalid_entities(
+        self,
+        dry_run: bool = True,
+    ) -> dict:
+        """
+        Scan all active entities and soft-delete those failing validation.
+
+        Cascade-deactivates orphaned relations for deleted entities.
+        Returns summary with counts and sample rejected names.
+        """
+        # Fetch all active entities (name + type + id)
+        result = await self.db.execute(
+            select(KGEntity.id, KGEntity.name, KGEntity.entity_type)
+            .where(KGEntity.is_active == True)  # noqa: E712
+        )
+        rows = result.fetchall()
+
+        invalid_ids = []
+        invalid_samples = []
+
+        for row in rows:
+            if not KnowledgeGraphService._is_valid_entity(row.name, row.entity_type):
+                invalid_ids.append(row.id)
+                if len(invalid_samples) < 50:
+                    invalid_samples.append({
+                        "id": row.id,
+                        "name": row.name,
+                        "entity_type": row.entity_type,
+                    })
+
+        if not dry_run and invalid_ids:
+            # Soft-delete invalid entities
+            await self.db.execute(
+                update(KGEntity)
+                .where(KGEntity.id.in_(invalid_ids))
+                .values(is_active=False)
+            )
+
+            # Cascade-deactivate orphaned relations
+            orphaned_result = await self.db.execute(
+                update(KGRelation)
+                .where(
+                    KGRelation.is_active == True,  # noqa: E712
+                    (KGRelation.subject_id.in_(invalid_ids)) | (KGRelation.object_id.in_(invalid_ids)),
+                )
+                .values(is_active=False)
+                .returning(KGRelation.id)
+            )
+            orphaned_count = len(orphaned_result.fetchall())
+
+            await self.db.commit()
+            logger.info(
+                f"KG cleanup: Deleted {len(invalid_ids)} invalid entities, "
+                f"{orphaned_count} orphaned relations"
+            )
+        else:
+            orphaned_count = 0
+            if invalid_ids:
+                # Count relations that would be orphaned
+                count_result = await self.db.execute(
+                    select(func.count(KGRelation.id))
+                    .where(
+                        KGRelation.is_active == True,  # noqa: E712
+                        (KGRelation.subject_id.in_(invalid_ids)) | (KGRelation.object_id.in_(invalid_ids)),
+                    )
+                )
+                orphaned_count = count_result.scalar() or 0
+
+        return {
+            "dry_run": dry_run,
+            "total_scanned": len(rows),
+            "invalid_count": len(invalid_ids),
+            "orphaned_relations": orphaned_count,
+            "samples": invalid_samples,
+        }
+
+    async def find_duplicate_clusters(
+        self,
+        entity_type: str | None = None,
+        threshold: float | None = None,
+        limit: int = 50,
+    ) -> list[dict]:
+        """
+        Find clusters of likely-duplicate entities via embedding similarity.
+
+        Returns clusters sorted by size, each with a canonical entity
+        (highest mention_count) and its duplicates.
+        """
+        if threshold is None:
+            threshold = settings.kg_similarity_threshold
+
+        # Build entity type filter
+        type_filter = ""
+        params: dict = {"threshold": threshold}
+        if entity_type:
+            type_filter = "AND a.entity_type = :entity_type AND b.entity_type = :entity_type"
+            params["entity_type"] = entity_type
+
+        # Find pairs of similar entities using pgvector
+        sql = text(f"""
+            SELECT a.id as id_a, a.name as name_a, a.mention_count as mc_a,
+                   a.entity_type as type_a,
+                   b.id as id_b, b.name as name_b, b.mention_count as mc_b,
+                   b.entity_type as type_b,
+                   1 - (a.embedding <=> b.embedding) as similarity
+            FROM kg_entities a
+            JOIN kg_entities b ON a.id < b.id
+            WHERE a.is_active = true AND b.is_active = true
+              AND a.embedding IS NOT NULL AND b.embedding IS NOT NULL
+              AND a.entity_type = b.entity_type
+              AND 1 - (a.embedding <=> b.embedding) >= :threshold
+              {type_filter}
+            ORDER BY similarity DESC
+            LIMIT 500
+        """)
+
+        result = await self.db.execute(sql, params)
+        pairs = result.fetchall()
+
+        # Build clusters via union-find
+        parent: dict[int, int] = {}
+        entity_info: dict[int, dict] = {}
+
+        def find(x: int) -> int:
+            while parent.get(x, x) != x:
+                parent[x] = parent.get(parent[x], parent[x])
+                x = parent[x]
+            return x
+
+        def union(x: int, y: int) -> None:
+            rx, ry = find(x), find(y)
+            if rx != ry:
+                parent[rx] = ry
+
+        for row in pairs:
+            entity_info[row.id_a] = {
+                "id": row.id_a,
+                "name": row.name_a,
+                "mention_count": row.mc_a or 1,
+                "entity_type": row.type_a,
+            }
+            entity_info[row.id_b] = {
+                "id": row.id_b,
+                "name": row.name_b,
+                "mention_count": row.mc_b or 1,
+                "entity_type": row.type_b,
+            }
+            parent.setdefault(row.id_a, row.id_a)
+            parent.setdefault(row.id_b, row.id_b)
+            union(row.id_a, row.id_b)
+
+        # Group by cluster root
+        clusters_map: dict[int, list[int]] = {}
+        for eid in entity_info:
+            root = find(eid)
+            clusters_map.setdefault(root, []).append(eid)
+
+        # Build output clusters (only multi-entity clusters)
+        clusters = []
+        for member_ids in clusters_map.values():
+            if len(member_ids) < 2:
+                continue
+
+            members = [entity_info[eid] for eid in member_ids]
+            # Canonical = highest mention_count
+            members.sort(key=lambda m: m["mention_count"], reverse=True)
+            canonical = members[0]
+            duplicates = members[1:]
+
+            clusters.append({
+                "canonical": canonical,
+                "duplicates": duplicates,
+                "cluster_size": len(members),
+                "entity_type": canonical["entity_type"],
+            })
+
+        # Sort by cluster size descending
+        clusters.sort(key=lambda c: c["cluster_size"], reverse=True)
+        return clusters[:limit]
+
+    async def merge_duplicate_clusters(
+        self,
+        entity_type: str | None = None,
+        threshold: float | None = None,
+        dry_run: bool = True,
+    ) -> dict:
+        """
+        Auto-merge duplicate clusters found by find_duplicate_clusters().
+
+        Picks highest mention_count as canonical, merges others into it.
+        """
+        clusters = await self.find_duplicate_clusters(
+            entity_type=entity_type,
+            threshold=threshold,
+            limit=200,
+        )
+
+        if not clusters:
+            return {
+                "dry_run": dry_run,
+                "clusters_found": 0,
+                "entities_merged": 0,
+                "clusters": [],
+            }
+
+        kg_service = KnowledgeGraphService(self.db)
+        merged_count = 0
+        cluster_summaries = []
+
+        for cluster in clusters:
+            canonical_id = cluster["canonical"]["id"]
+            dup_ids = [d["id"] for d in cluster["duplicates"]]
+
+            summary = {
+                "canonical": cluster["canonical"],
+                "merged": cluster["duplicates"],
+            }
+            cluster_summaries.append(summary)
+
+            if not dry_run:
+                for dup_id in dup_ids:
+                    try:
+                        await kg_service.merge_entities(dup_id, canonical_id)
+                        merged_count += 1
+                    except Exception as e:
+                        logger.warning(f"KG cleanup: Failed to merge {dup_id} → {canonical_id}: {e}")
+            else:
+                merged_count += len(dup_ids)
+
+        if not dry_run:
+            logger.info(
+                f"KG cleanup: Merged {merged_count} duplicate entities "
+                f"across {len(clusters)} clusters"
+            )
+
+        return {
+            "dry_run": dry_run,
+            "clusters_found": len(clusters),
+            "entities_merged": merged_count,
+            "clusters": cluster_summaries[:50],  # Limit response size
+        }

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -161,7 +161,7 @@ class Settings(BaseSettings):
     # Knowledge Graph (Entity-Relation triples from conversations)
     knowledge_graph_enabled: bool = False                                        # Opt-in
     kg_extraction_model: str = ""                                                # Empty = use default model
-    kg_similarity_threshold: float = Field(default=0.92, ge=0.5, le=1.0)        # Entity dedup threshold
+    kg_similarity_threshold: float = Field(default=0.85, ge=0.5, le=1.0)        # Entity dedup threshold (0.85 merges OCR variants)
     kg_retrieval_threshold: float = Field(default=0.70, ge=0.0, le=1.0)         # Context retrieval threshold
     kg_max_entities_per_user: int = Field(default=5000, ge=10, le=50000)         # Max active entities per user
     kg_max_context_triples: int = Field(default=15, ge=1, le=50)                 # Max triples injected into prompt


### PR DESCRIPTION
## Summary
- **Layer 1:** Post-extraction entity filter (`_is_valid_entity()`) with compiled regex patterns rejects OCR garbage, URLs, emails, IDs, dates, phone numbers, IBANs, and generic roles before they enter the graph
- **Layer 2:** Hardened DE/EN extraction prompts with explicit IGNORE rules for OCR artifacts, generic roles, reference codes
- **Layer 3:** Lowered `kg_similarity_threshold` default from 0.92 → 0.85 to merge OCR name variants (e.g. "Ivduard" vs "Eduard")
- **Layer 4:** New `KGCleanupService` with 3 admin API endpoints for bulk cleanup (all dry_run=true by default):
  - `POST /cleanup/invalid` — scan + soft-delete invalid entities
  - `GET /cleanup/duplicates` — find duplicate clusters via embedding similarity
  - `POST /cleanup/merge-duplicates` — auto-merge duplicate clusters

Closes #182

## Test plan
- [x] 31 unit tests for `_is_valid_entity()` covering all rejection rules + valid entities
- [ ] Dry-run cleanup on production: `curl -X POST "https://renfield.local/api/knowledge-graph/cleanup/invalid?dry_run=true" -k`
- [ ] Review dry-run results, then apply: `curl -X POST "https://renfield.local/api/knowledge-graph/cleanup/invalid?dry_run=false" -k`
- [ ] Check duplicate clusters: `curl "https://renfield.local/api/knowledge-graph/cleanup/duplicates?entity_type=person&threshold=0.85" -k`
- [ ] Verify stats improved: `curl "https://renfield.local/api/knowledge-graph/stats" -k`

🤖 Generated with [Claude Code](https://claude.com/claude-code)