### PR TITLE
fix(security): Auth hardening — 7 route modules, JWT blacklist, port binding

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,7 +117,7 @@ services:
     networks:
       - renfield-network
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health')"]
@@ -179,7 +179,7 @@ services:
     networks:
       - renfield-network
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     restart: unless-stopped
     profiles:
       - gpu

--- a/src/backend/api/lifecycle.py
+++ b/src/backend/api/lifecycle.py
@@ -487,6 +487,19 @@ async def lifespan(app: "FastAPI"):
         )
         raise SystemExit(1)
 
+    # Warn about insecure defaults when auth is enabled
+    if settings.auth_enabled:
+        if not settings.ws_auth_enabled:
+            logger.warning(
+                "⚠️  WS_AUTH_ENABLED=false — WebSocket connections are NOT authenticated. "
+                "Set WS_AUTH_ENABLED=true in production."
+            )
+        if settings.cors_origins == "*":
+            logger.warning(
+                "⚠️  CORS_ORIGINS='*' — all origins allowed. "
+                "Set CORS_ORIGINS to your frontend domain(s) in production."
+            )
+
     # Stage 1: Sequential (auth depends on database)
     await _init_database()
     await _init_auth()

--- a/src/backend/api/routes/auth.py
+++ b/src/backend/api/routes/auth.py
@@ -28,6 +28,7 @@ from services.auth_service import (
     get_current_user,
     get_role_by_name,
     get_user_by_id,
+    oauth2_scheme,
     require_auth,
     validate_password,
 )
