### PR TITLE
feat(satellite): configurable IDLE LED color per satellite

### DIFF
--- a/src/satellite/provisioning/host_vars/satellite-esszimmer.yml
+++ b/src/satellite/provisioning/host_vars/satellite-esszimmer.yml
@@ -16,3 +16,6 @@ beamforming_mic_spacing: 0.058
 led_num: 3
 led_spi_device: 0
 led_power_pin: null
+
+# IDLE LED color for visual identification
+led_idle_color: "yellow"

--- a/src/satellite/provisioning/host_vars/satellite-wohnzimmer.yml
+++ b/src/satellite/provisioning/host_vars/satellite-wohnzimmer.yml
@@ -17,5 +17,8 @@ led_num: 3
 led_spi_device: 0
 led_power_pin: null
 
+# IDLE LED color for visual identification
+led_idle_color: "green"
+
 # 2-mic overlay variant: "simple" or "full"
 overlay_variant: "simple"

--- a/src/satellite/provisioning/templates/satellite.yaml.j2
+++ b/src/satellite/provisioning/templates/satellite.yaml.j2
@@ -43,6 +43,7 @@ vad:
 led:
   type: "{{ led_type | default('apa102') }}"
   brightness: {{ led_brightness }}
+  idle_color: "{{ led_idle_color | default('blue') }}"
 {% if led_type | default('apa102') == 'gpio_rgb' %}
   gpio_red: {{ led_gpio_red }}
   gpio_green: {{ led_gpio_green }}

--- a/src/satellite/renfield_satellite/config.py
+++ b/src/satellite/renfield_satellite/config.py
@@ -90,6 +90,7 @@ class LEDConfig:
     spi_device: int = 0
     num_leds: int = 3
     led_power_pin: Optional[int] = None  # GPIO pin to enable LED power (4-mic HAT: 5)
+    idle_color: Optional[str] = None  # IDLE pulse color name (e.g. "green", "yellow"); None = blue
     # GPIO RGB LED pins (Whisplay HAT)
     gpio_red: Optional[int] = None
     gpio_green: Optional[int] = None
@@ -244,6 +245,7 @@ def load_config(config_path: Optional[str] = None) -> Config:
         config.led.spi_bus = led.get("spi_bus", config.led.spi_bus)
         config.led.spi_device = led.get("spi_device", config.led.spi_device)
         config.led.led_power_pin = led.get("led_power_pin", config.led.led_power_pin)
+        config.led.idle_color = led.get("idle_color", config.led.idle_color)
         config.led.gpio_red = led.get("gpio_red", config.led.gpio_red)
         config.led.gpio_green = led.get("gpio_green", config.led.gpio_green)
         config.led.gpio_blue = led.get("gpio_blue", config.led.gpio_blue)

--- a/src/satellite/renfield_satellite/hardware/led.py
+++ b/src/satellite/renfield_satellite/hardware/led.py
@@ -88,6 +88,7 @@ class LEDController:
         spi_device: int = 0,
         brightness: int = 20,
         led_power_pin: Optional[int] = None,
+        idle_color: Optional[str] = None,
     ):
         """
         Initialize LED controller.
@@ -98,12 +99,14 @@ class LEDController:
             spi_device: SPI device number
             brightness: Default brightness 0-31
             led_power_pin: GPIO pin to enable LED power (4-mic HAT uses GPIO5)
+            idle_color: Color name for IDLE pulse (e.g. "green", "yellow"); defaults to blue
         """
         self.num_leds = num_leds
         self.spi_bus = spi_bus
         self.spi_device = spi_device
         self.brightness = min(31, max(0, brightness))
         self.led_power_pin = led_power_pin
+        self.idle_color = idle_color
         self._power = None
 
         self._spi: Optional["spidev.SpiDev"] = None
@@ -269,8 +272,9 @@ class LEDController:
             pattern = self._pattern
 
             if pattern == LEDPattern.IDLE:
-                # Dim blue pulse
-                self._animate_pulse(frame, COLORS["blue"], 0.05)
+                # Dim pulse in configured idle color (default: blue)
+                idle = COLORS.get(self.idle_color, COLORS["blue"])
+                self._animate_pulse(frame, idle, 0.05)
 
             elif pattern == LEDPattern.LISTENING:
                 # Solid green
@@ -397,11 +401,13 @@ class GPIOLEDController:
         gpio_green: int = 24,
         gpio_blue: int = 23,
         brightness: int = 20,
+        idle_color: Optional[str] = None,
     ):
         self.gpio_red = gpio_red
         self.gpio_green = gpio_green
         self.gpio_blue = gpio_blue
         self.brightness = min(31, max(0, brightness))
+        self.idle_color = idle_color
 
         self._red: Optional["PWMLED"] = None
         self._green: Optional["PWMLED"] = None
@@ -477,7 +483,8 @@ class GPIOLEDController:
             pattern = self._pattern
 
             if pattern == LEDPattern.IDLE:
-                self._animate_pulse(frame, 0, 0, 255, 0.05)
+                idle = COLORS.get(self.idle_color, COLORS["blue"])
+                self._animate_pulse(frame, idle.r, idle.g, idle.b, 0.05)
             elif pattern == LEDPattern.LISTENING:
                 self._set_color(0, 255, 0)
                 time.sleep(0.1)

--- a/src/satellite/renfield_satellite/satellite.py
+++ b/src/satellite/renfield_satellite/satellite.py
@@ -155,6 +155,7 @@ class Satellite:
                 gpio_green=self.config.led.gpio_green or 24,
                 gpio_blue=self.config.led.gpio_blue or 23,
                 brightness=self.config.led.brightness,
+                idle_color=self.config.led.idle_color,
             )
         else:
             self.leds = LEDController(
@@ -163,6 +164,7 @@ class Satellite:
                 spi_device=self.config.led.spi_device,
                 brightness=self.config.led.brightness,
                 led_power_pin=self.config.led.led_power_pin,
+                idle_color=self.config.led.idle_color,
             )
 
         # Display controller (optional, Whisplay HAT)


### PR DESCRIPTION
## Summary
- Each satellite can now display a distinct IDLE pulse color for visual room identification
- Wohnzimmer = green, Esszimmer = yellow, default = blue (backwards compatible)
- New `idle_color` field in `LEDConfig`, supported by both `LEDController` (APA102/SPI) and `GPIOLEDController` (Whisplay)

## Test plan
- [x] All 155 satellite tests pass
- [ ] Deploy to Wohnzimmer → verify green IDLE pulse
- [ ] Deploy to Esszimmer → verify yellow IDLE pulse
- [ ] Satellite without `idle_color` config → verify blue default

🤖 Generated with [Claude Code](https://claude.com/claude-code)