### PR TITLE
fix(agent): escape unescaped control chars in JSON string values

### DIFF
--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -314,6 +314,44 @@ def _resolve_blobs(params: any, blob_store: dict[str, str]) -> any:
     return params
 
 
+def _fix_json_control_chars(raw: str) -> str:
+    """Escape literal control characters inside JSON string values.
+
+    Some LLMs (e.g. Qwen3) emit literal newlines/tabs inside JSON strings
+    instead of the required \\n / \\t escapes, causing json.loads to fail.
+    This walks the string tracking in-string state and replaces only control
+    chars that appear inside quoted strings.
+    """
+    out: list[str] = []
+    in_string = False
+    escape = False
+    for ch in raw:
+        if escape:
+            out.append(ch)
+            escape = False
+            continue
+        if ch == '\\' and in_string:
+            out.append(ch)
+            escape = True
+            continue
+        if ch == '"':
+            in_string = not in_string
+            out.append(ch)
+            continue
+        if in_string and ord(ch) < 0x20:
+            if ch == '\n':
+                out.append('\\n')
+            elif ch == '\r':
+                out.append('\\r')
+            elif ch == '\t':
+                out.append('\\t')
+            else:
+                out.append(f'\\u{ord(ch):04x}')
+            continue
+        out.append(ch)
+    return ''.join(out)
+
+
 def _parse_agent_json(raw: str) -> dict | None:
     """
     Robustly parse JSON from LLM output.
@@ -335,6 +373,16 @@ def _parse_agent_json(raw: str) -> dict | None:
             return result
     except json.JSONDecodeError:
         pass
+
+    # Method 1.5: Fix unescaped control characters in string values
+    fixed = _fix_json_control_chars(raw)
+    if fixed != raw:
+        try:
+            result = json.loads(fixed)
+            if isinstance(result, dict):
+                return result
+        except json.JSONDecodeError:
+            pass
 
     # Method 2: Markdown code block
     if "```" in raw:

--- a/tests/backend/test_agent_service.py
+++ b/tests/backend/test_agent_service.py
@@ -115,6 +115,35 @@ class TestParseAgentJson:
         assert result["parameters"]["attachments"][0]["filename"] == "invoice1.pdf"
 
     @pytest.mark.unit
+    def test_literal_newlines_in_string_value(self):
+        """Qwen3 emits literal newlines inside JSON strings — these must be escaped."""
+        raw = '{"action": "final_answer", "answer": "Line 1\nLine 2"}'
+        result = _parse_agent_json(raw)
+        assert result is not None
+        assert result["action"] == "final_answer"
+        assert result["answer"] == "Line 1\nLine 2"
+
+    @pytest.mark.unit
+    def test_literal_tabs_in_string_value(self):
+        """Literal tabs inside JSON strings should be escaped."""
+        raw = '{"action": "final_answer", "answer": "Col1\tCol2"}'
+        result = _parse_agent_json(raw)
+        assert result is not None
+        assert result["answer"] == "Col1\tCol2"
+
+    @pytest.mark.unit
+    def test_multiline_release_list(self):
+        """Realistic scenario: 21-entry release list with literal newlines between entries."""
+        entries = [f"[{i}] Release {i} | FAILED | 2026-02-{i:02d} | ID: Applications/Release{i}" for i in range(1, 22)]
+        answer = "\n".join(entries)
+        raw = '{"action": "final_answer", "answer": "' + answer + '"}'
+        result = _parse_agent_json(raw)
+        assert result is not None
+        assert result["action"] == "final_answer"
+        assert "[21]" in result["answer"]
+        assert result["answer"].count("\n") == 20
+
+    @pytest.mark.unit
     def test_deeply_nested_json_with_surrounding_text(self):
         """Deeply nested JSON embedded in text should still be parsed."""
         inner = json.dumps({


### PR DESCRIPTION
## Summary

- Add `_fix_json_control_chars()` helper that walks JSON strings char-by-char, tracks `in_string` state, and escapes literal control characters (`\n` → `\\n`, `\r` → `\\r`, `\t` → `\\t`, others → `\\uXXXX`)
- Insert as **Method 1.5** in `_parse_agent_json` between direct parse and markdown block extraction — only runs when the fix actually changes something
- Add 3 tests: literal newlines, literal tabs, and a realistic 21-entry release list with embedded newlines

## Context

Qwen3:14b emits literal newline characters (0x0A) inside JSON string values instead of the JSON-required `\n` escape. This causes `json.loads` to fail in all 4 parse methods, triggering the summary fallback (`num_predict: 1500`) that truncates long results (e.g. 21 releases → 14).

## Test plan

- [x] `python -m pytest tests/backend/test_agent_service.py::TestParseAgentJson -v` — 13/13 pass
- [x] E2E release flow on production — 21 releases with dates, correct ID resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)