### PR TITLE
feat(personality): Per-user communication style

### DIFF
--- a/src/backend/alembic/versions/t4c5d6e7f8g9_add_user_personality_fields.py
+++ b/src/backend/alembic/versions/t4c5d6e7f8g9_add_user_personality_fields.py
@@ -1,0 +1,27 @@
+"""add user personality fields
+
+Revision ID: t4c5d6e7f8g9
+Revises: s3b4c5d6e7f8
+Create Date: 2026-02-25 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 't4c5d6e7f8g9'
+down_revision: Union[str, None] = 's3b4c5d6e7f8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('users', sa.Column('personality_style', sa.String(20), nullable=False, server_default='freundlich'))
+    op.add_column('users', sa.Column('personality_prompt', sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('users', 'personality_prompt')
+    op.drop_column('users', 'personality_style')

--- a/src/backend/api/routes/auth.py
+++ b/src/backend/api/routes/auth.py
@@ -72,6 +72,8 @@ class UserResponse(BaseModel):
     role_id: int
     permissions: list[str]
     is_active: bool
+    personality_style: str = "freundlich"
+    personality_prompt: str | None = None
     created_at: datetime
     last_login: datetime | None
     speaker_id: int | None
@@ -260,6 +262,8 @@ async def register(
         role_id=user.role_id,
         permissions=user.get_permissions(),
         is_active=user.is_active,
+        personality_style=user.personality_style,
+        personality_prompt=user.personality_prompt,
         created_at=user.created_at,
         last_login=user.last_login,
         speaker_id=user.speaker_id
@@ -283,6 +287,8 @@ async def get_current_user_info(
         role_id=user.role_id,
         permissions=user.get_permissions(),
         is_active=user.is_active,
+        personality_style=user.personality_style,
+        personality_prompt=user.personality_prompt,
         created_at=user.created_at,
         last_login=user.last_login,
         speaker_id=user.speaker_id

--- a/src/backend/api/routes/users.py
+++ b/src/backend/api/routes/users.py
@@ -52,6 +52,8 @@ class UserResponse(BaseModel):
     role_name: str
     permissions: list[str]
     is_active: bool
+    personality_style: str = "freundlich"
+    personality_prompt: str | None = None
     speaker_id: int | None
     speaker_name: str | None
     created_at: datetime
@@ -79,6 +81,8 @@ class CreateUserRequest(BaseModel):
     last_name: str | None = Field(None, max_length=100)
     role_id: int
     is_active: bool = True
+    personality_style: str = Field("freundlich", max_length=20)
+    personality_prompt: str | None = None
 
 
 class UpdateUserRequest(BaseModel):
@@ -89,6 +93,8 @@ class UpdateUserRequest(BaseModel):
     last_name: str | None = None
     role_id: int | None = None
     is_active: bool | None = None
+    personality_style: str | None = Field(None, max_length=20)
+    personality_prompt: str | None = None
 
 
 class ResetPasswordRequest(BaseModel):
@@ -159,6 +165,8 @@ async def list_users(
                 role_name=user.role.name if user.role else "Unknown",
                 permissions=user.get_permissions(),
                 is_active=user.is_active,
+                personality_style=user.personality_style,
+                personality_prompt=user.personality_prompt,
                 speaker_id=user.speaker_id,
                 speaker_name=user.speaker.name if user.speaker else None,
                 created_at=user.created_at,
@@ -207,6 +215,8 @@ async def get_user(
         role_name=user.role.name if user.role else "Unknown",
         permissions=user.get_permissions(),
         is_active=user.is_active,
+        personality_style=user.personality_style,
+        personality_prompt=user.personality_prompt,
         speaker_id=user.speaker_id,
         speaker_name=user.speaker.name if user.speaker else None,
         created_at=user.created_at,
@@ -267,7 +277,9 @@ async def create_user(
         email=request.email,
         password_hash=get_password_hash(request.password),
         role_id=request.role_id,
-        is_active=request.is_active
+        is_active=request.is_active,
+        personality_style=request.personality_style,
+        personality_prompt=request.personality_prompt,
     )
 
     db.add(user)
@@ -286,6 +298,8 @@ async def create_user(
         role_name=role.name,
         permissions=user.get_permissions(),
         is_active=user.is_active,
+        personality_style=user.personality_style,
+        personality_prompt=user.personality_prompt,
         speaker_id=user.speaker_id,
         speaker_name=None,
         created_at=user.created_at,
@@ -366,6 +380,12 @@ async def update_user(
             )
         user.is_active = request.is_active
 
+    # Update personality fields
+    if request.personality_style is not None:
+        user.personality_style = request.personality_style
+    if request.personality_prompt is not None:
+        user.personality_prompt = request.personality_prompt or None
+
     await db.commit()
     await db.refresh(user, ["role", "speaker"])
 
@@ -381,6 +401,8 @@ async def update_user(
         role_name=user.role.name if user.role else "Unknown",
         permissions=user.get_permissions(),
         is_active=user.is_active,
+        personality_style=user.personality_style,
+        personality_prompt=user.personality_prompt,
         speaker_id=user.speaker_id,
         speaker_name=user.speaker.name if user.speaker else None,
         created_at=user.created_at,
@@ -528,6 +550,8 @@ async def link_speaker(
         role_name=user.role.name if user.role else "Unknown",
         permissions=user.get_permissions(),
         is_active=user.is_active,
+        personality_style=user.personality_style,
+        personality_prompt=user.personality_prompt,
         speaker_id=user.speaker_id,
         speaker_name=speaker.name,
         created_at=user.created_at,
@@ -581,6 +605,8 @@ async def unlink_speaker(
         role_name=user.role.name if user.role else "Unknown",
         permissions=user.get_permissions(),
         is_active=user.is_active,
+        personality_style=user.personality_style,
+        personality_prompt=user.personality_prompt,
         speaker_id=None,
         speaker_name=None,
         created_at=user.created_at,

--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -433,6 +433,8 @@ async def _stream_rag_response(
     websocket: WebSocket,
     memory_context: str = "",
     document_context: str = "",
+    personality_style: str | None = None,
+    personality_prompt: str | None = None,
 ) -> str:
     """Stream a RAG-enhanced or plain conversation response.
 
