### PR TITLE
feat(conversations): context variables, LLM summary, agent prompt integration

### DIFF
--- a/src/backend/alembic/versions/x7y8z9a0b1c2_add_context_vars_and_summary.py
+++ b/src/backend/alembic/versions/x7y8z9a0b1c2_add_context_vars_and_summary.py
@@ -1,0 +1,31 @@
+"""Add context_vars and summary to conversations
+
+Revision ID: x7y8z9a0b1c2
+Revises: w6x7y8z9a0b1
+Create Date: 2026-03-08
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+# revision identifiers
+revision = "x7y8z9a0b1c2"
+down_revision = "w6x7y8z9a0b1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    columns = {c["name"] for c in inspector.get_columns("conversations")}
+
+    if "context_vars" not in columns:
+        op.add_column("conversations", sa.Column("context_vars", sa.JSON(), nullable=True))
+    if "summary" not in columns:
+        op.add_column("conversations", sa.Column("summary", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("conversations", "summary")
+    op.drop_column("conversations", "context_vars")

--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -733,6 +733,23 @@ async def websocket_endpoint(
                 if hook_results:
                     session_state.conversation_history = hook_results[0]
 
+                # Load conversation context vars and summary for agent prompt
+                _context_vars_text = ""
+                _summary_text = ""
+                if msg_session_id:
+                    try:
+                        from services.conversation_service import ConversationService
+                        async with AsyncSessionLocal() as _cv_db:
+                            _cv_svc = ConversationService(_cv_db)
+                            _ctx_vars = await _cv_svc.load_context_vars(msg_session_id)
+                            if _ctx_vars:
+                                _context_vars_text = "\n".join(
+                                    f"{k}: {v}" for k, v in _ctx_vars.items()
+                                )
+                            _summary_text = await _cv_svc.load_summary(msg_session_id) or ""
+                    except Exception as _e:
+                        logger.warning(f"Failed to load context vars/summary: {_e}")
+
                 if role.name == "conversation":
                     # Direct LLM response — no tools, no agent loop
                     intent = {"intent": "general.conversation", "parameters": {}, "confidence": 1.0}
@@ -786,6 +803,8 @@ async def websocket_endpoint(
                         personality_context=personality_context,
                         user_permissions=user_permissions,
                         user_id=user_id,
+                        context_vars_text=_context_vars_text,
+                        summary_text=_summary_text,
                     ):
                         ws_msg = step_to_ws_message(step)
                         await websocket.send_json(ws_msg)
@@ -960,6 +979,17 @@ WICHTIG: Nutze die ECHTEN Daten aus dem Ergebnis! Gib NUR die Antwort, KEIN JSON
                             metadata=assistant_metadata
                         )
                         logger.debug(f"💾 Messages saved to DB: session_id={msg_session_id}")
+
+                        # Trigger summary generation if conversation is long enough
+                        if settings.conversation_summary_threshold > 0:
+                            from services.conversation_service import ConversationService
+                            _sum_svc = ConversationService(db_session)
+                            await _sum_svc.update_summary(
+                                msg_session_id,
+                                llm_client=ollama.client,
+                                model=settings.ollama_chat_model or settings.ollama_model,
+                                threshold=settings.conversation_summary_threshold,
+                            )
                 except Exception as e:
                     logger.warning(f"⚠️ Failed to save messages to DB: {e}")
 

--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -38,6 +38,10 @@ class Conversation(Base):
     # Ownership (nullable for anonymous/legacy conversations)
     user_id = Column(Integer, ForeignKey("users.id"), nullable=True, index=True)
 
+    # Conversation state (survives history truncation)
+    context_vars = Column(JSON, nullable=True)   # Pinned structured state (entities, focus)
+    summary = Column(Text, nullable=True)         # LLM-generated summary of older messages
+
     # Beziehungen
     messages = relationship("Message", back_populates="conversation", cascade="all, delete-orphan")
     user = relationship("User", back_populates="conversations", foreign_keys=[user_id])

--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -479,6 +479,8 @@ class AgentService:
         memory_context: str = "",
         document_context: str = "",
         personality_context: str = "",
+        context_vars_text: str = "",
+        summary_text: str = "",
     ) -> str:
         """Build the prompt for the Agent LLM call."""
         tools_prompt = self.tool_registry.build_tools_prompt()
@@ -491,6 +493,13 @@ class AgentService:
                 "agent", "room_context_template", lang=lang,
                 room_name=room_context["room_name"]
             )
+
+        # Conversation context prefix: context vars + summary before raw history
+        conv_prefix = ""
+        if context_vars_text:
+            conv_prefix += f"## Conversation Context\n{context_vars_text}\n\n"
+        if summary_text:
+            conv_prefix += f"## Earlier in this conversation\n{summary_text}\n\n"
 
         # With 32k context, include conversation history for follow-up references
         # like "Schick die gleiche Rechnung nochmal" or "Und wie ist es morgen?"
@@ -513,6 +522,10 @@ class AgentService:
                 "agent", "conv_context_template", lang=lang,
                 history_lines="\n".join(history_lines)
             )
+
+        # Prepend context vars and summary before raw history
+        if conv_prefix:
+            conv_context = conv_prefix + conv_context
 
         # Determine step directive based on whether we have history
         if context.steps:
@@ -583,6 +596,8 @@ class AgentService:
         personality_context: str = "",
         user_permissions: list[str] | None = None,
         user_id: int | None = None,
+        context_vars_text: str = "",
+        summary_text: str = "",
     ) -> AsyncGenerator[AgentStep, None]:
         """
         Run the Agent Loop. Yields AgentStep objects for real-time feedback.
