### PR TITLE
feat(satellite): Add Whisplay HAT support for satellite-arbeitszimmer

### DIFF
--- a/src/satellite/provisioning/group_vars/satellites.yml
+++ b/src/satellite/provisioning/group_vars/satellites.yml
@@ -33,6 +33,10 @@ vad_silero_threshold: 0.5
 
 # LED
 led_brightness: 20
+led_type: "apa102"
+
+# Display
+display_enabled: false
 
 # Button
 button_gpio_pin: 17
@@ -76,6 +80,7 @@ satellite_python_packages:
   - aiohttp
   - requests
   - bleak
+  - Pillow
 
 # BLE Presence Detection
 ble_enabled: true
@@ -90,7 +95,7 @@ openwakeword_package: "openwakeword"
 seeed_dtoverlays_repo: "https://github.com/Seeed-Studio/seeed-linux-dtoverlays.git"
 
 # Model URLs
-oww_base_url: "https://github.com/dscripka/openWakeWord/releases/download/v0.6.0"
+oww_base_url: "https://github.com/dscripka/openWakeWord/releases/download/v0.5.1"
 oww_models:
   - melspectrogram.onnx
   - embedding_model.onnx

--- a/src/satellite/provisioning/host_vars/satellite-arbeitszimmer.yml
+++ b/src/satellite/provisioning/host_vars/satellite-arbeitszimmer.yml
@@ -1,0 +1,27 @@
+---
+# Whisplay HAT configuration (WM8960 codec + LCD + GPIO RGB LED)
+
+hat_type: "whisplay"
+satellite_id: "sat-arbeitszimmer"
+satellite_room: "Arbeitszimmer"
+
+# Audio (stereo with beamforming)
+audio_device: "capture"
+audio_playback_device: "plughw:0,0"
+audio_channels: 2
+beamforming_enabled: true
+beamforming_mic_spacing: 0.040   # ~40mm estimated MEMS spacing
+
+# Whisplay GPIO RGB LED (not APA102)
+led_type: "gpio_rgb"
+led_gpio_red: 25
+led_gpio_green: 24
+led_gpio_blue: 23
+
+# Display
+display_enabled: true
+
+# No SPI LEDs
+led_num: 0
+led_spi_device: 0
+led_power_pin: null

--- a/src/satellite/provisioning/inventory.yml
+++ b/src/satellite/provisioning/inventory.yml
@@ -12,3 +12,6 @@ all:
         satellite-kinderbad:
           ansible_host: satellite-kinderbad.local
           ansible_user: evdb
+        satellite-arbeitszimmer:
+          ansible_host: satellite-arbeitszimmer.local
+          ansible_user: evdb

--- a/src/satellite/provisioning/provision.yml
+++ b/src/satellite/provisioning/provision.yml
@@ -181,6 +181,35 @@
         state: present
       notify: reboot after driver install
 
+    # --- Whisplay HAT: WM8960 codec driver ---
+
+    - name: Clone Whisplay driver for WM8960 codec
+      tags: [driver]
+      when: hat_type == "whisplay"
+      ansible.builtin.git:
+        repo: https://github.com/PiSugar/Whisplay.git
+        dest: /tmp/whisplay
+        depth: 1
+        force: true
+
+    - name: Install WM8960 driver (Whisplay)
+      tags: [driver]
+      when: hat_type == "whisplay"
+      ansible.builtin.shell: |
+        cd /tmp/whisplay/Driver && bash install_wm8960_drive.sh
+      args:
+        creates: /boot/firmware/overlays/wm8960-soundcard.dtbo
+      notify: reboot after driver install
+
+    - name: Ensure wm8960-soundcard overlay in config.txt
+      tags: [driver]
+      when: hat_type == "whisplay"
+      ansible.builtin.lineinfile:
+        path: /boot/firmware/config.txt
+        line: "dtoverlay=wm8960-soundcard"
+        state: present
+      notify: reboot after driver install
+
     # --- Flush handlers (reboot if driver was installed) ---
 
     - name: Reboot now if driver was installed
@@ -191,7 +220,7 @@
       tags: [driver]
       ansible.builtin.wait_for:
         path: /proc/asound/cards
-        search_regex: "seeed"
+        search_regex: "seeed|wm8960"
         timeout: 30
       register: soundcard_check
       ignore_errors: true
@@ -341,6 +370,16 @@
         recurse: true
       register: oww_dirs
 
+    - name: Create openwakeword models directory in venv
+      tags: [models]
+      when: oww_dirs.files | length > 0
+      ansible.builtin.file:
+        path: "{{ oww_dirs.files[0].path }}/resources/models"
+        state: directory
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: "0755"
+
     - name: Copy models to openwakeword package directory
       tags: [models]
       when: oww_dirs.files | length > 0
