### PR TITLE
feat(frontend): Apply design system to all admin pages

### DIFF
--- a/src/frontend/src/pages/CameraPage.jsx
+++ b/src/frontend/src/pages/CameraPage.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Camera, RefreshCw, User, Car, Dog } from 'lucide-react';
 import apiClient from '../utils/axios';
+import PageHeader from '../components/PageHeader';
 
 export default function CameraPage() {
   const { t, i18n } = useTranslation();
@@ -54,27 +55,15 @@ export default function CameraPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="card">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-4">
-            <div className="p-3 bg-primary-100 dark:bg-primary-900/30 rounded-xl">
-              <Camera className="w-6 h-6 text-primary-600 dark:text-primary-400" />
-            </div>
-            <div>
-              <h1 className="text-2xl font-bold font-display text-gray-900 dark:text-white">{t('cameras.title')}</h1>
-              <p className="text-gray-500 dark:text-gray-400">{t('cameras.subtitle')}</p>
-            </div>
-          </div>
-          <button
-            onClick={() => { loadCameras(); loadEvents(); }}
-            className="btn btn-secondary"
-            aria-label={t('cameras.refreshCameras')}
-          >
-            <RefreshCw className="w-5 h-5" aria-hidden="true" />
-          </button>
-        </div>
-      </div>
+      <PageHeader icon={Camera} title={t('cameras.title')} subtitle={t('cameras.subtitle')}>
+        <button
+          onClick={() => { loadCameras(); loadEvents(); }}
+          className="btn btn-secondary"
+          aria-label={t('cameras.refreshCameras')}
+        >
+          <RefreshCw className="w-5 h-5" aria-hidden="true" />
+        </button>
+      </PageHeader>
 
       {/* Cameras Overview */}
       <div className="card">

--- a/src/frontend/src/pages/HomeAssistantPage.jsx
+++ b/src/frontend/src/pages/HomeAssistantPage.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Lightbulb, Power, Search, Loader, Sun, Thermometer } from 'lucide-react';
 import apiClient from '../utils/axios';
