### PR TITLE
Add Impressum and Datenschutz pages for renfield.de

### DIFF
--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -42,6 +42,13 @@
           />
         </a>
       </div>
+
+      <!-- Legal Links -->
+      <div class="flex items-center gap-4 text-xs">
+        <a href="/impressum" class="hover:text-gray-900 dark:hover:text-white transition-colors">Impressum</a>
+        <span>&middot;</span>
+        <a href="/datenschutz" class="hover:text-gray-900 dark:hover:text-white transition-colors">Datenschutz</a>
+      </div>
     </div>
   </div>
 </footer>

--- a/site/src/pages/datenschutz.astro
+++ b/site/src/pages/datenschutz.astro
@@ -1,0 +1,103 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import '../styles/global.css';
+---
+
+<BaseLayout>
+  <Header />
+  <main class="pt-28 pb-16">
+    <div class="max-w-3xl mx-auto px-4 sm:px-6">
+      <h1 class="font-serif text-3xl sm:text-4xl font-bold text-gray-900 dark:text-white mb-8">Datenschutzerkl&auml;rung</h1>
+
+      <div class="prose prose-gray dark:prose-invert max-w-none space-y-6 text-gray-700 dark:text-gray-300">
+
+        <h2 class="font-serif text-xl font-semibold text-gray-900 dark:text-white">1. Verantwortlicher</h2>
+        <p>
+          Eduard van den Bongard<br />
+          Am Stirkenbend 20<br />
+          41352 Korschenbroich<br />
+          E-Mail: info@x-idra.de<br />
+          Telefon: +49&nbsp;(0)2161&nbsp;82&nbsp;95&nbsp;777
+        </p>
+
+        <h2 class="font-serif text-xl font-semibold text-gray-900 dark:text-white">2. &Uuml;bersicht der Datenverarbeitung</h2>
+        <p>
+          Diese Webseite dient der Pr&auml;sentation des Open-Source-Projekts Renfield. Wir erheben und verarbeiten personenbezogene Daten nur im technisch notwendigen Umfang. Es werden <strong>keine Cookies</strong> gesetzt und <strong>keine Tracking-Dienste Dritter</strong> eingebunden.
+        </p>
+
+        <h2 class="font-serif text-xl font-semibold text-gray-900 dark:text-white">3. Hosting</h2>
+        <p>
+          Diese Webseite wird bei <strong>Hetzner Online GmbH</strong>, Industriestr. 25, 91710 Gunzenhausen, Deutschland gehostet. Hetzner verarbeitet Daten im Rahmen der Auftragsverarbeitung gem&auml;&szlig; Art.&nbsp;28 DSGVO. Weitere Informationen finden Sie in der <a href="https://www.hetzner.com/de/legal/privacy-policy" target="_blank" rel="noopener noreferrer" class="text-brand-cyan hover:underline">Datenschutzerkl&auml;rung von Hetzner</a>.
+        </p>
+
+        <h2 class="font-serif text-xl font-semibold text-gray-900 dark:text-white">4. Server-Logdateien</h2>
+        <p>
+          Der Hosting-Provider erhebt und speichert automatisch Informationen in Server-Logdateien, die Ihr Browser automatisch &uuml;bermittelt. Dies sind:
+        </p>
+        <ul class="list-disc pl-6 space-y-1">
+          <li>Browsertyp und -version</li>
+          <li>Verwendetes Betriebssystem</li>
+          <li>Referrer-URL</li>
+          <li>Hostname des zugreifenden Rechners</li>
+          <li>IP-Adresse</li>
+          <li>Uhrzeit der Serveranfrage</li>
+        </ul>
+        <p>
+          Diese Daten sind nicht bestimmten Personen zuordenbar. Eine Zusammenf&uuml;hrung mit anderen Datenquellen wird nicht vorgenommen. Die Daten werden nach sp&auml;testens 14 Tagen gel&ouml;scht. Die Speicherung erfolgt auf Grundlage von Art.&nbsp;6 Abs.&nbsp;1 lit.&nbsp;f DSGVO (berechtigtes Interesse an der Sicherstellung eines st&ouml;rungsfreien Betriebs).
+        </p>
+
+        <h2 class="font-serif text-xl font-semibold text-gray-900 dark:text-white">5. Webanalyse mit Umami</h2>
+        <p>
+          Wir verwenden <strong>Umami</strong>, eine datenschutzfreundliche, selbstgehostete Webanalyse-Software. Die Umami-Instanz l&auml;uft auf unserer eigenen Infrastruktur unter <code class="text-sm bg-gray-100 dark:bg-gray-800 px-1.5 py-0.5 rounded">analytics.renfield.de</code>. Es werden <strong>keine Daten an Dritte</strong> &uuml;bertragen.
+        </p>
+        <p>Umami erhebt folgende Informationen:</p>
+        <ul class="list-disc pl-6 space-y-1">
+          <li>Seitenaufrufe (URL, Referrer)</li>
+          <li>Ger&auml;tetyp, Betriebssystem, Browser</li>
+          <li>Ungef&auml;hrer Standort (Land/Region, abgeleitet aus anonymisierter IP)</li>
+        </ul>
+        <p>
+          Umami setzt <strong>keine Cookies</strong> und speichert <strong>keine IP-Adressen</strong>. IP-Adressen werden nur zur Ableitung des ungef&auml;hren Standorts und zur Erkennung eindeutiger Besucher innerhalb eines Tages genutzt und sofort verworfen. Ein geräte&uuml;bergreifendes Tracking findet nicht statt. Die Verarbeitung erfolgt auf Grundlage von Art.&nbsp;6 Abs.&nbsp;1 lit.&nbsp;f DSGVO (berechtigtes Interesse an der anonymen Nutzungsanalyse zur Verbesserung des Webangebots).
+        </p>
+
+        <h2 class="font-serif text-xl font-semibold text-gray-900 dark:text-white">6. Kontaktaufnahme</h2>
+        <p>
+          Wenn Sie uns per E-Mail kontaktieren, werden Ihre Angaben einschlie&szlig;lich der von Ihnen angegebenen Kontaktdaten zwecks Bearbeitung der Anfrage und f&uuml;r den Fall von Anschlussfragen bei uns gespeichert. Diese Daten geben wir nicht ohne Ihre Einwilligung weiter. Die Verarbeitung erfolgt auf Grundlage von Art.&nbsp;6 Abs.&nbsp;1 lit.&nbsp;b DSGVO (vorvertragliche Anfragen) bzw. Art.&nbsp;6 Abs.&nbsp;1 lit.&nbsp;f DSGVO (berechtigtes Interesse).
+        </p>
+
+        <h2 class="font-serif text-xl font-semibold text-gray-900 dark:text-white">7. Externe Inhalte</h2>
+        <p>
+          Diese Webseite bindet Schriftarten von <strong>Google Fonts</strong> (Google Ireland Limited, Gordon House, Barrow Street, Dublin 4, Irland) ein. Beim Aufruf der Seite stellt Ihr Browser eine Verbindung zu den Servern von Google her, wobei Ihre IP-Adresse an Google &uuml;bermittelt wird. Rechtsgrundlage ist Art.&nbsp;6 Abs.&nbsp;1 lit.&nbsp;f DSGVO (berechtigtes Interesse an einer ansprechenden Darstellung). Weitere Informationen: <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer" class="text-brand-cyan hover:underline">Google Datenschutzerkl&auml;rung</a>.
+        </p>
+        <p>
+          Au&szlig;erdem wird ein Badge von <strong>shields.io</strong> geladen, um die Anzahl der GitHub-Sterne anzuzeigen. Dabei kann Ihre IP-Adresse an shields.io &uuml;bermittelt werden.
+        </p>
+
+        <h2 class="font-serif text-xl font-semibold text-gray-900 dark:text-white">8. Ihre Rechte</h2>
+        <p>Sie haben gem&auml;&szlig; DSGVO folgende Rechte:</p>
+        <ul class="list-disc pl-6 space-y-1">
+          <li><strong>Auskunft</strong> (Art.&nbsp;15 DSGVO) &uuml;ber Ihre gespeicherten Daten</li>
+          <li><strong>Berichtigung</strong> (Art.&nbsp;16 DSGVO) unrichtiger Daten</li>
+          <li><strong>L&ouml;schung</strong> (Art.&nbsp;17 DSGVO) Ihrer Daten</li>
+          <li><strong>Einschr&auml;nkung der Verarbeitung</strong> (Art.&nbsp;18 DSGVO)</li>
+          <li><strong>Daten&uuml;bertragbarkeit</strong> (Art.&nbsp;20 DSGVO)</li>
+          <li><strong>Widerspruch</strong> (Art.&nbsp;21 DSGVO) gegen die Verarbeitung</li>
+        </ul>
+        <p>
+          Zur Aus&uuml;bung Ihrer Rechte wenden Sie sich bitte an: <a href="mailto:info@x-idra.de" class="text-brand-cyan hover:underline">info@x-idra.de</a>
+        </p>
+        <p>
+          Dar&uuml;ber hinaus steht Ihnen ein Beschwerderecht bei einer Datenschutz-Aufsichtsbeh&ouml;rde zu (Art.&nbsp;77 DSGVO). Die f&uuml;r uns zust&auml;ndige Aufsichtsbeh&ouml;rde ist der <strong>Landesbeauftragte f&uuml;r Datenschutz und Informationsfreiheit Nordrhein-Westfalen</strong> (LDI NRW), Kavalleriestr.&nbsp;2&ndash;4, 40213 D&uuml;sseldorf.
+        </p>
+
+        <h2 class="font-serif text-xl font-semibold text-gray-900 dark:text-white">9. Aktualit&auml;t</h2>
+        <p>
+          Stand: Februar 2026
+        </p>
+      </div>
+    </div>
+  </main>
+  <Footer />
+</BaseLayout>

