### PR TITLE
feat(agent): Add dual-source document search with date filter (#192)

### DIFF
--- a/config/agent_roles.yaml
+++ b/config/agent_roles.yaml
@@ -33,9 +33,10 @@ roles:
 
   documents:
     description:
-      de: "Dokumente und E-Mail: Suche, Download, Versand von Dokumenten"
-      en: "Documents and email: search, download, send documents"
+      de: "Dokumente und E-Mail: Suche in Wissensdatenbank und Paperless, Download, Versand"
+      en: "Documents and email: search knowledge base and Paperless, download, send"
     mcp_servers: [paperless, email]
+    internal_tools: [internal.knowledge_search]
     max_steps: 8
     prompt_key: agent_prompt_documents
 

--- a/src/backend/prompts/agent.yaml
+++ b/src/backend/prompts/agent.yaml
@@ -159,6 +159,9 @@ de:
     - Rufe pro Antwort GENAU EIN Tool auf
     - Erfinde NIEMALS IDs — hole sie IMMER zuerst ueber search_documents
     - Wenn im KONVERSATIONS-KONTEXT bereits Suchergebnisse vorliegen, nutze diese IDs direkt
+    - Bei Dokumenten-Suchen: Durchsuche IMMER BEIDE Quellen: (1) internal.knowledge_search fuer die lokale Wissensdatenbank, (2) mcp.paperless.search_documents fuer Paperless
+    - Wenn ein Zeitraum genannt wird (z.B. "2022", "letztes Jahr"), nutze created_after/created_before in search_documents
+    - Fasse die Ergebnisse beider Quellen zusammen und filtere Duplikate nach Titel
     - Um Dokumente per E-Mail zu versenden: (1) search_documents, (2) download_document, (3) send_email
     - Heruntergeladene Dokumente werden AUTOMATISCH als Anhaenge eingefuegt
     - Uebergib bei send_email KEINE attachments
@@ -507,6 +510,9 @@ en:
     - Call EXACTLY ONE tool per response
     - NEVER invent IDs — always fetch them via search_documents first
     - If the CONVERSATION CONTEXT already has search results, use those IDs directly
+    - For document searches: ALWAYS search BOTH sources: (1) internal.knowledge_search for the local knowledge base, (2) mcp.paperless.search_documents for Paperless
+    - When a time period is mentioned (e.g. "2022", "last year"), use created_after/created_before in search_documents
+    - Combine results from both sources and deduplicate by title
     - To send documents by email: (1) search_documents, (2) download_document, (3) send_email
     - Downloaded documents are AUTOMATICALLY attached
     - Do NOT pass attachments to send_email


### PR DESCRIPTION
## Summary
- New `internal.knowledge_search` agent tool that searches the local RAG knowledge base
- Documents agent now searches **both** RAG and Paperless for every document query
- Agent prompts (de/en) instruct LLM to use `created_after`/`created_before` date filters when a time period is mentioned
- Companion change: [renfield-mcp-paperless](https://github.com/ebongard/renfield-mcp-paperless) v1.1.0 adds `created_after`/`created_before` params to `search_documents`

## Test plan
- [x] 5 new tests for `internal.knowledge_search` handler (results, empty, missing query, empty query, exception)
- [x] 4 new tests in renfield-mcp-paperless for date filter forwarding
- [ ] Production: pip install updated paperless MCP + backend restart
- [ ] Query: "Welche Rechnungen gab es 2022 für Am Stirkenbend 20?" — agent calls both sources with date filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)