### PR TITLE
fix: KG graph fills available container height

### DIFF
--- a/src/frontend/src/components/knowledge-graph/GraphView.jsx
+++ b/src/frontend/src/components/knowledge-graph/GraphView.jsx
@@ -48,18 +48,25 @@ export default function GraphView({ onEntityClick, onSwitchToEntities, isDark })
 
   const colors = isDark ? TYPE_COLORS_DARK : TYPE_COLORS;
 
-  // Measure container size
+  // Measure container size — also re-measure when loading finishes
   useEffect(() => {
     if (!containerRef.current) return;
-    const observer = new ResizeObserver((entries) => {
-      for (const entry of entries) {
-        const { width, height } = entry.contentRect;
-        setDimensions({ width: Math.max(400, width), height: Math.max(300, height) });
+
+    const measure = () => {
+      if (!containerRef.current) return;
+      const { width, height } = containerRef.current.getBoundingClientRect();
+      if (width > 0 && height > 0) {
+        setDimensions({ width: Math.floor(width), height: Math.floor(height) });
       }
-    });
+    };
+
+    // Measure immediately
+    measure();
+
+    const observer = new ResizeObserver(() => measure());
     observer.observe(containerRef.current);
     return () => observer.disconnect();
-  }, []);
+  }, [loading]);
 
   // Fetch initial data
   useEffect(() => {


### PR DESCRIPTION
## Summary
Graph canvas stayed at 800x600 default instead of filling the 1064x982 container. ResizeObserver now re-measures when loading state changes (spinner → graph) and uses getBoundingClientRect for reliable dimensions.

## Test plan
- [x] Verified container is 982px, canvas should now match

🤖 Generated with [Claude Code](https://claude.com/claude-code)