### PR TITLE
fix(media): Add DLNA MCP transitive deps to requirements.txt (#198)

### DIFF
--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -80,6 +80,8 @@ aiosmtplib>=3.0                  # Required by renfield-mcp-mail (not auto-resol
 renfield-mcp-jellyfin @ https://github.com/ebongard/renfield-mcp-jellyfin/archive/refs/heads/main.tar.gz
 renfield-mcp-calendar @ https://github.com/ebongard/renfield-mcp-calendar/archive/refs/heads/main.tar.gz
 renfield-mcp-dlna @ https://github.com/ebongard/renfield-mcp-dlna/archive/refs/heads/main.tar.gz
+async-upnp-client>=0.40.0               # Required by renfield-mcp-dlna (UPnP device control)
+python-didl-lite>=1.4.0                  # Required by renfield-mcp-dlna (DIDL-Lite metadata)
 exchangelib>=5.4                     # Required by renfield-mcp-calendar (EWS backend)
 caldav>=1.4                          # Required by renfield-mcp-calendar (CalDAV backend)
 


### PR DESCRIPTION
## Summary
- Add `async-upnp-client` and `python-didl-lite` to requirements.txt as explicit dependencies
- GitHub archive packages are installed with `--no-deps`, so transitive dependencies must be listed

## Test plan
- [x] Verified on production — DLNA MCP server connects successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)