### PR TITLE
feat(whatsapp): Schellen Reservierung → WhatsApp-Benachrichtigung

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,14 @@ HOME_ASSISTANT_URL=http://homeassistant.local:8123
 # MAIL_ACCOUNTS_CONFIG=/config/mail_accounts.yaml
 # MAIL_REGFISH_PASSWORD=                  # (Produktion: secrets/mail_regfish_password)
 
+# Evolution API (WhatsApp — self-hosted, Profile: whatsapp)
+# EVOLUTION_API_KEY=                      # Starker zufaelliger Key fuer Evolution API Auth
+# EVOLUTION_API_URL=http://evolution-api:8080  # Docker-interne URL (n8n → Evolution)
+
+# Gaststaette Schellen Reservierung
+# MAIL_SCHELLEN_PASSWORD=                 # IMAP/SMTP Passwort (Regfish)
+# WHATSAPP_RAMONA_NUMBER=                 # WhatsApp-Nummer, Format: 49XXXXXXXXX
+
 # Frigate (Kamera-System)
 FRIGATE_URL=http://frigate.local:5000
 

--- a/config/mail_accounts.yaml
+++ b/config/mail_accounts.yaml
@@ -14,3 +14,19 @@ accounts:
       method: password
       username: 41172-001b
       password_env: MAIL_REGFISH_PASSWORD
+
+  - name: schellen
+    email: info@gaststaette-schellen.de
+    provider: generic
+    imap:
+      host: mailserv.regfish.com
+      port: 993
+      security: ssl
+    smtp:
+      host: mailserv.regfish.com
+      port: 587
+      security: starttls
+    auth:
+      method: password
+      username: info@gaststaette-schellen.de
+      password_env: MAIL_SCHELLEN_PASSWORD

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -251,6 +251,38 @@ services:
       retries: 3
       start_period: 10s
 
+  # Evolution API (WhatsApp via self-hosted API)
+  # Aktiviere mit: docker compose --profile whatsapp up -d evolution-api
+  evolution-api:
+    image: atendai/evolution-api:v2.1.1
+    container_name: renfield-evolution-api
+    environment:
+      SERVER_TYPE: http
+      SERVER_PORT: 8080
+      SERVER_URL: http://evolution-api:8080
+      AUTHENTICATION_API_KEY: ${EVOLUTION_API_KEY:-changeme}
+      DATABASE_PROVIDER: postgresql
+      DATABASE_CONNECTION_URI: postgresql://renfield:${POSTGRES_PASSWORD:-changeme}@postgres:5432/evolution
+      CACHE_REDIS_ENABLED: "true"
+      CACHE_REDIS_URI: redis://redis:6379/3
+      CACHE_REDIS_PREFIX_KEY: evolution
+      CACHE_LOCAL_ENABLED: "false"
+      LOG_LEVEL: WARN
+    volumes:
+      - evolution_instances:/evolution/instances
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - renfield-network
+    ports:
+      - "127.0.0.1:8080:8080"
+    restart: unless-stopped
+    profiles:
+      - whatsapp
+
 networks:
   renfield-network:
     driver: bridge
@@ -264,6 +296,7 @@ volumes:
   huggingface_cache:
   rag_uploads:        # RAG document uploads
   calendar_tokens:    # Google Calendar OAuth2 token persistence
+  evolution_instances: # WhatsApp session data (Evolution API)
 
 secrets:
   postgres_password:

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -937,6 +937,59 @@ PAPERLESS_API_URL=http://paperless.local:8000
 
 ---
 
