### PR TITLE
feat: Video playback on DLNA Smart TVs

### DIFF
--- a/config/agent_roles.yaml
+++ b/config/agent_roles.yaml
@@ -45,7 +45,7 @@ roles:
       de: "Medien: Musik, Filme, Serien, Radio suchen und abspielen (auch in bestimmten Raeumen)"
       en: "Media: search and play music, movies, series, radio (also in specific rooms)"
     mcp_servers: [jellyfin, dlna, radio]
-    internal_tools: [internal.resolve_room_player, internal.play_in_room, internal.play_album_on_dlna, internal.media_control, internal.play_radio, internal.save_radio_favorite, internal.list_radio_favorites, internal.remove_radio_favorite]
+    internal_tools: [internal.resolve_room_player, internal.play_in_room, internal.play_album_on_dlna, internal.play_video_on_dlna, internal.media_control, internal.play_radio, internal.save_radio_favorite, internal.list_radio_favorites, internal.remove_radio_favorite]
     max_steps: 6
     prompt_key: agent_prompt_media
     model: "qwen3:14b"

--- a/config/mcp_servers.yaml
+++ b/config/mcp_servers.yaml
@@ -115,6 +115,9 @@ servers:
       - list_artists
       - list_movies
       - list_series
+      - get_series_seasons
+      - get_season_episodes
+      - get_next_up
       - library_stats
     examples:
       de:
@@ -122,11 +125,15 @@ servers:
         - "Zeige meine Alben"
         - "Welche Filme habe ich?"
         - "Zeige meine Serien"
+        - "Spiel den Film Interstellar"
+        - "Naechste Folge Breaking Bad"
       en:
         - "Search music by Queen"
         - "Show my albums"
         - "What movies do I have?"
         - "Show my series"
+        - "Play the movie Interstellar"
+        - "Next episode of Breaking Bad"
 
   # --- TuneIn Radio MCP Server ---
   # Custom Python MCP server for TuneIn radio station search and streaming.

--- a/src/backend/prompts/agent.yaml
+++ b/src/backend/prompts/agent.yaml
@@ -229,6 +229,12 @@ de:
     - RADIO-FAVORITEN: internal.list_radio_favorites zeigt gespeicherte Sender. internal.save_radio_favorite speichert einen Sender. internal.remove_radio_favorite entfernt einen.
     - Wenn der Nutzer "mein Lieblingssender" oder "meine Radiosender" sagt, nutze internal.list_radio_favorites.
     - RADIO-GENRE: Um Sender nach Genre zu finden, nutze mcp.radio.browse_categories(category="music") und dann browse_categories(category_id="<genre_id>").
+    - WICHTIG — FILM abspielen: (1) search_media(type="Movie", query="<filmname>"), (2) internal.play_video_on_dlna(item_id="<id>", room_name="<Raum>"). Nur 2 Schritte! Das Tool holt automatisch die Stream-URL und spielt den Film auf dem visuellen DLNA-Renderer (Smart TV) ab.
+    - SERIEN-FOLGE abspielen: (1) get_next_up(series_id="<id>") fuer die naechste ungesehene Folge ODER get_season_episodes(series_id, season_id) fuer eine bestimmte Folge. (2) internal.play_video_on_dlna(item_id="<episode_id>", room_name="<Raum>").
+    - SERIE DURCHSTOEBERN: Nutze get_series_seasons(series_id) und dann get_season_episodes(series_id, season_id) um Staffeln und Folgen aufzulisten.
+    - "Naechste Folge X" → get_next_up(series_id="<id>"). Wenn der Nutzer keinen konkreten Seriennamen nennt, nutze get_next_up() ohne series_id fuer alle Serien.
+    - Wenn play_video_on_dlna ERFOLGREICH war (success=true), gib SOFORT final_answer. NIEMALS dasselbe Play-Tool nochmal aufrufen!
+    - DLNA-Wiedergabesteuerung (pause/stop/resume) funktioniert auch fuer Videos per internal.media_control.
     - Beschreibe NIEMALS API-Aufrufe gegenueber dem Benutzer
     - Wenn ein Such-Tool 0 Ergebnisse liefert, wiederhole NICHT dieselbe Suche. Versuche: (1) Kuerzeren Suchbegriff (nur Titel, ohne Kuenstler/Autor), (2) alternative Schreibweise, (3) anderes Tool. Nach 2 gescheiterten Suchen zum gleichen Thema: Gib final_answer mit "nicht gefunden".
     - Die finale Antwort muss kurz, natuerlich und auf Deutsch sein
