### PR TITLE
feat(media): Add internal.play_album_on_dlna for server-side DLNA playback

### DIFF
--- a/config/agent_roles.yaml
+++ b/config/agent_roles.yaml
@@ -44,8 +44,8 @@ roles:
     description:
       de: "Medien: Musik, Filme, Serien suchen und abspielen (auch in bestimmten Raeumen)"
       en: "Media: search and play music, movies, series (also in specific rooms)"
-    mcp_servers: [jellyfin]
-    internal_tools: [internal.resolve_room_player, internal.play_in_room]
+    mcp_servers: [jellyfin, dlna]
+    internal_tools: [internal.resolve_room_player, internal.play_in_room, internal.play_album_on_dlna, internal.media_control]
     max_steps: 6
     prompt_key: agent_prompt_media
     model: "qwen3:14b"

--- a/src/backend/prompts/agent.yaml
+++ b/src/backend/prompts/agent.yaml
@@ -39,8 +39,9 @@ de:
     - Wenn im KONVERSATIONS-KONTEXT bereits Suchergebnisse vorliegen, die zur aktuellen AUFGABE passen, nutze diese Ergebnisse (IDs, Titel) direkt weiter, anstatt eine neue Suche zu starten.
     - Um Dokumente per E-Mail zu versenden, MUSST du sie ZUERST mit download_document herunterladen. Heruntergeladene Dokumente werden dann AUTOMATISCH als Anhänge eingefügt. Übergib bei send_email KEINE attachments.
     - Wenn der Nutzer ein Dokument versenden will ("schick mir", "sende mir", "per mail"), nutze ZUERST die Paperless-Suchergebnisse aus dem KONVERSATIONS-KONTEXT (IDs, Titel), dann download_document, dann send_email an die vom Nutzer genannte Adresse. Starte KEINE neue Suche, wenn passende Ergebnisse bereits im Kontext vorliegen.
-    - Um Medien in einem Raum abzuspielen: Nutze zuerst das Such-Tool des Providers (z.B. mcp.jellyfin.search_media), dann mcp.jellyfin.get_stream_url für die URL, dann internal.play_in_room mit der URL und dem Raumnamen. Uebergib dabei title (Trackname) und thumb (image_url) an play_in_room, damit der Media Player Titel und Cover anzeigt. Fuer Alben/Kuenstler: Wenn mcp.dlna Tools verfuegbar sind, nutze mcp.dlna.list_renderers() und mcp.dlna.play_tracks() fuer gapless Queue-Wiedergabe. Sonst: Uebergib die restlichen Tracks als queue Parameter (JSON-Array mit url, title, thumb pro Track).
-    - Um die Wiedergabe zu stoppen, pausieren, fortzusetzen oder Tracks zu wechseln: Nutze internal.media_control mit action (stop/pause/resume/next/previous) und room_name.
+    - WICHTIG — Album/Kuenstler abspielen: (1) search_media, (2) internal.play_album_on_dlna(album_id="<id>", renderer_name="<Raum>"). Das Tool holt automatisch alle Tracks und spielt sie auf dem DLNA-Renderer ab. NIEMALS mcp.dlna.play_tracks direkt aufrufen!
+    - Einzelnen Song abspielen: (1) search_media(type="Audio"), (2) internal.play_in_room mit api_stream URL.
+    - Um die Wiedergabe zu stoppen oder Tracks zu wechseln: Nutze mcp.dlna.stop/mcp.dlna.next_track/mcp.dlna.previous_track wenn eine DLNA-Session aktiv ist. Alternativ: internal.media_control mit action (stop/pause/resume/next/previous) und room_name.
     - Beende NICHT mit final_answer, wenn noch offene Schritte aus der AUFGABE übrig sind. "Schick mir X zu Y" erfordert ALLE Schritte: (1) ggf. search, (2) download_document, (3) send_email. Erst NACH dem letzten Schritt darfst du final_answer geben.
     - Gib final_answer wenn alle Informationen gesammelt sind und ALLE geforderten Aktionen abgeschlossen wurden
     - Die finale Antwort muss natürlich und auf Deutsch sein
@@ -205,15 +206,15 @@ de:
     - Erfinde NIEMALS Medien, IDs oder Wiedergabe-Status
     - Rufe pro Antwort GENAU EIN Tool auf
     - IMMER zuerst suchen, dann abspielen. Wenn die Anfrage einen konkreten Titel, Kuenstler oder Album NENNT, fuehre IMMER eine neue Suche durch. Wenn der Nutzer sich auf vorherige Suchergebnisse bezieht ("spiel den ab", "den ersten Track", "davon das dritte"), nutze die IDs aus dem Konversations-Kontext.
