### PR TITLE
Remove analytics subdomain from Datenschutz page

### DIFF
--- a/site/src/pages/datenschutz.astro
+++ b/site/src/pages/datenschutz.astro
@@ -50,7 +50,7 @@ import '../styles/global.css';
 
         <h2 class="font-serif text-xl font-semibold text-gray-900 dark:text-white">5. Webanalyse mit Umami</h2>
         <p>
-          Wir verwenden <strong>Umami</strong>, eine datenschutzfreundliche, selbstgehostete Webanalyse-Software. Die Umami-Instanz l&auml;uft auf unserer eigenen Infrastruktur unter <code class="text-sm bg-gray-100 dark:bg-gray-800 px-1.5 py-0.5 rounded">analytics.renfield.de</code>. Es werden <strong>keine Daten an Dritte</strong> &uuml;bertragen.
+          Wir verwenden <strong>Umami</strong>, eine datenschutzfreundliche, selbstgehostete Webanalyse-Software. Die Umami-Instanz l&auml;uft auf unserer eigenen Infrastruktur. Es werden <strong>keine Daten an Dritte</strong> &uuml;bertragen.
         </p>
         <p>Umami erhebt folgende Informationen:</p>
         <ul class="list-disc pl-6 space-y-1">


### PR DESCRIPTION
## Summary
- Remove explicit `analytics.renfield.de` subdomain from privacy policy text

🤖 Generated with [Claude Code](https://claude.com/claude-code)