@@ -408,5 +447,6 @@
           - HAT: {{ hat_type }}
           - ID: {{ satellite_id }}
           - Room: {{ satellite_room }}
-          - LEDs: {{ led_num }} on SPI 0:{{ led_spi_device }}
+          - LED type: {{ led_type | default('apa102') }}
+          - Display: {{ display_enabled | default(false) }}
           - Server: {{ server_url }}

--- a/src/satellite/provisioning/templates/asoundrc-whisplay.j2
+++ b/src/satellite/provisioning/templates/asoundrc-whisplay.j2
@@ -1,0 +1,54 @@
+# Renfield Satellite — ALSA Configuration for Whisplay HAT (WM8960)
+# Managed by Ansible — do not edit manually
+
+defaults.pcm.rate_converter "samplerate"
+
+pcm.!default {
+    type asym
+    playback.pcm "playback"
+    capture.pcm "capture"
+}
+
+pcm.playback {
+    type plug
+    slave.pcm "dmixed"
+}
+
+pcm.capture {
+    type plug
+    slave.pcm "array"
+}
+
+pcm.dmixed {
+    type dmix
+    slave.pcm "hw:wm8960soundcard"
+    ipc_key 555555
+}
+
+# Stereo microphone array (for beamforming)
+pcm.array {
+    type dsnoop
+    slave {
+        pcm "hw:wm8960soundcard"
+        channels 2
+    }
+    ipc_key 666666
+}
+
+# Mono capture (single channel, downmixed)
+pcm.mono {
+    type plug
+    slave {
+        pcm "array"
+        channels 1
+    }
+}
+
+# 16kHz stereo capture (for beamforming with openwakeword)
+pcm.array16k {
+    type rate
+    slave {
+        pcm "array"
+        rate 16000
+    }
+}

--- a/src/satellite/provisioning/templates/satellite.yaml.j2
+++ b/src/satellite/provisioning/templates/satellite.yaml.j2
@@ -23,10 +23,10 @@ audio:
   playback_device: "{{ audio_playback_device }}"
   beamforming:
     enabled: {{ beamforming_enabled | lower }}
-{%- if beamforming_enabled %}
+{% if beamforming_enabled %}
     mic_spacing: {{ beamforming_mic_spacing }}
     steering_angle: 0.0
-{%- endif %}
+{% endif %}
 
 wakeword:
   model: "{{ wakeword_model }}"
@@ -41,13 +41,25 @@ vad:
   silero_threshold: {{ vad_silero_threshold }}
 
 led:
+  type: "{{ led_type | default('apa102') }}"
   brightness: {{ led_brightness }}
+{% if led_type | default('apa102') == 'gpio_rgb' %}
+  gpio_red: {{ led_gpio_red }}
+  gpio_green: {{ led_gpio_green }}
+  gpio_blue: {{ led_gpio_blue }}
+{% else %}
   num_leds: {{ led_num }}
   spi_bus: 0
   spi_device: {{ led_spi_device }}
-{%- if led_power_pin is not none %}
+{% if led_power_pin is not none %}
   led_power_pin: {{ led_power_pin }}
-{%- endif %}
+{% endif %}
+{% endif %}
+
+display:
+  enabled: {{ display_enabled | default(false) | lower }}
+  width: 240
+  height: 280
 
 button:
   gpio_pin: {{ button_gpio_pin }}

--- a/src/satellite/renfield_satellite/config.py
+++ b/src/satellite/renfield_satellite/config.py
@@ -84,11 +84,16 @@ class VADConfig:
 @dataclass
 class LEDConfig:
     """LED control settings"""
+    type: str = "apa102"  # "apa102" or "gpio_rgb"
     brightness: int = 20  # 0-255
     spi_bus: int = 0
     spi_device: int = 0
     num_leds: int = 3
     led_power_pin: Optional[int] = None  # GPIO pin to enable LED power (4-mic HAT: 5)
+    # GPIO RGB LED pins (Whisplay HAT)
+    gpio_red: Optional[int] = None
+    gpio_green: Optional[int] = None
+    gpio_blue: Optional[int] = None
 
 
 @dataclass
@@ -96,6 +101,14 @@ class ButtonConfig:
     """Button settings"""
     gpio_pin: int = 17
     debounce_ms: int = 50
+
+
+@dataclass
+class DisplayConfig:
+    """Display settings (Whisplay HAT ST7789)"""
+    enabled: bool = False
+    width: int = 240
+    height: int = 280
 
 
 @dataclass
@@ -118,6 +131,7 @@ class Config:
     vad: VADConfig = field(default_factory=VADConfig)
     led: LEDConfig = field(default_factory=LEDConfig)
     button: ButtonConfig = field(default_factory=ButtonConfig)
+    display: DisplayConfig = field(default_factory=DisplayConfig)
     ble: BLEConfig = field(default_factory=BLEConfig)
 
 