@@ -330,6 +331,34 @@ async def change_password(
     logger.info(f"Password changed for user: {user.username}")
 
     return {"message": "Password changed successfully"}
+
+
+@router.post("/logout")
+async def logout(
+    user: User = Depends(require_auth),
+    token: str = Depends(oauth2_scheme),
+):
+    """
+    Logout the current user by revoking their access token.
+
+    The token's JTI is added to a Redis blacklist with TTL matching
+    the token's remaining lifetime.
+    """
+    from services.token_blacklist import token_blacklist
+
+    if token:
+        payload = decode_token(token)
+        if payload:
+            jti = payload.get("jti")
+            exp = payload.get("exp")
+            if jti and exp:
+                import time
+                ttl = int(exp - time.time())
+                if ttl > 0:
+                    await token_blacklist.add(jti, ttl)
+
+    logger.info(f"User logged out: {user.username}")
+    return {"message": "Successfully logged out"}
 
 
 @router.get("/status", response_model=AuthStatusResponse)

--- a/src/backend/api/routes/intents.py
+++ b/src/backend/api/routes/intents.py
@@ -4,9 +4,12 @@ Intent Registry API Routes
 Provides endpoints for viewing available intents and integration status.
 Admin-only endpoints for system monitoring and debugging.
 """
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 
+from models.database import User
+from models.permissions import Permission
+from services.auth_service import require_permission
 from services.intent_registry import CORE_INTEGRATIONS, intent_registry
 from utils.config import settings
 
@@ -71,7 +74,8 @@ class IntentPromptResponse(BaseModel):
 
 @router.get("/status", response_model=IntentRegistryStatusResponse)
 async def get_intent_status(
-    lang: str = Query("de", description="Language for descriptions (de/en)")
+    lang: str = Query("de", description="Language for descriptions (de/en)"),
+    _user: User = Depends(require_permission(Permission.ADMIN)),
 ):
     """
     Get full status of the intent registry.
@@ -144,7 +148,8 @@ async def get_intent_status(
 
 @router.get("/prompt", response_model=IntentPromptResponse)
 async def get_intent_prompt(
-    lang: str = Query("de", description="Language for prompt (de/en)")
+    lang: str = Query("de", description="Language for prompt (de/en)"),
+    _user: User = Depends(require_permission(Permission.ADMIN)),
 ):
     """
     Get the generated intent prompt for debugging.
@@ -162,7 +167,7 @@ async def get_intent_prompt(
 
 
 @router.get("/check/{intent_name}")
-async def check_intent_available(intent_name: str):
+async def check_intent_available(intent_name: str, _user: User = Depends(require_permission(Permission.ADMIN))):
     """
     Check if a specific intent is available.
 
@@ -192,7 +197,7 @@ async def check_intent_available(intent_name: str):
 
 
 @router.get("/integrations/summary")
-async def get_integrations_summary():
+async def get_integrations_summary(_user: User = Depends(require_permission(Permission.ADMIN))):
     """
     Get a quick summary of integration status.
 

--- a/src/backend/api/routes/paperless_audit.py
+++ b/src/backend/api/routes/paperless_audit.py
@@ -7,8 +7,12 @@ Paperless MCP server is configured. See lifecycle.py.
 
 import logging
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
+
+from models.database import User
+from models.permissions import Permission
+from services.auth_service import require_permission
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +56,7 @@ def _get_service(request: Request):
 # --- Endpoints ---
 
 @router.post("/start")
-async def start_audit(body: AuditStartRequest, request: Request):
+async def start_audit(body: AuditStartRequest, request: Request, _user: User = Depends(require_permission(Permission.ADMIN))):
     """Start a new audit run."""
     service = _get_service(request)
 
@@ -71,14 +75,14 @@ async def start_audit(body: AuditStartRequest, request: Request):
 
 
 @router.get("/status")
-async def get_status(request: Request):
+async def get_status(request: Request, _user: User = Depends(require_permission(Permission.ADMIN))):
     """Get current audit status."""
     service = _get_service(request)
     return service.get_status()
 
 
 @router.post("/stop")
-async def stop_audit(request: Request):
+async def stop_audit(request: Request, _user: User = Depends(require_permission(Permission.ADMIN))):
     """Cancel running audit."""
     service = _get_service(request)
     await service.stop()
@@ -100,6 +104,7 @@ async def get_results(
     sort_by: str | None = None,
     sort_order: str = "desc",
     search: str | None = None,
+    _user: User = Depends(require_permission(Permission.ADMIN)),
 ):
     """Get paginated audit results with optional filters, sorting, and search."""
     service = _get_service(request)
@@ -120,7 +125,7 @@ async def get_results(
 
 
 @router.get("/results/{result_id}")
-async def get_result(result_id: int, request: Request):
+async def get_result(result_id: int, request: Request, _user: User = Depends(require_permission(Permission.ADMIN))):
     """Get a single audit result."""
     service = _get_service(request)
     result = await service.get_result_by_id(result_id)
@@ -130,35 +135,35 @@ async def get_result(result_id: int, request: Request):
 
 
 @router.post("/apply")
-async def apply_results(body: ApplyRequest, request: Request):
+async def apply_results(body: ApplyRequest, request: Request, _user: User = Depends(require_permission(Permission.ADMIN))):
     """Apply fixes for selected results."""
     service = _get_service(request)
     return await service.apply_results(body.result_ids)
 
 
 @router.post("/skip")
-async def skip_results(body: SkipRequest, request: Request):
+async def skip_results(body: SkipRequest, request: Request, _user: User = Depends(require_permission(Permission.ADMIN))):
     """Skip selected results."""
     service = _get_service(request)
     return await service.skip_results(body.result_ids)
 
 
 @router.get("/stats")
-async def get_stats(request: Request):
+async def get_stats(request: Request, _user: User = Depends(require_permission(Permission.ADMIN))):
     """Get aggregated audit statistics."""
     service = _get_service(request)
     return await service.get_stats()
 
 
 @router.post("/re-ocr")
-async def trigger_reocr(body: ReOcrRequest, request: Request):
+async def trigger_reocr(body: ReOcrRequest, request: Request, _user: User = Depends(require_permission(Permission.ADMIN))):
     """Trigger re-OCR for selected results."""
     service = _get_service(request)
     return await service.reprocess_documents(body.result_ids)
 
 
 @router.post("/detect-duplicates")
-async def detect_duplicates(request: Request):
+async def detect_duplicates(request: Request, _user: User = Depends(require_permission(Permission.ADMIN))):
     """Run duplicate detection post-audit pass."""
     service = _get_service(request)
 
@@ -169,7 +174,7 @@ async def detect_duplicates(request: Request):
 
 
 @router.get("/duplicate-groups")
-async def get_duplicate_groups(request: Request):
+async def get_duplicate_groups(request: Request, _user: User = Depends(require_permission(Permission.ADMIN))):
     """Get all duplicate groups with their documents."""
     service = _get_service(request)
     return await service.get_duplicate_groups()
@@ -179,6 +184,7 @@ async def get_duplicate_groups(request: Request):
 async def correspondent_normalization(
     request: Request,
     threshold: float = Query(0.82, ge=0.5, le=1.0),
+    _user: User = Depends(require_permission(Permission.ADMIN)),
 ):
     """Scan for similar correspondent names that may be duplicates."""
     service = _get_service(request)

--- a/src/backend/api/routes/rooms.py
+++ b/src/backend/api/routes/rooms.py
@@ -10,6 +10,9 @@ from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from integrations.homeassistant import HomeAssistantClient
+from models.database import User
+from models.permissions import Permission
+from services.auth_service import require_permission
 from services.database import get_db
 from services.room_service import RoomService
 
@@ -42,7 +45,8 @@ router = APIRouter()
 @router.post("", response_model=RoomResponse)
 async def create_room(
     room: RoomCreate,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.ROOMS_MANAGE)),
 ):
     """Create a new room"""
     service = RoomService(db)
@@ -66,7 +70,7 @@ async def create_room(
 
 
 @router.get("", response_model=list[RoomResponse])
-async def list_rooms(db: AsyncSession = Depends(get_db)):
+async def list_rooms(db: AsyncSession = Depends(get_db), _user: User = Depends(require_permission(Permission.ROOMS_READ))):
     """List all rooms with their satellites"""
     service = RoomService(db)
     rooms = await service.get_all_rooms()
@@ -76,7 +80,8 @@ async def list_rooms(db: AsyncSession = Depends(get_db)):
 @router.get("/{room_id}", response_model=RoomResponse)
 async def get_room(
     room_id: int,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.ROOMS_READ)),
 ):
     """Get a specific room with its satellites"""
     service = RoomService(db)
@@ -92,7 +97,8 @@ async def get_room(
 async def update_room(
     room_id: int,
     update: RoomUpdate,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.ROOMS_MANAGE)),
 ):
     """Update room details"""
     service = RoomService(db)
@@ -123,6 +129,7 @@ async def set_room_owner(
     room_id: int,
     owner_id: int | None = None,
     db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.ROOMS_MANAGE)),
 ):
     """Set or clear the owner of a room (for Media Follow Me conflict resolution)."""
     from models.database import Room, User
@@ -144,7 +151,8 @@ async def set_room_owner(
 @router.delete("/{room_id}")
 async def delete_room(
     room_id: int,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.ROOMS_MANAGE)),
 ):
     """Delete a room and all satellite assignments"""
     service = RoomService(db)
@@ -165,7 +173,7 @@ async def delete_room(
 # --- Home Assistant Sync Endpoints ---
 
 @router.get("/ha/areas", response_model=list[HAAreaResponse])
-async def list_ha_areas(db: AsyncSession = Depends(get_db)):
+async def list_ha_areas(db: AsyncSession = Depends(get_db), _user: User = Depends(require_permission(Permission.ROOMS_READ))):
     """
     List all Home Assistant areas with their link status.
 
@@ -207,7 +215,8 @@ async def list_ha_areas(db: AsyncSession = Depends(get_db)):
 @router.post("/ha/import", response_model=HAImportResponse)
 async def import_ha_areas(
     request: HAImportRequest,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.ROOMS_MANAGE)),
 ):
     """
     Import areas from Home Assistant into Renfield.
@@ -238,7 +247,7 @@ async def import_ha_areas(
 
 
 @router.post("/ha/export", response_model=HAExportResponse)
-async def export_rooms_to_ha(db: AsyncSession = Depends(get_db)):
+async def export_rooms_to_ha(db: AsyncSession = Depends(get_db), _user: User = Depends(require_permission(Permission.ROOMS_MANAGE))):
     """
     Export Renfield rooms to Home Assistant as areas.
 
