### PR TITLE
feat(auth): pluggable authentication via hook system

### DIFF
--- a/src/backend/api/routes/auth.py
+++ b/src/backend/api/routes/auth.py
@@ -115,7 +115,22 @@ async def login(
     Uses OAuth2 password flow (username + password in form data).
     Returns access token (short-lived) and refresh token (long-lived).
     """
-    user = await authenticate_user(db, form_data.username, form_data.password)
+    # Pluggable auth: check hooks first (e.g. LDAP, SAML, OAuth).
+    # If a hook returns a User object, skip the default DB-based auth.
+    # If all hooks return None, fall through to the default.
+    from utils.hooks import run_hooks
+
+    hook_results = await run_hooks(
+        "authenticate",
+        username=form_data.username,
+        password=form_data.password,
+        db=db,
+    )
+    user = next((r for r in hook_results if r is not None), None)
+
+    # Default: DB-based bcrypt authentication
+    if user is None:
+        user = await authenticate_user(db, form_data.username, form_data.password)
 
     if not user:
         raise HTTPException(

--- a/src/backend/utils/hooks.py
+++ b/src/backend/utils/hooks.py
@@ -28,6 +28,7 @@ HOOK_EVENTS: frozenset[str] = frozenset({
     "presence_first_arrived",
     "presence_last_left",
     "compact_mcp_result",
+    "authenticate",
 })
 
 HookFn = Callable[..., Coroutine[Any, Any, Any]]


### PR DESCRIPTION
## Summary
- Adds `authenticate` to `HOOK_EVENTS` in `utils/hooks.py`
- Login route in `api/routes/auth.py` checks hooks BEFORE default DB auth
- Backwards compatible: if no hooks registered, existing bcrypt auth runs unchanged

## Motivation
Reva (X-idra-Systems-GmbH/reva#122) needs LDAP authentication for enterprise web chat.
This hook lets Reva register an LDAP auth handler without modifying Renfield core.

## Hook signature
```python
async def on_authenticate(username: str, password: str, db: AsyncSession) -> User | None
```

Returns a `User` object to skip default auth, or `None` to fall through.

## Test plan
- [ ] Existing login tests still pass (no hooks = default auth)
- [ ] Hook returns User → login succeeds without DB password check
- [ ] Hook returns None → falls through to DB auth
- [ ] Hook raises exception → caught by hook system, falls through to DB auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)