### PR TITLE
feat(frontend): UI polish — design system, chat experience, brand consistency

### DIFF
--- a/src/frontend/src/components/Alert.jsx
+++ b/src/frontend/src/components/Alert.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { AlertCircle, CheckCircle, AlertTriangle, Info } from 'lucide-react';
+
+const VARIANTS = {
+  error: {
+    icon: AlertCircle,
+    container: 'bg-red-100 dark:bg-red-900/20 border-red-300 dark:border-red-700',
+    icon_color: 'text-red-500',
+    text: 'text-red-700 dark:text-red-400',
+  },
+  success: {
+    icon: CheckCircle,
+    container: 'bg-green-100 dark:bg-green-900/20 border-green-300 dark:border-green-700',
+    icon_color: 'text-green-500',
+    text: 'text-green-700 dark:text-green-400',
+  },
+  warning: {
+    icon: AlertTriangle,
+    container: 'bg-yellow-100 dark:bg-yellow-900/20 border-yellow-300 dark:border-yellow-700',
+    icon_color: 'text-yellow-500',
+    text: 'text-yellow-700 dark:text-yellow-400',
+  },
+  info: {
+    icon: Info,
+    container: 'bg-blue-100 dark:bg-blue-900/20 border-blue-300 dark:border-blue-700',
+    icon_color: 'text-blue-500',
+    text: 'text-blue-700 dark:text-blue-400',
+  },
+};
+
+export default function Alert({ variant = 'info', children, className = '' }) {
+  const v = VARIANTS[variant] || VARIANTS.info;
+  const Icon = v.icon;
+
+  return (
+    <div className={`card ${v.container} ${className}`}>
+      <div className="flex items-center space-x-3">
+        <Icon className={`w-5 h-5 shrink-0 ${v.icon_color}`} aria-hidden="true" />
+        <p className={v.text}>{children}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/components/Badge.jsx
+++ b/src/frontend/src/components/Badge.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+const COLOR_MAP = {
+  blue:   'bg-blue-100 text-blue-600 dark:bg-blue-600/20 dark:text-blue-400',
+  green:  'bg-green-100 text-green-600 dark:bg-green-600/20 dark:text-green-400',
+  red:    'bg-red-100 text-red-600 dark:bg-red-600/20 dark:text-red-400',
+  yellow: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-600/20 dark:text-yellow-400',
+  purple: 'bg-purple-100 text-purple-600 dark:bg-purple-600/20 dark:text-purple-400',
+  amber:  'bg-amber-100 text-amber-700 dark:bg-amber-600/20 dark:text-amber-400',
+  pink:   'bg-pink-100 text-pink-600 dark:bg-pink-600/20 dark:text-pink-400',
+  teal:   'bg-teal-100 text-teal-600 dark:bg-teal-600/20 dark:text-teal-400',
+  gray:   'bg-gray-200 text-gray-600 dark:bg-gray-600/20 dark:text-gray-400',
+  accent: 'bg-accent-100 text-accent-700 dark:bg-accent-600/20 dark:text-accent-400',
+};
+
+export default function Badge({ color = 'gray', icon: Icon, children, className = '' }) {
+  const colors = COLOR_MAP[color] || COLOR_MAP.gray;
+
+  return (
+    <span className={`inline-flex items-center gap-1 px-2 py-1 text-xs rounded-sm font-medium ${colors} ${className}`}>
+      {Icon && <Icon className="w-3 h-3" aria-hidden="true" />}
+      {children}
+    </span>
+  );
+}

--- a/src/frontend/src/components/Layout.jsx
+++ b/src/frontend/src/components/Layout.jsx
@@ -191,7 +191,7 @@ export default function Layout({ children }) {
         aria-current={isActive ? 'page' : undefined}
       >
         {isActive && (
-          <span className="absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-5 bg-primary-600 rounded-r" />
+          <span className="absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-5 bg-accent-400 rounded-r" />
         )}
         <Icon className="w-5 h-5 shrink-0" aria-hidden="true" />
         <span className="lg:opacity-0 lg:group-hover/sidebar:opacity-100 transition-opacity duration-200 overflow-hidden whitespace-nowrap">{item.name}</span>

--- a/src/frontend/src/components/PageHeader.jsx
+++ b/src/frontend/src/components/PageHeader.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export default function PageHeader({ icon: Icon, title, subtitle, children }) {
+  return (
+    <div className="card">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <div className="p-3 bg-primary-100 dark:bg-primary-900/30 rounded-xl">
+            <Icon className="w-6 h-6 text-primary-600 dark:text-primary-400" aria-hidden="true" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold font-display text-gray-900 dark:text-white">{title}</h1>
+            {subtitle && <p className="text-gray-500 dark:text-gray-400">{subtitle}</p>}
+          </div>
+        </div>
+        {children && <div className="flex items-center space-x-2">{children}</div>}
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -151,7 +151,10 @@
     "documentIndexed": "In Wissensdatenbank indexiert",
     "agentThinking": "Denkt nach...",
     "agentStepsCount": "{{count}} Schritt ausgeführt",
-    "agentStepsCount_other": "{{count}} Schritte ausgeführt"
+    "agentStepsCount_other": "{{count}} Schritte ausgeführt",
+    "exampleWeather": "Wie wird das Wetter?",
+    "exampleLight": "Schalte das Licht im Wohnzimmer ein",
+    "exampleMusic": "Spiel Jazz Musik"
   },
   "voice": {
     "startRecording": "Sprachaufnahme starten",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -151,7 +151,10 @@
     "documentIndexed": "Indexed to KB",
     "agentThinking": "Thinking...",
     "agentStepsCount": "{{count}} step completed",
-    "agentStepsCount_other": "{{count}} steps completed"
+    "agentStepsCount_other": "{{count}} steps completed",
+    "exampleWeather": "How's the weather?",
+    "exampleLight": "Turn on the living room light",
+    "exampleMusic": "Play some jazz music"
   },
   "voice": {
     "startRecording": "Start voice recording",

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -66,8 +66,36 @@
            active:scale-[0.97] transition-all;
 }
 
+@utility btn-danger {
+  @apply bg-red-600 hover:bg-red-700 text-white active:scale-[0.97] transition-all;
+}
+
+@utility btn-success {
+  @apply bg-green-600 hover:bg-green-700 text-white active:scale-[0.97] transition-all;
+}
+
+@utility btn-ghost {
+  @apply bg-transparent hover:bg-gray-100 text-gray-600
+         dark:hover:bg-gray-700 dark:text-gray-300
+         active:scale-[0.97] transition-all;
+}
+
+@utility btn-icon {
+  @apply p-2 rounded-lg transition-colors active:scale-95;
+}
+
+@utility btn-icon-danger {
+  @apply bg-red-100 hover:bg-red-200 text-red-600
+         dark:bg-red-600/20 dark:hover:bg-red-600/40 dark:text-red-400;
+}
+
+@utility btn-icon-ghost {
+  @apply bg-gray-200 hover:bg-gray-300 text-gray-600
+         dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-300;
+}
+
 @utility card {
-  @apply bg-white rounded-lg p-6 shadow-lg border border-gray-200
+  @apply bg-white rounded-lg p-6 shadow-sm border border-gray-200
            dark:bg-gray-800 dark:border-gray-700;
 }
 
@@ -75,6 +103,11 @@
   @apply bg-white rounded-lg p-6 shadow-lg border border-gray-200
            dark:bg-gray-800 dark:border-gray-700
            border-t-2 border-t-primary-600;
+}
+
+@utility card-elevated {
+  @apply bg-white rounded-lg p-6 shadow-lg border border-gray-200
+           dark:bg-gray-800 dark:border-gray-700;
 }
 
 @utility card-flat {

--- a/src/frontend/src/pages/ChatPage/ChatHeader.jsx
+++ b/src/frontend/src/pages/ChatPage/ChatHeader.jsx
@@ -72,7 +72,7 @@ export default function ChatHeader() {
 
           {/* Connection Status */}
           <div className="flex items-center space-x-2">
-            <div className={`w-3 h-3 rounded-full ${wsConnected ? 'bg-green-500 animate-gentle-pulse' : 'bg-red-500'}`} />
+            <div className={`w-3 h-3 rounded-full ${wsConnected ? 'bg-accent-400 animate-gentle-pulse' : 'bg-red-500'}`} />
             <span className="text-sm text-gray-500 dark:text-gray-400">
               {wsConnected ? t('common.connected') : t('common.disconnected')}
             </span>

--- a/src/frontend/src/pages/ChatPage/ChatInput.jsx
+++ b/src/frontend/src/pages/ChatPage/ChatInput.jsx
@@ -78,7 +78,7 @@ export default function ChatInput() {
 
   return (
     <div
-      className={`card mx-4 mb-4 md:mx-0 md:mb-0 ${isDragOver ? 'ring-2 ring-primary-500' : ''}`}
+      className={`card border-t-2 border-t-primary-600/30 dark:border-t-primary-500/20 mx-4 mb-4 md:mx-0 md:mb-0 ${isDragOver ? 'ring-2 ring-primary-500' : ''}`}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}

--- a/src/frontend/src/pages/ChatPage/ChatMessages.jsx
+++ b/src/frontend/src/pages/ChatPage/ChatMessages.jsx
@@ -78,6 +78,7 @@ export default function ChatMessages() {
     messages, loading, historyLoading, speakText, handleFeedbackSubmit,
     actionLoading, actionResult, indexToKb, sendToPaperless, handleSummarize,
     handleSendViaEmail, emailDialog, confirmSendViaEmail, cancelEmailDialog,
+    sendMessage,
   } = useChatContext();
   const messagesEndRef = useRef(null);
 
@@ -105,11 +106,26 @@ export default function ChatMessages() {
       {/* Empty State */}
       {!historyLoading && messages.length === 0 && (
         <div className="text-center py-16">
-          <img src="/logo-icon.svg" alt="" className="w-16 h-16 mx-auto mb-6 opacity-30" aria-hidden="true" />
-          <h2 className="font-display text-xl text-gray-400 dark:text-gray-500 mb-2">{t('chat.startConversation')}</h2>
-          <p className="text-sm text-gray-400 dark:text-gray-500">
+          <img src="/logo-icon.svg" alt="" className="w-20 h-20 mx-auto mb-6 opacity-30" aria-hidden="true" />
+          <h2 className="font-display text-2xl text-gray-400 dark:text-gray-500 mb-2">{t('chat.startConversation')}</h2>
+          <p className="text-sm text-gray-400 dark:text-gray-500 mb-6">
             {t('chat.useTextOrMic')}
           </p>
+          <div className="flex flex-wrap justify-center gap-2">
+            {[
+              t('chat.exampleWeather'),
+              t('chat.exampleLight'),
+              t('chat.exampleMusic'),
+            ].map((example) => (
+              <button
+                key={example}
+                onClick={() => sendMessage?.(example, false)}
+                className="px-4 py-2 rounded-full text-sm border border-gray-300 dark:border-gray-600 text-gray-500 dark:text-gray-400 hover:border-accent-400 hover:text-accent-600 dark:hover:border-accent-500 dark:hover:text-accent-400 transition-colors"
+              >
+                {example}
+              </button>
+            ))}
+          </div>
         </div>
       )}
 
@@ -125,7 +141,7 @@ export default function ChatMessages() {
             className={`max-w-[70%] px-4 py-2 rounded-lg ${
               message.role === 'user'
                 ? 'bg-primary-600 text-white'
-                : 'bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-gray-100'
+                : 'bg-gray-100 text-gray-900 dark:bg-gray-700 dark:text-gray-100'
             }`}
           >
             {/* Agent Steps (collapsible) */}
@@ -139,43 +155,43 @@ export default function ChatMessages() {
 
               return (
                 <details className="mb-2 group" open={isStillRunning || undefined}>
-                  <summary className="flex items-center gap-1.5 text-xs cursor-pointer select-none list-none text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300">
-                    <ChevronRight className="w-3 h-3 flex-shrink-0 transition-transform group-open:rotate-90" aria-hidden="true" />
+                  <summary className="flex items-center gap-1.5 text-sm cursor-pointer select-none list-none text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300">
+                    <ChevronRight className="w-4 h-4 flex-shrink-0 transition-transform group-open:rotate-90" aria-hidden="true" />
                     {isStillRunning ? (
                       <>
-                        <Loader className="w-3 h-3 animate-spin text-blue-400" aria-hidden="true" />
+                        <Loader className="w-4 h-4 animate-spin text-accent-500 dark:text-accent-400" aria-hidden="true" />
                         <span>{t('chat.agentThinking')}</span>
                       </>
                     ) : (
                       <>
                         {hasError
-                          ? <XCircle className="w-3 h-3 flex-shrink-0 text-red-500 dark:text-red-400" aria-hidden="true" />
-                          : <CheckCircle2 className="w-3 h-3 flex-shrink-0 text-green-500 dark:text-green-400" aria-hidden="true" />
+                          ? <XCircle className="w-4 h-4 flex-shrink-0 text-red-500 dark:text-red-400" aria-hidden="true" />
+                          : <CheckCircle2 className="w-4 h-4 flex-shrink-0 text-green-500 dark:text-green-400" aria-hidden="true" />
                         }
                         <span>{t('chat.agentStepsCount', { count: toolCalls.length })}</span>
                       </>
                     )}
                   </summary>
-                  <div className="mt-1.5 ml-4.5 space-y-1 border-l-2 border-gray-300 dark:border-gray-600 pl-2.5">
+                  <div className="mt-1.5 ml-5 space-y-1 border-l-2 border-accent-400 dark:border-accent-600 pl-2.5 bg-gray-100/50 dark:bg-gray-800/50 rounded-lg p-2.5">
                     {message.agentSteps.map((step, stepIdx) => (
-                      <div key={stepIdx} className="flex items-start gap-1.5 text-xs">
+                      <div key={stepIdx} className="flex items-start gap-1.5 text-sm">
                         {step.type === 'tool_call' && (
                           <>
-                            <Search className="w-3.5 h-3.5 mt-0.5 flex-shrink-0 text-blue-500 dark:text-blue-400" aria-hidden="true" />
+                            <Search className="w-4 h-4 mt-0.5 flex-shrink-0 text-accent-500 dark:text-accent-400" aria-hidden="true" />
                             <span className="text-gray-600 dark:text-gray-300">
                               <span className="font-medium">{step.tool?.split('.').pop()}</span>
                               {step.reason && <span className="ml-1 text-gray-400 dark:text-gray-500">— {step.reason}</span>}
                             </span>
                             {!message.agentSteps.find(s => s.type === 'tool_result' && s.step === step.step) && (
-                              <Loader className="w-3 h-3 mt-0.5 animate-spin text-blue-400" aria-hidden="true" />
+                              <Loader className="w-4 h-4 mt-0.5 animate-spin text-accent-500 dark:text-accent-400" aria-hidden="true" />
                             )}
                           </>
                         )}
                         {step.type === 'tool_result' && (
                           <>
                             {step.success
-                              ? <CheckCircle2 className="w-3.5 h-3.5 mt-0.5 flex-shrink-0 text-green-500 dark:text-green-400" aria-hidden="true" />
-                              : <XCircle className="w-3.5 h-3.5 mt-0.5 flex-shrink-0 text-red-500 dark:text-red-400" aria-hidden="true" />
+                              ? <CheckCircle2 className="w-4 h-4 mt-0.5 flex-shrink-0 text-green-500 dark:text-green-400" aria-hidden="true" />
+                              : <XCircle className="w-4 h-4 mt-0.5 flex-shrink-0 text-red-500 dark:text-red-400" aria-hidden="true" />
                             }
                             <span className={`${step.success ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
                               {step.tool?.split('.').pop()}{step.success ? '' : ` — ${step.message || 'failed'}`}

--- a/src/frontend/src/pages/RoomsPage.jsx
+++ b/src/frontend/src/pages/RoomsPage.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
-  Home, Plus, Edit3, Trash2, Loader, CheckCircle, XCircle,
-  AlertCircle, RefreshCw, Link as LinkIcon, Unlink, Radio,
+  Home, Plus, Edit3, Trash2, Loader,
+  RefreshCw, Link as LinkIcon, Unlink, Radio,
   ArrowDownToLine, ArrowUpFromLine, ArrowLeftRight,
   Monitor, Tablet, Smartphone, Tv, User
 } from 'lucide-react';
@@ -10,6 +10,9 @@ import apiClient from '../utils/axios';
 import RoomOutputSettings from '../components/RoomOutputSettings';
 import { useConfirmDialog } from '../components/ConfirmDialog';
 import Modal from '../components/Modal';
+import PageHeader from '../components/PageHeader';
+import Alert from '../components/Alert';
+import Badge from '../components/Badge';
 
 // Device type icons and labels
 const DEVICE_TYPE_CONFIG = {
@@ -319,58 +322,27 @@ export default function RoomsPage() {
   const getSourceBadge = (source) => {
     switch (source) {
       case 'homeassistant':
-        return <span className="px-2 py-1 bg-blue-100 text-blue-600 dark:bg-blue-600/20 dark:text-blue-400 text-xs rounded-sm">HA</span>;
+        return <Badge color="blue">HA</Badge>;
       case 'satellite':
-        return <span className="px-2 py-1 bg-green-100 text-green-600 dark:bg-green-600/20 dark:text-green-400 text-xs rounded-sm">Satellite</span>;
+        return <Badge color="green">Satellite</Badge>;
       default:
-        return <span className="px-2 py-1 bg-gray-200 text-gray-600 dark:bg-gray-600/20 dark:text-gray-400 text-xs rounded-sm">Renfield</span>;
+        return <Badge color="gray">Renfield</Badge>;
     }
   };
 
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="card">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-4">
-            <div className="p-3 bg-primary-100 dark:bg-primary-900/30 rounded-xl">
-              <Home className="w-6 h-6 text-primary-600 dark:text-primary-400" />
-            </div>
-            <div>
-              <h1 className="text-2xl font-bold font-display text-gray-900 dark:text-white">{t('rooms.title')}</h1>
-              <p className="text-gray-500 dark:text-gray-400">{t('rooms.subtitle')}</p>
-            </div>
-          </div>
-          <div className="flex items-center space-x-2">
-            <button
-              onClick={loadRooms}
-              className="p-2 rounded-lg bg-gray-200 hover:bg-gray-300 text-gray-600 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-300"
-              aria-label={t('rooms.refreshRooms')}
-            >
-              <RefreshCw className="w-5 h-5" aria-hidden="true" />
-            </button>
-          </div>
-        </div>
-      </div>
+      <PageHeader icon={Home} title={t('rooms.title')} subtitle={t('rooms.subtitle')}>
+        <button onClick={loadRooms} className="btn-icon btn-icon-ghost" aria-label={t('rooms.refreshRooms')}>
+          <RefreshCw className="w-5 h-5" aria-hidden="true" />
+        </button>
+      </PageHeader>
 
       {/* Alerts */}
-      {error && (
-        <div className="card bg-red-100 dark:bg-red-900/20 border-red-300 dark:border-red-700">
-          <div className="flex items-center space-x-3">
-            <AlertCircle className="w-5 h-5 text-red-500" />
-            <p className="text-red-700 dark:text-red-400">{error}</p>
-          </div>
-        </div>
-      )}
+      {error && <Alert variant="error">{error}</Alert>}
 
-      {success && (
-        <div className="card bg-green-100 dark:bg-green-900/20 border-green-300 dark:border-green-700">
-          <div className="flex items-center space-x-3">
-            <CheckCircle className="w-5 h-5 text-green-500" />
-            <p className="text-green-700 dark:text-green-400">{success}</p>
-          </div>
-        </div>
-      )}
+      {success && <Alert variant="success">{success}</Alert>}
 
       {/* Actions */}
       <div className="flex flex-wrap gap-3">
@@ -384,7 +356,7 @@ export default function RoomsPage() {
 
         <button
           onClick={openSyncPanel}
-          className="btn bg-blue-600 hover:bg-blue-700 text-white flex items-center space-x-2"
+          className="btn btn-secondary flex items-center space-x-2"
         >
           <ArrowLeftRight className="w-4 h-4" />
           <span>HA Sync</span>
@@ -529,14 +501,14 @@ export default function RoomsPage() {
                   )}
                   <button
                     onClick={() => openEditModal(room)}
-                    className="p-2 rounded-lg bg-gray-200 hover:bg-gray-300 text-gray-600 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-300"
+                    className="btn-icon btn-icon-ghost"
                     aria-label={`${room.name} ${t('common.edit').toLowerCase()}`}
                   >
                     <Edit3 className="w-4 h-4" aria-hidden="true" />
                   </button>
                   <button
                     onClick={() => deleteRoom(room)}
-                    className="p-2 rounded-lg bg-red-100 hover:bg-red-200 text-red-600 dark:bg-red-600/20 dark:hover:bg-red-600/40 dark:text-red-400"
+                    className="btn-icon btn-icon-danger"
                     aria-label={`${room.name} ${t('common.delete').toLowerCase()}`}
                   >
                     <Trash2 className="w-4 h-4" aria-hidden="true" />
@@ -549,295 +521,276 @@ export default function RoomsPage() {
       </div>
 
       {/* Create Room Modal */}
-      {showCreateModal && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="card max-w-md w-full">
-            <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-4">{t('rooms.createRoom')}</h2>
+      <Modal isOpen={showCreateModal} onClose={() => setShowCreateModal(false)} title={t('rooms.createRoom')}>
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">{t('common.name')}</label>
+            <input
+              type="text"
+              value={newRoomName}
+              onChange={(e) => setNewRoomName(e.target.value)}
+              placeholder="Wohnzimmer"
+              className="input w-full"
+            />
+          </div>
 
-            <div className="space-y-4">
-              <div>
-                <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">{t('common.name')}</label>
-                <input
-                  type="text"
-                  value={newRoomName}
-                  onChange={(e) => setNewRoomName(e.target.value)}
-                  placeholder="Wohnzimmer"
-                  className="input w-full"
-                />
-              </div>
-
-              <div>
-                <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">{t('rooms.icon')}</label>
-                <input
-                  type="text"
-                  value={newRoomIcon}
-                  onChange={(e) => setNewRoomIcon(e.target.value)}
-                  placeholder="mdi:sofa"
-                  className="input w-full"
-                />
-                <p className="text-xs text-gray-500 mt-1">{t('rooms.iconHint')}</p>
-              </div>
-            </div>
-
-            <div className="flex space-x-3 mt-6">
-              <button
-                onClick={() => setShowCreateModal(false)}
-                className="flex-1 btn btn-secondary"
-              >
-                {t('common.cancel')}
-              </button>
-              <button
-                onClick={createRoom}
-                className="flex-1 btn btn-primary"
-              >
-                {t('common.create')}
-              </button>
-            </div>
+          <div>
+            <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">{t('rooms.icon')}</label>
+            <input
+              type="text"
+              value={newRoomIcon}
+              onChange={(e) => setNewRoomIcon(e.target.value)}
+              placeholder="mdi:sofa"
+              className="input w-full"
+            />
+            <p className="text-xs text-gray-500 mt-1">{t('rooms.iconHint')}</p>
           </div>
         </div>
-      )}
+
+        <div className="flex space-x-3 mt-6">
+          <button
+            onClick={() => setShowCreateModal(false)}
+            className="flex-1 btn btn-secondary"
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            onClick={createRoom}
+            className="flex-1 btn btn-primary"
+          >
+            {t('common.create')}
+          </button>
+        </div>
+      </Modal>
 
       {/* Edit Room Modal */}
-      {showEditModal && selectedRoom && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="card max-w-md w-full">
-            <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-4">{t('rooms.editRoom')}</h2>
-
-            <div className="space-y-4">
-              <div>
-                <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">{t('common.name')}</label>
-                <input
-                  type="text"
-                  value={editRoomName}
-                  onChange={(e) => setEditRoomName(e.target.value)}
-                  placeholder="Wohnzimmer"
-                  className="input w-full"
-                />
-              </div>
-
-              <div>
-                <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">{t('rooms.icon')}</label>
-                <input
-                  type="text"
-                  value={editRoomIcon}
-                  onChange={(e) => setEditRoomIcon(e.target.value)}
-                  placeholder="mdi:sofa"
-                  className="input w-full"
-                />
-              </div>
-
-              <div>
-                <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">{t('rooms.owner')}</label>
-                <select
-                  value={editRoomOwnerId}
-                  onChange={(e) => setEditRoomOwnerId(e.target.value)}
-                  className="input w-full"
-                >
-                  <option value="">{t('rooms.noOwner')}</option>
-                  {users.map(u => (
-                    <option key={u.id} value={u.id}>
-                      {u.first_name || u.username}
-                    </option>
-                  ))}
-                </select>
-                <p className="text-xs text-gray-500 mt-1">{t('rooms.ownerHint')}</p>
-              </div>
-
-              <div className="text-sm text-gray-500">
-                {t('rooms.alias')}: @{selectedRoom.alias}
-              </div>
-            </div>
-
-            <div className="flex space-x-3 mt-6">
-              <button
-                onClick={() => setShowEditModal(false)}
-                className="flex-1 btn btn-secondary"
-              >
-                {t('common.cancel')}
-              </button>
-              <button
-                onClick={updateRoom}
-                disabled={updating}
-                className="flex-1 btn btn-primary disabled:opacity-50"
-              >
-                {updating ? (
-                  <Loader className="w-4 h-4 animate-spin mx-auto" />
-                ) : (
-                  t('common.save')
-                )}
-              </button>
-            </div>
+      <Modal isOpen={showEditModal && !!selectedRoom} onClose={() => setShowEditModal(false)} title={t('rooms.editRoom')}>
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">{t('common.name')}</label>
+            <input
+              type="text"
+              value={editRoomName}
+              onChange={(e) => setEditRoomName(e.target.value)}
+              placeholder="Wohnzimmer"
+              className="input w-full"
+            />
           </div>
+
+          <div>
+            <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">{t('rooms.icon')}</label>
+            <input
+              type="text"
+              value={editRoomIcon}
+              onChange={(e) => setEditRoomIcon(e.target.value)}
+              placeholder="mdi:sofa"
+              className="input w-full"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">{t('rooms.owner')}</label>
+            <select
+              value={editRoomOwnerId}
+              onChange={(e) => setEditRoomOwnerId(e.target.value)}
+              className="input w-full"
+            >
+              <option value="">{t('rooms.noOwner')}</option>
+              {users.map(u => (
+                <option key={u.id} value={u.id}>
+                  {u.first_name || u.username}
+                </option>
+              ))}
+            </select>
+            <p className="text-xs text-gray-500 mt-1">{t('rooms.ownerHint')}</p>
+          </div>
+
+          {selectedRoom && (
+            <div className="text-sm text-gray-500">
+              {t('rooms.alias')}: @{selectedRoom.alias}
+            </div>
+          )}
         </div>
-      )}
+
+        <div className="flex space-x-3 mt-6">
+          <button
+            onClick={() => setShowEditModal(false)}
+            className="flex-1 btn btn-secondary"
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            onClick={updateRoom}
+            disabled={updating}
+            className="flex-1 btn btn-primary disabled:opacity-50"
+          >
+            {updating ? (
+              <Loader className="w-4 h-4 animate-spin mx-auto" />
+            ) : (
+              t('common.save')
+            )}
+          </button>
+        </div>
+      </Modal>
 
       {/* Link to HA Area Modal */}
-      {showLinkModal && selectedRoom && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="card max-w-md w-full">
-            <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-2">{t('rooms.linkToHAArea')}</h2>
-            <p className="text-gray-500 dark:text-gray-400 mb-4">{t('device.room')}: {selectedRoom.name}</p>
+      <Modal isOpen={showLinkModal && !!selectedRoom} onClose={() => setShowLinkModal(false)} title={t('rooms.linkToHAArea')}>
+        {selectedRoom && (
+          <p className="text-gray-500 dark:text-gray-400 mb-4">{t('device.room')}: {selectedRoom.name}</p>
+        )}
 
-            <div className="space-y-4">
-              {loadingAreas ? (
-                <div className="text-center py-4">
-                  <Loader className="w-6 h-6 animate-spin mx-auto text-gray-500 dark:text-gray-400" />
-                </div>
-              ) : haAreas.length === 0 ? (
-                <p className="text-gray-500 dark:text-gray-400 text-center py-4">
-                  {t('rooms.noHAAreas')}
-                </p>
-              ) : (
-                <div>
-                  <label className="block text-sm text-gray-500 dark:text-gray-400 mb-2">{t('rooms.selectArea')}:</label>
-                  <select
-                    value={selectedHAArea}
-                    onChange={(e) => setSelectedHAArea(e.target.value)}
-                    className="input w-full"
-                  >
-                    <option value="">{t('rooms.selectAreaPlaceholder')}</option>
-                    {haAreas
-                      .filter(a => !a.is_linked)
-                      .map(area => (
-                        <option key={area.area_id} value={area.area_id}>
-                          {area.name}
-                        </option>
-                      ))
-                    }
-                  </select>
-                  {haAreas.filter(a => !a.is_linked).length === 0 && (
-                    <p className="text-yellow-600 dark:text-yellow-400 text-sm mt-2">
-                      {t('rooms.allAreasLinked')}
-                    </p>
-                  )}
-                </div>
-              )}
+        <div className="space-y-4">
+          {loadingAreas ? (
+            <div className="text-center py-4">
+              <Loader className="w-6 h-6 animate-spin mx-auto text-gray-500 dark:text-gray-400" />
             </div>
-
-            <div className="flex space-x-3 mt-6">
-              <button
-                onClick={() => setShowLinkModal(false)}
-                className="flex-1 btn btn-secondary"
-              >
-                {t('common.cancel')}
-              </button>
-              <button
-                onClick={linkToHAArea}
-                disabled={!selectedHAArea || updating}
-                className="flex-1 btn btn-primary disabled:opacity-50"
-              >
-                {updating ? (
-                  <Loader className="w-4 h-4 animate-spin mx-auto" />
-                ) : (
-                  t('rooms.linkToHA')
-                )}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* HA Sync Panel Modal */}
-      {showSyncPanel && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="card max-w-lg w-full max-h-[90vh] overflow-y-auto">
-            <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-4">{t('rooms.haSyncTitle')}</h2>
-
-            {/* Conflict Resolution */}
-            <div className="mb-6">
-              <label className="block text-sm text-gray-500 dark:text-gray-400 mb-2">{t('rooms.conflictResolution')}:</label>
+          ) : haAreas.length === 0 ? (
+            <p className="text-gray-500 dark:text-gray-400 text-center py-4">
+              {t('rooms.noHAAreas')}
+            </p>
+          ) : (
+            <div>
+              <label className="block text-sm text-gray-500 dark:text-gray-400 mb-2">{t('rooms.selectArea')}:</label>
               <select
-                value={conflictResolution}
-                onChange={(e) => setConflictResolution(e.target.value)}
+                value={selectedHAArea}
+                onChange={(e) => setSelectedHAArea(e.target.value)}
                 className="input w-full"
               >
-                <option value="skip">{t('rooms.conflictSkip')}</option>
-                <option value="link">{t('rooms.conflictLink')}</option>
-                <option value="overwrite">{t('rooms.conflictOverwrite')}</option>
+                <option value="">{t('rooms.selectAreaPlaceholder')}</option>
+                {haAreas
+                  .filter(a => !a.is_linked)
+                  .map(area => (
+                    <option key={area.area_id} value={area.area_id}>
+                      {area.name}
+                    </option>
+                  ))
+                }
               </select>
-            </div>
-
-            {/* Sync Actions */}
-            <div className="grid grid-cols-3 gap-3 mb-6">
-              <button
-                onClick={importFromHA}
-                disabled={syncing}
-                className="btn bg-green-600 hover:bg-green-700 text-white flex flex-col items-center py-4"
-              >
-                <ArrowDownToLine className="w-6 h-6 mb-2" />
-                <span className="text-sm">{t('rooms.import')}</span>
-              </button>
-              <button
-                onClick={exportToHA}
-                disabled={syncing}
-                className="btn bg-blue-600 hover:bg-blue-700 text-white flex flex-col items-center py-4"
-              >
-                <ArrowUpFromLine className="w-6 h-6 mb-2" />
-                <span className="text-sm">{t('rooms.export')}</span>
-              </button>
-              <button
-                onClick={syncWithHA}
-                disabled={syncing}
-                className="btn bg-purple-600 hover:bg-purple-700 text-white flex flex-col items-center py-4"
-              >
-                {syncing ? (
-                  <Loader className="w-6 h-6 mb-2 animate-spin" />
-                ) : (
-                  <ArrowLeftRight className="w-6 h-6 mb-2" />
-                )}
-                <span className="text-sm">{t('rooms.sync')}</span>
-              </button>
-            </div>
-
-            {/* HA Areas List */}
-            <div>
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">
-                {t('rooms.haAreasCount', { count: haAreas.length })}
-              </h3>
-              {loadingAreas ? (
-                <div className="text-center py-4">
-                  <Loader className="w-6 h-6 animate-spin mx-auto text-gray-500 dark:text-gray-400" />
-                </div>
-              ) : haAreas.length === 0 ? (
-                <p className="text-gray-500 dark:text-gray-400 text-center py-4">
-                  {t('rooms.haNotConnected')}
+              {haAreas.filter(a => !a.is_linked).length === 0 && (
+                <p className="text-yellow-600 dark:text-yellow-400 text-sm mt-2">
+                  {t('rooms.allAreasLinked')}
                 </p>
-              ) : (
-                <div className="space-y-2 max-h-60 overflow-y-auto">
-                  {haAreas.map(area => (
-                    <div
-                      key={area.area_id}
-                      className="flex items-center justify-between p-3 bg-gray-100 dark:bg-gray-800 rounded-lg"
-                    >
-                      <div>
-                        <p className="text-gray-900 dark:text-white">{area.name}</p>
-                        <p className="text-xs text-gray-500">{area.area_id}</p>
-                      </div>
-                      {area.is_linked ? (
-                        <span className="text-green-600 dark:text-green-400 text-sm flex items-center space-x-1">
-                          <LinkIcon className="w-3 h-3" />
-                          <span>{area.linked_room_name}</span>
-                        </span>
-                      ) : (
-                        <span className="text-gray-500 text-sm">{t('rooms.haNotLinked')}</span>
-                      )}
-                    </div>
-                  ))}
-                </div>
               )}
             </div>
-
-            <div className="flex space-x-3 mt-6">
-              <button
-                onClick={() => setShowSyncPanel(false)}
-                className="flex-1 btn btn-secondary"
-              >
-                {t('common.close')}
-              </button>
-            </div>
-          </div>
+          )}
         </div>
-      )}
+
+        <div className="flex space-x-3 mt-6">
+          <button
+            onClick={() => setShowLinkModal(false)}
+            className="flex-1 btn btn-secondary"
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            onClick={linkToHAArea}
+            disabled={!selectedHAArea || updating}
+            className="flex-1 btn btn-primary disabled:opacity-50"
+          >
+            {updating ? (
+              <Loader className="w-4 h-4 animate-spin mx-auto" />
+            ) : (
+              t('rooms.linkToHA')
+            )}
+          </button>
+        </div>
+      </Modal>
+
+      {/* HA Sync Panel Modal */}
+      <Modal isOpen={showSyncPanel} onClose={() => setShowSyncPanel(false)} title={t('rooms.haSyncTitle')} maxWidth="max-w-lg">
+        {/* Conflict Resolution */}
+        <div className="mb-6">
+          <label className="block text-sm text-gray-500 dark:text-gray-400 mb-2">{t('rooms.conflictResolution')}:</label>
+          <select
+            value={conflictResolution}
+            onChange={(e) => setConflictResolution(e.target.value)}
+            className="input w-full"
+          >
+            <option value="skip">{t('rooms.conflictSkip')}</option>
+            <option value="link">{t('rooms.conflictLink')}</option>
+            <option value="overwrite">{t('rooms.conflictOverwrite')}</option>
+          </select>
+        </div>
+
+        {/* Sync Actions */}
+        <div className="grid grid-cols-3 gap-3 mb-6">
+          <button
+            onClick={importFromHA}
+            disabled={syncing}
+            className="btn bg-green-600 hover:bg-green-700 text-white flex flex-col items-center py-4"
+          >
+            <ArrowDownToLine className="w-6 h-6 mb-2" />
+            <span className="text-sm">{t('rooms.import')}</span>
+          </button>
+          <button
+            onClick={exportToHA}
+            disabled={syncing}
+            className="btn bg-blue-600 hover:bg-blue-700 text-white flex flex-col items-center py-4"
+          >
+            <ArrowUpFromLine className="w-6 h-6 mb-2" />
+            <span className="text-sm">{t('rooms.export')}</span>
+          </button>
+          <button
+            onClick={syncWithHA}
+            disabled={syncing}
+            className="btn bg-purple-600 hover:bg-purple-700 text-white flex flex-col items-center py-4"
+          >
+            {syncing ? (
+              <Loader className="w-6 h-6 mb-2 animate-spin" />
+            ) : (
+              <ArrowLeftRight className="w-6 h-6 mb-2" />
+            )}
+            <span className="text-sm">{t('rooms.sync')}</span>
+          </button>
+        </div>
+
+        {/* HA Areas List */}
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">
+            {t('rooms.haAreasCount', { count: haAreas.length })}
+          </h3>
+          {loadingAreas ? (
+            <div className="text-center py-4">
+              <Loader className="w-6 h-6 animate-spin mx-auto text-gray-500 dark:text-gray-400" />
+            </div>
+          ) : haAreas.length === 0 ? (
+            <p className="text-gray-500 dark:text-gray-400 text-center py-4">
+              {t('rooms.haNotConnected')}
+            </p>
+          ) : (
+            <div className="space-y-2 max-h-60 overflow-y-auto">
+              {haAreas.map(area => (
+                <div
+                  key={area.area_id}
+                  className="flex items-center justify-between p-3 bg-gray-100 dark:bg-gray-800 rounded-lg"
+                >
+                  <div>
+                    <p className="text-gray-900 dark:text-white">{area.name}</p>
+                    <p className="text-xs text-gray-500">{area.area_id}</p>
+                  </div>
+                  {area.is_linked ? (
+                    <span className="text-green-600 dark:text-green-400 text-sm flex items-center space-x-1">
+                      <LinkIcon className="w-3 h-3" />
+                      <span>{area.linked_room_name}</span>
+                    </span>
+                  ) : (
+                    <span className="text-gray-500 text-sm">{t('rooms.haNotLinked')}</span>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="flex space-x-3 mt-6">
+          <button
+            onClick={() => setShowSyncPanel(false)}
+            className="flex-1 btn btn-secondary"
+          >
+            {t('common.close')}
+          </button>
+        </div>
+      </Modal>
 
       {/* Confirm Dialog */}
       {ConfirmDialogComponent}

--- a/src/frontend/src/pages/SpeakersPage.jsx
+++ b/src/frontend/src/pages/SpeakersPage.jsx
@@ -2,12 +2,15 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Users, UserPlus, Mic, MicOff, Trash2, Loader, CheckCircle,
-  XCircle, AlertCircle, Volume2, Shield, ShieldCheck, RefreshCw,
+  AlertCircle, Volume2, Shield, ShieldCheck, RefreshCw,
   Edit3, GitMerge
 } from 'lucide-react';
 import apiClient from '../utils/axios';
 import { useConfirmDialog } from '../components/ConfirmDialog';
 import Modal from '../components/Modal';
+import PageHeader from '../components/PageHeader';
+import Alert from '../components/Alert';
+import Badge from '../components/Badge';
 
 export default function SpeakersPage() {
   const { t } = useTranslation();
@@ -386,66 +389,28 @@ export default function SpeakersPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="card">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-4">
-            <div className="p-3 bg-primary-100 dark:bg-primary-900/30 rounded-xl">
-              <Users className="w-6 h-6 text-primary-600 dark:text-primary-400" />
-            </div>
-            <div>
-              <h1 className="text-2xl font-bold font-display text-gray-900 dark:text-white">{t('speakers.title')}</h1>
-              <p className="text-gray-500 dark:text-gray-400">{t('speakers.subtitle')}</p>
-            </div>
-          </div>
-          <div className="flex items-center space-x-2">
-            <button
-              onClick={loadSpeakers}
-              className="p-2 rounded-lg bg-gray-200 hover:bg-gray-300 text-gray-600 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-300"
-              aria-label={t('speakers.refreshSpeakers')}
-            >
-              <RefreshCw className="w-5 h-5" aria-hidden="true" />
-            </button>
-          </div>
-        </div>
-      </div>
+      <PageHeader icon={Users} title={t('speakers.title')} subtitle={t('speakers.subtitle')}>
+        <button onClick={loadSpeakers} className="btn-icon btn-icon-ghost" aria-label={t('speakers.refreshSpeakers')}>
+          <RefreshCw className="w-5 h-5" aria-hidden="true" />
+        </button>
+      </PageHeader>
 
       {/* Service Status */}
       {serviceStatus && (
-        <div className={`card ${serviceStatus.available ? 'bg-green-100 dark:bg-green-900/20 border-green-300 dark:border-green-700' : 'bg-red-100 dark:bg-red-900/20 border-red-300 dark:border-red-700'}`}>
-          <div className="flex items-center space-x-3">
-            {serviceStatus.available ? (
-              <CheckCircle className="w-5 h-5 text-green-500" />
-            ) : (
-              <XCircle className="w-5 h-5 text-red-500" />
-            )}
-            <div>
-              <p className={`font-medium ${serviceStatus.available ? 'text-green-700 dark:text-green-400' : 'text-red-700 dark:text-red-400'}`}>
-                {serviceStatus.available ? t('speakers.serviceActive') : t('speakers.serviceNotAvailable')}
-              </p>
-              <p className="text-sm text-gray-500 dark:text-gray-400">{serviceStatus.message}</p>
-            </div>
+        <Alert variant={serviceStatus.available ? 'success' : 'error'}>
+          <div>
+            <p className="font-medium">
+              {serviceStatus.available ? t('speakers.serviceActive') : t('speakers.serviceNotAvailable')}
+            </p>
+            <p className="text-sm opacity-80">{serviceStatus.message}</p>
           </div>
-        </div>
+        </Alert>
       )}
 
       {/* Alerts */}
-      {error && (
-        <div className="card bg-red-100 dark:bg-red-900/20 border-red-300 dark:border-red-700">
-          <div className="flex items-center space-x-3">
-            <AlertCircle className="w-5 h-5 text-red-500" />
-            <p className="text-red-700 dark:text-red-400">{error}</p>
-          </div>
-        </div>
-      )}
+      {error && <Alert variant="error">{error}</Alert>}
 
-      {success && (
-        <div className="card bg-green-100 dark:bg-green-900/20 border-green-300 dark:border-green-700">
-          <div className="flex items-center space-x-3">
-            <CheckCircle className="w-5 h-5 text-green-500" />
-            <p className="text-green-700 dark:text-green-400">{success}</p>
-          </div>
-        </div>
-      )}
+      {success && <Alert variant="success">{success}</Alert>}
 
       {/* Actions */}
       <div className="flex flex-wrap gap-3">
@@ -460,7 +425,7 @@ export default function SpeakersPage() {
 
         <button
           onClick={openIdentifyModal}
-          className="btn bg-purple-600 hover:bg-purple-700 text-white flex items-center space-x-2"
+          className="btn btn-secondary flex items-center space-x-2"
           disabled={!serviceStatus?.available || speakers.length === 0}
         >
           <Volume2 className="w-4 h-4" />
@@ -510,9 +475,7 @@ export default function SpeakersPage() {
                     </div>
                   </div>
                   {speaker.is_admin && (
-                    <span className="px-2 py-1 bg-yellow-100 text-yellow-700 dark:bg-yellow-600/20 dark:text-yellow-400 text-xs rounded-sm">
-                      Admin
-                    </span>
+                    <Badge color="yellow">Admin</Badge>
                   )}
                 </div>
 
@@ -529,7 +492,7 @@ export default function SpeakersPage() {
                 <div className="flex space-x-2">
                   <button
                     onClick={() => openEnrollModal(speaker)}
-                    className="flex-1 btn bg-green-600 hover:bg-green-700 text-white text-sm flex items-center justify-center space-x-1"
+                    className="flex-1 btn btn-success text-sm flex items-center justify-center space-x-1"
                     aria-label={t('speakers.recordFor', { name: speaker.name })}
                   >
                     <Mic className="w-4 h-4" aria-hidden="true" />
@@ -537,14 +500,14 @@ export default function SpeakersPage() {
                   </button>
                   <button
                     onClick={() => openEditModal(speaker)}
-                    className="p-2 rounded-lg bg-blue-100 hover:bg-blue-200 text-blue-600 dark:bg-blue-600/20 dark:hover:bg-blue-600/40 dark:text-blue-400"
+                    className="btn-icon btn-icon-ghost"
                     aria-label={`${speaker.name} ${t('common.edit').toLowerCase()}`}
                   >
                     <Edit3 className="w-4 h-4" aria-hidden="true" />
                   </button>
                   <button
                     onClick={() => openMergeModal(speaker)}
-                    className="p-2 rounded-lg bg-purple-100 hover:bg-purple-200 text-purple-600 dark:bg-purple-600/20 dark:hover:bg-purple-600/40 dark:text-purple-400"
+                    className="btn-icon btn-icon-ghost"
                     aria-label={`${speaker.name} ${t('speakers.merge').toLowerCase()}`}
                     disabled={speakers.length < 2}
                   >
@@ -552,7 +515,7 @@ export default function SpeakersPage() {
                   </button>
                   <button
                     onClick={() => deleteSpeaker(speaker)}
-                    className="p-2 rounded-lg bg-red-100 hover:bg-red-200 text-red-600 dark:bg-red-600/20 dark:hover:bg-red-600/40 dark:text-red-400"
+                    className="btn-icon btn-icon-danger"
                     aria-label={`${speaker.name} ${t('common.delete').toLowerCase()}`}
                   >
                     <Trash2 className="w-4 h-4" aria-hidden="true" />
@@ -565,465 +528,438 @@ export default function SpeakersPage() {
       </div>
 
       {/* Create Speaker Modal */}
-      {showCreateModal && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="card max-w-md w-full">
-            <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-4">{t('speakers.createSpeaker')}</h2>
+      <Modal isOpen={showCreateModal} onClose={() => setShowCreateModal(false)} title={t('speakers.createSpeaker')}>
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">{t('common.name')}</label>
+            <input
+              type="text"
+              value={newSpeakerName}
+              onChange={(e) => setNewSpeakerName(e.target.value)}
+              placeholder="Max Mustermann"
+              className="input w-full"
+            />
+          </div>
 
-            <div className="space-y-4">
-              <div>
-                <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">{t('common.name')}</label>
-                <input
-                  type="text"
-                  value={newSpeakerName}
-                  onChange={(e) => setNewSpeakerName(e.target.value)}
-                  placeholder="Max Mustermann"
-                  className="input w-full"
-                />
-              </div>
+          <div>
+            <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">{t('speakers.aliasLabel')}</label>
+            <input
+              type="text"
+              value={newSpeakerAlias}
+              onChange={(e) => setNewSpeakerAlias(e.target.value.toLowerCase().replace(/\s/g, '_'))}
+              placeholder="max"
+              className="input w-full"
+            />
+          </div>
 
-              <div>
-                <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">{t('speakers.aliasLabel')}</label>
-                <input
-                  type="text"
-                  value={newSpeakerAlias}
-                  onChange={(e) => setNewSpeakerAlias(e.target.value.toLowerCase().replace(/\s/g, '_'))}
-                  placeholder="max"
-                  className="input w-full"
-                />
-              </div>
-
-              <div className="flex items-center space-x-3">
-                <input
-                  type="checkbox"
-                  id="isAdmin"
-                  checked={newSpeakerIsAdmin}
-                  onChange={(e) => setNewSpeakerIsAdmin(e.target.checked)}
-                  className="w-4 h-4 rounded-sm"
-                />
-                <label htmlFor="isAdmin" className="text-sm text-gray-600 dark:text-gray-300 flex items-center space-x-2">
-                  <Shield className="w-4 h-4" />
-                  <span>{t('speakers.adminPermission')}</span>
-                </label>
-              </div>
-            </div>
-
-            <div className="flex space-x-3 mt-6">
-              <button
-                onClick={() => setShowCreateModal(false)}
-                className="flex-1 btn btn-secondary"
-              >
-                {t('common.cancel')}
-              </button>
-              <button
-                onClick={createSpeaker}
-                className="flex-1 btn btn-primary"
-              >
-                {t('common.create')}
-              </button>
-            </div>
+          <div className="flex items-center space-x-3">
+            <input
+              type="checkbox"
+              id="isAdmin"
+              checked={newSpeakerIsAdmin}
+              onChange={(e) => setNewSpeakerIsAdmin(e.target.checked)}
+              className="w-4 h-4 rounded-sm"
+            />
+            <label htmlFor="isAdmin" className="text-sm text-gray-600 dark:text-gray-300 flex items-center space-x-2">
+              <Shield className="w-4 h-4" />
+              <span>{t('speakers.adminPermission')}</span>
+            </label>
           </div>
         </div>
-      )}
+
+        <div className="flex space-x-3 mt-6">
+          <button
+            onClick={() => setShowCreateModal(false)}
+            className="flex-1 btn btn-secondary"
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            onClick={createSpeaker}
+            className="flex-1 btn btn-primary"
+          >
+            {t('common.create')}
+          </button>
+        </div>
+      </Modal>
 
       {/* Enroll Modal */}
-      {showEnrollModal && selectedSpeaker && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="card max-w-md w-full">
-            <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-2">{t('speakers.recordVoiceSample')}</h2>
-            <p className="text-gray-500 dark:text-gray-400 mb-4">{t('speakers.recordFor', { name: selectedSpeaker.name })}</p>
+      <Modal isOpen={showEnrollModal && !!selectedSpeaker} onClose={() => { setShowEnrollModal(false); setAudioBlob(null); }} title={t('speakers.recordVoiceSample')}>
+        <p className="text-gray-500 dark:text-gray-400 mb-4">{t('speakers.recordFor', { name: selectedSpeaker?.name })}</p>
 
-            <div className="bg-gray-100 dark:bg-gray-800 rounded-lg p-6 mb-4">
-              <div className="text-center">
-                {recording ? (
-                  <div>
-                    {/* Recording Header */}
-                    <div className="flex items-center justify-center space-x-2 mb-4">
-                      <div className="w-2.5 h-2.5 bg-red-500 rounded-full animate-pulse"></div>
-                      <span className="text-sm font-medium text-red-600 dark:text-red-400">
-                        {audioLevel > 10 ? t('voice.speechDetected') : t('voice.listening')}
-                      </span>
-                    </div>
-
-                    {/* Waveform Visualization */}
-                    <div className="flex items-center justify-center space-x-1.5 h-16 mb-4">
-                      {[0, 1, 2, 3, 4, 5, 6, 7, 8].map((i) => {
-                        const variation = Math.sin((Date.now() / 100) + i) * 0.3 + 0.7;
-                        const baseHeight = Math.max(10, audioLevel) * variation;
-                        const height = Math.min(100, baseHeight);
-                        const colorClass = audioLevel > 50 ? 'bg-green-500' :
-                                           audioLevel > 10 ? 'bg-primary-500' :
-                                           'bg-gray-400 dark:bg-gray-600';
-
-                        return (
-                          <div
-                            key={i}
-                            className={`w-2 rounded-full transition-all duration-150 ease-out ${colorClass}`}
-                            style={{
-                              height: `${height}%`,
-                              opacity: audioLevel > 5 ? 1 : 0.3
-                            }}
-                          />
-                        );
-                      })}
-                    </div>
-
-                    <p className="text-sm text-gray-500 dark:text-gray-400">{t('speakers.speak3to10seconds')}</p>
-                    <p className="text-xs text-gray-500 mt-1">{t('voice.level')}: {audioLevel}</p>
-                  </div>
-                ) : audioBlob ? (
-                  <div>
-                    <div className="w-16 h-16 mx-auto mb-4 bg-green-600 rounded-full flex items-center justify-center">
-                      <CheckCircle className="w-8 h-8 text-white" />
-                    </div>
-                    <p className="text-green-600 dark:text-green-400 font-medium">{t('speakers.recordingReady')}</p>
-                    <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
-                      {(audioBlob.size / 1024).toFixed(1)} KB
-                    </p>
-                  </div>
-                ) : (
-                  <div>
-                    <div className="w-16 h-16 mx-auto mb-4 bg-gray-300 dark:bg-gray-700 rounded-full flex items-center justify-center">
-                      <Mic className="w-8 h-8 text-gray-500 dark:text-gray-400" />
-                    </div>
-                    <p className="text-gray-500 dark:text-gray-400">{t('speakers.readyToRecord')}</p>
-                    <p className="text-sm text-gray-500 mt-2">{t('speakers.speakAnySentence')}</p>
-                  </div>
-                )}
-              </div>
-            </div>
-
-            <div className="flex space-x-3 mb-4">
-              {recording ? (
-                <button
-                  onClick={stopRecording}
-                  className="flex-1 btn bg-red-600 hover:bg-red-700 text-white flex items-center justify-center space-x-2"
-                >
-                  <MicOff className="w-4 h-4" />
-                  <span>{t('speakers.stop')}</span>
-                </button>
-              ) : (
-                <button
-                  onClick={startRecording}
-                  className="flex-1 btn bg-green-600 hover:bg-green-700 text-white flex items-center justify-center space-x-2"
-                >
-                  <Mic className="w-4 h-4" />
-                  <span>{t('speakers.record')}</span>
-                </button>
-              )}
-            </div>
-
-            <div className="flex space-x-3">
-              <button
-                onClick={() => {
-                  setShowEnrollModal(false);
-                  setAudioBlob(null);
-                }}
-                className="flex-1 btn btn-secondary"
-              >
-                {t('common.cancel')}
-              </button>
-              <button
-                onClick={enrollVoiceSample}
-                disabled={!audioBlob || enrolling}
-                className="flex-1 btn btn-primary disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {enrolling ? (
-                  <Loader className="w-4 h-4 animate-spin mx-auto" />
-                ) : (
-                  t('common.save')
-                )}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Identify Modal */}
-      {showIdentifyModal && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="card max-w-md w-full">
-            <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-2">{t('speakers.identifySpeaker')}</h2>
-            <p className="text-gray-500 dark:text-gray-400 mb-4">{t('speakers.identifySubtitle')}</p>
-
-            <div className="bg-gray-100 dark:bg-gray-800 rounded-lg p-6 mb-4">
-              <div className="text-center">
-                {recording ? (
-                  <div>
-                    {/* Recording Header */}
-                    <div className="flex items-center justify-center space-x-2 mb-4">
-                      <div className="w-2.5 h-2.5 bg-red-500 rounded-full animate-pulse"></div>
-                      <span className="text-sm font-medium text-red-600 dark:text-red-400">
-                        {audioLevel > 10 ? t('voice.speechDetected') : t('voice.listening')}
-                      </span>
-                    </div>
-
-                    {/* Waveform Visualization */}
-                    <div className="flex items-center justify-center space-x-1.5 h-16 mb-4">
-                      {[0, 1, 2, 3, 4, 5, 6, 7, 8].map((i) => {
-                        const variation = Math.sin((Date.now() / 100) + i) * 0.3 + 0.7;
-                        const baseHeight = Math.max(10, audioLevel) * variation;
-                        const height = Math.min(100, baseHeight);
-                        const colorClass = audioLevel > 50 ? 'bg-green-500' :
-                                           audioLevel > 10 ? 'bg-purple-500' :
-                                           'bg-gray-400 dark:bg-gray-600';
-
-                        return (
-                          <div
-                            key={i}
-                            className={`w-2 rounded-full transition-all duration-150 ease-out ${colorClass}`}
-                            style={{
-                              height: `${height}%`,
-                              opacity: audioLevel > 5 ? 1 : 0.3
-                            }}
-                          />
-                        );
-                      })}
-                    </div>
-
-                    <p className="text-xs text-gray-500">{t('voice.level')}: {audioLevel}</p>
-                  </div>
-                ) : audioBlob && !identifyResult ? (
-                  <div>
-                    <div className="w-16 h-16 mx-auto mb-4 bg-green-600 rounded-full flex items-center justify-center">
-                      <CheckCircle className="w-8 h-8 text-white" />
-                    </div>
-                    <p className="text-green-600 dark:text-green-400 font-medium">{t('speakers.recordingReady')}</p>
-                  </div>
-                ) : identifyResult ? (
-                  <div>
-                    {identifyResult.is_identified ? (
-                      <>
-                        <div className="w-16 h-16 mx-auto mb-4 bg-green-600 rounded-full flex items-center justify-center">
-                          <CheckCircle className="w-8 h-8 text-white" />
-                        </div>
-                        <p className="text-green-600 dark:text-green-400 font-medium text-lg">{identifyResult.speaker_name}</p>
-                        <p className="text-gray-500 dark:text-gray-400">@{identifyResult.speaker_alias}</p>
-                        <p className="text-sm text-gray-500 mt-2">
-                          {t('speakers.confidence')}: {(identifyResult.confidence * 100).toFixed(1)}%
-                        </p>
-                      </>
-                    ) : (
-                      <>
-                        <div className="w-16 h-16 mx-auto mb-4 bg-yellow-600 rounded-full flex items-center justify-center">
-                          <AlertCircle className="w-8 h-8 text-white" />
-                        </div>
-                        <p className="text-yellow-600 dark:text-yellow-400 font-medium">{t('speakers.speakerNotIdentified')}</p>
-                        <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
-                          {t('speakers.noRegisteredSpeakerFound')}
-                        </p>
-                      </>
-                    )}
-                  </div>
-                ) : (
-                  <div>
-                    <div className="w-16 h-16 mx-auto mb-4 bg-purple-600 rounded-full flex items-center justify-center">
-                      <Volume2 className="w-8 h-8 text-white" />
-                    </div>
-                    <p className="text-gray-500 dark:text-gray-400">{t('speakers.readyToIdentify')}</p>
-                  </div>
-                )}
-              </div>
-            </div>
-
-            <div className="flex space-x-3 mb-4">
-              {recording ? (
-                <button
-                  onClick={stopRecording}
-                  className="flex-1 btn bg-red-600 hover:bg-red-700 text-white flex items-center justify-center space-x-2"
-                >
-                  <MicOff className="w-4 h-4" />
-                  <span>{t('speakers.stop')}</span>
-                </button>
-              ) : (
-                <button
-                  onClick={() => {
-                    setIdentifyResult(null);
-                    startRecording();
-                  }}
-                  className="flex-1 btn bg-green-600 hover:bg-green-700 text-white flex items-center justify-center space-x-2"
-                >
-                  <Mic className="w-4 h-4" />
-                  <span>{identifyResult ? t('speakers.recordAgain') : t('speakers.record')}</span>
-                </button>
-              )}
-            </div>
-
-            <div className="flex space-x-3">
-              <button
-                onClick={() => {
-                  setShowIdentifyModal(false);
-                  setAudioBlob(null);
-                  setIdentifyResult(null);
-                }}
-                className="flex-1 btn btn-secondary"
-              >
-                {t('common.close')}
-              </button>
-              <button
-                onClick={identifySpeaker}
-                disabled={!audioBlob || identifying || identifyResult}
-                className="flex-1 btn btn-primary disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {identifying ? (
-                  <Loader className="w-4 h-4 animate-spin mx-auto" />
-                ) : (
-                  t('speakers.identify')
-                )}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Edit Speaker Modal */}
-      {showEditModal && selectedSpeaker && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="card max-w-md w-full">
-            <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-4">{t('speakers.editSpeaker')}</h2>
-
-            <div className="space-y-4">
+        <div className="bg-gray-100 dark:bg-gray-800 rounded-lg p-6 mb-4">
+          <div className="text-center">
+            {recording ? (
               <div>
-                <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">{t('common.name')}</label>
-                <input
-                  type="text"
-                  value={editSpeakerName}
-                  onChange={(e) => setEditSpeakerName(e.target.value)}
-                  placeholder="Max Mustermann"
-                  className="input w-full"
-                />
-              </div>
+                {/* Recording Header */}
+                <div className="flex items-center justify-center space-x-2 mb-4">
+                  <div className="w-2.5 h-2.5 bg-red-500 rounded-full animate-pulse"></div>
+                  <span className="text-sm font-medium text-red-600 dark:text-red-400">
+                    {audioLevel > 10 ? t('voice.speechDetected') : t('voice.listening')}
+                  </span>
+                </div>
 
+                {/* Waveform Visualization */}
+                <div className="flex items-center justify-center space-x-1.5 h-16 mb-4">
+                  {[0, 1, 2, 3, 4, 5, 6, 7, 8].map((i) => {
+                    const variation = Math.sin((Date.now() / 100) + i) * 0.3 + 0.7;
+                    const baseHeight = Math.max(10, audioLevel) * variation;
+                    const height = Math.min(100, baseHeight);
+                    const colorClass = audioLevel > 50 ? 'bg-green-500' :
+                                       audioLevel > 10 ? 'bg-primary-500' :
+                                       'bg-gray-400 dark:bg-gray-600';
+
+                    return (
+                      <div
+                        key={i}
+                        className={`w-2 rounded-full transition-all duration-150 ease-out ${colorClass}`}
+                        style={{
+                          height: `${height}%`,
+                          opacity: audioLevel > 5 ? 1 : 0.3
+                        }}
+                      />
+                    );
+                  })}
+                </div>
+
+                <p className="text-sm text-gray-500 dark:text-gray-400">{t('speakers.speak3to10seconds')}</p>
+                <p className="text-xs text-gray-500 mt-1">{t('voice.level')}: {audioLevel}</p>
+              </div>
+            ) : audioBlob ? (
               <div>
-                <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">{t('speakers.aliasLabel')}</label>
-                <input
-                  type="text"
-                  value={editSpeakerAlias}
-                  onChange={(e) => setEditSpeakerAlias(e.target.value.toLowerCase().replace(/\s/g, '_'))}
-                  placeholder="max"
-                  className="input w-full"
-                />
-              </div>
-
-              <div className="flex items-center space-x-3">
-                <input
-                  type="checkbox"
-                  id="editIsAdmin"
-                  checked={editSpeakerIsAdmin}
-                  onChange={(e) => setEditSpeakerIsAdmin(e.target.checked)}
-                  className="w-4 h-4 rounded-sm"
-                />
-                <label htmlFor="editIsAdmin" className="text-sm text-gray-600 dark:text-gray-300 flex items-center space-x-2">
-                  <Shield className="w-4 h-4" />
-                  <span>{t('speakers.adminPermission')}</span>
-                </label>
-              </div>
-
-              <div className="text-sm text-gray-500">
-                {t('speakers.voiceSamples')}: {selectedSpeaker.embedding_count}
-              </div>
-            </div>
-
-            <div className="flex space-x-3 mt-6">
-              <button
-                onClick={() => setShowEditModal(false)}
-                className="flex-1 btn btn-secondary"
-              >
-                {t('common.cancel')}
-              </button>
-              <button
-                onClick={updateSpeaker}
-                disabled={updating}
-                className="flex-1 btn btn-primary disabled:opacity-50"
-              >
-                {updating ? (
-                  <Loader className="w-4 h-4 animate-spin mx-auto" />
-                ) : (
-                  t('common.save')
-                )}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Merge Speakers Modal */}
-      {showMergeModal && selectedSpeaker && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="card max-w-md w-full">
-            <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-2">{t('speakers.mergeSpeakers')}</h2>
-            <p className="text-gray-500 dark:text-gray-400 mb-4">
-              {t('speakers.mergeSubtitle', { name: selectedSpeaker.name })}
-            </p>
-
-            <div className="bg-gray-100 dark:bg-gray-800 rounded-lg p-4 mb-4">
-              <div className="flex items-center space-x-3 mb-4">
-                <div className="p-2 bg-purple-600 rounded-lg">
-                  <GitMerge className="w-5 h-5 text-white" />
+                <div className="w-16 h-16 mx-auto mb-4 bg-green-600 rounded-full flex items-center justify-center">
+                  <CheckCircle className="w-8 h-8 text-white" />
                 </div>
-                <div>
-                  <p className="text-gray-900 dark:text-white font-medium">{selectedSpeaker.name}</p>
-                  <p className="text-sm text-gray-500 dark:text-gray-400">
-                    {selectedSpeaker.embedding_count} {t('speakers.voiceSamples')}
-                  </p>
-                </div>
-              </div>
-
-              <div className="border-t border-gray-200 dark:border-gray-700 pt-4">
-                <label className="block text-sm text-gray-500 dark:text-gray-400 mb-2">{t('speakers.mergeTarget')}:</label>
-                <select
-                  value={mergeTargetId || ''}
-                  onChange={(e) => setMergeTargetId(e.target.value)}
-                  className="input w-full"
-                >
-                  <option value="">{t('speakers.mergeTargetPlaceholder')}</option>
-                  {speakers
-                    .filter(s => s.id !== selectedSpeaker.id)
-                    .map(s => (
-                      <option key={s.id} value={s.id}>
-                        {s.name} (@{s.alias}) - {s.embedding_count} Samples
-                      </option>
-                    ))
-                  }
-                </select>
-              </div>
-            </div>
-
-            <div className="bg-yellow-100 dark:bg-yellow-900/20 border border-yellow-300 dark:border-yellow-700 rounded-lg p-3 mb-4">
-              <div className="flex items-start space-x-2">
-                <AlertCircle className="w-5 h-5 text-yellow-600 dark:text-yellow-500 shrink-0 mt-0.5" />
-                <p className="text-sm text-yellow-700 dark:text-yellow-400">
-                  {t('speakers.mergeWarning', { name: selectedSpeaker.name })}
+                <p className="text-green-600 dark:text-green-400 font-medium">{t('speakers.recordingReady')}</p>
+                <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
+                  {(audioBlob.size / 1024).toFixed(1)} KB
                 </p>
               </div>
-            </div>
-
-            <div className="flex space-x-3">
-              <button
-                onClick={() => {
-                  setShowMergeModal(false);
-                  setSelectedSpeaker(null);
-                  setMergeTargetId(null);
-                }}
-                className="flex-1 btn btn-secondary"
-              >
-                {t('common.cancel')}
-              </button>
-              <button
-                onClick={mergeSpeakers}
-                disabled={!mergeTargetId || merging}
-                className="flex-1 btn bg-purple-600 hover:bg-purple-700 text-white disabled:opacity-50"
-              >
-                {merging ? (
-                  <Loader className="w-4 h-4 animate-spin mx-auto" aria-label={t('common.loading')} />
-                ) : (
-                  t('speakers.merge')
-                )}
-              </button>
-            </div>
+            ) : (
+              <div>
+                <div className="w-16 h-16 mx-auto mb-4 bg-gray-300 dark:bg-gray-700 rounded-full flex items-center justify-center">
+                  <Mic className="w-8 h-8 text-gray-500 dark:text-gray-400" />
+                </div>
+                <p className="text-gray-500 dark:text-gray-400">{t('speakers.readyToRecord')}</p>
+                <p className="text-sm text-gray-500 mt-2">{t('speakers.speakAnySentence')}</p>
+              </div>
+            )}
           </div>
         </div>
-      )}
+
+        <div className="flex space-x-3 mb-4">
+          {recording ? (
+            <button
+              onClick={stopRecording}
+              className="flex-1 btn btn-danger flex items-center justify-center space-x-2"
+            >
+              <MicOff className="w-4 h-4" />
+              <span>{t('speakers.stop')}</span>
+            </button>
+          ) : (
+            <button
+              onClick={startRecording}
+              className="flex-1 btn btn-success flex items-center justify-center space-x-2"
+            >
+              <Mic className="w-4 h-4" />
+              <span>{t('speakers.record')}</span>
+            </button>
+          )}
+        </div>
+
+        <div className="flex space-x-3">
+          <button
+            onClick={() => {
+              setShowEnrollModal(false);
+              setAudioBlob(null);
+            }}
+            className="flex-1 btn btn-secondary"
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            onClick={enrollVoiceSample}
+            disabled={!audioBlob || enrolling}
+            className="flex-1 btn btn-primary disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {enrolling ? (
+              <Loader className="w-4 h-4 animate-spin mx-auto" />
+            ) : (
+              t('common.save')
+            )}
+          </button>
+        </div>
+      </Modal>
+
+      {/* Identify Modal */}
+      <Modal isOpen={showIdentifyModal} onClose={() => { setShowIdentifyModal(false); setAudioBlob(null); setIdentifyResult(null); }} title={t('speakers.identifySpeaker')}>
+        <p className="text-gray-500 dark:text-gray-400 mb-4">{t('speakers.identifySubtitle')}</p>
+
+        <div className="bg-gray-100 dark:bg-gray-800 rounded-lg p-6 mb-4">
+          <div className="text-center">
+            {recording ? (
+              <div>
+                {/* Recording Header */}
+                <div className="flex items-center justify-center space-x-2 mb-4">
+                  <div className="w-2.5 h-2.5 bg-red-500 rounded-full animate-pulse"></div>
+                  <span className="text-sm font-medium text-red-600 dark:text-red-400">
+                    {audioLevel > 10 ? t('voice.speechDetected') : t('voice.listening')}
+                  </span>
+                </div>
+
+                {/* Waveform Visualization */}
+                <div className="flex items-center justify-center space-x-1.5 h-16 mb-4">
+                  {[0, 1, 2, 3, 4, 5, 6, 7, 8].map((i) => {
+                    const variation = Math.sin((Date.now() / 100) + i) * 0.3 + 0.7;
+                    const baseHeight = Math.max(10, audioLevel) * variation;
+                    const height = Math.min(100, baseHeight);
+                    const colorClass = audioLevel > 50 ? 'bg-green-500' :
+                                       audioLevel > 10 ? 'bg-purple-500' :
+                                       'bg-gray-400 dark:bg-gray-600';
+
+                    return (
+                      <div
+                        key={i}
+                        className={`w-2 rounded-full transition-all duration-150 ease-out ${colorClass}`}
+                        style={{
+                          height: `${height}%`,
+                          opacity: audioLevel > 5 ? 1 : 0.3
+                        }}
+                      />
+                    );
+                  })}
+                </div>
+
+                <p className="text-xs text-gray-500">{t('voice.level')}: {audioLevel}</p>
+              </div>
+            ) : audioBlob && !identifyResult ? (
+              <div>
+                <div className="w-16 h-16 mx-auto mb-4 bg-green-600 rounded-full flex items-center justify-center">
+                  <CheckCircle className="w-8 h-8 text-white" />
+                </div>
+                <p className="text-green-600 dark:text-green-400 font-medium">{t('speakers.recordingReady')}</p>
+              </div>
+            ) : identifyResult ? (
+              <div>
+                {identifyResult.is_identified ? (
+                  <>
+                    <div className="w-16 h-16 mx-auto mb-4 bg-green-600 rounded-full flex items-center justify-center">
+                      <CheckCircle className="w-8 h-8 text-white" />
+                    </div>
+                    <p className="text-green-600 dark:text-green-400 font-medium text-lg">{identifyResult.speaker_name}</p>
+                    <p className="text-gray-500 dark:text-gray-400">@{identifyResult.speaker_alias}</p>
+                    <p className="text-sm text-gray-500 mt-2">
+                      {t('speakers.confidence')}: {(identifyResult.confidence * 100).toFixed(1)}%
+                    </p>
+                  </>
+                ) : (
+                  <>
+                    <div className="w-16 h-16 mx-auto mb-4 bg-yellow-600 rounded-full flex items-center justify-center">
+                      <AlertCircle className="w-8 h-8 text-white" />
+                    </div>
+                    <p className="text-yellow-600 dark:text-yellow-400 font-medium">{t('speakers.speakerNotIdentified')}</p>
+                    <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
+                      {t('speakers.noRegisteredSpeakerFound')}
+                    </p>
+                  </>
+                )}
+              </div>
+            ) : (
+              <div>
+                <div className="w-16 h-16 mx-auto mb-4 bg-purple-600 rounded-full flex items-center justify-center">
+                  <Volume2 className="w-8 h-8 text-white" />
+                </div>
+                <p className="text-gray-500 dark:text-gray-400">{t('speakers.readyToIdentify')}</p>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="flex space-x-3 mb-4">
+          {recording ? (
+            <button
+              onClick={stopRecording}
+              className="flex-1 btn btn-danger flex items-center justify-center space-x-2"
+            >
+              <MicOff className="w-4 h-4" />
+              <span>{t('speakers.stop')}</span>
+            </button>
+          ) : (
+            <button
+              onClick={() => {
+                setIdentifyResult(null);
+                startRecording();
+              }}
+              className="flex-1 btn btn-success flex items-center justify-center space-x-2"
+            >
+              <Mic className="w-4 h-4" />
+              <span>{identifyResult ? t('speakers.recordAgain') : t('speakers.record')}</span>
+            </button>
+          )}
+        </div>
+
+        <div className="flex space-x-3">
+          <button
+            onClick={() => {
+              setShowIdentifyModal(false);
+              setAudioBlob(null);
+              setIdentifyResult(null);
+            }}
+            className="flex-1 btn btn-secondary"
+          >
+            {t('common.close')}
+          </button>
+          <button
+            onClick={identifySpeaker}
+            disabled={!audioBlob || identifying || identifyResult}
+            className="flex-1 btn btn-primary disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {identifying ? (
+              <Loader className="w-4 h-4 animate-spin mx-auto" />
+            ) : (
+              t('speakers.identify')
+            )}
+          </button>
+        </div>
+      </Modal>
+
+      {/* Edit Speaker Modal */}
+      <Modal isOpen={showEditModal && !!selectedSpeaker} onClose={() => setShowEditModal(false)} title={t('speakers.editSpeaker')}>
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">{t('common.name')}</label>
+            <input
+              type="text"
+              value={editSpeakerName}
+              onChange={(e) => setEditSpeakerName(e.target.value)}
+              placeholder="Max Mustermann"
+              className="input w-full"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm text-gray-500 dark:text-gray-400 mb-1">{t('speakers.aliasLabel')}</label>
+            <input
+              type="text"
+              value={editSpeakerAlias}
+              onChange={(e) => setEditSpeakerAlias(e.target.value.toLowerCase().replace(/\s/g, '_'))}
+              placeholder="max"
+              className="input w-full"
+            />
+          </div>
+
+          <div className="flex items-center space-x-3">
+            <input
+              type="checkbox"
+              id="editIsAdmin"
+              checked={editSpeakerIsAdmin}
+              onChange={(e) => setEditSpeakerIsAdmin(e.target.checked)}
+              className="w-4 h-4 rounded-sm"
+            />
+            <label htmlFor="editIsAdmin" className="text-sm text-gray-600 dark:text-gray-300 flex items-center space-x-2">
+              <Shield className="w-4 h-4" />
+              <span>{t('speakers.adminPermission')}</span>
+            </label>
+          </div>
+
+          <div className="text-sm text-gray-500">
+            {t('speakers.voiceSamples')}: {selectedSpeaker?.embedding_count}
+          </div>
+        </div>
+
+        <div className="flex space-x-3 mt-6">
+          <button
+            onClick={() => setShowEditModal(false)}
+            className="flex-1 btn btn-secondary"
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            onClick={updateSpeaker}
+            disabled={updating}
+            className="flex-1 btn btn-primary disabled:opacity-50"
+          >
+            {updating ? (
+              <Loader className="w-4 h-4 animate-spin mx-auto" />
+            ) : (
+              t('common.save')
+            )}
+          </button>
+        </div>
+      </Modal>
+
+      {/* Merge Speakers Modal */}
+      <Modal isOpen={showMergeModal && !!selectedSpeaker} onClose={() => { setShowMergeModal(false); setSelectedSpeaker(null); setMergeTargetId(null); }} title={t('speakers.mergeSpeakers')}>
+        <p className="text-gray-500 dark:text-gray-400 mb-4">
+          {t('speakers.mergeSubtitle', { name: selectedSpeaker?.name })}
+        </p>
+
+        <div className="bg-gray-100 dark:bg-gray-800 rounded-lg p-4 mb-4">
+          <div className="flex items-center space-x-3 mb-4">
+            <div className="p-2 bg-purple-600 rounded-lg">
+              <GitMerge className="w-5 h-5 text-white" />
+            </div>
+            <div>
+              <p className="text-gray-900 dark:text-white font-medium">{selectedSpeaker?.name}</p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                {selectedSpeaker?.embedding_count} {t('speakers.voiceSamples')}
+              </p>
+            </div>
+          </div>
+
+          <div className="border-t border-gray-200 dark:border-gray-700 pt-4">
+            <label className="block text-sm text-gray-500 dark:text-gray-400 mb-2">{t('speakers.mergeTarget')}:</label>
+            <select
+              value={mergeTargetId || ''}
+              onChange={(e) => setMergeTargetId(e.target.value)}
+              className="input w-full"
+            >
+              <option value="">{t('speakers.mergeTargetPlaceholder')}</option>
+              {speakers
+                .filter(s => s.id !== selectedSpeaker?.id)
+                .map(s => (
+                  <option key={s.id} value={s.id}>
+                    {s.name} (@{s.alias}) - {s.embedding_count} Samples
+                  </option>
+                ))
+              }
+            </select>
+          </div>
+        </div>
+
+        <div className="bg-yellow-100 dark:bg-yellow-900/20 border border-yellow-300 dark:border-yellow-700 rounded-lg p-3 mb-4">
+          <div className="flex items-start space-x-2">
+            <AlertCircle className="w-5 h-5 text-yellow-600 dark:text-yellow-500 shrink-0 mt-0.5" />
+            <p className="text-sm text-yellow-700 dark:text-yellow-400">
+              {t('speakers.mergeWarning', { name: selectedSpeaker?.name })}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex space-x-3">
+          <button
+            onClick={() => {
+              setShowMergeModal(false);
+              setSelectedSpeaker(null);
+              setMergeTargetId(null);
+            }}
+            className="flex-1 btn btn-secondary"
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            onClick={mergeSpeakers}
+            disabled={!mergeTargetId || merging}
+            className="flex-1 btn btn-secondary disabled:opacity-50"
+          >
+            {merging ? (
+              <Loader className="w-4 h-4 animate-spin mx-auto" aria-label={t('common.loading')} />
+            ) : (
+              t('speakers.merge')
+            )}
+          </button>
+        </div>
+      </Modal>
 
       {/* Confirm Dialog */}
       {ConfirmDialogComponent}


### PR DESCRIPTION
## Summary
- Add semantic button variants (`btn-danger`, `btn-success`, `btn-ghost`, `btn-icon-*`) and `card-elevated` utility
- Soften default card shadow (`shadow-lg` → `shadow-sm`)
- Create reusable `PageHeader`, `Alert`, `Badge` components
- Polish chat: larger agent steps with accent-cyan, suggestion chips in empty state, input separator
- Integrate accent cyan: sidebar active indicator, connection status dot
- Refactor RoomsPage (4 inline modals → `Modal`, inline styles → design system)
- Refactor SpeakersPage (5 inline modals → `Modal`, inline styles → design system)

Closes #245

## Test plan
- [x] `vite build` passes clean
- [x] All 313 React component tests pass (21 test files)
- [ ] Visual review: chat empty state, agent steps, card shadows in light + dark mode
- [ ] Visual review: sidebar active indicator (cyan), connection dot
- [ ] RoomsPage: all 4 modals functional (create, edit, link, sync)
- [ ] SpeakersPage: all 5 modals functional (create, enroll, identify, edit, merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)