@@ -600,6 +606,12 @@ en:
     - RADIO FAVORITES: internal.list_radio_favorites shows saved stations. internal.save_radio_favorite saves a station. internal.remove_radio_favorite removes one.
     - When the user says "my favorite stations" or "my radio presets", use internal.list_radio_favorites.
     - RADIO GENRE: To find stations by genre, use mcp.radio.browse_categories(category="music") then browse_categories(category_id="<genre_id>").
+    - IMPORTANT — Play a MOVIE: (1) search_media(type="Movie", query="<title>"), (2) internal.play_video_on_dlna(item_id="<id>", room_name="<room>"). Only 2 steps! The tool automatically fetches the stream URL and plays the movie on the visual DLNA renderer (Smart TV).
+    - Play a SERIES EPISODE: (1) get_next_up(series_id="<id>") for the next unwatched episode OR get_season_episodes(series_id, season_id) for a specific episode. (2) internal.play_video_on_dlna(item_id="<episode_id>", room_name="<room>").
+    - BROWSE A SERIES: Use get_series_seasons(series_id) then get_season_episodes(series_id, season_id) to list seasons and episodes.
+    - "Next episode of X" → get_next_up(series_id="<id>"). If the user doesn't name a specific series, use get_next_up() without series_id for all series.
+    - When play_video_on_dlna returns SUCCESS (success=true), give final_answer IMMEDIATELY. NEVER call the same play tool again!
+    - DLNA playback control (pause/stop/resume) also works for videos via internal.media_control.
     - Never describe API calls to the user
     - If a search tool returns 0 results, do NOT repeat the same search. Try: (1) Shorter query (title only, without artist/author), (2) alternative spelling, (3) different tool. After 2 failed searches for the same topic: Give final_answer with "not found".
     - The final answer must be concise, natural, and in English

--- a/src/backend/services/internal_tools.py
+++ b/src/backend/services/internal_tools.py
@@ -72,6 +72,16 @@ class InternalToolService:
                 "album_name": "Album title for display metadata (optional, from search_media results)",
             },
         },
