### PR TITLE
feat(satellite): Add Esszimmer satellite and fix overlay install script (#292)

### DIFF
--- a/src/satellite/hardware/install-overlay.sh
+++ b/src/satellite/hardware/install-overlay.sh
@@ -112,10 +112,12 @@ echo "To complete installation, reboot the system:"
 echo "  sudo reboot"
 echo ""
 
-# Ask to reboot
-read -p "Reboot now? [y/N] " -n 1 -r
-echo
-if [[ $REPLY =~ ^[Yy]$ ]]; then
-    echo "Rebooting..."
-    reboot
+# Ask to reboot (only when running interactively — skip in Ansible/CI)
+if [ -t 0 ]; then
+    read -p "Reboot now? [y/N] " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        echo "Rebooting..."
+        reboot
+    fi
 fi

--- a/src/satellite/provisioning/host_vars/satellite-esszimmer.yml
+++ b/src/satellite/provisioning/host_vars/satellite-esszimmer.yml
@@ -1,0 +1,18 @@
+---
+# ReSpeaker 2-Mic HAT V2 configuration (TLV320AIC3104 codec at I2C 0x18)
+
+hat_type: "2mic-v2"
+satellite_id: "sat-esszimmer"
+satellite_room: "Esszimmer"
+
+# Audio (stereo with beamforming)
+audio_device: "capture"
+audio_playback_device: "plughw:0,0"
+audio_channels: 2
+beamforming_enabled: true
+beamforming_mic_spacing: 0.058
+
+# LEDs (2-Mic HAT: 3 LEDs on SPI 0:0, no power pin)
+led_num: 3
+led_spi_device: 0
+led_power_pin: null

--- a/src/satellite/provisioning/inventory.yml
+++ b/src/satellite/provisioning/inventory.yml
@@ -15,3 +15,6 @@ all:
         satellite-arbeitszimmer:
           ansible_host: satellite-arbeitszimmer.local
           ansible_user: evdb
+        satellite-esszimmer:
+          ansible_host: satellite-esszimmer.local
+          ansible_user: evdb


### PR DESCRIPTION
## Summary
- Add satellite-esszimmer (ReSpeaker 2-Mic V2 / TLV320AIC3104) to provisioning inventory and host_vars
- Fix `install-overlay.sh`: guard interactive `read -p` prompt with `[ -t 0 ]` to prevent hanging in Ansible/CI

## Changes
- `src/satellite/provisioning/inventory.yml` — add satellite-esszimmer entry
- `src/satellite/provisioning/host_vars/satellite-esszimmer.yml` — new file, `hat_type: "2mic-v2"`
- `src/satellite/hardware/install-overlay.sh` — non-interactive guard for reboot prompt

## Test plan
- [x] Full Ansible provisioning run against satellite-esszimmer
- [x] Sound card `seeed2micvoicec` detected after reboot
- [x] Systemd service running on satellite

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)