### PR TITLE
fix(frontend): Handle Pydantic 422 validation errors without React crash

### DIFF
--- a/src/frontend/src/pages/LoginPage.jsx
+++ b/src/frontend/src/pages/LoginPage.jsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate, useLocation, Link } from 'react-router';
 import { useAuth } from '../context/AuthContext';
 import { LogIn, UserPlus, Loader, AlertCircle, Eye, EyeOff } from 'lucide-react';
+import { extractApiError } from '../utils/axios';
 
 export default function LoginPage() {
   const { t } = useTranslation();
@@ -53,7 +54,7 @@ export default function LoginPage() {
       await login(username, password);
       navigate(from, { replace: true });
     } catch (err) {
-      setError(err.response?.data?.detail || t('auth.loginFailed'));
+      setError(extractApiError(err, t('auth.loginFailed')));
     } finally {
       setLoading(false);
     }

--- a/src/frontend/src/pages/RegisterPage.jsx
+++ b/src/frontend/src/pages/RegisterPage.jsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate, Link } from 'react-router';
 import { useAuth } from '../context/AuthContext';
 import { UserPlus, Loader, AlertCircle, CheckCircle, Eye, EyeOff } from 'lucide-react';
+import { extractApiError } from '../utils/axios';
 
 export default function RegisterPage() {
   const { t } = useTranslation();
@@ -77,7 +78,7 @@ export default function RegisterPage() {
         navigate('/login', { replace: true });
       }, 2000);
     } catch (err) {
-      setError(err.response?.data?.detail || t('auth.registrationFailed'));
+      setError(extractApiError(err, t('auth.registrationFailed')));
     } finally {
       setLoading(false);
     }

--- a/src/frontend/src/pages/RolesPage.jsx
+++ b/src/frontend/src/pages/RolesPage.jsx
@@ -6,7 +6,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../context/AuthContext';
-import apiClient from '../utils/axios';
+import apiClient, { extractApiError } from '../utils/axios';
 import Modal from '../components/Modal';
 import PageHeader from '../components/PageHeader';
 import Alert from '../components/Alert';
@@ -113,7 +113,7 @@ export default function RolesPage() {
       setRoles(Array.isArray(rolesRes.data) ? rolesRes.data : []);
       setAllPermissions(Array.isArray(permsRes.data) ? permsRes.data : []);
     } catch (err) {
-      setError(err.response?.data?.detail || t('roles.failedToLoad'));
+      setError(extractApiError(err, t('roles.failedToLoad')));
     } finally {
       setLoading(false);
     }
@@ -235,7 +235,7 @@ export default function RolesPage() {
       setShowModal(false);
       loadData();
     } catch (err) {
-      setError(err.response?.data?.detail || t('roles.failedToSave'));
+      setError(extractApiError(err, t('roles.failedToSave')));
     } finally {
       setFormLoading(false);
     }
@@ -265,7 +265,7 @@ export default function RolesPage() {
       setSuccess(t('roles.roleDeleted'));
       loadData();
     } catch (err) {
-      setError(err.response?.data?.detail || t('roles.failedToDelete'));
+      setError(extractApiError(err, t('roles.failedToDelete')));
     }
   };
 

--- a/src/frontend/src/pages/UsersPage.jsx
+++ b/src/frontend/src/pages/UsersPage.jsx
@@ -6,7 +6,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../context/AuthContext';
-import apiClient from '../utils/axios';
+import apiClient, { extractApiError } from '../utils/axios';
 import Modal from '../components/Modal';
 import PageHeader from '../components/PageHeader';
 import Alert from '../components/Alert';
@@ -69,7 +69,7 @@ export default function UsersPage() {
       setRoles(rolesRes.data.roles || rolesRes.data || []);
       setSpeakers(speakersRes.data || []);
     } catch (err) {
-      setError(err.response?.data?.detail || t('users.failedToLoad'));
+      setError(extractApiError(err, t('users.failedToLoad')));
     } finally {
       setLoading(false);
     }
@@ -99,7 +99,7 @@ export default function UsersPage() {
       last_name: '',
       email: '',
       password: '',
-      role_id: roles.find(r => r.name === 'Gast')?.id || roles[0]?.id || '',
+      role_id: String(roles.find(r => r.name === 'Gast')?.id || roles[0]?.id || ''),
       is_active: true,
       personality_style: 'freundlich',
       personality_prompt: ''
@@ -117,7 +117,7 @@ export default function UsersPage() {
       last_name: user.last_name || '',
       email: user.email || '',
       password: '',
-      role_id: user.role_id,
+      role_id: String(user.role_id),
       is_active: user.is_active,
       personality_style: user.personality_style || 'freundlich',
       personality_prompt: user.personality_prompt || ''
@@ -177,7 +177,7 @@ export default function UsersPage() {
       setShowModal(false);
       loadData();
     } catch (err) {
-      setError(err.response?.data?.detail || t('users.failedToSave'));
+      setError(extractApiError(err, t('users.failedToSave')));
     } finally {
       setFormLoading(false);
     }
@@ -207,7 +207,7 @@ export default function UsersPage() {
       setSuccess(t('users.userDeleted'));
       loadData();
     } catch (err) {
-      setError(err.response?.data?.detail || t('users.failedToDelete'));
+      setError(extractApiError(err, t('users.failedToDelete')));
     }
   };
 
@@ -229,7 +229,7 @@ export default function UsersPage() {
       setLinkingUserId(null);
       loadData();
     } catch (err) {
-      setError(err.response?.data?.detail || t('users.failedToLink'));
+      setError(extractApiError(err, t('users.failedToLink')));
     }
   };
 
@@ -252,7 +252,7 @@ export default function UsersPage() {
       setSuccess(t('users.speakerUnlinked'));
       loadData();
     } catch (err) {
-      setError(err.response?.data?.detail || t('users.failedToUnlink'));
+      setError(extractApiError(err, t('users.failedToUnlink')));
     }
   };
 
@@ -517,7 +517,7 @@ export default function UsersPage() {
             >
               <option value="">{t('users.selectRole')}</option>
               {roles.map((role) => (
-                <option key={role.id} value={role.id}>
+                <option key={role.id} value={String(role.id)}>
                   {role.name} - {role.description}
                 </option>
               ))}

--- a/src/frontend/src/utils/axios.ts
+++ b/src/frontend/src/utils/axios.ts
@@ -32,4 +32,18 @@ apiClient.interceptors.response.use(
   }
 );
 
+/**
+ * Extract a displayable error message from an Axios error.
+ * Handles both simple string details and Pydantic 422 validation arrays.
+ */
+export function extractApiError(err: unknown, fallback: string): string {
+  const detail = (err as AxiosError<{ detail?: unknown }>)?.response?.data?.detail;
+  if (!detail) return fallback;
+  if (typeof detail === 'string') return detail;
+  if (Array.isArray(detail)) {
+    return detail.map((d: { msg?: string }) => d.msg || JSON.stringify(d)).join(', ');
+  }
+  return fallback;
+}
+
 export default apiClient;


### PR DESCRIPTION
## Summary

- Pydantic 422 validation errors (e.g. invalid email on user creation) caused React error #31 because the raw error detail array was passed as a React child
- Add `extractApiError()` utility in `axios.ts` that extracts readable `msg` strings from both simple string and array detail formats
- Applied to UsersPage, LoginPage, RegisterPage, and RolesPage error handlers

## Test plan

- [x] Tested on production: invalid email shows readable error message, no React crash
- [x] Tested on production: valid user creation works (happy path)
- [x] eslint passes with no new errors
- [ ] Verify other pages with validation errors display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)