### PR TITLE
feat(frontend): Add admin maintenance page

### DIFF
--- a/src/frontend/src/App.jsx
+++ b/src/frontend/src/App.jsx
@@ -27,6 +27,7 @@ const SatellitesPage = lazy(() => import('./pages/SatellitesPage'));
 const IntentsPage = lazy(() => import('./pages/IntentsPage'));
 const PresencePage = lazy(() => import('./pages/PresencePage'));
 const KnowledgeGraphPage = lazy(() => import('./pages/KnowledgeGraphPage'));
+const MaintenancePage = lazy(() => import('./pages/MaintenancePage'));
 
 function AppRoutes() {
   const { isFeatureEnabled } = useAuth();
@@ -117,6 +118,11 @@ function AppRoutes() {
             <Route path="/admin/knowledge-graph" element={
               <AdminRoute>
                 <KnowledgeGraphPage />
+              </AdminRoute>
+            } />
+            <Route path="/admin/maintenance" element={
+              <AdminRoute>
+                <MaintenancePage />
               </AdminRoute>
             } />
           </Routes>

--- a/src/frontend/src/components/Layout.jsx
+++ b/src/frontend/src/components/Layout.jsx
@@ -22,7 +22,8 @@ import {
   Blocks,
   Zap,
   Brain,
-  MapPin
+  MapPin,
+  Wrench
 } from 'lucide-react';
 import DeviceStatus from './DeviceStatus';
 import ThemeToggle from './ThemeToggle';
@@ -51,6 +52,7 @@ const adminNavigationConfig = [
   { nameKey: 'nav.satellites', href: '/admin/satellites', icon: Satellite, permission: ['admin'], feature: 'satellites' },
   { nameKey: 'nav.presence', href: '/admin/presence', icon: MapPin, permission: ['admin'] },
   { nameKey: 'nav.knowledgeGraph', href: '/admin/knowledge-graph', icon: Brain, permission: ['admin'] },
+  { nameKey: 'nav.maintenance', href: '/admin/maintenance', icon: Wrench, permission: ['admin'] },
   { nameKey: 'nav.settings', href: '/admin/settings', icon: Settings, permission: ['admin'] },
 ];
 

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -42,6 +42,7 @@
     "knowledgeGraph": "Wissensgraph",
     "memory": "Erinnerungen",
     "intents": "Intents",
+    "maintenance": "Wartung",
     "settings": "Einstellungen",
     "admin": "Admin",
     "skipToContent": "Zum Inhalt springen",
@@ -795,6 +796,50 @@
     "confirm": "Bestätigen",
     "cancel": "Abbrechen",
     "loading": "Wird ausgeführt..."
+  },
+  "maintenance": {
+    "title": "Wartung",
+    "subtitle": "Systemwartung und Diagnose-Tools",
+    "searchIndexing": {
+      "title": "Suche & Indexierung",
+      "description": "Volltextsuche und Home-Assistant-Keywords verwalten",
+      "reindexFts": "FTS neu indexieren",
+      "reindexFtsDescription": "Volltextindex aller Dokumente in der Wissensdatenbank neu aufbauen",
+      "reindexFtsSuccess": "FTS-Index erfolgreich aktualisiert",
+      "updatedCount": "Aktualisierte Dokumente",
+      "ftsConfig": "FTS-Konfiguration",
+      "refreshKeywords": "HA-Keywords aktualisieren",
+      "refreshKeywordsDescription": "Gerätenamen und Keywords aus Home Assistant neu laden",
+      "refreshKeywordsSuccess": "Keywords erfolgreich aktualisiert",
+      "keywordsCount": "Anzahl Keywords",
+      "sampleKeywords": "Beispiel-Keywords"
+    },
+    "embeddings": {
+      "title": "Embeddings",
+      "description": "Alle Vektoren nach Modellwechsel neu berechnen",
+      "reembedAll": "Alle neu einbetten",
+      "reembedWarning": "Dieser Vorgang dauert 10\u201330 Minuten. Nur nach einem Wechsel des Embedding-Modells ausf\u00fchren.",
+      "reembedSuccess": "Vektoren erfolgreich neu berechnet",
+      "reembedModel": "Modell",
+      "reembedTable": "Tabelle",
+      "reembedErrors": "Fehler",
+      "confirmReembed": "Alle Vektoren neu berechnen? Dies kann 10\u201330 Minuten dauern."
+    },
+    "debug": {
+      "title": "Debug",
+      "description": "Diagnose-Tools f\u00fcr Intent-Erkennung",
+      "testIntent": "Intent testen",
+      "testIntentDescription": "Nachricht eingeben um die Intent-Erkennung zu testen",
+      "messagePlaceholder": "z.B. Schalte das Licht im Wohnzimmer ein",
+      "extractedIntent": "Erkannter Intent",
+      "noMessage": "Bitte eine Nachricht eingeben"
+    },
+    "errors": {
+      "reindexFailed": "FTS-Neuindexierung fehlgeschlagen",
+      "refreshKeywordsFailed": "Keyword-Aktualisierung fehlgeschlagen",
+      "reembedFailed": "Neu-Einbettung fehlgeschlagen",
+      "intentTestFailed": "Intent-Test fehlgeschlagen"
+    }
   },
   "knowledgeGraph": {
     "title": "Wissensgraph",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -42,6 +42,7 @@
     "knowledgeGraph": "Knowledge Graph",
     "memory": "Memories",
     "intents": "Intents",
+    "maintenance": "Maintenance",
     "settings": "Settings",
     "admin": "Admin",
     "skipToContent": "Skip to content",
@@ -795,6 +796,50 @@
     "confirm": "Confirm",
     "cancel": "Cancel",
     "loading": "Processing..."
+  },
+  "maintenance": {
+    "title": "Maintenance",
+    "subtitle": "System maintenance and diagnostic tools",
+    "searchIndexing": {
+      "title": "Search & Indexing",
+      "description": "Manage full-text search and Home Assistant keywords",
+      "reindexFts": "Reindex FTS",
+      "reindexFtsDescription": "Rebuild the full-text search index of all knowledge base documents",
+      "reindexFtsSuccess": "FTS index updated successfully",
+      "updatedCount": "Updated documents",
+      "ftsConfig": "FTS configuration",
+      "refreshKeywords": "Refresh HA Keywords",
+      "refreshKeywordsDescription": "Reload device names and keywords from Home Assistant",
+      "refreshKeywordsSuccess": "Keywords refreshed successfully",
+      "keywordsCount": "Keyword count",
+      "sampleKeywords": "Sample keywords"
+    },
+    "embeddings": {
+      "title": "Embeddings",
+      "description": "Re-calculate all vectors after changing the embedding model",
+      "reembedAll": "Re-embed All",
+      "reembedWarning": "This operation takes 10\u201330 minutes. Only run after changing the embedding model.",
+      "reembedSuccess": "Vectors re-calculated successfully",
+      "reembedModel": "Model",
+      "reembedTable": "Table",
+      "reembedErrors": "Errors",
+      "confirmReembed": "Re-embed all vectors? This can take 10\u201330 minutes."
+    },
+    "debug": {
+      "title": "Debug",
+      "description": "Diagnostic tools for intent recognition",
+      "testIntent": "Test Intent",
+      "testIntentDescription": "Enter a message to test intent recognition",
+      "messagePlaceholder": "e.g. Turn on the living room light",
+      "extractedIntent": "Extracted Intent",
+      "noMessage": "Please enter a message"
+    },
+    "errors": {
+      "reindexFailed": "FTS reindex failed",
+      "refreshKeywordsFailed": "Keyword refresh failed",
+      "reembedFailed": "Re-embedding failed",
+      "intentTestFailed": "Intent test failed"
+    }
   },
   "knowledgeGraph": {
     "title": "Knowledge Graph",

--- a/src/frontend/src/pages/MaintenancePage.jsx
+++ b/src/frontend/src/pages/MaintenancePage.jsx
@@ -1,0 +1,336 @@
+/**
+ * Admin Maintenance Page
+ *
+ * Admin page for system maintenance operations:
+ * - FTS reindex, HA keyword refresh
+ * - Re-embed all vectors
+ * - Intent debugging
+ */
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '../context/AuthContext';
+import apiClient from '../utils/axios';
+import {
+  Wrench, Search, Database, Bug, Loader, AlertCircle, CheckCircle
+} from 'lucide-react';
+
+function ActionRow({ title, description, buttonLabel, icon: Icon, loading, onAction, variant }) {
+  return (
+    <div className="flex items-center justify-between py-3">
+      <div className="flex-1 min-w-0 mr-4">
+        <h3 className="text-sm font-medium text-gray-900 dark:text-white">{title}</h3>
+        <p className="text-sm text-gray-500 dark:text-gray-400">{description}</p>
+      </div>
+      <button
+        onClick={onAction}
+        disabled={loading}
+        className={`btn flex items-center gap-2 shrink-0 ${
+          variant === 'warning' ? 'btn-secondary' : 'btn-primary'
+        }`}
+      >
+        {loading ? (
+          <Loader className="w-4 h-4 animate-spin" />
+        ) : Icon ? (
+          <Icon className="w-4 h-4" />
+        ) : null}
+        {buttonLabel}
+      </button>
+    </div>
+  );
+}
+
+function ResultBox({ success, children }) {
+  if (!children) return null;
+  return (
+    <div className={`mt-2 p-3 rounded-lg flex items-start gap-2 text-sm ${
+      success
+        ? 'bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 text-green-700 dark:text-green-400'
+        : 'bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-400'
+    }`}>
+      {success ? (
+        <CheckCircle className="w-4 h-4 shrink-0 mt-0.5" />
+      ) : (
+        <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" />
+      )}
+      <div className="min-w-0">{children}</div>
+    </div>
+  );
+}
+
+export default function MaintenancePage() {
+  const { t } = useTranslation();
+  const { getAccessToken } = useAuth();
+
+  // FTS Reindex
+  const [ftsLoading, setFtsLoading] = useState(false);
+  const [ftsResult, setFtsResult] = useState(null);
+  const [ftsError, setFtsError] = useState(null);
+
+  // HA Keywords
+  const [kwLoading, setKwLoading] = useState(false);
+  const [kwResult, setKwResult] = useState(null);
+  const [kwError, setKwError] = useState(null);
+
+  // Re-embed
+  const [embedLoading, setEmbedLoading] = useState(false);
+  const [embedResult, setEmbedResult] = useState(null);
+  const [embedError, setEmbedError] = useState(null);
+
+  // Intent debug
+  const [intentMessage, setIntentMessage] = useState('');
+  const [intentLoading, setIntentLoading] = useState(false);
+  const [intentResult, setIntentResult] = useState(null);
+  const [intentError, setIntentError] = useState(null);
+
+  const getAuthHeaders = async () => {
+    const token = await getAccessToken();
+    return token ? { Authorization: `Bearer ${token}` } : {};
+  };
+
+  // --- Actions ---
+
+  const handleReindexFts = async () => {
+    setFtsLoading(true);
+    setFtsResult(null);
+    setFtsError(null);
+    try {
+      const headers = await getAuthHeaders();
+      const response = await apiClient.post('/api/knowledge/reindex-fts', null, { headers });
+      setFtsResult(response.data);
+    } catch (err) {
+      setFtsError(err.response?.data?.detail || t('maintenance.errors.reindexFailed'));
+    } finally {
+      setFtsLoading(false);
+    }
+  };
+
+  const handleRefreshKeywords = async () => {
+    setKwLoading(true);
+    setKwResult(null);
+    setKwError(null);
+    try {
+      const headers = await getAuthHeaders();
+      const response = await apiClient.post('/admin/refresh-keywords', null, { headers });
+      setKwResult(response.data);
+    } catch (err) {
+      setKwError(err.response?.data?.detail || t('maintenance.errors.refreshKeywordsFailed'));
+    } finally {
+      setKwLoading(false);
+    }
+  };
+
+  const handleReembed = async () => {
+    if (!window.confirm(t('maintenance.embeddings.confirmReembed'))) return;
+    setEmbedLoading(true);
+    setEmbedResult(null);
+    setEmbedError(null);
+    try {
+      const headers = await getAuthHeaders();
+      const response = await apiClient.post('/admin/reembed', null, {
+        headers,
+        timeout: 1800000 // 30 minutes
+      });
+      setEmbedResult(response.data);
+    } catch (err) {
+      setEmbedError(err.response?.data?.detail || t('maintenance.errors.reembedFailed'));
+    } finally {
+      setEmbedLoading(false);
+    }
+  };
+
+  const handleTestIntent = async () => {
+    if (!intentMessage.trim()) return;
+    setIntentLoading(true);
+    setIntentResult(null);
+    setIntentError(null);
+    try {
+      const headers = await getAuthHeaders();
+      const response = await apiClient.post(
+        `/debug/intent?message=${encodeURIComponent(intentMessage.trim())}`,
+        null,
+        { headers }
+      );
+      setIntentResult(response.data);
+    } catch (err) {
+      setIntentError(err.response?.data?.detail || t('maintenance.errors.intentTestFailed'));
+    } finally {
+      setIntentLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-6">
+        <Wrench className="w-8 h-8 text-blue-500" />
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+            {t('maintenance.title')}
+          </h1>
+          <p className="text-gray-600 dark:text-gray-400">{t('maintenance.subtitle')}</p>
+        </div>
+      </div>
+
+      {/* Section 1: Search & Indexing */}
+      <div className="card mb-6">
+        <div className="flex items-center gap-2 mb-4">
+          <Search className="w-6 h-6 text-blue-500" />
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            {t('maintenance.searchIndexing.title')}
+          </h2>
+        </div>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+          {t('maintenance.searchIndexing.description')}
+        </p>
+
+        {/* Reindex FTS */}
+        <ActionRow
+          title={t('maintenance.searchIndexing.reindexFts')}
+          description={t('maintenance.searchIndexing.reindexFtsDescription')}
+          buttonLabel={t('maintenance.searchIndexing.reindexFts')}
+          loading={ftsLoading}
+          onAction={handleReindexFts}
+        />
+        {ftsResult && (
+          <ResultBox success>
+            <p className="font-medium">{t('maintenance.searchIndexing.reindexFtsSuccess')}</p>
+            <p>{t('maintenance.searchIndexing.updatedCount')}: {ftsResult.updated_count ?? ftsResult.updated ?? '—'}</p>
+            {ftsResult.fts_config && (
+              <p>{t('maintenance.searchIndexing.ftsConfig')}: {ftsResult.fts_config}</p>
+            )}
+          </ResultBox>
+        )}
+        {ftsError && <ResultBox success={false}>{ftsError}</ResultBox>}
+
+        <div className="border-t border-gray-200 dark:border-gray-700 my-2" />
+
+        {/* Refresh HA Keywords */}
+        <ActionRow
+          title={t('maintenance.searchIndexing.refreshKeywords')}
+          description={t('maintenance.searchIndexing.refreshKeywordsDescription')}
+          buttonLabel={t('maintenance.searchIndexing.refreshKeywords')}
+          loading={kwLoading}
+          onAction={handleRefreshKeywords}
+        />
+        {kwResult && (
+          <ResultBox success>
+            <p className="font-medium">{t('maintenance.searchIndexing.refreshKeywordsSuccess')}</p>
+            <p>{t('maintenance.searchIndexing.keywordsCount')}: {kwResult.keywords_count ?? kwResult.count ?? '—'}</p>
+            {kwResult.sample && (
+              <p>{t('maintenance.searchIndexing.sampleKeywords')}: {
+                Array.isArray(kwResult.sample) ? kwResult.sample.join(', ') : String(kwResult.sample)
+              }</p>
+            )}
+          </ResultBox>
+        )}
+        {kwError && <ResultBox success={false}>{kwError}</ResultBox>}
+      </div>
+
+      {/* Section 2: Embeddings */}
+      <div className="card mb-6">
+        <div className="flex items-center gap-2 mb-4">
+          <Database className="w-6 h-6 text-blue-500" />
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            {t('maintenance.embeddings.title')}
+          </h2>
+        </div>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+          {t('maintenance.embeddings.description')}
+        </p>
+
+        {/* Warning */}
+        <div className="mb-4 p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg text-sm text-amber-700 dark:text-amber-400">
+          {t('maintenance.embeddings.reembedWarning')}
+        </div>
+
+        <ActionRow
+          title={t('maintenance.embeddings.reembedAll')}
+          description={t('maintenance.embeddings.description')}
+          buttonLabel={t('maintenance.embeddings.reembedAll')}
+          loading={embedLoading}
+          onAction={handleReembed}
+          variant="warning"
+        />
+        {embedResult && (
+          <ResultBox success>
+            <p className="font-medium">{t('maintenance.embeddings.reembedSuccess')}</p>
+            {embedResult.model && (
+              <p>{t('maintenance.embeddings.reembedModel')}: {embedResult.model}</p>
+            )}
+            {embedResult.counts && typeof embedResult.counts === 'object' && (
+              <div className="mt-1">
+                {Object.entries(embedResult.counts).map(([table, count]) => (
+                  <p key={table}>{t('maintenance.embeddings.reembedTable')}: {table} — {count}</p>
+                ))}
+              </div>
+            )}
+            {embedResult.errors && embedResult.errors.length > 0 && (
+              <div className="mt-1 text-amber-700 dark:text-amber-400">
+                <p>{t('maintenance.embeddings.reembedErrors')}:</p>
+                {embedResult.errors.map((err, i) => (
+                  <p key={i} className="ml-2">- {err}</p>
+                ))}
+              </div>
+            )}
+          </ResultBox>
+        )}
+        {embedError && <ResultBox success={false}>{embedError}</ResultBox>}
+      </div>
+
+      {/* Section 3: Debug */}
+      <div className="card">
+        <div className="flex items-center gap-2 mb-4">
+          <Bug className="w-6 h-6 text-blue-500" />
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            {t('maintenance.debug.title')}
+          </h2>
+        </div>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+          {t('maintenance.debug.description')}
+        </p>
+
+        {/* Intent Test */}
+        <div className="mb-4">
+          <h3 className="text-sm font-medium text-gray-900 dark:text-white mb-1">
+            {t('maintenance.debug.testIntent')}
+          </h3>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">
+            {t('maintenance.debug.testIntentDescription')}
+          </p>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={intentMessage}
+              onChange={(e) => setIntentMessage(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleTestIntent()}
+              placeholder={t('maintenance.debug.messagePlaceholder')}
+              className="input flex-1"
+            />
+            <button
+              onClick={handleTestIntent}
+              disabled={intentLoading || !intentMessage.trim()}
+              className="btn btn-primary flex items-center gap-2 shrink-0"
+            >
+              {intentLoading ? (
+                <Loader className="w-4 h-4 animate-spin" />
+              ) : (
+                <Bug className="w-4 h-4" />
+              )}
+              {t('maintenance.debug.testIntent')}
+            </button>
+          </div>
+        </div>
+
+        {intentResult && (
+          <ResultBox success>
+            <p className="font-medium mb-1">{t('maintenance.debug.extractedIntent')}</p>
+            <pre className="text-xs bg-gray-100 dark:bg-gray-800 p-3 rounded overflow-x-auto whitespace-pre-wrap">
+              {JSON.stringify(intentResult, null, 2)}
+            </pre>
+          </ResultBox>
+        )}
+        {intentError && <ResultBox success={false}>{intentError}</ResultBox>}
+      </div>
+    </div>
+  );
+}

--- a/tests/frontend/react/pages/MaintenancePage.test.jsx
+++ b/tests/frontend/react/pages/MaintenancePage.test.jsx
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '../mocks/server.js';
+import { BASE_URL } from '../mocks/handlers.js';
+import MaintenancePage from '../../../../src/frontend/src/pages/MaintenancePage';
+import { renderWithProviders } from '../test-utils.jsx';
+import { useAuth } from '../../../../src/frontend/src/context/AuthContext';
+
+// Mock AuthContext
+vi.mock('../../../../src/frontend/src/context/AuthContext', () => ({
+  useAuth: vi.fn()
+}));
+
+const adminAuthMock = {
+  getAccessToken: () => Promise.resolve('mock-token'),
+  hasPermission: () => true,
+  hasAnyPermission: () => true,
+  isAuthenticated: true,
+  authEnabled: true,
+  loading: false,
+  user: { username: 'admin', role: 'Admin', permissions: ['admin'] }
+};
+
+describe('MaintenancePage', () => {
+  beforeEach(() => {
+    server.resetHandlers();
+    vi.mocked(useAuth).mockReturnValue(adminAuthMock);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('renders the page title and subtitle', () => {
+      renderWithProviders(<MaintenancePage />);
+
+      expect(screen.getByText('Wartung')).toBeInTheDocument();
+      expect(screen.getByText('Systemwartung und Diagnose-Tools')).toBeInTheDocument();
+    });
+
+    it('renders all three sections', () => {
+      renderWithProviders(<MaintenancePage />);
+
+      expect(screen.getByText('Suche & Indexierung')).toBeInTheDocument();
+      expect(screen.getByText('Embeddings')).toBeInTheDocument();
+      expect(screen.getByText('Debug')).toBeInTheDocument();
+    });
+
+    it('renders the re-embed warning box', () => {
+      renderWithProviders(<MaintenancePage />);
+
+      expect(screen.getByText(/10–30 Minuten/)).toBeInTheDocument();
+    });
+
+    it('renders the intent test input', () => {
+      renderWithProviders(<MaintenancePage />);
+
+      expect(screen.getByPlaceholderText(/Schalte das Licht/)).toBeInTheDocument();
+    });
+  });
+
+  describe('FTS Reindex', () => {
+    it('calls reindex endpoint and shows result', async () => {
+      server.use(
+        http.post(`${BASE_URL}/api/knowledge/reindex-fts`, () => {
+          return HttpResponse.json({ updated_count: 42, fts_config: 'german' });
+        })
+      );
+
+      renderWithProviders(<MaintenancePage />);
+
+      const buttons = screen.getAllByRole('button', { name: /FTS neu indexieren/i });
+      fireEvent.click(buttons[0]);
+
+      await waitFor(() => {
+        expect(screen.getByText(/FTS-Index erfolgreich aktualisiert/)).toBeInTheDocument();
+      });
+
+      expect(screen.getByText(/42/)).toBeInTheDocument();
+      expect(screen.getByText(/german/)).toBeInTheDocument();
+    });
+
+    it('shows error when reindex fails', async () => {
+      server.use(
+        http.post(`${BASE_URL}/api/knowledge/reindex-fts`, () => {
+          return HttpResponse.json({ detail: 'DB error' }, { status: 500 });
+        })
+      );
+
+      renderWithProviders(<MaintenancePage />);
+
+      const buttons = screen.getAllByRole('button', { name: /FTS neu indexieren/i });
+      fireEvent.click(buttons[0]);
+
+      await waitFor(() => {
+        expect(screen.getByText(/DB error/)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('HA Keywords', () => {
+    it('calls refresh-keywords endpoint and shows result', async () => {
+      server.use(
+        http.post(`${BASE_URL}/admin/refresh-keywords`, () => {
+          return HttpResponse.json({ keywords_count: 15, sample: ['Wohnzimmer Licht', 'Küche'] });
+        })
+      );
+
+      renderWithProviders(<MaintenancePage />);
+
+      const buttons = screen.getAllByRole('button', { name: /HA-Keywords aktualisieren/i });
+      fireEvent.click(buttons[0]);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Keywords erfolgreich aktualisiert/)).toBeInTheDocument();
+      });
+
+      expect(screen.getByText(/15/)).toBeInTheDocument();
+      expect(screen.getByText(/Wohnzimmer Licht, Küche/)).toBeInTheDocument();
+    });
+  });
+
+  describe('Re-embed', () => {
+    it('asks for confirmation before re-embedding', () => {
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+      renderWithProviders(<MaintenancePage />);
+
+      const buttons = screen.getAllByRole('button', { name: /Alle neu einbetten/i });
+      fireEvent.click(buttons[0]);
+
+      expect(confirmSpy).toHaveBeenCalled();
+      confirmSpy.mockRestore();
+    });
+
+    it('calls reembed endpoint when confirmed', async () => {
+      vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+      server.use(
+        http.post(`${BASE_URL}/admin/reembed`, () => {
+          return HttpResponse.json({
+            model: 'qwen3-embedding:4b',
+            counts: { rag_chunks: 100, memories: 20 }
+          });
+        })
+      );
+
+      renderWithProviders(<MaintenancePage />);
+
+      const buttons = screen.getAllByRole('button', { name: /Alle neu einbetten/i });
+      fireEvent.click(buttons[0]);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Vektoren erfolgreich neu berechnet/)).toBeInTheDocument();
+      });
+
+      expect(screen.getByText(/qwen3-embedding:4b/)).toBeInTheDocument();
+
+      window.confirm.mockRestore();
+    });
+  });
+
+  describe('Intent Test', () => {
+    it('calls debug/intent endpoint and shows JSON result', async () => {
+      server.use(
+        http.post(`${BASE_URL}/debug/intent`, ({ request }) => {
+          const url = new URL(request.url);
+          const message = url.searchParams.get('message');
+          return HttpResponse.json({
+            intent: 'mcp.ha.light_turn_on',
+            confidence: 0.95,
+            message
+          });
+        })
+      );
+
+      renderWithProviders(<MaintenancePage />);
+
+      const input = screen.getByPlaceholderText(/Schalte das Licht/);
+      fireEvent.change(input, { target: { value: 'Licht an' } });
+
+      const testButton = screen.getByRole('button', { name: /Intent testen/i });
+      fireEvent.click(testButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Erkannter Intent/)).toBeInTheDocument();
+      });
+
+      expect(screen.getByText(/mcp.ha.light_turn_on/)).toBeInTheDocument();
+    });
+
+    it('disables test button when input is empty', () => {
+      renderWithProviders(<MaintenancePage />);
+
+      const testButton = screen.getByRole('button', { name: /Intent testen/i });
+      expect(testButton).toBeDisabled();
+    });
+
+    it('supports Enter key to submit', async () => {
+      server.use(
+        http.post(`${BASE_URL}/debug/intent`, () => {
+          return HttpResponse.json({ intent: 'general.conversation' });
+        })
+      );
+
+      renderWithProviders(<MaintenancePage />);
+
+      const input = screen.getByPlaceholderText(/Schalte das Licht/);
+      fireEvent.change(input, { target: { value: 'Hallo' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      await waitFor(() => {
+        expect(screen.getByText(/general.conversation/)).toBeInTheDocument();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- New admin page at `/admin/maintenance` with UI for 4 maintenance operations previously only accessible via curl
- **Search & Indexing**: FTS reindex + HA keyword refresh
- **Embeddings**: Re-embed all vectors (with confirmation dialog + 30min timeout)
- **Debug**: Intent recognition test with formatted JSON output
- Full i18n support (DE/EN), dark mode, 12 component tests

## Test plan
- [ ] Navigate to `/admin/maintenance` as admin user
- [ ] Verify all 3 sections render correctly
- [ ] Test FTS reindex button → shows updated count
- [ ] Test HA keywords refresh → shows keyword count + samples
- [ ] Test re-embed with confirmation dialog
- [ ] Test intent debug input with Enter key and button
- [ ] Verify nav entry appears under Admin section with Wrench icon
- [ ] Run `npx vitest run pages/MaintenancePage.test.jsx` — 12 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)