### PR TITLE
fix(conversation): include metadata in load_context() return dicts

### DIFF
--- a/src/backend/services/conversation_service.py
+++ b/src/backend/services/conversation_service.py
@@ -81,7 +81,11 @@ class ConversationService:
                         f"[Aktionsergebnis — Verwende diese Daten für "
                         f"Folgeanfragen (IDs, Titel, etc.):\n{summary}]\n\n{content}"
                     )
-                context.append({"role": msg.role, "content": content})
+                context.append({
+                    "role": msg.role,
+                    "content": content,
+                    "metadata": msg.message_metadata,
+                })
 
             logger.info(f"Geladen: {len(context)} Nachrichten für Session {session_id}")
             return context


### PR DESCRIPTION
## Summary
- Include `message_metadata` in the dicts returned by `load_context()` so plugins can read per-message metadata (e.g. truncation flags)
- Backward-compatible: `agent_service.py` only reads `role` and `content` from history dicts, extra keys are ignored

## Context
Reva marks long assistant messages as `truncated: true` in metadata at save time. At load time it needs to read this flag to replace truncated messages with a re-fetch hint, preventing the LLM from reproducing incomplete data.

## Test plan
- [x] All 204 Reva tests pass
- [x] 1-line addition, no behavior change for existing consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)