### PR TITLE
feat(media): Add Media Follow Me — playback follows user between rooms (#240)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,6 +368,27 @@ Voice/auth presence bypasses BLE hysteresis — a single interaction moves the u
 
 When `PRESENCE_ENABLED=false`, only `public` notifications get TTS. Web notifications are always delivered regardless of privacy level. Calendar MCP derives privacy from `visibility: owner` → `confidential`, `visibility: shared` → `personal`.
 
+### Media Follow Me
+
+Opt-in feature (`MEDIA_FOLLOW_ENABLED=true`, requires `PRESENCE_ENABLED=true`) that makes media playback follow users between rooms. When a user leaves a room with active playback, the music suspends and resumes in the new room after a configurable delay.
+
+- **Session Tracking:** In-memory `MediaFollowService` singleton tracks `MediaSession` per user (type, URL, station, album, room)
+- **Media Types:** `single_url` (HA play_media), `dlna_album` (DLNA queue), `radio` (TuneIn stream)
+- **Conflict Resolution:** Room owner > Role priority (`Role.priority`, lower=higher) > First-come
+- **Per-User Opt-out:** `User.media_follow_enabled` (default: true)
+- **Room Owner:** `Room.owner_id` (nullable FK → users) — set via `PATCH /api/rooms/{id}/owner`
+- **Hooks:** `presence_leave_room` (suspend), `presence_enter_room` (resume), `presence_last_left` (safety stop)
+- **Playback Registration:** `InternalToolService._play_in_room`, `_play_radio`, `_play_album_on_dlna` register sessions; `_media_control(stop)` clears them.
+
+**Key files:** `services/media_follow_service.py`, `services/internal_tools.py` (registration), `api/lifecycle.py` (hook setup), `api/routes/rooms.py` (owner endpoint)
+
+**Configuration:**
+```bash
+MEDIA_FOLLOW_ENABLED=false               # Master switch (requires PRESENCE_ENABLED=true)
+MEDIA_FOLLOW_SUSPEND_TIMEOUT=600.0       # Seconds before suspended session expires
+MEDIA_FOLLOW_RESUME_DELAY=2.0            # Delay before resuming in new room
+```
+
 ### Device Management
 
 Multiple device types (satellite, web_panel, web_tablet, web_browser, web_kiosk) connect via `/ws/device`. IP-based room detection for stationary devices provides automatic room context:
@@ -481,6 +502,9 @@ All configuration via `.env`, loaded by `src/backend/utils/config.py` (Pydantic 
 - `PRESENCE_HOUSEHOLD_ROLES` — Comma-separated role names considered household members for privacy TTS (default: `"Admin,Familie"`)
 - `PRESENCE_WEBHOOK_URL` — URL to POST presence events to (empty = disabled). Supports n8n webhook triggers (default: `""`)
 - `PRESENCE_WEBHOOK_SECRET` — Shared secret sent as X-Webhook-Secret header for webhook authentication (default: `""`)
+- `MEDIA_FOLLOW_ENABLED` — Media playback follows user between rooms (default: `false`, opt-in). Requires `PRESENCE_ENABLED=true`.
+- `MEDIA_FOLLOW_SUSPEND_TIMEOUT` — Seconds before suspended media session expires (default: `600.0`)
+- `MEDIA_FOLLOW_RESUME_DELAY` — Delay before resuming playback in new room (default: `2.0`)
 - `PAPERLESS_AUDIT_ENABLED` — Automated document metadata audit using local LLMs (default: `false`, opt-in). Requires `PAPERLESS_ENABLED=true`.
 - `KNOWLEDGE_GRAPH_ENABLED` — Entity-relation triples extracted from conversations via LLM (default: `false`, opt-in)
 - `METRICS_ENABLED` — Prometheus `/metrics` endpoint (default: `false`, opt-in)

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -368,6 +368,23 @@ ble:
 
 ---
 
+### Media Follow Me
+
+```bash
+# Playback folgt dem User zwischen Räumen (erfordert PRESENCE_ENABLED=true)
+MEDIA_FOLLOW_ENABLED=false
+MEDIA_FOLLOW_SUSPEND_TIMEOUT=600.0       # Sekunden bis suspendierte Session verfällt
+MEDIA_FOLLOW_RESUME_DELAY=2.0            # Verzögerung vor Resume im neuen Raum (Sekunden)
+```
+
+**Funktionsweise:** Wenn ein User Radio im Arbeitszimmer abspielt und ins Wohnzimmer geht, stoppt die Musik im Arbeitszimmer und wird im Wohnzimmer fortgesetzt. Bei Konflikten (anderer User spielt bereits): Room-Owner > Rollen-Priorität (Admin > Familie > Gast) > First-Come.
+
+**Per-User Opt-out:** Jeder User hat ein `media_follow_enabled` Flag (default: true). Kann in der Admin-UI deaktiviert werden.
+
+**Room Owner:** `PATCH /api/rooms/{id}/owner` setzt den Raum-Besitzer (für Konflikt-Priorisierung).
+
+---
+
 ### RAG (Wissensspeicher)
 
 ```bash

--- a/src/backend/alembic/versions/s3b4c5d6e7f8_add_media_follow_fields.py
+++ b/src/backend/alembic/versions/s3b4c5d6e7f8_add_media_follow_fields.py
@@ -1,0 +1,39 @@
+"""add media follow fields
+
+Revision ID: s3b4c5d6e7f8
+Revises: r2a3d4i5o6f7
+Create Date: 2026-02-22 18:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 's3b4c5d6e7f8'
+down_revision: Union[str, None] = 'r2a3d4i5o6f7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Room owner for Media Follow Me conflict resolution
+    op.add_column('rooms', sa.Column('owner_id', sa.Integer(), sa.ForeignKey('users.id'), nullable=True))
+
+    # Per-user Media Follow Me opt-out
+    op.add_column('users', sa.Column('media_follow_enabled', sa.Boolean(), nullable=False, server_default='true'))
+
+    # Role priority for conflict resolution (lower = higher priority)
+    op.add_column('roles', sa.Column('priority', sa.Integer(), nullable=False, server_default='100'))
+
+    # Set default priorities for existing system roles
+    op.execute("UPDATE roles SET priority = 10 WHERE name = 'Admin'")
+    op.execute("UPDATE roles SET priority = 50 WHERE name = 'Familie'")
+    op.execute("UPDATE roles SET priority = 90 WHERE name = 'Gast'")
+
+
+def downgrade() -> None:
+    op.drop_column('roles', 'priority')
+    op.drop_column('users', 'media_follow_enabled')
+    op.drop_column('rooms', 'owner_id')

--- a/src/backend/api/lifecycle.py
+++ b/src/backend/api/lifecycle.py
@@ -542,6 +542,17 @@ async def lifespan(app: "FastAPI"):
             for room in rooms:
                 presence_svc.set_room_name(room.id, room.name)
 
+    # Media Follow Me hooks (requires both presence and media_follow enabled)
+    if settings.media_follow_enabled and settings.presence_enabled:
+        from services.media_follow_service import get_media_follow_service
+        from utils.hooks import register_hook
+
+        mf_service = get_media_follow_service()
+        register_hook("presence_leave_room", mf_service.on_user_leave_room)
+        register_hook("presence_enter_room", mf_service.on_user_enter_room)
+        register_hook("presence_last_left", mf_service.on_last_left)
+        logger.info("✅ Media Follow Me hooks registered")
+
     # Knowledge Graph hooks
     if settings.knowledge_graph_enabled:
         from services.knowledge_graph_service import (

--- a/src/backend/api/routes/rooms.py
+++ b/src/backend/api/routes/rooms.py
@@ -118,6 +118,29 @@ async def update_room(
     return service.room_to_dict(room)
 
 
+@router.patch("/{room_id}/owner")
+async def set_room_owner(
+    room_id: int,
+    owner_id: int | None = None,
+    db: AsyncSession = Depends(get_db),
+):
+    """Set or clear the owner of a room (for Media Follow Me conflict resolution)."""
+    from models.database import Room, User
+
+    room = await db.get(Room, room_id)
+    if not room:
+        raise HTTPException(status_code=404, detail="Room not found")
+
+    if owner_id is not None:
+        user = await db.get(User, owner_id)
+        if not user:
+            raise HTTPException(status_code=404, detail="User not found")
+
+    room.owner_id = owner_id
+    await db.commit()
+    return {"room_id": room_id, "owner_id": owner_id}
+
+
 @router.delete("/{room_id}")
 async def delete_room(
     room_id: int,

--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -147,6 +147,10 @@ class Room(Base):
     ha_area_id = Column(String(100), nullable=True, unique=True, index=True)
     source = Column(String(20), default="renfield")  # renfield/homeassistant/satellite/device
 
+    # Room owner (for Media Follow Me conflict resolution)
+    owner_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    owner = relationship("User", foreign_keys="Room.owner_id")
+
     # Metadata
     icon = Column(String(50), nullable=True)  # "mdi:sofa"
 
@@ -589,6 +593,10 @@ class Role(Base):
     # System roles cannot be deleted
     is_system = Column(Boolean, default=False, nullable=False)
 
+    # Priority for conflict resolution (lower = higher priority)
+    # Admin=10, Familie=50, Gast=90, new roles=100
+    priority = Column(Integer, default=100, nullable=False, server_default="100")
+
     # Timestamps
     created_at = Column(DateTime, default=_utcnow)
     updated_at = Column(DateTime, default=_utcnow, onupdate=_utcnow)
@@ -632,6 +640,7 @@ class User(Base):
 
     # User preferences
     preferred_language = Column(String(10), default="de", nullable=False)
+    media_follow_enabled = Column(Boolean, default=True, nullable=False, server_default="true")
 
     # Optional link to Speaker for voice authentication
     speaker_id = Column(Integer, ForeignKey("speakers.id"), nullable=True, unique=True)

--- a/src/backend/services/internal_tools.py
+++ b/src/backend/services/internal_tools.py
@@ -261,6 +261,51 @@ class InternalToolService:
                 "action_taken": False,
             }
 
+    async def _get_room_id(self, room_name: str) -> int | None:
+        """Resolve room_name → room_id via RoomService."""
+        try:
+            from services.database import AsyncSessionLocal
+            from services.room_service import RoomService
+
+            async with AsyncSessionLocal() as db:
+                rs = RoomService(db)
+                room = await rs.get_room_by_name(room_name)
+                if not room:
+                    room = await rs.get_room_by_alias(room_name)
+                return room.id if room else None
+        except Exception:
+            return None
+
+    async def _register_media_follow(
+        self, params: dict, room_name: str, media_type, **kwargs
+    ) -> None:
+        """Register playback with MediaFollowService if enabled (async version)."""
+        from utils.config import settings as _settings
+
+        if not _settings.media_follow_enabled:
+            return
+        user_id = params.get("user_id")
+        if not user_id:
+            return
+        try:
+            from services.media_follow_service import MediaType, get_media_follow_service
+
+            mf = get_media_follow_service()
+            # Convert string to enum if needed
+            if isinstance(media_type, str):
+                media_type = MediaType(media_type)
+            rid = await self._get_room_id(room_name)
+            if rid is not None:
+                mf.register_playback(
+                    user_id=int(user_id),
+                    room_id=rid,
+                    room_name=room_name,
+                    media_type=media_type,
+                    **kwargs,
+                )
+        except Exception as e:
+            logger.debug(f"Media follow registration failed: {e}")
+
     async def _play_in_room(self, params: dict) -> dict:
         """
         Play a media URL on the audio device in a room.
@@ -358,6 +403,10 @@ class InternalToolService:
             player_state = (state or {}).get("state", "unknown")
 
             if player_state in ("playing", "buffering", "paused"):
+                await self._register_media_follow(
+                    params, resolved_room_name, "single_url",
+                    media_url=media_url, title=title, thumb=thumb,
+                )
                 return {
                     "success": True,
                     "message": f"Playing on {device_name} in {resolved_room_name}",
@@ -410,6 +459,10 @@ class InternalToolService:
                 player_state = (state or {}).get("state", "unknown")
 
                 if player_state in ("playing", "buffering", "paused"):
+                    await self._register_media_follow(
+                        params, resolved_room_name, "single_url",
+                        media_url=transcode_url, title=title, thumb=thumb,
+                    )
                     return {
                         "success": True,
                         "message": f"Playing (transcoded) on {device_name} in {resolved_room_name}",
@@ -500,8 +553,24 @@ class InternalToolService:
         target_type = device_data.get("target_type", "homeassistant")
 
         if target_type == "dlna":
-            return await self._media_control_dlna(action, device_data, resolved_room_name, params)
-        return await self._media_control_ha(action, device_data, resolved_room_name, params)
+            result = await self._media_control_dlna(action, device_data, resolved_room_name, params)
+        else:
+            result = await self._media_control_ha(action, device_data, resolved_room_name, params)
+
+        # Clear media follow session on explicit stop
+        if action == "stop" and result.get("success"):
+            from utils.config import settings as _settings
+            if _settings.media_follow_enabled:
+                try:
+                    from services.media_follow_service import get_media_follow_service
+                    mf = get_media_follow_service()
+                    room_id = await self._get_room_id(resolved_room_name)
+                    if room_id is not None:
+                        mf.clear_session_by_room(room_id)
+                except Exception:
+                    pass
+
+        return result
 
     async def _media_control_dlna(self, action: str, device_data: dict, room_name: str, params: dict) -> dict:
         """Execute media control action on a DLNA renderer via MCP."""
@@ -767,6 +836,16 @@ class InternalToolService:
 
             album_name = album_title or (jellyfin_tracks[0].get("album", "Unknown Album") if jellyfin_tracks else "Unknown")
             artist_name = jellyfin_tracks[0].get("artist", "Unknown Artist") if jellyfin_tracks else "Unknown"
+
+            # Resolve the room name for media follow (might come from renderer_name or room_name param)
+            follow_room = room_name or renderer_name
+            await self._register_media_follow(
+                params, follow_room, "dlna_album",
+                album_id=album_id, album_name=album_name,
+                renderer_name=renderer_name,
+                total_tracks=len(dlna_tracks),
+                title=f"{album_name} - {artist_name}",
+            )
 
             return {
                 "success": True,
@@ -1060,6 +1139,11 @@ class InternalToolService:
                         "message": f"DLNA playback failed: {dlna_result.get('message', 'unknown error')}",
                         "action_taken": False,
                     }
+                await self._register_media_follow(
+                    params, resolved_room, "radio",
+                    media_url=stream_url, station_id=station_id,
+                    station_name=station_name,
+                )
                 return {
                     "success": True,
                     "message": f"Playing '{display_name}' in {resolved_room}",
@@ -1073,6 +1157,7 @@ class InternalToolService:
                     "room_name": room_name,
                     "media_type": "music",
                     "force": str(force).lower(),
+                    "user_id": params.get("user_id"),
                 }
                 if station_name:
                     play_params["title"] = station_name
@@ -1081,8 +1166,15 @@ class InternalToolService:
 
                 result = await self._play_in_room(play_params)
 
-                if result.get("success") and station_name:
-                    result["message"] = f"Playing '{station_name}' in {resolved_room}"
+                if result.get("success"):
+                    # Re-register as radio (not single_url) with station metadata
+                    await self._register_media_follow(
+                        params, resolved_room, "radio",
+                        media_url=stream_url, station_id=station_id,
+                        station_name=station_name,
+                    )
+                    if station_name:
+                        result["message"] = f"Playing '{station_name}' in {resolved_room}"
 
                 return result
 

--- a/src/backend/services/media_follow_service.py
+++ b/src/backend/services/media_follow_service.py
@@ -1,0 +1,435 @@
+"""
+Media Follow Me — Playback follows the user between rooms.
+
+Tracks active media sessions per user and handles presence hooks to
+suspend/resume playback as users move between rooms.
+
+Requires: MEDIA_FOLLOW_ENABLED=true AND PRESENCE_ENABLED=true
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+
+from loguru import logger
+
+from utils.config import settings
+
+
+class MediaType(str, Enum):
+    SINGLE_URL = "single_url"      # HA media_player.play_media
+    DLNA_ALBUM = "dlna_album"      # DLNA play_tracks (album queue)
+    RADIO = "radio"                # Radio stream (TuneIn)
+
+
+class SessionState(str, Enum):
+    PLAYING = "playing"
+    SUSPENDED = "suspended"
+
+
+@dataclass
+class MediaSession:
+    user_id: int
+    room_id: int
+    room_name: str
+    media_type: MediaType
+    state: SessionState = SessionState.PLAYING
+
+    # Playback data
+    media_url: str | None = None
+    station_id: str | None = None
+    station_name: str | None = None
+    album_id: str | None = None
+    album_name: str | None = None
+    renderer_name: str | None = None
+    current_track: int | None = None       # 1-based
+    total_tracks: int | None = None
+    title: str | None = None
+    thumb: str | None = None
+
+    # Timestamps
+    started_at: float = field(default_factory=time.time)
+    suspended_at: float | None = None
+
+
+class MediaFollowService:
+    """In-memory singleton that tracks media sessions and handles room transitions."""
+
+    def __init__(self) -> None:
+        self._sessions: dict[int, MediaSession] = {}   # user_id → session
+
+    # ------------------------------------------------------------------
+    # Playback Registration (called by InternalToolService)
+    # ------------------------------------------------------------------
+
+    def register_playback(
+        self,
+        user_id: int,
+        room_id: int,
+        room_name: str,
+        media_type: MediaType,
+        **kwargs,
+    ) -> None:
+        """Register a new media playback session for a user."""
+        session = MediaSession(
+            user_id=user_id,
+            room_id=room_id,
+            room_name=room_name,
+            media_type=media_type,
+            media_url=kwargs.get("media_url"),
+            station_id=kwargs.get("station_id"),
+            station_name=kwargs.get("station_name"),
+            album_id=kwargs.get("album_id"),
+            album_name=kwargs.get("album_name"),
+            renderer_name=kwargs.get("renderer_name"),
+            current_track=kwargs.get("current_track"),
+            total_tracks=kwargs.get("total_tracks"),
+            title=kwargs.get("title"),
+            thumb=kwargs.get("thumb"),
+        )
+        self._sessions[user_id] = session
+        logger.info(
+            f"🎵 Media session registered: user={user_id} "
+            f"type={media_type.value} room={room_name}"
+        )
+
+    def clear_session(self, user_id: int) -> None:
+        """Remove a user's media session."""
+        removed = self._sessions.pop(user_id, None)
+        if removed:
+            logger.debug(f"🎵 Media session cleared: user={user_id}")
+
+    def clear_session_by_room(self, room_id: int) -> None:
+        """Clear all sessions in a given room (e.g. on explicit stop)."""
+        to_remove = [
+            uid for uid, s in self._sessions.items()
+            if s.room_id == room_id and s.state == SessionState.PLAYING
+        ]
+        for uid in to_remove:
+            self._sessions.pop(uid, None)
+            logger.debug(f"🎵 Media session cleared by room stop: user={uid} room_id={room_id}")
+
+    def get_session(self, user_id: int) -> MediaSession | None:
+        return self._sessions.get(user_id)
+
+    # ------------------------------------------------------------------
+    # Presence Hook Handlers
+    # ------------------------------------------------------------------
+
+    async def on_user_leave_room(
+        self, user_id: int, room_id: int, room_name: str, **kw
+    ) -> None:
+        """Called when a user leaves a room (presence hook)."""
+        session = self._sessions.get(user_id)
+        if not session or session.room_id != room_id:
+            return
+        if session.state != SessionState.PLAYING:
+            return
+
+        # Check per-user opt-in
+        if not await self._is_user_opted_in(user_id):
+            logger.debug(f"🎵 User {user_id} has media_follow disabled, clearing session")
+            self.clear_session(user_id)
+            return
+
+        # Suspend: stop playback, mark session
+        logger.info(
+            f"🎵 User {user_id} left {room_name} — suspending "
+            f"'{session.title or session.station_name or session.album_name}'"
+        )
+        await self._stop_playback(session)
+        session.state = SessionState.SUSPENDED
+        session.suspended_at = time.time()
+
+    async def on_user_enter_room(
+        self, user_id: int, room_id: int, room_name: str, **kw
+    ) -> None:
+        """Called when a user enters a room (presence hook)."""
+        session = self._sessions.get(user_id)
+        if not session or session.state != SessionState.SUSPENDED:
+            return
+
+        # Cleanup expired sessions
+        self._cleanup_expired_sessions()
+        # Re-check after cleanup
+        session = self._sessions.get(user_id)
+        if not session or session.state != SessionState.SUSPENDED:
+            return
+
+        # Check for conflict: another user playing in this room
+        existing_user_id = self._find_playing_user_in_room(room_id)
+
+        if existing_user_id is not None:
+            winner = await self._resolve_conflict(user_id, existing_user_id, room_id)
+            if winner == existing_user_id:
+                # Entering user loses — keep session suspended
+                logger.info(
+                    f"🎵 Conflict in {room_name}: user {existing_user_id} wins, "
+                    f"user {user_id} stays suspended"
+                )
+                return
+            else:
+                # Entering user wins — suspend existing
+                existing_session = self._sessions.get(existing_user_id)
+                if existing_session:
+                    logger.info(
+                        f"🎵 Conflict in {room_name}: user {user_id} wins, "
+                        f"suspending user {existing_user_id}"
+                    )
+                    await self._stop_playback(existing_session)
+                    existing_session.state = SessionState.SUSPENDED
+                    existing_session.suspended_at = time.time()
+
+        # Resume in new room
+        logger.info(
+            f"🎵 User {user_id} entered {room_name} — resuming "
+            f"'{session.title or session.station_name or session.album_name}'"
+        )
+
+        if settings.media_follow_resume_delay > 0:
+            await asyncio.sleep(settings.media_follow_resume_delay)
+
+        await self._resume_playback(session, room_id, room_name)
+
+    async def on_last_left(self, room_id: int, room_name: str, **kw) -> None:
+        """Safety net: stop all playback when the last user leaves a room."""
+        to_stop = [
+            s for s in self._sessions.values()
+            if s.room_id == room_id and s.state == SessionState.PLAYING
+        ]
+        for session in to_stop:
+            logger.info(
+                f"🎵 Last user left {room_name} — stopping playback for user {session.user_id}"
+            )
+            await self._stop_playback(session)
+            session.state = SessionState.SUSPENDED
+            session.suspended_at = time.time()
+
+    # ------------------------------------------------------------------
+    # Internal: Stop / Resume
+    # ------------------------------------------------------------------
+
+    async def _stop_playback(self, session: MediaSession) -> None:
+        """Stop current playback via MCP/HA."""
+        try:
+            from services.internal_tools import InternalToolService
+
+            svc = InternalToolService()
+            result = await svc._media_control({
+                "action": "stop",
+                "room_name": session.room_name,
+                "force": "true",
+            })
+            if not result.get("success"):
+                logger.warning(
+                    f"🎵 Stop playback failed in {session.room_name}: "
+                    f"{result.get('message')}"
+                )
+        except Exception as e:
+            logger.error(f"🎵 Error stopping playback in {session.room_name}: {e}")
+
+    async def _resume_playback(
+        self, session: MediaSession, new_room_id: int, new_room_name: str
+    ) -> None:
+        """Resume playback in a new room."""
+        try:
+            from services.internal_tools import InternalToolService
+
+            svc = InternalToolService()
+            result: dict = {}
+
+            if session.media_type == MediaType.RADIO:
+                if session.station_id:
+                    result = await svc._play_radio({
+                        "station_id": session.station_id,
+                        "room_name": new_room_name,
+                        "station_name": session.station_name or "",
+                        "force": "true",
+                    })
+                elif session.media_url:
+                    result = await svc._play_in_room({
+                        "media_url": session.media_url,
+                        "room_name": new_room_name,
+                        "title": session.station_name or session.title or "",
+                        "force": "true",
+                    })
+
+            elif session.media_type == MediaType.SINGLE_URL:
+                if session.media_url:
+                    result = await svc._play_in_room({
+                        "media_url": session.media_url,
+                        "room_name": new_room_name,
+                        "title": session.title or "",
+                        "thumb": session.thumb or "",
+                        "force": "true",
+                    })
+
+            elif session.media_type == MediaType.DLNA_ALBUM:
+                if session.album_id:
+                    result = await svc._play_album_on_dlna({
+                        "album_id": session.album_id,
+                        "room_name": new_room_name,
+                        "album_name": session.album_name or "",
+                    })
+
+            if result.get("success"):
+                session.room_id = new_room_id
+                session.room_name = new_room_name
+                session.state = SessionState.PLAYING
+                session.suspended_at = None
+                logger.info(f"🎵 Resumed playback for user {session.user_id} in {new_room_name}")
+
+                # Notify user via WebSocket
+                await self._notify_user(
+                    session.user_id,
+                    new_room_name,
+                    session.title or session.station_name or session.album_name or "Media",
+                )
+            else:
+                logger.warning(
+                    f"🎵 Resume failed for user {session.user_id} in {new_room_name}: "
+                    f"{result.get('message', 'unknown error')}"
+                )
+
+        except Exception as e:
+            logger.error(f"🎵 Error resuming playback in {new_room_name}: {e}")
+
+    # ------------------------------------------------------------------
+    # Internal: Conflict Resolution
+    # ------------------------------------------------------------------
+
+    async def _resolve_conflict(
+        self, entering_user_id: int, existing_user_id: int, room_id: int
+    ) -> int:
+        """
+        Determine whose media should play. Returns the winner's user_id.
+
+        Priority: Room owner > Role priority (lower=higher) > First-come.
+        """
+        # 1. Room owner always wins
+        owner_id = await self._get_room_owner_id(room_id)
+        if owner_id == entering_user_id:
+            return entering_user_id
+        if owner_id == existing_user_id:
+            return existing_user_id
+
+        # 2. Higher role priority wins (lower number = higher priority)
+        entering_prio = await self._get_role_priority(entering_user_id)
+        existing_prio = await self._get_role_priority(existing_user_id)
+        if entering_prio < existing_prio:
+            return entering_user_id
+        if existing_prio < entering_prio:
+            return existing_user_id
+
+        # 3. Equal: first-come keeps media
+        return existing_user_id
+
+    # ------------------------------------------------------------------
+    # Internal: DB Lookups
+    # ------------------------------------------------------------------
+
+    async def _is_user_opted_in(self, user_id: int) -> bool:
+        """Check if user has media_follow_enabled."""
+        try:
+            from models.database import User
+            from services.database import AsyncSessionLocal
+
+            async with AsyncSessionLocal() as db:
+                user = await db.get(User, user_id)
+                if user is None:
+                    return False
+                return bool(user.media_follow_enabled)
+        except Exception:
+            logger.exception(f"🎵 Error checking media_follow opt-in for user {user_id}")
+            return False
+
+    async def _get_role_priority(self, user_id: int) -> int:
+        """Lookup role priority. Returns 100 (lowest) on failure."""
+        try:
+            from models.database import Role, User
+            from services.database import AsyncSessionLocal
+
+            async with AsyncSessionLocal() as db:
+                user = await db.get(User, user_id)
+                if user and user.role_id:
+                    role = await db.get(Role, user.role_id)
+                    if role:
+                        return role.priority
+        except Exception:
+            logger.exception(f"🎵 Error looking up role priority for user {user_id}")
+        return 100
+
+    async def _get_room_owner_id(self, room_id: int) -> int | None:
+        """Get room owner_id. Returns None if no owner set."""
+        try:
+            from models.database import Room
+            from services.database import AsyncSessionLocal
+
+            async with AsyncSessionLocal() as db:
+                room = await db.get(Room, room_id)
+                return room.owner_id if room else None
+        except Exception:
+            logger.exception(f"🎵 Error looking up room owner for room {room_id}")
+            return None
+
+    # ------------------------------------------------------------------
+    # Internal: Helpers
+    # ------------------------------------------------------------------
+
+    def _find_playing_user_in_room(self, room_id: int) -> int | None:
+        """Find user_id of someone actively playing in a room."""
+        for uid, s in self._sessions.items():
+            if s.room_id == room_id and s.state == SessionState.PLAYING:
+                return uid
+        return None
+
+    def _cleanup_expired_sessions(self) -> None:
+        """Remove suspended sessions that have exceeded the timeout."""
+        now = time.time()
+        timeout = settings.media_follow_suspend_timeout
+        expired = [
+            uid for uid, s in self._sessions.items()
+            if s.state == SessionState.SUSPENDED
+            and s.suspended_at is not None
+            and (now - s.suspended_at) > timeout
+        ]
+        for uid in expired:
+            logger.debug(f"🎵 Session expired for user {uid} (timeout={timeout}s)")
+            self._sessions.pop(uid, None)
+
+    async def _notify_user(
+        self, user_id: int, room_name: str, media_title: str
+    ) -> None:
+        """Send an info notification to the user via Device WebSocket."""
+        try:
+            from services.device_manager import get_device_manager
+
+            dm = get_device_manager()
+            message = {
+                "type": "info",
+                "message": (
+                    f"Musik folgt dir: '{media_title}' spielt jetzt im {room_name}"
+                ),
+            }
+            # Broadcast to the room the user just entered
+            await dm.broadcast_to_room(room_name, message)
+        except Exception:
+            # Non-critical — don't let notification failure break the flow
+            logger.debug(f"🎵 Could not notify user {user_id} about media follow")
+
+
+# ------------------------------------------------------------------
+# Singleton
+# ------------------------------------------------------------------
+
+_media_follow_service: MediaFollowService | None = None
+
+
+def get_media_follow_service() -> MediaFollowService:
+    """Get the singleton MediaFollowService instance."""
+    global _media_follow_service
+    if _media_follow_service is None:
+        _media_follow_service = MediaFollowService()
+    return _media_follow_service

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -333,6 +333,11 @@ class Settings(BaseSettings):
     presence_webhook_secret: str = ""                        # Shared secret for webhook auth (X-Webhook-Secret header)
     presence_analytics_retention_days: int = 90              # Days to keep presence events for analytics
 
+    # Media Follow Me (playback follows user between rooms)
+    media_follow_enabled: bool = False                         # Master switch (requires presence_enabled)
+    media_follow_suspend_timeout: float = 600.0                # Seconds before suspended session expires
+    media_follow_resume_delay: float = 2.0                     # Delay before resuming in new room
+
     # Notification Polling (generic MCP server polling)
     notification_poller_enabled: bool = False           # Master-Switch for MCP notification polling
     notification_poller_startup_delay: int = 30         # Delay before first poll (seconds)

--- a/tests/backend/test_media_follow_service.py
+++ b/tests/backend/test_media_follow_service.py
@@ -1,0 +1,481 @@
+"""
+Tests for MediaFollowService — Media Follow Me.
+
+Tests session lifecycle, conflict resolution, opt-in/opt-out, timeout expiry.
+"""
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.media_follow_service import (
+    MediaFollowService,
+    MediaSession,
+    MediaType,
+    SessionState,
+)
+
+
+@pytest.fixture
+def service():
+    """Create a fresh MediaFollowService for each test."""
+    svc = MediaFollowService()
+    return svc
+
+
+@pytest.fixture
+def playing_session(service):
+    """Register a playing radio session for user 1 in room 1."""
+    service.register_playback(
+        user_id=1,
+        room_id=10,
+        room_name="Arbeitszimmer",
+        media_type=MediaType.RADIO,
+        station_id="s12345",
+        station_name="BBC Radio 1",
+        media_url="http://stream.example.com/bbc1",
+    )
+    return service
+
+
+# =============================================================================
+# Session Registration
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestSessionRegistration:
+    def test_register_playback_creates_session(self, service):
+        service.register_playback(
+            user_id=1,
+            room_id=10,
+            room_name="Wohnzimmer",
+            media_type=MediaType.RADIO,
+            station_id="s123",
+            station_name="BBC Radio 1",
+        )
+        session = service.get_session(1)
+        assert session is not None
+        assert session.user_id == 1
+        assert session.room_id == 10
+        assert session.room_name == "Wohnzimmer"
+        assert session.media_type == MediaType.RADIO
+        assert session.station_id == "s123"
+        assert session.state == SessionState.PLAYING
+
+    def test_register_replaces_existing_session(self, playing_session):
+        playing_session.register_playback(
+            user_id=1,
+            room_id=20,
+            room_name="Wohnzimmer",
+            media_type=MediaType.SINGLE_URL,
+            media_url="http://example.com/song.mp3",
+        )
+        session = playing_session.get_session(1)
+        assert session.room_id == 20
+        assert session.media_type == MediaType.SINGLE_URL
+
+    def test_clear_session(self, playing_session):
+        playing_session.clear_session(1)
+        assert playing_session.get_session(1) is None
+
+    def test_clear_session_nonexistent_user(self, service):
+        # Should not raise
+        service.clear_session(999)
+
+    def test_clear_session_by_room(self, playing_session):
+        playing_session.clear_session_by_room(10)
+        assert playing_session.get_session(1) is None
+
+    def test_clear_session_by_room_only_playing(self, service):
+        """Suspended sessions should not be cleared by room stop."""
+        service.register_playback(
+            user_id=1, room_id=10, room_name="Room",
+            media_type=MediaType.RADIO,
+        )
+        session = service.get_session(1)
+        session.state = SessionState.SUSPENDED
+        service.clear_session_by_room(10)
+        # Suspended session should remain
+        assert service.get_session(1) is not None
+
+    def test_register_album_session(self, service):
+        service.register_playback(
+            user_id=2,
+            room_id=20,
+            room_name="Wohnzimmer",
+            media_type=MediaType.DLNA_ALBUM,
+            album_id="abc123",
+            album_name="Dark Side of the Moon",
+            renderer_name="Wohnzimmer DLNA",
+            total_tracks=10,
+        )
+        session = service.get_session(2)
+        assert session.media_type == MediaType.DLNA_ALBUM
+        assert session.album_id == "abc123"
+        assert session.total_tracks == 10
+
+
+# =============================================================================
+# User Leave Room
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestOnUserLeaveRoom:
+    @pytest.mark.asyncio
+    async def test_leave_suspends_session(self, playing_session):
+        with patch.object(playing_session, "_is_user_opted_in", return_value=True), \
+             patch.object(playing_session, "_stop_playback", new_callable=AsyncMock):
+            await playing_session.on_user_leave_room(
+                user_id=1, room_id=10, room_name="Arbeitszimmer"
+            )
+        session = playing_session.get_session(1)
+        assert session.state == SessionState.SUSPENDED
+        assert session.suspended_at is not None
+
+    @pytest.mark.asyncio
+    async def test_leave_stops_playback(self, playing_session):
+        mock_stop = AsyncMock()
+        with patch.object(playing_session, "_is_user_opted_in", return_value=True), \
+             patch.object(playing_session, "_stop_playback", mock_stop):
+            await playing_session.on_user_leave_room(
+                user_id=1, room_id=10, room_name="Arbeitszimmer"
+            )
+        mock_stop.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_leave_wrong_room_no_action(self, playing_session):
+        """Leaving a different room should not affect the session."""
+        with patch.object(playing_session, "_stop_playback", new_callable=AsyncMock) as mock_stop:
+            await playing_session.on_user_leave_room(
+                user_id=1, room_id=99, room_name="Other"
+            )
+        mock_stop.assert_not_called()
+        assert playing_session.get_session(1).state == SessionState.PLAYING
+
+    @pytest.mark.asyncio
+    async def test_leave_no_session_no_action(self, service):
+        """User without a session should not cause errors."""
+        with patch.object(service, "_stop_playback", new_callable=AsyncMock) as mock_stop:
+            await service.on_user_leave_room(
+                user_id=99, room_id=10, room_name="Room"
+            )
+        mock_stop.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_leave_opted_out_clears_session(self, playing_session):
+        """User with media_follow disabled should have session cleared, not suspended."""
+        with patch.object(playing_session, "_is_user_opted_in", return_value=False):
+            await playing_session.on_user_leave_room(
+                user_id=1, room_id=10, room_name="Arbeitszimmer"
+            )
+        assert playing_session.get_session(1) is None
+
+
+# =============================================================================
+# User Enter Room
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestOnUserEnterRoom:
+    @pytest.mark.asyncio
+    async def test_enter_resumes_suspended_session(self, playing_session):
+        # Manually suspend
+        session = playing_session.get_session(1)
+        session.state = SessionState.SUSPENDED
+        session.suspended_at = time.time()
+
+        mock_resume = AsyncMock()
+        with patch.object(playing_session, "_resume_playback", mock_resume), \
+             patch("services.media_follow_service.settings") as mock_settings:
+            mock_settings.media_follow_suspend_timeout = 600.0
+            mock_settings.media_follow_resume_delay = 0  # no delay in tests
+            await playing_session.on_user_enter_room(
+                user_id=1, room_id=20, room_name="Wohnzimmer"
+            )
+        mock_resume.assert_called_once_with(session, 20, "Wohnzimmer")
+
+    @pytest.mark.asyncio
+    async def test_enter_no_suspended_session_no_action(self, playing_session):
+        """Playing session (not suspended) should not trigger resume."""
+        mock_resume = AsyncMock()
+        with patch.object(playing_session, "_resume_playback", mock_resume):
+            await playing_session.on_user_enter_room(
+                user_id=1, room_id=20, room_name="Wohnzimmer"
+            )
+        mock_resume.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_enter_expired_session_no_resume(self, playing_session):
+        """Expired suspended session should be cleaned up."""
+        session = playing_session.get_session(1)
+        session.state = SessionState.SUSPENDED
+        session.suspended_at = time.time() - 700  # Expired (>600s)
+
+        mock_resume = AsyncMock()
+        with patch.object(playing_session, "_resume_playback", mock_resume), \
+             patch("services.media_follow_service.settings") as mock_settings:
+            mock_settings.media_follow_suspend_timeout = 600.0
+            mock_settings.media_follow_resume_delay = 0
+            await playing_session.on_user_enter_room(
+                user_id=1, room_id=20, room_name="Wohnzimmer"
+            )
+        mock_resume.assert_not_called()
+        assert playing_session.get_session(1) is None
+
+
+# =============================================================================
+# Conflict Resolution
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestConflictResolution:
+    @pytest.mark.asyncio
+    async def test_room_owner_wins(self, service):
+        with patch.object(service, "_get_room_owner_id", return_value=1), \
+             patch.object(service, "_get_role_priority", return_value=50):
+            winner = await service._resolve_conflict(
+                entering_user_id=1, existing_user_id=2, room_id=10
+            )
+        assert winner == 1
+
+    @pytest.mark.asyncio
+    async def test_room_owner_existing_wins(self, service):
+        with patch.object(service, "_get_room_owner_id", return_value=2), \
+             patch.object(service, "_get_role_priority", return_value=50):
+            winner = await service._resolve_conflict(
+                entering_user_id=1, existing_user_id=2, room_id=10
+            )
+        assert winner == 2
+
+    @pytest.mark.asyncio
+    async def test_higher_role_priority_wins(self, service):
+        """Lower priority number = higher privilege."""
+        with patch.object(service, "_get_room_owner_id", return_value=None):
+            # User 1: Admin (10), User 2: Familie (50)
+            async def mock_priority(uid):
+                return 10 if uid == 1 else 50
+            with patch.object(service, "_get_role_priority", side_effect=mock_priority):
+                winner = await service._resolve_conflict(
+                    entering_user_id=1, existing_user_id=2, room_id=10
+                )
+        assert winner == 1
+
+    @pytest.mark.asyncio
+    async def test_lower_role_priority_loses(self, service):
+        with patch.object(service, "_get_room_owner_id", return_value=None):
+            async def mock_priority(uid):
+                return 90 if uid == 1 else 10
+            with patch.object(service, "_get_role_priority", side_effect=mock_priority):
+                winner = await service._resolve_conflict(
+                    entering_user_id=1, existing_user_id=2, room_id=10
+                )
+        assert winner == 2
+
+    @pytest.mark.asyncio
+    async def test_equal_priority_first_come_wins(self, service):
+        """Same priority → existing user keeps their media."""
+        with patch.object(service, "_get_room_owner_id", return_value=None), \
+             patch.object(service, "_get_role_priority", return_value=50):
+            winner = await service._resolve_conflict(
+                entering_user_id=1, existing_user_id=2, room_id=10
+            )
+        assert winner == 2
+
+    @pytest.mark.asyncio
+    async def test_no_owner_falls_through_to_role(self, service):
+        with patch.object(service, "_get_room_owner_id", return_value=None):
+            async def mock_priority(uid):
+                return 50 if uid == 1 else 90
+            with patch.object(service, "_get_role_priority", side_effect=mock_priority):
+                winner = await service._resolve_conflict(
+                    entering_user_id=1, existing_user_id=2, room_id=10
+                )
+        assert winner == 1
+
+
+# =============================================================================
+# Conflict During Enter
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestConflictDuringEnter:
+    @pytest.mark.asyncio
+    async def test_entering_user_wins_conflict(self, service):
+        """When entering user has higher priority, existing user gets suspended."""
+        # User 2 is playing in room 20
+        service.register_playback(
+            user_id=2, room_id=20, room_name="Wohnzimmer",
+            media_type=MediaType.RADIO, station_id="s1",
+        )
+        # User 1 has a suspended session
+        service.register_playback(
+            user_id=1, room_id=10, room_name="Arbeitszimmer",
+            media_type=MediaType.RADIO, station_id="s2",
+        )
+        session1 = service.get_session(1)
+        session1.state = SessionState.SUSPENDED
+        session1.suspended_at = time.time()
+
+        mock_resume = AsyncMock()
+        mock_stop = AsyncMock()
+        with patch.object(service, "_resume_playback", mock_resume), \
+             patch.object(service, "_stop_playback", mock_stop), \
+             patch.object(service, "_resolve_conflict", return_value=1), \
+             patch("services.media_follow_service.settings") as mock_settings:
+            mock_settings.media_follow_suspend_timeout = 600.0
+            mock_settings.media_follow_resume_delay = 0
+            await service.on_user_enter_room(
+                user_id=1, room_id=20, room_name="Wohnzimmer"
+            )
+
+        # Existing user's playback should be stopped
+        mock_stop.assert_called_once()
+        # Entering user's session should be resumed
+        mock_resume.assert_called_once()
+        # Existing user should be suspended
+        assert service.get_session(2).state == SessionState.SUSPENDED
+
+    @pytest.mark.asyncio
+    async def test_entering_user_loses_conflict(self, service):
+        """When existing user has higher priority, entering user stays suspended."""
+        # User 2 is playing in room 20
+        service.register_playback(
+            user_id=2, room_id=20, room_name="Wohnzimmer",
+            media_type=MediaType.RADIO, station_id="s1",
+        )
+        # User 1 has a suspended session
+        service.register_playback(
+            user_id=1, room_id=10, room_name="Arbeitszimmer",
+            media_type=MediaType.RADIO, station_id="s2",
+        )
+        session1 = service.get_session(1)
+        session1.state = SessionState.SUSPENDED
+        session1.suspended_at = time.time()
+
+        mock_resume = AsyncMock()
+        with patch.object(service, "_resume_playback", mock_resume), \
+             patch.object(service, "_resolve_conflict", return_value=2), \
+             patch("services.media_follow_service.settings") as mock_settings:
+            mock_settings.media_follow_suspend_timeout = 600.0
+            mock_settings.media_follow_resume_delay = 0
+            await service.on_user_enter_room(
+                user_id=1, room_id=20, room_name="Wohnzimmer"
+            )
+
+        # No resume should happen
+        mock_resume.assert_not_called()
+        # User 1 stays suspended
+        assert service.get_session(1).state == SessionState.SUSPENDED
+
+
+# =============================================================================
+# Last Left
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestOnLastLeft:
+    @pytest.mark.asyncio
+    async def test_last_left_stops_all_playback(self, playing_session):
+        mock_stop = AsyncMock()
+        with patch.object(playing_session, "_stop_playback", mock_stop):
+            await playing_session.on_last_left(room_id=10, room_name="Arbeitszimmer")
+        mock_stop.assert_called_once()
+        session = playing_session.get_session(1)
+        assert session.state == SessionState.SUSPENDED
+
+    @pytest.mark.asyncio
+    async def test_last_left_no_sessions_in_room(self, service):
+        """Should not raise for empty rooms."""
+        mock_stop = AsyncMock()
+        with patch.object(service, "_stop_playback", mock_stop):
+            await service.on_last_left(room_id=99, room_name="Empty")
+        mock_stop.assert_not_called()
+
+
+# =============================================================================
+# Session Expiry
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestSessionExpiry:
+    def test_cleanup_removes_expired(self, service):
+        service.register_playback(
+            user_id=1, room_id=10, room_name="Room",
+            media_type=MediaType.RADIO,
+        )
+        session = service.get_session(1)
+        session.state = SessionState.SUSPENDED
+        session.suspended_at = time.time() - 700
+
+        with patch("services.media_follow_service.settings") as mock_settings:
+            mock_settings.media_follow_suspend_timeout = 600.0
+            service._cleanup_expired_sessions()
+
+        assert service.get_session(1) is None
+
+    def test_cleanup_keeps_non_expired(self, service):
+        service.register_playback(
+            user_id=1, room_id=10, room_name="Room",
+            media_type=MediaType.RADIO,
+        )
+        session = service.get_session(1)
+        session.state = SessionState.SUSPENDED
+        session.suspended_at = time.time() - 100  # Not expired
+
+        with patch("services.media_follow_service.settings") as mock_settings:
+            mock_settings.media_follow_suspend_timeout = 600.0
+            service._cleanup_expired_sessions()
+
+        assert service.get_session(1) is not None
+
+    def test_cleanup_keeps_playing_sessions(self, playing_session):
+        """Playing sessions should never be cleaned up."""
+        with patch("services.media_follow_service.settings") as mock_settings:
+            mock_settings.media_follow_suspend_timeout = 600.0
+            playing_session._cleanup_expired_sessions()
+
+        assert playing_session.get_session(1) is not None
+
+
+# =============================================================================
+# Find Playing User in Room
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestFindPlayingUserInRoom:
+    def test_finds_playing_user(self, playing_session):
+        assert playing_session._find_playing_user_in_room(10) == 1
+
+    def test_returns_none_for_empty_room(self, service):
+        assert service._find_playing_user_in_room(99) is None
+
+    def test_ignores_suspended_sessions(self, playing_session):
+        session = playing_session.get_session(1)
+        session.state = SessionState.SUSPENDED
+        assert playing_session._find_playing_user_in_room(10) is None
+
+
+# =============================================================================
+# MediaType Enum
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestMediaType:
+    def test_string_values(self):
+        assert MediaType.SINGLE_URL == "single_url"
+        assert MediaType.DLNA_ALBUM == "dlna_album"
+        assert MediaType.RADIO == "radio"
+
+    def test_from_string(self):
+        assert MediaType("single_url") == MediaType.SINGLE_URL
+        assert MediaType("radio") == MediaType.RADIO


### PR DESCRIPTION
## Summary

- **MediaFollowService** (in-memory singleton) tracks active media sessions per user and hooks into presence detection to suspend/resume playback as users move between rooms
- Supports 3 media types: `radio` (TuneIn), `single_url` (HA play_media), `dlna_album` (DLNA queue)
- **Conflict resolution** when two users meet in a room: Room owner > Role priority (Admin=10 > Familie=50 > Gast=90) > First-come
- **Per-user opt-out** via `User.media_follow_enabled` flag
- **Opt-in**: `MEDIA_FOLLOW_ENABLED=true` + `PRESENCE_ENABLED=true`

## Changes

| File | Change |
|------|--------|
| `services/media_follow_service.py` | **NEW** — Core service with session tracking, presence hooks, stop/resume |
| `alembic/versions/s3b4c5d6e7f8_...py` | **NEW** — Migration: `rooms.owner_id`, `users.media_follow_enabled`, `roles.priority` |
| `tests/backend/test_media_follow_service.py` | **NEW** — 33 unit tests |
| `utils/config.py` | 3 new settings |
| `models/database.py` | `Room.owner_id`, `User.media_follow_enabled`, `Role.priority` |
| `services/internal_tools.py` | Playback registration in 3 methods + session clear on stop |
| `api/lifecycle.py` | Hook registration (3 presence hooks) |
| `api/routes/rooms.py` | `PATCH /{room_id}/owner` endpoint |
| `CLAUDE.md` + `docs/ENVIRONMENT_VARIABLES.md` | Documentation |

## Test plan

- [x] 33/33 unit tests pass (`test_media_follow_service.py`)
- [x] No regressions in existing backend tests (1555 passed)
- [x] Ruff lint clean
- [ ] E2E: Radio im Arbeitszimmer starten → Raum wechseln → Radio stoppt/resumed
- [ ] E2E: Konflikt-Test mit zwei Usern im selben Raum
- [ ] E2E: Opt-out Test (User.media_follow_enabled=false)

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)