@@ -647,7 +662,7 @@ class AgentService:
                 return
 
             # Build prompt with all available tools (32k context fits all tools)
-            prompt = await self._build_agent_prompt(message, context, conversation_history, room_context=room_context, lang=lang, memory_context=memory_context, document_context=document_context, personality_context=personality_context)
+            prompt = await self._build_agent_prompt(message, context, conversation_history, room_context=room_context, lang=lang, memory_context=memory_context, document_context=document_context, personality_context=personality_context, context_vars_text=context_vars_text, summary_text=summary_text)
             logger.info(f"🤖 Agent step {step_num} prompt ({len(prompt)} chars, {total_tools} tools)")
 
             # Check circuit breaker before LLM call

--- a/src/backend/services/conversation_service.py
+++ b/src/backend/services/conversation_service.py
@@ -160,6 +160,141 @@ class ConversationService:
             await self.db.rollback()
             raise
 
+    async def save_context_vars(
+        self,
+        session_id: str,
+        vars_dict: dict,
+    ) -> None:
+        """Merge-update conversation context variables (pinned state).
+
+        Existing keys are preserved; new keys are added; keys set to None are removed.
+        """
+        try:
+            result = await self.db.execute(
+                select(Conversation).where(Conversation.session_id == session_id)
+            )
+            conversation = result.scalar_one_or_none()
+            if not conversation:
+                return
+
+            current = dict(conversation.context_vars or {})
+            for k, v in vars_dict.items():
+                if v is None:
+                    current.pop(k, None)
+                else:
+                    current[k] = v
+            conversation.context_vars = current
+            await self.db.commit()
+            logger.debug(f"Context vars updated for {session_id}: {list(current.keys())}")
+        except Exception as e:
+            logger.warning(f"Failed to save context vars: {e}")
+            await self.db.rollback()
+
+    async def load_context_vars(self, session_id: str) -> dict:
+        """Load conversation context variables. Returns empty dict if none."""
+        try:
+            result = await self.db.execute(
+                select(Conversation.context_vars).where(
+                    Conversation.session_id == session_id
+                )
+            )
+            row = result.scalar_one_or_none()
+            return dict(row) if row else {}
+        except Exception as e:
+            logger.warning(f"Failed to load context vars: {e}")
+            return {}
+
+    async def update_summary(
+        self,
+        session_id: str,
+        llm_client,
+        model: str,
+        threshold: int = 10,
+        keep_recent: int = 4,
+    ) -> str | None:
+        """Generate an LLM summary of older messages when conversation grows.
+
+        Triggers only when message count exceeds *threshold*. Summarizes all
+        messages except the most recent *keep_recent* ones. Stores the result
+        in ``conversations.summary``.
+
+        Returns the summary text, or None if not triggered / failed.
+        """
+        try:
+            result = await self.db.execute(
+                select(Conversation).where(Conversation.session_id == session_id)
+            )
+            conversation = result.scalar_one_or_none()
+            if not conversation:
+                return None
+
+            # Count messages
+            result = await self.db.execute(
+                select(func.count(Message.id)).where(
+                    Message.conversation_id == conversation.id
+                )
+            )
+            msg_count = result.scalar() or 0
+            if msg_count < threshold:
+                return conversation.summary  # return existing summary if any
+
+            # Load oldest messages (all except keep_recent)
+            result = await self.db.execute(
+                select(Message)
+                .where(Message.conversation_id == conversation.id)
+                .order_by(Message.timestamp.asc())
+                .limit(msg_count - keep_recent)
+            )
+            old_messages = result.scalars().all()
+            if not old_messages:
+                return conversation.summary
+
+            # Build text to summarize
+            lines = []
+            for msg in old_messages:
+                role = "User" if msg.role == "user" else "Assistant"
+                content = msg.content[:300] if msg.content else ""
+                lines.append(f"{role}: {content}")
+            conversation_text = "\n".join(lines)
+
+            # LLM summarization
+            from utils.llm_client import extract_response_content
+            response = await llm_client.chat(
+                model=model,
+                messages=[
+                    {"role": "system", "content": (
+                        "Summarize this conversation in 3-5 sentences. "
+                        "Preserve key decisions, entity names/IDs, and open questions. "
+                        "Write in the same language as the conversation."
+                    )},
+                    {"role": "user", "content": conversation_text},
+                ],
+            )
+            summary = extract_response_content(response)
+
+            conversation.summary = summary
+            await self.db.commit()
+            logger.info(f"Conversation summary updated for {session_id} ({len(summary)} chars)")
+            return summary
+
+        except Exception as e:
+            logger.warning(f"Failed to update summary: {e}")
+            await self.db.rollback()
+            return None
+
+    async def load_summary(self, session_id: str) -> str | None:
+        """Load the conversation summary. Returns None if none exists."""
+        try:
+            result = await self.db.execute(
+                select(Conversation.summary).where(
+                    Conversation.session_id == session_id
+                )
+            )
+            return result.scalar_one_or_none()
+        except Exception as e:
+            logger.warning(f"Failed to load summary: {e}")
+            return None
+
     async def get_summary(
         self,
         session_id: str

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -108,6 +108,7 @@ class Settings(BaseSettings):
     agent_model: str | None = None     # Optional: separate model for agent (default: ollama_model)
     agent_ollama_url: str | None = None # Optional: separate Ollama instance for agent (default: ollama_url)
     agent_conv_context_messages: int = 12  # Number of conversation history messages in agent loop
+    conversation_summary_threshold: int = 10  # Trigger LLM summary when message count exceeds this
     agent_roles_path: str = "config/agent_roles.yaml"  # Path to agent role definitions
     agent_router_timeout: float = 30.0    # Timeout for router classification LLM call (seconds)
 


### PR DESCRIPTION
## Summary
- Add `context_vars` (JSON) and `summary` (TEXT) columns to `conversations` table with Alembic migration
- Add `save_context_vars()`, `load_context_vars()`, `update_summary()`, `load_summary()` to ConversationService
- `update_summary()` triggers LLM summarization when message count exceeds `conversation_summary_threshold` (default 10)
- Pass `context_vars_text` and `summary_text` through `agent.run()` into `_build_agent_prompt()`
- Inject `## Conversation Context` and `## Earlier in this conversation` prefixes before raw history
- Load context vars + summary in WebSocket chat handler, trigger summary after message save

## Test plan
- [ ] `make test-backend` passes
- [ ] Deploy, send 10+ messages in one conversation → summary generated
- [ ] Check DB: `context_vars` and `summary` columns populated
- [ ] Agent prompt includes context vars and summary sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)