### PR TITLE
fix(rag): Balance hybrid search weights for proper noun queries

### DIFF
--- a/src/backend/services/rag_service.py
+++ b/src/backend/services/rag_service.py
@@ -277,7 +277,9 @@ class RAGService:
         # Hybrid Search or Dense-only
         if settings.rag_hybrid_enabled:
             candidate_k = top_k * 3  # Over-fetch for RRF fusion
-            dense_results = await self._search_dense(query_embedding, candidate_k, knowledge_base_id)
+            dense_results = await self._search_dense(
+                query_embedding, candidate_k, knowledge_base_id, threshold
+            )
             bm25_results = await self._search_bm25(query, candidate_k, knowledge_base_id)
             results = self._reciprocal_rank_fusion(dense_results, bm25_results, top_k)
             logger.info(
@@ -316,7 +318,7 @@ class RAGService:
             query_embedding: Pre-computed query embedding
             top_k: Number of results
             knowledge_base_id: Optional KB filter
-            threshold: Minimum cosine similarity (only applied in non-hybrid mode)
+            threshold: Minimum cosine similarity filter
 
         Returns:
             List of {chunk, document, similarity}

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -132,8 +132,8 @@ class Settings(BaseSettings):
 
     # Hybrid Search (Dense + BM25 via PostgreSQL Full-Text Search)
     rag_hybrid_enabled: bool = True           # Enable hybrid search (BM25 + dense)
-    rag_hybrid_bm25_weight: float = Field(default=0.3, ge=0.0, le=1.0)
-    rag_hybrid_dense_weight: float = Field(default=0.7, ge=0.0, le=1.0)
+    rag_hybrid_bm25_weight: float = Field(default=0.5, ge=0.0, le=1.0)
+    rag_hybrid_dense_weight: float = Field(default=0.5, ge=0.0, le=1.0)
     rag_hybrid_rrf_k: int = 60                # RRF constant k (standard: 60)
     rag_hybrid_fts_config: str = "german"     # PostgreSQL FTS config: simple/german/english
 

--- a/tests/backend/test_rag_hybrid_search.py
+++ b/tests/backend/test_rag_hybrid_search.py
@@ -555,8 +555,8 @@ class TestHybridSearchConfig:
             database_url="sqlite:///:memory:",
             postgres_host="localhost"
         )
-        assert s.rag_hybrid_bm25_weight == 0.3
-        assert s.rag_hybrid_dense_weight == 0.7
+        assert s.rag_hybrid_bm25_weight == 0.5
+        assert s.rag_hybrid_dense_weight == 0.5
         assert s.rag_hybrid_bm25_weight + s.rag_hybrid_dense_weight == pytest.approx(1.0)
 
     @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Balance RRF weights from 0.7/0.3 (dense/bm25) to **0.5/0.5**
- Apply `rag_similarity_threshold` to dense candidates in hybrid mode (was dense-only)

## Problem
Proper nouns like "Alternate" (a webshop) are not recognized by embedding models — all German invoices score 0.65-0.73 cosine similarity while actual Alternate docs score only 0.30-0.56. With 0.7 dense weight, BM25 text matches could never outrank irrelevant dense results.

## Results
| Query | Before | After |
|---|---|---|
| "Alternate" | 0 relevant docs | 3 relevant docs in top 20 |
| "Stirkenbend 2022" | 16 results | 17 results (no regression) |

## Test plan
- [x] `test_default_weights` updated and passing
- [x] Production tested: "Alternate" returns 3 matching documents
- [x] "Stirkenbend" query unchanged (no regression)

Fixes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)