### PR TITLE
feat(llm): Add separate embedding client via OLLAMA_EMBED_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,10 @@ OLLAMA_URL=http://ollama:11434
 # Im Container: http://host.docker.internal:11434 = Ollama auf dem Docker-Host
 # OLLAMA_FALLBACK_URL=http://host.docker.internal:11434
 
+# Optional: Separate Ollama-Instanz für Embedding-Erzeugung
+# Nützlich wenn die GPU-Instanz unter Last steht (z.B. während Dokument-Ingestion)
+# OLLAMA_EMBED_URL=http://host.docker.internal:11434
+
 # Timeout-Konfiguration (Standard: connect=10s, read=300s)
 # OLLAMA_CONNECT_TIMEOUT=10.0
 # OLLAMA_READ_TIMEOUT=300.0

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -69,6 +69,10 @@ OLLAMA_URL=http://cuda.local:11434  # Externe GPU-Instanz
 # Im Docker-Container: http://host.docker.internal:11434 = Ollama auf dem Docker-Host
 OLLAMA_FALLBACK_URL=http://host.docker.internal:11434
 
+# Optional: Separate Ollama-Instanz nur für Embedding-Erzeugung
+# Verhindert, dass Embedding-Calls mit LLM-Inferenz um GPU-Ressourcen konkurrieren
+OLLAMA_EMBED_URL=http://host.docker.internal:11434
+
 # Timeout-Konfiguration
 OLLAMA_CONNECT_TIMEOUT=10.0    # TCP-Verbindungs-Timeout in Sekunden (Default: 10)
 OLLAMA_READ_TIMEOUT=300.0      # Lese-Timeout für lange LLM-Antworten (Default: 300)
@@ -87,6 +91,7 @@ OLLAMA_NUM_CTX=32768                  # Context Window für alle Ollama-Calls
 **Defaults:**
 - `OLLAMA_URL`: `http://ollama:11434`
 - `OLLAMA_FALLBACK_URL`: `""` (kein Fallback)
+- `OLLAMA_EMBED_URL`: `None` (verwendet `OLLAMA_URL`)
 - `OLLAMA_CONNECT_TIMEOUT`: `10.0` Sekunden
 - `OLLAMA_READ_TIMEOUT`: `300.0` Sekunden
 - `OLLAMA_MODEL`: `llama3.2:3b` (dev fallback)

--- a/src/backend/services/conversation_memory_service.py
+++ b/src/backend/services/conversation_memory_service.py
@@ -27,7 +27,7 @@ from models.database import (
     MemoryHistory,
 )
 from utils.config import settings
-from utils.llm_client import get_default_client
+from utils.llm_client import get_embed_client
 
 
 class ConversationMemoryService:
@@ -43,7 +43,7 @@ class ConversationMemoryService:
     async def _get_ollama_client(self):
         """Lazy initialization of Ollama client for embeddings."""
         if self._ollama_client is None:
-            self._ollama_client = get_default_client()
+            self._ollama_client = get_embed_client()
         return self._ollama_client
 
     async def _get_embedding(self, text_input: str) -> list[float]:

--- a/src/backend/services/intent_feedback_service.py
+++ b/src/backend/services/intent_feedback_service.py
@@ -18,7 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.database import IntentCorrection
 from utils.config import settings
-from utils.llm_client import get_default_client
+from utils.llm_client import get_embed_client
 
 
 class IntentFeedbackService:
@@ -40,7 +40,7 @@ class IntentFeedbackService:
     async def _get_ollama_client(self):
         """Lazy initialization of Ollama client for embeddings."""
         if self._ollama_client is None:
-            self._ollama_client = get_default_client()
+            self._ollama_client = get_embed_client()
         return self._ollama_client
 
     async def _get_embedding(self, text: str) -> list[float]:

--- a/src/backend/services/knowledge_graph_service.py
+++ b/src/backend/services/knowledge_graph_service.py
@@ -18,7 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.database import KG_ENTITY_TYPES, KG_SCOPE_PERSONAL, KGEntity, KGRelation
 from utils.config import settings
-from utils.llm_client import get_default_client
+from utils.llm_client import get_embed_client
 
 # =============================================================================
 # Compiled regex patterns for entity validation (module-level for performance)
@@ -112,7 +112,7 @@ class KnowledgeGraphService:
 
     async def _get_ollama_client(self):
         if self._ollama_client is None:
-            self._ollama_client = get_default_client()
+            self._ollama_client = get_embed_client()
         return self._ollama_client
 
     async def _get_embedding(self, text_input: str) -> list[float]:

