### PR TITLE
feat(hooks): add execute_tool hook for plugin tool dispatch

### DIFF
--- a/src/backend/services/action_executor.py
+++ b/src/backend/services/action_executor.py
@@ -75,6 +75,15 @@ class ActionExecutor:
                 user_id=user_id,
             )
 
+        # Plugin tool dispatch — plugins can register custom tool handlers
+        from utils.hooks import run_hooks
+        hook_results = await run_hooks(
+            "execute_tool", intent=intent, parameters=parameters,
+            user_permissions=user_permissions, user_id=user_id,
+        )
+        if hook_results:
+            return hook_results[0]
+
         # Unknown intent
         return {
             "success": False,

--- a/src/backend/utils/hooks.py
+++ b/src/backend/utils/hooks.py
@@ -17,6 +17,7 @@ HOOK_EVENTS: frozenset[str] = frozenset({
     "shutdown",
     "register_routes",
     "register_tools",
+    "execute_tool",
     "post_message",
     "post_document_ingest",
     "retrieve_context",

--- a/tests/backend/test_hooks.py
+++ b/tests/backend/test_hooks.py
@@ -143,7 +143,7 @@ async def test_multiple_hooks_same_event():
 def test_hook_events_is_frozenset():
     """HOOK_EVENTS is immutable."""
     assert isinstance(HOOK_EVENTS, frozenset)
-    assert len(HOOK_EVENTS) == 6
+    assert len(HOOK_EVENTS) == 12
 
 
 # --- plugin loading integration ---


### PR DESCRIPTION
## Summary
- Add `execute_tool` to `HOOK_EVENTS` — allows plugins to handle custom agent tool calls
- Add plugin dispatch in `ActionExecutor.execute()` before the "Unknown intent" fallback
- Fix stale test assertion (event count was hardcoded to 6, actual is 12)

This enables the Reva plugin (and future plugins like renfield-twin) to register and execute their own agent tools without modifying Renfield core.

## Changes
- `src/backend/utils/hooks.py`: +1 line (new event)
- `src/backend/services/action_executor.py`: +8 lines (hook dispatch)
- `tests/backend/test_hooks.py`: fix assertion

## Test plan
- [x] All 13 hook tests pass
- [x] Reva plugin successfully registers and executes tools via this hook (42 tests in reva repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)