+        "internal.play_video_on_dlna": {
+            "description": "Play a Jellyfin movie or episode on a DLNA renderer (Smart TV). Fetches the video stream URL from Jellyfin and plays it with video DIDL metadata. Provide either renderer_name (direct) or room_name (resolves via visual output config).",
+            "parameters": {
+                "item_id": "Jellyfin item ID for the movie or episode (required)",
+                "renderer_name": "DLNA renderer name (optional if room_name given)",
+                "room_name": "Room name to resolve visual DLNA renderer (optional if renderer_name given)",
+                "title": "Display title (optional)",
+                "image_url": "Thumbnail URL (optional)",
+            },
+        },
         "internal.play_radio": {
             "description": "Play a radio station in a room. Resolves the stream URL from a station ID and plays it on the room's audio device. Use after mcp.radio.search_stations to get a station_id.",
             "parameters": {
@@ -111,6 +121,7 @@ class InternalToolService:
         "internal.knowledge_search": "_knowledge_search",
         "internal.media_control": "_media_control",
         "internal.play_album_on_dlna": "_play_album_on_dlna",
+        "internal.play_video_on_dlna": "_play_video_on_dlna",
         "internal.play_radio": "_play_radio",
         "internal.save_radio_favorite": "_save_radio_favorite",
         "internal.list_radio_favorites": "_list_radio_favorites",
@@ -865,6 +876,223 @@ class InternalToolService:
             return {
                 "success": False,
                 "message": f"Error playing album on DLNA: {e!s}",
+                "action_taken": False,
+            }
+
+    async def _resolve_room_visual_player(self, params: dict) -> dict:
+        """
+        Resolve room_name → visual DLNA renderer (Smart TV).
+
+        Analogous to _resolve_room_player but uses get_visual_output_for_room
+        instead of get_audio_output_for_room.
+        """
+        room_name = params.get("room_name", "").strip()
+        if not room_name:
+            return {
+                "success": False,
+                "message": "Parameter 'room_name' is required",
+                "action_taken": False,
+            }
+
+        try:
+            from services.database import AsyncSessionLocal
+            from services.output_routing_service import OutputRoutingService
+            from services.room_service import RoomService
+
+            async with AsyncSessionLocal() as db:
+                room_service = RoomService(db)
+                room = await room_service.get_room_by_name(room_name)
+                if not room:
+                    room = await room_service.get_room_by_alias(room_name)
+
+                if not room:
+                    return {
+                        "success": False,
+                        "message": f"Room '{room_name}' not found",
+                        "action_taken": False,
+                    }
+
+                routing_service = OutputRoutingService(db)
+                decision = await routing_service.get_visual_output_for_room(room.id)
+
+                if decision.reason == "no_output_devices_configured":
+                    return {
+                        "success": False,
+                        "message": f"No visual output device (Smart TV) configured for room '{room.name}'",
+                        "action_taken": False,
+                    }
+
+                if not decision.output_device:
+                    return {
+                        "success": False,
+                        "message": f"No visual output device available for room '{room.name}'",
+                        "action_taken": False,
+                    }
+
+                if decision.target_type == "dlna":
+                    return {
+                        "success": True,
+                        "message": f"Found visual DLNA renderer for {room.name}: {decision.output_device.dlna_renderer_name}",
+                        "action_taken": True,
+                        "data": {
+                            "target_type": "dlna",
+                            "dlna_renderer_name": decision.output_device.dlna_renderer_name,
+                            "room_name": room.name,
+                            "device_name": decision.output_device.device_name or decision.output_device.dlna_renderer_name,
+                        },
+                    }
+
+                return {
+                    "success": False,
+                    "message": f"Visual output device in room '{room.name}' is not a DLNA renderer",
+                    "action_taken": False,
+                }
+
+        except Exception as e:
+            logger.error(f"Error resolving visual player for '{room_name}': {e}")
+            return {
+                "success": False,
+                "message": f"Error resolving visual player: {e!s}",
+                "action_taken": False,
+            }
+
+    async def _play_video_on_dlna(self, params: dict) -> dict:
+        """
+        Play a Jellyfin movie or episode on a DLNA renderer (Smart TV).
+
+        1. Resolve renderer: room_name → visual output → DLNA renderer
+        2. Get video stream URL from Jellyfin via get_stream_url
+        3. Send to DLNA with media_type="video" for Movie DIDL metadata
+        """
+        item_id = (params.get("item_id") or "").strip()
+        renderer_name = (params.get("renderer_name") or "").strip()
+        room_name = (params.get("room_name") or "").strip()
+        title = (params.get("title") or "").strip()
+        image_url = (params.get("image_url") or "").strip()
+
+        if not item_id:
+            return {
+                "success": False,
+                "message": "Parameter 'item_id' is required",
+                "action_taken": False,
+            }
+
+        # Resolve renderer_name from room config (visual output) if not provided
+        if not renderer_name and room_name:
+            resolve_result = await self._resolve_room_visual_player({"room_name": room_name})
+            if not resolve_result.get("success"):
+                return resolve_result
+            data = resolve_result.get("data", {})
+            renderer_name = data.get("dlna_renderer_name", "")
+
+        if not renderer_name:
+            return {
+                "success": False,
+                "message": "Either 'renderer_name' or 'room_name' is required",
+                "action_taken": False,
+            }
+
+        try:
+            import json as _json
+
+            from main import app
+            mcp_manager = getattr(app.state, "mcp_manager", None)
+            if not mcp_manager:
+                return {
+                    "success": False,
+                    "message": "MCP manager not available",
+                    "action_taken": False,
+                }
+
+            # Step 1: Get video stream URL from Jellyfin
+            stream_result = await mcp_manager.execute_tool(
+                "mcp.jellyfin.get_stream_url",
+                {"item_id": item_id},
+            )
+            if not stream_result.get("success"):
+                return {
+                    "success": False,
+                    "message": f"Failed to get stream URL: {stream_result.get('message', 'unknown error')}",
+                    "action_taken": False,
+                }
+
+            # Parse MCP response to extract video_stream URL
+            raw_text = ""
+            stream_data = stream_result.get("data", [])
+            if isinstance(stream_data, list):
+                for item in stream_data:
+                    if isinstance(item, dict) and item.get("type") == "text":
+                        raw_text = item.get("text", "")
+                        break
+            if not raw_text:
+                raw_text = stream_result.get("message", "")
+
+            try:
+                parsed = _json.loads(raw_text)
+            except (ValueError, TypeError):
+                parsed = {}
+
+            video_url = parsed.get("video_stream", "")
+            if not video_url:
+                return {
+                    "success": False,
+                    "message": "No video stream URL found for this item",
+                    "action_taken": False,
+                }
+
+            display_title = title or parsed.get("name", "Video")
+
+            # Step 2: Play via DLNA with video media_type
+            dlna_tracks = [{
+                "url": video_url,
+                "title": display_title,
+                "media_type": "video",
+            }]
+            if image_url:
+                dlna_tracks[0]["art_url"] = image_url
+
+            dlna_result = await mcp_manager.execute_tool(
+                "mcp.dlna.play_tracks",
+                {
+                    "renderer_name": renderer_name,
+                    "tracks": _json.dumps(dlna_tracks),
+                },
+            )
+
+            if not dlna_result.get("success"):
+                return {
+                    "success": False,
+                    "message": f"DLNA video playback failed: {dlna_result.get('message', 'unknown error')}",
+                    "action_taken": False,
+                }
+
+            # Register with Media Follow (reuse album_id field for item_id)
+            follow_room = room_name or renderer_name
+            await self._register_media_follow(
+                params, follow_room, "dlna_video",
+                album_id=item_id,
+                renderer_name=renderer_name,
+                title=display_title,
+                media_url=video_url,
+            )
+
+            return {
+                "success": True,
+                "message": f"Playing '{display_title}' on {renderer_name}",
+                "action_taken": True,
+                "data": {
+                    "title": display_title,
+                    "renderer": renderer_name,
+                    "item_id": item_id,
+                    "video_url": video_url,
+                },
+            }
+
+        except Exception as e:
+            logger.error(f"Error playing video on DLNA: {e}")
+            return {
+                "success": False,
+                "message": f"Error playing video on DLNA: {e!s}",
                 "action_taken": False,
             }
 

--- a/src/backend/services/media_follow_service.py
+++ b/src/backend/services/media_follow_service.py
@@ -22,6 +22,7 @@ class MediaType(str, Enum):
     SINGLE_URL = "single_url"      # HA media_player.play_media
     DLNA_ALBUM = "dlna_album"      # DLNA play_tracks (album queue)
     RADIO = "radio"                # Radio stream (TuneIn)
+    DLNA_VIDEO = "dlna_video"      # DLNA video playback (Jellyfin movie/episode)
 
 
 class SessionState(str, Enum):
@@ -272,6 +273,14 @@ class MediaFollowService:
                         "album_id": session.album_id,
                         "room_name": new_room_name,
                         "album_name": session.album_name or "",
+                    })
+
+            elif session.media_type == MediaType.DLNA_VIDEO:
+                if session.album_id:  # album_id reused as item_id for videos
+                    result = await svc._play_video_on_dlna({
+                        "item_id": session.album_id,
+                        "room_name": new_room_name,
+                        "title": session.title or "",
                     })
 
             if result.get("success"):

