### PR TITLE
fix(dlna): Add transport control tools to prompt_tools (#198)

### DIFF
--- a/config/mcp_servers.yaml
+++ b/config/mcp_servers.yaml
@@ -142,6 +142,12 @@ servers:
     prompt_tools:
       - list_renderers
       - play_tracks
+      - stop
+      - pause
+      - resume
+      - next_track
+      - previous_track
+      - set_volume
     examples:
       de:
         - "Spiel das Album im Arbeitszimmer"


### PR DESCRIPTION
## Summary
- DLNA transport controls (stop, pause, resume, next_track, previous_track, set_volume) were missing from `prompt_tools` in `mcp_servers.yaml`
- `execute_tool()` only searches the filtered `_tool_index`, so these tools were not found at runtime — causing `next` and `pause` commands to fail silently

## Test plan
- [x] Verified via E2E Playwright test: play → next → pause → resume → stop all succeed on DLNA renderer
- [x] MCP status API confirms 9/9 DLNA tools registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)