### PR TITLE
feat(kg): Extract entity names from queries for better retrieval

### DIFF
--- a/src/backend/prompts/knowledge_graph.yaml
+++ b/src/backend/prompts/knowledge_graph.yaml
@@ -43,6 +43,17 @@ de:
       "relations": [{{"subject": "...", "predicate": "...", "object": "...", "confidence": 0.8}}]
     }}
 
+  query_entities_system: "Extrahiere Entitaetsnamen aus Fragen. Antworte NUR mit einem JSON-Array von Strings."
+
+  query_entities_prompt: |
+    Welche konkreten Personen, Orte, Organisationen oder Dinge werden in dieser Frage namentlich erwaehnt?
+    Nur Eigennamen extrahieren, keine generischen Begriffe.
+
+    Frage: {query}
+
+    Antworte als JSON-Array (leer wenn keine Eigennamen):
+    ["Name1", "Name2"]
+
   document_extraction_prompt: |
     Analysiere den folgenden Textabschnitt aus einem Dokument und extrahiere benannte Entitaeten und ihre Beziehungen.
 
@@ -127,6 +138,17 @@ en:
       "entities": [{{"name": "...", "type": "person|place|organization|thing|event|concept", "description": "..."}}],
       "relations": [{{"subject": "...", "predicate": "...", "object": "...", "confidence": 0.8}}]
     }}
+
+  query_entities_system: "Extract entity names from questions. Reply ONLY with a JSON array of strings."
+
+  query_entities_prompt: |
+    Which specific people, places, organizations, or things are mentioned by name in this question?
+    Only extract proper names, no generic terms.
+
+    Question: {query}
+
+    Reply as JSON array (empty if no proper names):
+    ["Name1", "Name2"]
 
   document_extraction_prompt: |
     Analyze the following text passage from a document and extract named entities and their relationships.


### PR DESCRIPTION
## Summary
- Adds LLM-based entity name extraction from natural-language queries before KG embedding search (#187)
- Sentence embeddings ("Was weiss ich über Eduard van den Bongard?") had ~0.58 cosine similarity to entity name embeddings, below the 0.70 threshold — now extracts "Eduard van den Bongard" and embeds that instead (~1.0 similarity)
- Falls back to full query embedding when no entity names are found (e.g. "Wie wird das Wetter?")

## Changes
- **`knowledge_graph.yaml`**: New `query_entities_system` + `query_entities_prompt` (de + en)
- **`knowledge_graph_service.py`**: New `_extract_query_entities()` method + refactored `get_relevant_context()` search loop
- **`test_knowledge_graph_service.py`**: 7 new tests for extraction and integration

## Test plan
- [ ] CI passes (lint + tests)
- [ ] Deploy to production, test: "Was weiss ich über Eduard van den Bongard?" → returns triples (was empty before)
- [ ] Test: "Wer wohnt in Krefeld?" → returns triples (was empty before)
- [ ] Test: "Wie wird das Wetter?" → falls back gracefully (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)