### PR TITLE
feat(memory): Always-inject essential memories regardless of similarity (#251)

### DIFF
--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -386,10 +386,20 @@ async def _retrieve_memory_context(content: str, user_id: int | None, lang: str)
         try:
             async with AsyncSessionLocal() as db:
                 service = ConversationMemoryService(db)
-                memories = await service.retrieve(content, user_id=user_id)
-                if memories:
+                # Essential memories (always injected, similarity-independent)
+                essential = await service.retrieve_essential(user_id=user_id)
+                # Semantic memories (query-dependent)
+                semantic = await service.retrieve(content, user_id=user_id)
+                # Merge: essential first, then semantic (deduplicated)
+                seen_ids = {m["id"] for m in essential}
+                combined = list(essential)
+                for m in semantic:
+                    if m["id"] not in seen_ids:
+                        combined.append(m)
+
+                if combined:
                     lines = []
-                    for m in memories:
+                    for m in combined:
                         cat_label = m["category"].upper()
                         lines.append(f"- [{cat_label}] {m['content']}")
                     memories_str = "\n".join(lines)

--- a/src/backend/services/conversation_memory_service.py
+++ b/src/backend/services/conversation_memory_service.py
@@ -388,6 +388,72 @@ class ConversationMemoryService:
 
         return memories
 
+    async def retrieve_essential(
+        self,
+        user_id: int | None = None,
+        limit: int | None = None,
+    ) -> list[dict]:
+        """
+        Retrieve high-importance memories regardless of query similarity.
+
+        Essential memories (importance >= threshold, category != 'context')
+        are always injected into the LLM context so the assistant knows
+        the user's name, location, preferences, etc.
+
+        Returns:
+            List of dicts with id, content, category, importance, similarity=1.0
+        """
+        threshold = settings.memory_essential_threshold
+        limit = limit or settings.memory_retrieval_limit
+
+        user_filter = "AND user_id = :user_id" if user_id is not None else ""
+
+        sql = text(f"""
+            SELECT id, content, category, importance, access_count, created_at
+            FROM conversation_memories
+            WHERE is_active = true
+              AND importance >= :threshold
+              AND category != 'context'
+              {user_filter}
+            ORDER BY importance DESC
+            LIMIT :limit
+        """)
+
+        params: dict = {"threshold": threshold, "limit": limit}
+        if user_id is not None:
+            params["user_id"] = user_id
+
+        result = await self.db.execute(sql, params)
+        rows = result.fetchall()
+
+        memories = []
+        memory_ids = []
+        for row in rows:
+            memories.append({
+                "id": row.id,
+                "content": row.content,
+                "category": row.category,
+                "importance": row.importance,
+                "access_count": row.access_count,
+                "created_at": row.created_at.isoformat() if row.created_at else None,
+                "similarity": 1.0,
+            })
+            memory_ids.append(row.id)
+
+        # Update access tracking
+        if memory_ids:
+            await self.db.execute(
+                update(ConversationMemory)
+                .where(ConversationMemory.id.in_(memory_ids))
+                .values(
+                    access_count=ConversationMemory.access_count + 1,
+                    last_accessed_at=datetime.now(UTC).replace(tzinfo=None),
+                )
+            )
+            await self.db.commit()
+
+        return memories
+
     # =========================================================================
     # Cleanup
     # =========================================================================

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -155,6 +155,7 @@ class Settings(BaseSettings):
     memory_dedup_threshold: float = Field(default=0.9, ge=0.5, le=1.0)     # Deduplication threshold
     memory_extraction_enabled: bool = False                                  # Auto-extract memories from conversations
     memory_cleanup_interval: int = Field(default=3600, ge=60, le=86400)     # Cleanup interval in seconds
+    memory_essential_threshold: float = Field(default=0.9, ge=0.0, le=1.0)   # Importance threshold for always-inject
     memory_contradiction_resolution: bool = False                            # LLM-based contradiction resolution
     memory_contradiction_threshold: float = Field(default=0.6, ge=0.3, le=0.89)  # Similarity range lower bound
     memory_contradiction_top_k: int = Field(default=5, ge=1, le=10)         # Max similar memories to compare

--- a/tests/backend/test_conversation_memory.py
+++ b/tests/backend/test_conversation_memory.py
@@ -1580,3 +1580,226 @@ class TestGetHistory:
         """get_history() returns empty list for unknown memory_id."""
         entries = await memory_service.get_history(99999)
         assert entries == []
+
+
+# ==========================================================================
+# Essential Memory Tests
+# ==========================================================================
+
+class TestEssentialMemoryConfig:
+    """Tests for memory_essential_threshold config setting."""
+
+    @pytest.mark.unit
+    def test_default_threshold(self):
+        """Default essential threshold is 0.9."""
+        from utils.config import Settings
+        s = Settings(database_url="sqlite:///:memory:")
+        assert s.memory_essential_threshold == 0.9
+
+    @pytest.mark.unit
+    def test_custom_threshold(self):
+        """Essential threshold can be customized."""
+        from utils.config import Settings
+        s = Settings(
+            database_url="sqlite:///:memory:",
+            memory_essential_threshold=0.8,
+        )
+        assert s.memory_essential_threshold == 0.8
+
+
+class TestRetrieveEssential:
+    """Tests for ConversationMemoryService.retrieve_essential()."""
+
+    @pytest.mark.unit
+    async def test_retrieve_essential_returns_high_importance(self, memory_service, db_session, test_user):
+        """retrieve_essential() returns memories with importance >= threshold."""
+        # High importance fact (should be returned)
+        m1 = ConversationMemory(
+            content="Ich wohne in Kleinenbroich",
+            category="fact",
+            user_id=test_user.id,
+            importance=1.0,
+        )
+        # Low importance fact (should NOT be returned)
+        m2 = ConversationMemory(
+            content="Hat letzte Woche Pizza gegessen",
+            category="fact",
+            user_id=test_user.id,
+            importance=0.3,
+        )
+        db_session.add_all([m1, m2])
+        await db_session.commit()
+
+        with patch('services.conversation_memory_service.settings') as mock_settings:
+            mock_settings.memory_essential_threshold = 0.9
+            mock_settings.memory_retrieval_limit = 10
+
+            results = await memory_service.retrieve_essential(user_id=test_user.id)
+
+        assert len(results) == 1
+        assert results[0]["content"] == "Ich wohne in Kleinenbroich"
+        assert results[0]["importance"] == 1.0
+        assert results[0]["similarity"] == 1.0
+
+    @pytest.mark.unit
+    async def test_retrieve_essential_excludes_context_category(self, memory_service, db_session, test_user):
+        """retrieve_essential() excludes context-category memories."""
+        # High importance context (should NOT be returned — context decays)
+        m1 = ConversationMemory(
+            content="Gerade Urlaub geplant",
+            category="context",
+            user_id=test_user.id,
+            importance=1.0,
+        )
+        # High importance fact (should be returned)
+        m2 = ConversationMemory(
+            content="Name ist Max",
+            category="fact",
+            user_id=test_user.id,
+            importance=0.95,
+        )
+        db_session.add_all([m1, m2])
+        await db_session.commit()
+
+        with patch('services.conversation_memory_service.settings') as mock_settings:
+            mock_settings.memory_essential_threshold = 0.9
+            mock_settings.memory_retrieval_limit = 10
+
+            results = await memory_service.retrieve_essential(user_id=test_user.id)
+
+        assert len(results) == 1
+        assert results[0]["content"] == "Name ist Max"
+
+    @pytest.mark.unit
+    async def test_retrieve_essential_excludes_inactive(self, memory_service, db_session, test_user):
+        """retrieve_essential() excludes inactive (deleted) memories."""
+        m = ConversationMemory(
+            content="Alte Info",
+            category="fact",
+            user_id=test_user.id,
+            importance=1.0,
+            is_active=False,
+        )
+        db_session.add(m)
+        await db_session.commit()
+
+        with patch('services.conversation_memory_service.settings') as mock_settings:
+            mock_settings.memory_essential_threshold = 0.9
+            mock_settings.memory_retrieval_limit = 10
+
+            results = await memory_service.retrieve_essential(user_id=test_user.id)
+
+        assert len(results) == 0
+
+    @pytest.mark.unit
+    async def test_retrieve_essential_sorted_by_importance(self, memory_service, db_session, test_user):
+        """retrieve_essential() returns memories sorted by importance DESC."""
+        m1 = ConversationMemory(
+            content="Less important",
+            category="preference",
+            user_id=test_user.id,
+            importance=0.91,
+        )
+        m2 = ConversationMemory(
+            content="Most important",
+            category="fact",
+            user_id=test_user.id,
+            importance=1.0,
+        )
+        db_session.add_all([m1, m2])
+        await db_session.commit()
+
+        with patch('services.conversation_memory_service.settings') as mock_settings:
+            mock_settings.memory_essential_threshold = 0.9
+            mock_settings.memory_retrieval_limit = 10
+
+            results = await memory_service.retrieve_essential(user_id=test_user.id)
+
+        assert len(results) == 2
+        assert results[0]["content"] == "Most important"
+        assert results[1]["content"] == "Less important"
+
+    @pytest.mark.unit
+    async def test_retrieve_essential_without_user_id(self, memory_service, db_session):
+        """retrieve_essential() without user_id returns all users' essential memories."""
+        m = ConversationMemory(
+            content="Global essential",
+            category="fact",
+            user_id=None,
+            importance=1.0,
+        )
+        db_session.add(m)
+        await db_session.commit()
+
+        with patch('services.conversation_memory_service.settings') as mock_settings:
+            mock_settings.memory_essential_threshold = 0.9
+            mock_settings.memory_retrieval_limit = 10
+
+            results = await memory_service.retrieve_essential()
+
+        assert len(results) == 1
+        assert results[0]["content"] == "Global essential"
+
+    @pytest.mark.unit
+    async def test_retrieve_essential_respects_limit(self, memory_service, db_session, test_user):
+        """retrieve_essential() respects the limit parameter."""
+        for i in range(5):
+            m = ConversationMemory(
+                content=f"Essential fact {i}",
+                category="fact",
+                user_id=test_user.id,
+                importance=0.95 + i * 0.01,
+            )
+            db_session.add(m)
+        await db_session.commit()
+
+        with patch('services.conversation_memory_service.settings') as mock_settings:
+            mock_settings.memory_essential_threshold = 0.9
+            mock_settings.memory_retrieval_limit = 3
+
+            results = await memory_service.retrieve_essential(user_id=test_user.id, limit=2)
+
+        assert len(results) == 2
+
+    @pytest.mark.unit
+    async def test_retrieve_essential_empty_when_none_qualify(self, memory_service, db_session, test_user):
+        """retrieve_essential() returns empty list when no memories meet threshold."""
+        m = ConversationMemory(
+            content="Low importance",
+            category="fact",
+            user_id=test_user.id,
+            importance=0.5,
+        )
+        db_session.add(m)
+        await db_session.commit()
+
+        with patch('services.conversation_memory_service.settings') as mock_settings:
+            mock_settings.memory_essential_threshold = 0.9
+            mock_settings.memory_retrieval_limit = 10
+
+            results = await memory_service.retrieve_essential(user_id=test_user.id)
+
+        assert len(results) == 0
+
+    @pytest.mark.unit
+    async def test_retrieve_essential_includes_all_non_context_categories(self, memory_service, db_session, test_user):
+        """retrieve_essential() includes fact, preference, and instruction categories."""
+        for cat in ("fact", "preference", "instruction"):
+            m = ConversationMemory(
+                content=f"Essential {cat}",
+                category=cat,
+                user_id=test_user.id,
+                importance=1.0,
+            )
+            db_session.add(m)
+        await db_session.commit()
+
+        with patch('services.conversation_memory_service.settings') as mock_settings:
+            mock_settings.memory_essential_threshold = 0.9
+            mock_settings.memory_retrieval_limit = 10
+
+            results = await memory_service.retrieve_essential(user_id=test_user.id)
+
+        assert len(results) == 3
+        categories = {r["category"] for r in results}
+        assert categories == {"fact", "preference", "instruction"}


### PR DESCRIPTION
## Summary
- High-importance memories (importance >= 0.9, category != context) are now always included in the LLM context, regardless of query similarity
- Fixes the problem where "Wie wird das Wetter morgen?" couldn't find "Ich wohne in Kleinenbroich" (similarity only 0.309, threshold 0.7)
- New `memory_essential_threshold` config setting (default: 0.9), no DB migration needed

## Changes
- `config.py`: New `memory_essential_threshold` setting
- `conversation_memory_service.py`: New `retrieve_essential()` method
- `chat_handler.py`: Merge essential + semantic memories in `_retrieve_memory_context()`
- `test_conversation_memory.py`: 10 new tests (config + service)

## Test plan
- [x] Config tests pass (default + custom threshold)
- [x] Ruff lint passes
- [ ] PRD-Test: Wetteranfrage ohne Ort → Agent nutzt Kleinenbroich statt Berlin

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)