-    - Kuenstler abspielen: (1) search_media(type="MusicArtist"), (2) get_artist_albums(artist_id), (3) get_album_tracks(album_id), (4) Wenn mcp.dlna Tools verfuegbar: mcp.dlna.list_renderers() um DLNA-Renderer zu finden, dann mcp.dlna.play_tracks(renderer_name, tracks=[{{url, title, artist, album}}, ...]). Sonst: internal.play_in_room mit api_stream des ersten Tracks als media_url, restliche Tracks als queue.
-    - Song abspielen: (1) search_media(type="Audio"), (2) internal.play_in_room mit api_stream URL aus Schritt 1. Uebergib title (name) und thumb (image_url) aus den Suchergebnissen.
-    - Album abspielen: (1) search_media(type="MusicAlbum"), (2) get_album_tracks(album_id), (3) Wenn mcp.dlna Tools verfuegbar: mcp.dlna.list_renderers() um den passenden DLNA-Renderer fuer den Raum zu finden, dann mcp.dlna.play_tracks(renderer_name, tracks=[{{url, title, artist, album}}, ...]) mit ALLEN Tracks. Sonst: internal.play_in_room mit api_stream des ersten Tracks als media_url, restliche als queue.
-    - search_media und get_album_tracks liefern api_stream URLs direkt mit — kein extra get_stream_url noetig
+    - WICHTIG — Album abspielen: (1) search_media(type="MusicAlbum"), (2) internal.play_album_on_dlna(album_id="<id>", renderer_name="<Raum>"). Nur 2 Schritte! Das Tool holt automatisch alle Tracks und spielt sie auf dem DLNA-Renderer ab.
+    - Kuenstler abspielen: (1) search_media(type="MusicArtist"), (2) get_artist_albums(artist_id), (3) internal.play_album_on_dlna(album_id="<album_id>", renderer_name="<Raum>") fuer jedes Album.
+    - Song abspielen (einzelner Track): (1) search_media(type="Audio"), (2) internal.play_in_room mit api_stream URL.
+    - Der renderer_name ist der Raumname (z.B. "Arbeitszimmer", "Garten"). Das Tool findet den passenden DLNA-Renderer per Namens-Suche.
+    - NIEMALS mcp.dlna.play_tracks direkt aufrufen — immer internal.play_album_on_dlna verwenden!
     - NIEMALS get_album_tracks mit einer Artist-ID aufrufen — nutze get_artist_albums fuer Kuenstler
     - Bei mehreren Treffern: waehle den besten Match nach Titel und Kuenstler
     - Wenn Informationen fehlen, frage den Benutzer
-    - Um die Wiedergabe zu stoppen, pausieren, fortzusetzen oder Tracks zu wechseln: Nutze internal.media_control mit action (stop/pause/resume/next/previous) und room_name. Nutze NICHT play_in_room oder resolve_room_player dafuer.
-    - Wenn play_in_room meldet, dass das Geraet "busy" ist, informiere den Benutzer und frage ob die aktuelle Wiedergabe unterbrochen werden soll. Wenn ja, rufe play_in_room erneut mit force=true auf.
+    - Um die Wiedergabe zu stoppen oder Tracks zu wechseln: Nutze mcp.dlna.stop/mcp.dlna.next_track/mcp.dlna.previous_track wenn eine DLNA-Session aktiv ist. Alternativ: internal.media_control mit action (stop/pause/resume/next/previous) und room_name. Nutze NICHT play_in_room oder resolve_room_player dafuer.
     - Beschreibe NIEMALS API-Aufrufe gegenueber dem Benutzer
     - Die finale Antwort muss kurz, natuerlich und auf Deutsch sein
     - Antworte NUR mit JSON
@@ -392,8 +393,9 @@ en:
     - If the CONVERSATION CONTEXT already contains search results relevant to the current TASK, use those results (IDs, titles) directly instead of running a new search.
     - To send documents by email, you MUST first download them with download_document. Downloaded documents are then AUTOMATICALLY attached. Do NOT pass attachments to send_email.
     - When the user wants to send a document ("send me", "email me"), FIRST use the Paperless search results from the CONVERSATION CONTEXT (IDs, titles), then download_document, then send_email to the address the user specified. Do NOT start a new search if matching results already exist in the context.
-    - To play media in a room: First use the provider's search tool (e.g. mcp.jellyfin.search_media), then mcp.jellyfin.get_stream_url for the URL, then internal.play_in_room with the URL and room name. Pass title (track name) and thumb (image_url) to play_in_room so the media player shows title and cover art. For albums/artists: If mcp.dlna tools are available, use mcp.dlna.list_renderers() and mcp.dlna.play_tracks() for gapless queue playback. Otherwise: Pass remaining tracks as queue parameter (JSON array with url, title, thumb per track).
-    - To stop, pause, resume playback or skip tracks: Use internal.media_control with action (stop/pause/resume/next/previous) and room_name.
+    - IMPORTANT — Playing albums/artists: (1) search_media, (2) internal.play_album_on_dlna(album_id="<id>", renderer_name="<room>"). The tool automatically fetches all tracks and plays them on the DLNA renderer. NEVER call mcp.dlna.play_tracks directly!
+    - Playing a single song: (1) search_media(type="Audio"), (2) internal.play_in_room with the api_stream URL.
+    - To stop playback or skip tracks: Use mcp.dlna.stop/mcp.dlna.next_track/mcp.dlna.previous_track if a DLNA session is active. Alternatively: internal.media_control with action (stop/pause/resume/next/previous) and room_name.
     - Do NOT give final_answer if there are still open steps from the TASK. "Send me X to Y" requires ALL steps: (1) optionally search, (2) download_document, (3) send_email. Only give final_answer AFTER the last step is completed.
     - Give final_answer when all information is gathered and ALL required actions have been completed
     - The final answer must be natural and in English
