### PR TITLE
feat(chat): Render album art images inline in chat messages

### DIFF
--- a/src/frontend/src/pages/ChatPage/ChatMessages.jsx
+++ b/src/frontend/src/pages/ChatPage/ChatMessages.jsx
@@ -6,6 +6,49 @@ import AttachmentQuickActions from './AttachmentQuickActions';
 import EmailForwardDialog from './EmailForwardDialog';
 import { useChatContext } from './context/ChatContext';
 
+function renderMessageContent(text) {
+  const imageUrlPattern = /https?:\/\/[^\s]+?\/Items\/[^\s]+?\/Images\/[^\s]+|https?:\/\/[^\s]+\.(?:jpg|jpeg|png|gif|webp)(?:\?[^\s]*)?/gi;
+
+  const parts = [];
+  let lastIndex = 0;
+  let match;
+
+  while ((match = imageUrlPattern.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push({ type: 'text', content: text.slice(lastIndex, match.index) });
+    }
+    parts.push({ type: 'image', url: match[0] });
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    parts.push({ type: 'text', content: text.slice(lastIndex) });
+  }
+
+  if (parts.length === 1 && parts[0].type === 'text') {
+    return <p className="whitespace-pre-wrap">{text}</p>;
+  }
+
+  return (
+    <div className="whitespace-pre-wrap">
+      {parts.map((part, i) =>
+        part.type === 'image' ? (
+          <img
+            key={i}
+            src={part.url}
+            alt="Album Art"
+            className="rounded-lg max-w-[200px] max-h-[200px] my-2 shadow-md"
+            loading="lazy"
+            onError={(e) => { e.target.style.display = 'none'; }}
+          />
+        ) : (
+          <span key={i}>{part.content}</span>
+        )
+      )}
+    </div>
+  );
+}
+
 export default function ChatMessages() {
   const { t } = useTranslation();
   const {
@@ -123,7 +166,7 @@ export default function ChatMessages() {
               );
             })()}
 
-            <p className="whitespace-pre-wrap">{message.content}</p>
+            {message.role === 'assistant' ? renderMessageContent(message.content) : <p className="whitespace-pre-wrap">{message.content}</p>}
 
             {/* Attachment chips */}
             {message.attachments && message.attachments.length > 0 && (

--- a/src/frontend/src/pages/ChatPage/context/ChatContext.jsx
+++ b/src/frontend/src/pages/ChatPage/context/ChatContext.jsx
@@ -390,7 +390,7 @@ export function ChatProvider({ children }) {
     setMessages(prev => {
       const lastMsg = prev[prev.length - 1];
       if (lastMsg && lastMsg.role === 'assistant' && lastMsg.streaming) {
-        const steps = [...(lastMsg.agentSteps || []), { type: 'tool_result', step: data.step, tool: data.tool, success: data.success, message: data.message }];
+        const steps = [...(lastMsg.agentSteps || []), { type: 'tool_result', step: data.step, tool: data.tool, success: data.success, message: data.message, data: data.data }];
         return [...prev.slice(0, -1), { ...lastMsg, agentSteps: steps }];
       }
       return prev;


### PR DESCRIPTION
## Summary
- Detect Jellyfin image URLs (`/Items/.../Images/...`) and common image extensions (`.jpg`, `.png`, `.gif`, `.webp`) in assistant messages and render them as `<img>` tags instead of plain text
- Persist `data` field from `agent_tool_result` WebSocket messages in agent steps state for future use
- Images styled with `max-w-[200px]`, `rounded-lg`, `shadow-md`; broken images auto-hidden via `onError`

Closes #232

## Test plan
- [x] `make test-frontend-react` — 313/313 tests pass
- [ ] "Spiele Afterburner von ZZ Top im Arbeitszimmer" → Album-Cover als Bild in der Chat-Antwort
- [ ] Normale Textnachrichten ohne URLs → unverändert
- [ ] Nachricht mit ungültiger Bild-URL → kein broken-image-Icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)