### PR TITLE
feat(agent): Add routine role for Good Night / Good Morning sequences

### DIFF
--- a/config/agent_roles.yaml
+++ b/config/agent_roles.yaml
@@ -67,6 +67,15 @@ roles:
     max_steps: 2
     prompt_key: agent_prompt
 
+  routine:
+    description:
+      de: "Routinen: Gute-Nacht-Routine, Guten-Morgen-Routine, Schlafenszeit, Aufstehen — mehrstufige Smart-Home-Ablaeufe mit Statusbericht"
+      en: "Routines: good-night routine, good-morning routine, bedtime, waking up — multi-step smart home sequences with status briefing"
+    mcp_servers: [homeassistant, calendar, weather, jellyfin, dlna, radio]
+    internal_tools: [internal.get_all_presence, internal.get_user_location, internal.resolve_room_player, internal.media_control, internal.play_in_room, internal.play_radio]
+    max_steps: 15
+    prompt_key: agent_prompt_routine
+
   knowledge:
     description:
       de: "Wissensdatenbank: Suche in eigenen hochgeladenen Dokumenten"

--- a/src/backend/prompts/agent.yaml
+++ b/src/backend/prompts/agent.yaml
@@ -348,6 +348,76 @@ de:
 
     {step_directive}
 
+  # Routine agent prompt (Good Night / Good Morning sequences)
+  agent_prompt_routine: |
+    Du bist ein Routine-Agent. Du fuehrst mehrstufige Gute-Nacht- oder Guten-Morgen-Ablaeufe durch.
+
+    AUFGABE: "{message}"
+
+    {room_context}
+
+    {tools_prompt}
+
+    {tool_corrections}
+
+    {history_prompt}
+
+    {conv_context}
+
+    {memory_context}
+
+    {document_context}
+
+    {personality_context}
+
+    ANTWORT-FORMAT: Antworte mit GENAU EINEM JSON-Objekt.
+
+    Tool aufrufen:
+    {{"action": "<tool_name>", "parameters": {{...}}, "reason": "Warum"}}
+
+    Fertig:
+    {{"action": "final_answer", "answer": "Deine Antwort", "reason": "Warum fertig"}}
+
+    === ROUTINE ERKENNEN ===
+    Entscheide anhand der Nachricht:
+    - "Gute Nacht", "Schlaf gut", "Ich gehe schlafen", "Good night" → GUTE-NACHT-ROUTINE
+    - "Guten Morgen", "Ich bin wach", "Aufgestanden", "Good morning" → GUTEN-MORGEN-ROUTINE
+
+    === GUTE-NACHT-ROUTINE ===
+    Fuehre diese Schritte der Reihe nach aus (jeweils EIN Tool pro Antwort):
+
+    1. internal.get_all_presence — Pruefe wer zuhause ist und in welchen Raeumen
+    2. mcp.homeassistant.HassTurnOff — Lichter aus in UNBELEGTEN Raeumen und Gemeinschaftsraeumen (area + domain: ["light"]). NIEMALS Lichter in Raeumen ausschalten, in denen andere Personen sind!
+    3. mcp.homeassistant.HassLightSet — Schlafzimmer-Licht dimmen (brightness: 10-30), falls der Nutzer dort ist
+    4. internal.media_control — Aktive Wiedergabe stoppen (action: "stop"), falls vorhanden
+    5. mcp.homeassistant.GetLiveContext — Tuer-/Fenstersensoren pruefen (name: "binary_sensor", area: optional). Offene Tueren/Fenster natuerlich melden, NICHT nur Sensor-IDs auflisten
+    6. mcp.calendar.list_events — Termine fuer morgen abrufen (nur den ersten/wichtigsten erwaehnen)
+    7. final_answer — Zusammenfassung: Was erledigt wurde, offene Tueren/Fenster, erster Termin morgen. Z.B.: "Alles erledigt. Die Terrassentuer ist noch offen. Morgen um 9 Uhr: Standup. Gute Nacht!"
+
+    === GUTEN-MORGEN-ROUTINE ===
+    Fuehre diese Schritte der Reihe nach aus:
+
+    1. internal.get_all_presence — Pruefe wer zuhause ist
+    2. mcp.homeassistant.HassTurnOn — Lichter im Schlafzimmer/Kueche einschalten (area + domain: ["light"])
+    3. mcp.weather.get_weather — Wetterbericht abrufen. Pruefe den MEMORY-KONTEXT fuer den Wohnort
+    4. mcp.calendar.list_events — Heutige Termine abrufen
+    5. Optional: Wenn der MEMORY-KONTEXT eine Morgen-Musik-Praeferenz enthaelt, spiele Musik ab
+    6. final_answer — Zusammenfassung: Wetter, Termine, ggf. Musik. Z.B.: "Guten Morgen! 14°C und sonnig. Um 9 Uhr: Standup, um 14 Uhr: Kundentermin."
+
+    === WICHTIGE REGELN ===
+    - Rufe IMMER zuerst internal.get_all_presence auf (Multi-User-Awareness)
+    - Wenn ein MCP-Server oder eine Entity nicht verfuegbar ist: Schritt UEBERSPRINGEN, keinen Fehler melden
+    - NIEMALS Lichter in Raeumen ausschalten, in denen andere Personen anwesend sind
+    - Offene Tueren/Fenster natuerlich und konversationell melden (z.B. "Die Terrassentuer steht noch offen"), NICHT als Sensor-ID-Liste
+    - Nutze den MEMORY-KONTEXT fuer Praeferenzen (bevorzugte Temperatur, Musik, etc.)
+    - ZEITCHECK: Wenn "Gute Nacht" morgens (vor 12 Uhr) oder "Guten Morgen" nachts (nach 22 Uhr) gesagt wird, weise freundlich darauf hin, fuehre die Routine aber trotzdem aus
+    - Nutze NUR Tools aus der Liste oben
+    - Rufe pro Antwort GENAU EIN Tool auf
+    - Die finale Antwort muss natuerlich und auf Deutsch sein
+    - Antworte NUR mit JSON
+
+    {step_directive}
+
   # Room context template (injected when user is in a detected room)
   room_context_template: |
     RAUM-KONTEXT: Der Benutzer befindet sich im Raum "{room_name}".