--- a/tests/backend/test_internal_tools.py
+++ b/tests/backend/test_internal_tools.py
@@ -1895,6 +1895,234 @@ class TestPlayAlbumOnDlna:
             assert result["success"] is True
 
 
+class TestPlayVideoOnDlna:
+    """Test internal.play_video_on_dlna tool."""
+
+    @staticmethod
+    def _patch_main_app(mock_mcp_manager):
+        """Patch main.app without importing the real main module."""
+        mock_app = MagicMock()
+        mock_app.state.mcp_manager = mock_mcp_manager
+        fake_main = ModuleType("main")
+        fake_main.app = mock_app  # type: ignore
+        return patch.dict(sys.modules, {"main": fake_main})
+
+    @pytest.mark.unit
+    async def test_play_video_success(self, internal_tools):
+        """Video played successfully via Jellyfin get_stream_url + DLNA play_tracks."""
+        import json
+        stream_response = json.dumps({
+            "id": "movie1",
+            "name": "Interstellar",
+            "type": "Movie",
+            "video_stream": "http://jellyfin:8096/Videos/movie1/stream?static=true&api_key=k",
+        })
+        mock_mcp_manager = MagicMock()
+        mock_mcp_manager.execute_tool = AsyncMock(side_effect=[
+            {"success": True, "message": stream_response, "data": [{"type": "text", "text": stream_response}]},
+            {"success": True, "message": "Playing on Samsung TV"},
+        ])
+
+        with self._patch_main_app(mock_mcp_manager):
+            result = await internal_tools._play_video_on_dlna({
+                "item_id": "movie1",
+                "renderer_name": "Samsung TV",
+                "title": "Interstellar",
+            })
+
+        assert result["success"] is True
+        assert result["data"]["title"] == "Interstellar"
+        assert result["data"]["renderer"] == "Samsung TV"
+
+        # Verify correct MCP calls
+        calls = mock_mcp_manager.execute_tool.call_args_list
+        assert calls[0].args[0] == "mcp.jellyfin.get_stream_url"
+        assert calls[0].args[1] == {"item_id": "movie1"}
+        assert calls[1].args[0] == "mcp.dlna.play_tracks"
+        # Verify video media_type in the tracks JSON
+        tracks_json = json.loads(calls[1].args[1]["tracks"])
+        assert tracks_json[0]["media_type"] == "video"
+
+    @pytest.mark.unit
+    async def test_play_video_missing_item_id(self, internal_tools):
+        """Missing item_id returns error."""
+        result = await internal_tools._play_video_on_dlna({"renderer_name": "Samsung TV"})
+        assert result["success"] is False
+        assert "item_id" in result["message"]
+
+    @pytest.mark.unit
+    async def test_play_video_missing_renderer_and_room(self, internal_tools):
+        """Missing both renderer_name and room_name returns error."""
+        result = await internal_tools._play_video_on_dlna({"item_id": "movie1"})
+        assert result["success"] is False
+        assert "renderer_name" in result["message"] or "room_name" in result["message"]
+
+    @pytest.mark.unit
+    async def test_play_video_via_room_name(self, internal_tools):
+        """room_name resolves visual DLNA renderer from room config."""
+        import json
+        resolve_result = {
+            "success": True,
+            "message": "Found visual DLNA renderer",
+            "action_taken": True,
+            "data": {
+                "target_type": "dlna",
+                "dlna_renderer_name": "Samsung TV Wohnzimmer",
+                "room_name": "Wohnzimmer",
+                "device_name": "Samsung TV Wohnzimmer",
+            },
+        }
+
+        stream_response = json.dumps({
+            "id": "movie1",
+            "name": "Interstellar",
+            "video_stream": "http://jellyfin:8096/Videos/movie1/stream?static=true&api_key=k",
+        })
+        mock_mcp_manager = MagicMock()
+        mock_mcp_manager.execute_tool = AsyncMock(side_effect=[
+            {"success": True, "message": stream_response, "data": [{"type": "text", "text": stream_response}]},
+            {"success": True, "message": "Playing"},
+        ])
+
+        with patch.object(internal_tools, "_resolve_room_visual_player",
+                          new_callable=AsyncMock, return_value=resolve_result), \
+             self._patch_main_app(mock_mcp_manager):
+            result = await internal_tools._play_video_on_dlna({
+                "item_id": "movie1",
+                "room_name": "Wohnzimmer",
+            })
+
+        assert result["success"] is True
+        assert result["data"]["renderer"] == "Samsung TV Wohnzimmer"
+
+    @pytest.mark.unit
+    async def test_play_video_no_video_stream(self, internal_tools):
+        """Item without video_stream URL returns error."""
+        import json
+        stream_response = json.dumps({
+            "id": "audio1",
+            "name": "Song",
+            "type": "Audio",
+            "api_stream": "http://jellyfin:8096/Audio/audio1/stream",
+        })
+        mock_mcp_manager = MagicMock()
+        mock_mcp_manager.execute_tool = AsyncMock(return_value={
+            "success": True, "message": stream_response, "data": [{"type": "text", "text": stream_response}],
+        })
+
+        with self._patch_main_app(mock_mcp_manager):
+            result = await internal_tools._play_video_on_dlna({
+                "item_id": "audio1",
+                "renderer_name": "Samsung TV",
+            })
+
+        assert result["success"] is False
+        assert "No video stream URL" in result["message"]
+
+    @pytest.mark.unit
+    async def test_play_video_jellyfin_fails(self, internal_tools):
+        """Jellyfin get_stream_url failure returns error."""
+        mock_mcp_manager = MagicMock()
+        mock_mcp_manager.execute_tool = AsyncMock(return_value={
+            "success": False, "message": "Item not found",
+        })
+
+        with self._patch_main_app(mock_mcp_manager):
+            result = await internal_tools._play_video_on_dlna({
+                "item_id": "invalid",
+                "renderer_name": "Samsung TV",
+            })
+
+        assert result["success"] is False
+        assert "Failed to get stream URL" in result["message"]
+
+    @pytest.mark.unit
+    async def test_execute_routes_to_play_video(self, internal_tools):
+        """execute() routes internal.play_video_on_dlna correctly."""
+        with patch.object(internal_tools, "_play_video_on_dlna", new_callable=AsyncMock) as mock:
+            mock.return_value = {"success": True}
+            params = {"item_id": "movie1", "renderer_name": "Samsung TV"}
+            result = await internal_tools.execute("internal.play_video_on_dlna", params)
+            mock.assert_called_once_with(params)
+            assert result["success"] is True
+
+
+class TestResolveRoomVisualPlayer:
+    """Test _resolve_room_visual_player helper."""
+
+    @pytest.mark.unit
+    async def test_resolve_visual_dlna_success(self, internal_tools):
+        """Room with visual DLNA device resolves correctly."""
+        mock_room = MagicMock()
+        mock_room.id = 1
+        mock_room.name = "Wohnzimmer"
+
+        mock_room_service = MagicMock()
+        mock_room_service.get_room_by_name = AsyncMock(return_value=mock_room)
+        mock_room_service.get_room_by_alias = AsyncMock(return_value=None)
+
+        mock_output_device = MagicMock()
+        mock_output_device.dlna_renderer_name = "Samsung TV"
+        mock_output_device.device_name = "Samsung TV"
+
+        mock_decision = MagicMock()
+        mock_decision.reason = "ok"
+        mock_decision.output_device = mock_output_device
+        mock_decision.target_type = "dlna"
+
+        mock_routing_service = MagicMock()
+        mock_routing_service.get_visual_output_for_room = AsyncMock(return_value=mock_decision)
+
+        with _patch_resolve_deps(mock_room_service, mock_routing_service):
+            result = await internal_tools._resolve_room_visual_player({"room_name": "Wohnzimmer"})
+
+        assert result["success"] is True
+        assert result["data"]["target_type"] == "dlna"
+        assert result["data"]["dlna_renderer_name"] == "Samsung TV"
+
+    @pytest.mark.unit
+    async def test_resolve_visual_room_not_found(self, internal_tools):
+        """Unknown room returns error."""
+        mock_room_service = MagicMock()
+        mock_room_service.get_room_by_name = AsyncMock(return_value=None)
+        mock_room_service.get_room_by_alias = AsyncMock(return_value=None)
+
+        with _patch_resolve_deps(mock_room_service):
+            result = await internal_tools._resolve_room_visual_player({"room_name": "Narnia"})
+
+        assert result["success"] is False
+        assert "not found" in result["message"]
+
+    @pytest.mark.unit
+    async def test_resolve_visual_no_devices(self, internal_tools):
+        """Room with no visual devices returns error."""
+        mock_room = MagicMock()
+        mock_room.id = 1
+        mock_room.name = "Kueche"
+
+        mock_room_service = MagicMock()
+        mock_room_service.get_room_by_name = AsyncMock(return_value=mock_room)
+
+        mock_decision = MagicMock()
+        mock_decision.reason = "no_output_devices_configured"
+
+        mock_routing_service = MagicMock()
+        mock_routing_service.get_visual_output_for_room = AsyncMock(return_value=mock_decision)
+
+        with _patch_resolve_deps(mock_room_service, mock_routing_service):
+            result = await internal_tools._resolve_room_visual_player({"room_name": "Kueche"})
+
+        assert result["success"] is False
+        assert "No visual output device" in result["message"]
+
+    @pytest.mark.unit
+    async def test_resolve_visual_missing_room_name(self, internal_tools):
+        """Missing room_name returns error."""
+        result = await internal_tools._resolve_room_visual_player({})
+        assert result["success"] is False
+        assert "room_name" in result["message"]
+
+
 class TestFormatLastSeen:
     """Test relative time formatting."""
 

