### PR TITLE
fix(audio): DLNA TTS routing, auth, and vision docs (#290)

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -18,7 +18,14 @@ http {
     server {
         listen 80;
         server_name _;
-        
+
+        # TTS cache: served over plain HTTP for DLNA renderers that can't do HTTPS
+        location /api/voice/tts-cache/ {
+            proxy_pass http://backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
         location / {
             return 301 https://$host$request_uri;
         }

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -110,6 +110,28 @@ Siehe `docs/LLM_MODEL_GUIDE.md` für eine vollständige Modell-Übersicht pro Ro
 
 ---
 
+### Vision LLM (Satellite Camera)
+
+```bash
+# Vision-fähiges Modell für Kamera-Snapshots von Satellites
+# Leer = Visual Queries deaktiviert (Bilder werden ignoriert)
+OLLAMA_VISION_MODEL=qwen3-vl
+
+# Optional: Separate Ollama-URL für das Vision-Modell
+# Nützlich wenn Vision auf einer anderen GPU läuft als Chat
+OLLAMA_VISION_URL=http://host.docker.internal:11434
+```
+
+**Defaults:**
+- `OLLAMA_VISION_MODEL`: `""` (deaktiviert)
+- `OLLAMA_VISION_URL`: `None` (verwendet Standard-OLLAMA_URL)
+
+**Empfohlenes Modell:** `qwen3-vl` (~12 GB VRAM, passt auf 16 GB Karten, gutes Deutsch).
+
+Siehe [SATELLITE_CAMERA.md](SATELLITE_CAMERA.md) für Setup und Modellvergleich.
+
+---
+
 ### Sprache & Voice
 
 ```bash
@@ -512,31 +534,38 @@ ADVERTISE_IP=192.168.1.100
 ### Audio Output Routing
 
 ```bash
-# Hostname/IP die externe Dienste (z.B. Home Assistant) erreichen können
-ADVERTISE_HOST=demeter.local
+# Hostname/IP die externe Dienste (HA Media Player, DLNA Renderer) erreichen können
+ADVERTISE_HOST=192.168.1.159
 
-# Port für ADVERTISE_HOST (optional)
-ADVERTISE_PORT=8000
+# Port für ADVERTISE_HOST (Default: 8000, setze 80 wenn über Nginx)
+ADVERTISE_PORT=80
 ```
 
 **Defaults:**
-- `ADVERTISE_HOST`: None (muss gesetzt werden für HA Media Player Output)
+- `ADVERTISE_HOST`: None (muss gesetzt werden für HA Media Player / DLNA Output)
 - `ADVERTISE_PORT`: `8000`
 
 **Wann benötigt:**
-- Wenn TTS-Ausgabe auf Home Assistant Media Playern erfolgen soll
+- Wenn TTS-Ausgabe auf Home Assistant Media Playern oder DLNA Renderern erfolgen soll
 - Der Wert muss eine Adresse sein, die Home Assistant erreichen kann (nicht `localhost`!)
 
 **Beispiele:**
 ```bash
-ADVERTISE_HOST=192.168.1.100      # IP-Adresse
-ADVERTISE_HOST=renfield.local     # mDNS Hostname
-ADVERTISE_HOST=demeter.local      # Server Hostname
+ADVERTISE_HOST=192.168.1.159      # IP-Adresse (empfohlen für DLNA)
+ADVERTISE_HOST=renfield.local     # mDNS Hostname (funktioniert NICHT für DLNA Renderer)
 ```
+
+**Wichtig:** DLNA-Renderer (z.B. HiFiBerry) können mDNS-Hostnamen (`.local`) oft
+nicht auflösen. **IP-Adresse verwenden** wenn DLNA-Ausgabe genutzt wird.
+
+**Port 80 vs 8000:** Der Backend-Container exposed Port 8000 nur auf `127.0.0.1`.
+Für externe Zugriffe (DLNA, HA) muss der Traffic über Nginx (Port 80) laufen.
+Setze `ADVERTISE_PORT=80` in Produktion. Nginx leitet `/api/voice/tts-cache/`
+über plain HTTP (ohne HTTPS-Redirect) an den Backend weiter.
 
 **Ohne ADVERTISE_HOST:**
 - TTS wird nur auf Renfield-Geräten (Satellites, Web Panels) abgespielt
-- HA Media Player können keine TTS-Dateien abrufen
+- HA Media Player und DLNA Renderer können keine TTS-Dateien abrufen
 
 **Dokumentation:** Siehe `OUTPUT_ROUTING.md` für Details zum Output Routing System.
 
@@ -1210,8 +1239,8 @@ WAKE_WORD_THRESHOLD=0.5
 # Audio Output Routing
 # -----------------------------------------------------------------------------
 # Hostname/IP die externe Dienste (z.B. HA) erreichen können
-ADVERTISE_HOST=demeter.local
-ADVERTISE_PORT=8000
+ADVERTISE_HOST=192.168.1.159
+ADVERTISE_PORT=80
 
 # -----------------------------------------------------------------------------
 # MCP Server

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -48,6 +48,15 @@ Renfield ist ein vollständig offline-fähiger, selbst-gehosteter **digitaler As
 
 Siehe [SPEAKER_RECOGNITION.md](SPEAKER_RECOGNITION.md) für Details.
 
+### Visual Queries (Satellite Camera)
+- **Kamera-Snapshot bei Wakeword**: Satellites mit Kamera (z.B. IMX219) fotografieren automatisch bei Wakeword-Erkennung
+- **Vision-LLM**: Bild + Transkription werden an ein Vision-fähiges Modell (z.B. `qwen3-vl`) geschickt
+- **Anwendungsbeispiele**: "Was steht auf diesem Zettel?", "Was siehst du?", "Welche Farbe hat das?"
+- **Graceful Degradation**: Satellites ohne Kamera sind nicht betroffen; ohne Vision-Modell wird das Bild ignoriert
+- **Audio-Ausgabe**: Antwort wird per TTS über DLNA-Renderer oder Satellite-Speaker abgespielt
+
+Siehe [SATELLITE_CAMERA.md](SATELLITE_CAMERA.md) für Details.
+
 ## Konversations-Gedächtnis (Langzeit)
 
 Renfield kann sich Dinge über Nutzer langfristig merken — Präferenzen, Fakten und Anweisungen werden als semantische Embeddings gespeichert und bei relevanten zukünftigen Gesprächen automatisch eingeblendet.

--- a/docs/LLM_MODEL_GUIDE.md
+++ b/docs/LLM_MODEL_GUIDE.md
@@ -11,7 +11,8 @@ Keine Cloud-LLMs — alles laeuft lokal auf eigener Hardware.
 
 1. [Aktueller Stand (Produktion)](#aktueller-stand-produktion)
 2. [Alle LLM-Funktionen im Detail](#alle-llm-funktionen-im-detail)
-3. [Embedding-Modell](#8-embeddings)
+3. [Vision-Modell](#8-vision-satellite-camera)
+4. [Embedding-Modell](#9-embeddings)
 4. [Hardware-Architektur: Dual-Ollama](#hardware-architektur-dual-ollama)
 5. [Konfiguration](#konfiguration)
 6. [Qualitaetsvergleich](#qualitaetsvergleich-qwen314b-vs-30b-a3b)
@@ -29,6 +30,7 @@ Keine Cloud-LLMs — alles laeuft lokal auf eigener Hardware.
 | `ollama_intent_model` | `qwen3:8b` | RTX 5070 Ti (cuda.local) | Intent-Erkennung |
 | `ollama_embed_model` | `qwen3-embedding:4b` | RTX 5070 Ti (cuda.local) | Alle Embeddings (5 Services, 2560 dim) |
 | `agent_model` | `qwen3:14b` | RTX 5060 Ti (renfield.local) | Agent Loop, Router |
+| `ollama_vision_model` | `qwen3-vl` | RTX 5060 Ti (renfield.local) | Satellite Camera Visual Queries |
 | `proactive_enrichment_model` | `None` (Fallback auf chat_model) | — | Notification-Enrichment |
 
 **Qwen3-Familie** — Vollstaendig migriert (Februar 2026). Alle Rollen nutzen Qwen3-Modelle mit `think=False` fuer schnelle, deterministische Antworten. Exzellentes Deutsch, zuverlaessiges JSON, starkes Tool-Calling.
@@ -156,7 +158,33 @@ Keine Cloud-LLMs — alles laeuft lokal auf eigener Hardware.
 
 ---
 
-### 8. Embeddings
+### 8. Vision (Satellite Camera)
+
+| Aspekt | Detail |
+|--------|--------|
+| **Config** | `ollama_vision_model` + `ollama_vision_url` |
+| **Service** | `ollama_service.py` → `chat_stream_with_image()` |
+| **Aufgabe** | Bild + Text → natuerliche Bildbeschreibung (Deutsch/Englisch) |
+| **Output** | Freitext (Beschreibung der Szene) |
+| **Anforderung** | Vision-faehig, gutes Deutsch, muss in 16 GB VRAM passen |
+
+**Aktuell (PRD):** `qwen3-vl` (~12 GB VRAM) auf RTX 5060 Ti (renfield.local) — Unterstuetzt Thinking-Modus (`think=False` aktiv), exzellentes Deutsch, ~30s pro Query (davon ~25s Prompt-Evaluation fuer Bild-Tokens).
+
+**Alternativen:**
+
+| Modell | VRAM | Geschwindigkeit | Qualitaet | Anmerkung |
+|--------|------|-----------------|-----------|-----------|
+| **`qwen3-vl`** | ~12 GB | ~30s | Exzellent | Empfohlen, passt auf 16 GB |
+| `qwen2.5vl` | ~10 GB | ~25s | Gut | Aeltere Generation |
+| `llava:7b` | ~6 GB | ~8s | Gut | Schnell, aber schwaecher auf Deutsch |
+| `llava:13b` | ~12 GB | ~15s | Sehr gut | Guter Kompromiss |
+| `minicpm-v` | ~19 GB | ~50s | Gut | Passt NICHT auf 16 GB (Partial Offload) |
+
+**WARNUNG:** `minicpm-v` benoetigt ~19 GB VRAM. Auf einer 16 GB Karte wird es teilweise auf die CPU ausgelagert, was die Latenz auf ~50s erhoehen kann.
+
+---
+
+### 9. Embeddings
 
 | Aspekt | Detail |
 |--------|--------|
@@ -224,7 +252,8 @@ Ollama Primary (cuda.local — RTX 5070 Ti 16 GB, 896 GB/s)
 └── qwen3-embedding:4b  ~3 GB  [Embeddings, 2560 dim] keep_alive=-1
 
 Ollama Agent (renfield.local — RTX 5060 Ti 16 GB, 448 GB/s)
-└── qwen3:14b          ~10 GB  [Agent Loop + Router]  keep_alive=5m
+├── qwen3:14b          ~10 GB  [Agent Loop + Router]  keep_alive=5m
+└── qwen3-vl           ~12 GB  [Vision / Camera]      keep_alive=5m
 ```
 
 Alle Modelle nutzen `think=False` fuer schnelle, deterministische Antworten. Dense-Architektur = vorhersagbare Latenz. Ollama laedt Modelle on-demand; qwen3:14b und qwen3:8b teilen sich den VRAM auf der Primary GPU (nur eines aktiv, `keep_alive=5m`).
@@ -262,6 +291,10 @@ AGENT_TOTAL_TIMEOUT=600.0
 
 # Fallback: Wenn cuda.local offline, nutze renfield.local's GPU
 OLLAMA_FALLBACK_URL=http://host.docker.internal:11434
+
+# === Vision (Satellite Camera — RTX 5060 Ti auf renfield.local) ===
+OLLAMA_VISION_MODEL=qwen3-vl
+OLLAMA_VISION_URL=http://host.docker.internal:11434
 ```
 
 **`host.docker.internal`** wird von Docker zu der IP des Host-Systems aufgeloest. Da das Renfield-Backend als Docker-Container auf renfield.local laeuft, zeigt `host.docker.internal` auf die lokale Ollama-Instanz (RTX 5060 Ti).
@@ -362,6 +395,11 @@ Ungefaehre Werte fuer Q4_K_M Quantisierung:
 | qwen3:30b-a3b | 30B (3B aktiv) | MoE | ~20 GB | ~0.2 GB | ~20.2 GB |
 | qwen3:32b | 32B | Dense | ~22 GB | ~1.0 GB | ~23 GB |
 | mistral-small3.2:24b | 24B | Dense | ~15 GB | ~1.7 GB | **~16.7 GB** |
+| **qwen3-vl** | **8.8B** | **Vision** | **~10 GB** | **~2 GB** | **~12 GB** |
+| qwen2.5vl | 7B | Vision | ~8 GB | ~2 GB | ~10 GB |
+| minicpm-v | 8B | Vision | ~17 GB | ~2 GB | ~19 GB |
+| llava:7b | 7B | Vision | ~5 GB | ~1 GB | ~6 GB |
+| llava:13b | 13B | Vision | ~10 GB | ~2 GB | ~12 GB |
 | qwen3-embedding:4b | 4B | — | ~3 GB | — | ~3 GB |
 | qwen3-embedding:0.6b | 0.6B | — | ~0.5 GB | — | ~0.5 GB |
 | nomic-embed-text | 137M | — | ~0.3 GB | — | ~0.3 GB |

--- a/docs/OUTPUT_ROUTING.md
+++ b/docs/OUTPUT_ROUTING.md
@@ -16,15 +16,18 @@ Renfield unterstützt intelligentes Routing von TTS-Ausgaben an das beste verfü
 
 ### ADVERTISE_HOST Konfiguration
 
-Damit Home Assistant die TTS-Audio-Dateien vom Renfield-Backend abrufen kann, muss `ADVERTISE_HOST` in der `.env` Datei gesetzt werden:
+Damit HA Media Player und DLNA Renderer die TTS-Audio-Dateien vom Renfield-Backend abrufen können, muss `ADVERTISE_HOST` in der `.env` Datei gesetzt werden:
 
 ```bash
 # .env
-ADVERTISE_HOST=192.168.1.100  # IP oder Hostname des Renfield-Servers
-ADVERTISE_PORT=8000           # Optional, Standard: 8000
+ADVERTISE_HOST=192.168.1.159  # IP-Adresse des Renfield-Servers
+ADVERTISE_PORT=80             # Port 80 = Nginx (empfohlen für Produktion)
 ```
 
-Der Wert muss eine Adresse sein, die Home Assistant erreichen kann (nicht `localhost`).
+**Wichtig:**
+- **IP-Adresse verwenden**, nicht mDNS (`.local`) — DLNA-Renderer können mDNS oft nicht auflösen
+- **Port 80** verwenden — Port 8000 ist nur auf `127.0.0.1` gebunden und von extern nicht erreichbar
+- Nginx muss `/api/voice/tts-cache/` über **plain HTTP** weiterleiten (ohne HTTPS-Redirect), da DLNA-Renderer kein HTTPS/self-signed Certs unterstützen
 
 ## Konfiguration über das Frontend
 
@@ -252,18 +255,21 @@ User spricht zum Tablet: "Wie ist das Wetter?"
 
 ## Troubleshooting
 
-### TTS wird nicht auf HA Media Player abgespielt
+### TTS wird nicht auf HA Media Player / DLNA Renderer abgespielt
 
 1. **ADVERTISE_HOST prüfen:**
    ```bash
    docker exec renfield-backend env | grep ADVERTISE
    ```
-   Muss auf erreichbare IP/Hostname gesetzt sein.
+   Muss auf erreichbare IP gesetzt sein (nicht `.local` für DLNA!).
 
-2. **Kann HA die URL erreichen?**
+2. **Kann der Renderer die URL erreichen?**
    ```bash
-   # Von HA aus testen:
-   curl http://<ADVERTISE_HOST>:8000/api/voice/tts-cache/test
+   # Von einem anderen Gerät im LAN testen:
+   curl http://<ADVERTISE_HOST>/api/voice/tts-cache/test
+   # Erwartung: 404 (Not Found) = Endpoint erreichbar
+   # 301 = HTTPS-Redirect (Nginx-Konfig prüfen)
+   # Connection refused = Port/IP falsch
    ```
 
 3. **Media Player Status prüfen:**

--- a/docs/SATELLITE_CAMERA.md
+++ b/docs/SATELLITE_CAMERA.md
@@ -54,18 +54,26 @@ Requires `rpicam-still` to be available on the Pi (standard with Raspberry Pi OS
 Set in `.env`:
 
 ```bash
-OLLAMA_VISION_MODEL=minicpm-v
+# Vision model (must support Ollama's images parameter)
+OLLAMA_VISION_MODEL=qwen3-vl
+
+# Optional: dedicated Ollama instance for vision (e.g. GPU server)
+OLLAMA_VISION_URL=http://host.docker.internal:11434
 ```
 
 Then pull the model:
 
 ```bash
-ollama pull minicpm-v
+ollama pull qwen3-vl
 ```
 
 If `OLLAMA_VISION_MODEL` is empty (default), visual queries are disabled and the
 image is silently ignored — the satellite still captures but the backend uses the
 standard text-only chat model.
+
+**Important:** The TTS cache endpoint (`/api/voice/tts-cache/`) must be reachable
+by DLNA renderers over plain HTTP. See [OUTPUT_ROUTING.md](OUTPUT_ROUTING.md) for
+`ADVERTISE_HOST` / `ADVERTISE_PORT` configuration.
 
 ### 3. Provisioning
 
@@ -114,11 +122,17 @@ No new message types are introduced. Satellites without cameras simply omit the 
 
 Tested models:
 
-| Model | Size | Speed | Quality |
-|-------|------|-------|---------|
-| `minicpm-v` | 5.5GB | ~10s | Good for text reading, scene description |
-| `llava:7b` | 4.7GB | ~8s | Good general vision |
-| `llava:13b` | 8.0GB | ~15s | Better quality, slower |
+| Model | Size | VRAM | Speed (GPU) | Quality |
+|-------|------|------|-------------|---------|
+| **`qwen3-vl`** | 6.0GB | ~12GB | ~30s | Excellent scene description, good German |
+| `qwen2.5vl` | 5.0GB | ~10GB | ~25s | Good vision, slightly older |
+| `minicpm-v` | 5.5GB | ~19GB | ~50s (partial offload on 16GB) | Good for text reading |
+| `llava:7b` | 4.7GB | ~6GB | ~8s | Good general vision |
+| `llava:13b` | 8.0GB | ~12GB | ~15s | Better quality, slower |
 
-Choose based on your hardware. On `cuda.local` with GPU, `minicpm-v` provides a good
-balance of speed and quality.
+**Recommendation:** `qwen3-vl` fits entirely in 16GB VRAM and delivers excellent results
+in German. `minicpm-v` requires 19GB and partially offloads to CPU on 16GB cards, causing
+~50s latency.
+
+**Production (renfield.local):** `qwen3-vl` on RTX 5060 Ti (16GB), ~30s per query
+(including ~25s prompt evaluation for image tokens).

--- a/src/backend/api/routes/voice.py
+++ b/src/backend/api/routes/voice.py
@@ -148,7 +148,7 @@ async def text_to_speech(request: Request, tts_request: TTSRequest, _user=Depend
         raise HTTPException(status_code=500, detail=str(e))
 
 @router.get("/tts-cache/{audio_id}")
-async def get_tts_cache(audio_id: str, _user=Depends(get_current_user)):
+async def get_tts_cache(audio_id: str):
     """
     Serve cached TTS audio files.
 

--- a/src/backend/services/audio_output_service.py
+++ b/src/backend/services/audio_output_service.py
@@ -69,6 +69,13 @@ class AudioOutputService:
                 device_id=output_device.renfield_device_id,
                 session_id=session_id
             )
+        elif output_device.is_dlna_device:
+            return await self._play_on_dlna_renderer(
+                audio_bytes=audio_bytes,
+                renderer_name=output_device.dlna_renderer_name,
+                tts_volume=output_device.tts_volume,
+                session_id=session_id
+            )
         else:
             return await self._play_on_ha_media_player(
                 audio_bytes=audio_bytes,
@@ -113,6 +120,64 @@ class AudioOutputService:
 
         except Exception as e:
             logger.error(f"Failed to send audio to Renfield device {device_id}: {e}")
+            return False
+
+    async def _play_on_dlna_renderer(
+        self,
+        audio_bytes: bytes,
+        renderer_name: str,
+        tts_volume: float | None,
+        session_id: str
+    ) -> bool:
+        """
+        Play audio on a DLNA renderer via the DLNA MCP server.
+
+        1. Save audio to cache file
+        2. Call mcp.dlna.play_tracks with the cache URL
+        """
+        import json
+
+        await self._cleanup_old_cache_files()
+
+        audio_id = f"tts_{session_id}_{uuid.uuid4().hex[:8]}"
+        audio_path = self.TTS_CACHE_DIR / f"{audio_id}.wav"
+
+        try:
+            audio_path.write_bytes(audio_bytes)
+        except Exception as e:
+            logger.error(f"Failed to cache TTS audio for DLNA: {e}")
+            return False
+
+        base_url = self._get_backend_url()
+        audio_url = f"{base_url}/api/voice/tts-cache/{audio_id}"
+
+        try:
+            from main import app
+            mcp_manager = getattr(app.state, "mcp_manager", None)
+            if not mcp_manager:
+                logger.warning(f"MCP manager not available for DLNA playback on {renderer_name}")
+                return False
+
+            tracks = [{"url": audio_url, "title": "Renfield TTS"}]
+            logger.info(f"🔊 DLNA play_tracks: renderer={renderer_name}, url={audio_url}")
+            result = await mcp_manager.execute_tool(
+                "mcp.dlna.play_tracks",
+                {
+                    "renderer_name": renderer_name,
+                    "tracks": json.dumps(tracks),
+                },
+            )
+            logger.info(f"🔊 DLNA play_tracks result: {result}")
+
+            if result.get("success"):
+                logger.info(f"🔊 Playing TTS audio on DLNA renderer {renderer_name}")
+                return True
+            else:
+                logger.warning(f"DLNA playback failed on {renderer_name}: {result.get('message', 'unknown')}")
+                return False
+
+        except Exception as e:
+            logger.error(f"Failed to play audio on DLNA renderer {renderer_name}: {e}")
             return False
 
     async def _play_on_ha_media_player(
@@ -239,8 +304,10 @@ class AudioOutputService:
         """
         if settings.advertise_host:
             host = settings.advertise_host
-            port = settings.advertise_port or 8000
-            return f"http://{host}:{port}"
+            port = settings.advertise_port
+            if port and port != 80:
+                return f"http://{host}:{port}"
+            return f"http://{host}"
 
         # Use internal Docker URL - works when HA and Renfield are on same Docker network
         logger.debug(f"Using internal backend URL: {settings.backend_internal_url}")

--- a/src/satellite/renfield_satellite/satellite.py
+++ b/src/satellite/renfield_satellite/satellite.py
@@ -76,7 +76,7 @@ class Satellite:
         self._silence_chunks: int = 0  # Consecutive non-speech chunks (for audio-time silence detection)
         self._listening_start: Optional[float] = None  # When listening state began
         self._processing_start: Optional[float] = None  # Track when processing started
-        self._processing_timeout: float = 30.0  # Max time to wait for server response
+        self._processing_timeout: float = 60.0  # Max time to wait for server response (vision models need more time)
         self._reconnecting: bool = False  # Prevent duplicate reconnection attempts
         self._wakeword_pending: bool = False  # Prevent duplicate wakeword processing
         self._pending_snapshot: Optional[asyncio.Task] = None  # Background camera capture


### PR DESCRIPTION
## Summary
- Add DLNA renderer support in `audio_output_service.py` (play via `mcp.dlna.play_tracks`)
- Remove auth from `/api/voice/tts-cache/` endpoint (DLNA renderers can't authenticate)
- Add Nginx HTTP passthrough for TTS cache path (DLNA renderers can't do HTTPS)
- Fix `ADVERTISE_HOST`: use IP address instead of mDNS (`.local` unresolvable by DLNA renderers)
- Fix `ADVERTISE_PORT`: use 80 (Nginx) instead of 8000 (localhost-only binding)
- Increase satellite processing timeout from 30s to 60s for vision model queries
- Update docs: SATELLITE_CAMERA, ENVIRONMENT_VARIABLES, LLM_MODEL_GUIDE, FEATURES, OUTPUT_ROUTING

## Test plan
- [x] End-to-end: "Hey Renfield, was siehst du?" → Vision response via qwen3-vl → TTS on HiFiBerry DLNA
- [x] TTS cache URL reachable over plain HTTP (port 80, no auth)
- [x] DLNA renderer fetches audio (verified in nginx access logs)
- [x] Vision model (qwen3-vl) responds in ~30s on RTX 5060 Ti

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)