@@ -215,15 +229,25 @@ def load_config(config_path: Optional[str] = None) -> Config:
 
     if "led" in config_data:
         led = config_data["led"]
+        config.led.type = led.get("type", config.led.type)
         config.led.brightness = led.get("brightness", config.led.brightness)
         config.led.num_leds = led.get("num_leds", config.led.num_leds)
         config.led.spi_bus = led.get("spi_bus", config.led.spi_bus)
         config.led.spi_device = led.get("spi_device", config.led.spi_device)
         config.led.led_power_pin = led.get("led_power_pin", config.led.led_power_pin)
+        config.led.gpio_red = led.get("gpio_red", config.led.gpio_red)
+        config.led.gpio_green = led.get("gpio_green", config.led.gpio_green)
+        config.led.gpio_blue = led.get("gpio_blue", config.led.gpio_blue)
 
     if "button" in config_data:
         btn = config_data["button"]
         config.button.gpio_pin = btn.get("gpio_pin", config.button.gpio_pin)
+
+    if "display" in config_data:
+        disp = config_data["display"]
+        config.display.enabled = disp.get("enabled", config.display.enabled)
+        config.display.width = disp.get("width", config.display.width)
+        config.display.height = disp.get("height", config.display.height)
 
     if "ble" in config_data:
         ble = config_data["ble"]

--- a/src/satellite/renfield_satellite/hardware/display.py
+++ b/src/satellite/renfield_satellite/hardware/display.py
@@ -139,7 +139,7 @@ class ST7789Display:
         self._spi = self._dc = self._rst = self._bl = None
 
     def _init_display(self):
-        """ST7789 initialization sequence."""
+        """ST7789 initialization sequence (from WhisPlay.py reference)."""
         # Hardware reset
         self._rst.on()
         time.sleep(0.01)
@@ -148,19 +148,36 @@ class ST7789Display:
         self._rst.on()
         time.sleep(0.12)
 
-        self._cmd(_SWRESET)
-        time.sleep(0.15)
         self._cmd(_SLPOUT)
         time.sleep(0.12)
 
+        # Memory access control (0xC0 = row/col mirrored for Whisplay orientation)
+        self._cmd(_MADCTL, bytes([0xC0]))
         # 16-bit color (RGB565)
-        self._cmd(_COLMOD, bytes([0x55]))
-        # Memory access control: row/col exchange for correct orientation
-        self._cmd(_MADCTL, bytes([0x00]))
+        self._cmd(_COLMOD, bytes([0x05]))
+        # Porch setting
+        self._cmd(0xB2, bytes([0x0C, 0x0C, 0x00, 0x33, 0x33]))
+        # Gate control
+        self._cmd(0xB7, bytes([0x35]))
+        # VCOM setting
+        self._cmd(0xBB, bytes([0x32]))
+        # Power control
+        self._cmd(0xC2, bytes([0x01]))
+        # VDV/VRH
+        self._cmd(0xC3, bytes([0x15]))
+        self._cmd(0xC4, bytes([0x20]))
+        # Frame rate
+        self._cmd(0xC6, bytes([0x0F]))
+        # Power control 2
+        self._cmd(0xD0, bytes([0xA4, 0xA1]))
+        # Positive gamma
+        self._cmd(0xE0, bytes([0xD0, 0x08, 0x0E, 0x09, 0x09, 0x05, 0x31, 0x33,
+                               0x48, 0x17, 0x14, 0x15, 0x31, 0x34]))
+        # Negative gamma
+        self._cmd(0xE1, bytes([0xD0, 0x08, 0x0E, 0x09, 0x09, 0x15, 0x31, 0x33,
+                               0x48, 0x17, 0x14, 0x15, 0x31, 0x34]))
         # Inversion on (required for ST7789)
         self._cmd(_INVON)
-        self._cmd(_NORON)
-        time.sleep(0.01)
         self._cmd(_DISPON)
         time.sleep(0.01)
 
@@ -175,9 +192,9 @@ class ST7789Display:
             self._spi.writebytes(list(data))
 
     def set_window(self, x0: int, y0: int, x1: int, y1: int):
-        """Set the drawing window."""
+        """Set the drawing window. Applies Y+20 offset for 240x280 panel."""
         self._cmd(_CASET, struct.pack(">HH", x0, x1))
-        self._cmd(_RASET, struct.pack(">HH", y0, y1))
+        self._cmd(_RASET, struct.pack(">HH", y0 + 20, y1 + 20))
         self._cmd(_RAMWR)
 
     def draw_image(self, image: "Image.Image"):

