### PR TITLE
fix(kg): Replace embedding with string similarity for duplicate detection (#183)

### DIFF
--- a/src/backend/api/routes/knowledge_graph_schemas.py
+++ b/src/backend/api/routes/knowledge_graph_schemas.py
@@ -116,6 +116,7 @@ class DuplicateEntityInfo(BaseModel):
     name: str
     mention_count: int
     entity_type: str
+    similarity: float | None = None
 
 
 class DuplicateCluster(BaseModel):


### PR DESCRIPTION
## Summary

- **Problem:** Embedding-based duplicate detection clustered semantically similar but distinct entities (Berlin/Hamburg, Commerzbank/Bundesbank, different persons) — auto-merge would be destructive at any threshold
- **Fix:** Replace pgvector cosine similarity with `difflib.SequenceMatcher` string comparison, which correctly identifies OCR typo variants (Kreiswefke→Kreiswerke, Spltzweg→Spitzweg, Hastercard→Mastercard) without false positives
- **Includes:** Name normalization (strips Herr/Frau/Dr./GmbH/AG), length pre-filter for performance, similarity score per duplicate in API response

## Test plan

- [x] Unit tests pass (`pytest tests/backend/test_knowledge_graph_service.py -k Validation`)
- [x] Deployed to production and verified with live data (3,200+ entities)
- [x] Confirmed OCR variants correctly clustered (X-idra/X-IDA/X-ldra, Kreiswerke variants, etc.)
- [x] Confirmed distinct entities no longer falsely clustered (Berlin≠Hamburg, different persons separated)
- [ ] Verify dry-run merge at threshold 0.85+ produces safe merge candidates

🤖 Generated with [Claude Code](https://claude.com/claude-code)