### PR TITLE
fix: lazy-import voice route to avoid whisper import when disabled

### DIFF
--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -36,7 +36,6 @@ from api.routes import (
     speakers,
     tasks,
     users,
-    voice,
 )
 from api.routes import homeassistant as ha_routes
 from api.routes import knowledge_graph as kg_routes
@@ -137,6 +136,7 @@ app.include_router(chat.router, prefix="/api/chat", tags=["Chat"])
 app.include_router(chat_upload.router, prefix="/api/chat", tags=["Chat Upload"])
 app.include_router(tasks.router, prefix="/api/tasks", tags=["Tasks"])
 if settings.features["voice"]:
+    from api.routes import voice
     app.include_router(voice.router, prefix="/api/voice", tags=["Voice"])
 if settings.features["cameras"]:
     app.include_router(camera.router, prefix="/api/camera", tags=["Camera"])


### PR DESCRIPTION
## Summary
- Move `from api.routes import voice` inside the `features["voice"]` gate
- Prevents `ModuleNotFoundError: No module named 'whisper'` on Reva (pro edition) where whisper is not installed

## Context
Follow-up to #296. The top-level import of the voice route module triggers `import whisper` at module load time, before the feature flag check can skip mounting the router.

## Test plan
- [ ] Reva starts without whisper import error
- [ ] Renfield (community) still mounts voice route normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)