--- a/src/satellite/renfield_satellite/hardware/display.py
+++ b/src/satellite/renfield_satellite/hardware/display.py
@@ -1,0 +1,348 @@
+"""
+Display Controller for Whisplay HAT (ST7789P3 240x280 LCD)
+
+Renders satellite state information on the built-in LCD display.
+Uses spidev for SPI communication and Pillow for rendering.
+"""
+
+import struct
+import threading
+import time
+from typing import Optional
+
+try:
+    import spidev
+    SPI_AVAILABLE = True
+except ImportError:
+    spidev = None
+    SPI_AVAILABLE = False
+
+try:
+    from gpiozero import OutputDevice, PWMLED
+    GPIO_AVAILABLE = True
+except ImportError:
+    OutputDevice = None
+    PWMLED = None
+    GPIO_AVAILABLE = False
+
+try:
+    from PIL import Image, ImageDraw, ImageFont
+    PIL_AVAILABLE = True
+except ImportError:
+    Image = None
+    ImageDraw = None
+    ImageFont = None
+    PIL_AVAILABLE = False
+
+
+# ST7789 commands
+_SWRESET = 0x01
+_SLPOUT = 0x11
+_COLMOD = 0x3A
+_MADCTL = 0x36
+_CASET = 0x2A
+_RASET = 0x2B
+_RAMWR = 0x2C
+_INVON = 0x21
+_NORON = 0x13
+_DISPON = 0x29
+
+# Color constants (RGB tuples for Pillow)
+_COLORS = {
+    "black": (0, 0, 0),
+    "white": (255, 255, 255),
+    "green": (0, 200, 0),
+    "yellow": (230, 200, 0),
+    "cyan": (0, 200, 200),
+    "red": (200, 0, 0),
+    "blue": (0, 40, 80),
+    "dim_blue": (0, 20, 40),
+}
+
+
+class ST7789Display:
+    """
+    Low-level ST7789P3 LCD driver via SPI.
+
+    Uses gpiozero OutputDevice for DC/RST pins to avoid
+    RPi.GPIO conflicts with other gpiozero usage.
+    """
+
+    def __init__(
+        self,
+        width: int = 240,
+        height: int = 280,
+        spi_bus: int = 0,
+        spi_device: int = 0,
+        spi_speed_hz: int = 80_000_000,
+        dc_pin: int = 27,
+        rst_pin: int = 4,
+        bl_pin: int = 22,
+    ):
+        self.width = width
+        self.height = height
+        self.spi_bus = spi_bus
+        self.spi_device = spi_device
+        self.spi_speed_hz = spi_speed_hz
+        self.dc_pin = dc_pin
+        self.rst_pin = rst_pin
+        self.bl_pin = bl_pin
+
+        self._spi: Optional["spidev.SpiDev"] = None
+        self._dc: Optional["OutputDevice"] = None
+        self._rst: Optional["OutputDevice"] = None
+        self._bl: Optional["PWMLED"] = None
+
+    def open(self) -> bool:
+        """Initialize SPI and GPIO, run display init sequence."""
+        if not SPI_AVAILABLE or not GPIO_AVAILABLE:
+            print("Display: spidev or gpiozero not available")
+            return False
+
+        try:
+            self._dc = OutputDevice(self.dc_pin)
+            self._rst = OutputDevice(self.rst_pin)
+            self._bl = PWMLED(self.bl_pin, initial_value=0)
+
+            self._spi = spidev.SpiDev()
+            self._spi.open(self.spi_bus, self.spi_device)
+            self._spi.max_speed_hz = self.spi_speed_hz
+            self._spi.mode = 0
+
+            self._init_display()
+            self._bl.value = 0.8  # 80% backlight
+            print(f"ST7789 display initialized: {self.width}x{self.height}")
+            return True
+        except Exception as e:
+            print(f"Failed to initialize display: {e}")
+            return False
+
+    def close(self):
+        """Turn off backlight and release resources."""
+        if self._bl:
+            try:
+                self._bl.value = 0
+                self._bl.close()
+            except Exception:
+                pass
+        if self._spi:
+            try:
+                self._spi.close()
+            except Exception:
+                pass
+        for pin in (self._dc, self._rst):
+            if pin:
+                try:
+                    pin.close()
+                except Exception:
+                    pass
+        self._spi = self._dc = self._rst = self._bl = None
+
+    def _init_display(self):
+        """ST7789 initialization sequence."""
+        # Hardware reset
+        self._rst.on()
+        time.sleep(0.01)
+        self._rst.off()
+        time.sleep(0.01)
+        self._rst.on()
+        time.sleep(0.12)
+
+        self._cmd(_SWRESET)
+        time.sleep(0.15)
+        self._cmd(_SLPOUT)
+        time.sleep(0.12)
+
+        # 16-bit color (RGB565)
+        self._cmd(_COLMOD, bytes([0x55]))
+        # Memory access control: row/col exchange for correct orientation
+        self._cmd(_MADCTL, bytes([0x00]))
+        # Inversion on (required for ST7789)
+        self._cmd(_INVON)
+        self._cmd(_NORON)
+        time.sleep(0.01)
+        self._cmd(_DISPON)
+        time.sleep(0.01)
+
+    def _cmd(self, command: int, data: Optional[bytes] = None):
+        """Send command (and optional data) to display."""
+        if not self._spi:
+            return
+        self._dc.off()  # Command mode
+        self._spi.writebytes([command])
+        if data:
+            self._dc.on()  # Data mode
+            self._spi.writebytes(list(data))
+
+    def set_window(self, x0: int, y0: int, x1: int, y1: int):
+        """Set the drawing window."""
+        self._cmd(_CASET, struct.pack(">HH", x0, x1))
+        self._cmd(_RASET, struct.pack(">HH", y0, y1))
+        self._cmd(_RAMWR)
+
+    def draw_image(self, image: "Image.Image"):
+        """Draw a Pillow RGB image to the full screen."""
+        if not self._spi:
+            return
+
+        # Convert to RGB565
+        rgb565 = self._rgb_to_565(image)
+
+        self.set_window(0, 0, self.width - 1, self.height - 1)
+        self._dc.on()  # Data mode
+
+        # Send in chunks (SPI transfer limit)
+        chunk_size = 4096
+        for i in range(0, len(rgb565), chunk_size):
+            self._spi.writebytes(list(rgb565[i:i + chunk_size]))
+
+    def fill_screen(self, r: int, g: int, b: int):
+        """Fill entire screen with a solid color."""
+        if not PIL_AVAILABLE:
+            return
+        img = Image.new("RGB", (self.width, self.height), (r, g, b))
+        self.draw_image(img)
+
+    @staticmethod
+    def _rgb_to_565(image: "Image.Image") -> bytes:
+        """Convert Pillow RGB image to RGB565 bytes (big-endian)."""
+        pixels = image.tobytes()
+        result = bytearray(len(pixels) // 3 * 2)
+        idx = 0
+        for i in range(0, len(pixels), 3):
+            r, g, b = pixels[i], pixels[i + 1], pixels[i + 2]
+            rgb565 = ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3)
+            result[idx] = (rgb565 >> 8) & 0xFF
+            result[idx + 1] = rgb565 & 0xFF
+            idx += 2
+        return bytes(result)
+
+    def set_backlight(self, value: float):
+        """Set backlight brightness (0.0 to 1.0)."""
+        if self._bl:
+            self._bl.value = max(0.0, min(1.0, value))
+
+
+class DisplayController:
+    """
+    High-level display controller that renders satellite state.
+
+    Renders status screens using Pillow and pushes them to the
+    ST7789 display. Uses a background thread to avoid blocking.
+    """
+
+    def __init__(self, width: int = 240, height: int = 280, room: str = ""):
+        self.width = width
+        self.height = height
+        self.room = room
+
+        self._display: Optional[ST7789Display] = None
+        self._lock = threading.Lock()
+        self._current_state: Optional[str] = None
+        self._font: Optional["ImageFont.FreeTypeFont"] = None
+        self._font_large: Optional["ImageFont.FreeTypeFont"] = None
+
+    def open(self) -> bool:
+        """Initialize display hardware."""
+        if not PIL_AVAILABLE:
+            print("Display: Pillow not installed")
+            return False
+
+        self._display = ST7789Display(width=self.width, height=self.height)
+        if not self._display.open():
+            self._display = None
+            return False
+
+        # Load fonts (fall back to default if not available)
+        try:
+            self._font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 20)
+            self._font_large = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", 28)
+        except (OSError, IOError):
+            self._font = ImageFont.load_default()
+            self._font_large = self._font
+
+        return True
+
+    def close(self):
+        """Shut down display."""
+        if self._display:
+            self._display.fill_screen(0, 0, 0)
+            self._display.set_backlight(0)
+            self._display.close()
+            self._display = None
+
+    def update_state(self, state: str):
+        """Update display to reflect new satellite state (non-blocking)."""
+        if not self._display or state == self._current_state:
+            return
+        self._current_state = state
+        threading.Thread(target=self._render_state, args=(state,), daemon=True).start()
+
+    def _render_state(self, state: str):
+        """Render a state screen and push to display."""
+        with self._lock:
+            if not self._display:
+                return
+
+            screens = {
+                "boot": (self._render_boot, 0.8),
+                "idle": (self._render_idle, 0.3),
+                "listening": (self._render_listening, 0.8),
+                "processing": (self._render_processing, 0.8),
+                "speaking": (self._render_speaking, 0.8),
+                "error": (self._render_error, 0.8),
+            }
+
+            renderer, backlight = screens.get(state, (self._render_idle, 0.3))
+            image = renderer()
+            self._display.set_backlight(backlight)
+            self._display.draw_image(image)
+
+    def _new_image(self, bg_color: tuple) -> tuple:
+        """Create a new image with draw context."""
+        img = Image.new("RGB", (self.width, self.height), bg_color)
+        draw = ImageDraw.Draw(img)
+        return img, draw
+
+    def _draw_centered_text(self, draw: "ImageDraw.Draw", y: int, text: str, font, fill):
+        """Draw text centered horizontally."""
+        bbox = draw.textbbox((0, 0), text, font=font)
+        text_width = bbox[2] - bbox[0]
+        x = (self.width - text_width) // 2
+        draw.text((x, y), text, font=font, fill=fill)
+
+    def _render_boot(self) -> "Image.Image":
+        img, draw = self._new_image(_COLORS["blue"])
+        self._draw_centered_text(draw, 100, "Renfield", self._font_large, _COLORS["white"])
+        self._draw_centered_text(draw, 145, self.room, self._font, (180, 180, 180))
+        self._draw_centered_text(draw, 220, "Starting...", self._font, (120, 120, 120))
+        return img
+
+    def _render_idle(self) -> "Image.Image":
+        img, draw = self._new_image(_COLORS["dim_blue"])
+        self._draw_centered_text(draw, 120, self.room, self._font_large, (100, 100, 120))
+        return img
+
+    def _render_listening(self) -> "Image.Image":
+        img, draw = self._new_image(_COLORS["green"])
+        self._draw_centered_text(draw, 110, "Listening...", self._font_large, _COLORS["white"])
+        self._draw_centered_text(draw, 155, self.room, self._font, (200, 255, 200))
+        return img
+
+    def _render_processing(self) -> "Image.Image":
+        img, draw = self._new_image(_COLORS["yellow"])
+        self._draw_centered_text(draw, 110, "Processing...", self._font_large, _COLORS["black"])
+        self._draw_centered_text(draw, 155, self.room, self._font, (80, 80, 0))
+        return img
+
+    def _render_speaking(self) -> "Image.Image":
+        img, draw = self._new_image(_COLORS["cyan"])
+        self._draw_centered_text(draw, 110, "Speaking...", self._font_large, _COLORS["black"])
+        self._draw_centered_text(draw, 155, self.room, self._font, (0, 80, 80))
+        return img
+
+    def _render_error(self) -> "Image.Image":
+        img, draw = self._new_image(_COLORS["red"])
+        self._draw_centered_text(draw, 110, "Error", self._font_large, _COLORS["white"])
+        self._draw_centered_text(draw, 155, self.room, self._font, (255, 180, 180))
+        return img

