### PR TITLE
fix(media): Add media_control to agent prompts and role config

### DIFF
--- a/src/backend/config/agent_roles.yaml
+++ b/src/backend/config/agent_roles.yaml
@@ -1,0 +1,89 @@
+# Agent Role Definitions
+# ======================
+# Each role defines a specialized agent with filtered tools and step limits.
+# The AgentRouter classifies user messages into exactly one role.
+#
+# Fields:
+#   description:     Bilingual description (de/en) shown to the router LLM
+#   mcp_servers:     List of MCP server names to include (null = all servers)
+#   internal_tools:  List of internal tool names to include (null = all)
+#   max_steps:       Maximum agent loop steps for this role
+#   prompt_key:      Key in agent.yaml for the role-specific prompt
+#   model:           Optional per-role model override (default: AGENT_MODEL or OLLAMA_MODEL)
+#   ollama_url:      Optional per-role Ollama URL override (default: AGENT_OLLAMA_URL or OLLAMA_URL)
+
+roles:
+  smart_home:
+    description:
+      de: "Smart Home: Licht, Schalter, Sensoren, Heizung, Szenen steuern, Temperatur/Luftfeuchte in Raeumen abfragen (NICHT Musik/Medien, NICHT Aussenwetter)"
+      en: "Smart home: control lights, switches, sensors, heating, scenes, query temperature/humidity in rooms (NOT music/media, NOT outdoor weather)"
+    mcp_servers: [homeassistant]
+    internal_tools: [internal.resolve_room_player, internal.play_in_room, internal.media_control]
+    max_steps: 4
+    prompt_key: agent_prompt_smart_home
+    model: "qwen3:8b"
+
+  research:
+    description:
+      de: "Recherche: Websuche, Nachrichten, Aussenwetter/Wettervorhersage (NICHT Raumtemperatur)"
+      en: "Research: web search, news, outdoor weather/forecast (NOT room temperature)"
+    mcp_servers: [search, news, weather]
+    max_steps: 6
+    prompt_key: agent_prompt_research
+
+  documents:
+    description:
+      de: "Dokumente und E-Mail: Suche in Wissensdatenbank und Paperless, Download, Versand"
+      en: "Documents and email: search knowledge base and Paperless, download, send"
+    mcp_servers: [paperless, email]
+    internal_tools: [internal.knowledge_search]
+    max_steps: 8
+    prompt_key: agent_prompt_documents
+
+  media:
+    description:
+      de: "Medien: Musik, Filme, Serien suchen und abspielen (auch in bestimmten Raeumen)"
+      en: "Media: search and play music, movies, series (also in specific rooms)"
+    mcp_servers: [jellyfin]
+    internal_tools: [internal.resolve_room_player, internal.play_in_room, internal.media_control]
+    max_steps: 6
+    prompt_key: agent_prompt_media
+    model: "qwen3:14b"
+
+  workflow:
+    description:
+      de: "Automatisierungen: n8n Workflows erstellen, bearbeiten, verwalten, ausfuehren"
+      en: "Automations: create, edit, manage, execute n8n workflows"
+    mcp_servers: [n8n]
+    max_steps: 10
+    prompt_key: agent_prompt_workflow
+
+  presence:
+    description:
+      de: "Anwesenheit: Wo ist eine Person, wer ist zuhause, in welchem Raum ist jemand"
+      en: "Presence: where is a person, who is home, which room is someone in"
+    mcp_servers: []
+    internal_tools: [internal.get_user_location, internal.get_all_presence]
+    max_steps: 2
+    prompt_key: agent_prompt
+
+  knowledge:
+    description:
+      de: "Wissensdatenbank: Suche in eigenen hochgeladenen Dokumenten"
+      en: "Knowledge base: search in own uploaded documents"
+    # No agent loop - uses RAG path directly
+
+  general:
+    description:
+      de: "Allgemein: Komplexe oder domainuebergreifende Anfragen"
+      en: "General: complex or cross-domain queries"
+    mcp_servers: null
+    internal_tools: null
+    max_steps: 12
+    prompt_key: agent_prompt
+
+  conversation:
+    description:
+      de: "Konversation: Smalltalk, Allgemeinwissen, Meinungen, keine Aktion noetig"
+      en: "Conversation: smalltalk, general knowledge, opinions, no action needed"
+    # No agent loop - direct LLM response

