### PR TITLE
fix: Add ollama_vision_url and bump satellite to v1.3.0

### DIFF
--- a/src/backend/services/ollama_service.py
+++ b/src/backend/services/ollama_service.py
@@ -300,8 +300,15 @@ WICHTIGE REGELN FÜR ANTWORTEN:
                 "images": [image_b64],
             })
 
+            # Use dedicated vision URL if configured, otherwise default client
+            if settings.ollama_vision_url:
+                from utils.llm_client import _make_client_with_fallback
+                vision_client = _make_client_with_fallback(settings.ollama_vision_url)
+            else:
+                vision_client = self.client
+
             classification_kwargs = get_classification_chat_kwargs(vision_model)
-            async for chunk in await self.client.chat(
+            async for chunk in await vision_client.chat(
                 model=vision_model,
                 messages=messages,
                 stream=True,

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -42,6 +42,7 @@ class Settings(BaseSettings):
     ollama_read_timeout: float = 300.0            # Read timeout for long LLM responses
     ollama_fallback_url: str = ""                 # Fallback Ollama URL if primary is unreachable (e.g. http://host.docker.internal:11434)
     ollama_vision_model: str = ""                  # Vision-capable model (e.g. "minicpm-v"). Empty = vision disabled.
+    ollama_vision_url: str | None = None         # Separate Ollama URL for vision model (default: ollama_url)
     ollama_embed_url: str | None = None          # Separate Ollama URL for embeddings (default: ollama_url)
 
     # Home Assistant

--- a/src/satellite/renfield_satellite/__init__.py
+++ b/src/satellite/renfield_satellite/__init__.py
@@ -5,7 +5,7 @@ A headless voice assistant satellite for the Renfield ecosystem.
 Designed for Raspberry Pi Zero 2 W with ReSpeaker 2-Mics Pi HAT.
 """
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 __author__ = "Renfield Team"
 
 # Lazy imports to allow CLI tools to run without all dependencies


### PR DESCRIPTION
## Summary

- Add `OLLAMA_VISION_URL` setting for running vision model on a separate Ollama instance
- `chat_stream_with_image()` uses dedicated vision client when URL is configured
- Bump satellite version 1.2.0 → 1.3.0 for camera support release

## Context

Production runs the vision model (`minicpm-v`) on `renfield.local` (host Ollama) while other models run on `cuda.local`. The new `OLLAMA_VISION_URL` setting allows routing vision requests to a different Ollama instance.

## Test plan

- [x] Already deployed and running in production
- [x] Camera initialized successfully on satellite-arbeitszimmer

🤖 Generated with [Claude Code](https://claude.com/claude-code)