--- a/src/satellite/renfield_satellite/hardware/led.py
+++ b/src/satellite/renfield_satellite/hardware/led.py
@@ -24,10 +24,11 @@ except ImportError:
     print("Warning: spidev not installed. LED control disabled.")
 
 try:
-    from gpiozero import LED as GpioLED
+    from gpiozero import LED as GpioLED, PWMLED
     GPIO_AVAILABLE = True
 except ImportError:
     GpioLED = None
+    PWMLED = None
     GPIO_AVAILABLE = False
 
 
@@ -378,6 +379,156 @@ class LEDController:
     @property
     def current_pattern(self) -> LEDPattern:
         """Get current pattern"""
+        return self._pattern
+
+
+class GPIOLEDController:
+    """
+    Controls a single GPIO RGB LED (e.g. Whisplay HAT).
+
+    Uses gpiozero PWMLED for PWM-based color mixing.
+    Whisplay LEDs are active-low (inverted duty cycle).
+    Implements the same set_pattern()/stop_animation() interface as LEDController.
+    """
+
+    def __init__(
+        self,
+        gpio_red: int = 25,
+        gpio_green: int = 24,
+        gpio_blue: int = 23,
+        brightness: int = 20,
+    ):
+        self.gpio_red = gpio_red
+        self.gpio_green = gpio_green
+        self.gpio_blue = gpio_blue
+        self.brightness = min(31, max(0, brightness))
+
+        self._red: Optional["PWMLED"] = None
+        self._green: Optional["PWMLED"] = None
+        self._blue: Optional["PWMLED"] = None
+
+        self._pattern: LEDPattern = LEDPattern.OFF
+        self._running = False
+        self._thread: Optional[threading.Thread] = None
+        self._lock = threading.Lock()
+
+    def open(self) -> bool:
+        """Initialize GPIO PWM pins. Returns True if successful."""
+        if not GPIO_AVAILABLE or PWMLED is None:
+            print("gpiozero/PWMLED not available for GPIO LED control")
+            return False
+
+        try:
+            # active_high=False for Whisplay's active-low LED
+            self._red = PWMLED(self.gpio_red, active_high=False, initial_value=0)
+            self._green = PWMLED(self.gpio_green, active_high=False, initial_value=0)
+            self._blue = PWMLED(self.gpio_blue, active_high=False, initial_value=0)
+            print(f"GPIO RGB LED initialized: R={self.gpio_red}, G={self.gpio_green}, B={self.gpio_blue}")
+            return True
+        except Exception as e:
+            print(f"Failed to initialize GPIO LED: {e}")
+            return False
+
+    def close(self):
+        """Turn off LED and release GPIO."""
+        self.stop_animation()
+        self._set_color(0, 0, 0)
+
+        for pin in (self._red, self._green, self._blue):
+            if pin:
+                try:
+                    pin.close()
+                except Exception:
+                    pass
+        self._red = self._green = self._blue = None
+
+    def _set_color(self, r: int, g: int, b: int):
+        """Set RGB color (0-255 per channel), scaled by brightness."""
+        if not self._red:
+            return
+        scale = self.brightness / 31.0
+        with self._lock:
+            self._red.value = (r / 255.0) * scale
+            self._green.value = (g / 255.0) * scale
+            self._blue.value = (b / 255.0) * scale
+
+    def set_pattern(self, pattern: LEDPattern):
+        """Start an LED animation pattern."""
+        if pattern == self._pattern:
+            return
+        self.stop_animation()
+        self._pattern = pattern
+        if pattern != LEDPattern.OFF:
+            self._running = True
+            self._thread = threading.Thread(target=self._animation_loop, daemon=True)
+            self._thread.start()
+
+    def stop_animation(self):
+        """Stop current animation."""
+        self._running = False
+        if self._thread:
+            self._thread.join(timeout=0.5)
+            self._thread = None
+
+    def _animation_loop(self):
+        """Background thread running LED animations."""
+        frame = 0
+        while self._running:
+            pattern = self._pattern
+
+            if pattern == LEDPattern.IDLE:
+                self._animate_pulse(frame, 0, 0, 255, 0.05)
+            elif pattern == LEDPattern.LISTENING:
+                self._set_color(0, 255, 0)
+                time.sleep(0.1)
+            elif pattern == LEDPattern.PROCESSING:
+                self._animate_breathe(frame, 255, 255, 0)
+            elif pattern == LEDPattern.SPEAKING:
+                self._animate_breathe(frame, 0, 255, 255)
+            elif pattern == LEDPattern.ERROR:
+                self._animate_blink(frame, 255, 0, 0)
+            elif pattern == LEDPattern.SUCCESS:
+                self._animate_flash(frame, 0, 255, 0)
+            elif pattern == LEDPattern.BOOT:
+                self._animate_rainbow(frame)
+            else:
+                self._set_color(0, 0, 0)
+                time.sleep(0.1)
+
+            frame += 1
+            time.sleep(0.05)
+
+    def _animate_pulse(self, frame: int, r: int, g: int, b: int, min_brightness: float):
+        phase = (frame % 60) / 60.0 * 2 * math.pi
+        factor = (math.sin(phase) + 1) / 2
+        factor = min_brightness + factor * (1 - min_brightness)
+        self._set_color(int(r * factor), int(g * factor), int(b * factor))
+
+    def _animate_breathe(self, frame: int, r: int, g: int, b: int):
+        phase = (frame % 80) / 80.0 * 2 * math.pi
+        factor = 0.2 + ((math.sin(phase) + 1) / 2) * 0.8
+        self._set_color(int(r * factor), int(g * factor), int(b * factor))
+
+    def _animate_blink(self, frame: int, r: int, g: int, b: int):
+        if (frame // 10) % 2 == 0:
+            self._set_color(r, g, b)
+        else:
+            self._set_color(0, 0, 0)
+
+    def _animate_flash(self, frame: int, r: int, g: int, b: int):
+        if frame < 10:
+            self._set_color(r, g, b)
+        else:
+            self._set_color(0, 0, 0)
+            self._running = False
+
+    def _animate_rainbow(self, frame: int):
+        hue = (frame * 5) % 360
+        r, g, b = colorsys.hsv_to_rgb(hue / 360.0, 1.0, 1.0)
+        self._set_color(int(r * 255), int(g * 255), int(b * 255))
+
+    @property
+    def current_pattern(self) -> LEDPattern:
         return self._pattern
 
 

--- a/src/satellite/renfield_satellite/satellite.py
+++ b/src/satellite/renfield_satellite/satellite.py
@@ -22,8 +22,9 @@ from .audio.playback import AudioPlayback, AudioPlaybackAsync
 from .audio.preprocessor import AudioPreprocessor
 from .audio.vad import VoiceActivityDetector, VADBackend
 from .wakeword.detector import WakeWordDetector, Detection
-from .hardware.led import LEDController, LEDPattern
+from .hardware.led import LEDController, GPIOLEDController, LEDPattern
 from .hardware.button import ButtonHandler
+from .hardware.display import DisplayController
 from .network.websocket_client import WebSocketClient, ServerConfig
 from .network.discovery import ServiceDiscovery
 from .network.auth import fetch_ws_token, http_url_from_ws
@@ -145,14 +146,31 @@ class Satellite:
             refractory_seconds=self.config.wakeword.refractory_seconds,
         )
 
