### PR TITLE
feat(paperless): Add sorting and search to audit review queue

### DIFF
--- a/src/backend/api/routes/paperless_audit.py
+++ b/src/backend/api/routes/paperless_audit.py
@@ -97,8 +97,11 @@ async def get_results(
     detected_language: str | None = None,
     completeness_max: int | None = None,
     duplicate_group_id: str | None = None,
+    sort_by: str | None = None,
+    sort_order: str = "desc",
+    search: str | None = None,
 ):
-    """Get paginated audit results with optional filters."""
+    """Get paginated audit results with optional filters, sorting, and search."""
     service = _get_service(request)
     return await service.get_results(
         page=page,
@@ -110,6 +113,9 @@ async def get_results(
         detected_language=detected_language,
         completeness_max=completeness_max,
         duplicate_group_id=duplicate_group_id,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        search=search,
     )
 
 

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -931,7 +931,9 @@
       "skip": "Überspringen",
       "approveSelected": "Ausgewählte übernehmen",
       "skipSelected": "Ausgewählte überspringen",
-      "noResults": "Keine ausstehenden Änderungen"
+      "noResults": "Keine ausstehenden Änderungen",
+      "noSearchResults": "Keine Ergebnisse für diese Suche",
+      "searchPlaceholder": "Titel, Ansprechpartner, Typ suchen..."
     },
     "ocr": {
       "quality": "OCR-Qualität",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -931,7 +931,9 @@
       "skip": "Skip",
       "approveSelected": "Approve Selected",
       "skipSelected": "Skip Selected",
-      "noResults": "No pending changes"
+      "noResults": "No pending changes",
+      "noSearchResults": "No results for this search",
+      "searchPlaceholder": "Search title, correspondent, type..."
     },
     "ocr": {
       "quality": "OCR Quality",


### PR DESCRIPTION
## Summary
- Server-side sorting by any column via `sort_by` + `sort_order` query params
- Text search across title, correspondent, type, and reasoning via `search` param
- Clickable column headers with sort direction indicators
- Debounced search input (300ms) with search icon
- Whitelist of 16 sortable columns prevents SQL injection

## Test plan
- [x] 83 backend tests passing
- [x] ruff lint clean
- [x] i18n JSON valid (de + en)
- [ ] Click column headers to sort asc/desc
- [ ] Type in search field to filter results
- [ ] Pagination resets on sort/search change

🤖 Generated with [Claude Code](https://claude.com/claude-code)