@@ -305,7 +314,8 @@ async def export_rooms_to_ha(db: AsyncSession = Depends(get_db)):
 @router.post("/ha/sync", response_model=SyncResponse)
 async def sync_with_ha(
     conflict_resolution: str = "link",
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.ROOMS_MANAGE)),
 ):
     """
     Bidirectional sync with Home Assistant.
@@ -369,7 +379,8 @@ async def sync_with_ha(
 async def link_room_to_ha_area(
     room_id: int,
     ha_area_id: str,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.ROOMS_MANAGE)),
 ):
     """Link a room to a specific Home Assistant area"""
     service = RoomService(db)
@@ -393,7 +404,8 @@ async def link_room_to_ha_area(
 @router.delete("/{room_id}/link", response_model=RoomResponse)
 async def unlink_room_from_ha(
     room_id: int,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.ROOMS_MANAGE)),
 ):
     """Remove Home Assistant area link from a room"""
     service = RoomService(db)
@@ -411,7 +423,8 @@ async def unlink_room_from_ha(
 @router.get("/{room_id}/satellites")
 async def get_room_satellites(
     room_id: int,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.ROOMS_READ)),
 ):
     """Get all satellites assigned to a room"""
     service = RoomService(db)
@@ -438,7 +451,8 @@ async def get_room_satellites(
 async def assign_satellite_to_room(
     room_id: int,
     request: SatelliteAssignRequest,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.ROOMS_MANAGE)),
 ):
     """Manually assign a satellite to a room"""
     service = RoomService(db)
@@ -459,7 +473,8 @@ async def assign_satellite_to_room(
 async def unassign_satellite(
     room_id: int,
     satellite_id: str,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.ROOMS_MANAGE)),
 ):
     """Remove a satellite from a room"""
     service = RoomService(db)
@@ -484,7 +499,7 @@ async def unassign_satellite(
 # --- Device Endpoints ---
 
 @router.get("/devices/connected", response_model=list[ConnectedDeviceResponse])
-async def get_connected_devices():
+async def get_connected_devices(_user: User = Depends(require_permission(Permission.ROOMS_READ))):
     """
     Get all currently connected devices (via WebSocket).
 
