### PR TITLE
fix(rag): Switch BM25 to OR matching with German FTS config (#189)

### DIFF
--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -134,7 +134,7 @@ class Settings(BaseSettings):
     rag_hybrid_bm25_weight: float = Field(default=0.3, ge=0.0, le=1.0)
     rag_hybrid_dense_weight: float = Field(default=0.7, ge=0.0, le=1.0)
     rag_hybrid_rrf_k: int = 60                # RRF constant k (standard: 60)
-    rag_hybrid_fts_config: str = "simple"     # PostgreSQL FTS config: simple/german/english
+    rag_hybrid_fts_config: str = "german"     # PostgreSQL FTS config: simple/german/english
 
     # Context Window Retrieval
     rag_context_window: int = 1               # Adjacent chunks per direction (0=disabled)


### PR DESCRIPTION
## Summary

- **BM25 search returned 0 results** for natural-language queries because `plainto_tsquery` AND-joined all terms — including German stop words like "welche", "es", "für". No chunk contained every single word.
- Switch to `websearch_to_tsquery` with OR matching: any query term can match, `ts_rank_cd` ranks by term coverage
- Change default FTS config from `simple` to `german` for stop word removal and snowball stemming (Rechnungen → rechnung)

## Test plan

- [x] All 29 tests pass in `test_rag_hybrid_search.py` (3 new tests added)
- [x] `ruff check` clean on all changed files
- [ ] Deploy to production, then reindex FTS: `curl -X POST http://renfield.local:8000/api/knowledge/reindex-fts`
- [ ] Verify: "Welche Rechnungen gab es 2022 für Am Stirkenbend 20?" returns relevant invoices

🤖 Generated with [Claude Code](https://claude.com/claude-code)