+import PageHeader from '../components/PageHeader';
 
 export default function HomeAssistantPage() {
   const { t } = useTranslation();
@@ -89,18 +90,7 @@ export default function HomeAssistantPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="card">
-        <div className="flex items-center gap-4">
-          <div className="p-3 bg-primary-100 dark:bg-primary-900/30 rounded-xl">
-            <Lightbulb className="w-6 h-6 text-primary-600 dark:text-primary-400" />
-          </div>
-          <div>
-            <h1 className="text-2xl font-bold font-display text-gray-900 dark:text-white">{t('homeassistant.title')}</h1>
-            <p className="text-gray-500 dark:text-gray-400">{t('homeassistant.subtitle')}</p>
-          </div>
-        </div>
-      </div>
+      <PageHeader icon={Lightbulb} title={t('homeassistant.title')} subtitle={t('homeassistant.subtitle')} />
 
       {/* Search */}
       <div className="card">

--- a/src/frontend/src/pages/IntegrationsPage.jsx
+++ b/src/frontend/src/pages/IntegrationsPage.jsx
@@ -7,18 +7,19 @@ import { useTranslation } from 'react-i18next';
 import { useAuth } from '../context/AuthContext';
 import apiClient from '../utils/axios';
 import Modal from '../components/Modal';
+import PageHeader from '../components/PageHeader';
+import Alert from '../components/Alert';
+import Badge from '../components/Badge';
 import {
   Server,
   RefreshCw,
   AlertCircle,
-  CheckCircle,
   Loader,
   Wrench,
   Wifi,
   WifiOff,
   ChevronDown,
   ChevronRight,
-  Info,
 } from 'lucide-react';
 
 export default function IntegrationsPage() {
@@ -173,13 +174,9 @@ export default function IntegrationsPage() {
     }
   };
 
-  const getTransportBadge = (transport) => {
-    const colors = {
-      stdio: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
-      streamable_http: 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300',
-      sse: 'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300',
-    };
-    return colors[transport] || 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300';
+  const transportBadgeColor = (transport) => {
+    const map = { stdio: 'blue', streamable_http: 'purple', sse: 'amber' };
+    return map[transport] || 'gray';
   };
 
   // Calculate stats
@@ -191,17 +188,7 @@ export default function IntegrationsPage() {
   if (loading) {
     return (
       <div className="space-y-6">
-        <div className="card">
-          <div className="flex items-center gap-4">
-            <div className="p-3 bg-primary-100 dark:bg-primary-900/30 rounded-xl">
-              <Server className="w-6 h-6 text-primary-600 dark:text-primary-400" />
-            </div>
-            <div>
-              <h1 className="text-2xl font-bold font-display text-gray-900 dark:text-white">{t('integrations.title')}</h1>
-              <p className="text-gray-500 dark:text-gray-400">{t('integrations.subtitle')}</p>
-            </div>
-          </div>
-        </div>
+        <PageHeader icon={Server} title={t('integrations.title')} subtitle={t('integrations.subtitle')} />
         <div className="card text-center py-12">
           <Loader className="w-8 h-8 animate-spin mx-auto text-gray-500 dark:text-gray-400 mb-2" />
           <p className="text-gray-500 dark:text-gray-400">{t('integrations.loading')}</p>
@@ -213,46 +200,20 @@ export default function IntegrationsPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="card">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-4">
-            <div className="p-3 bg-primary-100 dark:bg-primary-900/30 rounded-xl">
-              <Server className="w-6 h-6 text-primary-600 dark:text-primary-400" />
-            </div>
-            <div>
-              <h1 className="text-2xl font-bold font-display text-gray-900 dark:text-white">{t('integrations.title')}</h1>
-              <p className="text-gray-500 dark:text-gray-400">{t('integrations.subtitle')}</p>
-            </div>
-          </div>
-          <button
-            onClick={handleRefresh}
-            disabled={refreshing}
-            className="btn btn-secondary flex items-center space-x-2"
-          >
-            <RefreshCw className={`w-4 h-4 ${refreshing ? 'animate-spin' : ''}`} />
-            <span>{t('integrations.refresh')}</span>
-          </button>
-        </div>
-      </div>
+      <PageHeader icon={Server} title={t('integrations.title')} subtitle={t('integrations.subtitle')}>
+        <button
+          onClick={handleRefresh}
+          disabled={refreshing}
+          className="btn btn-secondary flex items-center space-x-2"
+        >
+          <RefreshCw className={`w-4 h-4 ${refreshing ? 'animate-spin' : ''}`} />
+          <span>{t('integrations.refresh')}</span>
+        </button>
+      </PageHeader>
 
       {/* Alerts */}
-      {error && (
-        <div className="card bg-red-100 dark:bg-red-900/20 border-red-300 dark:border-red-700">
-          <div className="flex items-center space-x-3">
-            <AlertCircle className="w-5 h-5 text-red-500 flex-shrink-0" />
-            <p className="text-red-700 dark:text-red-400">{error}</p>
-          </div>
-        </div>
-      )}
-
-      {success && (
-        <div className="card bg-green-100 dark:bg-green-900/20 border-green-300 dark:border-green-700">
-          <div className="flex items-center space-x-3">
-            <CheckCircle className="w-5 h-5 text-green-500 flex-shrink-0" />
-            <p className="text-green-700 dark:text-green-400">{success}</p>
-          </div>
-        </div>
-      )}
+      {error && <Alert variant="error">{error}</Alert>}
+      {success && <Alert variant="success">{success}</Alert>}
 
       {/* Overall Stats */}
       <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
@@ -277,15 +238,9 @@ export default function IntegrationsPage() {
           <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
             {t('integrations.mcpServers')}
           </h2>
-          {mcpStatus?.enabled ? (
-            <span className="px-2 py-0.5 text-xs font-medium rounded-full bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300">
-              {t('integrations.enabled')}
-            </span>
-          ) : (
-            <span className="px-2 py-0.5 text-xs font-medium rounded-full bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300">
-              {t('integrations.disabled')}
-            </span>
-          )}
+          <Badge color={mcpStatus?.enabled ? 'green' : 'gray'}>
+            {mcpStatus?.enabled ? t('integrations.enabled') : t('integrations.disabled')}
+          </Badge>
         </div>
 
         {/* Server List */}
@@ -319,23 +274,17 @@ export default function IntegrationsPage() {
                       <span className="font-medium text-gray-900 dark:text-white">
                         {server.name}
                       </span>
-                      <span className={`px-2 py-0.5 text-xs font-medium rounded-full ${getTransportBadge(server.transport)}`}>
+                      <Badge color={transportBadgeColor(server.transport)}>
                         {server.transport}
-                      </span>
+                      </Badge>
                     </div>
                     <div className="flex items-center space-x-4">
                       <span className="text-sm text-gray-500 dark:text-gray-400">
                         {server.tool_count}/{server.total_tool_count || server.tool_count} {t('integrations.tools')}
                       </span>
-                      {server.connected ? (
-                        <span className="px-2 py-1 text-xs font-medium rounded-full bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300">
-                          {t('integrations.online')}
-                        </span>
-                      ) : (
-                        <span className="px-2 py-1 text-xs font-medium rounded-full bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300">
-                          {t('integrations.offline')}
-                        </span>
-                      )}
+                      <Badge color={server.connected ? 'green' : 'red'}>
+                        {server.connected ? t('integrations.online') : t('integrations.offline')}
+                      </Badge>
                     </div>
                   </div>
 

--- a/src/frontend/src/pages/IntentsPage.jsx
+++ b/src/frontend/src/pages/IntentsPage.jsx
@@ -8,8 +8,11 @@ import { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../context/AuthContext';
 import apiClient from '../utils/axios';
+import PageHeader from '../components/PageHeader';
+import Alert from '../components/Alert';
+import Badge from '../components/Badge';
 import {
-  Zap, Loader, AlertCircle, RefreshCw, CheckCircle, XCircle,
+  Zap, Loader, RefreshCw, CheckCircle, XCircle,
   ChevronDown, ChevronRight, Home, Brain, Camera, Workflow,
   MessageSquare, Puzzle, Server, Code
 } from 'lucide-react';
@@ -109,16 +112,17 @@ export default function IntentsPage() {
   if (error) {
     return (
       <div className="p-4">
-        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 flex items-center gap-3">
-          <AlertCircle className="w-5 h-5 text-red-500" />
-          <span className="text-red-700 dark:text-red-300">{error}</span>
-          <button
-            onClick={loadStatus}
-            className="ml-auto text-red-600 hover:text-red-800 dark:text-red-400"
-          >
-            <RefreshCw className="w-4 h-4" />
-          </button>
-        </div>
+        <Alert variant="error">
+          <span className="flex items-center gap-3">
+            <span className="flex-1">{error}</span>
+            <button
+              onClick={loadStatus}
+              className="btn-icon btn-icon-ghost ml-auto"
+            >
+              <RefreshCw className="w-4 h-4" />
+            </button>
+          </span>
+        </Alert>
       </div>
     );
   }
@@ -126,34 +130,23 @@ export default function IntentsPage() {
   return (
     <div className="p-4 md:p-6 max-w-6xl mx-auto">
       {/* Header */}
-      <div className="card mb-6">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-4">
-            <div className="p-3 bg-primary-100 dark:bg-primary-900/30 rounded-xl">
-              <Zap className="w-6 h-6 text-primary-600 dark:text-primary-400" />
-            </div>
-            <div>
-              <h1 className="text-2xl font-bold font-display text-gray-900 dark:text-white">{t('intents.title')}</h1>
-              <p className="text-gray-500 dark:text-gray-400">{t('intents.subtitle')}</p>
-            </div>
-          </div>
-          <div className="flex gap-2">
-            <button
-              onClick={loadPrompt}
-              className="btn btn-secondary flex items-center gap-2"
-            >
-              <Code className="w-4 h-4" />
-              {t('intents.viewPrompt')}
-            </button>
-            <button
-              onClick={loadStatus}
-              className="btn btn-secondary flex items-center gap-2"
-            >
-              <RefreshCw className="w-4 h-4" />
-              {t('common.refresh')}
-            </button>
-          </div>
-        </div>
+      <div className="mb-6">
+        <PageHeader icon={Zap} title={t('intents.title')} subtitle={t('intents.subtitle')}>
+          <button
+            onClick={loadPrompt}
+            className="btn btn-secondary flex items-center gap-2"
+          >
+            <Code className="w-4 h-4" />
+            {t('intents.viewPrompt')}
+          </button>
+          <button
+            onClick={loadStatus}
+            className="btn btn-secondary flex items-center gap-2"
+          >
+            <RefreshCw className="w-4 h-4" />
+            {t('common.refresh')}
+          </button>
+        </PageHeader>
       </div>
 
       {/* Summary Cards */}
@@ -280,17 +273,12 @@ export default function IntentsPage() {
                             {intent.parameters.length > 0 ? (
                               <div className="flex flex-wrap gap-1">
                                 {intent.parameters.map((param) => (
-                                  <span
+                                  <Badge
                                     key={param.name}
-                                    className={`px-2 py-0.5 rounded text-xs ${
-                                      param.required
-                                        ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300'
-                                        : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300'
-                                    }`}
-                                    title={param.description}
+                                    color={param.required ? 'red' : 'gray'}
                                   >
                                     {param.name}{param.required && '*'}
-                                  </span>
+                                  </Badge>
                                 ))}
                               </div>
                             ) : (

--- a/src/frontend/src/pages/KnowledgeGraphPage.jsx
+++ b/src/frontend/src/pages/KnowledgeGraphPage.jsx
@@ -6,17 +6,20 @@ import {
 } from 'lucide-react';
 import apiClient from '../utils/axios';
 import Modal from '../components/Modal';
+import PageHeader from '../components/PageHeader';
+import Alert from '../components/Alert';
+import Badge from '../components/Badge';
 import { useConfirmDialog } from '../components/ConfirmDialog';
 
 const ENTITY_TYPES = ['person', 'place', 'organization', 'thing', 'event', 'concept'];
 
-const TYPE_COLORS = {
-  person: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300',
-  place: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300',
-  organization: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300',
-  thing: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300',
-  event: 'bg-pink-100 text-pink-700 dark:bg-pink-900/30 dark:text-pink-300',
-  concept: 'bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-300',
+const TYPE_BADGE_COLORS = {
+  person: 'blue',
+  place: 'green',
+  organization: 'purple',
+  thing: 'amber',
+  event: 'pink',
+  concept: 'teal',
 };
 
 const TABS = ['entities', 'relations', 'stats'];
@@ -371,37 +374,15 @@ export default function KnowledgeGraphPage() {
   const totalRelationsPages = Math.ceil(relationsTotal / PAGE_SIZE);
 
   return (
-    <div>
+    <div className="space-y-6">
       {ConfirmDialogComponent}
 
       {/* Header */}
-      <div className="card mb-6">
-        <div className="flex items-center gap-4">
-          <div className="p-3 bg-primary-100 dark:bg-primary-900/30 rounded-xl">
-            <Brain className="w-6 h-6 text-primary-600 dark:text-primary-400" />
-          </div>
-          <div>
-            <h1 className="text-2xl font-bold font-display text-gray-900 dark:text-white">
-              {t('knowledgeGraph.title')}
-            </h1>
-            <p className="text-gray-500 dark:text-gray-400">
-              {t('knowledgeGraph.subtitle')}
-            </p>
-          </div>
-        </div>
-      </div>
+      <PageHeader icon={Brain} title={t('knowledgeGraph.title')} subtitle={t('knowledgeGraph.subtitle')} />
 
       {/* Messages */}
-      {error && (
-        <div className="mb-4 p-3 bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 rounded-lg">
-          {error}
-        </div>
-      )}
-      {success && (
-        <div className="mb-4 p-3 bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 rounded-lg">
-          {success}
-        </div>
-      )}
+      {error && <Alert variant="error">{error}</Alert>}
+      {success && <Alert variant="success">{success}</Alert>}
 
       {/* Tabs */}
       <div className="flex gap-1 mb-6 border-b border-gray-200 dark:border-gray-700">
@@ -550,13 +531,13 @@ export default function KnowledgeGraphPage() {
                         </td>
                         <td className="py-3 px-3">
                           <div className="flex items-center gap-2">
-                            <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${TYPE_COLORS[entity.entity_type] || TYPE_COLORS.thing}`}>
+                            <Badge color={TYPE_BADGE_COLORS[entity.entity_type] || 'amber'}>
                               {t(`knowledgeGraph.${entity.entity_type}`)}
-                            </span>
+                            </Badge>
                             {entity.scope && entity.scope !== 'personal' && (
-                              <span className="px-2 py-0.5 rounded-full text-xs bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300">
+                              <Badge color="green">
                                 {availableScopes.find(s => s.name === entity.scope)?.label || entity.scope}
-                              </span>
+                              </Badge>
                             )}
                           </div>
                         </td>
@@ -573,10 +554,10 @@ export default function KnowledgeGraphPage() {
                                     e.stopPropagation();
                                     setScopeMenuEntity(scopeMenuEntity?.id === entity.id ? null : entity);
                                   }}
-                                  className={`p-1.5 rounded ${
-                                    entity.scope === 'personal' ? 'text-gray-400' :
-                                    'text-green-600 dark:text-green-400'
-                                  } hover:bg-gray-100 dark:hover:bg-gray-800`}
+                                  className={`btn-icon ${
+                                    entity.scope === 'personal' ? 'btn-icon-ghost' :
+                                    'text-green-600 dark:text-green-400 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg'
+                                  }`}
                                   title={t('knowledgeGraph.changeScope')}
                                 >
                                   {entity.scope === 'personal' ? <Lock className="w-4 h-4" /> : <Users className="w-4 h-4" />}
@@ -601,21 +582,21 @@ export default function KnowledgeGraphPage() {
                               </div>
                               <button
                                 onClick={() => showRelationsForEntity(entity.id)}
-                                className="p-1.5 rounded text-gray-400 hover:text-indigo-600 dark:hover:text-indigo-400 hover:bg-gray-100 dark:hover:bg-gray-800"
+                                className="btn-icon btn-icon-ghost"
                                 title={t('knowledgeGraph.showRelations')}
                               >
                                 <Link2 className="w-4 h-4" />
                               </button>
                               <button
                                 onClick={() => openEditModal(entity)}
-                                className="p-1.5 rounded text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-gray-100 dark:hover:bg-gray-800"
+                                className="btn-icon btn-icon-ghost"
                                 title={t('common.edit')}
                               >
                                 <Edit3 className="w-4 h-4" />
                               </button>
                               <button
                                 onClick={() => handleDeleteEntity(entity)}
-                                className="p-1.5 rounded text-gray-400 hover:text-red-600 dark:hover:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-800"
+                                className="btn-icon btn-icon-danger"
                                 title={t('common.delete')}
                               >
                                 <Trash2 className="w-4 h-4" />
@@ -718,14 +699,14 @@ export default function KnowledgeGraphPage() {
                   <span className="ml-auto text-xs text-gray-400">{Math.round((rel.confidence || 0) * 100)}%</span>
                   <button
                     onClick={() => openRelationEditModal(rel)}
-                    className="p-1.5 rounded text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-gray-100 dark:hover:bg-gray-800"
+                    className="btn-icon btn-icon-ghost"
                     title={t('common.edit')}
                   >
                     <Edit3 className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => handleDeleteRelation(rel)}
-                    className="p-1.5 rounded text-gray-400 hover:text-red-600 dark:hover:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-800"
+                    className="btn-icon btn-icon-danger"
                     title={t('common.delete')}
                   >
                     <Trash2 className="w-4 h-4" />
@@ -809,9 +790,9 @@ export default function KnowledgeGraphPage() {
                 <div className="space-y-3">
                   {Object.entries(stats.entity_types || {}).sort((a, b) => b[1] - a[1]).map(([type, count]) => (
                     <div key={type} className="flex items-center gap-3">
-                      <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium min-w-[100px] justify-center ${TYPE_COLORS[type] || TYPE_COLORS.thing}`}>
+                      <Badge color={TYPE_BADGE_COLORS[type] || 'amber'} className="min-w-[100px] justify-center">
                         {t(`knowledgeGraph.${type}`)}
-                      </span>
+                      </Badge>
                       <div className="flex-1 h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
                         <div
                           className="h-full bg-indigo-500 rounded-full transition-all"
@@ -926,9 +907,9 @@ export default function KnowledgeGraphPage() {
                           }}
                           className="w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2"
                         >
-                          <span className={`inline-flex px-1.5 py-0.5 rounded text-xs ${TYPE_COLORS[e.entity_type] || TYPE_COLORS.thing}`}>
+                          <Badge color={TYPE_BADGE_COLORS[e.entity_type] || 'amber'}>
                             {e.entity_type}
-                          </span>
+                          </Badge>
                           {e.name}
                         </button>
                       ))}
@@ -990,9 +971,9 @@ export default function KnowledgeGraphPage() {
                           }}
                           className="w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2"
                         >
-                          <span className={`inline-flex px-1.5 py-0.5 rounded text-xs ${TYPE_COLORS[e.entity_type] || TYPE_COLORS.thing}`}>
+                          <Badge color={TYPE_BADGE_COLORS[e.entity_type] || 'amber'}>
                             {e.entity_type}
-                          </span>
+                          </Badge>
                           {e.name}
                         </button>
                       ))}

--- a/src/frontend/src/pages/KnowledgePage.jsx
+++ b/src/frontend/src/pages/KnowledgePage.jsx
@@ -21,6 +21,9 @@ import {
 } from 'lucide-react';
 import apiClient from '../utils/axios';
 import { useConfirmDialog } from '../components/ConfirmDialog';
+import PageHeader from '../components/PageHeader';
+import Alert from '../components/Alert';
+import Badge from '../components/Badge';
 
 export default function KnowledgePage() {
   const { t } = useTranslation();
@@ -323,26 +326,15 @@ export default function KnowledgePage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="card">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-4">
-            <div className="p-3 bg-primary-100 dark:bg-primary-900/30 rounded-xl">
-              <BookOpen className="w-6 h-6 text-primary-600 dark:text-primary-400" />
-            </div>
-            <div>
-              <h1 className="text-2xl font-bold font-display text-gray-900 dark:text-white">{t('knowledge.title')}</h1>
-              <p className="text-gray-500 dark:text-gray-400">{t('knowledge.subtitle')}</p>
-            </div>
-          </div>
-          <button
-            onClick={() => setShowNewKbModal(true)}
-            className="btn-primary flex items-center gap-2"
-          >
-            <Plus className="w-4 h-4" />
-            {t('knowledge.newKnowledgeBase')}
-          </button>
-        </div>
-      </div>
+      <PageHeader icon={BookOpen} title={t('knowledge.title')} subtitle={t('knowledge.subtitle')}>
+        <button
+          onClick={() => setShowNewKbModal(true)}
+          className="btn-primary flex items-center gap-2"
+        >
+          <Plus className="w-4 h-4" />
+          {t('knowledge.newKnowledgeBase')}
+        </button>
+      </PageHeader>
 
       {/* Statistics */}
       {stats && (
@@ -469,15 +461,16 @@ export default function KnowledgePage() {
           </label>
         </div>
         {uploadProgress && (
-          <div className={`mt-4 p-3 rounded-lg ${
-            uploadProgress.includes('Fehler')
-              ? 'bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-300'
-              : uploadProgress.includes('Erfolgreich')
-              ? 'bg-green-100 text-green-700 dark:bg-green-900/50 dark:text-green-300'
-              : 'bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-300'
-          }`}>
+          <Alert
+            variant={
+              uploadProgress.includes('Fehler') ? 'error'
+              : uploadProgress.includes('Erfolgreich') ? 'success'
+              : 'info'
+            }
+            className="mt-4"
+          >
             {uploadProgress}
-          </div>
+          </Alert>
         )}
       </div>
 
@@ -531,9 +524,9 @@ export default function KnowledgePage() {
                       </span>
                     )}
                   </div>
-                  <span className="text-xs px-2 py-1 bg-primary-100 text-primary-700 dark:bg-primary-600/30 dark:text-primary-300 rounded-sm">
+                  <Badge color="accent">
                     {t('knowledge.relevance', { percent: Math.round(result.similarity * 100) })}
-                  </span>
+                  </Badge>
                 </div>
                 <p className="text-gray-700 dark:text-gray-300 text-sm line-clamp-3">
                   {result.chunk.content}
@@ -661,25 +654,20 @@ export default function KnowledgePage() {
                   <div className="flex items-center gap-2">
                     <div className="flex items-center gap-2">
                       {getStatusIcon(doc.status)}
-                      <span
-                        className={`px-3 py-1 rounded-full text-xs font-medium ${
-                          doc.status === 'completed'
-                            ? 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300'
-                            : doc.status === 'failed'
-                            ? 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300'
-                            : doc.status === 'processing'
-                            ? 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300'
-                            : 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300'
-                        }`}
-                      >
+                      <Badge color={
+                        doc.status === 'completed' ? 'green'
+                        : doc.status === 'failed' ? 'red'
+                        : doc.status === 'processing' ? 'blue'
+                        : 'yellow'
+                      }>
                         {doc.status}
-                      </span>
+                      </Badge>
                     </div>
                     {knowledgeBases.length > 0 && (
                       <div className="relative">
                         <button
                           onClick={() => setShowMoveDropdown(showMoveDropdown === doc.id ? null : doc.id)}
-                          className="p-2 text-gray-500 hover:text-primary-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-primary-400 dark:hover:bg-gray-700 rounded-lg transition-colors"
+                          className="btn-icon btn-icon-ghost"
                           title={t('knowledge.moveDocument')}
                         >
                           <ArrowRightLeft className="w-4 h-4" />
@@ -694,14 +682,14 @@ export default function KnowledgePage() {
                     )}
                     <button
                       onClick={() => handleReindexDocument(doc.id)}
-                      className="p-2 text-gray-500 hover:text-primary-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-primary-400 dark:hover:bg-gray-700 rounded-lg transition-colors"
+                      className="btn-icon btn-icon-ghost"
                       title={t('knowledge.reindex')}
                     >
                       <RefreshCw className="w-4 h-4" />
                     </button>
                     <button
                       onClick={() => handleDeleteDocument(doc.id, doc.filename)}
-                      className="p-2 text-gray-500 hover:text-red-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-red-400 dark:hover:bg-gray-700 rounded-lg transition-colors"
+                      className="btn-icon btn-icon-danger"
                       title={t('common.delete')}
                     >
                       <Trash2 className="w-4 h-4" />

--- a/src/frontend/src/pages/MaintenancePage.jsx
+++ b/src/frontend/src/pages/MaintenancePage.jsx
@@ -13,6 +13,8 @@ import apiClient from '../utils/axios';
 import {
   Wrench, Search, Database, Bug, Loader, AlertCircle, CheckCircle
 } from 'lucide-react';
+import PageHeader from '../components/PageHeader';
+import Alert from '../components/Alert';
 
 function ActionRow({ title, description, buttonLabel, icon: Icon, loading, onAction, variant }) {
   return (
@@ -161,18 +163,8 @@ export default function MaintenancePage() {
   return (
     <div className="p-6 max-w-4xl mx-auto">
       {/* Header */}
-      <div className="card mb-6">
-        <div className="flex items-center gap-4">
-          <div className="p-3 bg-primary-100 dark:bg-primary-900/30 rounded-xl">
-            <Wrench className="w-6 h-6 text-primary-600 dark:text-primary-400" />
-          </div>
-          <div>
-            <h1 className="text-2xl font-bold font-display text-gray-900 dark:text-white">
-              {t('maintenance.title')}
-            </h1>
-            <p className="text-gray-500 dark:text-gray-400">{t('maintenance.subtitle')}</p>
-          </div>
-        </div>
+      <div className="mb-6">
+        <PageHeader icon={Wrench} title={t('maintenance.title')} subtitle={t('maintenance.subtitle')} />
       </div>
 
       {/* Section 1: Search & Indexing */}
@@ -243,9 +235,9 @@ export default function MaintenancePage() {
         </p>
 
         {/* Warning */}
-        <div className="mb-4 p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg text-sm text-amber-700 dark:text-amber-400">
+        <Alert variant="warning" className="mb-4">
           {t('maintenance.embeddings.reembedWarning')}
-        </div>
+        </Alert>
 
         <ActionRow
           title={t('maintenance.embeddings.reembedAll')}

--- a/src/frontend/src/pages/MemoryPage.jsx
+++ b/src/frontend/src/pages/MemoryPage.jsx
@@ -7,19 +7,21 @@ import {
   Edit3,
   Eye,
   Calendar,
-  X
 } from 'lucide-react';
 import apiClient from '../utils/axios';
 import Modal from '../components/Modal';
+import PageHeader from '../components/PageHeader';
+import Alert from '../components/Alert';
+import Badge from '../components/Badge';
 import { useConfirmDialog } from '../components/ConfirmDialog';
 
 const CATEGORIES = ['preference', 'fact', 'instruction', 'context'];
 
-const CATEGORY_COLORS = {
-  preference: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300',
-  fact: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300',
-  instruction: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300',
-  context: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300',
+const CATEGORY_BADGE_COLORS = {
+  preference: 'purple',
+  fact: 'blue',
+  instruction: 'amber',
+  context: 'green',
 };
 
 export default function MemoryPage() {
@@ -166,44 +168,19 @@ export default function MemoryPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="card">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-4">
-            <div className="p-3 bg-primary-100 dark:bg-primary-900/30 rounded-xl">
-              <Brain className="w-6 h-6 text-primary-600 dark:text-primary-400" />
-            </div>
-            <div>
-              <h1 className="text-2xl font-bold font-display text-gray-900 dark:text-white">
-                {t('memory.title')}
-              </h1>
-              <p className="text-gray-500 dark:text-gray-400">
-                {t('memory.subtitle')}
-              </p>
-            </div>
-          </div>
-          <div className="flex items-center space-x-3">
-            <span className="text-sm text-gray-500 dark:text-gray-400">
-              {t('memory.count', { count: total })}
-            </span>
-            <button onClick={openCreateModal} className="btn-primary flex items-center space-x-2">
-              <Plus className="w-4 h-4" />
-              <span className="hidden sm:inline">{t('memory.addMemory')}</span>
-            </button>
-          </div>
-        </div>
-      </div>
+      <PageHeader icon={Brain} title={t('memory.title')} subtitle={t('memory.subtitle')}>
+        <span className="text-sm text-gray-500 dark:text-gray-400">
+          {t('memory.count', { count: total })}
+        </span>
+        <button onClick={openCreateModal} className="btn-primary flex items-center space-x-2">
+          <Plus className="w-4 h-4" />
+          <span className="hidden sm:inline">{t('memory.addMemory')}</span>
+        </button>
+      </PageHeader>
 
       {/* Status messages */}
-      {error && (
-        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3 text-sm text-red-700 dark:text-red-300">
-          {error}
-        </div>
-      )}
-      {success && (
-        <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-3 text-sm text-green-700 dark:text-green-300">
-          {success}
-        </div>
-      )}
+      {error && <Alert variant="error">{error}</Alert>}
+      {success && <Alert variant="success">{success}</Alert>}
 
       {/* Category filter */}
       <div className="flex flex-wrap gap-2">
@@ -251,20 +228,20 @@ export default function MemoryPage() {
             >
               {/* Category badge + actions */}
               <div className="flex items-start justify-between mb-2">
-                <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${CATEGORY_COLORS[memory.category] || 'bg-gray-100 text-gray-700'}`}>
+                <Badge color={CATEGORY_BADGE_COLORS[memory.category] || 'gray'}>
                   {t(`memory.categories.${memory.category}`)}
-                </span>
+                </Badge>
                 <div className="flex items-center space-x-1">
                   <button
                     onClick={() => openEditModal(memory)}
-                    className="p-1 rounded text-gray-400 hover:text-primary-600 dark:hover:text-primary-400 transition-colors"
+                    className="btn-icon btn-icon-ghost"
                     title={t('common.edit')}
                   >
                     <Edit3 className="w-3.5 h-3.5" />
                   </button>
                   <button
                     onClick={() => handleDelete(memory)}
-                    className="p-1 rounded text-gray-400 hover:text-red-600 dark:hover:text-red-400 transition-colors"
+                    className="btn-icon btn-icon-danger"
                     title={t('common.delete')}
                   >
                     <Trash2 className="w-3.5 h-3.5" />

--- a/src/frontend/src/pages/PaperlessAuditPage.jsx
+++ b/src/frontend/src/pages/PaperlessAuditPage.jsx
@@ -9,10 +9,13 @@ import { useTranslation } from 'react-i18next';
 import { useAuth } from '../context/AuthContext';
 import apiClient from '../utils/axios';
 import {
-  FileSearch, Play, Square, Loader, AlertCircle, Check, X,
+  FileSearch, Play, Square, Loader, Check, X,
   RotateCcw, BarChart3, ClipboardList, Eye, ChevronLeft, ChevronRight,
-  Copy, Users, FileText, Languages
+  Copy, Users, FileText,
 } from 'lucide-react';
+import PageHeader from '../components/PageHeader';
+import Alert from '../components/Alert';
+import Badge from '../components/Badge';
 
 const TABS = ['control', 'review', 'ocr', 'completeness', 'duplicates', 'correspondents', 'stats'];
 const PAGE_SIZE = 20;
@@ -407,22 +410,8 @@ export default function PaperlessAuditPage() {
   if (notConfigured) {
     return (
       <div className="space-y-6">
-        <div className="card">
-          <div className="flex items-center gap-4">
-            <div className="p-3 bg-primary-100 dark:bg-primary-900/30 rounded-xl">
-              <FileSearch className="w-6 h-6 text-primary-600 dark:text-primary-400" />
-            </div>
-            <div>
-              <h1 className="text-2xl font-bold font-display text-gray-900 dark:text-white">
-                {t('paperlessAudit.title')}
-              </h1>
-            </div>
-          </div>
-        </div>
-        <div className="card p-8 text-center">
-          <AlertCircle className="w-12 h-12 text-yellow-500 mx-auto mb-4" />
-          <p className="text-gray-600 dark:text-gray-300">{t('paperlessAudit.notConfigured')}</p>
-        </div>
+        <PageHeader icon={FileSearch} title={t('paperlessAudit.title')} />
+        <Alert variant="warning">{t('paperlessAudit.notConfigured')}</Alert>
       </div>
     );
   }
@@ -440,26 +429,10 @@ export default function PaperlessAuditPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="card">
-        <div className="flex items-center gap-4">
-          <div className="p-3 bg-primary-100 dark:bg-primary-900/30 rounded-xl">
-            <FileSearch className="w-6 h-6 text-primary-600 dark:text-primary-400" />
-          </div>
-          <div>
-            <h1 className="text-2xl font-bold font-display text-gray-900 dark:text-white">
-              {t('paperlessAudit.title')}
-            </h1>
-          </div>
-        </div>
-      </div>
+      <PageHeader icon={FileSearch} title={t('paperlessAudit.title')} />
 
       {/* Error */}
-      {error && (
-        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 flex items-center gap-3">
-          <AlertCircle className="w-5 h-5 text-red-500 shrink-0" />
-          <p className="text-red-700 dark:text-red-300">{error}</p>
-        </div>
-      )}
+      {error && <Alert variant="error">{error}</Alert>}
 
       {/* Tabs */}
       <div className="border-b border-gray-200 dark:border-gray-700">
@@ -681,7 +654,7 @@ function ControlTab({ t, auditStatus, mode, setMode, fixMode, setFixMode, confid
           <button
             onClick={onStop}
             disabled={stopping}
-            className="btn-secondary flex items-center gap-2 text-red-600 dark:text-red-400 border-red-300 dark:border-red-700 hover:bg-red-50 dark:hover:bg-red-900/20"
+            className="btn btn-danger flex items-center gap-2"
           >
             {stopping ? <Loader className="w-4 h-4 animate-spin" /> : <Square className="w-4 h-4" />}
             {t('paperlessAudit.control.stop')}
@@ -807,9 +780,7 @@ function ReviewTab({ t, results, loading, total, page, setPage, selectedIds, act
                     {r.suggested_tags && r.suggested_tags.length > 0 && (
                       <div className="mt-1 flex flex-wrap gap-1">
                         {r.suggested_tags.map((tag, i) => (
-                          <span key={i} className="inline-block px-1.5 py-0.5 text-xs bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300 rounded">
-                            {tag}
-                          </span>
+                          <Badge key={i} color="accent">{tag}</Badge>
                         ))}
                       </div>
                     )}
@@ -825,9 +796,7 @@ function ReviewTab({ t, results, loading, total, page, setPage, selectedIds, act
                   </td>
                   <td className="py-3 px-2">
                     {r.detected_language && (
-                      <span className="inline-block px-1.5 py-0.5 text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded font-mono">
-                        {r.detected_language}
-                      </span>
+                      <Badge color="blue" className="font-mono">{r.detected_language}</Badge>
                     )}
                   </td>
                   <td className="py-3 px-2">
@@ -837,9 +806,7 @@ function ReviewTab({ t, results, loading, total, page, setPage, selectedIds, act
                     {r.missing_fields && r.missing_fields.length > 0 && (
                       <div className="flex flex-wrap gap-1">
                         {r.missing_fields.map((f, i) => (
-                          <span key={i} className="inline-block px-1.5 py-0.5 text-xs bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-300 rounded">
-                            {f}
-                          </span>
+                          <Badge key={i} color="yellow">{f}</Badge>
                         ))}
                       </div>
                     )}
@@ -852,7 +819,7 @@ function ReviewTab({ t, results, loading, total, page, setPage, selectedIds, act
                       <button
                         onClick={() => onApprove([r.id])}
                         disabled={isLoading}
-                        className="p-1.5 rounded text-green-600 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-900/20 transition-colors"
+                        className="btn-icon text-green-600 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-900/20"
                         title={t('paperlessAudit.review.approve')}
                       >
                         {isLoading ? <Loader className="w-4 h-4 animate-spin" /> : <Check className="w-4 h-4" />}
@@ -860,7 +827,7 @@ function ReviewTab({ t, results, loading, total, page, setPage, selectedIds, act
                       <button
                         onClick={() => onSkip([r.id])}
                         disabled={isLoading}
-                        className="p-1.5 rounded text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+                        className="btn-icon btn-icon-ghost"
                         title={t('paperlessAudit.review.skip')}
                       >
                         <X className="w-4 h-4" />
@@ -1046,10 +1013,9 @@ function StatsTab({ t, stats, loading }) {
             {Object.entries(stats.language_distribution)
               .sort(([, a], [, b]) => b - a)
               .map(([lang, count]) => (
-                <div key={lang} className="flex items-center gap-2 px-3 py-2 bg-blue-50 dark:bg-blue-900/20 rounded">
-                  <span className="font-mono text-sm font-medium text-blue-700 dark:text-blue-300">{lang}</span>
-                  <span className="text-sm text-gray-600 dark:text-gray-400">{count}</span>
-                </div>
+                <Badge key={lang} color="blue" className="font-mono text-sm px-3 py-2">
+                  {lang} <span className="text-gray-600 dark:text-gray-400 ml-1">{count}</span>
+                </Badge>
               ))}
           </div>
         </div>
@@ -1187,9 +1153,7 @@ function DuplicatesTab({ t, groups, loading, detecting, onDetect }) {
                     <span className="text-sm text-gray-900 dark:text-gray-100 flex-1 truncate">{doc.current_title || '-'}</span>
                     <span className="text-xs text-gray-500 dark:text-gray-400">{doc.current_correspondent}</span>
                     {doc.duplicate_score != null && (
-                      <span className="text-xs font-mono text-orange-600 dark:text-orange-400">
-                        {(doc.duplicate_score * 100).toFixed(0)}%
-                      </span>
+                      <Badge color="amber" className="font-mono">{(doc.duplicate_score * 100).toFixed(0)}%</Badge>
                     )}
                   </div>
                 ))}
@@ -1247,10 +1211,10 @@ function CorrespondentsTab({ t, clusters, loading, threshold, setThreshold, onSc
               <div className="font-medium text-gray-900 dark:text-white mb-2">{cluster.canonical}</div>
               <div className="flex flex-wrap gap-2">
                 {cluster.variants.map((v, j) => (
-                  <span key={j} className="inline-flex items-center gap-1.5 px-2 py-1 bg-orange-50 dark:bg-orange-900/20 text-orange-700 dark:text-orange-300 rounded text-sm">
+                  <Badge key={j} color="amber">
                     {v.name}
-                    <span className="text-xs font-mono opacity-70">{(v.similarity * 100).toFixed(0)}%</span>
-                  </span>
+                    <span className="text-xs font-mono opacity-70 ml-1">{(v.similarity * 100).toFixed(0)}%</span>
+                  </Badge>
                 ))}
               </div>
             </div>
@@ -1289,9 +1253,9 @@ function Pagination({ page, totalPages, onPageChange }) {
       <button
         onClick={() => onPageChange(Math.max(0, page - 1))}
         disabled={page === 0}
-        className="p-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-30 transition-colors"
+        className="btn-icon btn-icon-ghost disabled:opacity-30"
       >
-        <ChevronLeft className="w-4 h-4 text-gray-600 dark:text-gray-300" />
+        <ChevronLeft className="w-4 h-4" />
       </button>
       <span className="text-sm text-gray-600 dark:text-gray-400">
         {page + 1} / {totalPages}
@@ -1299,9 +1263,9 @@ function Pagination({ page, totalPages, onPageChange }) {
       <button
         onClick={() => onPageChange(Math.min(totalPages - 1, page + 1))}
         disabled={page >= totalPages - 1}
-        className="p-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-30 transition-colors"
+        className="btn-icon btn-icon-ghost disabled:opacity-30"
       >
-        <ChevronRight className="w-4 h-4 text-gray-600 dark:text-gray-300" />
+        <ChevronRight className="w-4 h-4" />
       </button>
     </div>
   );

--- a/src/frontend/src/pages/PresencePage.jsx
+++ b/src/frontend/src/pages/PresencePage.jsx
@@ -12,8 +12,11 @@ import Modal from '../components/Modal';
 import { useConfirmDialog } from '../components/ConfirmDialog';
 import {
   MapPin, Users, Wifi, Smartphone, Plus, Trash2, RefreshCw,
-  AlertCircle, Clock, Watch, Radio, BarChart3, Bluetooth, Info,
+  Clock, Watch, Radio, BarChart3, Bluetooth, Info,
 } from 'lucide-react';
+import PageHeader from '../components/PageHeader';
+import Alert from '../components/Alert';
+import Badge from '../components/Badge';
 import AnalyticsTab from '../components/presence/AnalyticsTab';
 
 
@@ -167,12 +170,7 @@ function AddDeviceModal({ isOpen, onClose, onSave, users }) {
   return (
     <Modal isOpen={isOpen} onClose={onClose} title={t('presence.addDevice')}>
       <form onSubmit={handleSubmit} className="space-y-4">
-        {error && (
-          <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-sm text-red-700 dark:text-red-400 flex items-center gap-2">
-            <AlertCircle className="w-4 h-4 shrink-0" />
-            {error}
-          </div>
-        )}
+        {error && <Alert variant="error">{error}</Alert>}
 
         <div>
           <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
@@ -378,16 +376,7 @@ export default function PresencePage() {
   if (loading) {
     return (
       <div className="p-6">
-        <div className="card mb-6">
-          <div className="flex items-center gap-4">
-            <div className="p-3 bg-primary-100 dark:bg-primary-900/30 rounded-xl">
-              <MapPin className="w-6 h-6 text-primary-600 dark:text-primary-400" />
-            </div>
-            <div>
-              <h1 className="text-2xl font-bold font-display text-gray-900 dark:text-white">{t('presence.title')}</h1>
-            </div>
-          </div>
-        </div>
+        <PageHeader icon={MapPin} title={t('presence.title')} />
         <div className="flex items-center justify-center p-12">
           <RefreshCw className="w-8 h-8 animate-spin text-blue-500" />
         </div>
@@ -398,20 +387,10 @@ export default function PresencePage() {
   return (
     <div className="p-6 max-w-6xl mx-auto">
       {/* Header */}
-      <div className="card mb-6">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-4">
-            <div className="p-3 bg-primary-100 dark:bg-primary-900/30 rounded-xl">
-              <MapPin className="w-6 h-6 text-primary-600 dark:text-primary-400" />
-            </div>
-            <div>
-              <h1 className="text-2xl font-bold font-display text-gray-900 dark:text-white">{t('presence.title')}</h1>
-              <p className="text-gray-500 dark:text-gray-400">{t('presence.subtitle')}</p>
-            </div>
-          </div>
-
+      <div className="mb-6">
+        <PageHeader icon={MapPin} title={t('presence.title')} subtitle={t('presence.subtitle')}>
           {activeTab === 'live' && (
-            <div className="flex items-center gap-4">
+            <>
               <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 cursor-pointer">
                 <input
                   type="checkbox"
@@ -424,14 +403,14 @@ export default function PresencePage() {
 
               <button
                 onClick={loadPresence}
-                className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                className="btn-icon btn-icon-ghost"
                 title={t('common.refresh')}
               >
                 <RefreshCw className="w-5 h-5" />
               </button>
-            </div>
+            </>
           )}
-        </div>
+        </PageHeader>
       </div>
 
       {/* Tabs */}
@@ -496,12 +475,7 @@ export default function PresencePage() {
       </div>
 
       {/* Error */}
-      {error && (
-        <div className="mb-4 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg flex items-center gap-2 text-red-700 dark:text-red-400">
-          <AlertCircle className="w-5 h-5" />
-          {error}
-        </div>
-      )}
+      {error && <Alert variant="error" className="mb-4">{error}</Alert>}
 
       {/* Room Occupancy Section */}
       <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
@@ -599,18 +573,14 @@ export default function PresencePage() {
                         </button>
                       </td>
                       <td className="py-3 px-4">
-                        <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
-                          device.is_enabled
-                            ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
-                            : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
-                        }`}>
+                        <Badge color={device.is_enabled ? 'green' : 'gray'}>
                           {device.is_enabled ? t('presence.enabled') : t('common.offline')}
-                        </span>
+                        </Badge>
                       </td>
                       <td className="py-3 px-4 text-right">
                         <button
                           onClick={() => handleDeleteDevice(device)}
-                          className="p-1.5 text-gray-400 hover:text-red-600 dark:hover:text-red-400 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+                          className="btn-icon btn-icon-danger"
                           title={t('presence.deleteDevice')}
                         >
                           <Trash2 className="w-4 h-4" />

--- a/src/frontend/src/pages/RolesPage.jsx
+++ b/src/frontend/src/pages/RolesPage.jsx
@@ -8,10 +8,13 @@ import { useTranslation } from 'react-i18next';
 import { useAuth } from '../context/AuthContext';
 import apiClient from '../utils/axios';
 import Modal from '../components/Modal';
+import PageHeader from '../components/PageHeader';
+import Alert from '../components/Alert';
+import Badge from '../components/Badge';
 import { useConfirmDialog } from '../components/ConfirmDialog';
 import {
-  Shield, Plus, Pencil, Trash2, Loader, AlertCircle, CheckCircle,
-  Lock, RefreshCw, ChevronDown, ChevronRight, Info
+  Shield, Plus, Pencil, Trash2, Loader,
+  Lock, RefreshCw, ChevronDown, ChevronRight
 } from 'lucide-react';
 
 // Permission categories for better organization
@@ -275,17 +278,7 @@ export default function RolesPage() {
   if (loading) {
     return (
       <div className="space-y-6">
-        <div className="card">
-          <div className="flex items-center gap-4">
-            <div className="p-3 bg-primary-100 dark:bg-primary-900/30 rounded-xl">
-              <Shield className="w-6 h-6 text-primary-600 dark:text-primary-400" />
-            </div>
-            <div>
-              <h1 className="text-2xl font-bold font-display text-gray-900 dark:text-white">{t('roles.title')}</h1>
-              <p className="text-gray-500 dark:text-gray-400">{t('roles.subtitle')}</p>
-            </div>
-          </div>
-        </div>
+        <PageHeader icon={Shield} title={t('roles.title')} subtitle={t('roles.subtitle')} />
         <div className="card text-center py-12">
           <Loader className="w-8 h-8 animate-spin mx-auto text-gray-500 dark:text-gray-400 mb-2" />
           <p className="text-gray-500 dark:text-gray-400">{t('roles.loading')}</p>
@@ -297,36 +290,11 @@ export default function RolesPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="card">
-        <div className="flex items-center gap-4">
-          <div className="p-3 bg-primary-100 dark:bg-primary-900/30 rounded-xl">
-            <Shield className="w-6 h-6 text-primary-600 dark:text-primary-400" />
-          </div>
-          <div>
-            <h1 className="text-2xl font-bold font-display text-gray-900 dark:text-white">{t('roles.title')}</h1>
-            <p className="text-gray-500 dark:text-gray-400">{t('roles.subtitle')}</p>
-          </div>
-        </div>
-      </div>
+      <PageHeader icon={Shield} title={t('roles.title')} subtitle={t('roles.subtitle')} />
 
       {/* Alerts */}
-      {error && (
-        <div className="card bg-red-100 dark:bg-red-900/20 border-red-300 dark:border-red-700">
-          <div className="flex items-center space-x-3">
-            <AlertCircle className="w-5 h-5 text-red-500" />
-            <p className="text-red-700 dark:text-red-400">{error}</p>
-          </div>
-        </div>
-      )}
-
-      {success && (
-        <div className="card bg-green-100 dark:bg-green-900/20 border-green-300 dark:border-green-700">
-          <div className="flex items-center space-x-3">
-            <CheckCircle className="w-5 h-5 text-green-500" />
-            <p className="text-green-700 dark:text-green-400">{success}</p>
-          </div>
-        </div>
-      )}
+      {error && <Alert variant="error">{error}</Alert>}
+      {success && <Alert variant="success">{success}</Alert>}
 
       {/* Actions */}
       <div className="flex flex-wrap gap-3">
@@ -370,10 +338,7 @@ export default function RolesPage() {
                     <div className="flex items-center space-x-2">
                       <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{role.name}</h3>
                       {role.is_system && (
-                        <span className="flex items-center space-x-1 text-xs bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300 px-2 py-0.5 rounded-sm">
-                          <Lock className="w-3 h-3" />
-                          <span>{t('roles.system')}</span>
-                        </span>
+                        <Badge color="gray" icon={Lock}>{t('roles.system')}</Badge>
                       )}
                     </div>
                     {role.description && (
@@ -381,18 +346,14 @@ export default function RolesPage() {
                     )}
                     <div className="flex flex-wrap gap-1 mt-2">
                       {role.permissions.slice(0, 5).map((perm) => (
-                        <span
-                          key={perm}
-                          className="text-xs bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300 px-2 py-0.5 rounded-sm"
-                          title={PERMISSION_DESCRIPTIONS[perm]}
-                        >
-                          {perm}
+                        <span key={perm} title={PERMISSION_DESCRIPTIONS[perm]}>
+                          <Badge color="gray">{perm}</Badge>
                         </span>
                       ))}
                       {role.permissions.length > 5 && (
-                        <span className="text-xs bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-400 px-2 py-0.5 rounded-sm">
+                        <Badge color="gray">
                           {t('roles.more', { count: role.permissions.length - 5 })}
-                        </span>
+                        </Badge>
                       )}
                     </div>
                   </div>
@@ -402,7 +363,7 @@ export default function RolesPage() {
                 <div className="flex items-center space-x-2">
                   <button
                     onClick={() => handleEdit(role)}
-                    className="p-2 text-gray-500 hover:text-primary-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-primary-400 dark:hover:bg-gray-700 rounded-lg transition-colors"
+                    className="btn-icon btn-icon-ghost"
                     title={t('roles.editRole')}
                   >
                     <Pencil className="w-5 h-5" />
@@ -410,7 +371,7 @@ export default function RolesPage() {
                   {!role.is_system && (
                     <button
                       onClick={() => handleDelete(role)}
-                      className="p-2 text-gray-500 hover:text-red-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-red-400 dark:hover:bg-gray-700 rounded-lg transition-colors"
+                      className="btn-icon btn-icon-danger"
                       title={t('roles.deleteRole')}
                     >
                       <Trash2 className="w-5 h-5" />
@@ -559,15 +520,11 @@ export default function RolesPage() {
 
           {/* Info for system roles */}
           {editingRole?.is_system && (
-            <div className="flex items-start space-x-3 p-3 bg-yellow-100 dark:bg-yellow-900/20 border border-yellow-300 dark:border-yellow-700 rounded-lg">
-              <Info className="w-5 h-5 text-yellow-500 shrink-0 mt-0.5" />
-              <div>
-                <p className="text-yellow-700 dark:text-yellow-400 font-medium">{t('roles.systemRole')}</p>
-                <p className="text-yellow-600 dark:text-yellow-400/70 text-sm">
-                  {t('roles.systemRoleInfo')}
-                </p>
-              </div>
-            </div>
+            <Alert variant="warning">
+              <span className="font-medium">{t('roles.systemRole')}</span>
+              {' '}
+              <span className="text-sm opacity-80">{t('roles.systemRoleInfo')}</span>
+            </Alert>
           )}
 
           {/* Actions */}

--- a/src/frontend/src/pages/SatellitesPage.jsx
+++ b/src/frontend/src/pages/SatellitesPage.jsx
@@ -7,6 +7,9 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import apiClient from '../utils/axios';
+import PageHeader from '../components/PageHeader';
+import Alert from '../components/Alert';
+import Badge from '../components/Badge';
 import {
   Satellite, Wifi, WifiOff, Mic, Volume2, Cpu, Thermometer,
   Activity, Clock, AlertCircle, CheckCircle, RefreshCw, ChevronDown,
@@ -43,21 +46,19 @@ function StateBadge({ state }) {
   const { t } = useTranslation();
 
   const stateConfig = {
-    idle: { color: 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300', icon: Radio },
-    listening: { color: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400', icon: Mic },
-    processing: { color: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400', icon: Zap },
-    speaking: { color: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400', icon: Volume2 },
-    error: { color: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400', icon: AlertCircle },
+    idle: { color: 'gray', icon: Radio },
+    listening: { color: 'green', icon: Mic },
+    processing: { color: 'yellow', icon: Zap },
+    speaking: { color: 'blue', icon: Volume2 },
+    error: { color: 'red', icon: AlertCircle },
   };
 
   const config = stateConfig[state] || stateConfig.idle;
-  const Icon = config.icon;
 
   return (
-    <span className={`inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium ${config.color}`}>
-      <Icon className="w-3 h-3" />
+    <Badge color={config.color} icon={config.icon}>
       {t(`satellites.states.${state}`, state.toUpperCase())}
-    </span>
+    </Badge>
   );
 }
 
@@ -128,24 +129,20 @@ function SatelliteCard({ satellite, expanded, onToggle, latestVersion, onUpdate 
 
         <div className="flex items-center gap-3">
           {/* Version badge */}
-          <span className="text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 px-2 py-1 rounded-sm">
-            v{satellite.version || 'unknown'}
-          </span>
+          <Badge color="gray">v{satellite.version || 'unknown'}</Badge>
 
           {/* Update available indicator */}
           {hasUpdate && !isUpdating && (
-            <span className="inline-flex items-center gap-1 text-xs bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-400 px-2 py-1 rounded-sm">
-              <ArrowUpCircle className="w-3 h-3" />
+            <Badge color="yellow" icon={ArrowUpCircle}>
               {t('satellites.updateAvailable', 'Update')}
-            </span>
+            </Badge>
           )}
 
           {/* Updating indicator */}
           {isUpdating && (
-            <span className="inline-flex items-center gap-1 text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-400 px-2 py-1 rounded-sm">
-              <Loader2 className="w-3 h-3 animate-spin" />
+            <Badge color="blue" icon={Loader2} className="[&_svg]:animate-spin">
               {t('satellites.updating', 'Updating...')}
-            </span>
+            </Badge>
           )}
 
           <StateBadge state={satellite.state} />
@@ -287,21 +284,15 @@ function SatelliteCard({ satellite, expanded, onToggle, latestVersion, onUpdate 
           )}
 
           {/* Capabilities */}
-          <div className="flex flex-wrap gap-2 text-xs">
+          <div className="flex flex-wrap gap-2">
             {satellite.capabilities?.local_wakeword && (
-              <span className="px-2 py-1 bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400 rounded-sm">
-                Wake Word
-              </span>
+              <Badge color="blue">Wake Word</Badge>
             )}
             {satellite.capabilities?.speaker && (
-              <span className="px-2 py-1 bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400 rounded-sm">
-                Speaker
-              </span>
+              <Badge color="purple">Speaker</Badge>
             )}
             {satellite.capabilities?.led_count > 0 && (
-              <span className="px-2 py-1 bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400 rounded-sm">
-                {satellite.capabilities.led_count} LEDs
-              </span>
+              <Badge color="amber">{satellite.capabilities.led_count} LEDs</Badge>
             )}
           </div>
 
@@ -456,15 +447,8 @@ export default function SatellitesPage() {
   if (loading) {
     return (
       <div className="p-6">
-        <div className="card mb-6">
-          <div className="flex items-center gap-4">
-            <div className="p-3 bg-primary-100 dark:bg-primary-900/30 rounded-xl">
-              <Satellite className="w-6 h-6 text-primary-600 dark:text-primary-400" />
-            </div>
-            <div>
-              <h1 className="text-2xl font-bold font-display text-gray-900 dark:text-white">{t('satellites.title', 'Satellite Monitor')}</h1>
-            </div>
-          </div>
+        <div className="mb-6">
+          <PageHeader icon={Satellite} title={t('satellites.title', 'Satellite Monitor')} />
         </div>
         <div className="flex items-center justify-center p-12">
           <RefreshCw className="w-8 h-8 animate-spin text-blue-500" />
@@ -476,39 +460,31 @@ export default function SatellitesPage() {
   return (
     <div className="p-6 max-w-6xl mx-auto">
       {/* Header */}
-      <div className="card mb-6">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-4">
-            <div className="p-3 bg-primary-100 dark:bg-primary-900/30 rounded-xl">
-              <Satellite className="w-6 h-6 text-primary-600 dark:text-primary-400" />
-            </div>
-            <div>
-              <h1 className="text-2xl font-bold font-display text-gray-900 dark:text-white">{t('satellites.title', 'Satellite Monitor')}</h1>
-              <p className="text-gray-500 dark:text-gray-400">{t('satellites.subtitle', 'Live status of connected satellites')}</p>
-            </div>
-          </div>
+      <div className="mb-6">
+        <PageHeader
+          icon={Satellite}
+          title={t('satellites.title', 'Satellite Monitor')}
+          subtitle={t('satellites.subtitle', 'Live status of connected satellites')}
+        >
+          {/* Auto-refresh toggle */}
+          <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={autoRefresh}
+              onChange={(e) => setAutoRefresh(e.target.checked)}
+              className="rounded-sm border-gray-300 text-blue-600 focus:ring-blue-500"
+            />
+            {t('satellites.autoRefresh', 'Auto-refresh')}
+          </label>
 
-          <div className="flex items-center gap-4">
-            {/* Auto-refresh toggle */}
-            <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={autoRefresh}
-                onChange={(e) => setAutoRefresh(e.target.checked)}
-                className="rounded-sm border-gray-300 text-blue-600 focus:ring-blue-500"
-              />
-              {t('satellites.autoRefresh', 'Auto-refresh')}
-            </label>
-
-            <button
-              onClick={loadSatellites}
-              className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
-              title={t('common.refresh')}
-            >
-              <RefreshCw className="w-5 h-5" />
-            </button>
-          </div>
-        </div>
+          <button
+            onClick={loadSatellites}
+            className="btn-icon btn-icon-ghost"
+            title={t('common.refresh')}
+          >
+            <RefreshCw className="w-5 h-5" />
+          </button>
+        </PageHeader>
       </div>
 
       {/* Stats */}
@@ -540,10 +516,7 @@ export default function SatellitesPage() {
 
       {/* Error message */}
       {error && (
-        <div className="mb-4 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg flex items-center gap-2 text-red-700 dark:text-red-400">
-          <AlertCircle className="w-5 h-5" />
-          {error}
-        </div>
+        <Alert variant="error" className="mb-4">{error}</Alert>
       )}
 
       {/* Satellite list */}

--- a/src/frontend/src/pages/SettingsPage.jsx
+++ b/src/frontend/src/pages/SettingsPage.jsx
@@ -8,9 +8,11 @@ import { useTranslation } from 'react-i18next';
 import { useAuth } from '../context/AuthContext';
 import apiClient from '../utils/axios';
 import {
-  Settings, Mic, Loader, AlertCircle, CheckCircle, RefreshCw, Save,
+  Settings, Mic, Loader, CheckCircle, RefreshCw, Save,
   Satellite, Monitor, XCircle, Clock
 } from 'lucide-react';
+import PageHeader from '../components/PageHeader';
+import Alert from '../components/Alert';
 
 export default function SettingsPage() {
   const { t } = useTranslation();
@@ -165,18 +167,8 @@ export default function SettingsPage() {
   if (loading) {
     return (
       <div className="p-6">
-        <div className="card mb-6">
-          <div className="flex items-center gap-4">
-            <div className="p-3 bg-primary-100 dark:bg-primary-900/30 rounded-xl">
-              <Settings className="w-6 h-6 text-primary-600 dark:text-primary-400" />
-            </div>
-            <div>
-              <h1 className="text-2xl font-bold font-display text-gray-900 dark:text-white">
-                {t('settings.title')}
-              </h1>
-              <p className="text-gray-500 dark:text-gray-400">{t('settings.subtitle')}</p>
-            </div>
-          </div>
+        <div className="mb-6">
+          <PageHeader icon={Settings} title={t('settings.title')} subtitle={t('settings.subtitle')} />
         </div>
         <div className="flex items-center justify-center p-12">
           <Loader className="w-8 h-8 animate-spin text-blue-500" />
@@ -189,42 +181,25 @@ export default function SettingsPage() {
   return (
     <div className="p-6 max-w-4xl mx-auto">
       {/* Header */}
-      <div className="card mb-6">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-4">
-            <div className="p-3 bg-primary-100 dark:bg-primary-900/30 rounded-xl">
-              <Settings className="w-6 h-6 text-primary-600 dark:text-primary-400" />
-            </div>
-            <div>
-              <h1 className="text-2xl font-bold font-display text-gray-900 dark:text-white">
-                {t('settings.title')}
-              </h1>
-              <p className="text-gray-500 dark:text-gray-400">{t('settings.subtitle')}</p>
-            </div>
-          </div>
+      <div className="mb-6">
+        <PageHeader icon={Settings} title={t('settings.title')} subtitle={t('settings.subtitle')}>
           <button
             onClick={loadSettings}
-            className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+            className="btn-icon btn-icon-ghost"
             title={t('common.refresh')}
           >
             <RefreshCw className="w-5 h-5" />
           </button>
-        </div>
+        </PageHeader>
       </div>
 
       {/* Error/Success Messages */}
       {error && (
-        <div className="mb-4 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg flex items-center gap-2 text-red-700 dark:text-red-400">
-          <AlertCircle className="w-5 h-5" />
-          {error}
-        </div>
+        <Alert variant="error" className="mb-4">{error}</Alert>
       )}
 
       {success && (
-        <div className="mb-4 p-4 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg flex items-center gap-2 text-green-700 dark:text-green-400">
-          <CheckCircle className="w-5 h-5" />
-          {success}
-        </div>
+        <Alert variant="success" className="mb-4">{success}</Alert>
       )}
 
       {/* Wake Word Settings Card */}

--- a/src/frontend/src/pages/TasksPage.jsx
+++ b/src/frontend/src/pages/TasksPage.jsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CheckSquare, Clock, CheckCircle, XCircle, Loader } from 'lucide-react';
 import apiClient from '../utils/axios';
+import PageHeader from '../components/PageHeader';
+import Badge from '../components/Badge';
 
 export default function TasksPage() {
   const { t } = useTranslation();
@@ -45,17 +47,11 @@ export default function TasksPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="card">
-        <div className="flex items-center gap-4">
-          <div className="p-3 bg-primary-100 dark:bg-primary-900/30 rounded-xl">
-            <CheckSquare className="w-6 h-6 text-primary-600 dark:text-primary-400" />
-          </div>
-          <div>
-            <h1 className="text-2xl font-bold font-display text-gray-900 dark:text-white">{t('tasks.title')}</h1>
-            <p className="text-gray-500 dark:text-gray-400">{t('tasks.subtitle')}</p>
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        icon={CheckSquare}
+        title={t('tasks.title')}
+        subtitle={t('tasks.subtitle')}
+      />
 
       {/* Filters */}
       <div className="flex space-x-2 overflow-x-auto">
@@ -107,14 +103,13 @@ export default function TasksPage() {
                     </p>
                   )}
                 </div>
-                <span className={`px-3 py-1 rounded-full text-xs font-medium ${
-                  task.status === 'completed' ? 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300' :
-                  task.status === 'failed' ? 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300' :
-                  task.status === 'running' ? 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300' :
-                  'bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300'
-                }`}>
+                <Badge color={
+                  task.status === 'completed' ? 'green' :
+                  task.status === 'failed' ? 'red' :
+                  task.status === 'running' ? 'blue' : 'yellow'
+                }>
                   {t(`tasks.${task.status}`)}
-                </span>
+                </Badge>
               </div>
             </div>
           ))

--- a/src/frontend/src/pages/UsersPage.jsx
+++ b/src/frontend/src/pages/UsersPage.jsx
@@ -8,9 +8,12 @@ import { useTranslation } from 'react-i18next';
 import { useAuth } from '../context/AuthContext';
 import apiClient from '../utils/axios';
 import Modal from '../components/Modal';
+import PageHeader from '../components/PageHeader';
+import Alert from '../components/Alert';
+import Badge from '../components/Badge';
 import { useConfirmDialog } from '../components/ConfirmDialog';
 import {
-  Users, UserPlus, UserCog, Pencil, Trash2, Loader, AlertCircle, CheckCircle,
+  Users, UserPlus, UserCog, Pencil, Trash2, Loader,
   Shield, User, Mic, Link2, Unlink, Eye, EyeOff, RefreshCw
 } from 'lucide-react';
 
@@ -251,17 +254,7 @@ export default function UsersPage() {
   if (loading) {
     return (
       <div className="space-y-6">
-        <div className="card">
-          <div className="flex items-center gap-4">
-            <div className="p-3 bg-primary-100 dark:bg-primary-900/30 rounded-xl">
-              <UserCog className="w-6 h-6 text-primary-600 dark:text-primary-400" />
-            </div>
-            <div>
-              <h1 className="text-2xl font-bold font-display text-gray-900 dark:text-white">{t('users.title')}</h1>
-              <p className="text-gray-500 dark:text-gray-400">{t('users.subtitle')}</p>
-            </div>
-          </div>
-        </div>
+        <PageHeader icon={UserCog} title={t('users.title')} subtitle={t('users.subtitle')} />
         <div className="card text-center py-12">
           <Loader className="w-8 h-8 animate-spin mx-auto text-gray-500 dark:text-gray-400 mb-2" />
           <p className="text-gray-500 dark:text-gray-400">{t('users.loading')}</p>
@@ -273,36 +266,11 @@ export default function UsersPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="card">
-        <div className="flex items-center gap-4">
-          <div className="p-3 bg-primary-100 dark:bg-primary-900/30 rounded-xl">
-            <UserCog className="w-6 h-6 text-primary-600 dark:text-primary-400" />
-          </div>
-          <div>
-            <h1 className="text-2xl font-bold font-display text-gray-900 dark:text-white">{t('users.title')}</h1>
-            <p className="text-gray-500 dark:text-gray-400">{t('users.subtitle')}</p>
-          </div>
-        </div>
-      </div>
+      <PageHeader icon={UserCog} title={t('users.title')} subtitle={t('users.subtitle')} />
 
       {/* Alerts */}
-      {error && (
-        <div className="card bg-red-100 dark:bg-red-900/20 border-red-300 dark:border-red-700">
-          <div className="flex items-center space-x-3">
-            <AlertCircle className="w-5 h-5 text-red-500" />
-            <p className="text-red-700 dark:text-red-400">{error}</p>
-          </div>
-        </div>
-      )}
-
-      {success && (
-        <div className="card bg-green-100 dark:bg-green-900/20 border-green-300 dark:border-green-700">
-          <div className="flex items-center space-x-3">
-            <CheckCircle className="w-5 h-5 text-green-500" />
-            <p className="text-green-700 dark:text-green-400">{success}</p>
-          </div>
-        </div>
-      )}
+      {error && <Alert variant="error">{error}</Alert>}
+      {success && <Alert variant="success">{success}</Alert>}
 
       {/* Actions */}
       <div className="flex flex-wrap gap-3">
@@ -353,20 +321,20 @@ export default function UsersPage() {
                         <span className="text-sm text-gray-500 dark:text-gray-400">({user.username})</span>
                       )}
                       {user.id === currentUser?.id && (
-                        <span className="text-xs bg-primary-600 text-white px-2 py-0.5 rounded-sm">{t('users.you')}</span>
+                        <Badge color="accent">{t('users.you')}</Badge>
                       )}
                       {!user.is_active && (
-                        <span className="text-xs bg-red-600 text-white px-2 py-0.5 rounded-sm">{t('users.inactive')}</span>
+                        <Badge color="red">{t('users.inactive')}</Badge>
                       )}
                     </div>
                     <div className="flex items-center space-x-3 text-sm text-gray-500 dark:text-gray-400">
-                      <span className={`px-2 py-0.5 rounded ${
-                        user.role_name === 'Admin' ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400' :
-                        user.role_name === 'Familie' ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400' :
-                        'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300'
-                      }`}>
+                      <Badge color={
+                        user.role_name === 'Admin' ? 'red' :
+                        user.role_name === 'Familie' ? 'blue' :
+                        'gray'
+                      }>
                         {user.role_name}
-                      </span>
+                      </Badge>
                       {user.email && <span>{user.email}</span>}
                       {user.speaker_id && (
                         <span className="flex items-center space-x-1 text-green-600 dark:text-green-400">
@@ -383,7 +351,7 @@ export default function UsersPage() {
                   {user.speaker_id ? (
                     <button
                       onClick={() => handleUnlinkSpeaker(user.id)}
-                      className="p-2 text-gray-500 hover:text-yellow-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-yellow-400 dark:hover:bg-gray-700 rounded-lg transition-colors"
+                      className="btn-icon btn-icon-ghost"
                       title={t('users.unlinkSpeaker')}
                     >
                       <Unlink className="w-5 h-5" />
@@ -391,7 +359,7 @@ export default function UsersPage() {
                   ) : (
                     <button
                       onClick={() => handleLinkSpeaker(user.id)}
-                      className="p-2 text-gray-500 hover:text-green-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-green-400 dark:hover:bg-gray-700 rounded-lg transition-colors"
+                      className="btn-icon btn-icon-ghost"
                       title={t('users.linkSpeaker')}
                       disabled={availableSpeakers.length === 0}
                     >
@@ -400,14 +368,14 @@ export default function UsersPage() {
                   )}
                   <button
                     onClick={() => handleEdit(user)}
-                    className="p-2 text-gray-500 hover:text-primary-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-primary-400 dark:hover:bg-gray-700 rounded-lg transition-colors"
+                    className="btn-icon btn-icon-ghost"
                     title={t('users.editUser')}
                   >
                     <Pencil className="w-5 h-5" />
                   </button>
                   <button
                     onClick={() => handleDelete(user)}
-                    className="p-2 text-gray-500 hover:text-red-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-red-400 dark:hover:bg-gray-700 rounded-lg transition-colors"
+                    className="btn-icon btn-icon-danger"
                     title={t('users.deleteUser')}
                     disabled={user.id === currentUser?.id}
                   >


### PR DESCRIPTION
## Summary
- Apply PageHeader, Alert, Badge components and semantic button utilities (btn-icon, btn-icon-ghost, btn-icon-danger, btn-danger, btn-success, btn-ghost) to all 15 remaining admin pages
- Net reduction of 344 lines (-667/+323) through consistent design system adoption
- All 313 React tests pass, build clean

## Pages cleaned up
CameraPage, HomeAssistantPage, IntegrationsPage, IntentsPage, KnowledgeGraphPage, KnowledgePage, MaintenancePage, MemoryPage, PaperlessAuditPage, PresencePage, RolesPage, SatellitesPage, SettingsPage, TasksPage, UsersPage

## Test plan
- [x] `make test-frontend-react` — 313/313 tests pass
- [x] `vite build` — clean production build
- [ ] Visual review of all pages in light + dark mode on PRD

🤖 Generated with [Claude Code](https://claude.com/claude-code)