@@ -499,7 +514,7 @@ async def get_connected_devices():
 
 
 @router.get("/devices/connected/{room_id}", response_model=list[ConnectedDeviceResponse])
-async def get_connected_devices_in_room(room_id: int):
+async def get_connected_devices_in_room(room_id: int, _user: User = Depends(require_permission(Permission.ROOMS_READ))):
     """Get all connected devices in a specific room"""
     from services.device_manager import get_device_manager
 
@@ -527,7 +542,8 @@ async def get_connected_devices_in_room(room_id: int):
 @router.get("/{room_id}/devices", response_model=list[DeviceResponse])
 async def get_room_devices(
     room_id: int,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.ROOMS_READ)),
 ):
     """
     Get all devices registered in a room (from database).
@@ -566,7 +582,8 @@ async def get_room_devices(
 async def register_device(
     room_id: int,
     request: DeviceRegisterRequest,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.ROOMS_MANAGE)),
 ):
     """
     Manually register a device to a room.
@@ -616,7 +633,8 @@ async def register_device(
 @router.get("/devices/{device_id}", response_model=DeviceResponse)
 async def get_device(
     device_id: str,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.ROOMS_READ)),
 ):
     """Get a specific device by ID"""
     service = RoomService(db)
@@ -644,7 +662,8 @@ async def get_device(
 @router.delete("/devices/{device_id}")
 async def delete_device(
     device_id: str,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.ROOMS_MANAGE)),
 ):
     """Delete a device from the system"""
     service = RoomService(db)
@@ -662,7 +681,8 @@ async def delete_device(
 async def move_device_to_room(
     device_id: str,
     room_id: int,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.ROOMS_MANAGE)),
 ):
     """Move a device to a different room"""
     service = RoomService(db)
@@ -709,7 +729,8 @@ def _output_device_to_response(device) -> OutputDeviceResponse:
 @router.get("/{room_id}/output-devices", response_model=list[OutputDeviceResponse])
 async def get_room_output_devices(
     room_id: int,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.ROOMS_READ)),
 ):
     """Get all output devices configured for a room"""
     from services.output_routing_service import OutputRoutingService
@@ -729,7 +750,8 @@ async def get_room_output_devices(
 async def add_output_device(
     room_id: int,
     request: OutputDeviceCreate,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.ROOMS_MANAGE)),
 ):
     """Add an output device to a room"""
     from services.output_routing_service import OutputRoutingService
@@ -784,7 +806,8 @@ async def add_output_device(
 async def update_output_device(
     device_id: int,
     request: OutputDeviceUpdate,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.ROOMS_MANAGE)),
 ):
     """Update an output device"""
     from services.output_routing_service import OutputRoutingService
@@ -809,7 +832,8 @@ async def update_output_device(
 @router.delete("/output-devices/{device_id}")
 async def delete_output_device(
     device_id: int,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.ROOMS_MANAGE)),
 ):
     """Delete an output device"""
     from services.output_routing_service import OutputRoutingService
