### PR TITLE
fix(chat): Hide raw action metadata from chat UI

### DIFF
--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -884,6 +884,7 @@ WICHTIG: Nutze die ECHTEN Daten aus dem Ergebnis! Gib NUR die Antwort, KEIN JSON
             # Update conversation history with this exchange (in-memory)
             # Enrich assistant message with action result context for follow-up resolution.
             # Action summary goes FIRST so it survives truncation in conv_context (500-2000 chars).
+            action_summary = None
             history_content = full_response
             if action_result and action_result.get("success") and action_result.get("data"):
                 # Use agent's tool name if available (from _build_agent_action_result)
@@ -912,13 +913,17 @@ WICHTIG: Nutze die ECHTEN Daten aus dem Ergebnis! Gib NUR die Antwort, KEIN JSON
                             msg_session_id, "user", content, db_session,
                             metadata=user_metadata if user_metadata else None
                         )
-                        # Save assistant response (with action context for follow-ups)
+                        # Save assistant response (clean content for UI display)
+                        # action_summary stored in metadata for LLM context reconstruction
+                        assistant_metadata = {
+                            "intent": intent.get("intent") if intent else None,
+                            "action_success": action_result.get("success") if action_result else None,
+                        }
+                        if action_summary:
+                            assistant_metadata["action_summary"] = action_summary
                         await ollama.save_message(
-                            msg_session_id, "assistant", history_content, db_session,
-                            metadata={
-                                "intent": intent.get("intent") if intent else None,
-                                "action_success": action_result.get("success") if action_result else None
-                            }
+                            msg_session_id, "assistant", full_response, db_session,
+                            metadata=assistant_metadata
                         )
                         logger.debug(f"💾 Messages saved to DB: session_id={msg_session_id}")
                 except Exception as e:

--- a/src/backend/services/conversation_service.py
+++ b/src/backend/services/conversation_service.py
@@ -69,10 +69,19 @@ class ConversationService:
             messages = result.scalars().all()
 
             # Konvertiere zu Chat-Format (älteste zuerst)
-            context = [
-                {"role": msg.role, "content": msg.content}
-                for msg in reversed(messages)
-            ]
+            # Reconstruct action summary prefix for LLM context (kept out of DB content for clean UI)
+            context = []
+            for msg in reversed(messages):
+                content = msg.content
+                if (msg.role == "assistant"
+                        and msg.message_metadata
+                        and msg.message_metadata.get("action_summary")):
+                    summary = msg.message_metadata["action_summary"]
+                    content = (
+                        f"[Aktionsergebnis — Verwende diese Daten für "
+                        f"Folgeanfragen (IDs, Titel, etc.):\n{summary}]\n\n{content}"
+                    )
+                context.append({"role": msg.role, "content": content})
 
             logger.info(f"Geladen: {len(context)} Nachrichten für Session {session_id}")
             return context


### PR DESCRIPTION
## Summary

- **Save clean response text** (`full_response`) to DB instead of `history_content` (which contains the `[Aktionsergebnis...]` prefix)
- **Store `action_summary` in message metadata** so it's preserved but not displayed
- **Reconstruct prefix in `load_context()`** when loading conversation history for LLM context, ensuring follow-up resolution still works

Fixes raw metadata like `[Aktionsergebnis — mcp.calendar.get_events → {"events":[]}]` being visible in chat bubbles when loading conversation history.

## Test plan

- [ ] `make test-backend` — existing tests pass (no regressions)
- [ ] Manual: send calendar/news query, verify no `[Aktionsergebnis...]` in chat bubble
- [ ] Follow-up: ask a follow-up after an action — still resolves correctly
- [ ] E2E: `python3 tests/e2e/test_day_simulation.py --fast` — 0 warnings for scenarios #3 and #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)