### PR TITLE
docs(kg): Update documentation for KG quality improvements (#183)

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -777,8 +777,8 @@ KNOWLEDGE_GRAPH_ENABLED=false
 # Modell für KG-Extraktion (leer = Standard-Modell verwenden)
 KG_EXTRACTION_MODEL=
 
-# Schwellenwert für Entity-Deduplizierung (Embedding-Ähnlichkeit)
-KG_SIMILARITY_THRESHOLD=0.92
+# Schwellenwert für Entity-Deduplizierung (Embedding-Ähnlichkeit, 0.85 mergt OCR-Varianten)
+KG_SIMILARITY_THRESHOLD=0.85
 
 # Schwellenwert für Kontext-Retrieval (Embedding-Ähnlichkeit)
 KG_RETRIEVAL_THRESHOLD=0.70


### PR DESCRIPTION
## Summary

- Document post-extraction entity validation (`_is_valid_entity()`) in CLAUDE.md
- Document bulk cleanup API endpoints (invalid cleanup, duplicate detection, auto-merge)
- Add `kg_cleanup_service.py` to key files list
- Update `KG_SIMILARITY_THRESHOLD` default from 0.92 to 0.85 in both CLAUDE.md and ENVIRONMENT_VARIABLES.md

## Test plan

- [x] Documentation-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)