### PR TITLE
feat(media): Bypass agent loop for simple transport commands

### DIFF
--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -10,6 +10,7 @@ This module handles:
 """
 
 import asyncio
+import re
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
 from loguru import logger
@@ -30,6 +31,60 @@ from .shared import (
 )
 
 router = APIRouter()
+
+# ---------------------------------------------------------------------------
+# Media transport shortcut — regex-based, zero LLM calls
+# ---------------------------------------------------------------------------
+
+_MEDIA_TRANSPORT_PATTERNS: list[tuple[re.Pattern, str]] = [
+    # stop
+    (re.compile(
+        r'^(?:stopp?(?:\s+die\s+musik)?|halt|beende\s+die\s+musik|musik\s+aus)(?:\s|$)',
+        re.I | re.UNICODE,
+    ), "stop"),
+    # pause
+    (re.compile(
+        r'^(?:pause|pausiere?)(?:\s|$)',
+        re.I | re.UNICODE,
+    ), "pause"),
+    # resume  (anchor "weiter" only as full word or with "abspielen/spielen")
+    (re.compile(
+        r'^(?:weiter\s*(?:abspielen|spielen)|fortsetzen|resume|play)(?:\s|$)',
+        re.I | re.UNICODE,
+    ), "resume"),
+    # next
+    (re.compile(
+        r'^(?:(?:nächste[rs]?|next)\s+(?:track|lied|song|titel)|skip|überspring(?:en|e)?)(?:\s|$)',
+        re.I | re.UNICODE,
+    ), "next"),
+    # previous
+    (re.compile(
+        r'^(?:(?:vorherige[rs]?|previous)\s+(?:track|lied|song|titel)|zurück)(?:\s|$)',
+        re.I | re.UNICODE,
+    ), "previous"),
+]
+
+_ROOM_PATTERN = re.compile(
+    r'\b(?:im|in\s+(?:der|dem|die|das)?)\s+(\w+)', re.I | re.UNICODE,
+)
+
+
+def _detect_media_transport(message: str) -> tuple[str, str | None] | None:
+    """Detect simple media transport commands (stop/pause/resume/next/previous).
+
+    Returns ``(action, explicit_room_name)`` or ``None`` if the message is not
+    a simple transport command.  ``explicit_room_name`` is ``None`` when no room
+    was mentioned in the message.
+    """
+    text = message.strip()
+    for pattern, action in _MEDIA_TRANSPORT_PATTERNS:
+        if pattern.search(text):
+            # Try to extract an explicit room from the message
+            room_match = _ROOM_PATTERN.search(text)
+            room_name = room_match.group(1) if room_match else None
+            return action, room_name
+    return None
+
 
 # Prevent background tasks from being garbage-collected
 _background_tasks: set[asyncio.Task] = set()
@@ -636,47 +691,75 @@ async def websocket_endpoint(
                     )
 
                 else:
-                    # Specialized agent loop (smart_home, documents, media, research, workflow, general)
-                    agent_used = True
-                    tool_registry = AgentToolRegistry(
-                        mcp_manager=mcp_manager,
-                        server_filter=role.mcp_servers,
-                        internal_filter=role.internal_tools,
-                    )
-                    agent = AgentService(tool_registry, role=role)
-                    executor = ActionExecutor(mcp_manager=mcp_manager)
+                    # === Media Transport Shortcut ===
+                    # Simple stop/pause/resume/next/previous bypass the agent loop entirely.
+                    media_shortcut_handled = False
+                    if role.name == "media":
+                        transport = _detect_media_transport(content)
+                        if transport:
+                            action_name, explicit_room = transport
+                            room = explicit_room or (room_context.get("room_name") if room_context else None)
+                            if room:
+                                from services.internal_tools import InternalToolService
+                                tool_svc = InternalToolService()
+                                result = await tool_svc.execute(
+                                    "internal.media_control",
+                                    {"action": action_name, "room_name": room},
+                                )
+                                intent = {
+                                    "intent": "internal.media_control",
+                                    "parameters": {"action": action_name, "room_name": room},
+                                    "confidence": 1.0,
+                                }
+                                action_result = result
+                                await websocket.send_json({"type": "action", "intent": intent, "result": result})
+                                full_response = result.get("message", "")
+                                await websocket.send_json({"type": "stream", "content": full_response})
+                                logger.info(f"⚡ Media transport shortcut: {action_name} in {room}")
+                                media_shortcut_handled = True
 
-                    agent_tool_results = []
-                    async for step in agent.run(
-                        message=content,
-                        ollama=ollama,
-                        executor=executor,
-                        conversation_history=session_state.conversation_history if session_state.conversation_history else None,
-                        room_context=room_context,
-                        memory_context=memory_context,
-                        document_context=document_context,
-                        user_permissions=user_permissions,
-                        user_id=user_id,
-                    ):
-                        ws_msg = step_to_ws_message(step)
-                        await websocket.send_json(ws_msg)
+                    if not media_shortcut_handled:
+                        # Specialized agent loop (smart_home, documents, media, research, workflow, general)
+                        agent_used = True
+                        tool_registry = AgentToolRegistry(
+                            mcp_manager=mcp_manager,
+                            server_filter=role.mcp_servers,
+                            internal_filter=role.internal_tools,
+                        )
+                        agent = AgentService(tool_registry, role=role)
+                        executor = ActionExecutor(mcp_manager=mcp_manager)
 
-                        if step.step_type == "final_answer":
-                            full_response = step.content
-                        if step.step_type == "tool_result" and step.success and step.data:
-                            agent_tool_results.append((step.tool, step.data))
-                        if step.step_type in ("tool_call", "tool_result"):
-                            agent_steps_count += 1
+                        agent_tool_results = []
+                        async for step in agent.run(
+                            message=content,
+                            ollama=ollama,
+                            executor=executor,
+                            conversation_history=session_state.conversation_history if session_state.conversation_history else None,
+                            room_context=room_context,
+                            memory_context=memory_context,
+                            document_context=document_context,
+                            user_permissions=user_permissions,
+                            user_id=user_id,
+                        ):
+                            ws_msg = step_to_ws_message(step)
+                            await websocket.send_json(ws_msg)
 
-                    # Build action summary from agent tool results for conversation history
-                    if agent_tool_results:
-                        action_result = _build_agent_action_result(agent_tool_results)
+                            if step.step_type == "final_answer":
+                                full_response = step.content
+                            if step.step_type == "tool_result" and step.success and step.data:
+                                agent_tool_results.append((step.tool, step.data))
+                            if step.step_type in ("tool_call", "tool_result"):
+                                agent_steps_count += 1
 
-                    logger.info(f"🤖 Agent [{role.name}] abgeschlossen: {agent_steps_count} Steps")
+                        # Build action summary from agent tool results for conversation history
+                        if agent_tool_results:
+                            action_result = _build_agent_action_result(agent_tool_results)
 
-                    # Set intent info so frontend can show correction button
-                    if not intent:
-                        intent = {"intent": f"agent.{role.name}", "confidence": 1.0, "parameters": {}}
+                        logger.info(f"🤖 Agent [{role.name}] abgeschlossen: {agent_steps_count} Steps")
+
+                        # Set intent info so frontend can show correction button
+                        if not intent:
+                            intent = {"intent": f"agent.{role.name}", "confidence": 1.0, "parameters": {}}
 
             else:
                 # === Legacy Ranked Intent Path (agent_enabled=false or no router) ===

--- a/tests/backend/test_media_transport.py
+++ b/tests/backend/test_media_transport.py
@@ -1,0 +1,185 @@
+"""Tests for media transport shortcut detection.
+
+Tests the regex-based _detect_media_transport() function that allows simple
+media commands (stop, pause, resume, next, previous) to bypass the agent loop.
+
+NOTE: Imports from api.websocket trigger services.database which needs asyncpg.
+We mock missing modules in sys.modules before importing.
+"""
+import sys
+from unittest.mock import MagicMock
+
+_missing_stubs = [
+    "asyncpg", "whisper", "piper", "piper.voice", "speechbrain",
+    "speechbrain.inference", "speechbrain.inference.speaker",
+    "openwakeword", "openwakeword.model",
+]
+for _mod in _missing_stubs:
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+import pytest
+
+from api.websocket.chat_handler import _detect_media_transport
+
+
+# ---------------------------------------------------------------------------
+# Stop variants
+# ---------------------------------------------------------------------------
+
+class TestDetectStop:
+    @pytest.mark.parametrize("msg", [
+        "Stop",
+        "stop",
+        "Stopp",
+        "stopp",
+        "Halt",
+        "Stopp die Musik",
+        "Musik aus",
+        "Beende die Musik",
+    ])
+    def test_stop_variants(self, msg):
+        result = _detect_media_transport(msg)
+        assert result is not None
+        action, room = result
+        assert action == "stop"
+        assert room is None
+
+
+# ---------------------------------------------------------------------------
+# Pause variants
+# ---------------------------------------------------------------------------
+
+class TestDetectPause:
+    @pytest.mark.parametrize("msg", [
+        "Pause",
+        "pause",
+        "Pausiere",
+        "pausiere",
+    ])
+    def test_pause_variants(self, msg):
+        result = _detect_media_transport(msg)
+        assert result is not None
+        action, room = result
+        assert action == "pause"
+        assert room is None
+
+
+# ---------------------------------------------------------------------------
+# Resume variants
+# ---------------------------------------------------------------------------
+
+class TestDetectResume:
+    @pytest.mark.parametrize("msg", [
+        "Weiter abspielen",
+        "weiter abspielen",
+        "Weiter spielen",
+        "Fortsetzen",
+        "fortsetzen",
+        "Resume",
+        "resume",
+        "Play",
+        "play",
+    ])
+    def test_resume_variants(self, msg):
+        result = _detect_media_transport(msg)
+        assert result is not None
+        action, room = result
+        assert action == "resume"
+        assert room is None
+
+
+# ---------------------------------------------------------------------------
+# Next track variants
+# ---------------------------------------------------------------------------
+
+class TestDetectNext:
+    @pytest.mark.parametrize("msg", [
+        "Nächster Track",
+        "nächster track",
+        "Nächstes Lied",
+        "Nächster Song",
+        "Nächster Titel",
+        "Next Track",
+        "Skip",
+        "skip",
+        "Überspringen",
+        "überspringe",
+    ])
+    def test_next_variants(self, msg):
+        result = _detect_media_transport(msg)
+        assert result is not None
+        action, room = result
+        assert action == "next"
+        assert room is None
+
+
+# ---------------------------------------------------------------------------
+# Previous track variants
+# ---------------------------------------------------------------------------
+
+class TestDetectPrevious:
+    @pytest.mark.parametrize("msg", [
+        "Vorheriger Track",
+        "vorheriger track",
+        "Vorheriges Lied",
+        "Vorheriger Song",
+        "Vorheriger Titel",
+        "Previous Track",
+        "Zurück",
+        "zurück",
+    ])
+    def test_previous_variants(self, msg):
+        result = _detect_media_transport(msg)
+        assert result is not None
+        action, room = result
+        assert action == "previous"
+        assert room is None
+
+
+# ---------------------------------------------------------------------------
+# Room extraction
+# ---------------------------------------------------------------------------
+
+class TestRoomExtraction:
+    def test_stop_with_room_im(self):
+        result = _detect_media_transport("Stop im Arbeitszimmer")
+        assert result == ("stop", "Arbeitszimmer")
+
+    def test_stop_with_room_in_der(self):
+        result = _detect_media_transport("Stopp in der Küche")
+        assert result == ("stop", "Küche")
+
+    def test_pause_with_room_in_dem(self):
+        result = _detect_media_transport("Pause in dem Bad")
+        assert result == ("pause", "Bad")
+
+    def test_next_with_room(self):
+        result = _detect_media_transport("Nächster Track im Wohnzimmer")
+        assert result == ("next", "Wohnzimmer")
+
+    def test_musik_aus_with_room(self):
+        result = _detect_media_transport("Musik aus im Schlafzimmer")
+        assert result == ("stop", "Schlafzimmer")
+
+
+# ---------------------------------------------------------------------------
+# Negative cases — must NOT match
+# ---------------------------------------------------------------------------
+
+class TestNoMatch:
+    @pytest.mark.parametrize("msg", [
+        "Spiele Afterburner von ZZ Top",
+        "Spiele Musik im Arbeitszimmer",
+        "Was läuft gerade?",
+        "Wie wird das Wetter morgen?",
+        "Schalte das Licht ein",
+        "Suche nach Rock Musik",
+        "Spiele den nächsten Song von Queen",
+        "Welcher Track ist das?",
+        "Stoppe den Timer",
+        "",
+    ])
+    def test_no_match(self, msg):
+        result = _detect_media_transport(msg)
+        assert result is None


### PR DESCRIPTION
## Summary

- Simple media transport commands (stop, pause, resume, next, previous) now bypass the full agent loop via regex-based detection in `chat_handler.py`
- Reduces latency from ~5s (3 LLM calls: Router + Agent Reasoning + Final Answer) to <1s (direct `internal.media_control` call)
- Falls through to the agent loop when no transport match or no room context is available

## Changes

| File | Change |
|---|---|
| `src/backend/api/websocket/chat_handler.py` | `_detect_media_transport()` function + transport shortcut in routing |
| `tests/backend/test_media_transport.py` | 54 tests for detection patterns, room extraction, and negative cases |

## How it works

1. Router classifies message as `media` role (existing behavior)
2. **New:** `_detect_media_transport()` checks if it's a simple transport command
3. If match + room available → direct `InternalToolService.execute("internal.media_control", ...)` — zero LLM calls
4. If no match or no room → falls through to full agent loop (existing behavior)

## Test plan

- [x] `python3 -m pytest tests/backend/test_media_transport.py` — 54/54 pass
- [x] `python3 -m pytest tests/backend/test_ws_chat_integration.py` — 42/42 pass (no regressions)
- [x] `ruff check` — clean
- [ ] PRD: "Spiele Afterburner von ZZ Top im Arbeitszimmer" → Agent Loop (wie bisher)
- [ ] PRD: "Stop" nach Abspielen → Direkt-Ausführung in <2s
- [ ] PRD: "Nächster Track" → Direkt-Ausführung
- [ ] Backend-Logs: `⚡ Media transport shortcut` statt `🤖 Agent [media]`

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)