@@ -828,7 +852,8 @@ async def reorder_output_devices(
     room_id: int,
     request: OutputDeviceReorderRequest,
     output_type: str = "audio",
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.ROOMS_MANAGE)),
 ):
     """
     Reorder output devices by setting new priorities.
@@ -862,7 +887,8 @@ async def reorder_output_devices(
 @router.get("/{room_id}/available-outputs", response_model=AvailableOutputResponse)
 async def get_available_outputs(
     room_id: int,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.ROOMS_READ)),
 ):
     """
     Get all available output devices for a room.

--- a/src/backend/api/routes/satellites.py
+++ b/src/backend/api/routes/satellites.py
@@ -7,10 +7,13 @@ Includes live status, metrics, session history, and error logs.
 from datetime import datetime
 from typing import Any
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from loguru import logger
 from pydantic import BaseModel, Field
 
+from models.database import User
+from models.permissions import Permission
+from services.auth_service import require_permission
 from services.satellite_manager import get_satellite_manager
 from utils.config import settings
 
@@ -191,7 +194,7 @@ def _satellite_to_response(sat_id: str, sat_data: dict[str, Any]) -> SatelliteRe
 # =============================================================================
 
 @router.get("", response_model=SatelliteListResponse)
-async def list_satellites():
+async def list_satellites(_user: User = Depends(require_permission(Permission.ADMIN))):
     """
     List all connected satellites with their current status.
 
@@ -248,7 +251,7 @@ class UpdateStatusResponse(BaseModel):
 
 
 @router.get("/versions", response_model=VersionInfoResponse)
-async def get_versions():
+async def get_versions(_user: User = Depends(require_permission(Permission.ADMIN))):
     """
     Get version information for all satellites.
 
@@ -278,7 +281,7 @@ async def get_versions():
 
 
 @router.get("/update-package")
-async def get_update_package():
+async def get_update_package(_user: User = Depends(require_permission(Permission.ADMIN))):
     """
     Download the satellite update package.
 
@@ -317,7 +320,7 @@ async def get_update_package():
 # =============================================================================
 
 @router.get("/{satellite_id}", response_model=SatelliteResponse)
-async def get_satellite(satellite_id: str):
+async def get_satellite(satellite_id: str, _user: User = Depends(require_permission(Permission.ADMIN))):
     """
     Get detailed status for a specific satellite.
 
@@ -346,7 +349,7 @@ async def get_satellite(satellite_id: str):
 
 
 @router.get("/{satellite_id}/metrics", response_model=SatelliteMetricsResponse)
-async def get_satellite_metrics(satellite_id: str):
+async def get_satellite_metrics(satellite_id: str, _user: User = Depends(require_permission(Permission.ADMIN))):
     """
     Get live metrics for a specific satellite.
 
@@ -368,7 +371,7 @@ async def get_satellite_metrics(satellite_id: str):
 
 
 @router.get("/{satellite_id}/session", response_model=SatelliteSessionResponse)
-async def get_satellite_session(satellite_id: str):
+async def get_satellite_session(satellite_id: str, _user: User = Depends(require_permission(Permission.ADMIN))):
     """
     Get current active session for a satellite.
 
@@ -412,7 +415,7 @@ async def get_satellite_session(satellite_id: str):
 
 
 @router.get("/{satellite_id}/history", response_model=SatelliteHistoryResponse)
-async def get_satellite_history(satellite_id: str, limit: int = 50):
+async def get_satellite_history(satellite_id: str, limit: int = 50, _user: User = Depends(require_permission(Permission.ADMIN))):
     """
     Get event history for a satellite.
 
@@ -445,7 +448,7 @@ async def get_satellite_history(satellite_id: str, limit: int = 50):
 
 
 @router.post("/{satellite_id}/ping")
-async def ping_satellite(satellite_id: str):
+async def ping_satellite(satellite_id: str, _user: User = Depends(require_permission(Permission.ADMIN))):
     """
     Send a ping to a satellite to check connectivity.
 
@@ -475,7 +478,7 @@ async def ping_satellite(satellite_id: str):
 
 
 @router.post("/{satellite_id}/update", response_model=UpdateInitiateResponse)
-async def initiate_update(satellite_id: str):
+async def initiate_update(satellite_id: str, _user: User = Depends(require_permission(Permission.ADMIN))):
     """
     Initiate an OTA update for a specific satellite.
 
@@ -501,7 +504,7 @@ async def initiate_update(satellite_id: str):
 
 
 @router.get("/{satellite_id}/update-status", response_model=UpdateStatusResponse)
-async def get_update_status(satellite_id: str):
+async def get_update_status(satellite_id: str, _user: User = Depends(require_permission(Permission.ADMIN))):
     """
     Get the current update status for a satellite.
 