-        # LED controller
-        self.leds = LEDController(
-            num_leds=self.config.led.num_leds,
-            spi_bus=self.config.led.spi_bus,
-            spi_device=self.config.led.spi_device,
-            brightness=self.config.led.brightness,
-            led_power_pin=self.config.led.led_power_pin,
-        )
+        # LED controller (select based on type)
+        if self.config.led.type == "gpio_rgb":
+            self.leds = GPIOLEDController(
+                gpio_red=self.config.led.gpio_red or 25,
+                gpio_green=self.config.led.gpio_green or 24,
+                gpio_blue=self.config.led.gpio_blue or 23,
+                brightness=self.config.led.brightness,
+            )
+        else:
+            self.leds = LEDController(
+                num_leds=self.config.led.num_leds,
+                spi_bus=self.config.led.spi_bus,
+                spi_device=self.config.led.spi_device,
+                brightness=self.config.led.brightness,
+                led_power_pin=self.config.led.led_power_pin,
+            )
+
+        # Display controller (optional, Whisplay HAT)
+        self.display: Optional[DisplayController] = None
+        if self.config.display.enabled:
+            self.display = DisplayController(
+                width=self.config.display.width,
+                height=self.config.display.height,
+                room=self.config.satellite.room,
+            )
 
         # Button handler
         self.button = ButtonHandler(
@@ -242,6 +260,10 @@ class Satellite:
         if not self.leds.open():
             print("Warning: LED control not available")
 
+        if self.display and not self.display.open():
+            print("Warning: Display not available")
+            self.display = None
+
         if not self.button.setup():
             print("Warning: Button control not available")
 
@@ -307,9 +329,12 @@ class Satellite:
         # Stop discovery if running
         await self.discovery.stop_continuous_discovery()
 
-        # Turn off LEDs
+        # Turn off LEDs and display
         self.leds.set_pattern(LEDPattern.OFF)
         self.leds.close()
+
+        if self.display:
+            self.display.close()
 
         # Cleanup GPIO
         self.button.cleanup()
@@ -456,6 +481,10 @@ class Satellite:
             SatelliteState.ERROR: LEDPattern.ERROR,
         }
         self.leds.set_pattern(pattern_map.get(state, LEDPattern.OFF))
