### PR TITLE
feat(hooks): add pre_agent_context and pre_save_message hooks (#302)

### DIFF
--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -599,7 +599,7 @@ async def websocket_endpoint(
                     try:
                         async with AsyncSessionLocal() as db_session:
                             db_history = await ollama.load_conversation_context(
-                                msg_session_id, db_session, max_messages=10
+                                msg_session_id, db_session, max_messages=settings.agent_conv_context_messages
                             )
                             if db_history:
                                 session_state.conversation_history = db_history
@@ -721,6 +721,17 @@ async def websocket_endpoint(
                     lang=ollama.default_lang,
                 )
                 logger.info(f"🎯 Router: '{content[:60]}...' → {role.name}")
+
+                # Let plugins modify conversation history before the agent sees it
+                from utils.hooks import run_hooks
+                hook_results = await run_hooks(
+                    "pre_agent_context",
+                    history=session_state.conversation_history or [],
+                    session_id=msg_session_id or "",
+                    lang=ollama.default_lang,
+                )
+                if hook_results:
+                    session_state.conversation_history = hook_results[0]
 
                 if role.name == "conversation":
                     # Direct LLM response — no tools, no agent loop

--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -496,7 +496,14 @@ class AgentService:
         # like "Schick die gleiche Rechnung nochmal" or "Und wie ist es morgen?"
         conv_context = ""
         if conversation_history:
-            recent = conversation_history[-settings.agent_conv_context_messages:]
+            n = settings.agent_conv_context_messages
+            recent = conversation_history[-n:]
+            # Never split tool call / tool result pairs — if the first message
+            # is a tool result, include the preceding tool call too.
+            if (recent
+                    and recent[0].get("role") == "tool"
+                    and len(conversation_history) > n):
+                recent = conversation_history[-(n + 1):]
             history_lines = []
             for msg in recent:
                 role = "User" if msg.get("role") == "user" else "Assistant"

--- a/src/backend/services/conversation_service.py
+++ b/src/backend/services/conversation_service.py
@@ -114,6 +114,18 @@ class ConversationService:
             Gespeicherte Message
         """
         try:
+            # Let plugins modify content/metadata before saving
+            from utils.hooks import run_hooks
+            hook_results = await run_hooks(
+                "pre_save_message",
+                role=role, content=content,
+                metadata=metadata or {}, session_id=session_id,
+            )
+            if hook_results:
+                result = hook_results[0]
+                content = result.get("content", content)
+                metadata = result.get("metadata", metadata)
+
             # Finde oder erstelle Conversation
             result = await self.db.execute(
                 select(Conversation).where(Conversation.session_id == session_id)

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -107,7 +107,7 @@ class Settings(BaseSettings):
     agent_total_timeout: float = Field(default=120.0, ge=5.0, le=600.0)
     agent_model: str | None = None     # Optional: separate model for agent (default: ollama_model)
     agent_ollama_url: str | None = None # Optional: separate Ollama instance for agent (default: ollama_url)
-    agent_conv_context_messages: int = 6  # Number of conversation history messages in agent loop
+    agent_conv_context_messages: int = 12  # Number of conversation history messages in agent loop
     agent_roles_path: str = "config/agent_roles.yaml"  # Path to agent role definitions
     agent_router_timeout: float = 30.0    # Timeout for router classification LLM call (seconds)
 

--- a/src/backend/utils/hooks.py
+++ b/src/backend/utils/hooks.py
@@ -21,6 +21,8 @@ HOOK_EVENTS: frozenset[str] = frozenset({
     "post_message",
     "post_document_ingest",
     "retrieve_context",
+    "pre_agent_context",
+    "pre_save_message",
     "presence_enter_room",
     "presence_leave_room",
     "presence_first_arrived",


### PR DESCRIPTION
## Summary
- Expand `agent_conv_context_messages` default from 6 → 12 for richer follow-up context
- Replace hardcoded `max_messages=10` in chat_handler with `settings.agent_conv_context_messages`
- Add `pre_agent_context` hook: plugins can modify conversation history before the agent sees it
- Add `pre_save_message` hook: plugins can enrich content/metadata before DB save
- Add tool pair protection in `_build_agent_prompt()`: never split tool call / tool result pairs when truncating history

## Test plan
- [ ] `make test-backend` passes
- [ ] Deploy and verify 12-message context window
- [ ] Plugin hooks called correctly for save and context loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)