--- a/src/backend/api/routes/speakers.py
+++ b/src/backend/api/routes/speakers.py
@@ -13,7 +13,9 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from models.database import Speaker, SpeakerEmbedding
+from models.database import Speaker, SpeakerEmbedding, User
+from models.permissions import Permission
+from services.auth_service import require_permission
 from services.database import get_db
 from services.speaker_service import SPEECHBRAIN_ERROR, get_speaker_service
 
@@ -128,7 +130,7 @@ async def get_speaker_embeddings_averaged(
 # --- Endpoints ---
 
 @router.get("/status", response_model=ServiceStatusResponse)
-async def get_service_status():
+async def get_service_status(_user: User = Depends(require_permission(Permission.SPEAKERS_ALL))):
     """Check if speaker recognition service is available"""
     service = get_speaker_service()
 
@@ -149,7 +151,8 @@ async def get_service_status():
 @router.post("", response_model=SpeakerResponse)
 async def create_speaker(
     speaker: SpeakerCreate,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.SPEAKERS_ALL)),
 ):
     """Create a new speaker profile"""
     # Check if alias already exists
@@ -186,7 +189,7 @@ async def create_speaker(
 
 
 @router.get("", response_model=list[SpeakerResponse])
-async def list_speakers(db: AsyncSession = Depends(get_db)):
+async def list_speakers(db: AsyncSession = Depends(get_db), _user: User = Depends(require_permission(Permission.SPEAKERS_ALL))):
     """List all registered speakers"""
     # Use selectinload to eagerly load embeddings (avoids lazy-load in async context)
     result = await db.execute(
@@ -209,7 +212,8 @@ async def list_speakers(db: AsyncSession = Depends(get_db)):
 @router.get("/{speaker_id}", response_model=SpeakerResponse)
 async def get_speaker(
     speaker_id: int,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.SPEAKERS_ALL)),
 ):
     """Get a specific speaker"""
     result = await db.execute(
@@ -235,7 +239,8 @@ async def get_speaker(
 async def update_speaker(
     speaker_id: int,
     update: SpeakerUpdate,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.SPEAKERS_ALL)),
 ):
     """Update a speaker's information"""
     result = await db.execute(
@@ -288,7 +293,8 @@ async def update_speaker(
 @router.delete("/{speaker_id}")
 async def delete_speaker(
     speaker_id: int,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.SPEAKERS_ALL)),
 ):
     """Delete a speaker and all their embeddings"""
     result = await db.execute(
@@ -311,7 +317,8 @@ async def delete_speaker(
 @router.post("/merge", response_model=MergeSpeakersResponse)
 async def merge_speakers(
     request: MergeSpeakersRequest,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.SPEAKERS_ALL)),
 ):
     """
     Merge two speakers into one.
@@ -406,7 +413,8 @@ async def merge_speakers(
 async def enroll_speaker(
     speaker_id: int,
     audio: UploadFile = File(...),
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.SPEAKERS_ALL)),
 ):
     """
     Enroll a speaker with a voice sample.
@@ -484,7 +492,8 @@ async def enroll_speaker(
 @router.post("/identify", response_model=IdentifyResponse)
 async def identify_speaker(
     audio: UploadFile = File(...),
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.SPEAKERS_ALL)),
 ):
     """
     Identify speaker from audio.
@@ -561,7 +570,8 @@ async def identify_speaker(
 async def verify_speaker(
     speaker_id: int,
     audio: UploadFile = File(...),
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.SPEAKERS_ALL)),
 ):
     """
     Verify if audio matches a specific speaker.
@@ -630,7 +640,8 @@ async def verify_speaker(
 async def delete_embedding(
     speaker_id: int,
     embedding_id: int,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.SPEAKERS_ALL)),
 ):
     """Delete a specific voice embedding"""
     result = await db.execute(

--- a/src/backend/api/routes/tasks.py
+++ b/src/backend/api/routes/tasks.py
@@ -9,7 +9,9 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from models.database import Task
+from models.database import Task, User
+from models.permissions import Permission
+from services.auth_service import require_permission
 from services.database import get_db
 
 router = APIRouter()
@@ -29,7 +31,8 @@ class TaskUpdate(BaseModel):
 @router.post("/create")
 async def create_task(
     task: TaskCreate,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.TASKS_MANAGE)),
 ):
     """Neue Aufgabe erstellen"""
     try:
