### PR TITLE
feat(media): Add DLNA renderer to room management

### DIFF
--- a/src/backend/alembic/versions/a1b2c3d4e5f6_add_dlna_renderer_name.py
+++ b/src/backend/alembic/versions/a1b2c3d4e5f6_add_dlna_renderer_name.py
@@ -1,0 +1,27 @@
+"""Add dlna_renderer_name column to room_output_devices.
+
+Revision ID: a1b2c3d4e5f6
+Revises: q2r3s4t5u6v7
+Create Date: 2026-02-21
+
+Nullable column — no data migration needed.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a1b2c3d4e5f6'
+down_revision: Union[str, None] = 'q2r3s4t5u6v7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('room_output_devices', sa.Column('dlna_renderer_name', sa.String(255), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('room_output_devices', 'dlna_renderer_name')

--- a/src/backend/api/routes/rooms_schemas.py
+++ b/src/backend/api/routes/rooms_schemas.py
@@ -136,6 +136,7 @@ class OutputDeviceCreate(BaseModel):
     output_type: str = "audio"  # "audio" or "visual"
     renfield_device_id: str | None = None
     ha_entity_id: str | None = None
+    dlna_renderer_name: str | None = None
     priority: int = 1
     allow_interruption: bool = False
     tts_volume: float | None = 0.5
@@ -158,6 +159,7 @@ class OutputDeviceResponse(BaseModel):
     output_type: str
     renfield_device_id: str | None
     ha_entity_id: str | None
+    dlna_renderer_name: str | None = None
     priority: int
     allow_interruption: bool
     tts_volume: float | None
@@ -176,6 +178,7 @@ class OutputDeviceReorderRequest(BaseModel):
 
 
 class AvailableOutputResponse(BaseModel):
-    """Response model for available output devices (HA + Renfield)"""
+    """Response model for available output devices (HA + Renfield + DLNA)"""
     renfield_devices: list[dict]
     ha_media_players: list[dict]
+    dlna_renderers: list[dict] = []

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -249,7 +249,9 @@
     "deleteDevice": "Gerät entfernen?",
     "deleteDeviceConfirm": "Möchtest du \"{{name}}\" wirklich entfernen?",
     "removeOutputDevice": "Ausgabegerät entfernen",
-    "removeOutputDeviceConfirm": "Ausgabegerät wirklich entfernen?"
+    "removeOutputDeviceConfirm": "Ausgabegerät wirklich entfernen?",
+    "dlnaRenderer": "DLNA Renderer",
+    "dlnaRendererDesc": "DLNA-Renderer werden per SSDP im Netzwerk erkannt. Die Verfügbarkeit wird erst bei Wiedergabe geprüft."
   },
   "speakers": {
     "title": "Sprechererkennung",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -249,7 +249,9 @@
     "deleteDevice": "Delete device?",
     "deleteDeviceConfirm": "Do you really want to remove \"{{name}}\"?",
     "removeOutputDevice": "Remove output device",
-    "removeOutputDeviceConfirm": "Really remove this output device?"
+    "removeOutputDeviceConfirm": "Really remove this output device?",
+    "dlnaRenderer": "DLNA Renderer",
+    "dlnaRendererDesc": "DLNA renderers are discovered via SSDP on the network. Availability is checked at playback time."
   },
   "speakers": {
     "title": "Speaker Recognition",


### PR DESCRIPTION
## Summary

- DLNA renderers are now a **first-class device type** in room management (alongside Renfield devices and HA media players)
- Admins can discover and assign DLNA renderers to rooms via the UI
- The agent can resolve DLNA renderers by room name (e.g. "Spiel das Album im Garten")
- `internal.play_album_on_dlna` now accepts `room_name` as alternative to `renderer_name`

## Changes

- **DB Migration**: Add `dlna_renderer_name` column to `room_output_devices`
- **Model**: `RoomOutputDevice` gains `is_dlna_device` property and `target_type` property
- **Schemas**: DLNA fields in create/response schemas, `dlna_renderers` in available outputs
- **API Routes**: Three-way validation (exactly one identifier), available outputs includes DLNA
- **OutputRoutingService**: DLNA always-available check, `get_available_dlna_renderers()` via MCP
- **Internal Tools**: `_resolve_room_player` returns DLNA target type, `_play_album_on_dlna` accepts `room_name`
- **Frontend**: Third device type tab (DLNA Renderer, purple Wifi icon) in RoomOutputSettings
- **i18n**: German + English translation keys
- **Tests**: 10 new tests across `test_internal_tools.py` and `test_output_routing_service.py`

## Test plan

- [ ] `python3 -m pytest tests/backend/test_internal_tools.py tests/backend/test_output_routing_service.py -v`
- [ ] Run migration: `docker exec -it renfield-backend alembic upgrade head`
- [ ] API: `curl http://localhost:8000/api/rooms/{id}/available-outputs` → includes `dlna_renderers`
- [ ] UI: Open `/rooms`, expand audio output, see DLNA tab, add a renderer
- [ ] E2E: "Spiel das Album im Garten" → resolves room → DLNA renderer → plays

🤖 Generated with [Claude Code](https://claude.com/claude-code)