### PR TITLE
feat: add voice feature flag to gate Whisper/STT by edition

### DIFF
--- a/src/backend/api/lifecycle.py
+++ b/src/backend/api/lifecycle.py
@@ -516,8 +516,10 @@ async def lifespan(app: "FastAPI"):
     await _init_paperless_audit(app)
 
     # Background preloading
-    _schedule_whisper_preload()
-    _schedule_ha_keywords_preload()
+    if settings.features["voice"]:
+        _schedule_whisper_preload()
+    if settings.features["smart_home"]:
+        _schedule_ha_keywords_preload()
     _schedule_notification_cleanup()
     _schedule_reminder_checker()
     _schedule_notification_poller(app)

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -136,7 +136,8 @@ app.include_router(users.router, prefix="/api/users", tags=["Users"])
 app.include_router(chat.router, prefix="/api/chat", tags=["Chat"])
 app.include_router(chat_upload.router, prefix="/api/chat", tags=["Chat Upload"])
 app.include_router(tasks.router, prefix="/api/tasks", tags=["Tasks"])
-app.include_router(voice.router, prefix="/api/voice", tags=["Voice"])
+if settings.features["voice"]:
+    app.include_router(voice.router, prefix="/api/voice", tags=["Voice"])
 if settings.features["cameras"]:
     app.include_router(camera.router, prefix="/api/camera", tags=["Camera"])
 if settings.features["smart_home"]:

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -15,6 +15,7 @@ class Settings(BaseSettings):
     feature_smart_home: bool | None = None   # None = use edition default
     feature_cameras: bool | None = None      # None = use edition default
     feature_satellites: bool | None = None   # None = use edition default
+    feature_voice: bool | None = None       # None = use edition default
 
     # Datenbank - Einzelfelder für dynamischen DATABASE_URL-Aufbau
     database_url: str | None = None
@@ -353,14 +354,15 @@ class Settings(BaseSettings):
     def features(self) -> dict[str, bool]:
         """Resolve feature flags: explicit override > edition preset."""
         presets = {
-            "community": {"smart_home": True, "cameras": True, "satellites": True},
-            "pro": {"smart_home": False, "cameras": False, "satellites": False},
+            "community": {"smart_home": True, "cameras": True, "satellites": True, "voice": True},
+            "pro": {"smart_home": False, "cameras": False, "satellites": False, "voice": False},
         }
         defaults = presets.get(self.renfield_edition, presets["pro"])
         return {
             "smart_home": self.feature_smart_home if self.feature_smart_home is not None else defaults["smart_home"],
             "cameras": self.feature_cameras if self.feature_cameras is not None else defaults["cameras"],
             "satellites": self.feature_satellites if self.feature_satellites is not None else defaults["satellites"],
+            "voice": self.feature_voice if self.feature_voice is not None else defaults["voice"],
         }
 
     @property

--- a/tests/backend/test_feature_flags.py
+++ b/tests/backend/test_feature_flags.py
@@ -24,6 +24,7 @@ class TestEditionPresets:
             "smart_home": True,
             "cameras": True,
             "satellites": True,
+            "voice": True,
         }
 
     def test_pro_edition_disables_home_features(self):
@@ -33,6 +34,7 @@ class TestEditionPresets:
             "smart_home": False,
             "cameras": False,
             "satellites": False,
+            "voice": False,
         }
 
     def test_unknown_edition_falls_back_to_pro(self):
@@ -42,6 +44,7 @@ class TestEditionPresets:
             "smart_home": False,
             "cameras": False,
             "satellites": False,
+            "voice": False,
         }
 
     def test_default_edition_is_community(self):
@@ -95,6 +98,7 @@ class TestFeatureOverrides:
             "smart_home": True,
             "cameras": True,
             "satellites": True,
+            "voice": False,
         }
 
     def test_none_means_use_default(self):
@@ -104,6 +108,26 @@ class TestFeatureOverrides:
             feature_smart_home=None,
             _env_file=None,
         )
+        assert s.features["smart_home"] is True
+
+    def test_voice_override_enables_on_pro(self):
+        """Explicit True enables voice on pro edition."""
+        s = Settings(
+            renfield_edition="pro",
+            feature_voice=True,
+            _env_file=None,
+        )
+        assert s.features["voice"] is True
+        assert s.features["smart_home"] is False
+
+    def test_voice_override_disables_on_community(self):
+        """Explicit False disables voice on community edition."""
+        s = Settings(
+            renfield_edition="community",
+            feature_voice=False,
+            _env_file=None,
+        )
+        assert s.features["voice"] is False
         assert s.features["smart_home"] is True
 
 
@@ -122,6 +146,7 @@ class TestAuthStatusFeatures:
             "smart_home": True,
             "cameras": True,
             "satellites": True,
+            "voice": True,
         }
 
     def test_pro_features_for_status(self):
@@ -132,6 +157,7 @@ class TestAuthStatusFeatures:
             "smart_home": False,
             "cameras": False,
             "satellites": False,
+            "voice": False,
         }
 
     def test_override_in_features_for_status(self):
@@ -164,6 +190,11 @@ class TestRouteGuards:
         s = Settings(renfield_edition="pro", _env_file=None)
         assert s.features["satellites"] is False
 
+    def test_voice_route_not_mounted_when_disabled(self):
+        """Voice routes should not be mounted when voice feature is disabled."""
+        s = Settings(renfield_edition="pro", _env_file=None)
+        assert s.features["voice"] is False
+
     def test_all_routes_mounted_when_community(self):
         """All feature routes should be mounted in community edition."""
         s = Settings(renfield_edition="community", _env_file=None)
@@ -178,10 +209,10 @@ class TestFeaturesPropertyConsistency:
     """Test that features property is always consistent."""
 
     def test_features_returns_all_keys(self):
-        """Features dict always contains all three keys."""
+        """Features dict always contains all four keys."""
         for edition in ["community", "pro", "enterprise"]:
             s = Settings(renfield_edition=edition, _env_file=None)
-            assert set(s.features.keys()) == {"smart_home", "cameras", "satellites"}
+            assert set(s.features.keys()) == {"smart_home", "cameras", "satellites", "voice"}
 
     def test_features_values_are_bool(self):
         """All feature values are booleans."""


### PR DESCRIPTION
## Summary
- Add `feature_voice` flag to edition presets (`community=on`, `pro=off`)
- Gate Whisper preload and `/api/voice` route behind `features["voice"]`
- Gate HA keywords preload behind `features["smart_home"]`
- Eliminates noisy Whisper/HA error logs on Reva (pro edition) startup

## Override
Set `FEATURE_VOICE=true` in `.env` to re-enable voice on pro edition.

## Test plan
- [x] Backend tests pass (1599 passed, no new failures)
- [ ] Deploy to Reva server, verify no Whisper/HA errors in logs
- [ ] Verify `FEATURE_VOICE=true` override works

🤖 Generated with [Claude Code](https://claude.com/claude-code)