@@ -558,15 +560,15 @@ en:
     - Do NOT invent media, IDs, or playback states
     - Call EXACTLY ONE tool per response
     - ALWAYS search before play. When the request names a specific title, artist, or album, ALWAYS perform a new search. When the user refers to previous search results ("play that", "the first track", "the third one"), use the IDs from the conversation context.
-    - Play an artist: (1) search_media(type="MusicArtist"), (2) get_artist_albums(artist_id), (3) get_album_tracks(album_id), (4) If mcp.dlna tools available: mcp.dlna.list_renderers() to find DLNA renderers, then mcp.dlna.play_tracks(renderer_name, tracks=[{{url, title, artist, album}}, ...]) with ALL tracks. Otherwise: internal.play_in_room with first track's api_stream as media_url, remaining tracks as queue.
-    - Play a song: (1) search_media(type="Audio"), (2) internal.play_in_room with api_stream URL from step 1. Pass title (name) and thumb (image_url) from the search results.
-    - Play an album: (1) search_media(type="MusicAlbum"), (2) get_album_tracks(album_id), (3) If mcp.dlna tools available: mcp.dlna.list_renderers() to find the matching DLNA renderer for the room, then mcp.dlna.play_tracks(renderer_name, tracks=[{{url, title, artist, album}}, ...]) with ALL tracks. Otherwise: internal.play_in_room with first track's api_stream as media_url, remaining as queue.
-    - search_media and get_album_tracks return api_stream URLs inline — no extra get_stream_url needed
+    - IMPORTANT — Play an album: (1) search_media(type="MusicAlbum"), (2) internal.play_album_on_dlna(album_id="<id>", renderer_name="<room>"). Only 2 steps! The tool automatically fetches all tracks and plays them on the DLNA renderer.
+    - Play an artist: (1) search_media(type="MusicArtist"), (2) get_artist_albums(artist_id), (3) internal.play_album_on_dlna(album_id="<album_id>", renderer_name="<room>") for each album.
+    - Play a song (single track): (1) search_media(type="Audio"), (2) internal.play_in_room with api_stream URL.
+    - The renderer_name is the room name (e.g. "Arbeitszimmer", "Garten"). The tool finds the matching DLNA renderer by name search.
+    - NEVER call mcp.dlna.play_tracks directly — always use internal.play_album_on_dlna!
     - NEVER call get_album_tracks with an artist ID — use get_artist_albums for artists
     - When multiple results exist, choose the best match by title and artist
     - If information is missing, ask the user
-    - To stop, pause, resume playback or skip tracks: Use internal.media_control with action (stop/pause/resume/next/previous) and room_name. Do NOT use play_in_room or resolve_room_player for this.
-    - If play_in_room reports the device is "busy", inform the user and ask if current playback should be interrupted. If yes, call play_in_room again with force=true.
+    - To stop playback or skip tracks: Use mcp.dlna.stop/mcp.dlna.next_track/mcp.dlna.previous_track if a DLNA session is active. Alternatively: internal.media_control with action (stop/pause/resume/next/previous) and room_name. Do NOT use play_in_room or resolve_room_player for this.
     - Never describe API calls to the user
     - The final answer must be concise, natural, and in English
     - Reply ONLY with JSON


### PR DESCRIPTION
## Summary
- Adds `internal.play_album_on_dlna` internal tool that combines Jellyfin `get_album_tracks` + DLNA `play_tracks` server-side, avoiding LLM token truncation when generating 16+ track URLs
- Updates all 4 agent prompts (DE/EN general + media) to use the new 2-step flow: `search_media` → `play_album_on_dlna`
- Adds `dlna` MCP server and the new tool to the media agent role in `agent_roles.yaml`
- 7 unit tests covering success, error cases, and routing

## Context
The LLM's `num_predict: 2048` token limit truncates the JSON when it tries to generate all track URLs for `mcp.dlna.play_tracks` directly. With the new internal tool, the LLM only passes `album_id` + `renderer_name` (2 small params) and the backend handles the rest.

## Test plan
- [x] 7 unit tests pass (`TestPlayAlbumOnDlna`)
- [x] E2E browser test: "Spiel The Very Best of Foreigner im Arbeitszimmer" → agent uses `search_media` then `play_album_on_dlna`, 16 tracks play on HiFiBerry

🤖 Generated with [Claude Code](https://claude.com/claude-code)