### PR TITLE
fix(agent): Move credential sanitization to output layer (#197)

### DIFF
--- a/src/backend/services/internal_tools.py
+++ b/src/backend/services/internal_tools.py
@@ -268,7 +268,7 @@ class InternalToolService:
             state = await ha_client.get_state(entity_id)
             player_state = (state or {}).get("state", "unknown")
 
-            if player_state in ("playing", "buffering", "paused", "idle"):
+            if player_state in ("playing", "buffering", "paused"):
                 return {
                     "success": True,
                     "message": f"Playing on {device_name} in {resolved_room_name}",

--- a/src/backend/services/mcp_client.py
+++ b/src/backend/services/mcp_client.py
@@ -1151,8 +1151,10 @@ class MCPManager:
             # Truncate final message if still too large
             message = _truncate_response(message)
 
-            # Redact credentials (API keys, tokens) from response text
-            message = _sanitize_credentials(message)
+            # NOTE: Credential sanitization is NOT done here — the agent loop
+            # needs real API keys in tool results (e.g. Jellyfin stream URLs
+            # passed to play_in_room). Sanitization happens in
+            # step_to_ws_message() before sending to the frontend.
 
             # Some MCP servers (e.g. n8n-mcp) wrap responses in their own
             # JSON envelope: {"success": false, "error": "..."}. The MCP-level


### PR DESCRIPTION
## Summary
- **Credential redaction moved** from `execute_tool()` to `step_to_ws_message()` and `chat_handler.py` — agent loop keeps real API keys for inter-tool chaining (e.g. Jellyfin stream URL → play_in_room), frontend only sees redacted values
- **`idle` removed from success states** in `play_in_room` — agent now correctly detects when a media player didn't start playback

## Context
PR #205 introduced credential sanitization in `execute_tool()`, which broke Jellyfin playback: the agent received `api_key=***REDACTED***` in tool results and passed that broken URL to the HomePod.

## Test plan
- [x] 7 credential sanitization unit tests pass
- [x] Deployed and verified on production — agent loop works, frontend shows redacted keys
- [ ] Verify play_in_room reports failure when HomePod stays idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)