### PR TITLE
fix(presence): Support mac_address updates in PATCH endpoint (#258)

### DIFF
--- a/src/backend/api/routes/presence.py
+++ b/src/backend/api/routes/presence.py
@@ -234,6 +234,7 @@ async def register_device(
 
 class BLEDeviceUpdate(BaseModel):
     detection_method: str = Field(..., max_length=20)
+    mac_address: str | None = Field(None, max_length=17)
 
 
 @router.patch("/devices/{device_id}", response_model=BLEDeviceResponse)
@@ -243,7 +244,7 @@ async def update_device(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_permission(Permission.ADMIN)),
 ):
-    """Update a device's detection method."""
+    """Update a device's detection method and/or MAC address."""
     if body.detection_method not in VALID_DETECTION_METHODS:
         raise HTTPException(
             status_code=422,
@@ -251,7 +252,9 @@ async def update_device(
         )
 
     presence = get_presence_service()
-    device = await presence.update_device(device_id, body.detection_method, db)
+    device = await presence.update_device(
+        device_id, body.detection_method, db, mac_address=body.mac_address,
+    )
     if not device:
         raise HTTPException(status_code=404, detail="Device not found")
 

--- a/src/backend/services/presence_service.py
+++ b/src/backend/services/presence_service.py
@@ -535,8 +535,9 @@ class PresenceService:
         device_id: int,
         detection_method: str,
         db: AsyncSession,
+        mac_address: str | None = None,
     ):
-        """Update a device's detection method."""
+        """Update a device's detection method and/or MAC address."""
         from models.database import UserBleDevice
 
         result = await db.execute(
@@ -546,14 +547,24 @@ class PresenceService:
         if not device:
             return None
 
-        mac = device.mac_address.upper()
+        old_mac = device.mac_address.upper()
         device.detection_method = detection_method
+
+        if mac_address:
+            new_mac = mac_address.upper()
+            device.mac_address = new_mac
+            # Update MAC caches: remove old, add new
+            self._mac_to_user.pop(old_mac, None)
+            self._mac_to_method.pop(old_mac, None)
+            self._mac_to_user[new_mac] = device.user_id
+            self._mac_to_method[new_mac] = detection_method
+            logger.info(f"Presence: updated device {old_mac} -> {new_mac} ({detection_method})")
+        else:
+            self._mac_to_method[old_mac] = detection_method
+            logger.info(f"Presence: updated {old_mac} to {detection_method}")
+
         await db.commit()
         await db.refresh(device)
-
-        # Update cache
-        self._mac_to_method[mac] = detection_method
-        logger.info(f"Presence: updated {mac} to {detection_method}")
 
         # Push updated MACs to all connected satellites
         await self.push_macs_to_satellites()


### PR DESCRIPTION
## Summary

- `PATCH /api/presence/devices/{id}` now accepts optional `mac_address` field
- When MAC is updated, in-memory caches are refreshed and new MACs pushed to satellites
- Closes #258

## Test plan

- [x] 12/12 existing presence API tests pass
- [ ] Manual: PATCH device with new MAC → verify cache update + satellite push

🤖 Generated with [Claude Code](https://claude.com/claude-code)