--- a/site/src/pages/impressum.astro
+++ b/site/src/pages/impressum.astro
@@ -1,0 +1,55 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import '../styles/global.css';
+---
+
+<BaseLayout>
+  <Header />
+  <main class="pt-28 pb-16">
+    <div class="max-w-3xl mx-auto px-4 sm:px-6">
+      <h1 class="font-serif text-3xl sm:text-4xl font-bold text-gray-900 dark:text-white mb-8">Impressum</h1>
+
+      <div class="prose prose-gray dark:prose-invert max-w-none space-y-6 text-gray-700 dark:text-gray-300">
+        <h2 class="font-serif text-xl font-semibold text-gray-900 dark:text-white">Angaben gem&auml;&szlig; &sect; 5 DDG</h2>
+        <p>
+          Eduard van den Bongard<br />
+          Am Stirkenbend 20<br />
+          41352 Korschenbroich
+        </p>
+
+        <h2 class="font-serif text-xl font-semibold text-gray-900 dark:text-white">Kontakt</h2>
+        <p>
+          Telefon: +49&nbsp;(0)2161&nbsp;82&nbsp;95&nbsp;777<br />
+          E-Mail: info@x-idra.de
+        </p>
+
+        <h2 class="font-serif text-xl font-semibold text-gray-900 dark:text-white">Verantwortlich f&uuml;r den Inhalt nach &sect; 18 Abs. 2 MStV</h2>
+        <p>
+          Eduard van den Bongard<br />
+          Am Stirkenbend 20<br />
+          41352 Korschenbroich
+        </p>
+
+        <h2 class="font-serif text-xl font-semibold text-gray-900 dark:text-white">Haftungsausschluss</h2>
+
+        <h3 class="font-serif text-lg font-semibold text-gray-800 dark:text-gray-100">Haftung f&uuml;r Inhalte</h3>
+        <p>
+          Die Inhalte unserer Seiten wurden mit gr&ouml;&szlig;ter Sorgfalt erstellt. F&uuml;r die Richtigkeit, Vollst&auml;ndigkeit und Aktualit&auml;t der Inhalte k&ouml;nnen wir jedoch keine Gew&auml;hr &uuml;bernehmen. Als Diensteanbieter sind wir gem&auml;&szlig; &sect; 7 Abs. 1 DDG f&uuml;r eigene Inhalte auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich. Nach &sect;&sect; 8 bis 10 DDG sind wir als Diensteanbieter jedoch nicht verpflichtet, &uuml;bermittelte oder gespeicherte fremde Informationen zu &uuml;berwachen oder nach Umst&auml;nden zu forschen, die auf eine rechtswidrige T&auml;tigkeit hinweisen.
+        </p>
+
+        <h3 class="font-serif text-lg font-semibold text-gray-800 dark:text-gray-100">Haftung f&uuml;r Links</h3>
+        <p>
+          Unser Angebot enth&auml;lt Links zu externen Webseiten Dritter, auf deren Inhalte wir keinen Einfluss haben. Deshalb k&ouml;nnen wir f&uuml;r diese fremden Inhalte auch keine Gew&auml;hr &uuml;bernehmen. F&uuml;r die Inhalte der verlinkten Seiten ist stets der jeweilige Anbieter oder Betreiber der Seiten verantwortlich. Die verlinkten Seiten wurden zum Zeitpunkt der Verlinkung auf m&ouml;gliche Rechtsverst&ouml;&szlig;e &uuml;berpr&uuml;ft. Rechtswidrige Inhalte waren zum Zeitpunkt der Verlinkung nicht erkennbar. Eine permanente inhaltliche Kontrolle der verlinkten Seiten ist jedoch ohne konkrete Anhaltspunkte einer Rechtsverletzung nicht zumutbar. Bei Bekanntwerden von Rechtsverletzungen werden wir derartige Links umgehend entfernen.
+        </p>
+
+        <h3 class="font-serif text-lg font-semibold text-gray-800 dark:text-gray-100">Urheberrecht</h3>
+        <p>
+          Die durch die Seitenbetreiber erstellten Inhalte und Werke auf diesen Seiten unterliegen dem deutschen Urheberrecht. Die Vervielf&auml;ltigung, Bearbeitung, Verbreitung und jede Art der Verwertung au&szlig;erhalb der Grenzen des Urheberrechtes bed&uuml;rfen der schriftlichen Zustimmung des jeweiligen Autors bzw. Erstellers. Downloads und Kopien dieser Seite sind nur f&uuml;r den privaten, nicht kommerziellen Gebrauch gestattet. Die Software Renfield ist unter der MIT-Lizenz ver&ouml;ffentlicht; die Lizenzbedingungen finden Sie im <a href="https://github.com/ebongard/renfield" target="_blank" rel="noopener noreferrer" class="text-brand-cyan hover:underline">GitHub-Repository</a>.
+        </p>
+      </div>
+    </div>
+  </main>
+  <Footer />
+</BaseLayout>


### PR DESCRIPTION
## Summary
- Add legally required Impressum page (§ 5 DDG) with contact data and liability disclaimers
- Add Datenschutzerklärung page (DSGVO Art. 13) covering Hetzner hosting, self-hosted Umami analytics, Google Fonts, server logs, and data subject rights
- Add Impressum + Datenschutz links to site footer

## Test plan
- [x] Pages deployed and verified live at renfield.de/impressum/ and renfield.de/datenschutz/
- [x] Both return HTTP 200
- [x] Footer links visible on all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)