@@ -61,7 +64,8 @@ async def list_tasks(
     status: str | None = None,
     task_type: str | None = None,
     limit: int = 50,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.TASKS_VIEW)),
 ):
     """Aufgaben auflisten"""
     try:
@@ -97,7 +101,8 @@ async def list_tasks(
 @router.get("/{task_id}")
 async def get_task(
     task_id: int,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.TASKS_VIEW)),
 ):
     """Einzelne Aufgabe abrufen"""
     try:
@@ -131,7 +136,8 @@ async def get_task(
 async def update_task(
     task_id: int,
     update: TaskUpdate,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.TASKS_MANAGE)),
 ):
     """Task aktualisieren"""
     try:
@@ -166,7 +172,8 @@ async def update_task(
 @router.delete("/{task_id}")
 async def delete_task(
     task_id: int,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_permission(Permission.TASKS_MANAGE)),
 ):
     """Task löschen"""
     try:

--- a/src/backend/api/routes/voice.py
+++ b/src/backend/api/routes/voice.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from services.api_rate_limiter import limiter
+from services.auth_service import get_current_user
 from services.database import get_db
 from services.piper_service import PiperService
 from services.whisper_service import WhisperService
@@ -36,7 +37,8 @@ async def speech_to_text(
     request: Request,
     audio: UploadFile = File(...),
     language: str | None = Query(None, description="Language code (e.g., 'de', 'en'). Falls back to default."),
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user=Depends(get_current_user)
 ):
     """
     Speech-to-Text: Audio zu Text konvertieren mit optionaler Sprechererkennung.
@@ -111,7 +113,7 @@ async def speech_to_text(
 
 @router.post("/tts")
 @limiter.limit(settings.api_rate_limit_voice)
-async def text_to_speech(request: Request, tts_request: TTSRequest):
+async def text_to_speech(request: Request, tts_request: TTSRequest, _user=Depends(get_current_user)):
     """
     Text-to-Speech: Text zu Audio konvertieren.
 
@@ -146,7 +148,7 @@ async def text_to_speech(request: Request, tts_request: TTSRequest):
         raise HTTPException(status_code=500, detail=str(e))
 
 @router.get("/tts-cache/{audio_id}")
-async def get_tts_cache(audio_id: str):
+async def get_tts_cache(audio_id: str, _user=Depends(get_current_user)):
     """
     Serve cached TTS audio files.
 
@@ -179,7 +181,8 @@ async def voice_chat(
     request: Request,
     audio: UploadFile = File(...),
     language: str | None = Query(None, description="Language code (e.g., 'de', 'en'). Falls back to default."),
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _user=Depends(get_current_user)
 ):
     """
     Kompletter Voice-Chat Flow:

--- a/src/backend/services/auth_service.py
+++ b/src/backend/services/auth_service.py
@@ -6,6 +6,7 @@ Provides JWT-based authentication, password hashing, and permission checks.
 import secrets
 from datetime import UTC, datetime, timedelta
 from typing import Union