+## Evolution API (WhatsApp)
+
+Self-hosted WhatsApp API via [Evolution API](https://github.com/EvolutionAPI/evolution-api). Laeuft als Docker-Service mit Profile `whatsapp`.
+
+```bash
+# Evolution API Auth Key (starker zufaelliger Wert)
+EVOLUTION_API_KEY=changeme
+
+# Docker-interne URL (n8n → Evolution API)
+EVOLUTION_API_URL=http://evolution-api:8080
+```
+
+**Defaults:**
+- `EVOLUTION_API_KEY`: `changeme` (MUSS in Produktion geaendert werden!)
+- `EVOLUTION_API_URL`: `http://evolution-api:8080`
+
+**Setup:**
+1. `CREATE DATABASE evolution OWNER renfield;` in PostgreSQL
+2. `docker compose --profile whatsapp up -d evolution-api`
+3. WhatsApp-Instanz erstellen + QR-Code scannen
+4. Test-Nachricht senden zur Verifikation
+
+**Infrastruktur:**
+- Nutzt bestehende PostgreSQL (separate DB `evolution`) und Redis (Index 3)
+- Nur lokal erreichbar (127.0.0.1:8080), n8n greift via Docker-Netzwerk zu
+- Volume `evolution_instances` fuer WhatsApp-Session-Daten
+
+---
+
+### Gaststaette Schellen (Reservierung → WhatsApp)
+
+n8n-Workflow fuer automatische Reservierungserkennung per E-Mail mit WhatsApp-Benachrichtigung.
+
+```bash
+# IMAP/SMTP Passwort fuer info@gaststaette-schellen.de (Regfish)
+MAIL_SCHELLEN_PASSWORD=
+
+# WhatsApp-Nummer der Empfaengerin (Format: 49XXXXXXXXX, ohne +)
+WHATSAPP_RAMONA_NUMBER=
+```
+
+**E-Mail-Konto:** Konfiguriert in `config/mail_accounts.yaml` (Name: `schellen`).
+
+**n8n-Workflow:** `docs/n8n-workflows/schellen-reservation-whatsapp.json` — importieren und IMAP/SMTP Credentials anlegen.
+
+**Ablauf:**
+1. IMAP Trigger pollt `info@gaststaette-schellen.de` auf neue E-Mails
+2. Ollama klassifiziert: Reservierung oder nicht?
+3. Bei Reservierung: WhatsApp an Ramona mit extrahierten Details
+4. Wenn keine Telefonnummer: automatische Rueckfrage-Mail an Absender
+
+---
+
 ## Hook / Extension System
 
 Das Hook-System ermöglicht externen Paketen (z.B. `renfield-twin`) sich an definierten Lifecycle-Stellen einzuhängen, ohne dass renfield eine Abhängigkeit zum Plugin hat.

--- a/docs/n8n-workflows/schellen-reservation-whatsapp.json
+++ b/docs/n8n-workflows/schellen-reservation-whatsapp.json
@@ -1,0 +1,262 @@
+{
+  "name": "Schellen Reservierung → WhatsApp",
+  "nodes": [
+    {
+      "parameters": {
+        "mailbox": "INBOX",
+        "postProcessAction": "read",
+        "format": "simple",
+        "options": {
+          "customEmailConfig": "[\"UNSEEN\"]"
+        }
+      },
+      "id": "b2d3e5f7-2001-4b00-c001-000000000001",
+      "name": "IMAP Trigger",
+      "type": "n8n-nodes-base.emailReadImap",
+      "typeVersion": 2.1,
+      "position": [240, 300],
+      "credentials": {
+        "imap": {
+          "id": "IMAP_CREDENTIAL_ID",
+          "name": "Schellen IMAP"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extract email content for LLM classification\nconst item = $input.first().json;\n\nconst subject = item.subject || '';\nconst from = item.from?.text || item.from || '';\nconst textBody = item.text || item.textPlain || '';\nconst htmlBody = item.html || '';\n\n// Prefer text body, fall back to stripping HTML\nlet body = textBody;\nif (!body && htmlBody) {\n  body = htmlBody.replace(/<[^>]*>/g, ' ').replace(/\\s+/g, ' ').trim();\n}\n\n// Truncate to avoid overloading the LLM\nif (body.length > 2000) {\n  body = body.substring(0, 2000) + '...';\n}\n\nreturn [{\n  json: {\n    subject,\n    from,\n    body,\n    received_at: item.date || new Date().toISOString()\n  }\n}];\n"
+      },
+      "id": "b2d3e5f7-2001-4b00-c001-000000000002",
+      "name": "Extract Content",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [480, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.OLLAMA_URL || 'http://ollama:11434' }}/api/generate",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": \"{{ $env.OLLAMA_INTENT_MODEL || 'qwen3:8b' }}\",\n  \"prompt\": \"Du bist ein Klassifikations-Assistent fuer die Gaststaette Schellen. Analysiere die folgende E-Mail und extrahiere Reservierungsinformationen.\\n\\nE-Mail:\\nBetreff: {{ $json.subject }}\\nVon: {{ $json.from }}\\nInhalt: {{ $json.body }}\\n\\nAntworte NUR mit einem JSON-Objekt (keine Erklaerung, kein Markdown):\\n{\\n  \\\"is_reservation\\\": true/false,\\n  \\\"name\\\": \\\"Name des Gastes oder leer\\\",\\n  \\\"date\\\": \\\"YYYY-MM-DD oder leer\\\",\\n  \\\"time\\\": \\\"HH:MM oder leer\\\",\\n  \\\"party_size\\\": Anzahl oder null,\\n  \\\"phone_number\\\": \\\"Telefonnummer oder leer\\\",\\n  \\\"special_requests\\\": \\\"Sonderwuensche oder leer\\\"\\n}\\n\\nRegeln:\\n- is_reservation=true wenn es eine Tischreservierung oder Platzanfrage ist\\n- is_reservation=false bei Fragen zum Menu, Oeffnungszeiten, Bewerbungen, Werbung, etc.\\n- Extrahiere alle verfuegbaren Informationen, lasse Felder leer wenn nicht erwaehnt\\n- Telefonnummer: alle Formate akzeptieren (0171-123456, +49 171 123456, etc.)\",\n  \"format\": \"json\",\n  \"stream\": false,\n  \"options\": {\n    \"temperature\": 0.1,\n    \"num_ctx\": 4096\n  }\n}",
+        "options": {
+          "timeout": 60000
+        }
+      },
+      "id": "b2d3e5f7-2001-4b00-c001-000000000003",
+      "name": "Classify (Ollama)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [720, 300],
+      "retryOnFail": true,
+      "maxTries": 2,
+      "waitBetweenTries": 3000
+    },
+    {
+      "parameters": {
+        "jsCode": "// Parse LLM JSON response with fallback handling\nconst item = $input.first().json;\nconst prevData = $('Extract Content').first().json;\n\nlet parsed;\ntry {\n  // Ollama returns { response: \"...json string...\" }\n  const raw = item.response || '';\n  parsed = JSON.parse(raw);\n} catch (e) {\n  // If JSON parsing fails, treat as non-reservation\n  parsed = {\n    is_reservation: false,\n    name: '',\n    date: '',\n    time: '',\n    party_size: null,\n    phone_number: '',\n    special_requests: '',\n    parse_error: e.message\n  };\n}\n\nreturn [{\n  json: {\n    ...parsed,\n    // Carry forward email metadata\n    email_from: prevData.from,\n    email_subject: prevData.subject,\n    received_at: prevData.received_at\n  }\n}];\n"
+      },
+      "id": "b2d3e5f7-2001-4b00-c001-000000000004",
+      "name": "Parse Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [960, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "cond-is-reservation",
+              "leftValue": "={{ $json.is_reservation }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        }
+      },
+      "id": "b2d3e5f7-2001-4b00-c001-000000000005",
+      "name": "Is Reservation?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1200, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Format WhatsApp message for Ramona (German)\nconst d = $input.first().json;\n\nconst lines = [\n  '*Neue Reservierungsanfrage per E-Mail*',\n  ''\n];\n\nif (d.name) lines.push(`Name: ${d.name}`);\nif (d.date) lines.push(`Datum: ${d.date}`);\nif (d.time) lines.push(`Uhrzeit: ${d.time}`);\nif (d.party_size) lines.push(`Personen: ${d.party_size}`);\nif (d.phone_number) {\n  lines.push(`Telefon: ${d.phone_number}`);\n} else {\n  lines.push('Telefon: _nicht angegeben_');\n}\nif (d.special_requests) {\n  lines.push(`Sonderwuensche: ${d.special_requests}`);\n}\n\nlines.push('');\nlines.push(`Absender: ${d.email_from}`);\n\nreturn [{\n  json: {\n    ...d,\n    whatsapp_message: lines.join('\\n')\n  }\n}];\n"
+      },
+      "id": "b2d3e5f7-2001-4b00-c001-000000000006",
+      "name": "Format Message",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1440, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.EVOLUTION_API_URL || 'http://evolution-api:8080' }}/message/sendText/schellen",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "apikey",
+              "value": "={{ $env.EVOLUTION_API_KEY }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"number\": \"{{ $env.WHATSAPP_RAMONA_NUMBER }}\",\n  \"text\": {{ JSON.stringify($json.whatsapp_message) }}\n}",
+        "options": {
+          "timeout": 15000
+        }
+      },
+      "id": "b2d3e5f7-2001-4b00-c001-000000000007",
+      "name": "Send WhatsApp",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1680, 200],
+      "retryOnFail": true,
+      "maxTries": 2,
+      "waitBetweenTries": 3000
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose"
+          },
+          "conditions": [
+            {
+              "id": "cond-no-phone",
+              "leftValue": "={{ $('Parse Response').first().json.phone_number }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        }
+      },
+      "id": "b2d3e5f7-2001-4b00-c001-000000000008",
+      "name": "Has Phone?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1920, 200]
+    },
+    {
+      "parameters": {
+        "fromEmail": "Gaststaette Schellen <info@gaststaette-schellen.de>",
+        "toEmail": "={{ $('Parse Response').first().json.email_from }}",
+        "subject": "Re: {{ $('Extract Content').first().json.subject }}",
+        "emailType": "text",
+        "message": "Guten Tag{{ $('Parse Response').first().json.name ? ' ' + $('Parse Response').first().json.name : '' }},\n\nvielen Dank fuer Ihre Reservierungsanfrage bei der Gaststaette Schellen.\n\nUm Ihre Reservierung bestaetigen zu koennen, benoetigen wir noch Ihre Telefonnummer. Bitte antworten Sie auf diese E-Mail mit Ihrer Rufnummer, damit wir Sie bei Rueckfragen erreichen koennen.\n\nMit freundlichen Gruessen\nGaststaette Schellen",
+        "options": {}
+      },
+      "id": "b2d3e5f7-2001-4b00-c001-000000000009",
+      "name": "Send Reply",
+      "type": "n8n-nodes-base.emailSend",
+      "typeVersion": 2.1,
+      "position": [2160, 120],
+      "credentials": {
+        "smtp": {
+          "id": "SMTP_CREDENTIAL_ID",
+          "name": "Schellen SMTP"
+        }
+      }
+    },
+    {
+      "parameters": {},
+      "id": "b2d3e5f7-2001-4b00-c001-000000000010",
+      "name": "No-Op",
+      "type": "n8n-nodes-base.noOp",
+      "typeVersion": 1,
+      "position": [1440, 420]
+    }
+  ],
+  "connections": {
+    "IMAP Trigger": {
+      "main": [
+        [
+          { "node": "Extract Content", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Extract Content": {
+      "main": [
+        [
+          { "node": "Classify (Ollama)", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Classify (Ollama)": {
+      "main": [
+        [
+          { "node": "Parse Response", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Parse Response": {
+      "main": [
+        [
+          { "node": "Is Reservation?", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Is Reservation?": {
+      "main": [
+        [
+          { "node": "Format Message", "type": "main", "index": 0 }
+        ],
+        [
+          { "node": "No-Op", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Format Message": {
+      "main": [
+        [
+          { "node": "Send WhatsApp", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Send WhatsApp": {
+      "main": [
+        [
+          { "node": "Has Phone?", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Has Phone?": {
+      "main": [
+        [
+          { "node": "Send Reply", "type": "main", "index": 0 }
+        ],
+        []
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [],
+  "active": false
+}


### PR DESCRIPTION
## Summary

- **Evolution API** als Docker-Service hinzugefuegt (Profile `whatsapp`) — self-hosted WhatsApp Gateway mit bestehender PostgreSQL/Redis
- **n8n-Workflow** (10 Nodes): IMAP Trigger pollt `info@gaststaette-schellen.de`, Ollama klassifiziert Reservierungen, WhatsApp an Ramona, auto-Reply wenn Telefonnummer fehlt
- **Config**: Schellen E-Mail-Konto in `mail_accounts.yaml`, neue Env-Vars dokumentiert

## Geaenderte Dateien

| Datei | Aenderung |
|-------|-----------|
| `docker-compose.yml` | Evolution API Service + Volume |
| `.env.example` | `EVOLUTION_API_KEY`, `EVOLUTION_API_URL`, `MAIL_SCHELLEN_PASSWORD`, `WHATSAPP_RAMONA_NUMBER` |
| `config/mail_accounts.yaml` | Schellen IMAP/SMTP Konto (Regfish) |
| `docs/n8n-workflows/schellen-reservation-whatsapp.json` | **Neu**: 10-Node Workflow |
| `docs/ENVIRONMENT_VARIABLES.md` | Evolution API + Schellen Sektion |

## Manuelle Setup-Schritte nach Merge

1. `CREATE DATABASE evolution OWNER renfield;` in PostgreSQL
2. `.env` Variablen setzen (API Key, Passwort, Ramona-Nummer)
3. `docker compose --profile whatsapp up -d evolution-api`
4. WhatsApp-Instanz erstellen + QR-Code scannen
5. n8n: IMAP + SMTP Credentials anlegen, Workflow importieren + aktivieren

## Test plan

- [ ] `docker compose --profile whatsapp config` validiert ohne Fehler
- [ ] Evolution API startet und ist unter `localhost:8080` erreichbar
- [ ] n8n-Workflow laesst sich importieren (JSON valide, Nodes erkannt)
- [ ] Test-Mail A: Reservierung MIT Telefonnummer → WhatsApp an Ramona, keine Reply-Mail
- [ ] Test-Mail B: Reservierung OHNE Telefonnummer → WhatsApp + Reply-Mail mit Bitte um Telefonnummer
- [ ] Test-Mail C: Keine Reservierung (z.B. Menufrage) → nichts passiert

🤖 Generated with [Claude Code](https://claude.com/claude-code)