--- a/src/backend/prompts/agent.yaml
+++ b/src/backend/prompts/agent.yaml
@@ -40,6 +40,7 @@ de:
     - Um Dokumente per E-Mail zu versenden, MUSST du sie ZUERST mit download_document herunterladen. Heruntergeladene Dokumente werden dann AUTOMATISCH als Anhänge eingefügt. Übergib bei send_email KEINE attachments.
     - Wenn der Nutzer ein Dokument versenden will ("schick mir", "sende mir", "per mail"), nutze ZUERST die Paperless-Suchergebnisse aus dem KONVERSATIONS-KONTEXT (IDs, Titel), dann download_document, dann send_email an die vom Nutzer genannte Adresse. Starte KEINE neue Suche, wenn passende Ergebnisse bereits im Kontext vorliegen.
     - Um Medien in einem Raum abzuspielen: Nutze zuerst das Such-Tool des Providers (z.B. mcp.jellyfin.search_media), dann mcp.jellyfin.get_stream_url für die URL, dann internal.play_in_room mit der URL und dem Raumnamen.
+    - Um die Wiedergabe zu stoppen, pausieren, fortzusetzen oder Tracks zu wechseln: Nutze internal.media_control mit action (stop/pause/resume/next/previous) und room_name.
     - Beende NICHT mit final_answer, wenn noch offene Schritte aus der AUFGABE übrig sind. "Schick mir X zu Y" erfordert ALLE Schritte: (1) ggf. search, (2) download_document, (3) send_email. Erst NACH dem letzten Schritt darfst du final_answer geben.
     - Gib final_answer wenn alle Informationen gesammelt sind und ALLE geforderten Aktionen abgeschlossen wurden
     - Die finale Antwort muss natürlich und auf Deutsch sein
@@ -211,6 +212,7 @@ de:
     - NIEMALS get_album_tracks mit einer Artist-ID aufrufen — nutze get_artist_albums fuer Kuenstler
     - Bei mehreren Treffern: waehle den besten Match nach Titel und Kuenstler
     - Wenn Informationen fehlen, frage den Benutzer
+    - Um die Wiedergabe zu stoppen, pausieren, fortzusetzen oder Tracks zu wechseln: Nutze internal.media_control mit action (stop/pause/resume/next/previous) und room_name. Nutze NICHT play_in_room oder resolve_room_player dafuer.
     - Wenn play_in_room meldet, dass das Geraet "busy" ist, informiere den Benutzer und frage ob die aktuelle Wiedergabe unterbrochen werden soll. Wenn ja, rufe play_in_room erneut mit force=true auf.
     - Beschreibe NIEMALS API-Aufrufe gegenueber dem Benutzer
     - Die finale Antwort muss kurz, natuerlich und auf Deutsch sein
@@ -391,6 +393,7 @@ en:
     - To send documents by email, you MUST first download them with download_document. Downloaded documents are then AUTOMATICALLY attached. Do NOT pass attachments to send_email.
     - When the user wants to send a document ("send me", "email me"), FIRST use the Paperless search results from the CONVERSATION CONTEXT (IDs, titles), then download_document, then send_email to the address the user specified. Do NOT start a new search if matching results already exist in the context.
     - To play media in a room: First use the provider's search tool (e.g. mcp.jellyfin.search_media), then mcp.jellyfin.get_stream_url for the URL, then internal.play_in_room with the URL and room name.
+    - To stop, pause, resume playback or skip tracks: Use internal.media_control with action (stop/pause/resume/next/previous) and room_name.
     - Do NOT give final_answer if there are still open steps from the TASK. "Send me X to Y" requires ALL steps: (1) optionally search, (2) download_document, (3) send_email. Only give final_answer AFTER the last step is completed.
     - Give final_answer when all information is gathered and ALL required actions have been completed
     - The final answer must be natural and in English
@@ -562,6 +565,7 @@ en:
     - NEVER call get_album_tracks with an artist ID — use get_artist_albums for artists
     - When multiple results exist, choose the best match by title and artist
     - If information is missing, ask the user
+    - To stop, pause, resume playback or skip tracks: Use internal.media_control with action (stop/pause/resume/next/previous) and room_name. Do NOT use play_in_room or resolve_room_player for this.
     - If play_in_room reports the device is "busy", inform the user and ask if current playback should be interrupted. If yes, call play_in_room again with force=true.
     - Never describe API calls to the user
     - The final answer must be concise, natural, and in English


### PR DESCRIPTION
## Summary
- Add `internal.media_control` to `internal_tools` filter in media and smart_home roles in `agent_roles.yaml` — without this, the tool was registered but filtered out by the role config
- Add explicit instructions for stop/pause/resume/skip to media and general agent prompts (DE+EN) so the LLM knows to use `media_control` instead of `play_in_room`

## Context
Follow-up to #208 — the tool code was deployed but the agent couldn't use it because:
1. The media role's `internal_tools: [internal.resolve_room_player, internal.play_in_room]` excluded `media_control`
2. The agent prompt only described `play_in_room` workflows, not `media_control`

## Test plan
- [x] Browser test: "Stoppe die Musik im Arbeitszimmer" → agent uses `media_control` with action=stop (green checkmark)
- [x] Browser test: "Nächster Titel im Arbeitszimmer" → agent uses `media_control` with action=next
- [x] Deployed and verified on production

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)