### PR TITLE
fix(llm): Add list() and generate() to _FallbackLLMClient

### DIFF
--- a/src/backend/utils/llm_client.py
+++ b/src/backend/utils/llm_client.py
@@ -148,6 +148,12 @@ class _FallbackLLMClient:
     async def embeddings(self, *args: Any, **kwargs: Any) -> Any:  # noqa: D102
         return await self._call("embeddings", *args, **kwargs)
 
+    async def list(self, *args: Any, **kwargs: Any) -> Any:  # noqa: D102
+        return await self._call("list", *args, **kwargs)
+
+    async def generate(self, *args: Any, **kwargs: Any) -> Any:  # noqa: D102
+        return await self._call("generate", *args, **kwargs)
+
 
 def _make_client_with_fallback(primary_url: str) -> LLMClient:
     """Return a client for *primary_url*, wrapped with fallback if configured."""


### PR DESCRIPTION
## Summary
- `_FallbackLLMClient` only proxied `chat()` and `embeddings()`, but `ensure_model_loaded()` calls `client.list()` which crashed with `AttributeError` when `OLLAMA_FALLBACK_URL` was configured
- Added `list()` and `generate()` with the same transparent primary→fallback retry behavior

## Context
Discovered while configuring dual-GPU setup:
- **RTX 5070 Ti** (cuda.local) → Chat/RAG/Intent via `OLLAMA_URL`
- **RTX 5060 Ti** (renfield.local) → Agent via `AGENT_OLLAMA_URL`
- `OLLAMA_FALLBACK_URL` enables resilience if primary GPU host goes offline

## Test plan
- [x] Backend starts successfully with `OLLAMA_FALLBACK_URL` configured
- [x] `ensure_model_loaded()` works with fallback client
- [x] Full E2E test suite passes (40/40 on first run with fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)