### PR TITLE
feat(llm): Migrate all LLM roles to Qwen3 family (#225)

### DIFF
--- a/docs/LLM_MODEL_GUIDE.md
+++ b/docs/LLM_MODEL_GUIDE.md
@@ -9,29 +9,31 @@ Keine Cloud-LLMs — alles laeuft lokal auf eigener Hardware.
 
 ## Inhaltsverzeichnis
 
-1. [Aktueller Stand](#aktueller-stand)
+1. [Aktueller Stand (Produktion)](#aktueller-stand-produktion)
 2. [Alle LLM-Funktionen im Detail](#alle-llm-funktionen-im-detail)
 3. [Embedding-Modell](#8-embeddings)
 4. [Hardware-Architektur: Dual-Ollama](#hardware-architektur-dual-ollama)
-5. [Empfohlene Konfiguration](#empfohlene-konfiguration)
+5. [Konfiguration](#konfiguration)
 6. [Qualitaetsvergleich](#qualitaetsvergleich-qwen314b-vs-30b-a3b)
 7. [Migrations-Reihenfolge](#migrations-reihenfolge)
 8. [VRAM-Referenz](#vram-referenz)
 
 ---
 
-## Aktueller Stand
+## Aktueller Stand (Produktion)
 
-| Setting | Aktuell | Genutzt von |
-|---------|---------|-------------|
-| `ollama_chat_model` | `llama3.2:3b` | Chat, Fallback |
-| `ollama_rag_model` | `llama3.2:latest` | RAG-Antworten |
-| `ollama_intent_model` | `llama3.2:3b` | Intent-Erkennung |
-| `ollama_embed_model` | `nomic-embed-text` | Alle Embeddings (5 Services) |
-| `agent_model` | `None` (Fallback auf chat_model) | Agent Loop, Router |
-| `proactive_enrichment_model` | `None` (Fallback auf chat_model) | Notification-Enrichment |
+| Setting | Aktuell | GPU | Genutzt von |
+|---------|---------|-----|-------------|
+| `ollama_chat_model` | `qwen3:14b` | RTX 5070 Ti (cuda.local) | Chat, Fallback |
+| `ollama_rag_model` | `qwen3:14b` | RTX 5070 Ti (cuda.local) | RAG-Antworten |
+| `ollama_intent_model` | `qwen3:8b` | RTX 5070 Ti (cuda.local) | Intent-Erkennung |
+| `ollama_embed_model` | `qwen3-embedding:4b` | RTX 5070 Ti (cuda.local) | Alle Embeddings (5 Services, 2560 dim) |
+| `agent_model` | `qwen3:14b` | RTX 5060 Ti (renfield.local) | Agent Loop, Router |
+| `proactive_enrichment_model` | `None` (Fallback auf chat_model) | — | Notification-Enrichment |
 
-**Empfohlen:** Qwen3-Familie (siehe Abschnitte unten). Code-Defaults sind noch `llama3.2` fuer Kompatibilitaet mit kleiner Hardware.
+**Qwen3-Familie** — Vollstaendig migriert (Februar 2026). Alle Rollen nutzen Qwen3-Modelle mit `think=False` fuer schnelle, deterministische Antworten. Exzellentes Deutsch, zuverlaessiges JSON, starkes Tool-Calling.
+
+**Vorher:** `gpt-oss:latest` (OpenAI GPT-4o-mini als lokales MoE-Modell, 20B Parameter). Code-Defaults sind noch `llama3.2` fuer Kompatibilitaet mit kleiner Hardware.
 
 ---
 
@@ -48,13 +50,7 @@ Keine Cloud-LLMs — alles laeuft lokal auf eigener Hardware.
 | **LLM Options** | temp=0.0, top_p=0.1, num_predict=500 |
 | **Anforderung** | Schnell, deterministisch, zuverlaessiges JSON, Deutsch+Englisch |
 
-**Aktuell:** `llama3.2:3b` — Funktioniert, aber schwach bei Deutsch und JSON-Zuverlaessigkeit.
-
-**Empfehlung: `qwen3:8b`** (~6 GB VRAM)
-- Exzellentes strukturiertes JSON-Output
-- 100+ Sprachen inkl. Deutsch
-- Non-thinking Mode fuer maximale Geschwindigkeit
-- Deutlich bessere Klassifikations-Qualitaet als Llama 3.2:3b
+**Aktuell (PRD):** `qwen3:8b` — Exzellentes strukturiertes JSON, 100+ Sprachen, `think=False` fuer maximale Geschwindigkeit.
 
 **Budget-Alternative:** `qwen3:4b` (~3 GB) — Ueberraschend stark bei strukturierter Extraktion.
 
@@ -71,15 +67,7 @@ Keine Cloud-LLMs — alles laeuft lokal auf eigener Hardware.
 | **LLM Options** | temp=0.7, top_p=0.9, num_predict=1500 |
 | **Anforderung** | Natuerlich, persoenlich, bilingual, schnelles Streaming |
 
-**Aktuell:** `llama3.2:3b` — Zu klein fuer natuerliche Konversation, schwach auf Deutsch.
-
-**Empfehlung: `qwen3:14b`** (~10 GB VRAM)
-- Passt auf eine einzelne 16 GB GPU (kein Split noetig)
-- Sehr gutes Deutsch
-- Dense-Architektur = vorhersagbare Latenz
-- Stark genug fuer persoenliche, natuerliche Konversation
-
-**Auf 24 GB Single-GPU waere besser:** `qwen3:30b-a3b` (MoE, ~20 GB) — aber passt nicht auf 16 GB.
+**Aktuell (PRD):** `qwen3:14b` — Dense 14B, `think=False`, sehr gutes Deutsch, ~40-60 tok/s auf 5070 Ti.
 
 **Budget:** `qwen3:8b` (~6 GB) — Bestes Preis-Leistungs-Verhaeltnis fuer bilingualen Chat.
 
@@ -96,12 +84,7 @@ Keine Cloud-LLMs — alles laeuft lokal auf eigener Hardware.
 | **LLM Options** | temp=0.3, top_p=0.8, num_predict=2000 |
 | **Anforderung** | Kontexttreue, wenig Halluzination, Deutsch |
 
-**Aktuell:** `llama3.2:latest` (~3B) — Zu klein fuer zuverlaessige Kontextnutzung.
-
-**Empfehlung: `qwen3:14b`** (~10 GB VRAM)
-- Sehr gute Kontexttreue (wenig Halluzination)
-- Starkes Deutsch
-- Gleiches Modell wie Chat → kein zusaetzlicher VRAM noetig
+**Aktuell (PRD):** `qwen3:14b` — Gleiches Modell wie Chat, sehr gute Kontexttreue, wenig Halluzination.
 
 ---
 
@@ -116,16 +99,9 @@ Keine Cloud-LLMs — alles laeuft lokal auf eigener Hardware.
 | **LLM Options** | temp=0.1, top_p=0.2, num_predict=2048 |
 | **Anforderung** | Zuverlaessiges JSON, Tool-Calling, mehrstufiges Reasoning |
 
-**Aktuell:** Faellt auf `chat_model` zurueck (`llama3.2:3b`) — viel zu schwach fuer Agent-Loops.
+**Aktuell (PRD):** `qwen3:14b` auf eigener GPU (RTX 5060 Ti, renfield.local) — `think=False`, ~30-40 tok/s, zuverlaessiges Tool-Calling, blockiert nicht Chat.
 
-**Empfehlung: `qwen3:14b`** (~10 GB VRAM) auf separater GPU
-- Auf eigener GPU (5060 Ti) → blockiert nicht Chat
-- Thinking-Mode fuer komplexe Planungsschritte moeglich
-- Zuverlaessiges Tool-Calling und JSON-Output
-
-**Auf 24 GB Single-GPU:** `qwen3:30b-a3b` waere staerker, passt aber nicht auf 16 GB.
-
-**Alternative:** `mistral-small3.1:24b` (~16 GB) — passt knapp auf eine 16 GB Karte, native Function-Calling, 150 tok/s. Aber wenig Headroom fuer KV-Cache.
+**WARNUNG: `mistral-small3.2:24b` passt NICHT auf 16 GB!** Ollama laedt nur 32/41 Layers auf die GPU, 4.2 GB Gewichte + 1 GB KV-Cache werden auf die CPU ausgelagert. Resultat: 79s Ladezeit, jeder Agent-Step laeuft in Timeout. MoE-Modelle wie `gpt-oss` (20B gesamt, nur 3.6B aktiv, ~13 GB) sind die bessere Wahl fuer 16 GB Karten.
 
 ---
 
@@ -140,14 +116,9 @@ Keine Cloud-LLMs — alles laeuft lokal auf eigener Hardware.
 | **LLM Options** | temp=0.0, top_p=0.1, num_predict=128, num_ctx=4096 |
 | **Anforderung** | Ultra-schnell, einfache Klassifikation |
 
-**Aktuell:** Faellt auf Intent-Model zurueck.
+**Aktuell (PRD):** Nutzt `agent_model` (`qwen3:14b`) auf Agent-GPU, `think=False`.
 
-**Empfehlung: `qwen3:0.6b`** (~0.5 GB VRAM)
-- Ultra-schnell, minimaler VRAM
-- Fuer einfache Kategorisierung mehr als ausreichend
-- Kann permanent geladen bleiben (`keep_alive: -1`)
-
-**Alternative:** Gleicher Intent-Model (`qwen3:8b`) — wenn kein separates Modell gewuenscht.
+**Moeglicher Upgrade: `qwen3:0.6b`** (~0.5 GB VRAM) — Ultra-schnell, fuer einfache Kategorisierung ausreichend.
 
 ---
 
@@ -162,12 +133,7 @@ Keine Cloud-LLMs — alles laeuft lokal auf eigener Hardware.
 | **LLM Options** | temp=0.1, top_p=0.2, num_predict=500, num_ctx=4096 |
 | **Anforderung** | Zuverlaessiges JSON, Background-Task (Latenz unkritisch) |
 
-**Aktuell:** `ollama_model` (Fallback auf `llama3.2:3b`).
-
-**Empfehlung: `qwen3:8b`** (~6 GB) im Non-thinking Mode
-- Exzellentes strukturiertes JSON
-- Laeuft als Background-Task → Geschwindigkeit weniger kritisch
-- Starkes Deutsch fuer Fakten-Extraktion
+**Aktuell (PRD):** `ollama_model` = `qwen3:14b` auf Primary GPU, `think=False`. Exzellentes strukturiertes JSON.
 
 **Budget:** `qwen3:4b` (~3 GB) — Fuer Background-Tasks mit minimalem VRAM-Impact.
 
@@ -184,11 +150,9 @@ Keine Cloud-LLMs — alles laeuft lokal auf eigener Hardware.
 | **LLM Options** | temp=0.0/0.3, num_predict=10/200 |
 | **Anforderung** | Schnell, minimal, optional (Phase 2) |
 
-**Aktuell:** Faellt auf `ollama_model` zurueck.
+**Aktuell (PRD):** Faellt auf `ollama_model` (`qwen3:14b`) zurueck.
 
-**Empfehlung: `qwen3:4b`** (~3 GB)
-- Fuer 1-Wort-Klassifikation und kurze Anreicherung ausreichend
-- Schnell genug fuer Echtzeit-Notifications
+**Moeglicher Upgrade: `qwen3:4b`** (~3 GB) — Fuer 1-Wort-Klassifikation und kurze Anreicherung ausreichend.
 
 ---
 
@@ -201,127 +165,120 @@ Keine Cloud-LLMs — alles laeuft lokal auf eigener Hardware.
 | **Aufgabe** | Text → 768-dim Vektor fuer Cosine-Similarity (pgvector) |
 | **Anforderung** | Deutsch+Englisch, konsistente Qualitaet, immer geladen |
 
-**Aktuell:** `nomic-embed-text` (137M, 768 dim, ~0.3 GB) — Primaer Englisch, schwach auf Deutsch.
-
-**Empfehlung: `qwen3-embedding:4b`** (~3 GB VRAM)
-- \#1 auf MTEB Multilingual Leaderboard (Score 70.58)
-- Exzellentes Deutsch (massiv besser als nomic)
-- Matryoshka-Dimensionen (768 kompatibel, oder hoeher bei Bedarf)
-- Sollte mit `keep_alive: -1` permanent geladen bleiben
+**Aktuell (PRD):** `qwen3-embedding:4b` (~3 GB VRAM, 2560 dim) — \#1 auf MTEB Multilingual Leaderboard, exzellentes Deutsch, mit `EMBEDDING_DIMENSION=2560` und halfvec HNSW-Indexes.
 
 **Budget:** `granite-embedding:278m` (~0.4 GB) — Deutlich besser auf Deutsch als nomic bei aehnlichem VRAM.
-
-**Hinweis:** Ein Embedding-Modell-Wechsel erfordert Re-Embedding aller existierenden Vektoren (RAG-Chunks, Memories, Intent-Corrections, Notification-Suppressions).
 
 ---
 
 ## Hardware-Architektur: Dual-Ollama
 
-Mit 2x 16 GB GPUs ist die beste Strategie: **zwei separate Ollama-Instanzen**, eine pro GPU. Renfield unterstuetzt das bereits ueber `agent_ollama_url`.
+Zwei separate Ollama-Instanzen auf unterschiedlichen Hosts, jede mit eigener GPU. Renfield routet ueber `OLLAMA_URL` (Primary) und `AGENT_OLLAMA_URL` (Agent).
+
+**Status: AKTIV IN PRODUKTION** seit Februar 2026.
+
+### Netzwerk-Topologie
+
+```
+cuda.local (192.168.1.227)                renfield.local (Docker Host)
+┌──────────────────────────┐              ┌──────────────────────────┐
+│ Ollama (Host-Install)    │              │ Ollama (Host-Install)    │
+│ RTX 5070 Ti 16 GB        │              │ RTX 5060 Ti 16 GB        │
+│ 896 GB/s Bandwidth       │              │ 448 GB/s Bandwidth       │
+│ Port 11434               │              │ Port 11434               │
+└──────────┬───────────────┘              └──────────┬───────────────┘
+           │                                         │
+           │ LAN (1 Gbit)                            │ host.docker.internal
+           │                                         │
+     ┌─────┴─────────────────────────────────────────┴──────┐
+     │ renfield-backend (Docker Container)                   │
+     │ OLLAMA_URL=http://cuda.local:11434                    │
+     │ AGENT_OLLAMA_URL=http://host.docker.internal:11434    │
+     │ OLLAMA_FALLBACK_URL=http://host.docker.internal:11434 │
+     └───────────────────────────────────────────────────────┘
+```
+
+**Hinweis:** cuda.local ist per Docker-DNS erreichbar (IP-basiert), nicht per Avahi/mDNS. Der Backend-Container loest `cuda.local` korrekt auf. `host.docker.internal` zeigt auf den Docker-Host (renfield.local), wo die zweite Ollama-Instanz laeuft.
 
 ### Warum kein GPU-Split?
 
 Ein einzelnes grosses Modell (z.B. 30B) ueber zwei GPUs gesplittet hat Nachteile:
 - GPU-zu-GPU Kommunikation ueber PCIe addiert Latenz bei **jedem** Token
 - Bei MoE-Modellen besonders schlecht: Experts auf verschiedenen GPUs → staendiger Transfer
-- Ein **14B Dense-Modell auf einer GPU** ist schneller als ein 30B MoE ueber zwei
+- Zwei separate 16 GB Instanzen bieten **echte Parallelitaet** statt serielle Verarbeitung
 
 ### Warum Dual-Ollama?
 
 - **Parallelitaet:** Chat + Agent laufen gleichzeitig auf separater Hardware
-- **Keine Blockierung:** Ein Agent-Loop (8-12 Schritte × 30s) blockiert keine Chat-Antworten
+- **Keine Blockierung:** Ein Agent-Loop (5-8 Schritte × 4-9s) blockiert keine Chat-Antworten
 - **Multi-User:** Entscheidend fuer einen Household-Assistenten mit mehreren Nutzern
+- **Fallback:** Wenn cuda.local offline, uebernimmt renfield.local automatisch (`OLLAMA_FALLBACK_URL`)
+- **Bandbreite:** 896 + 448 = 1.344 GB/s gesamt — deutlich schneller als z.B. Mac Mini M4 Pro (273 GB/s)
 
-### GPU-Zuweisung
+### GPU-Zuweisung (Produktion — Qwen3)
 
 ```
-Ollama Primary (GPU 0 — RTX 5070 Ti 16 GB)
-├── qwen3:14b          ~10 GB  [Chat + RAG]      keep_alive=5m
-├── qwen3:8b            ~6 GB  [Intent]           keep_alive=5m
-├── qwen3:0.6b         ~0.5 GB [Router]           keep_alive=-1
-└── qwen3-embedding:4b  ~3 GB  [Embeddings]       keep_alive=-1
+Ollama Primary (cuda.local — RTX 5070 Ti 16 GB, 896 GB/s)
+├── qwen3:14b          ~10 GB  [Chat + RAG + Memory]  keep_alive=5m
+├── qwen3:8b            ~6 GB  [Intent]               keep_alive=5m
+└── qwen3-embedding:4b  ~3 GB  [Embeddings, 2560 dim] keep_alive=-1
 
-Ollama Agent (GPU 1 — RTX 5060 Ti 16 GB)
-├── qwen3:14b          ~10 GB  [Agent Loop]       keep_alive=5m
-└── qwen3:4b            ~3 GB  [Extraction/Enrichment]  keep_alive=0
+Ollama Agent (renfield.local — RTX 5060 Ti 16 GB, 448 GB/s)
+└── qwen3:14b          ~10 GB  [Agent Loop + Router]  keep_alive=5m
 ```
 
-Ollama laedt/entlaedt Modelle automatisch. Auf GPU 0 sind nie alle gleichzeitig geladen — Intent und Chat/RAG wechseln sich ab. Embeddings und Router bleiben permanent im VRAM.
+Alle Modelle nutzen `think=False` fuer schnelle, deterministische Antworten. Dense-Architektur = vorhersagbare Latenz. Ollama laedt Modelle on-demand; qwen3:14b und qwen3:8b teilen sich den VRAM auf der Primary GPU (nur eines aktiv, `keep_alive=5m`).
 
-### Docker Compose
+### Host-Ollama vs Docker-Ollama
 
-```yaml
-ollama-primary:
-  image: ollama/ollama:latest
-  deploy:
-    resources:
-      reservations:
-        devices:
-          - driver: nvidia
-            device_ids: ['0']       # RTX 5070 Ti
-            capabilities: [gpu]
-  ports:
-    - "11434:11434"
-  volumes:
-    - ollama-primary:/root/.ollama
-  environment:
-    OLLAMA_MAX_LOADED_MODELS: 3     # Chat/RAG + Embedding + Router
-    OLLAMA_KEEP_ALIVE: 5m
-
-ollama-agent:
-  image: ollama/ollama:latest
-  deploy:
-    resources:
-      reservations:
-        devices:
-          - driver: nvidia
-            device_ids: ['1']       # RTX 5060 Ti
-            capabilities: [gpu]
-  ports:
-    - "11435:11434"
-  volumes:
-    - ollama-agent:/root/.ollama
-  environment:
-    OLLAMA_MAX_LOADED_MODELS: 2     # Agent + Extraction
-    OLLAMA_KEEP_ALIVE: 5m
-```
+Die Produktion nutzt **Host-installiertes Ollama** (nicht Docker-Container):
+- Einfacher: `systemctl start ollama` auf beiden Hosts
+- Kein NVIDIA Container Toolkit noetig (Ollama nutzt GPU direkt)
+- Modelle liegen in `~/.ollama/models/` auf dem Host-Filesystem
+- Update: `ollama update` auf dem jeweiligen Host
 
 ---
 
-## Empfohlene Konfiguration
+## Konfiguration
 
-### .env
+### .env (Produktion — aktiv, Qwen3)
 
 ```bash
-# === Primary Ollama (GPU 0 — RTX 5070 Ti) ===
-OLLAMA_URL=http://ollama-primary:11434
+# === Ollama Primary (GPU 0 — RTX 5070 Ti 16 GB auf cuda.local) ===
+OLLAMA_URL=http://cuda.local:11434
 OLLAMA_CHAT_MODEL=qwen3:14b
 OLLAMA_RAG_MODEL=qwen3:14b
 OLLAMA_INTENT_MODEL=qwen3:8b
 OLLAMA_EMBED_MODEL=qwen3-embedding:4b
+OLLAMA_MODEL=qwen3:14b
+EMBEDDING_DIMENSION=2560
 
-# === Agent Ollama (GPU 1 — RTX 5060 Ti) ===
-AGENT_OLLAMA_URL=http://ollama-agent:11434
+# === Ollama Agent (GPU 1 — RTX 5060 Ti 16 GB auf renfield.local) ===
+AGENT_ENABLED=true
 AGENT_MODEL=qwen3:14b
+AGENT_OLLAMA_URL=http://host.docker.internal:11434
+AGENT_STEP_TIMEOUT=120.0
+AGENT_TOTAL_TIMEOUT=600.0
 
-# === Optionale spezialisierte Modelle ===
-# PROACTIVE_ENRICHMENT_MODEL=qwen3:4b   # Auf Agent-Ollama
-# Router nutzt automatisch OLLAMA_INTENT_MODEL als Fallback
+# Fallback: Wenn cuda.local offline, nutze renfield.local's GPU
+OLLAMA_FALLBACK_URL=http://host.docker.internal:11434
 ```
 
-### Modell-Vorladung (Startup-Script)
+**`host.docker.internal`** wird von Docker zu der IP des Host-Systems aufgeloest. Da das Renfield-Backend als Docker-Container auf renfield.local laeuft, zeigt `host.docker.internal` auf die lokale Ollama-Instanz (RTX 5060 Ti).
+
+**Fallback-Verhalten:** Wenn `OLLAMA_FALLBACK_URL` gesetzt ist und die primaere Ollama-Instanz (`cuda.local`) nicht erreichbar ist (ConnectError/ConnectTimeout innerhalb von 10s), wird der gleiche Request automatisch auf der Fallback-URL wiederholt. Implementiert in `utils/llm_client.py` (`_FallbackLLMClient`).
+
+**Thinking-Mode:** Alle Qwen3-Aufrufe nutzen `think=False` (via `get_classification_chat_kwargs()` in `llm_client.py`). Household-Assistent braucht schnelle Antworten, nicht langes Nachdenken. `extract_response_content()` ist als Failsafe fuer den ollama-python 0.6.1 Bug implementiert.
+
+### Modell-Vorladung
 
 ```bash
 #!/bin/bash
-# Modelle auf Primary GPU vorziehen
-ollama pull qwen3:14b
-ollama pull qwen3:8b
-ollama pull qwen3:0.6b
-ollama pull qwen3-embedding:4b
+# Modelle auf cuda.local (Primary GPU)
+ssh cuda.local 'ollama pull qwen3:14b && ollama pull qwen3:8b && ollama pull qwen3-embedding:4b'
 
-# Modelle auf Agent GPU vorziehen
-OLLAMA_HOST=http://localhost:11435 ollama pull qwen3:14b
-OLLAMA_HOST=http://localhost:11435 ollama pull qwen3:4b
+# Modelle auf renfield.local (Agent GPU)
+ollama pull qwen3:14b
 ```
 
 ---
@@ -372,25 +329,22 @@ Der moderate Qualitaetsverlust 30B→14B wird durch keine Split-Latenz und volle
 
 ## Migrations-Reihenfolge
 
-| Prio | Aktion | Impact | Aufwand |
-|------|--------|--------|---------|
-| 1 | **Embedding-Modell** → `qwen3-embedding:4b` | Deutsch-Retrieval massiv besser | Hoch (Re-Embedding aller Vektoren) |
-| 2 | **Dual-Ollama aufsetzen** (docker-compose.prod.yml) | Agent blockiert nicht mehr Chat | Mittel (Infra) |
-| 3 | **Chat/RAG** → `qwen3:14b` | Natuerlichere Konversation, besseres Deutsch | Gering (Config) |
-| 4 | **Intent** → `qwen3:8b` | Zuverlaessigeres JSON | Gering (Config) |
-| 5 | **Agent** → `qwen3:14b` auf zweiter GPU | Echtes Multi-Step Reasoning | Gering (Config) |
+| Prio | Aktion | Impact | Aufwand | Status |
+|------|--------|--------|---------|--------|
+| ~~2~~ | ~~**Dual-Ollama aufsetzen**~~ | ~~Agent blockiert nicht mehr Chat~~ | ~~Mittel (Infra)~~ | ERLEDIGT |
+| ~~1~~ | ~~**Embedding-Modell** → `qwen3-embedding:4b`~~ | ~~Deutsch-Retrieval massiv besser~~ | ~~Hoch (Re-Embedding)~~ | ERLEDIGT |
+| ~~2~~ | ~~**Chat/RAG** → `qwen3:14b`~~ | ~~Natuerlichere Konversation~~ | ~~Gering (Config + think=False)~~ | ERLEDIGT |
+| ~~3~~ | ~~**Intent** → `qwen3:8b`~~ | ~~Zuverlaessigeres JSON~~ | ~~Gering (Config)~~ | ERLEDIGT |
+| ~~4~~ | ~~**Agent** → `qwen3:14b` auf zweiter GPU~~ | ~~Echtes Multi-Step Reasoning~~ | ~~Gering (Config + think=False)~~ | ERLEDIGT |
 
-### Hinweise zur Embedding-Migration
+### Hinweise zur Embedding-Migration (abgeschlossen)
 
-Der Wechsel von `nomic-embed-text` (768 dim) zu `qwen3-embedding:4b` erfordert:
+Die Migration von `nomic-embed-text` (768 dim) zu `qwen3-embedding:4b` (2560 dim) wurde durchgefuehrt:
 
-1. **Dimensionen pruefen:** Qwen3-Embedding unterstuetzt Matryoshka (flexible Dimensionen). 768 kann beibehalten werden — kein Schema-Aenderung noetig.
-2. **Re-Embedding:** Alle existierenden Vektoren muessen neu berechnet werden:
-   - RAG Document Chunks (`document_chunks.embedding`)
-   - Conversation Memories (`conversation_memories.embedding`)
-   - Intent Corrections (`intent_corrections.embedding`)
-   - Notification Suppressions (`notification_suppressions.embedding`)
-3. **Downtime:** Re-Embedding kann im Hintergrund laufen, aber waehrend der Migration sind Similarity-Suchen inkonsistent (alte vs neue Vektoren).
+1. **DB-Spalten:** Bereits auf `vector(2560)` resized (Alembic-Migration)
+2. **HNSW-Indexes:** Nutzen `halfvec(2560)` Cast (pgvector 0.8.1 hat 2000-dim Limit fuer regulaere `vector`)
+3. **Config:** `EMBEDDING_DIMENSION=2560` in `.env` gesetzt
+4. **Re-Embedding:** Via `POST /admin/reembed` nach Modellwechsel (RAG-Chunks, Memories, Corrections, Suppressions)
 
 ---
 
@@ -398,20 +352,23 @@ Der Wechsel von `nomic-embed-text` (768 dim) zu `qwen3-embedding:4b` erfordert:
 
 Ungefaehre Werte fuer Q4_K_M Quantisierung:
 
-| Modell | Parameter | VRAM (Gewichte) | + KV-Cache (8K) | Gesamt |
-|--------|-----------|-----------------|-----------------|--------|
-| qwen3:0.6b | 0.6B | ~0.5 GB | ~0.1 GB | ~0.6 GB |
-| qwen3:4b | 4B | ~3 GB | ~0.2 GB | ~3.2 GB |
-| qwen3:8b | 8B | ~6 GB | ~0.3 GB | ~6.3 GB |
-| qwen3:14b | 14B | ~10 GB | ~0.5 GB | ~10.5 GB |
-| qwen3:30b-a3b | 30B (3B aktiv) | ~20 GB | ~0.2 GB | ~20.2 GB |
-| qwen3:32b | 32B | ~22 GB | ~1.0 GB | ~23 GB |
-| mistral-small3.1:24b | 24B | ~16 GB | ~0.7 GB | ~16.7 GB |
-| qwen3-embedding:4b | 4B | ~3 GB | — | ~3 GB |
-| qwen3-embedding:0.6b | 0.6B | ~0.5 GB | — | ~0.5 GB |
-| nomic-embed-text | 137M | ~0.3 GB | — | ~0.3 GB |
+| Modell | Parameter | Architektur | VRAM (Gewichte) | + KV-Cache (8K) | Gesamt |
+|--------|-----------|-------------|-----------------|-----------------|--------|
+| **gpt-oss:latest** | **20B (3.6B aktiv)** | **MoE** | **~13 GB** | **~0.2 GB** | **~13.2 GB** |
+| qwen3:0.6b | 0.6B | Dense | ~0.5 GB | ~0.1 GB | ~0.6 GB |
+| qwen3:4b | 4B | Dense | ~3 GB | ~0.2 GB | ~3.2 GB |
+| qwen3:8b | 8B | Dense | ~6 GB | ~0.3 GB | ~6.3 GB |
+| qwen3:14b | 14B | Dense | ~10 GB | ~0.5 GB | ~10.5 GB |
+| qwen3:30b-a3b | 30B (3B aktiv) | MoE | ~20 GB | ~0.2 GB | ~20.2 GB |
+| qwen3:32b | 32B | Dense | ~22 GB | ~1.0 GB | ~23 GB |
+| mistral-small3.2:24b | 24B | Dense | ~15 GB | ~1.7 GB | **~16.7 GB** |
+| qwen3-embedding:4b | 4B | — | ~3 GB | — | ~3 GB |
+| qwen3-embedding:0.6b | 0.6B | — | ~0.5 GB | — | ~0.5 GB |
+| nomic-embed-text | 137M | — | ~0.3 GB | — | ~0.3 GB |
 
-**16 GB GPU Limit:** Modelle bis ~14B Dense passen komfortabel. 24B ist grenzwertig (wenig KV-Cache Headroom). Alles ueber 16 GB erfordert GPU-Split.
+**16 GB GPU Limit:** Modelle bis ~14B Dense passen komfortabel. MoE-Modelle wie `gpt-oss` (20B gesamt, 3.6B aktiv, ~13 GB) nutzen 16 GB optimal — genug Headroom fuer KV-Cache bei hoher Qualitaet.
+
+**WARNUNG zu 24B Dense auf 16 GB:** `mistral-small3.2:24b` ueberschreitet mit KV-Cache die 16 GB. Ollama laedt nur 32/41 Layers auf GPU, der Rest wird auf CPU ausgelagert → 79s Ladezeit, massive Latenz, in der Praxis unbrauchbar fuer Echtzeit-Anwendungen.
 
 ---
 

--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -22,7 +22,7 @@ from services.agent_tools import AgentToolRegistry
 from services.prompt_manager import prompt_manager
 from utils.circuit_breaker import agent_circuit_breaker
 from utils.config import settings
-from utils.llm_client import get_agent_client
+from utils.llm_client import extract_response_content, get_agent_client, get_classification_chat_kwargs
 from utils.token_counter import token_counter
 
 if TYPE_CHECKING:
@@ -572,6 +572,7 @@ class AgentService:
 
             # Call LLM with per-step timeout
             try:
+                classification_kwargs = get_classification_chat_kwargs(agent_model)
                 raw_response = await asyncio.wait_for(
                     agent_client.chat(
                         model=agent_model,
@@ -580,10 +581,11 @@ class AgentService:
                             {"role": "user", "content": prompt},
                         ],
                         options=llm_options,
+                        **classification_kwargs,
                     ),
                     timeout=self.step_timeout,
                 )
-                response_text = raw_response.message.content or ""
+                response_text = extract_response_content(raw_response) or ""
                 await agent_circuit_breaker.record_success()
 
                 # Track token usage
@@ -634,10 +636,11 @@ class AgentService:
                                 {"role": "user", "content": nudge},
                             ],
                             options=llm_options_retry,
+                            **classification_kwargs,
                         ),
                         timeout=self.step_timeout,
                     )
-                    response_text = retry_response.message.content or ""
+                    response_text = extract_response_content(retry_response) or ""
                     context.track_tokens(nudge, response_text)
                     logger.info(f"🔄 Agent step {step_num} retry ({len(response_text)} chars): {response_text[:200]}")
                     parsed = _parse_agent_json(response_text)
@@ -895,6 +898,7 @@ class AgentService:
 
         client = agent_client or ollama.client
         try:
+            classification_kwargs = get_classification_chat_kwargs(agent_model)
             raw_response = await asyncio.wait_for(
                 client.chat(
                     model=agent_model,
@@ -903,10 +907,11 @@ class AgentService:
                         {"role": "user", "content": summary_prompt_text},
                     ],
                     options=llm_options_summary,
+                    **classification_kwargs,
                 ),
                 timeout=self.step_timeout,
             )
-            summary = (raw_response.message.content or "").strip()
+            summary = (extract_response_content(raw_response) or "").strip()
 
             # Track tokens for summary call
             context.track_tokens(summary_prompt_text, summary)

--- a/src/backend/services/ollama_service.py
+++ b/src/backend/services/ollama_service.py
@@ -139,14 +139,15 @@ WICHTIGE REGELN FÜR ANTWORTEN:
 
             messages.append({"role": "user", "content": message})
 
+            classification_kwargs = get_classification_chat_kwargs(self.chat_model)
             response = await self.client.chat(
-                model=self.model,
+                model=self.chat_model,
                 messages=messages,
-                options={"num_ctx": settings.ollama_num_ctx}
+                options={"num_ctx": settings.ollama_num_ctx},
+                **classification_kwargs,
             )
-            # ollama>=0.4.0 uses Pydantic models
             await llm_circuit_breaker.record_success()
-            return response.message.content
+            return extract_response_content(response) or ""
         except Exception as e:
             await llm_circuit_breaker.record_failure()
             logger.error(f"Chat Fehler: {e}")
@@ -183,11 +184,13 @@ WICHTIGE REGELN FÜR ANTWORTEN:
 
             messages.append({"role": "user", "content": message})
 
+            classification_kwargs = get_classification_chat_kwargs(self.chat_model)
             async for chunk in await self.client.chat(
-                model=self.model,
+                model=self.chat_model,
                 messages=messages,
                 stream=True,
-                options={"num_ctx": settings.ollama_num_ctx}
+                options={"num_ctx": settings.ollama_num_ctx},
+                **classification_kwargs,
             ):
                 # ollama>=0.4.0 uses Pydantic models
                 if chunk.message and chunk.message.content:
@@ -921,13 +924,14 @@ WICHTIGE REGELN FÜR ANTWORTEN:
 
             messages.append({"role": "user", "content": message})
 
+            classification_kwargs = get_classification_chat_kwargs(model)
             response = await self.client.chat(
                 model=model,
                 messages=messages,
-                options={"num_ctx": settings.ollama_num_ctx}
+                options={"num_ctx": settings.ollama_num_ctx},
+                **classification_kwargs,
             )
-            # ollama>=0.4.0 uses Pydantic models
-            return response.message.content
+            return extract_response_content(response) or ""
 
         except Exception as e:
             logger.error(f"RAG Chat Fehler: {e}")
@@ -975,11 +979,13 @@ WICHTIGE REGELN FÜR ANTWORTEN:
 
             logger.debug(f"RAG Stream: model={model}, context_len={len(rag_context) if rag_context else 0}")
 
+            classification_kwargs = get_classification_chat_kwargs(model)
             async for chunk in await self.client.chat(
                 model=model,
                 messages=messages,
                 stream=True,
-                options={"num_ctx": settings.ollama_num_ctx}
+                options={"num_ctx": settings.ollama_num_ctx},
+                **classification_kwargs,
             ):
                 # ollama>=0.4.0 uses Pydantic models
                 if chunk.message and chunk.message.content:


### PR DESCRIPTION
## Summary
- Migrate all LLM roles from `gpt-oss:latest` to Qwen3 family: Chat/RAG → `qwen3:14b`, Intent → `qwen3:8b`, Agent → `qwen3:14b`, Embeddings → `qwen3-embedding:4b`
- Fix thinking-model compatibility: add `think=False` + `extract_response_content()` to all LLM call sites in `ollama_service.py` and `agent_service.py`
- Fix `chat()` and `chat_stream()` using legacy `self.model` instead of `self.chat_model`
- Fix broken vector search: set `EMBEDDING_DIMENSION=2560`, created missing HNSW indexes on PRD
- Update `docs/LLM_MODEL_GUIDE.md` with current production config and mark all migration steps as complete

## Test plan
- [x] 41/41 `test_llm_client.py` tests pass
- [x] 48/48 non-integration `test_agent_service.py` tests pass (11 pre-existing failures due to missing `ollama` package in test env)
- [x] PRD deployed: backend starts cleanly, all 3 satellites reconnect
- [x] Intent recognition works with `qwen3:8b` (verified via `/debug/intent`)
- [x] Vector search works — no more dimension mismatch errors
- [x] HNSW indexes created (`halfvec(2560)` for pgvector 0.8.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)