@@ -735,6 +805,76 @@ en:
     - Call EXACTLY ONE tool per response
     - NEVER invent IDs — fetch them via list/get tools
     - If a search tool returns 0 results, do NOT repeat the same search. Try: (1) Shorter query, (2) alternative spelling, (3) different tool. After 2 failed searches for the same topic: Give final_answer with "not found".
+    - The final answer must be natural and in English
+    - Reply ONLY with JSON
+
+    {step_directive}
+
+  # Routine agent prompt (Good Night / Good Morning sequences)
+  agent_prompt_routine: |
+    You are a routine agent. You execute multi-step good-night or good-morning sequences.
+
+    TASK: "{message}"
+
+    {room_context}
+
+    {tools_prompt}
+
+    {tool_corrections}
+
+    {history_prompt}
+
+    {conv_context}
+
+    {memory_context}
+
+    {document_context}
+
+    {personality_context}
+
+    RESPONSE FORMAT: Reply with EXACTLY ONE JSON object.
+
+    Call a tool:
+    {{"action": "<tool_name>", "parameters": {{...}}, "reason": "Why"}}
+
+    Done:
+    {{"action": "final_answer", "answer": "Your answer", "reason": "Why finished"}}
+
+    === DETECT ROUTINE ===
+    Determine from the message:
+    - "Gute Nacht", "Schlaf gut", "Ich gehe schlafen", "Good night" → GOOD-NIGHT ROUTINE
+    - "Guten Morgen", "Ich bin wach", "Aufgestanden", "Good morning" → GOOD-MORNING ROUTINE
+
+    === GOOD-NIGHT ROUTINE ===
+    Execute these steps in order (ONE tool per response):
+
+    1. internal.get_all_presence — Check who is home and in which rooms
+    2. mcp.homeassistant.HassTurnOff — Turn off lights in UNOCCUPIED rooms and common areas (area + domain: ["light"]). NEVER turn off lights in rooms where other people are present!
+    3. mcp.homeassistant.HassLightSet — Dim bedroom light (brightness: 10-30), if the user is there
+    4. internal.media_control — Stop active playback (action: "stop"), if any
+    5. mcp.homeassistant.GetLiveContext — Check door/window sensors (name: "binary_sensor", area: optional). Report open doors/windows conversationally, do NOT just list sensor IDs
+    6. mcp.calendar.list_events — Fetch tomorrow's events (mention only the first/most important one)
+    7. final_answer — Summary: what was done, open doors/windows, first appointment tomorrow. E.g.: "All done. The terrace door is still open. Tomorrow at 9 AM: Standup. Good night!"
+
+    === GOOD-MORNING ROUTINE ===
+    Execute these steps in order:
+
+    1. internal.get_all_presence — Check who is home
+    2. mcp.homeassistant.HassTurnOn — Turn on lights in bedroom/kitchen (area + domain: ["light"])
+    3. mcp.weather.get_weather — Get weather briefing. Check the MEMORY CONTEXT for the user's location
+    4. mcp.calendar.list_events — Fetch today's events
+    5. Optional: If the MEMORY CONTEXT contains a morning music preference, play music
+    6. final_answer — Summary: weather, events, possibly music. E.g.: "Good morning! 14°C and sunny. At 9 AM: Standup, at 2 PM: Client meeting."
+
+    === IMPORTANT RULES ===
+    - ALWAYS call internal.get_all_presence first (multi-user awareness)
+    - If an MCP server or entity is unavailable: SKIP the step, do not report an error
+    - NEVER turn off lights in rooms where other people are present
+    - Report open doors/windows naturally and conversationally (e.g. "The terrace door is still open"), NOT as sensor ID lists
+    - Use the MEMORY CONTEXT for preferences (preferred temperature, music, etc.)
+    - TIME CHECK: If "Good night" is said in the morning (before noon) or "Good morning" at night (after 10 PM), gently point it out but still execute the routine
+    - Use ONLY tools from the list above
+    - Call EXACTLY ONE tool per response
     - The final answer must be natural and in English
     - Reply ONLY with JSON
 

--- a/src/backend/prompts/router.yaml
+++ b/src/backend/prompts/router.yaml
@@ -18,6 +18,10 @@ de:
     (z.B. Kueche, Wohnzimmer, Buero, Schlafzimmer), ist das IMMER smart_home (nicht research).
     research ist NUR fuer Aussenwetter und Wettervorhersagen.
 
+    ROUTINEN: "Gute Nacht", "Guten Morgen", "Ich gehe schlafen", "Schlaf gut", "Good night",
+    "Good morning", "Ich bin wach", "Aufgestanden" → routine (mehrstufige Ablauefe).
+    ACHTUNG: Ein beilaeufiges "Morgen!" oder "Moin!" ohne weiteren Kontext ist Smalltalk (conversation), NICHT routine.
+
     Antworte NUR mit JSON: {{"role": "<kategorie>", "reason": "..."}}
 
   # Conversation history context template
