### PR TITLE
fix(kg): Add instruction to KG context to prevent LLM hallucination

### DIFF
--- a/src/backend/services/knowledge_graph_service.py
+++ b/src/backend/services/knowledge_graph_service.py
@@ -957,7 +957,20 @@ class KnowledgeGraphService:
         if not triples:
             return None
 
-        header = "## Wissensgraph" if lang == "de" else "## Knowledge Graph"
+        if lang == "de":
+            header = (
+                "WISSENSGRAPH (persoenliche Fakten ueber den Benutzer und sein Umfeld):\n"
+                "Die folgenden Fakten stammen aus Dokumenten und Gespraechen des Benutzers.\n"
+                "Nutze NUR diese Fakten wenn die Frage sich auf genannte Personen/Orte/Organisationen bezieht.\n"
+                "Erfinde KEINE zusaetzlichen Informationen ueber diese Entitaeten."
+            )
+        else:
+            header = (
+                "KNOWLEDGE GRAPH (personal facts about the user and their environment):\n"
+                "The following facts come from the user's documents and conversations.\n"
+                "Use ONLY these facts when the question refers to named people/places/organizations.\n"
+                "Do NOT invent additional information about these entities."
+            )
         return f"{header}\n" + "\n".join(triples)
 
     # =========================================================================


### PR DESCRIPTION
## Summary
- LLM ignored injected KG triples and hallucinated a fake biography for "Eduard van den Bongard" (confusing him with Gerrit Rietveld / De Stijl)
- The `## Wissensgraph` header had no instruction telling the LLM to use the provided facts
- Now includes explicit directives: "Nutze NUR diese Fakten... Erfinde KEINE zusaetzlichen Informationen"

## Changes
- **`knowledge_graph_service.py`**: Replace bare `## Wissensgraph` header with instruction block (de + en)

## Test plan
- [x] Deployed to production, KG context now includes instructions
- [ ] Re-test "Was weiss ich über Eduard van den Bongard?" — should use KG facts, not hallucinate

🤖 Generated with [Claude Code](https://claude.com/claude-code)