### PR TITLE
fix(migration): Unique revision ID for DLNA migration

### DIFF
--- a/src/backend/alembic/versions/1a054148bfb1_add_dlna_renderer_name.py
+++ b/src/backend/alembic/versions/1a054148bfb1_add_dlna_renderer_name.py
@@ -1,6 +1,6 @@
 """Add dlna_renderer_name column to room_output_devices.
 
-Revision ID: a1b2c3d4e5f6
+Revision ID: 1a054148bfb1
 Revises: q2r3s4t5u6v7
 Create Date: 2026-02-21
 
@@ -13,7 +13,7 @@ from alembic import op
 
 
 # revision identifiers, used by Alembic.
-revision: str = 'a1b2c3d4e5f6'
+revision: str = '1a054148bfb1'
 down_revision: Union[str, None] = 'q2r3s4t5u6v7'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None


### PR DESCRIPTION
## Summary

- Rename DLNA migration from `a1b2c3d4e5f6` to `1a054148bfb1` — the old ID was already used by `add_room_output_devices`
- Fixes alembic "multiple heads" error on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)