@@ -489,6 +491,8 @@ async def _stream_rag_response(
                     history=session_state.conversation_history if is_followup else None,
                     memory_context=memory_context,
                     document_context=document_context,
+                    personality_style=personality_style,
+                    personality_prompt=personality_prompt,
                 ):
                     full_response += chunk
                     await websocket.send_json({"type": "stream", "content": chunk})
@@ -509,7 +513,7 @@ async def _stream_rag_response(
             logger.error(traceback.format_exc())
 
     # Fallback: plain conversation
-    async for chunk in ollama.chat_stream(content, history=session_state.conversation_history, memory_context=memory_context, document_context=document_context):
+    async for chunk in ollama.chat_stream(content, history=session_state.conversation_history, memory_context=memory_context, document_context=document_context, personality_style=personality_style, personality_prompt=personality_prompt):
         full_response += chunk
         await websocket.send_json({"type": "stream", "content": chunk})
 
@@ -607,6 +611,8 @@ async def websocket_endpoint(
             # Retrieve user info and permissions
             user_id = auth_result.get("user_id") if isinstance(auth_result, dict) else None
             user_permissions = None
+            user_personality_style = None
+            user_personality_prompt = None
             if user_id is not None:
                 try:
                     from sqlalchemy import select
@@ -619,6 +625,8 @@ async def websocket_endpoint(
                         user_obj = result.scalar_one_or_none()
                         if user_obj:
                             user_permissions = user_obj.get_permissions()
+                            user_personality_style = user_obj.personality_style
+                            user_personality_prompt = user_obj.personality_prompt
                 except Exception as e:
                     logger.warning(f"⚠️ Failed to load user permissions: {e}")
 
@@ -687,6 +695,14 @@ async def websocket_endpoint(
                         attachment_ids, lang=ollama.default_lang
                     )
 
+            # Build personality context for agent prompts
+            personality_context = ""
+            if user_personality_style:
+                from services.ollama_service import _build_personality_context
+                personality_context = _build_personality_context(
+                    user_personality_style, user_personality_prompt, ollama.default_lang
+                )
+
             # Get router from app state (initialized at startup if agent_enabled)
             agent_router = getattr(app.state, 'agent_router', None)
 
@@ -716,9 +732,11 @@ async def websocket_endpoint(
                             content, knowledge_base_id, ollama, session_state, websocket,
                             memory_context=memory_context,
                             document_context=document_context,
+                            personality_style=user_personality_style,
+                            personality_prompt=user_personality_prompt,
                         )
                     else:
-                        async for chunk in ollama.chat_stream(content, history=session_state.conversation_history, memory_context=memory_context, document_context=document_context):
+                        async for chunk in ollama.chat_stream(content, history=session_state.conversation_history, memory_context=memory_context, document_context=document_context, personality_style=user_personality_style, personality_prompt=user_personality_prompt):
                             full_response += chunk
                             await websocket.send_json({"type": "stream", "content": chunk})
 
@@ -730,6 +748,8 @@ async def websocket_endpoint(
                         content, knowledge_base_id, ollama, session_state, websocket,
                         memory_context=memory_context,
                         document_context=document_context,
+                        personality_style=user_personality_style,
+                        personality_prompt=user_personality_prompt,
                     )
 
                 else:
@@ -752,6 +772,7 @@ async def websocket_endpoint(
                         room_context=room_context,
                         memory_context=memory_context,
                         document_context=document_context,
+                        personality_context=personality_context,
                         user_permissions=user_permissions,
                         user_id=user_id,
                     ):
@@ -861,7 +882,7 @@ Die Aktion wurde ausgeführt:
 Gib eine kurze, natürliche Antwort basierend auf den Daten.
 WICHTIG: Nutze die ECHTEN Daten aus dem Ergebnis! Gib NUR die Antwort, KEIN JSON!"""
 
-                        async for chunk in ollama.chat_stream(enhanced_prompt, history=session_state.conversation_history, memory_context=memory_context, document_context=document_context):
+                        async for chunk in ollama.chat_stream(enhanced_prompt, history=session_state.conversation_history, memory_context=memory_context, document_context=document_context, personality_style=user_personality_style, personality_prompt=user_personality_prompt):
                             full_response += chunk
                             await websocket.send_json({"type": "stream", "content": chunk})
 
@@ -875,9 +896,11 @@ WICHTIG: Nutze die ECHTEN Daten aus dem Ergebnis! Gib NUR die Antwort, KEIN JSON
                                 content, knowledge_base_id, ollama, session_state, websocket,
                                 memory_context=memory_context,
                                 document_context=document_context,
+                                personality_style=user_personality_style,
+                                personality_prompt=user_personality_prompt,
                             )
                         else:
-                            async for chunk in ollama.chat_stream(content, history=session_state.conversation_history, memory_context=memory_context, document_context=document_context):
+                            async for chunk in ollama.chat_stream(content, history=session_state.conversation_history, memory_context=memory_context, document_context=document_context, personality_style=user_personality_style, personality_prompt=user_personality_prompt):
                                 full_response += chunk
                                 await websocket.send_json({"type": "stream", "content": chunk})
 

--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -641,6 +641,8 @@ class User(Base):
     # User preferences
     preferred_language = Column(String(10), default="de", nullable=False)
     media_follow_enabled = Column(Boolean, default=True, nullable=False, server_default="true")
+    personality_style = Column(String(20), default="freundlich", nullable=False, server_default="freundlich")
+    personality_prompt = Column(Text, nullable=True)  # Free-text personality fine-tuning
 
     # Optional link to Speaker for voice authentication
     speaker_id = Column(Integer, ForeignKey("speakers.id"), nullable=True, unique=True)

--- a/src/backend/prompts/agent.yaml
+++ b/src/backend/prompts/agent.yaml
@@ -4,7 +4,7 @@
 
 de:
   # Main agent prompt template
-  # Available variables: {message}, {conv_context}, {memory_context}, {document_context}, {tools_prompt}, {tool_corrections}, {history_prompt}, {step_directive}
+  # Available variables: {message}, {conv_context}, {memory_context}, {document_context}, {personality_context}, {tools_prompt}, {tool_corrections}, {history_prompt}, {step_directive}
   agent_prompt: |
     Du bist ein Agent, der komplexe Aufgaben Schritt für Schritt löst.
 
@@ -21,6 +21,8 @@ de:
     {memory_context}
 
     {document_context}
+
+    {personality_context}
 
     ANTWORT-FORMAT: Antworte mit GENAU EINEM JSON-Objekt.
 
@@ -43,7 +45,7 @@ de:
     - Einzelnen Song abspielen: (1) search_media(type="Audio"), (2) internal.play_in_room mit api_stream URL.
     - Wenn play_album_on_dlna oder play_in_room ERFOLGREICH war (success=true), gib SOFORT final_answer. NIEMALS dasselbe Play-Tool nochmal aufrufen!
     - Wenn ein Play-Tool FEHLSCHLAEGT (success=false): Gib SOFORT final_answer mit einer klaren Fehlermeldung. Beschreibe NICHT die Suchergebnisse und gib KEINE URLs oder technische Details aus.
-    - Um die Wiedergabe zu stoppen oder Tracks zu wechseln: Nutze mcp.dlna.stop/mcp.dlna.next_track/mcp.dlna.previous_track wenn eine DLNA-Session aktiv ist. Alternativ: internal.media_control mit action (stop/pause/resume/next/previous) und room_name.
+    - Um die Wiedergabe zu stoppen oder Tracks zu wechseln: Nutze mcp.dlna.stop/mcp.dlna.next_track/mcp.dlna.previous_track wenn eine DLNA-Session aktiv ist. Alternativ: internal.media_control mit action (stop/pause/resume/next/previous/volume) und room_name. Fuer Lautstaerke: action="volume", volume=0-100.
     - Beende NICHT mit final_answer, wenn noch offene Schritte aus der AUFGABE übrig sind. "Schick mir X zu Y" erfordert ALLE Schritte: (1) ggf. search, (2) download_document, (3) send_email. Erst NACH dem letzten Schritt darfst du final_answer geben.
     - Wenn ein Such-Tool 0 Ergebnisse liefert, wiederhole NICHT dieselbe Suche. Versuche: (1) Kuerzeren Suchbegriff (nur Titel, ohne Kuenstler/Autor), (2) alternative Schreibweise, (3) anderes Tool. Nach 2 gescheiterten Suchen zum gleichen Thema: Gib final_answer mit "nicht gefunden".
     - Gib final_answer wenn alle Informationen gesammelt sind und ALLE geforderten Aktionen abgeschlossen wurden
@@ -69,6 +71,8 @@ de:
     {memory_context}
 
     {document_context}
+
+    {personality_context}
 
     ANTWORT-FORMAT: Antworte mit GENAU EINEM JSON-Objekt.
 
@@ -114,6 +118,8 @@ de:
 
     {document_context}
 
+    {personality_context}
+
     ANTWORT-FORMAT: Antworte mit GENAU EINEM JSON-Objekt.
 
     Tool aufrufen:
@@ -152,6 +158,8 @@ de:
     {memory_context}
 
     {document_context}
+
+    {personality_context}
 
     ANTWORT-FORMAT: Antworte mit GENAU EINEM JSON-Objekt.
 
@@ -199,6 +207,8 @@ de:
 
     {document_context}
 
+    {personality_context}
+
     ANTWORT-FORMAT: Antworte mit GENAU EINEM JSON-Objekt.
 
     Tool aufrufen:
@@ -223,7 +233,8 @@ de:
     - Wenn play_album_on_dlna oder play_in_room ERFOLGREICH war (success=true), gib SOFORT final_answer. NIEMALS dasselbe Play-Tool nochmal aufrufen!
     - Bei mehreren Treffern: waehle den besten Match nach Titel und Kuenstler
     - Wenn Informationen fehlen, frage den Benutzer
-    - Um die Wiedergabe zu stoppen oder Tracks zu wechseln: Nutze mcp.dlna.stop/mcp.dlna.next_track/mcp.dlna.previous_track wenn eine DLNA-Session aktiv ist. Alternativ: internal.media_control mit action (stop/pause/resume/next/previous) und room_name. Nutze NICHT play_in_room oder resolve_room_player dafuer.
+    - Um die Wiedergabe zu stoppen oder Tracks zu wechseln: Nutze mcp.dlna.stop/mcp.dlna.next_track/mcp.dlna.previous_track wenn eine DLNA-Session aktiv ist. Alternativ: internal.media_control mit action (stop/pause/resume/next/previous/volume) und room_name. Fuer Lautstaerke: action="volume", volume=0-100 (z.B. {{"action": "internal.media_control", "parameters": {{"action": "volume", "volume": 30}}}}).
+    - Nutze NICHT play_in_room oder resolve_room_player dafuer.
     - WICHTIG — RADIO abspielen: (1) mcp.radio.search_stations(query="<sendername>"), (2) internal.play_radio(station_id="<id>", room_name="<Raum>"). Nur 2 Schritte! Das Tool loest automatisch die Stream-URL auf und spielt sie ab. Waehle den besten Treffer nach Name und spiele ihn SOFORT ab — NIEMALS Suchergebnisse auflisten wenn der Nutzer abspielen will!
     - Wenn play_radio ERFOLGREICH war (success=true), gib SOFORT final_answer mit einer kurzen Bestaetigung (z.B. "BBC Radio 1 spielt jetzt im Arbeitszimmer"). NIEMALS dasselbe Play-Tool nochmal aufrufen!
     - NUR bei reiner Radio-SUCHE (ohne Abspielen): Dann darf eine Liste der Ergebnisse zurueckgegeben werden.
@@ -261,6 +272,8 @@ de:
     {memory_context}
 
     {document_context}
+
+    {personality_context}
 
     ANTWORT-FORMAT: Antworte mit GENAU EINEM JSON-Objekt.
 
@@ -383,7 +396,7 @@ de:
 
 en:
   # Main agent prompt template
-  # Available variables: {message}, {conv_context}, {memory_context}, {document_context}, {tools_prompt}, {tool_corrections}, {history_prompt}, {step_directive}
+  # Available variables: {message}, {conv_context}, {memory_context}, {document_context}, {personality_context}, {tools_prompt}, {tool_corrections}, {history_prompt}, {step_directive}
   agent_prompt: |
     You are an agent that solves complex tasks step by step.
 
@@ -400,6 +413,8 @@ en:
     {memory_context}
 
     {document_context}
+
+    {personality_context}
 
     RESPONSE FORMAT: Reply with EXACTLY ONE JSON object.
 
@@ -449,6 +464,8 @@ en:
 
     {document_context}
 
+    {personality_context}
+
     RESPONSE FORMAT: Reply with EXACTLY ONE JSON object.
 
     Call a tool:
@@ -493,6 +510,8 @@ en:
 
     {document_context}
 
+    {personality_context}
+
     RESPONSE FORMAT: Reply with EXACTLY ONE JSON object.
 
     Call a tool:
@@ -531,6 +550,8 @@ en:
     {memory_context}
 
     {document_context}
+
+    {personality_context}
 
     RESPONSE FORMAT: Reply with EXACTLY ONE JSON object.
 
@@ -578,6 +599,8 @@ en:
 
     {document_context}
 
+    {personality_context}
+
     RESPONSE FORMAT: Reply with EXACTLY ONE JSON object.
 
     Call a tool:
@@ -602,7 +625,8 @@ en:
     - When play_album_on_dlna or play_in_room returns SUCCESS (success=true), give final_answer IMMEDIATELY. NEVER call the same play tool again!
     - When multiple results exist, choose the best match by title and artist
     - If information is missing, ask the user
-    - To stop playback or skip tracks: Use mcp.dlna.stop/mcp.dlna.next_track/mcp.dlna.previous_track if a DLNA session is active. Alternatively: internal.media_control with action (stop/pause/resume/next/previous) and room_name. Do NOT use play_in_room or resolve_room_player for this.
+    - To stop playback or skip tracks: Use mcp.dlna.stop/mcp.dlna.next_track/mcp.dlna.previous_track if a DLNA session is active. Alternatively: internal.media_control with action (stop/pause/resume/next/previous/volume) and room_name. For volume: action="volume", volume=0-100 (e.g. {{"action": "internal.media_control", "parameters": {{"action": "volume", "volume": 30}}}}).
+    - Do NOT use play_in_room or resolve_room_player for this.
     - IMPORTANT — RADIO playback: (1) mcp.radio.search_stations(query="<station>"), (2) internal.play_radio(station_id="<id>", room_name="<room>"). Only 2 steps! The tool automatically resolves the stream URL and plays it. Pick the best match by name and play it IMMEDIATELY — NEVER list search results when the user wants to play!
     - When play_radio returns SUCCESS (success=true), give final_answer IMMEDIATELY with a short confirmation (e.g. "BBC Radio 1 is now playing in the office"). NEVER call the same play tool again!
     - ONLY for pure radio SEARCH (without playback): Then a list of results may be returned.
@@ -640,6 +664,8 @@ en:
     {memory_context}
 
     {document_context}
+
+    {personality_context}
 
     RESPONSE FORMAT: Reply with EXACTLY ONE JSON object.
 

--- a/src/backend/prompts/chat.yaml
+++ b/src/backend/prompts/chat.yaml
@@ -62,6 +62,17 @@ de:
 
   document_separator: "--- DOKUMENT: {filename} ({file_size}) ---\n{document_text}"
 
+  personality_context: |
+    KOMMUNIKATIONSSTIL:
+    {personality_instructions}
+    Halte dich an diesen Stil in allen Antworten.
+
+  personality_styles:
+    freundlich: "Antworte warmherzig, hilfsbereit und ausfuehrlich. Zeige Empathie und Interesse."
+    direkt: "Antworte kurz, praezise und ohne Floskeln. Komm direkt zum Punkt."
+    formell: "Antworte hoeflich und professionell. Verwende Siezen."
+    casual: "Antworte locker und ungezwungen, wie unter Freunden."
+
   error_fallback: "Entschuldigung, es gab einen Fehler: {error}"
   error_service_unavailable: "Der Dienst ist vorübergehend nicht verfügbar. Bitte versuche es später erneut."
 
@@ -124,6 +135,17 @@ en:
     IMPORTANT: The user has uploaded these documents. Answer questions based on the document contents. Cite relevant passages and name the respective document.
 
   document_separator: "--- DOCUMENT: {filename} ({file_size}) ---\n{document_text}"
+
+  personality_context: |
+    COMMUNICATION STYLE:
+    {personality_instructions}
+    Maintain this style in all responses.
+
+  personality_styles:
+    freundlich: "Respond warmly, helpfully and in detail. Show empathy and interest."
+    direkt: "Respond briefly, precisely and without filler. Get straight to the point."
+    formell: "Respond politely and professionally. Use formal language."
+    casual: "Respond casually and informally, like among friends."
 
   error_fallback: "Sorry, there was an error: {error}"
   error_service_unavailable: "The service is temporarily unavailable. Please try again later."

--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -430,6 +430,7 @@ class AgentService:
         lang: str = "de",
         memory_context: str = "",
         document_context: str = "",
+        personality_context: str = "",
     ) -> str:
         """Build the prompt for the Agent LLM call."""
         tools_prompt = self.tool_registry.build_tools_prompt()
@@ -488,6 +489,7 @@ class AgentService:
             conv_context=conv_context,
             memory_context=memory_context,
             document_context=document_context,
+            personality_context=personality_context,
             tools_prompt=tools_prompt,
             tool_corrections=tool_corrections,
             history_prompt=history_prompt,
@@ -504,6 +506,7 @@ class AgentService:
                 conv_context=conv_context,
                 memory_context=memory_context,
                 document_context=document_context,
+                personality_context=personality_context,
                 tools_prompt=tools_prompt,
                 tool_corrections=tool_corrections,
                 history_prompt=history_prompt,
@@ -522,6 +525,7 @@ class AgentService:
         lang: str | None = None,
         memory_context: str = "",
         document_context: str = "",
+        personality_context: str = "",
         user_permissions: list[str] | None = None,
         user_id: int | None = None,
     ) -> AsyncGenerator[AgentStep, None]:
@@ -537,6 +541,7 @@ class AgentService:
             lang: Language for prompts and responses (de/en). None = default_lang
             memory_context: Formatted memory section for the agent prompt
             document_context: Formatted document section for the agent prompt
+            personality_context: Formatted personality section for the agent prompt
             user_permissions: User's permission strings for MCP access control.
                 None means no auth / allow all (backwards-compatible).
             user_id: Authenticated user ID for per-user tool filtering.
@@ -587,7 +592,7 @@ class AgentService:
                 return
 
             # Build prompt with all available tools (32k context fits all tools)
-            prompt = await self._build_agent_prompt(message, context, conversation_history, room_context=room_context, lang=lang, memory_context=memory_context, document_context=document_context)
+            prompt = await self._build_agent_prompt(message, context, conversation_history, room_context=room_context, lang=lang, memory_context=memory_context, document_context=document_context, personality_context=personality_context)
             logger.info(f"🤖 Agent step {step_num} prompt ({len(prompt)} chars, {total_tools} tools)")
 
             # Check circuit breaker before LLM call

--- a/src/backend/services/ollama_service.py
+++ b/src/backend/services/ollama_service.py
@@ -37,6 +37,33 @@ def _sanitize_user_input(text: str) -> str:
     return text.strip()
 
 
+_VALID_PERSONALITY_STYLES = {"freundlich", "direkt", "formell", "casual"}
+
+
+def _build_personality_context(personality_style: str, personality_prompt: str | None, lang: str) -> str:
+    """Build the personality context section for injection into system/agent prompts."""
+    if personality_style not in _VALID_PERSONALITY_STYLES:
+        return ""
+
+    # Access the raw YAML dict directly (prompt_manager.get returns str for dicts)
+    chat_data = prompt_manager._cache.get("chat", {})
+    lang_data = chat_data.get(lang, {})
+    styles_dict = lang_data.get("personality_styles", {})
+
+    instructions = styles_dict.get(personality_style, "") if isinstance(styles_dict, dict) else ""
+
+    if personality_prompt:
+        instructions += f"\n{personality_prompt}"
+
+    if not instructions:
+        return ""
+
+    return prompt_manager.get(
+        "chat", "personality_context", lang=lang,
+        personality_instructions=instructions,
+    )
+
+
 class OllamaService:
     """Service für Ollama LLM Interaktion mit Mehrsprachigkeit."""
 
@@ -54,10 +81,23 @@ class OllamaService:
         # Default language from settings
         self.default_lang = settings.default_language
 
-    def get_system_prompt(self, lang: str | None = None, memory_context: str | None = None) -> str:
-        """Get system prompt for the specified language, optionally with memory context."""
+    def get_system_prompt(
+        self,
+        lang: str | None = None,
+        memory_context: str | None = None,
+        personality_style: str | None = None,
+        personality_prompt: str | None = None,
+    ) -> str:
+        """Get system prompt for the specified language, optionally with memory and personality context."""
         lang = lang or self.default_lang
         base = prompt_manager.get("chat", "system_prompt", lang=lang, default=self._default_system_prompt(lang))
+
+        # Personality injection
+        if personality_style:
+            personality_section = _build_personality_context(personality_style, personality_prompt, lang)
+            if personality_section:
+                base += f"\n\n{personality_section}"
+
         if memory_context:
             base += f"\n\n{memory_context}"
         return base
@@ -153,7 +193,16 @@ WICHTIGE REGELN FÜR ANTWORTEN:
             logger.error(f"Chat Fehler: {e}")
             return prompt_manager.get("chat", "error_fallback", lang=lang, default=f"Entschuldigung, es gab einen Fehler: {e!s}", error=str(e))
 
-    async def chat_stream(self, message: str, history: list[dict] = None, lang: str | None = None, memory_context: str | None = None, document_context: str | None = None) -> AsyncGenerator[str, None]:
+    async def chat_stream(
+        self,
+        message: str,
+        history: list[dict] = None,
+        lang: str | None = None,
+        memory_context: str | None = None,
+        document_context: str | None = None,
+        personality_style: str | None = None,
+        personality_prompt: str | None = None,
+    ) -> AsyncGenerator[str, None]:
         """
         Streaming Chat with optional conversation history.
 
@@ -163,6 +212,8 @@ WICHTIGE REGELN FÜR ANTWORTEN:
             lang: Sprache für die Antwort (de/en). None = default_lang
             memory_context: Optional formatted memory section for the system prompt
             document_context: Optional formatted document section for the system prompt
+            personality_style: Optional personality style (freundlich/direkt/formell/casual)
+            personality_prompt: Optional free-text personality fine-tuning
         """
         lang = lang or self.default_lang
 
@@ -174,7 +225,7 @@ WICHTIGE REGELN FÜR ANTWORTEN:
 
         try:
             message = _sanitize_user_input(message)
-            system_prompt = self.get_system_prompt(lang, memory_context=memory_context)
+            system_prompt = self.get_system_prompt(lang, memory_context=memory_context, personality_style=personality_style, personality_prompt=personality_prompt)
             if document_context:
                 system_prompt += f"\n\n{document_context}"
             messages = [{"role": "system", "content": system_prompt}]
@@ -945,6 +996,8 @@ WICHTIGE REGELN FÜR ANTWORTEN:
         lang: str | None = None,
         memory_context: str | None = None,
         document_context: str | None = None,
+        personality_style: str | None = None,
+        personality_prompt: str | None = None,
     ) -> AsyncGenerator[str, None]:
         """
         Streaming Chat mit optionalem RAG-Kontext.
@@ -958,6 +1011,8 @@ WICHTIGE REGELN FÜR ANTWORTEN:
             lang: Sprache für die Antwort (de/en). None = default_lang
             memory_context: Optional formatted memory section for the system prompt
             document_context: Optional formatted document section for the system prompt
+            personality_style: Optional personality style (freundlich/direkt/formell/casual)
+            personality_prompt: Optional free-text personality fine-tuning
 
         Yields:
             Text-Chunks der Antwort
@@ -968,7 +1023,7 @@ WICHTIGE REGELN FÜR ANTWORTEN:
             model = self.rag_model if rag_context else self.chat_model
 
             # Baue System-Prompt mit RAG-Kontext
-            system_prompt = self._build_rag_system_prompt(rag_context, lang=lang, memory_context=memory_context, document_context=document_context)
+            system_prompt = self._build_rag_system_prompt(rag_context, lang=lang, memory_context=memory_context, document_context=document_context, personality_style=personality_style, personality_prompt=personality_prompt)
 
             messages = [{"role": "system", "content": system_prompt}]
 
@@ -995,7 +1050,7 @@ WICHTIGE REGELN FÜR ANTWORTEN:
             logger.error(f"RAG Streaming Fehler: {e}")
             yield prompt_manager.get("chat", "error_fallback", lang=lang, default=f"Error: {e!s}", error=str(e))
 
-    def _build_rag_system_prompt(self, context: str | None = None, lang: str | None = None, memory_context: str | None = None, document_context: str | None = None) -> str:
+    def _build_rag_system_prompt(self, context: str | None = None, lang: str | None = None, memory_context: str | None = None, document_context: str | None = None, personality_style: str | None = None, personality_prompt: str | None = None) -> str:
         """
         Erstellt System-Prompt mit optionalem RAG-Kontext.
 
@@ -1004,6 +1059,8 @@ WICHTIGE REGELN FÜR ANTWORTEN:
             lang: Sprache für den Prompt (de/en). None = default_lang
             memory_context: Optional formatted memory section
             document_context: Optional formatted document section
+            personality_style: Optional personality style
+            personality_prompt: Optional free-text personality fine-tuning
 
         Returns:
             System-Prompt für das LLM
@@ -1012,6 +1069,12 @@ WICHTIGE REGELN FÜR ANTWORTEN:
 
         # Base RAG system prompt from externalized prompts
         base_prompt = prompt_manager.get("chat", "rag_system_prompt", lang=lang)
+
+        # Personality injection
+        if personality_style:
+            personality_section = _build_personality_context(personality_style, personality_prompt, lang)
+            if personality_section:
+                base_prompt += f"\n\n{personality_section}"
 
         # Append memory context if available
         if memory_context:

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -474,7 +474,16 @@
     "firstName": "Vorname",
     "lastName": "Nachname",
     "firstNamePlaceholder": "z.B. Max",
-    "lastNamePlaceholder": "z.B. Mustermann"
+    "lastNamePlaceholder": "z.B. Mustermann",
+    "personalityStyle": "Kommunikationsstil",
+    "personalityPrompt": "Persoenlichkeits-Feintuning",
+    "personalityPromptPlaceholder": "z.B. Verwende Emojis, antworte immer mit einem Witz...",
+    "styles": {
+      "freundlich": "Freundlich",
+      "direkt": "Direkt",
+      "formell": "Formell",
+      "casual": "Casual"
+    }
   },
   "roles": {
     "title": "Rollenverwaltung",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -474,7 +474,16 @@
     "firstName": "First Name",
     "lastName": "Last Name",
     "firstNamePlaceholder": "e.g. John",
-    "lastNamePlaceholder": "e.g. Doe"
+    "lastNamePlaceholder": "e.g. Doe",
+    "personalityStyle": "Communication Style",
+    "personalityPrompt": "Personality Fine-tuning",
+    "personalityPromptPlaceholder": "e.g. Use emojis, always respond with a joke...",
+    "styles": {
+      "freundlich": "Friendly",
+      "direkt": "Direct",
+      "formell": "Formal",
+      "casual": "Casual"
+    }
   },
   "roles": {
     "title": "Role Management",

--- a/src/frontend/src/pages/UsersPage.jsx
+++ b/src/frontend/src/pages/UsersPage.jsx
@@ -43,7 +43,9 @@ export default function UsersPage() {
     email: '',
     password: '',
     role_id: '',
-    is_active: true
+    is_active: true,
+    personality_style: 'freundlich',
+    personality_prompt: ''
   });
   const [showPassword, setShowPassword] = useState(false);
   const [formLoading, setFormLoading] = useState(false);
@@ -98,7 +100,9 @@ export default function UsersPage() {
       email: '',
       password: '',
       role_id: roles.find(r => r.name === 'Gast')?.id || roles[0]?.id || '',
-      is_active: true
+      is_active: true,
+      personality_style: 'freundlich',
+      personality_prompt: ''
     });
     setShowPassword(false);
     setShowModal(true);
@@ -114,7 +118,9 @@ export default function UsersPage() {
       email: user.email || '',
       password: '',
       role_id: user.role_id,
-      is_active: user.is_active
+      is_active: user.is_active,
+      personality_style: user.personality_style || 'freundlich',
+      personality_prompt: user.personality_prompt || ''
     });
     setShowPassword(false);
     setShowModal(true);
@@ -137,7 +143,9 @@ export default function UsersPage() {
           last_name: formData.last_name || null,
           email: formData.email || null,
           role_id: parseInt(formData.role_id),
-          is_active: formData.is_active
+          is_active: formData.is_active,
+          personality_style: formData.personality_style,
+          personality_prompt: formData.personality_prompt || null
         };
 
         await apiClient.patch(`/api/users/${editingUser.id}`, updateData, { headers });
@@ -159,7 +167,9 @@ export default function UsersPage() {
           email: formData.email || null,
           password: formData.password,
           role_id: parseInt(formData.role_id),
-          is_active: formData.is_active
+          is_active: formData.is_active,
+          personality_style: formData.personality_style,
+          personality_prompt: formData.personality_prompt || null
         }, { headers });
         setSuccess(t('users.userCreated'));
       }
@@ -527,6 +537,40 @@ export default function UsersPage() {
             <label htmlFor="is_active" className="text-sm text-gray-700 dark:text-gray-300">
               {t('users.accountActive')}
             </label>
+          </div>
+
+          {/* Personality Style */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              {t('users.personalityStyle')}
+            </label>
+            <select
+              value={formData.personality_style}
+              onChange={(e) => setFormData({ ...formData, personality_style: e.target.value })}
+              className="input w-full"
+              disabled={formLoading}
+            >
+              <option value="freundlich">{t('users.styles.freundlich')}</option>
+              <option value="direkt">{t('users.styles.direkt')}</option>
+              <option value="formell">{t('users.styles.formell')}</option>
+              <option value="casual">{t('users.styles.casual')}</option>
+            </select>
+          </div>
+
+          {/* Personality Prompt */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              {t('users.personalityPrompt')}
+              <span className="text-gray-400 dark:text-gray-500 font-normal ml-1">({t('common.optional')})</span>
+            </label>
+            <textarea
+              value={formData.personality_prompt}
+              onChange={(e) => setFormData({ ...formData, personality_prompt: e.target.value })}
+              className="input w-full"
+              rows={3}
+              placeholder={t('users.personalityPromptPlaceholder')}
+              disabled={formLoading}
+            />
           </div>
 
           {/* Actions */}


### PR DESCRIPTION
## Summary
- Users can configure a **personality style** (freundlich/direkt/formell/casual) and optional free-text fine-tuning per user
- Style is injected into all LLM prompts (chat, RAG, agent) so Renfield adapts its tone per user
- New fields on User model with Alembic migration, API endpoints, and frontend UI (dropdown + textarea)

## Changes
- **Model:** `personality_style` (String, default "freundlich") + `personality_prompt` (Text, nullable) on User
- **Migration:** `t4c5d6e7f8g9_add_user_personality_fields.py`
- **Prompts:** Personality context templates in `chat.yaml` (de/en), `{personality_context}` in all 12 agent prompts
- **Services:** `_build_personality_context()` helper, extended `OllamaService` + `AgentService` + `chat_handler`
- **API:** Personality fields in users + auth request/response models
- **Frontend:** Style dropdown + prompt textarea in UsersPage, i18n translations (de/en)

## Test plan
- [ ] `alembic upgrade head` on production
- [ ] Set user personality to "direkt" → answers should be concise
- [ ] Set user personality to "freundlich" + "Verwende Emojis" → warm answers with emojis
- [ ] Agent path (e.g. Smart Home command) → personality preserved in final_answer
- [ ] Two users with different styles → different response tones confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)