### PR TITLE
fix(kg): Include unowned entities in KG retrieval and dedup

### DIFF
--- a/src/backend/api/routes/chat_upload.py
+++ b/src/backend/api/routes/chat_upload.py
@@ -23,6 +23,7 @@ from models.database import (
     ChatUpload,
     KnowledgeBase,
 )
+from services.auth_service import get_optional_user
 from services.database import AsyncSessionLocal, get_db
 from services.document_processor import DocumentProcessor
 from utils.config import settings
@@ -56,6 +57,7 @@ async def upload_chat_document(
     knowledge_base_id: int | None = Form(None),
     db: AsyncSession = Depends(get_db),
     background_tasks: BackgroundTasks = BackgroundTasks(),
+    user=Depends(get_optional_user),
 ):
     """
     Upload a document in chat for quick text extraction.
@@ -138,7 +140,7 @@ async def upload_chat_document(
             "post_document_ingest",
             chunks=[extracted_text],
             document_id=None,
-            user_id=None,
+            user_id=user.id if user else None,
         )
 
     # Auto-index to KB if enabled


### PR DESCRIPTION
## Summary

- **Retrieval filter** (`get_relevant_context`): Add `OR e.user_id IS NULL` so entities without ownership (from bulk imports / unauthenticated uploads) are visible to all authenticated users
- **Entity resolution** (`resolve_entity`, `_find_similar_entity`): Include unowned entities in exact name match and embedding similarity search to prevent duplicates
- **Chat upload** (`chat_upload.py`): Pass `user_id` from auth context to `post_document_ingest` hook — future uploads get proper ownership

Fixes #185

## Test plan

- [ ] Deploy to production, test via chat: "Welche Firmen haben mir Rechnungen geschickt?"
- [ ] Check backend logs for KG context injection (`docker compose logs backend | grep -i "wissensgraph\|retrieve_context"`)
- [ ] Verify no duplicate entities created for existing unowned names

🤖 Generated with [Claude Code](https://claude.com/claude-code)