### PR TITLE
fix(agent): Break loop on repeated empty search results (#229)

### DIFF
--- a/src/backend/prompts/agent.yaml
+++ b/src/backend/prompts/agent.yaml
@@ -43,6 +43,7 @@ de:
     - Einzelnen Song abspielen: (1) search_media(type="Audio"), (2) internal.play_in_room mit api_stream URL.
     - Um die Wiedergabe zu stoppen oder Tracks zu wechseln: Nutze mcp.dlna.stop/mcp.dlna.next_track/mcp.dlna.previous_track wenn eine DLNA-Session aktiv ist. Alternativ: internal.media_control mit action (stop/pause/resume/next/previous) und room_name.
     - Beende NICHT mit final_answer, wenn noch offene Schritte aus der AUFGABE übrig sind. "Schick mir X zu Y" erfordert ALLE Schritte: (1) ggf. search, (2) download_document, (3) send_email. Erst NACH dem letzten Schritt darfst du final_answer geben.
+    - Wenn ein Such-Tool 0 Ergebnisse liefert, wiederhole NICHT dieselbe Suche. Versuche: (1) Kuerzeren Suchbegriff (nur Titel, ohne Kuenstler/Autor), (2) alternative Schreibweise, (3) anderes Tool. Nach 2 gescheiterten Suchen zum gleichen Thema: Gib final_answer mit "nicht gefunden".
     - Gib final_answer wenn alle Informationen gesammelt sind und ALLE geforderten Aktionen abgeschlossen wurden
     - Die finale Antwort muss natürlich und auf Deutsch sein
     - Antworte NUR mit JSON, kein anderer Text
@@ -87,6 +88,7 @@ de:
     - Fuer Helligkeiten/Farben: Nutze HassLightSet mit "area"+"domain" oder "name"
     - Fuer Sensorwerte: Nutze GetLiveContext mit "name" und optional "area"
     - Uebergib NIEMALS "device_class"
+    - Wenn ein Such-Tool 0 Ergebnisse liefert, wiederhole NICHT dieselbe Suche. Versuche: (1) Kuerzeren Suchbegriff, (2) alternative Schreibweise, (3) anderes Tool. Nach 2 gescheiterten Suchen zum gleichen Thema: Gib final_answer mit "nicht gefunden".
     - Die finale Antwort muss natuerlich und auf Deutsch sein
     - Antworte NUR mit JSON
 
@@ -125,6 +127,7 @@ de:
     - Fuer Websuche: Nutze web_search/searxng_web_search
     - Fuer Nachrichten: Nutze search_articles oder get_top_headlines
     - Fasse Ergebnisse praezise zusammen mit konkreten Zahlen und Fakten
+    - Wenn ein Such-Tool 0 Ergebnisse liefert, wiederhole NICHT dieselbe Suche. Versuche: (1) Kuerzeren Suchbegriff, (2) alternative Schreibweise, (3) anderes Tool. Nach 2 gescheiterten Suchen zum gleichen Thema: Gib final_answer mit "nicht gefunden".
     - Die finale Antwort muss natuerlich und auf Deutsch sein
     - Antworte NUR mit JSON
 
@@ -168,6 +171,7 @@ de:
     - Heruntergeladene Dokumente werden AUTOMATISCH als Anhaenge eingefuegt
     - Uebergib bei send_email KEINE attachments
     - Beende NICHT mit final_answer wenn noch Schritte offen sind
+    - Wenn ein Such-Tool 0 Ergebnisse liefert, wiederhole NICHT dieselbe Suche. Versuche: (1) Kuerzeren Suchbegriff, (2) alternative Schreibweise, (3) anderes Tool. Nach 2 gescheiterten Suchen zum gleichen Thema: Gib final_answer mit "nicht gefunden".
     - Die finale Antwort muss natuerlich und auf Deutsch sein
     - Antworte NUR mit JSON
 
@@ -206,6 +210,7 @@ de:
     - Erfinde NIEMALS Medien, IDs oder Wiedergabe-Status
     - Rufe pro Antwort GENAU EIN Tool auf
     - IMMER zuerst suchen, dann abspielen. Wenn die Anfrage einen konkreten Titel, Kuenstler oder Album NENNT, fuehre IMMER eine neue Suche durch. Wenn der Nutzer sich auf vorherige Suchergebnisse bezieht ("spiel den ab", "den ersten Track", "davon das dritte"), nutze die IDs aus dem Konversations-Kontext.
+    - SUCHTIPP: Jellyfin findet "Album Artist" oft NICHT zusammen. Suche zuerst NUR nach dem Album-/Songnamen (z.B. query="Afterburner"). Pruefe dann im Ergebnis den Kuenstler.
     - WICHTIG — Album abspielen: (1) search_media(type="MusicAlbum"), (2) internal.play_album_on_dlna(album_id="<id>", renderer_name="<Raum>"). Nur 2 Schritte! Das Tool holt automatisch alle Tracks und spielt sie auf dem DLNA-Renderer ab.
     - Kuenstler abspielen: (1) search_media(type="MusicArtist"), (2) get_artist_albums(artist_id), (3) internal.play_album_on_dlna(album_id="<album_id>", renderer_name="<Raum>") fuer jedes Album.
     - Song abspielen (einzelner Track): (1) search_media(type="Audio"), (2) internal.play_in_room mit api_stream URL.
@@ -216,6 +221,7 @@ de:
     - Wenn Informationen fehlen, frage den Benutzer
     - Um die Wiedergabe zu stoppen oder Tracks zu wechseln: Nutze mcp.dlna.stop/mcp.dlna.next_track/mcp.dlna.previous_track wenn eine DLNA-Session aktiv ist. Alternativ: internal.media_control mit action (stop/pause/resume/next/previous) und room_name. Nutze NICHT play_in_room oder resolve_room_player dafuer.
     - Beschreibe NIEMALS API-Aufrufe gegenueber dem Benutzer
+    - Wenn ein Such-Tool 0 Ergebnisse liefert, wiederhole NICHT dieselbe Suche. Versuche: (1) Kuerzeren Suchbegriff (nur Titel, ohne Kuenstler/Autor), (2) alternative Schreibweise, (3) anderes Tool. Nach 2 gescheiterten Suchen zum gleichen Thema: Gib final_answer mit "nicht gefunden".
     - Die finale Antwort muss kurz, natuerlich und auf Deutsch sein
     - Antworte NUR mit JSON
 
@@ -306,6 +312,7 @@ de:
     - Nutze NUR Tools aus der Liste oben
     - Rufe pro Antwort GENAU EIN Tool auf
     - Erfinde NIEMALS IDs — hole sie ueber list/get Tools
+    - Wenn ein Such-Tool 0 Ergebnisse liefert, wiederhole NICHT dieselbe Suche. Versuche: (1) Kuerzeren Suchbegriff, (2) alternative Schreibweise, (3) anderes Tool. Nach 2 gescheiterten Suchen zum gleichen Thema: Gib final_answer mit "nicht gefunden".
     - Die finale Antwort muss natuerlich und auf Deutsch sein
     - Antworte NUR mit JSON
 
@@ -344,6 +351,7 @@ de:
 
   # Error messages
   error_loop_detected: "Loop erkannt: Tool '{tool}' wurde mehrfach identisch aufgerufen."
+  error_empty_results: "Wiederholte leere Ergebnisse fuer Tool '{tool}' — Suche abgebrochen."
   error_circuit_open: "LLM-Service vorübergehend nicht verfügbar (Circuit Breaker aktiv)."
   error_timeout: "Schritt {step} hat zu lange gedauert (Timeout)."
   error_llm_failed: "LLM-Fehler: {error}"
@@ -397,6 +405,7 @@ en:
     - Playing a single song: (1) search_media(type="Audio"), (2) internal.play_in_room with the api_stream URL.
     - To stop playback or skip tracks: Use mcp.dlna.stop/mcp.dlna.next_track/mcp.dlna.previous_track if a DLNA session is active. Alternatively: internal.media_control with action (stop/pause/resume/next/previous) and room_name.
     - Do NOT give final_answer if there are still open steps from the TASK. "Send me X to Y" requires ALL steps: (1) optionally search, (2) download_document, (3) send_email. Only give final_answer AFTER the last step is completed.
+    - If a search tool returns 0 results, do NOT repeat the same search. Try: (1) Shorter query (title only, without artist/author), (2) alternative spelling, (3) different tool. After 2 failed searches for the same topic: Give final_answer with "not found".
     - Give final_answer when all information is gathered and ALL required actions have been completed
     - The final answer must be natural and in English
     - Reply ONLY with JSON, no other text
@@ -441,6 +450,7 @@ en:
     - For brightness/colors: Use HassLightSet with "area"+"domain" or "name"
     - For sensor values: Use GetLiveContext with "name" and optionally "area"
     - NEVER pass "device_class"
+    - If a search tool returns 0 results, do NOT repeat the same search. Try: (1) Shorter query, (2) alternative spelling, (3) different tool. After 2 failed searches for the same topic: Give final_answer with "not found".
     - The final answer must be natural and in English
     - Reply ONLY with JSON
 
@@ -479,6 +489,7 @@ en:
     - For web search: Use web_search/searxng_web_search
     - For news: Use search_articles or get_top_headlines
     - Summarize results precisely with concrete numbers and facts
+    - If a search tool returns 0 results, do NOT repeat the same search. Try: (1) Shorter query, (2) alternative spelling, (3) different tool. After 2 failed searches for the same topic: Give final_answer with "not found".
     - The final answer must be natural and in English
     - Reply ONLY with JSON
 
@@ -522,6 +533,7 @@ en:
     - Downloaded documents are AUTOMATICALLY attached
     - Do NOT pass attachments to send_email
     - Do NOT give final_answer if steps are still open
+    - If a search tool returns 0 results, do NOT repeat the same search. Try: (1) Shorter query, (2) alternative spelling, (3) different tool. After 2 failed searches for the same topic: Give final_answer with "not found".
     - The final answer must be natural and in English
     - Reply ONLY with JSON
 
@@ -560,6 +572,7 @@ en:
     - Do NOT invent media, IDs, or playback states
     - Call EXACTLY ONE tool per response
     - ALWAYS search before play. When the request names a specific title, artist, or album, ALWAYS perform a new search. When the user refers to previous search results ("play that", "the first track", "the third one"), use the IDs from the conversation context.
+    - SEARCH TIP: Jellyfin often does NOT find "Album Artist" together. Search for the album/song name ONLY first (e.g. query="Afterburner"). Then verify the artist in the results.
     - IMPORTANT — Play an album: (1) search_media(type="MusicAlbum"), (2) internal.play_album_on_dlna(album_id="<id>", renderer_name="<room>"). Only 2 steps! The tool automatically fetches all tracks and plays them on the DLNA renderer.
     - Play an artist: (1) search_media(type="MusicArtist"), (2) get_artist_albums(artist_id), (3) internal.play_album_on_dlna(album_id="<album_id>", renderer_name="<room>") for each album.
     - Play a song (single track): (1) search_media(type="Audio"), (2) internal.play_in_room with api_stream URL.
@@ -570,6 +583,7 @@ en:
     - If information is missing, ask the user
     - To stop playback or skip tracks: Use mcp.dlna.stop/mcp.dlna.next_track/mcp.dlna.previous_track if a DLNA session is active. Alternatively: internal.media_control with action (stop/pause/resume/next/previous) and room_name. Do NOT use play_in_room or resolve_room_player for this.
     - Never describe API calls to the user
+    - If a search tool returns 0 results, do NOT repeat the same search. Try: (1) Shorter query (title only, without artist/author), (2) alternative spelling, (3) different tool. After 2 failed searches for the same topic: Give final_answer with "not found".
     - The final answer must be concise, natural, and in English
     - Reply ONLY with JSON
 
@@ -660,6 +674,7 @@ en:
     - Use ONLY tools from the list above
     - Call EXACTLY ONE tool per response
     - NEVER invent IDs — fetch them via list/get tools
+    - If a search tool returns 0 results, do NOT repeat the same search. Try: (1) Shorter query, (2) alternative spelling, (3) different tool. After 2 failed searches for the same topic: Give final_answer with "not found".
     - The final answer must be natural and in English
     - Reply ONLY with JSON
 
@@ -698,6 +713,7 @@ en:
 
   # Error messages
   error_loop_detected: "Loop detected: Tool '{tool}' was called identically multiple times."
+  error_empty_results: "Repeated empty results for tool '{tool}' — search aborted."
   error_circuit_open: "LLM service temporarily unavailable (Circuit Breaker active)."
   error_timeout: "Step {step} took too long (Timeout)."
   error_llm_failed: "LLM error: {error}"

--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -108,6 +108,9 @@ class AgentContext:
     # E.g. {2: {"filename": "invoice.pdf", "mime_type": "application/pdf"}}
     blob_meta: dict[int, dict[str, str]] = field(default_factory=dict)
 
+    # Track tools that return empty results (for empty-result loop detection)
+    empty_results_per_tool: dict[str, int] = field(default_factory=dict)
+
     # Token tracking
     total_input_tokens: int = 0
     total_output_tokens: int = 0
@@ -175,6 +178,14 @@ class AgentContext:
 
         return "\n".join(lines)
 
+    def record_empty_result(self, tool: str) -> None:
+        """Record that a tool returned an empty result."""
+        self.empty_results_per_tool[tool] = self.empty_results_per_tool.get(tool, 0) + 1
+
+    def has_repeated_empty(self, tool: str, threshold: int = 2) -> bool:
+        """Check if a tool has returned empty results repeatedly."""
+        return self.empty_results_per_tool.get(tool, 0) >= threshold
+
     def detect_infinite_loop(self, min_repetitions: int = 3) -> bool:
         """
         Detect if the agent is stuck in an infinite loop.
@@ -200,6 +211,27 @@ class AgentContext:
         # Check if last N calls are identical
         recent = tool_calls[-min_repetitions:]
         return len(set(recent)) == 1
+
+
+def _is_empty_result(result: dict) -> bool:
+    """Detect if a tool result is effectively empty (0 results).
+
+    Checks the result message for common empty-list patterns from
+    Jellyfin, Paperless, and other search APIs.
+    """
+    msg = result.get("message", "")
+    if not msg or msg in ("Kein Ergebnis", "No result"):
+        return True
+    # Check for common empty-list patterns in JSON responses
+    for pattern in (
+        '"TotalRecordCount":0', '"TotalRecordCount": 0',
+        '"total":0', '"total": 0',
+        '"items":[]', '"items": []',
+        '"Items":[]', '"Items": []',
+    ):
+        if pattern in msg:
+            return True
+    return False
 
 
 def _truncate(text: str, max_length: int = settings.agent_response_truncation) -> str:
@@ -834,6 +866,21 @@ class AgentService:
             context.steps.append(tool_result_step)
             context.tool_results.append(result)
             yield tool_result_step
+
+            # Check for repeated empty results from the same tool
+            if _is_empty_result(result):
+                context.record_empty_result(action)
+                if context.has_repeated_empty(action, threshold=2):
+                    logger.warning(f"🔄 Agent repeated empty results for '{action}' at step {step_num}")
+                    yield AgentStep(
+                        step_number=step_num,
+                        step_type="error",
+                        content=prompt_manager.get("agent", "error_empty_results", lang=lang, tool=action),
+                        tool=action,
+                    )
+                    summary_step = await self._build_summary_answer(context, step_num, message, ollama, agent_model, lang=lang, agent_client=agent_client)
+                    yield summary_step
+                    return
 
             # Check for infinite loop (same tool called repeatedly)
             if context.detect_infinite_loop(min_repetitions=3):

--- a/tests/backend/test_agent_service.py
+++ b/tests/backend/test_agent_service.py
@@ -14,6 +14,7 @@ from services.agent_service import (
     AgentStep,
     _auto_attach_blobs,
     _extract_blobs,
+    _is_empty_result,
     _parse_agent_json,
     _recover_send_email,
     _resolve_blobs,
@@ -1476,3 +1477,161 @@ class TestExtractBlobsMeta:
         data = {"content_base64": "A" * 600}
         result = _extract_blobs(data, 2, blob_store)
         assert "$blob:step2_content_base64" in blob_store
+
+
+# ============================================================================
+# Test _is_empty_result
+# ============================================================================
+
+class TestIsEmptyResult:
+    """Test empty-result detection for various API response formats."""
+
+    @pytest.mark.unit
+    def test_empty_message(self):
+        assert _is_empty_result({"message": ""}) is True
+
+    @pytest.mark.unit
+    def test_no_message_key(self):
+        assert _is_empty_result({"success": True}) is True
+
+    @pytest.mark.unit
+    def test_kein_ergebnis(self):
+        assert _is_empty_result({"message": "Kein Ergebnis"}) is True
+
+    @pytest.mark.unit
+    def test_no_result(self):
+        assert _is_empty_result({"message": "No result"}) is True
+
+    @pytest.mark.unit
+    def test_jellyfin_total_record_count_zero(self):
+        """Jellyfin returns TotalRecordCount:0 for empty searches."""
+        assert _is_empty_result({"message": '{"Items":[],"TotalRecordCount":0}'}) is True
+
+    @pytest.mark.unit
+    def test_jellyfin_total_record_count_zero_spaced(self):
+        assert _is_empty_result({"message": '{"Items": [], "TotalRecordCount": 0}'}) is True
+
+    @pytest.mark.unit
+    def test_generic_items_empty(self):
+        assert _is_empty_result({"message": '{"items":[],"total":0}'}) is True
+
+    @pytest.mark.unit
+    def test_non_empty_result(self):
+        assert _is_empty_result({"message": '{"Items":[{"Id":"abc"}],"TotalRecordCount":1}'}) is False
+
+    @pytest.mark.unit
+    def test_normal_message(self):
+        assert _is_empty_result({"message": "Licht eingeschaltet"}) is False
+
+    @pytest.mark.unit
+    def test_result_with_data(self):
+        assert _is_empty_result({"message": "Found 3 results", "data": [1, 2, 3]}) is False
+
+
+# ============================================================================
+# Test AgentContext Empty Results Tracking
+# ============================================================================
+
+class TestAgentContextEmptyResultsTracking:
+    """Test the empty_results_per_tool counter in AgentContext."""
+
+    @pytest.mark.unit
+    def test_initial_state(self):
+        ctx = AgentContext(original_message="test")
+        assert ctx.empty_results_per_tool == {}
+        assert ctx.has_repeated_empty("search_media") is False
+
+    @pytest.mark.unit
+    def test_record_and_check(self):
+        ctx = AgentContext(original_message="test")
+        ctx.record_empty_result("search_media")
+        assert ctx.empty_results_per_tool["search_media"] == 1
+        assert ctx.has_repeated_empty("search_media", threshold=2) is False
+
+        ctx.record_empty_result("search_media")
+        assert ctx.empty_results_per_tool["search_media"] == 2
+        assert ctx.has_repeated_empty("search_media", threshold=2) is True
+
+    @pytest.mark.unit
+    def test_different_tools_tracked_separately(self):
+        ctx = AgentContext(original_message="test")
+        ctx.record_empty_result("search_media")
+        ctx.record_empty_result("search_media")
+        ctx.record_empty_result("search_documents")
+
+        assert ctx.has_repeated_empty("search_media", threshold=2) is True
+        assert ctx.has_repeated_empty("search_documents", threshold=2) is False
+
+    @pytest.mark.unit
+    def test_custom_threshold(self):
+        ctx = AgentContext(original_message="test")
+        ctx.record_empty_result("tool_a")
+        ctx.record_empty_result("tool_a")
+        ctx.record_empty_result("tool_a")
+
+        assert ctx.has_repeated_empty("tool_a", threshold=3) is True
+        assert ctx.has_repeated_empty("tool_a", threshold=4) is False
+
+
+# ============================================================================
+# Test Agent Breaks After Repeated Empty Results
+# ============================================================================
+
+class TestAgentBreaksOnRepeatedEmptyResults:
+    """Test that the agent loop breaks after repeated empty results."""
+
+    def _make_registry(self):
+        return AgentToolRegistry(mcp_manager=_make_mock_mcp_manager())
+
+    @pytest.mark.unit
+    async def test_agent_breaks_after_repeated_empty_results(self):
+        """Agent should break out when the same tool returns empty results 2+ times."""
+        registry = self._make_registry()
+        ollama = MagicMock()
+        ollama.client = MagicMock()
+
+        call_count = 0
+
+        async def mock_chat(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            resp = MagicMock()
+            resp.message = MagicMock()
+            # Check if this is the summary call
+            messages = kwargs.get("messages", [])
+            user_content = messages[-1].get("content", "") if messages else ""
+            if "Fasse die Ergebnisse" in user_content:
+                resp.message.content = "Leider keine Ergebnisse gefunden."
+                return resp
+            # LLM keeps calling search_media with different params (not identical = no loop detection)
+            if call_count == 1:
+                resp.message.content = '{"action": "mcp.weather.get_current", "parameters": {"entity_id": "Afterburner ZZ Top"}, "reason": "Search"}'
+            else:
+                resp.message.content = '{"action": "mcp.weather.get_current", "parameters": {"entity_id": "Afterburner"}, "reason": "Retry search"}'
+            return resp
+
+        ollama.client.chat = mock_chat
+
+        executor = AsyncMock()
+        # Both calls return empty results (TotalRecordCount: 0)
+        executor.execute = AsyncMock(return_value={
+            "success": True,
+            "message": '{"Items":[],"TotalRecordCount":0}',
+            "action_taken": True,
+        })
+
+        agent = AgentService(registry, max_steps=10)
+        steps = await collect_steps(
+            agent, message="Spiele Afterburner von ZZ Top",
+            ollama=ollama, executor=executor
+        )
+
+        # Should have broken out after 2 empty results
+        step_types = [s.step_type for s in steps]
+        assert "error" in step_types
+        error_steps = [s for s in steps if s.step_type == "error"]
+        assert any("leere Ergebnisse" in s.content or "empty results" in s.content.lower() for s in error_steps)
+        assert steps[-1].step_type == "final_answer"
+        # Should not have used many steps
+        tool_calls = [s for s in steps if s.step_type == "tool_call"]
+        assert len(tool_calls) == 2


### PR DESCRIPTION
## Summary
- Agent no longer loops 5x on `search_media` when Jellyfin returns 0 results for combined "Album Artist" queries
- Adds `_is_empty_result()` heuristic detecting common empty-list patterns (`TotalRecordCount:0`, `items:[]`, etc.)
- Adds per-tool empty-result counter in `AgentContext` — breaks loop after 2 empty results from the same tool
- Adds empty-result prompt rule to all 12 role prompts (6 DE + 6 EN): try shorter query, alternative spelling, different tool
- Adds Jellyfin-specific search tip to media prompts: search album/song name only, verify artist in results

## Test plan
- [x] 14 new unit tests pass (`TestIsEmptyResult`, `TestAgentContextEmptyResultsTracking`)
- [ ] On PRD: "Spiele Afterburner von ZZ Top im Arbeitszimmer" — expect max 2-3 steps instead of 5+
- [ ] Backend logs: verify agent searches "Afterburner" (not "Afterburner ZZ Top"), finds album, plays

🤖 Generated with [Claude Code](https://claude.com/claude-code)