+
+        # Update display
+        if self.display:
+            self.display.update_state(state.value)
 
     def _schedule_async(self, coro):
         """Schedule a coroutine from a non-async context (thread-safe)"""


### PR DESCRIPTION
## Summary

- Add provisioning and runtime support for the **PiSugar Whisplay HAT** (WM8960 codec, ST7789 240x280 LCD, GPIO RGB LED) as a new satellite HAT type
- Provision new satellite `satellite-arbeitszimmer` in the Arbeitszimmer
- Add `GPIOLEDController` (PWM-based, active-low) and `DisplayController` (ST7789 SPI + Pillow renderer) to satellite code
- Fix Jinja2 template newline stripping (`{%-` → `{%`), openWakeWord model URL (v0.6.0 → v0.5.1), and missing openwakeword models directory

## Changes

**Provisioning (6 files):**
- `host_vars/satellite-arbeitszimmer.yml` — new Whisplay HAT config
- `inventory.yml` — add satellite-arbeitszimmer host
- `provision.yml` — WM8960 driver tasks, dtoverlay config.txt entry, sound card regex, models dir fix
- `templates/asoundrc-whisplay.j2` — ALSA config for wm8960soundcard
- `templates/satellite.yaml.j2` — LED type/GPIO + display sections, newline fix
- `group_vars/satellites.yml` — defaults (led_type, display_enabled), Pillow package, URL fix

**Satellite code (4 files):**
- `hardware/led.py` — new `GPIOLEDController` class
- `hardware/display.py` — new ST7789 driver + status screen renderer
- `config.py` — `LEDConfig.type/gpio_*` fields, `DisplayConfig` dataclass
- `satellite.py` — LED factory, display lifecycle integration

## Test plan

- [x] Ansible provisioning ran successfully against satellite-arbeitszimmer
- [x] WM8960 sound card detected after reboot (`/proc/asound/cards`)
- [x] Audio capture + playback verified (`arecord`/`aplay`)
- [x] Service running, wake word loaded, server connected
- [x] Existing satellite tests pass (no regressions)
- [ ] Verify display shows state screens on hardware
- [ ] Verify GPIO RGB LED animates on state changes
- [ ] End-to-end wake word detection test

🤖 Generated with [Claude Code](https://claude.com/claude-code)