### PR TITLE
fix(media): Allow context reuse for referential playback requests

### DIFF
--- a/src/backend/prompts/agent.yaml
+++ b/src/backend/prompts/agent.yaml
@@ -204,7 +204,7 @@ de:
     - Du MUSST MCP-Tools fuer jede Jellyfin-Aktion verwenden
     - Erfinde NIEMALS Medien, IDs oder Wiedergabe-Status
     - Rufe pro Antwort GENAU EIN Tool auf
-    - IMMER zuerst suchen, dann abspielen. Fuehre fuer JEDE neue Wiedergabe-Anfrage eine NEUE Suche durch — nutze NIEMALS IDs oder URLs aus vorherigen Anfragen im Konversations-Kontext.
+    - IMMER zuerst suchen, dann abspielen. Wenn die Anfrage einen konkreten Titel, Kuenstler oder Album NENNT, fuehre IMMER eine neue Suche durch. Wenn der Nutzer sich auf vorherige Suchergebnisse bezieht ("spiel den ab", "den ersten Track", "davon das dritte"), nutze die IDs aus dem Konversations-Kontext.
     - Kuenstler abspielen: (1) search_media(type="MusicArtist"), (2) get_artist_albums(artist_id), (3) get_album_tracks(album_id), (4) internal.play_in_room mit api_stream URL. Uebergib title (Trackname) und thumb (image_url) aus den Suchergebnissen.
     - Song abspielen: (1) search_media(type="Audio"), (2) internal.play_in_room mit api_stream URL aus Schritt 1. Uebergib title (name) und thumb (image_url) aus den Suchergebnissen.
     - Album abspielen: (1) search_media(type="MusicAlbum"), (2) get_album_tracks(album_id), (3) internal.play_in_room mit api_stream URL. Uebergib title (Trackname) und thumb (image_url) aus den Suchergebnissen.
@@ -557,7 +557,7 @@ en:
     - You MUST use MCP tools for any action involving Jellyfin
     - Do NOT invent media, IDs, or playback states
     - Call EXACTLY ONE tool per response
-    - ALWAYS search before play. Perform a NEW search for EVERY new playback request — NEVER reuse IDs or URLs from previous requests in the conversation context.
+    - ALWAYS search before play. When the request names a specific title, artist, or album, ALWAYS perform a new search. When the user refers to previous search results ("play that", "the first track", "the third one"), use the IDs from the conversation context.
     - Play an artist: (1) search_media(type="MusicArtist"), (2) get_artist_albums(artist_id), (3) get_album_tracks(album_id), (4) internal.play_in_room with api_stream URL. Pass title (track name) and thumb (image_url) from the search results.
     - Play a song: (1) search_media(type="Audio"), (2) internal.play_in_room with api_stream URL from step 1. Pass title (name) and thumb (image_url) from the search results.
     - Play an album: (1) search_media(type="MusicAlbum"), (2) get_album_tracks(album_id), (3) internal.play_in_room with api_stream URL. Pass title (track name) and thumb (image_url) from the search results.


### PR DESCRIPTION
## Summary
- Previous rule (#213) was too strict — blocked two-step flows like "Suche Foreigner" → "Spiel den ersten Track"
- New logic: request names a specific title/artist/album → always fresh search; referential requests ("spiel den ab", "den dritten") → reuse conversation context IDs

## Test plan
- [ ] "Spiele Album 4" then "Spiele Cold as Ice" → should search for Cold as Ice (not replay Album 4)
- [ ] "Suche Foreigner" then "Spiel den ersten Track" → should use search results from context

🤖 Generated with [Claude Code](https://claude.com/claude-code)