@@ -41,6 +45,10 @@ en:
     IMPORTANT: When asking about temperature, humidity or sensor values in a ROOM
     (e.g. kitchen, living room, office, bedroom), this is ALWAYS smart_home (not research).
     research is ONLY for outdoor weather and weather forecasts.
+
+    ROUTINES: "Gute Nacht", "Guten Morgen", "Ich gehe schlafen", "Schlaf gut", "Good night",
+    "Good morning", "Ich bin wach", "Aufgestanden" → routine (multi-step sequences).
+    NOTE: A casual "Morgen!" or "Moin!" without further context is smalltalk (conversation), NOT routine.
 
     Reply ONLY with JSON: {{"role": "<category>", "reason": "..."}}
 

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -115,6 +115,11 @@
            dark:bg-gray-800 dark:border-gray-700;
 }
 
+@utility input-error {
+  @apply border-red-500 focus:ring-red-500
+         dark:border-red-500 dark:focus:ring-red-500;
+}
+
 @utility input {
   @apply w-full px-4 py-2 bg-white border border-gray-300 rounded-lg
            text-gray-900 placeholder-gray-500

--- a/src/frontend/src/pages/UsersPage.jsx
+++ b/src/frontend/src/pages/UsersPage.jsx
@@ -6,7 +6,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../context/AuthContext';
-import apiClient, { extractApiError } from '../utils/axios';
+import apiClient, { extractApiError, extractFieldErrors } from '../utils/axios';
 import Modal from '../components/Modal';
 import PageHeader from '../components/PageHeader';
 import Alert from '../components/Alert';
@@ -49,6 +49,7 @@ export default function UsersPage() {
   });
   const [showPassword, setShowPassword] = useState(false);
   const [formLoading, setFormLoading] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState({});
 
   // Load data
   const loadData = useCallback(async () => {
@@ -105,6 +106,7 @@ export default function UsersPage() {
       personality_prompt: ''
     });
     setShowPassword(false);
+    setFieldErrors({});
     setShowModal(true);
   };
 
@@ -123,7 +125,16 @@ export default function UsersPage() {
       personality_prompt: user.personality_prompt || ''
     });
     setShowPassword(false);
+    setFieldErrors({});
     setShowModal(true);
+  };
+
+  // Update form field and clear its error
+  const updateField = (field, value) => {
+    setFormData(prev => ({ ...prev, [field]: value }));
+    if (fieldErrors[field]) {
+      setFieldErrors(prev => { const next = { ...prev }; delete next[field]; return next; });
+    }
   };
 
   // Submit form
@@ -177,7 +188,12 @@ export default function UsersPage() {
       setShowModal(false);
       loadData();
     } catch (err) {
-      setError(extractApiError(err, t('users.failedToSave')));
+      const fields = extractFieldErrors(err);
+      if (Object.keys(fields).length > 0) {
+        setFieldErrors(fields);
+      } else {
+        setError(extractApiError(err, t('users.failedToSave')));
+      }
     } finally {
       setFormLoading(false);
     }
