### PR TITLE
fix(auth): make /api/auth/status publicly accessible for auth-first mode

### DIFF
--- a/src/backend/api/routes/auth.py
+++ b/src/backend/api/routes/auth.py
@@ -26,6 +26,7 @@ from services.auth_service import (
     create_user,
     decode_token,
     get_current_user,
+    get_optional_user,
     get_role_by_name,
     get_user_by_id,
     oauth2_scheme,
@@ -378,7 +379,7 @@ async def logout(
 
 @router.get("/status", response_model=AuthStatusResponse)
 async def get_auth_status(
-    user: User | None = Depends(get_current_user)
+    user: User | None = Depends(get_optional_user)
 ):
     """
     Get authentication status and settings.

--- a/tests/backend/test_auth.py
+++ b/tests/backend/test_auth.py
@@ -487,6 +487,29 @@ class TestAuthAPIDisabled:
         # Auth is disabled by default in tests
         assert "auth_enabled" in data
 
+    async def test_get_auth_status_returns_200_when_auth_enabled_no_token(self, async_client):
+        """Test GET /api/auth/status returns 200 even when auth is enabled and no token is provided.
+
+        This is the auth-first mode fix: the status endpoint must be publicly
+        accessible so the frontend can determine whether to show the login page.
+        Previously it used get_current_user which raised 401 when auth was enabled,
+        creating a circular dependency (can't check if auth is required without auth).
+        """
+        from utils.config import settings
+
+        original = settings.auth_enabled
+        settings.auth_enabled = True
+
+        try:
+            response = await async_client.get("/api/auth/status")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["auth_enabled"] is True
+            assert data["authenticated"] is False
+            assert data["user"] is None
+        finally:
+            settings.auth_enabled = original
+
     async def test_list_permissions(self, async_client):
         """Test GET /api/auth/permissions returns all permissions"""
         response = await async_client.get("/api/auth/permissions")


### PR DESCRIPTION
## Summary
- Swap `get_current_user` → `get_optional_user` dependency on `/api/auth/status` endpoint
- Breaks the circular dependency where the frontend can't check if auth is required without already being authenticated
- Add test proving the endpoint returns 200 with `auth_enabled=true` and no token

## Problem
When `AUTH_ENABLED=true`, calling `GET /api/auth/status` without a token raises 401 because `get_current_user` enforces authentication. The frontend catches this as an error and never learns that `auth_enabled=true`, so it defaults to no-auth mode and lets everyone through.

## Fix
`get_optional_user` returns `None` instead of raising 401 when no token is present. The endpoint now always returns `{auth_enabled, authenticated, user}` regardless of auth state. The frontend already handles this response correctly (line 199 in AuthContext.tsx).

## Test plan
- [x] Test: `/api/auth/status` returns 200 with `auth_enabled=true` and no token
- [x] Test: response contains `auth_enabled: true, authenticated: false, user: null`
- [ ] Existing test: `/api/auth/status` with auth disabled still works (unchanged behavior)
- [ ] Manual: frontend shows login page when `AUTH_ENABLED=true` and no stored JWT

🤖 Generated with [Claude Code](https://claude.com/claude-code)