### PR TITLE
feat(auth): protect chat route with ProtectedRoute

### DIFF
--- a/src/frontend/src/App.jsx
+++ b/src/frontend/src/App.jsx
@@ -43,7 +43,11 @@ function AppRoutes() {
       <Route path="/*" element={
         <Layout>
           <Routes>
-            <Route path="/" element={<ChatPage />} />
+            <Route path="/" element={
+              <ProtectedRoute>
+                <ChatPage />
+              </ProtectedRoute>
+            } />
             <Route path="/chat" element={<Navigate to="/" replace />} />
             <Route path="/tasks" element={<TasksPage />} />
             {isFeatureEnabled('cameras') && (


### PR DESCRIPTION
## Summary
Wraps the main chat route (`/`) in `ProtectedRoute` so unauthenticated users are redirected to `/login` when `AUTH_ENABLED=true`.

## Problem
When auth is enabled, the chat page loads fully but the WebSocket fails silently (no token). Users see the complete UI with a "Disconnected" indicator — confusing UX.

## Fix
One-line change: wrap `<ChatPage />` in `<ProtectedRoute>`. The existing component handles the redirect logic. Backwards compatible: when `authEnabled=false`, `ProtectedRoute` passes through.

## Motivation
Reva web chat (X-idra-Systems-GmbH/reva#122) — enterprise LDAP auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)