+from uuid import uuid4
 
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
@@ -85,7 +86,8 @@ def create_access_token(
 
     to_encode.update({
         "exp": expire,
-        "type": "access"
+        "type": "access",
+        "jti": str(uuid4()),
     })
 
     encoded_jwt = jwt.encode(to_encode, settings.secret_key.get_secret_value(), algorithm=ALGORITHM)
@@ -103,7 +105,8 @@ def create_refresh_token(user_id: int) -> str:
     to_encode = {
         "sub": str(user_id),
         "exp": expire,
-        "type": "refresh"
+        "type": "refresh",
+        "jti": str(uuid4()),
     }
 
     encoded_jwt = jwt.encode(to_encode, settings.secret_key.get_secret_value(), algorithm=ALGORITHM)
@@ -224,6 +227,17 @@ async def get_current_user(
             detail="Invalid token type",
             headers={"WWW-Authenticate": "Bearer"},
         )
+
+    # Check if token has been revoked (logout)
+    jti = payload.get("jti")
+    if jti:
+        from services.token_blacklist import token_blacklist
+        if await token_blacklist.is_blacklisted(jti):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Token has been revoked",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
 
     user_id = payload.get("sub")
     if not user_id:
@@ -431,9 +445,11 @@ async def ensure_admin_user(db: AsyncSession) -> User | None:
     if configured_password == "changeme":
         password = secrets.token_urlsafe(16)
         must_change = True
+        # Print to stdout only (not captured by file-based loggers)
+        print(f"ADMIN_PASSWORD={password}")
         logger.warning(
-            f"Generated random admin password: {password} — "
-            f"CHANGE IT IMMEDIATELY via the admin UI!"
+            "Random admin password generated. "
+            "Retrieve via: docker logs renfield-backend 2>&1 | grep ADMIN_PASSWORD"
         )
     else:
         password = configured_password

--- a/src/backend/services/token_blacklist.py
+++ b/src/backend/services/token_blacklist.py
@@ -1,0 +1,64 @@
+"""
+JWT Token Blacklist Service
+
+Redis-based token blacklist for logout/revocation.
+Stores JTI (JWT ID) with TTL matching the token's remaining lifetime.
+"""
+import redis.asyncio as aioredis
+from loguru import logger
+
+from utils.config import settings
+
+BLACKLIST_PREFIX = "blacklist:"
+
+
+class TokenBlacklist:
+    """Redis-backed JWT token blacklist."""
+
+    def __init__(self):
+        self._redis: aioredis.Redis | None = None
+
+    def _get_redis(self) -> aioredis.Redis:
+        if self._redis is None:
+            self._redis = aioredis.from_url(
+                settings.redis_url, decode_responses=True
+            )
+        return self._redis
+
+    async def add(self, jti: str, ttl_seconds: int) -> None:
+        """
+        Blacklist a token JTI.
+
+        Args:
+            jti: The JWT ID to blacklist
+            ttl_seconds: Time-to-live in seconds (token's remaining lifetime)
+        """
+        if ttl_seconds <= 0:
+            return
+        try:
+            redis = self._get_redis()
+            await redis.setex(f"{BLACKLIST_PREFIX}{jti}", ttl_seconds, "1")
+        except Exception as e:
+            logger.error(f"Failed to blacklist token: {e}")
+
+    async def is_blacklisted(self, jti: str) -> bool:
+        """
+        Check if a token JTI is blacklisted.
+
+        Args:
+            jti: The JWT ID to check
+
+        Returns:
+            True if the token has been revoked
+        """
+        try:
+            redis = self._get_redis()
+            return await redis.exists(f"{BLACKLIST_PREFIX}{jti}") > 0
+        except Exception as e:
+            logger.error(f"Failed to check token blacklist: {e}")
+            # Fail open — if Redis is down, don't block all requests
+            return False
+
+
+# Singleton instance
+token_blacklist = TokenBlacklist()


### PR DESCRIPTION
## Summary

Security audit identified 6 actionable issues. This PR fixes all of them:

- **Auth on 7 unprotected route modules** (74 endpoints total): `satellites`, `rooms`, `voice`, `paperless_audit`, `tasks`, `intents`, `speakers` — each endpoint now requires the appropriate RPBAC permission via `Depends(require_permission(...))`. When `AUTH_ENABLED=false`, all routes remain accessible (graceful passthrough in `require_permission()`).
- **JWT token blacklist + logout**: New `POST /api/auth/logout` endpoint revokes the current access token. Redis-backed blacklist with TTL matching token expiry. JTI claims added to both access and refresh tokens.
- **Backend port binding**: `8000:8000` → `127.0.0.1:8000:8000` for both `backend` and `backend-gpu` services — prevents direct access bypassing the reverse proxy.
- **Admin password removed from logs**: Random admin password now printed to stdout only (`print()`), not captured by file-based loggers. Log message points to `docker logs | grep ADMIN_PASSWORD`.
- **Startup warnings**: When `AUTH_ENABLED=true`, warns if `WS_AUTH_ENABLED=false` or `CORS_ORIGINS='*'`.

## Test plan

- [ ] `make lint` passes (verified locally with `ruff check`)
- [ ] `make test-backend` — existing tests still pass (pre-existing TSVECTOR/SQLite failures unrelated)
- [ ] Manual: Route without token when `AUTH_ENABLED=true` → 401
- [ ] Manual: Route with token but missing permission → 403
- [ ] Manual: `AUTH_ENABLED=false` → all routes still accessible
- [ ] Manual: Login → Logout → reuse old token → 401
- [ ] Docker: Port 8000 only reachable on localhost

🤖 Generated with [Claude Code](https://claude.com/claude-code)