### PR TITLE
feat(chat): Make agent steps collapsible in chat UI (#197)

### DIFF
--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -148,7 +148,10 @@
     "emailSuccess": "Per E-Mail gesendet",
     "emailFailed": "E-Mail-Versand fehlgeschlagen",
     "documentIndexing": "Wird indexiert...",
-    "documentIndexed": "In Wissensdatenbank indexiert"
+    "documentIndexed": "In Wissensdatenbank indexiert",
+    "agentThinking": "Denkt nach...",
+    "agentStepsCount": "{{count}} Schritt ausgeführt",
+    "agentStepsCount_other": "{{count}} Schritte ausgeführt"
   },
   "voice": {
     "startRecording": "Sprachaufnahme starten",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -148,7 +148,10 @@
     "emailSuccess": "Sent via Email",
     "emailFailed": "Failed to send email",
     "documentIndexing": "Indexing to KB...",
-    "documentIndexed": "Indexed to KB"
+    "documentIndexed": "Indexed to KB",
+    "agentThinking": "Thinking...",
+    "agentStepsCount": "{{count}} step completed",
+    "agentStepsCount_other": "{{count}} steps completed"
   },
   "voice": {
     "startRecording": "Start voice recording",


### PR DESCRIPTION
## Summary
- Wrap agent tool call/result steps in a collapsible `<details>`/`<summary>` element
- Collapsed: shows chevron + step count with success/error icon (e.g. "2 steps completed")
- While streaming: auto-opens with spinner + "Thinking..." label so users see live progress
- Added i18n keys `agentThinking`, `agentStepsCount` to DE and EN locales

## Test plan
- [x] Frontend builds without errors
- [x] Browser test: agent steps collapse after completion, show correct count
- [x] Browser test: clicking chevron expands to show full step details
- [x] Deployed and verified on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)