--- a/src/backend/services/notification_service.py
+++ b/src/backend/services/notification_service.py
@@ -115,9 +115,9 @@ class NotificationService:
 
     async def _get_embedding(self, text_input: str) -> list[float]:
         """Generate embedding via Ollama (same pattern as IntentFeedbackService)."""
-        from utils.llm_client import get_default_client
+        from utils.llm_client import get_embed_client
 
-        client = get_default_client()
+        client = get_embed_client()
         response = await client.embeddings(
             model=settings.ollama_embed_model,
             prompt=text_input,

--- a/src/backend/services/ollama_service.py
+++ b/src/backend/services/ollama_service.py
@@ -22,6 +22,7 @@ from utils.llm_client import (
     extract_response_content,
     get_classification_chat_kwargs,
     get_default_client,
+    get_embed_client,
 )
 
 _MAX_USER_INPUT_LENGTH = 4000
@@ -41,6 +42,7 @@ class OllamaService:
 
     def __init__(self):
         self.client = get_default_client()
+        self.embed_client = get_embed_client()
 
         # Multi-Modell Konfiguration
         self.model = settings.ollama_model  # Legacy
@@ -873,7 +875,7 @@ WICHTIGE REGELN FÜR ANTWORTEN:
             Liste von Floats (768 Dimensionen für nomic-embed-text)
         """
         try:
-            response = await self.client.embeddings(
+            response = await self.embed_client.embeddings(
                 model=self.embed_model,
                 prompt=text
             )

--- a/src/backend/services/rag_service.py
+++ b/src/backend/services/rag_service.py
@@ -30,7 +30,7 @@ from models.database import (
 )
 from services.document_processor import DocumentProcessor
 from utils.config import settings
-from utils.llm_client import get_default_client
+from utils.llm_client import get_embed_client
 
 
 class RAGService:
@@ -58,7 +58,7 @@ class RAGService:
     async def _get_ollama_client(self):
         """Lazy initialization des Ollama Clients"""
         if self._ollama_client is None:
-            self._ollama_client = get_default_client()
+            self._ollama_client = get_embed_client()
         return self._ollama_client
 
     # ==========================================================================

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -41,6 +41,7 @@ class Settings(BaseSettings):
     ollama_connect_timeout: float = 10.0          # TCP connect timeout in seconds (fast-fail when host is down)
     ollama_read_timeout: float = 300.0            # Read timeout for long LLM responses
     ollama_fallback_url: str = ""                 # Fallback Ollama URL if primary is unreachable (e.g. http://host.docker.internal:11434)
+    ollama_embed_url: str | None = None          # Separate Ollama URL for embeddings (default: ollama_url)
 
     # Home Assistant
     home_assistant_url: str | None = None

--- a/src/backend/utils/llm_client.py
+++ b/src/backend/utils/llm_client.py
@@ -163,6 +163,18 @@ def get_default_client() -> LLMClient:
     return _make_client_with_fallback(settings.ollama_url)
 
 
+def get_embed_client() -> LLMClient:
+    """Return the client for embedding calls.
+
+    Uses ``settings.ollama_embed_url`` when configured (separate Ollama instance
+    dedicated to embeddings), otherwise falls back to ``get_default_client()``.
+    Both paths include transparent fallback via ``OLLAMA_FALLBACK_URL``.
+    """
+    if settings.ollama_embed_url:
+        return _make_client_with_fallback(settings.ollama_embed_url)
+    return get_default_client()
+
+
 def get_agent_client(
     role_url: str | None = None,
     fallback_url: str | None = None,


### PR DESCRIPTION
## Summary

- Adds `OLLAMA_EMBED_URL` setting to delegate embedding generation to a separate Ollama instance, preventing GPU contention during bulk document ingestion
- Adds `get_embed_client()` factory function in `llm_client.py` with full fallback support
- Switches all 6 embedding-consuming services (RAG, Ollama, ConversationMemory, IntentFeedback, KnowledgeGraph, Notification) to use the new embed client

Closes #191

## Context

Query "Welche Rechnungen gab es 2022 für Am Stirkenbend 20" returned no results because the GPU was overloaded during massive document ingestion (embeddings on cuda.local). Agent steps hit the 30s timeout → empty response. RAG itself works correctly.

## Production Deploy

```bash
# /opt/renfield/.env
AGENT_STEP_TIMEOUT=60.0
AGENT_TOTAL_TIMEOUT=180.0
OLLAMA_EMBED_URL=http://host.docker.internal:11434
```

## Test plan

- [x] `python3 -m pytest tests/backend/test_llm_client.py -v` — 41 tests pass (4 new)
- [ ] Production: Set `OLLAMA_EMBED_URL`, restart backend, verify embeddings use separate instance
- [ ] Verify agent queries complete within 60s timeout under GPU load

🤖 Generated with [Claude Code](https://claude.com/claude-code)