@@ -420,13 +436,16 @@ export default function UsersPage() {
             <input
               type="text"
               value={formData.username}
-              onChange={(e) => setFormData({ ...formData, username: e.target.value })}
-              className="input w-full"
+              onChange={(e) => updateField('username', e.target.value)}
+              className={`input w-full ${fieldErrors.username ? 'input-error' : ''}`}
               placeholder={t('auth.enterUsername')}
               required
               minLength={3}
               disabled={formLoading}
             />
+            {fieldErrors.username && (
+              <p className="mt-1 text-sm text-red-600 dark:text-red-400">{fieldErrors.username}</p>
+            )}
           </div>
 
           {/* First Name / Last Name */}
@@ -438,12 +457,15 @@ export default function UsersPage() {
               <input
                 type="text"
                 value={formData.first_name}
-                onChange={(e) => setFormData({ ...formData, first_name: e.target.value })}
-                className="input w-full"
+                onChange={(e) => updateField('first_name', e.target.value)}
+                className={`input w-full ${fieldErrors.first_name ? 'input-error' : ''}`}
                 placeholder={t('users.firstNamePlaceholder')}
                 maxLength={100}
                 disabled={formLoading}
               />
+              {fieldErrors.first_name && (
+                <p className="mt-1 text-sm text-red-600 dark:text-red-400">{fieldErrors.first_name}</p>
+              )}
             </div>
             <div>
               <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
@@ -452,12 +474,15 @@ export default function UsersPage() {
               <input
                 type="text"
                 value={formData.last_name}
-                onChange={(e) => setFormData({ ...formData, last_name: e.target.value })}
-                className="input w-full"
+                onChange={(e) => updateField('last_name', e.target.value)}
+                className={`input w-full ${fieldErrors.last_name ? 'input-error' : ''}`}
                 placeholder={t('users.lastNamePlaceholder')}
                 maxLength={100}
                 disabled={formLoading}
               />
+              {fieldErrors.last_name && (
+                <p className="mt-1 text-sm text-red-600 dark:text-red-400">{fieldErrors.last_name}</p>
+              )}
             </div>
           </div>
 
@@ -469,11 +494,14 @@ export default function UsersPage() {
             <input
               type="email"
               value={formData.email}
-              onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-              className="input w-full"
+              onChange={(e) => updateField('email', e.target.value)}
+              className={`input w-full ${fieldErrors.email ? 'input-error' : ''}`}
               placeholder={t('auth.emailPlaceholder')}
               disabled={formLoading}
             />
+            {fieldErrors.email && (
+              <p className="mt-1 text-sm text-red-600 dark:text-red-400">{fieldErrors.email}</p>
+            )}
           </div>
 
           {/* Password */}
@@ -486,8 +514,8 @@ export default function UsersPage() {
               <input
                 type={showPassword ? 'text' : 'password'}
                 value={formData.password}
-                onChange={(e) => setFormData({ ...formData, password: e.target.value })}
-                className="input w-full pr-10"
+                onChange={(e) => updateField('password', e.target.value)}
+                className={`input w-full pr-10 ${fieldErrors.password ? 'input-error' : ''}`}
                 placeholder={editingUser ? '••••••••' : t('auth.enterPassword')}
                 required={!editingUser}
                 minLength={8}
@@ -501,6 +529,9 @@ export default function UsersPage() {
                 {showPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
               </button>
             </div>
+            {fieldErrors.password && (
+              <p className="mt-1 text-sm text-red-600 dark:text-red-400">{fieldErrors.password}</p>
+            )}
           </div>
 
           {/* Role */}
@@ -510,8 +541,8 @@ export default function UsersPage() {
             </label>
             <select
               value={formData.role_id}
-              onChange={(e) => setFormData({ ...formData, role_id: e.target.value })}
-              className="input w-full"
+              onChange={(e) => updateField('role_id', e.target.value)}
+              className={`input w-full ${fieldErrors.role_id ? 'input-error' : ''}`}
               required
               disabled={formLoading}
             >
@@ -522,6 +553,9 @@ export default function UsersPage() {
                 </option>
               ))}
             </select>
+            {fieldErrors.role_id && (
+              <p className="mt-1 text-sm text-red-600 dark:text-red-400">{fieldErrors.role_id}</p>
+            )}
           </div>
 
           {/* Active */}
@@ -530,7 +564,7 @@ export default function UsersPage() {
               type="checkbox"
               id="is_active"
               checked={formData.is_active}
-              onChange={(e) => setFormData({ ...formData, is_active: e.target.checked })}
+              onChange={(e) => updateField('is_active', e.target.checked)}
               className="w-4 h-4 rounded-sm border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-700 text-primary-600 focus:ring-primary-500"
               disabled={formLoading}
             />
@@ -546,7 +580,7 @@ export default function UsersPage() {
             </label>
             <select
               value={formData.personality_style}
-              onChange={(e) => setFormData({ ...formData, personality_style: e.target.value })}
+              onChange={(e) => updateField('personality_style', e.target.value)}
               className="input w-full"
               disabled={formLoading}
             >
@@ -565,7 +599,7 @@ export default function UsersPage() {
             </label>
             <textarea
               value={formData.personality_prompt}
-              onChange={(e) => setFormData({ ...formData, personality_prompt: e.target.value })}
+              onChange={(e) => updateField('personality_prompt', e.target.value)}
               className="input w-full"
               rows={3}
               placeholder={t('users.personalityPromptPlaceholder')}

--- a/src/frontend/src/utils/axios.ts
+++ b/src/frontend/src/utils/axios.ts
@@ -33,6 +33,42 @@ apiClient.interceptors.response.use(
 );
 
 /**
+ * Extract per-field validation errors from a Pydantic 422 response.
+ * Returns a map of field name → error message. Empty {} for non-field errors.
+ */
+export function extractFieldErrors(err: unknown): Record<string, string> {
+  const resp = (err as AxiosError<{ detail?: unknown }>)?.response;
+  const detail = resp?.data?.detail;
+
+  // Pydantic 422: detail is an array of { loc, msg, type }
+  if (resp?.status === 422 && Array.isArray(detail)) {
+    const fields: Record<string, string> = {};
+    for (const d of detail) {
+      const loc = d.loc as string[] | undefined;
+      const msg = d.msg as string | undefined;
+      if (loc && msg) {
+        // loc is e.g. ["body", "username"] — take the last element as field name
+        const fieldName = loc[loc.length - 1];
+        if (fieldName && fieldName !== 'body') {
+          fields[fieldName] = msg;
+        }
+      }
+    }
+    if (Object.keys(fields).length > 0) return fields;
+  }
+
+  // Non-422 string detail with field name hints
+  if (typeof detail === 'string') {
+    const lower = detail.toLowerCase();
+    if (lower.includes('username')) return { username: detail };
+    if (lower.includes('email')) return { email: detail };
+    if (lower.includes('password')) return { password: detail };
+  }
+
+  return {};
+}
+
+/**
  * Extract a displayable error message from an Axios error.
  * Handles both simple string details and Pydantic 422 validation arrays.
  */

--- a/tests/backend/test_agent_router.py
+++ b/tests/backend/test_agent_router.py
@@ -39,6 +39,23 @@ SAMPLE_CONFIG = {
             "max_steps": 4,
             "prompt_key": "agent_prompt_smart_home",
         },
+        "routine": {
+            "description": {
+                "de": "Routinen: Gute-Nacht-Routine, Guten-Morgen-Routine",
+                "en": "Routines: good-night routine, good-morning routine",
+            },
+            "mcp_servers": ["homeassistant", "calendar", "weather", "jellyfin", "dlna", "radio"],
+            "internal_tools": [
+                "internal.get_all_presence",
+                "internal.get_user_location",
+                "internal.resolve_room_player",
+                "internal.media_control",
+                "internal.play_in_room",
+                "internal.play_radio",
+            ],
+            "max_steps": 15,
+            "prompt_key": "agent_prompt_routine",
+        },
         "research": {
             "description": {
                 "de": "Recherche: Websuche, Nachrichten, Wetter",
@@ -146,7 +163,7 @@ class TestParseRoles:
     @pytest.mark.unit
     def test_parse_all_roles(self):
         roles = _parse_roles(SAMPLE_CONFIG)
-        assert len(roles) == 9
+        assert len(roles) == 10
         assert "smart_home" in roles
         assert "research" in roles
         assert "documents" in roles
@@ -248,7 +265,7 @@ class TestFilterAvailableRoles:
     def test_no_filter_keeps_all(self):
         roles = _parse_roles(SAMPLE_CONFIG)
         filtered = _filter_available_roles(roles, connected_servers=None)
-        assert len(filtered) == 9
+        assert len(filtered) == 10
 
     @pytest.mark.unit
     def test_filter_excludes_unavailable_servers(self):
@@ -302,7 +319,7 @@ class TestAgentRouter:
     @pytest.mark.unit
     def test_init_without_mcp(self):
         router = AgentRouter(SAMPLE_CONFIG)
-        assert len(router.roles) == 9
+        assert len(router.roles) == 10
 
     @pytest.mark.unit
     def test_init_with_mcp_filter(self):
@@ -665,3 +682,109 @@ class TestPrebuiltRoles:
         assert GENERAL_ROLE.name == "general"
         assert GENERAL_ROLE.mcp_servers is None
         assert GENERAL_ROLE.max_steps == 12
+
+
+# ============================================================================
+# Test Routine Role
+# ============================================================================
+
+class TestRoutineRole:
+    """Test the routine role for good-night / good-morning sequences."""
+
+    @pytest.mark.unit
+    def test_routine_role_properties(self):
+        roles = _parse_roles(SAMPLE_CONFIG)
+        role = roles["routine"]
+        assert role.name == "routine"
+        assert role.max_steps == 15
+        assert role.prompt_key == "agent_prompt_routine"
+        assert role.has_agent_loop is True
+        assert "homeassistant" in role.mcp_servers
+        assert "calendar" in role.mcp_servers
+        assert "weather" in role.mcp_servers
+        assert "internal.get_all_presence" in role.internal_tools
+        assert "internal.media_control" in role.internal_tools
+
+    @pytest.mark.unit
+    def test_routine_role_available_with_homeassistant(self):
+        """Routine role is available when at least one of its MCP servers is connected."""
+        roles = _parse_roles(SAMPLE_CONFIG)
+        filtered = _filter_available_roles(roles, connected_servers=["homeassistant"])
+        assert "routine" in filtered
+
+    @pytest.mark.unit
+    def test_routine_role_unavailable_without_servers(self):
+        """Routine role is excluded when none of its MCP servers are connected."""
+        roles = _parse_roles(SAMPLE_CONFIG)
+        filtered = _filter_available_roles(roles, connected_servers=[])
+        assert "routine" not in filtered
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_classify_gute_nacht(self):
+        """'Gute Nacht' is classified as routine."""
+        ollama = make_mock_ollama('{"role": "routine", "reason": "Gute-Nacht-Routine"}')
+        router = AgentRouter(SAMPLE_CONFIG)
+
+        with patch("services.agent_router.settings") as mock_settings:
+            mock_settings.ollama_intent_model = "test-model"
+            mock_settings.ollama_model = "test-model"
+            mock_settings.agent_ollama_url = None
+
+            role = await router.classify("Gute Nacht", ollama)
+            assert role.name == "routine"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_classify_guten_morgen(self):
+        """'Guten Morgen' is classified as routine."""
+        ollama = make_mock_ollama('{"role": "routine", "reason": "Guten-Morgen-Routine"}')
+        router = AgentRouter(SAMPLE_CONFIG)
+
+        with patch("services.agent_router.settings") as mock_settings:
+            mock_settings.ollama_intent_model = "test-model"
+            mock_settings.ollama_model = "test-model"
+            mock_settings.agent_ollama_url = None
+
+            role = await router.classify("Guten Morgen", ollama)
+            assert role.name == "routine"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_classify_ich_gehe_schlafen(self):
+        """'Ich gehe schlafen' is classified as routine."""
+        ollama = make_mock_ollama('{"role": "routine", "reason": "Schlafenszeit"}')
+        router = AgentRouter(SAMPLE_CONFIG)
+
+        with patch("services.agent_router.settings") as mock_settings:
+            mock_settings.ollama_intent_model = "test-model"
+            mock_settings.ollama_model = "test-model"
+            mock_settings.agent_ollama_url = None
+
+            role = await router.classify("Ich gehe schlafen", ollama)
+            assert role.name == "routine"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_classify_casual_morgen_as_conversation(self):
+        """Casual 'Morgen!' is classified as conversation, not routine."""
+        ollama = make_mock_ollama('{"role": "conversation", "reason": "Beilaeufiger Gruss"}')
+        router = AgentRouter(SAMPLE_CONFIG)
+
+        with patch("services.agent_router.settings") as mock_settings:
+            mock_settings.ollama_intent_model = "test-model"
+            mock_settings.ollama_model = "test-model"
+            mock_settings.agent_ollama_url = None
+
+            role = await router.classify("Morgen!", ollama)
+            assert role.name == "conversation"
+
+    @pytest.mark.unit
+    def test_routine_in_actual_config(self):
+        """Verify that the actual agent_roles.yaml contains the routine role."""
+        config = load_roles_config("config/agent_roles.yaml")
+        assert "routine" in config["roles"]
+        role_cfg = config["roles"]["routine"]
+        assert "homeassistant" in role_cfg["mcp_servers"]
+        assert role_cfg["max_steps"] == 15
+        assert role_cfg["prompt_key"] == "agent_prompt_routine"

--- a/tests/backend/test_routine_agent.py
+++ b/tests/backend/test_routine_agent.py
@@ -1,0 +1,425 @@
+"""
+Tests for the Routine Agent — Good Night / Good Morning multi-step sequences.
+
+Verifies:
+- Presence check is always called first
+- Graceful degradation when MCP servers are unavailable
+- Multi-user awareness (don't turn off occupied rooms)
+- Correct prompt key and step limits from role config
+"""
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Ensure 'ollama' module is available even when the package isn't installed.
+if "ollama" not in sys.modules:
+    _ollama_stub = MagicMock()
+    _ollama_stub.AsyncClient = MagicMock()
+    sys.modules["ollama"] = _ollama_stub
+
+from services.agent_router import _parse_roles
+from services.agent_service import AgentService
+from services.agent_tools import AgentToolRegistry
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+async def collect_steps(agent, **kwargs) -> list:
+    """Collect all steps from an agent run."""
+    steps = []
+    async for step in agent.run(**kwargs):
+        steps.append(step)
+    return steps
+
+
+def _make_mock_agent_client(responses: list[str]):
+    """Create a mock LLM client whose chat() returns successive JSON responses.
+
+    This mocks the client returned by get_agent_client(), NOT ollama.client.
+    The agent_service.run() calls get_agent_client() to create its own client.
+    """
+    call_count = 0
+
+    async def mock_chat(**kwargs):
+        nonlocal call_count
+        idx = min(call_count, len(responses) - 1)
+        call_count += 1
+        resp = MagicMock()
+        resp.message = MagicMock()
+        resp.message.content = responses[idx]
+        return resp
+
+    client = MagicMock()
+    client.chat = mock_chat
+    return client
+
+
+def _make_ollama_mock():
+    """Create a minimal mock OllamaService (used for lang detection, not LLM calls)."""
+    ollama = MagicMock()
+    ollama.default_lang = "de"
+    ollama.client = MagicMock()
+    return ollama
+
+
+def _make_executor_mock(results=None):
+    """Create a mock ActionExecutor."""
+    executor = AsyncMock()
+    if results:
+        executor.execute = AsyncMock(side_effect=results)
+    else:
+        executor.execute = AsyncMock(return_value={
+            "success": True,
+            "message": "Aktion ausgefuehrt",
+            "action_taken": True,
+        })
+    return executor
+
+
+ROUTINE_ROLE_CONFIG = {
+    "roles": {
+        "routine": {
+            "description": {
+                "de": "Routinen: Gute-Nacht-Routine, Guten-Morgen-Routine",
+                "en": "Routines: good-night routine, good-morning routine",
+            },
+            "mcp_servers": ["homeassistant", "calendar", "weather", "jellyfin", "dlna", "radio"],
+            "internal_tools": [
+                "internal.get_all_presence",
+                "internal.get_user_location",
+                "internal.resolve_room_player",
+                "internal.media_control",
+                "internal.play_in_room",
+                "internal.play_radio",
+            ],
+            "max_steps": 15,
+            "prompt_key": "agent_prompt_routine",
+        },
+        "conversation": {
+            "description": {"de": "Konversation", "en": "Conversation"},
+        },
+        "general": {
+            "description": {"de": "Allgemein", "en": "General"},
+            "mcp_servers": None,
+            "internal_tools": None,
+            "max_steps": 12,
+            "prompt_key": "agent_prompt",
+        },
+    }
+}
+
+
+# ============================================================================
+# Test Routine Role Configuration
+# ============================================================================
+
+class TestRoutineRoleConfig:
+    """Test that the routine role is configured correctly."""
+
+    @pytest.mark.unit
+    def test_routine_role_parsed(self):
+        roles = _parse_roles(ROUTINE_ROLE_CONFIG)
+        assert "routine" in roles
+        role = roles["routine"]
+        assert role.max_steps == 15
+        assert role.prompt_key == "agent_prompt_routine"
+        assert role.has_agent_loop is True
+
+    @pytest.mark.unit
+    def test_routine_role_tools(self):
+        roles = _parse_roles(ROUTINE_ROLE_CONFIG)
+        role = roles["routine"]
+        assert "internal.get_all_presence" in role.internal_tools
+        assert "internal.get_user_location" in role.internal_tools
+        assert "internal.media_control" in role.internal_tools
+        assert "internal.play_in_room" in role.internal_tools
+        assert "internal.play_radio" in role.internal_tools
+
+    @pytest.mark.unit
+    def test_routine_role_mcp_servers(self):
+        roles = _parse_roles(ROUTINE_ROLE_CONFIG)
+        role = roles["routine"]
+        assert "homeassistant" in role.mcp_servers
+        assert "calendar" in role.mcp_servers
+        assert "weather" in role.mcp_servers
+
+    @pytest.mark.unit
+    def test_agent_service_uses_routine_role(self):
+        """AgentService respects routine role max_steps and prompt_key."""
+        roles = _parse_roles(ROUTINE_ROLE_CONFIG)
+        role = roles["routine"]
+
+        registry = AgentToolRegistry(
+            internal_filter=role.internal_tools,
+        )
+        agent = AgentService(registry, role=role)
+
+        assert agent.max_steps == 15
+        assert agent._prompt_key == "agent_prompt_routine"
+
+    @pytest.mark.unit
+    def test_routine_tool_registry_filters_internal_tools(self):
+        """Tool registry only includes routine-allowed internal tools."""
+        roles = _parse_roles(ROUTINE_ROLE_CONFIG)
+        role = roles["routine"]
+
+        registry = AgentToolRegistry(
+            server_filter=role.mcp_servers,
+            internal_filter=role.internal_tools,
+        )
+
+        tool_names = registry.get_tool_names()
+        # Without MCP manager, only internal tools are registered
+        for name in tool_names:
+            assert name in role.internal_tools, f"Unexpected tool: {name}"
+
+
+# ============================================================================
+# Test Routine Agent Execution
+# ============================================================================
+
+class TestRoutineAgentExecution:
+    """Test the routine agent's multi-step execution via mocked LLM + executor."""
+
+    def _make_routine_agent(self):
+        """Create an AgentService configured with the routine role."""
+        roles = _parse_roles(ROUTINE_ROLE_CONFIG)
+        role = roles["routine"]
+        registry = AgentToolRegistry(internal_filter=role.internal_tools)
+        return AgentService(registry, role=role)
+
+    def _patch_agent_deps(self, llm_responses: list[str]):
+        """Return a context manager that patches agent_service dependencies.
+
+        Mocks: settings, prompt_manager, get_agent_client.
+        """
+        mock_client = _make_mock_agent_client(llm_responses)
+
+        settings_patch = patch("services.agent_service.settings")
+        pm_patch = patch("services.agent_service.prompt_manager")
+        client_patch = patch(
+            "services.agent_service.get_agent_client",
+            return_value=(mock_client, "http://mock:11434"),
+        )
+
+        class _Combined:
+            def __enter__(self_inner):
+                mock_settings = settings_patch.start()
+                mock_pm = pm_patch.start()
+                client_patch.start()
+
+                mock_settings.agent_max_steps = 15
+                mock_settings.agent_step_timeout = 30.0
+                mock_settings.agent_total_timeout = 120.0
+                mock_settings.ollama_model = "test-model"
+                mock_settings.agent_ollama_url = None
+                mock_settings.agent_model = None
+                mock_pm.get.return_value = "Du bist ein Routine-Agent. AUFGABE: {message}"
+                return self_inner
+
+            def __exit__(self_inner, *args):
+                settings_patch.stop()
+                pm_patch.stop()
+                client_patch.stop()
+
+        return _Combined()
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_good_night_calls_presence_first(self):
+        """Good night routine should call get_all_presence as the first tool."""
+        agent = self._make_routine_agent()
+
+        responses = [
+            '{"action": "internal.get_all_presence", "parameters": {}, "reason": "Pruefe wer zuhause ist"}',
+            '{"action": "final_answer", "answer": "Gute Nacht! Alle Lichter aus.", "reason": "Routine abgeschlossen"}',
+        ]
+        executor = _make_executor_mock([
+            {"success": True, "message": "Erik: Schlafzimmer", "action_taken": True},
+        ])
+
+        with self._patch_agent_deps(responses):
+            steps = await collect_steps(
+                agent,
+                message="Gute Nacht",
+                ollama=_make_ollama_mock(),
+                executor=executor,
+            )
+
+        tool_calls = [s for s in steps if s.step_type == "tool_call"]
+        assert len(tool_calls) >= 1
+        assert tool_calls[0].tool == "internal.get_all_presence"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_good_morning_calls_presence_first(self):
+        """Good morning routine should also call get_all_presence as the first tool."""
+        agent = self._make_routine_agent()
+
+        responses = [
+            '{"action": "internal.get_all_presence", "parameters": {}, "reason": "Check who is home"}',
+            '{"action": "final_answer", "answer": "Guten Morgen! 14 Grad und sonnig.", "reason": "Routine done"}',
+        ]
+        executor = _make_executor_mock([
+            {"success": True, "message": "Erik: Schlafzimmer", "action_taken": True},
+        ])
+
+        with self._patch_agent_deps(responses):
+            steps = await collect_steps(
+                agent,
+                message="Guten Morgen",
+                ollama=_make_ollama_mock(),
+                executor=executor,
+            )
+
+        tool_calls = [s for s in steps if s.step_type == "tool_call"]
+        assert len(tool_calls) >= 1
+        assert tool_calls[0].tool == "internal.get_all_presence"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_graceful_degradation_on_tool_failure(self):
+        """Routine should continue to final_answer even when a tool fails."""
+        agent = self._make_routine_agent()
+
+        responses = [
+            '{"action": "internal.get_all_presence", "parameters": {}, "reason": "Presence check"}',
+            '{"action": "final_answer", "answer": "Gute Nacht! Kalender war nicht erreichbar.", "reason": "Kalender uebersprungen"}',
+        ]
+        executor = _make_executor_mock([
+            {"success": False, "message": "MCP server unavailable", "action_taken": False},
+        ])
+
+        with self._patch_agent_deps(responses):
+            steps = await collect_steps(
+                agent,
+                message="Gute Nacht",
+                ollama=_make_ollama_mock(),
+                executor=executor,
+            )
+
+        # Should still reach final_answer despite tool failure
+        final_steps = [s for s in steps if s.step_type == "final_answer"]
+        assert len(final_steps) == 1
+        assert "Gute Nacht" in final_steps[0].content
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_multi_step_good_night_sequence(self):
+        """Full good-night sequence with presence → media_control → final_answer."""
+        agent = self._make_routine_agent()
+
+        responses = [
+            '{"action": "internal.get_all_presence", "parameters": {}, "reason": "Wer ist zuhause?"}',
+            '{"action": "internal.media_control", "parameters": {"action": "stop"}, "reason": "Wiedergabe stoppen"}',
+            '{"action": "final_answer", "answer": "Alles erledigt. Gute Nacht!", "reason": "Routine fertig"}',
+        ]
+        executor = _make_executor_mock([
+            {"success": True, "message": "Erik: Schlafzimmer, Lisa: Wohnzimmer", "action_taken": True},
+            {"success": True, "message": "Playback stopped", "action_taken": True},
+        ])
+
+        with self._patch_agent_deps(responses):
+            steps = await collect_steps(
+                agent,
+                message="Gute Nacht",
+                ollama=_make_ollama_mock(),
+                executor=executor,
+            )
+
+        tool_calls = [s for s in steps if s.step_type == "tool_call"]
+        assert len(tool_calls) == 2
+        assert tool_calls[0].tool == "internal.get_all_presence"
+        assert tool_calls[1].tool == "internal.media_control"
+
+        final_steps = [s for s in steps if s.step_type == "final_answer"]
+        assert len(final_steps) == 1
+
+
+# ============================================================================
+# Test Routine Prompt Loading
+# ============================================================================
+
+class TestRoutinePromptLoading:
+    """Test that routine prompts are loadable from agent.yaml."""
+
+    @pytest.mark.unit
+    def test_routine_prompt_exists_in_yaml(self):
+        """Verify agent_prompt_routine is defined in the actual agent.yaml."""
+        from pathlib import Path
+
+        import yaml
+
+        agent_yaml_path = Path("src/backend/prompts/agent.yaml")
+        if not agent_yaml_path.exists():
+            pytest.skip("agent.yaml not found (running outside project root)")
+
+        with open(agent_yaml_path) as f:
+            prompts = yaml.safe_load(f)
+
+        # Check DE prompt
+        assert "agent_prompt_routine" in prompts["de"]
+        de_prompt = prompts["de"]["agent_prompt_routine"]
+        assert "Routine-Agent" in de_prompt
+        assert "GUTE-NACHT-ROUTINE" in de_prompt
+        assert "GUTEN-MORGEN-ROUTINE" in de_prompt
+        assert "internal.get_all_presence" in de_prompt
+        assert "{message}" in de_prompt
+
+        # Check EN prompt
+        assert "agent_prompt_routine" in prompts["en"]
+        en_prompt = prompts["en"]["agent_prompt_routine"]
+        assert "routine agent" in en_prompt.lower()
+        assert "GOOD-NIGHT ROUTINE" in en_prompt
+        assert "GOOD-MORNING ROUTINE" in en_prompt
+        assert "internal.get_all_presence" in en_prompt
+
+    @pytest.mark.unit
+    def test_routine_prompt_has_required_variables(self):
+        """Verify the routine prompt includes all required template variables."""
+        from pathlib import Path
+
+        import yaml
+
+        agent_yaml_path = Path("src/backend/prompts/agent.yaml")
+        if not agent_yaml_path.exists():
+            pytest.skip("agent.yaml not found (running outside project root)")
+
+        with open(agent_yaml_path) as f:
+            prompts = yaml.safe_load(f)
+
+        for lang in ("de", "en"):
+            prompt = prompts[lang]["agent_prompt_routine"]
+            assert "{message}" in prompt, f"Missing {{message}} in {lang}"
+            assert "{tools_prompt}" in prompt, f"Missing {{tools_prompt}} in {lang}"
+            assert "{step_directive}" in prompt, f"Missing {{step_directive}} in {lang}"
+            assert "{memory_context}" in prompt, f"Missing {{memory_context}} in {lang}"
+            assert "{room_context}" in prompt, f"Missing {{room_context}} in {lang}"
+
+    @pytest.mark.unit
+    def test_router_yaml_has_routine_hints(self):
+        """Verify router.yaml contains routine classification guidance."""
+        from pathlib import Path
+
+        import yaml
+
+        router_yaml_path = Path("src/backend/prompts/router.yaml")
+        if not router_yaml_path.exists():
+            pytest.skip("router.yaml not found (running outside project root)")
+
+        with open(router_yaml_path) as f:
+            router_prompts = yaml.safe_load(f)
+
+        # DE router prompt should mention routine triggers
+        de_prompt = router_prompts["de"]["classify_prompt"]
+        assert "routine" in de_prompt.lower()
+        assert "Gute Nacht" in de_prompt
+        assert "Guten Morgen" in de_prompt
+
+        # EN router prompt should mention routine triggers
+        en_prompt = router_prompts["en"]["classify_prompt"]
+        assert "routine" in en_prompt.lower()
+        assert "Good night" in en_prompt
+        assert "Good morning" in en_prompt


### PR DESCRIPTION
## Summary

Closes #271

- Adds a new `routine` agent role that orchestrates multi-step Good Night / Good Morning smart home sequences
- Uses the existing agent loop with a specialized prompt — no new models, services, or hooks needed
- The LLM handles all adaptive logic: presence awareness, room context, memory preferences, graceful degradation

## Changes

- **`config/agent_roles.yaml`** — New `routine` role (15 max steps, 6 MCP servers, 6 internal tools)
- **`src/backend/prompts/agent.yaml`** — New `agent_prompt_routine` (DE + EN) with sequenced Good Night / Good Morning steps
- **`src/backend/prompts/router.yaml`** — Routine classification hints (DE + EN), distinguishes "Gute Nacht" from casual "Morgen!"
- **`tests/backend/test_agent_router.py`** — 8 new routine classification + role tests
- **`tests/backend/test_routine_agent.py`** — 12 new tests: role config, agent execution (presence-first, degradation, multi-step), prompt validation

## Test plan

- [x] `python3 -m pytest tests/backend/test_agent_router.py tests/backend/test_routine_agent.py` — 64 passed
- [x] `ruff check` — clean
- [ ] Manual: Send "Gute Nacht" → routes to `routine`, executes multi-step sequence
- [ ] Manual: Send "Guten Morgen" → weather + calendar briefing
- [ ] Manual: Disable calendar MCP → routine skips calendar step without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)