--- a/tests/backend/test_media_follow_service.py
+++ b/tests/backend/test_media_follow_service.py
@@ -475,7 +475,48 @@ class TestMediaType:
         assert MediaType.SINGLE_URL == "single_url"
         assert MediaType.DLNA_ALBUM == "dlna_album"
         assert MediaType.RADIO == "radio"
+        assert MediaType.DLNA_VIDEO == "dlna_video"
 
     def test_from_string(self):
         assert MediaType("single_url") == MediaType.SINGLE_URL
         assert MediaType("radio") == MediaType.RADIO
+        assert MediaType("dlna_video") == MediaType.DLNA_VIDEO
+
+
+# =============================================================================
+# DLNA Video Resume
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestResumeVideoPlayback:
+    async def test_dlna_video_resume(self, service):
+        """DLNA_VIDEO session resumed correctly via _play_video_on_dlna."""
+        service.register_playback(
+            user_id=1,
+            room_id=10,
+            room_name="Wohnzimmer",
+            media_type=MediaType.DLNA_VIDEO,
+            album_id="movie1",  # reused as item_id
+            title="Interstellar",
+            media_url="http://jellyfin/Videos/movie1/stream",
+            renderer_name="Samsung TV",
+        )
+        session = service.get_session(1)
+        session.state = SessionState.SUSPENDED
+        session.suspended_at = time.time()
+
+        mock_result = {"success": True, "message": "Playing"}
+        with patch("services.media_follow_service.settings") as mock_settings, \
+             patch("services.internal_tools.InternalToolService._play_video_on_dlna",
+                   new_callable=AsyncMock, return_value=mock_result) as mock_play:
+            mock_settings.media_follow_resume_delay = 0
+            await service._resume_playback(session, 20, "Schlafzimmer")
+            mock_play.assert_called_once()
+            call_params = mock_play.call_args.args[0]
+            assert call_params["item_id"] == "movie1"
+            assert call_params["room_name"] == "Schlafzimmer"
+
+        assert session.state == SessionState.PLAYING
+        assert session.room_id == 20
+        assert session.room_name == "Schlafzimmer"


### PR DESCRIPTION
## Summary
- Add `internal.play_video_on_dlna` tool + handler for movie/episode playback
- Add `_resolve_room_visual_player()` for Smart TV output routing
- Add `DLNA_VIDEO` MediaType with Media Follow resume support
- Add bilingual agent prompts (DE + EN) for movie/series playback workflows
- Update `mcp_servers.yaml` with new Jellyfin series tools + examples

Closes #249

## Test plan
- [x] 134/140 backend tests pass (6 pre-existing failures unrelated)
- [x] 14 new tests: TestPlayVideoOnDlna (7), TestResolveRoomVisualPlayer (4), TestResumeVideoPlayback (1), TestMediaType (2)
- [ ] E2E: "Spiel den Film X im Wohnzimmer" → video plays on Smart TV
- [ ] E2E: "Nächste Folge Breaking Bad" → next episode plays

🤖 Generated with [Claude Code](https://claude.com/claude-code)