### PR TITLE
fix(paperless): Fix progress display and start endpoint timeout

### DIFF
--- a/src/backend/api/routes/paperless_audit.py
+++ b/src/backend/api/routes/paperless_audit.py
@@ -59,18 +59,15 @@ async def start_audit(body: AuditStartRequest, request: Request):
     if service.get_status()["running"]:
         raise HTTPException(status_code=409, detail="Audit already running")
 
-    # Run in background
-    result = await service.run_audit(
+    # Run in background — returns immediately so Nginx doesn't timeout
+    run_id = await service.run_audit_background(
         mode=body.mode,
         fix_mode=body.fix_mode,
         confidence_threshold=body.confidence_threshold,
         document_ids=body.document_ids,
     )
 
-    if "error" in result:
-        raise HTTPException(status_code=400, detail=result["error"])
-
-    return result
+    return {"run_id": run_id, "status": "started"}
 
 
 @router.get("/status")

--- a/src/frontend/src/pages/PaperlessAuditPage.jsx
+++ b/src/frontend/src/pages/PaperlessAuditPage.jsx
@@ -408,7 +408,8 @@ export default function PaperlessAuditPage() {
 // --- Control Tab Component ---
 function ControlTab({ t, auditStatus, mode, setMode, fixMode, setFixMode, confidenceThreshold, setConfidenceThreshold, starting, stopping, onStart, onStop }) {
   const running = auditStatus?.running;
-  const progress = auditStatus?.progress;
+  const current = auditStatus?.progress ?? 0;
+  const total = auditStatus?.total ?? 0;
 
   return (
     <div className="card p-6 space-y-6">
@@ -470,22 +471,19 @@ function ControlTab({ t, auditStatus, mode, setMode, fixMode, setFixMode, confid
       )}
 
       {/* Progress */}
-      {running && progress && (
+      {running && (
         <div className="space-y-2">
           <div className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
             <Loader className="w-4 h-4 animate-spin" />
             <span>{t('paperlessAudit.control.running')}</span>
             <span className="ml-auto">
-              {t('paperlessAudit.control.progress', {
-                current: progress.current || 0,
-                total: progress.total || 0,
-              })}
+              {t('paperlessAudit.control.progress', { current, total })}
             </span>
           </div>
           <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2.5">
             <div
               className="bg-primary-600 h-2.5 rounded-full transition-all duration-300"
-              style={{ width: `${progress.total ? (progress.current / progress.total) * 100 : 0}%` }}
+              style={{ width: `${total ? (current / total) * 100 : 0}%` }}
             />
           </div>
         </div>

--- a/tests/backend/test_paperless_audit.py
+++ b/tests/backend/test_paperless_audit.py
@@ -794,11 +794,10 @@ class TestRunAudit:
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_already_running(self, service):
-        """Should return error when audit is already running."""
+        """run_audit_background should return 'already_running' when audit is in progress."""
         service._running = True
-        result = await service.run_audit()
-        assert "error" in result
-        assert "already running" in result["error"].lower()
+        result = await service.run_audit_background()
+        assert result == "already_running"
 
     @pytest.mark.unit
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- **Frontend progress "0 von 0"**: `ControlTab` read `progress.current` / `progress.total` (nested), but the status API returns flat `{progress: N, total: M}`. Fixed to use `auditStatus.progress` and `auditStatus.total` directly.
- **Start endpoint 504 timeout**: `/start` route awaited `run_audit()` synchronously, blocking until all 1145 document IDs were paginated (~2 min). Now uses `run_audit_background()` which creates an asyncio task and returns immediately.

## Test plan
- [x] 66 paperless audit tests pass
- [x] Verified status endpoint returns correct flat structure on production
- [x] Frontend rebuilt and deployed — progress bar now shows correct values

🤖 Generated with [Claude Code](https://claude.com/claude-code)