### PR TITLE
fix(chat): Redact API keys in MCP responses and display agent steps in UI

### DIFF
--- a/src/frontend/src/pages/ChatPage/ChatMessages.jsx
+++ b/src/frontend/src/pages/ChatPage/ChatMessages.jsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Volume2, Loader, FileText, AlertCircle, CheckCircle } from 'lucide-react';
+import { Volume2, Loader, FileText, AlertCircle, CheckCircle, Search, CheckCircle2, XCircle } from 'lucide-react';
 import IntentCorrectionButton from '../../components/IntentCorrectionButton';
 import AttachmentQuickActions from './AttachmentQuickActions';
 import EmailForwardDialog from './EmailForwardDialog';
@@ -61,6 +61,39 @@ export default function ChatMessages() {
                 : 'bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-gray-100'
             }`}
           >
+            {/* Agent Steps (tool calls / results) */}
+            {message.agentSteps && message.agentSteps.length > 0 && (
+              <div className="mb-2 space-y-1.5">
+                {message.agentSteps.map((step, stepIdx) => (
+                  <div key={stepIdx} className="flex items-start gap-1.5 text-xs">
+                    {step.type === 'tool_call' && (
+                      <>
+                        <Search className="w-3.5 h-3.5 mt-0.5 flex-shrink-0 text-blue-500 dark:text-blue-400" aria-hidden="true" />
+                        <span className="text-gray-600 dark:text-gray-300">
+                          <span className="font-medium">{step.tool?.split('.').pop()}</span>
+                          {step.reason && <span className="ml-1 text-gray-400 dark:text-gray-500">— {step.reason}</span>}
+                        </span>
+                        {!message.agentSteps.find(s => s.type === 'tool_result' && s.step === step.step) && (
+                          <Loader className="w-3 h-3 mt-0.5 animate-spin text-blue-400" aria-hidden="true" />
+                        )}
+                      </>
+                    )}
+                    {step.type === 'tool_result' && (
+                      <>
+                        {step.success
+                          ? <CheckCircle2 className="w-3.5 h-3.5 mt-0.5 flex-shrink-0 text-green-500 dark:text-green-400" aria-hidden="true" />
+                          : <XCircle className="w-3.5 h-3.5 mt-0.5 flex-shrink-0 text-red-500 dark:text-red-400" aria-hidden="true" />
+                        }
+                        <span className={`${step.success ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+                          {step.tool?.split('.').pop()}{step.success ? '' : ` — ${step.message || 'failed'}`}
+                        </span>
+                      </>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+
             <p className="whitespace-pre-wrap">{message.content}</p>
 
             {/* Attachment chips */}

--- a/src/frontend/src/pages/ChatPage/hooks/useChatWebSocket.js
+++ b/src/frontend/src/pages/ChatPage/hooks/useChatWebSocket.js
@@ -22,6 +22,9 @@ export function useChatWebSocket({
   onDocumentProcessing,
   onDocumentReady,
   onDocumentError,
+  onAgentThinking,
+  onAgentToolCall,
+  onAgentToolResult,
 } = {}) {
   const [wsConnected, setWsConnected] = useState(false);
   const wsRef = useRef(null);
@@ -72,6 +75,15 @@ export function useChatWebSocket({
       } else if (data.type === 'document_error') {
         debug.log('Document error:', data.filename, data.error);
         onDocumentError?.(data);
+      } else if (data.type === 'agent_thinking') {
+        debug.log('Agent thinking:', data.content?.substring(0, 80));
+        onAgentThinking?.(data);
+      } else if (data.type === 'agent_tool_call') {
+        debug.log('Agent tool call:', data.tool, data.reason);
+        onAgentToolCall?.(data);
+      } else if (data.type === 'agent_tool_result') {
+        debug.log('Agent tool result:', data.tool, data.success ? 'success' : 'failed');
+        onAgentToolResult?.(data);
       }
     };
 
@@ -87,7 +99,7 @@ export function useChatWebSocket({
     };
 
     wsRef.current = ws;
-  }, [onStreamChunk, onStreamDone, onAction, onRagContext, onIntentFeedbackRequest, onDocumentProcessing, onDocumentReady, onDocumentError]);
+  }, [onStreamChunk, onStreamDone, onAction, onRagContext, onIntentFeedbackRequest, onDocumentProcessing, onDocumentReady, onDocumentError, onAgentThinking, onAgentToolCall, onAgentToolResult]);
 
   // Connect on mount, cleanup on unmount
   useEffect(() => {


### PR DESCRIPTION
## Summary
- **Credential sanitization:** API keys, tokens, passwords in MCP tool responses are redacted (`***REDACTED***`) before reaching the frontend or LLM. Regex-based, applied centrally in `MCPManager.execute_tool()`.
- **Agent step display:** Frontend now renders `agent_tool_call` and `agent_tool_result` WebSocket messages inline in the chat bubble — tool name, reason, success/failure status with icons.

Fixes #197

## Test plan
- [x] 7 new unit tests for `_sanitize_credentials()` (api_key, token, access_token, password, JSON-embedded URLs, case-insensitive, no false positives)
- [x] 94 existing MCP client tests still passing
- [ ] Manual: Send a Jellyfin playback query via chat → verify no API key visible in response
- [ ] Manual: Send a complex query triggering agent loop → verify tool call steps appear in chat UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)