### PR TITLE
fix(db): correct alembic migration parent revision

### DIFF
--- a/src/backend/alembic/versions/x7y8z9a0b1c2_add_context_vars_and_summary.py
+++ b/src/backend/alembic/versions/x7y8z9a0b1c2_add_context_vars_and_summary.py
@@ -1,7 +1,7 @@
 """Add context_vars and summary to conversations
 
 Revision ID: x7y8z9a0b1c2
-Revises: w6x7y8z9a0b1
+Revises: t4c5d6e7f8g9
 Create Date: 2026-03-08
 """
 from alembic import op
@@ -10,7 +10,7 @@ from sqlalchemy import inspect
 
 # revision identifiers
 revision = "x7y8z9a0b1c2"
-down_revision = "w6x7y8z9a0b1"
+down_revision = "t4c5d6e7f8g9"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- Fix `down_revision` in `x7y8z9a0b1c2_add_context_vars_and_summary.py` from `w6x7y8z9a0b1` to `t4c5d6e7f8g9`
- This resolves the "Multiple head revisions" error when running `alembic upgrade head`

## Test plan
- [ ] `alembic upgrade head` runs without multiple heads error
- [ ] `context_vars` and `summary` columns added to `conversations` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)