### PR TITLE
feat(memory): episodic lifecycle, confidence decay, trigger_pattern (#331)

### DIFF
--- a/src/backend/alembic/versions/pc20260402_add_episodic_hnsw_index.py
+++ b/src/backend/alembic/versions/pc20260402_add_episodic_hnsw_index.py
@@ -1,0 +1,64 @@
+"""Add HNSW vector index on episodic_memories.embedding
+
+The pc20260401 migration created the embedding column as sa.Text(),
+but SQLAlchemy create_all() may have already created it as vector(768).
+This migration:
+1. Converts the column to vector(768) if it's still text (idempotent)
+2. Creates the HNSW index for cosine similarity search
+
+Revision ID: pc20260402a1
+Revises: pc20260401a1
+Create Date: 2026-04-02
+"""
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers
+revision = "pc20260402a1"
+down_revision = "pc20260401a1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # Check if pgvector extension is available
+    result = conn.execute(
+        text("SELECT 1 FROM pg_extension WHERE extname = 'vector'")
+    )
+    if result.scalar() is None:
+        return  # pgvector not installed, skip
+
+    # Check current column type
+    result = conn.execute(text(
+        "SELECT data_type FROM information_schema.columns "
+        "WHERE table_name = 'episodic_memories' AND column_name = 'embedding'"
+    ))
+    row = result.first()
+    if row is None:
+        return  # table or column doesn't exist
+
+    # Convert from text to vector if needed
+    if row[0] == "text":
+        op.execute(text(
+            "ALTER TABLE episodic_memories "
+            "ALTER COLUMN embedding TYPE vector(768) "
+            "USING embedding::vector(768)"
+        ))
+
+    # Create HNSW index if it doesn't exist
+    result = conn.execute(
+        text("SELECT 1 FROM pg_indexes WHERE indexname = 'ix_episodic_embedding_hnsw'")
+    )
+    if result.scalar() is None:
+        op.execute(text(
+            "CREATE INDEX ix_episodic_embedding_hnsw "
+            "ON episodic_memories "
+            "USING hnsw (embedding vector_cosine_ops) "
+            "WITH (m = 16, ef_construction = 64)"
+        ))
+
+
+def downgrade() -> None:
+    op.execute(text("DROP INDEX IF EXISTS ix_episodic_embedding_hnsw"))

--- a/src/backend/api/lifecycle.py
+++ b/src/backend/api/lifecycle.py
@@ -163,6 +163,32 @@ def _schedule_memory_cleanup():
                         from utils.metrics import record_memory_cleanup
 
                         record_memory_cleanup(counts)
+
+                # Episodic memory: cleanup + summarization
+                if settings.memory_episodic_enabled:
+                    from services.episodic_memory_service import EpisodicMemoryService
+                    from sqlalchemy import select, func
+                    from models.database import EpisodicMemory
+
+                    async with AsyncSessionLocal() as db_session:
+                        ep_svc = EpisodicMemoryService(db_session)
+                        ep_counts = await ep_svc.cleanup()
+                        ep_total = sum(ep_counts.values())
+                        if ep_total > 0:
+                            logger.info(f"Episodic cleanup: {ep_counts}")
+
+                        # Summarize old episodes for users above threshold
+                        result = await db_session.execute(
+                            select(EpisodicMemory.user_id)
+                            .where(EpisodicMemory.is_active == True)  # noqa: E712
+                            .group_by(EpisodicMemory.user_id)
+                            .having(func.count(EpisodicMemory.id) > settings.memory_episodic_summarize_threshold)
+                        )
+                        user_ids = [row[0] for row in result.fetchall() if row[0] is not None]
+                        for uid in user_ids:
+                            summarized = await ep_svc.summarize_old(uid)
+                            if summarized > 0:
+                                logger.info(f"Episodic summarization: {summarized} episodes for user {uid}")
             except asyncio.CancelledError:
                 break
             except Exception as e:

--- a/src/backend/api/routes/knowledge.py
+++ b/src/backend/api/routes/knowledge.py
@@ -877,7 +877,7 @@ async def reindex_fts(
 
 @router.post("/rag-eval")
 async def run_rag_evaluation(
-    db: AsyncSession = Depends(get_async_session),
+    db: AsyncSession = Depends(get_db),
     user: User | None = Depends(get_optional_user),
     test_file: str | None = None,
 ):

--- a/src/backend/services/conversation_memory_service.py
+++ b/src/backend/services/conversation_memory_service.py
@@ -801,6 +801,31 @@ class ConversationMemoryService:
         await self.db.commit()
         return True
 
+    async def delete_all_for_user(
+        self,
+        user_id: int,
+        changed_by: str = "user",
+    ) -> int:
+        """Soft-delete ALL active memories for a user.
+
+        Counts total first, then processes in batches of 100 via
+        list_for_user + delete per item (with full audit history).
+        """
+        total = await self.get_count(user_id=user_id)
+        if total == 0:
+            return 0
+
+        deleted = 0
+        batch_size = 100
+        for _ in range(0, total, batch_size):
+            batch = await self.list_for_user(user_id, limit=batch_size)
+            for m in batch:
+                if await self.delete(m["id"], changed_by=changed_by):
+                    deleted += 1
+
+        logger.info(f"delete_all_for_user: {deleted}/{total} memories deleted for user_id={user_id}")
+        return deleted
+
     async def list_for_user(
         self,
         user_id: int,

--- a/src/backend/services/conversation_memory_service.py
+++ b/src/backend/services/conversation_memory_service.py
@@ -260,8 +260,9 @@ class ConversationMemoryService:
         # LLM call
         try:
             client = await self._get_ollama_client()
+            extraction_model = settings.memory_extraction_model or settings.ollama_model
             response = await client.chat(
-                model=settings.ollama_model,
+                model=extraction_model,
                 messages=[
                     {"role": "system", "content": system_msg},
                     {"role": "user", "content": prompt},
@@ -285,6 +286,7 @@ class ConversationMemoryService:
             content = item.get("content", "").strip()
             category = item.get("category", "").strip().lower()
             importance = item.get("importance", 0.5)
+            trigger_pattern = item.get("trigger_pattern")
 
             if not content:
                 continue
@@ -297,6 +299,13 @@ class ConversationMemoryService:
                 importance = max(0.1, min(1.0, float(importance)))
             except (TypeError, ValueError):
                 importance = 0.5
+
+            # Validate trigger_pattern if provided (procedural memories only)
+            if trigger_pattern and category == "procedural":
+                try:
+                    re.compile(trigger_pattern)
+                except re.error:
+                    trigger_pattern = None  # Invalid regex, discard
 
             if settings.memory_contradiction_resolution:
                 memory = await self._apply_contradiction_resolution(
@@ -314,6 +323,7 @@ class ConversationMemoryService:
                     user_id=user_id,
                     importance=importance,
                     source_session_id=session_id,
+                    trigger_pattern=trigger_pattern if category == "procedural" else None,
                 )
             if memory:
                 saved.append(memory)
@@ -426,6 +436,7 @@ class ConversationMemoryService:
                 content,
                 category,
                 importance,
+                confidence,
                 access_count,
                 created_at,
                 1 - (embedding <=> CAST(:embedding AS vector)) as similarity
@@ -433,7 +444,7 @@ class ConversationMemoryService:
             WHERE is_active = true
               AND embedding IS NOT NULL
               {user_filter}
-            ORDER BY (1 - (embedding <=> CAST(:embedding AS vector))) * importance DESC
+            ORDER BY (1 - (embedding <=> CAST(:embedding AS vector))) * importance * confidence DESC
             LIMIT :limit
         """)
 
@@ -600,7 +611,8 @@ class ConversationMemoryService:
         # --- 2. Procedural memories (scope: user + team + global) ---
         scope_filter = self._build_scope_filter(user_id, team_ids)
         procedural_sql = text(f"""
-            SELECT id, content, category, importance, access_count, created_at, source, scope
+            SELECT id, content, category, importance, access_count, created_at,
+                   source, scope, trigger_pattern
             FROM conversation_memories
             WHERE is_active = true
               AND category = 'procedural'
@@ -619,6 +631,16 @@ class ConversationMemoryService:
             for row in result.fetchall():
                 if row.id in seen_ids:
                     continue
+                # trigger_pattern matching: skip if pattern is set and doesn't match
+                pattern = getattr(row, "trigger_pattern", None)
+                if pattern:
+                    try:
+                        if not re.search(pattern, query, re.IGNORECASE):
+                            # Essential procedural memories (importance >= 0.9) always pass
+                            if (row.importance or 0) < settings.memory_essential_threshold:
+                                continue
+                    except re.error:
+                        pass  # Invalid regex — include the memory anyway
                 content_len = len(row.content)
                 if used_chars + content_len > budget:
                     break
@@ -749,6 +771,47 @@ class ConversationMemoryService:
             .values(is_active=False)
         )
         counts["decayed"] += result.rowcount
+
+        # 3. Confidence decay for unaccessed LLM-inferred memories
+        confidence_cutoff = now - timedelta(days=30)
+        result = await self.db.execute(
+            update(ConversationMemory)
+            .where(
+                ConversationMemory.is_active == True,  # noqa: E712
+                ConversationMemory.source == "llm_inferred",
+                ConversationMemory.confidence > 0.3,
+                ConversationMemory.last_accessed_at != None,  # noqa: E711
+                ConversationMemory.last_accessed_at < confidence_cutoff,
+            )
+            .values(confidence=ConversationMemory.confidence * 0.95)
+        )
+        counts["confidence_decayed"] = result.rowcount
+
+        # Also decay never-accessed llm_inferred memories older than 30 days
+        result = await self.db.execute(
+            update(ConversationMemory)
+            .where(
+                ConversationMemory.is_active == True,  # noqa: E712
+                ConversationMemory.source == "llm_inferred",
+                ConversationMemory.confidence > 0.3,
+                ConversationMemory.last_accessed_at == None,  # noqa: E711
+                ConversationMemory.created_at < confidence_cutoff,
+            )
+            .values(confidence=ConversationMemory.confidence * 0.95)
+        )
+        counts["confidence_decayed"] += result.rowcount
+
+        # Deactivate memories with confidence below threshold
+        result = await self.db.execute(
+            update(ConversationMemory)
+            .where(
+                ConversationMemory.is_active == True,  # noqa: E712
+                ConversationMemory.source == "llm_inferred",
+                ConversationMemory.confidence <= 0.3,
+            )
+            .values(is_active=False)
+        )
+        counts["low_confidence_deactivated"] = result.rowcount
 
         await self.db.commit()
 
@@ -1078,8 +1141,9 @@ class ConversationMemoryService:
 
         try:
             client = await self._get_ollama_client()
+            extraction_model = settings.memory_extraction_model or settings.ollama_model
             response = await client.chat(
-                model=settings.ollama_model,
+                model=extraction_model,
                 messages=[
                     {"role": "system", "content": system_msg},
                     {"role": "user", "content": prompt},

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -181,6 +181,7 @@ class Settings(BaseSettings):
     memory_context_decay_days: int = Field(default=30, ge=1, le=365)        # Days until context category expires
     memory_dedup_threshold: float = Field(default=0.9, ge=0.5, le=1.0)     # Deduplication threshold
     memory_extraction_enabled: bool = False                                  # Auto-extract memories from conversations
+    memory_extraction_model: str = ""                                         # Model for extraction (default: ollama_model)
     memory_cleanup_interval: int = Field(default=3600, ge=60, le=86400)     # Cleanup interval in seconds
     memory_essential_threshold: float = Field(default=0.9, ge=0.0, le=1.0)   # Importance threshold for always-inject
     memory_contradiction_resolution: bool = False                            # LLM-based contradiction resolution

--- a/tests/backend/test_episodic_memory.py
+++ b/tests/backend/test_episodic_memory.py
@@ -1,0 +1,416 @@
+"""
+Tests for EpisodicMemoryService — Episode creation, retrieval, summarization, and cleanup.
+
+Uses in-memory SQLite (no pgvector). Embedding generation is mocked.
+Actual similarity search requires PostgreSQL and is covered by e2e tests.
+"""
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import (
+    MEMORY_CATEGORY_FACT,
+    ConversationMemory,
+    EpisodicMemory,
+)
+from services.episodic_memory_service import EpisodicMemoryService
+
+
+# ==========================================================================
+# Fixtures
+# ==========================================================================
+
+
+@pytest.fixture
+def mock_embedding():
+    """Mock embedding vector (768 dims)."""
+    return [0.1] * 768
+
+
+@pytest.fixture
+def ep_service(db_session: AsyncSession, mock_embedding):
+    """EpisodicMemoryService with mocked embedding generation."""
+    svc = EpisodicMemoryService(db_session)
+    svc._get_embedding = AsyncMock(return_value=mock_embedding)
+    return svc
+
+
+# ==========================================================================
+# create_episode()
+# ==========================================================================
+
+
+class TestCreateEpisode:
+    """Tests for episode creation."""
+
+    @pytest.mark.unit
+    async def test_create_basic_episode(self, ep_service, db_session, test_user):
+        """Happy path: create an episode with all fields."""
+        episode = await ep_service.create_episode(
+            user_id=test_user.id,
+            session_id="session-123",
+            summary="User asked: show releases | Tools: get_release | Outcome: success",
+            topic="release_details",
+            entities={"release_id": "Release-1"},
+            tools_used=["get_release"],
+            outcome="success",
+            importance=0.6,
+        )
+
+        assert episode is not None
+        assert episode.id is not None
+        assert episode.user_id == test_user.id
+        assert episode.session_id == "session-123"
+        assert episode.summary.startswith("User asked:")
+        assert episode.topic == "release_details"
+        assert episode.entities == {"release_id": "Release-1"}
+        assert episode.tools_used == ["get_release"]
+        assert episode.outcome == "success"
+        assert episode.importance == 0.6
+        assert episode.is_active is True
+        assert episode.access_count == 0
+
+    @pytest.mark.unit
+    async def test_create_episode_embedding_failure(self, ep_service, db_session, test_user):
+        """Episode is created even when embedding generation fails."""
+        ep_service._get_embedding = AsyncMock(side_effect=Exception("Ollama down"))
+
+        episode = await ep_service.create_episode(
+            user_id=test_user.id,
+            session_id="session-456",
+            summary="User asked something",
+            topic="general",
+        )
+
+        assert episode is not None
+        assert episode.embedding is None
+
+    @pytest.mark.unit
+    async def test_create_episode_no_user(self, ep_service, db_session):
+        """Episode can be created without user_id."""
+        episode = await ep_service.create_episode(
+            user_id=None,
+            session_id="anon-session",
+            summary="Anonymous interaction",
+        )
+
+        assert episode is not None
+        assert episode.user_id is None
+
+    @pytest.mark.unit
+    async def test_per_user_limit_deactivates_oldest(self, ep_service, db_session, test_user):
+        """When at limit, oldest lowest-importance episode is deactivated."""
+        with patch("services.episodic_memory_service.settings") as mock_settings:
+            mock_settings.memory_episodic_max_per_user = 3
+            mock_settings.ollama_embed_model = "nomic-embed-text"
+
+            # Create 3 episodes (at limit)
+            episodes = []
+            for i in range(3):
+                ep = await ep_service.create_episode(
+                    user_id=test_user.id,
+                    session_id=f"session-{i}",
+                    summary=f"Episode {i}",
+                    importance=0.5 + i * 0.1,
+                )
+                episodes.append(ep)
+
+            # All 3 should be active
+            result = await db_session.execute(
+                select(func.count(EpisodicMemory.id))
+                .where(
+                    EpisodicMemory.user_id == test_user.id,
+                    EpisodicMemory.is_active == True,  # noqa: E712
+                )
+            )
+            assert result.scalar() == 3
+
+            # Create a 4th — should deactivate the oldest (lowest importance)
+            await ep_service.create_episode(
+                user_id=test_user.id,
+                session_id="session-3",
+                summary="Episode 3",
+                importance=0.8,
+            )
+
+            # Still 3 active
+            result = await db_session.execute(
+                select(func.count(EpisodicMemory.id))
+                .where(
+                    EpisodicMemory.user_id == test_user.id,
+                    EpisodicMemory.is_active == True,  # noqa: E712
+                )
+            )
+            assert result.scalar() == 3
+
+            # The first episode (lowest importance) should be deactivated
+            await db_session.refresh(episodes[0])
+            assert episodes[0].is_active is False
+
+
+# ==========================================================================
+# retrieve_recent()
+# ==========================================================================
+
+
+class TestRetrieveRecent:
+    """Tests for recent episode retrieval (no embedding needed)."""
+
+    @pytest.mark.unit
+    async def test_retrieve_recent_ordering(self, ep_service, db_session, test_user):
+        """Returns episodes ordered by created_at DESC."""
+        for i in range(5):
+            await ep_service.create_episode(
+                user_id=test_user.id,
+                session_id=f"session-{i}",
+                summary=f"Episode {i}",
+                topic="general",
+            )
+
+        recent = await ep_service.retrieve_recent(user_id=test_user.id, limit=3)
+
+        assert len(recent) == 3
+        assert recent[0]["summary"] == "Episode 4"
+        assert recent[1]["summary"] == "Episode 3"
+        assert recent[2]["summary"] == "Episode 2"
+
+    @pytest.mark.unit
+    async def test_retrieve_recent_excludes_inactive(self, ep_service, db_session, test_user):
+        """Inactive episodes are not returned."""
+        ep = await ep_service.create_episode(
+            user_id=test_user.id,
+            session_id="session-1",
+            summary="Active episode",
+        )
+        inactive = await ep_service.create_episode(
+            user_id=test_user.id,
+            session_id="session-2",
+            summary="Inactive episode",
+        )
+        inactive.is_active = False
+        await db_session.commit()
+
+        recent = await ep_service.retrieve_recent(user_id=test_user.id)
+        summaries = [r["summary"] for r in recent]
+        assert "Active episode" in summaries
+        assert "Inactive episode" not in summaries
+
+    @pytest.mark.unit
+    async def test_retrieve_recent_empty(self, ep_service, test_user):
+        """Returns empty list when no episodes exist."""
+        recent = await ep_service.retrieve_recent(user_id=test_user.id)
+        assert recent == []
+
+    @pytest.mark.unit
+    async def test_retrieve_recent_respects_limit(self, ep_service, db_session, test_user):
+        """Limit parameter controls max results."""
+        for i in range(10):
+            await ep_service.create_episode(
+                user_id=test_user.id,
+                session_id=f"session-{i}",
+                summary=f"Episode {i}",
+            )
+
+        recent = await ep_service.retrieve_recent(user_id=test_user.id, limit=2)
+        assert len(recent) == 2
+
+
+# ==========================================================================
+# summarize_old()
+# ==========================================================================
+
+
+class TestSummarizeOld:
+    """Tests for batch summarization of old episodes into semantic facts."""
+
+    @pytest.mark.unit
+    async def test_summarize_below_threshold_noop(self, ep_service, db_session, test_user):
+        """No summarization when episode count <= threshold."""
+        with patch("services.episodic_memory_service.settings") as mock_settings:
+            mock_settings.memory_episodic_summarize_threshold = 50
+            mock_settings.memory_episodic_decay_days = 90
+            mock_settings.ollama_embed_model = "nomic-embed-text"
+
+            # Create 5 episodes (well below threshold of 50)
+            for i in range(5):
+                await ep_service.create_episode(
+                    user_id=test_user.id,
+                    session_id=f"session-{i}",
+                    summary=f"Episode {i}",
+                )
+
+            result = await ep_service.summarize_old(user_id=test_user.id)
+            assert result == 0
+
+    @pytest.mark.unit
+    async def test_summarize_creates_facts_and_deactivates(self, ep_service, db_session, test_user):
+        """Old episodes are summarized into semantic facts and deactivated."""
+        with patch("services.episodic_memory_service.settings") as mock_settings:
+            mock_settings.memory_episodic_summarize_threshold = 3
+            mock_settings.memory_episodic_decay_days = 0  # All episodes are "old"
+            mock_settings.ollama_embed_model = "nomic-embed-text"
+
+            # Create 5 episodes with same topic
+            for i in range(5):
+                ep = await ep_service.create_episode(
+                    user_id=test_user.id,
+                    session_id=f"session-{i}",
+                    summary=f"Episode {i} about releases",
+                    topic="release_details",
+                )
+
+            summarized = await ep_service.summarize_old(user_id=test_user.id)
+
+            # Should summarize 2 episodes (5 total - 3 threshold = 2)
+            assert summarized == 2
+
+            # Check a fact was created in conversation_memories
+            result = await db_session.execute(
+                select(func.count(ConversationMemory.id))
+                .where(
+                    ConversationMemory.user_id == test_user.id,
+                    ConversationMemory.category == MEMORY_CATEGORY_FACT,
+                )
+            )
+            assert result.scalar() >= 1
+
+    @pytest.mark.unit
+    async def test_summarize_groups_by_topic(self, ep_service, db_session, test_user):
+        """Episodes are grouped by topic for coherent summaries."""
+        with patch("services.episodic_memory_service.settings") as mock_settings:
+            mock_settings.memory_episodic_summarize_threshold = 2
+            mock_settings.memory_episodic_decay_days = 0
+            mock_settings.ollama_embed_model = "nomic-embed-text"
+
+            # Create episodes with different topics
+            for topic in ["release_details", "release_details", "jira_search", "jira_search"]:
+                await ep_service.create_episode(
+                    user_id=test_user.id,
+                    session_id="session",
+                    summary=f"About {topic}",
+                    topic=topic,
+                )
+
+            summarized = await ep_service.summarize_old(user_id=test_user.id)
+            assert summarized == 2  # 4 - 2 threshold = 2
+
+            # Check facts were created (should be topic-grouped)
+            result = await db_session.execute(
+                select(ConversationMemory.content)
+                .where(
+                    ConversationMemory.user_id == test_user.id,
+                    ConversationMemory.category == MEMORY_CATEGORY_FACT,
+                )
+            )
+            facts = [row[0] for row in result.fetchall()]
+            assert len(facts) >= 1
+
+
+# ==========================================================================
+# cleanup()
+# ==========================================================================
+
+
+class TestEpisodicCleanup:
+    """Tests for episodic memory cleanup."""
+
+    @pytest.mark.unit
+    async def test_cleanup_decays_old_accessed_episodes(self, ep_service, db_session, test_user):
+        """Episodes not accessed within decay period are deactivated."""
+        with patch("services.episodic_memory_service.settings") as mock_settings:
+            mock_settings.memory_episodic_decay_days = 90
+            mock_settings.ollama_embed_model = "nomic-embed-text"
+
+            ep = await ep_service.create_episode(
+                user_id=test_user.id,
+                session_id="old-session",
+                summary="Old episode",
+            )
+            # Set last_accessed_at to 100 days ago
+            ep.last_accessed_at = datetime.utcnow() - timedelta(days=100)
+            await db_session.commit()
+
+            counts = await ep_service.cleanup()
+            assert counts["decayed"] >= 1
+
+            await db_session.refresh(ep)
+            assert ep.is_active is False
+
+    @pytest.mark.unit
+    async def test_cleanup_deactivates_very_old_episodes(self, ep_service, db_session, test_user):
+        """Episodes older than 365 days are deactivated regardless."""
+        with patch("services.episodic_memory_service.settings") as mock_settings:
+            mock_settings.memory_episodic_decay_days = 90
+            mock_settings.ollama_embed_model = "nomic-embed-text"
+
+            ep = await ep_service.create_episode(
+                user_id=test_user.id,
+                session_id="ancient-session",
+                summary="Ancient episode",
+            )
+            ep.created_at = datetime.utcnow() - timedelta(days=400)
+            await db_session.commit()
+
+            counts = await ep_service.cleanup()
+            assert counts["old"] >= 1
+
+            await db_session.refresh(ep)
+            assert ep.is_active is False
+
+    @pytest.mark.unit
+    async def test_cleanup_noop_when_fresh(self, ep_service, db_session, test_user):
+        """No deactivation when all episodes are fresh."""
+        with patch("services.episodic_memory_service.settings") as mock_settings:
+            mock_settings.memory_episodic_decay_days = 90
+            mock_settings.ollama_embed_model = "nomic-embed-text"
+
+            await ep_service.create_episode(
+                user_id=test_user.id,
+                session_id="fresh-session",
+                summary="Fresh episode",
+            )
+
+            counts = await ep_service.cleanup()
+            assert counts["decayed"] == 0
+            assert counts["old"] == 0
+
+
+# ==========================================================================
+# _deactivate_oldest()
+# ==========================================================================
+
+
+class TestDeactivateOldest:
+    """Tests for the internal _deactivate_oldest helper."""
+
+    @pytest.mark.unit
+    async def test_deactivates_lowest_importance_first(self, ep_service, db_session, test_user):
+        """Deactivates by importance ASC, then created_at ASC."""
+        ep_high = await ep_service.create_episode(
+            user_id=test_user.id,
+            session_id="high",
+            summary="High importance",
+            importance=0.9,
+        )
+        ep_low = await ep_service.create_episode(
+            user_id=test_user.id,
+            session_id="low",
+            summary="Low importance",
+            importance=0.1,
+        )
+
+        await ep_service._deactivate_oldest(test_user.id)
+
+        await db_session.refresh(ep_high)
+        await db_session.refresh(ep_low)
+        assert ep_high.is_active is True
+        assert ep_low.is_active is False
+
+    @pytest.mark.unit
+    async def test_deactivate_oldest_noop_when_empty(self, ep_service, db_session, test_user):
+        """No error when user has no episodes."""
+        await ep_service._deactivate_oldest(test_user.id)
+        # Should not raise


### PR DESCRIPTION
## Summary
- Add HNSW index on `episodic_memories.embedding` (idempotent migration)
- Wire `EpisodicMemoryService.cleanup()` + `summarize_old()` into hourly cleanup scheduler
- Implement confidence decay for unaccessed `llm_inferred` memories (×0.95/cycle, deactivate at <0.3)
- Factor confidence into semantic retrieval ranking (`similarity * importance * confidence`)
- Add `memory_extraction_model` setting for dedicated extraction LLM
- Implement `trigger_pattern` regex matching for procedural memory activation
- Pass `trigger_pattern` through from LLM extraction with regex validation
- Add 15 unit tests for `EpisodicMemoryService` (was 0% coverage)

## Context
Architecture review identified 13 gaps in the memory system. This PR addresses the Renfield-side fixes (A1–A5, B1) from the review plan.

## Test plan
- [ ] `test_episodic_memory.py` — 15 new tests for all EpisodicMemoryService methods
- [ ] Existing `test_conversation_memory.py` — verify no regressions
- [ ] Deploy and verify HNSW index via `\d episodic_memories`
- [ ] Verify cleanup scheduler logs episodic cleanup + summarization

🤖 Generated with [Claude Code](https://claude.com/claude-code)