### PR TITLE
refactor(models): split HA tables into ha_glue/ (#342)

### DIFF
--- a/src/backend/ha_glue/__init__.py
+++ b/src/backend/ha_glue/__init__.py
@@ -1,0 +1,39 @@
+"""Home-Assistant / smart-home glue layer for the Renfield platform.
+
+This package contains all the Home Assistant, satellite, presence, media,
+camera, and paperless-audit consumer features that currently ship with
+Renfield as a monorepo but will be extracted into `ebongard/renfield`
+(the home-automation product flavor) during Phase 1-3 of the open-source
+extraction.
+
+Target split (see `docs/architecture/renfield-platform-boundary.md` in
+the parent Reva repo):
+
+- `ha_glue.models` — HA-specific SQLAlchemy tables (Room, RoomDevice,
+  PresenceEvent, PaperlessAuditResult, etc.)
+- `ha_glue.services` — HA integrations (audio routing, presence, media
+  follow, satellite management, Zeroconf discovery). *Not yet populated.*
+- `ha_glue.api` — HA-specific REST + WebSocket routes. *Not yet populated.*
+
+## Layering rule
+
+`ha_glue.*` is allowed to import from `models.*`, `services.*`, `utils.*`,
+`api.*` (platform side). The REVERSE is forbidden and will be enforced
+by a CI lint in Phase 1 Week 4. Platform files that need data from
+ha_glue should use the hook system (`utils.hooks`) instead of direct
+imports.
+
+## Current state (Phase 1 Week 1 — models split only)
+
+As of 2026-04-14, only `ha_glue.models.database` is populated. The
+service and route extractions happen in Week 2; Alembic migration
+cutover in Week 3; CI lint gate in Week 4.
+
+Consumers can already import from the new location:
+
+    from ha_glue.models.database import Room, RoomDevice, PresenceEvent
+
+The legacy `from models.database import Room` path also still works
+via a compat re-export in `models/database.py`, which will be removed
+in Week 4 once every consumer has migrated.
+"""

--- a/src/backend/ha_glue/models/__init__.py
+++ b/src/backend/ha_glue/models/__init__.py
@@ -1,0 +1,12 @@
+"""Database models for the HA-glue layer.
+
+All SQLAlchemy classes here share the platform's `Base` (imported from
+`models.database`) so they register with the same metadata. This means
+`Base.metadata.create_all()` creates ha-glue tables as well when this
+package is imported, and platform string-based `relationship("Room")`
+references resolve correctly at mapper-configure time.
+
+For platform-only deployments that don't need HA features, simply don't
+import `ha_glue.*` — the tables won't register and `create_all()` will
+produce a lean platform-only schema.
+"""

--- a/src/backend/ha_glue/models/database.py
+++ b/src/backend/ha_glue/models/database.py
@@ -1,0 +1,506 @@
+"""HA-specific SQLAlchemy models extracted from `models/database.py`.
+
+Part of Phase 1 Week 1 of the Renfield open-source extraction. See
+`docs/architecture/renfield-platform-boundary.md` in the parent Reva
+repo for the full boundary definition.
+
+All classes here use the platform's `Base` and share its metadata so
+that:
+
+- `Base.metadata.create_all()` picks up these tables when ha_glue is
+  imported, and produces a platform-only schema when it isn't
+- Cross-side `relationship("User")` string references (e.g. for the
+  Room.owner FK to platform's users table) resolve correctly at
+  mapper-configure time
+- Foreign keys from ha-glue to platform tables (Room.owner_id → users.id,
+  UserBleDevice.user_id → users.id, PresenceEvent.user_id → users.id,
+  RadioFavorite.user_id → users.id) work transparently
+
+The reverse direction — platform tables with ForeignKeys pointing INTO
+ha-glue tables — was removed from Notification and Reminder in this
+same commit. They used to have `ForeignKey("rooms.id")` and
+`relationship("Room")`, but those relationships were never actually
+read by application code, only declared. Dropping them restores the
+layering rule that platform must not hard-depend on ha-glue.
+
+## Scope of this file
+
+Contains nine table classes:
+
+- `CameraEvent` — Frigate camera event log
+- `HomeAssistantEntity` — HA entity state cache
+- `Room` — room registry (includes HA area_id)
+- `RoomDevice` — unified satellite + web device registry (+ DEVICE_TYPE_*
+  constants and DEFAULT_CAPABILITIES dict)
+- `RoomOutputDevice` — per-room TTS output routing (+ OUTPUT_TYPE_*
+  constants)
+- `UserBleDevice` — registered BLE devices for presence detection
+- `PresenceEvent` — persisted presence enter/leave events
+- `PaperlessAuditResult` — LLM audit of paperless-ngx documents
+- `RadioFavorite` — user's favorite radio stations
+
+Also re-exports the legacy `RoomSatellite = RoomDevice` alias.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+)
+from sqlalchemy.orm import relationship
+
+from models.database import Base, _utcnow
+
+# Ensure User is registered with Base.metadata before ha_glue classes that
+# FK into users.id are defined. Importing the class triggers registration
+# as a side effect of the decorator-less declarative mapping.
+from models.database import User  # noqa: F401 — side-effect import
+
+
+# ---------------------------------------------------------------------------
+# CameraEvent — Frigate event log
+# ---------------------------------------------------------------------------
+
+
+class CameraEvent(Base):
+    """Kamera-Events."""
+
+    __tablename__ = "camera_events"
+
+    id = Column(Integer, primary_key=True, index=True)
+    camera_name = Column(String)
+    event_type = Column(String)  # 'person', 'car', 'animal'
+    confidence = Column(Integer)
+    timestamp = Column(DateTime, default=_utcnow)
+    snapshot_path = Column(String, nullable=True)
+    event_metadata = Column(JSON, nullable=True)
+    notified = Column(Boolean, default=False)
+
+
+# ---------------------------------------------------------------------------
+# HomeAssistantEntity — HA state cache
+# ---------------------------------------------------------------------------
+
+
+class HomeAssistantEntity(Base):
+    """Home Assistant Entities Cache."""
+
+    __tablename__ = "ha_entities"
+
+    id = Column(Integer, primary_key=True, index=True)
+    entity_id = Column(String, unique=True, index=True)
+    friendly_name = Column(String)
+    domain = Column(String)
+    state = Column(String, nullable=True)
+    attributes = Column(JSON, nullable=True)
+    last_updated = Column(DateTime, default=_utcnow)
+
+
+# ---------------------------------------------------------------------------
+# Room Management
+# ---------------------------------------------------------------------------
+
+
+class Room(Base):
+    """Raum für Smart Home und Device-Zuordnung."""
+
+    __tablename__ = "rooms"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100), nullable=False, unique=True)
+    alias = Column(String(50), index=True)
+
+    # Home Assistant Sync
+    ha_area_id = Column(String(100), nullable=True, unique=True, index=True)
+    source = Column(String(20), default="renfield")
+
+    # Room owner (for Media Follow Me conflict resolution)
+    owner_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    owner = relationship("User", foreign_keys="Room.owner_id")
+
+    icon = Column(String(50), nullable=True)
+
+    created_at = Column(DateTime, default=_utcnow)
+    updated_at = Column(DateTime, default=_utcnow, onupdate=_utcnow)
+    last_synced_at = Column(DateTime, nullable=True)
+
+    devices = relationship(
+        "RoomDevice",
+        back_populates="room",
+        cascade="all, delete-orphan",
+    )
+    output_devices = relationship(
+        "RoomOutputDevice",
+        back_populates="room",
+        cascade="all, delete-orphan",
+        order_by="RoomOutputDevice.priority",
+    )
+
+    @property
+    def satellites(self):
+        """Backward compatibility: get only satellite-type devices."""
+        return [d for d in self.devices if d.device_type == "satellite"]
+
+    @property
+    def online_devices(self):
+        """Get all online devices in this room."""
+        return [d for d in self.devices if d.is_online]
+
+
+# Device Types
+DEVICE_TYPE_SATELLITE = "satellite"      # Physical Pi Zero + ReSpeaker
+DEVICE_TYPE_WEB_PANEL = "web_panel"      # Stationary web device (wall-mounted iPad)
+DEVICE_TYPE_WEB_TABLET = "web_tablet"    # Mobile web device (iPad, tablet)
+DEVICE_TYPE_WEB_BROWSER = "web_browser"  # Desktop browser
+DEVICE_TYPE_WEB_KIOSK = "web_kiosk"      # Touch kiosk terminal
+
+DEVICE_TYPES = [
+    DEVICE_TYPE_SATELLITE,
+    DEVICE_TYPE_WEB_PANEL,
+    DEVICE_TYPE_WEB_TABLET,
+    DEVICE_TYPE_WEB_BROWSER,
+    DEVICE_TYPE_WEB_KIOSK,
+]
+
+
+class RoomDevice(Base):
+    """Unified device model for room-based input/output devices.
+
+    Supports both physical satellites (Raspberry Pi) and web-based clients
+    (iPad, Browser). Capabilities are stored as JSON for flexibility.
+    """
+
+    __tablename__ = "room_devices"
+
+    id = Column(Integer, primary_key=True, index=True)
+    room_id = Column(Integer, ForeignKey("rooms.id"), nullable=False, index=True)
+    device_id = Column(String(100), nullable=False, unique=True, index=True)
+
+    device_type = Column(String(20), nullable=False, default=DEVICE_TYPE_WEB_BROWSER)
+    device_name = Column(String(100), nullable=True)
+
+    capabilities = Column(JSON, nullable=False, default=dict)
+
+    is_online = Column(Boolean, default=False)
+    is_stationary = Column(Boolean, default=True)
+    last_connected_at = Column(DateTime, nullable=True)
+
+    user_agent = Column(String(500), nullable=True)
+    ip_address = Column(String(45), nullable=True)
+
+    created_at = Column(DateTime, default=_utcnow)
+    updated_at = Column(DateTime, default=_utcnow, onupdate=_utcnow)
+
+    room = relationship("Room", back_populates="devices")
+
+    def has_capability(self, capability: str) -> bool:
+        """Check if device has a specific capability."""
+        return self.capabilities.get(capability, False)
+
+    @property
+    def can_record_audio(self) -> bool:
+        return self.has_capability("has_microphone")
+
+    @property
+    def can_play_audio(self) -> bool:
+        return self.has_capability("has_speaker")
+
+    @property
+    def can_show_display(self) -> bool:
+        return self.has_capability("has_display")
+
+    @property
+    def has_wakeword(self) -> bool:
+        return self.has_capability("has_wakeword")
+
+
+DEFAULT_CAPABILITIES = {
+    DEVICE_TYPE_SATELLITE: {
+        "has_microphone": True,
+        "has_speaker": True,
+        "has_wakeword": True,
+        "wakeword_method": "openwakeword",
+        "has_display": False,
+        "has_leds": True,
+        "led_count": 3,
+        "has_button": True,
+    },
+    DEVICE_TYPE_WEB_PANEL: {
+        "has_microphone": True,
+        "has_speaker": True,
+        "has_wakeword": True,
+        "wakeword_method": "browser_wasm",
+        "has_display": True,
+        "display_size": "large",
+        "supports_notifications": True,
+        "has_leds": False,
+        "has_button": False,
+    },
+    DEVICE_TYPE_WEB_TABLET: {
+        "has_microphone": True,
+        "has_speaker": True,
+        "has_wakeword": True,
+        "wakeword_method": "browser_wasm",
+        "has_display": True,
+        "display_size": "medium",
+        "supports_notifications": True,
+        "has_leds": False,
+        "has_button": False,
+    },
+    DEVICE_TYPE_WEB_BROWSER: {
+        "has_microphone": False,
+        "has_speaker": False,
+        "has_wakeword": False,
+        "has_display": True,
+        "display_size": "large",
+        "supports_notifications": True,
+        "has_leds": False,
+        "has_button": False,
+    },
+    DEVICE_TYPE_WEB_KIOSK: {
+        "has_microphone": True,
+        "has_speaker": True,
+        "has_wakeword": False,
+        "has_display": True,
+        "display_size": "large",
+        "supports_notifications": False,
+        "has_leds": False,
+        "has_button": False,
+    },
+}
+
+
+# Output Device Types
+OUTPUT_TYPE_AUDIO = "audio"
+OUTPUT_TYPE_VISUAL = "visual"
+
+OUTPUT_TYPES = [OUTPUT_TYPE_AUDIO, OUTPUT_TYPE_VISUAL]
+
+
+class RoomOutputDevice(Base):
+    """Output device configuration for a room.
+
+    Defines which devices should be used for TTS audio output in a room,
+    with priority ordering and interruption settings.
+
+    Exactly one of renfield_device_id, ha_entity_id, or dlna_renderer_name
+    must be set.
+    """
+
+    __tablename__ = "room_output_devices"
+
+    id = Column(Integer, primary_key=True, index=True)
+    room_id = Column(Integer, ForeignKey("rooms.id"), nullable=False, index=True)
+
+    renfield_device_id = Column(
+        String(100), ForeignKey("room_devices.device_id"), nullable=True
+    )
+    ha_entity_id = Column(String(255), nullable=True)
+    dlna_renderer_name = Column(String(255), nullable=True)
+
+    output_type = Column(String(20), nullable=False, default=OUTPUT_TYPE_AUDIO)
+
+    priority = Column(Integer, nullable=False, default=1)
+
+    allow_interruption = Column(Boolean, default=False)
+
+    tts_volume = Column(Float, nullable=True, default=0.5)
+
+    device_name = Column(String(255), nullable=True)
+
+    is_enabled = Column(Boolean, default=True)
+
+    created_at = Column(DateTime, default=_utcnow)
+    updated_at = Column(DateTime, default=_utcnow, onupdate=_utcnow)
+
+    room = relationship("Room", back_populates="output_devices")
+    renfield_device = relationship("RoomDevice", foreign_keys=[renfield_device_id])
+
+    @property
+    def is_renfield_device(self) -> bool:
+        return self.renfield_device_id is not None
+
+    @property
+    def is_ha_device(self) -> bool:
+        return self.ha_entity_id is not None
+
+    @property
+    def is_dlna_device(self) -> bool:
+        return self.dlna_renderer_name is not None
+
+    @property
+    def target_id(self) -> str:
+        return self.renfield_device_id or self.ha_entity_id or self.dlna_renderer_name or ""
+
+    @property
+    def target_type(self) -> str:
+        if self.renfield_device_id:
+            return "renfield"
+        if self.ha_entity_id:
+            return "homeassistant"
+        if self.dlna_renderer_name:
+            return "dlna"
+        return "renfield"
+
+
+# Legacy alias for backward compatibility (kept next to RoomDevice so the
+# import stays local to ha_glue).
+RoomSatellite = RoomDevice
+
+
+# ---------------------------------------------------------------------------
+# Presence
+# ---------------------------------------------------------------------------
+
+
+class UserBleDevice(Base):
+    """Registered BLE device for room-level presence detection."""
+
+    __tablename__ = "user_ble_devices"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    mac_address = Column(String(17), unique=True, nullable=False, index=True)
+    device_name = Column(String(100), nullable=False)
+    device_type = Column(String(50), default="phone")
+    detection_method = Column(String(20), default="ble")
+    is_enabled = Column(Boolean, default=True)
+    created_at = Column(DateTime, default=_utcnow)
+
+    user = relationship("User", backref="ble_devices")
+
+
+class PresenceEvent(Base):
+    """Persisted presence event for analytics (heatmap, predictions)."""
+
+    __tablename__ = "presence_events"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    room_id = Column(Integer, ForeignKey("rooms.id"), nullable=False, index=True)
+    event_type = Column(String(20), nullable=False)  # "enter" | "leave"
+    source = Column(String(20), default="ble")        # "ble" | "voice" | "web"
+    confidence = Column(Float, nullable=True)
+    created_at = Column(DateTime, default=_utcnow, index=True)
+
+    __table_args__ = (
+        Index("ix_presence_events_analytics", "user_id", "room_id", "created_at"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Paperless Document Audit
+# ---------------------------------------------------------------------------
+
+
+class PaperlessAuditResult(Base):
+    """Paperless document audit results from LLM analysis."""
+
+    __tablename__ = "paperless_audit_results"
+
+    id = Column(Integer, primary_key=True)
+    paperless_doc_id = Column(Integer, index=True, unique=True)
+
+    current_title = Column(String, nullable=True)
+    current_correspondent = Column(String, nullable=True)
+    current_document_type = Column(String, nullable=True)
+    current_tags = Column(JSON, nullable=True)
+
+    suggested_title = Column(String, nullable=True)
+    suggested_correspondent = Column(String, nullable=True)
+    suggested_document_type = Column(String, nullable=True)
+    suggested_tags = Column(JSON, nullable=True)
+
+    current_date = Column(String, nullable=True)
+    suggested_date = Column(String, nullable=True)
+
+    missing_fields = Column(JSON, nullable=True)
+
+    duplicate_group_id = Column(String, nullable=True, index=True)
+    duplicate_score = Column(Float, nullable=True)
+
+    current_custom_fields = Column(JSON, nullable=True)
+    suggested_custom_fields = Column(JSON, nullable=True)
+
+    detected_language = Column(String(10), nullable=True)
+
+    current_storage_path = Column(String, nullable=True)
+    suggested_storage_path = Column(String, nullable=True)
+
+    content_completeness = Column(Integer, nullable=True)
+    completeness_issues = Column(String, nullable=True)
+
+    content_hash = Column(String(32), nullable=True)
+
+    ocr_quality = Column(Integer, nullable=True)
+    ocr_issues = Column(String, nullable=True)
+    confidence = Column(Float, nullable=True)
+    changes_needed = Column(Boolean, default=False)
+    reasoning = Column(Text, nullable=True)
+
+    status = Column(String, default="pending")
+
+    renfield_ocr_text = Column(Text, nullable=True)
+
+    audited_at = Column(DateTime, default=_utcnow)
+    applied_at = Column(DateTime, nullable=True)
+    audit_run_id = Column(String, nullable=True, index=True)
+
+
+# ---------------------------------------------------------------------------
+# Radio Favorites
+# ---------------------------------------------------------------------------
+
+
+class RadioFavorite(Base):
+    """User's favorite radio stations (provider-agnostic, currently TuneIn)."""
+
+    __tablename__ = "radio_favorites"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True, index=True)
+    station_id = Column(String(50), nullable=False)
+    station_name = Column(String(255), nullable=False)
+    station_image = Column(String(512), nullable=True)
+    genre = Column(String(100), nullable=True)
+    created_at = Column(DateTime, default=_utcnow)
+
+    __table_args__ = (
+        Index("ix_radio_favorites_user_station", "user_id", "station_id", unique=True),
+    )
+
+
+__all__ = [
+    # Tables
+    "CameraEvent",
+    "HomeAssistantEntity",
+    "Room",
+    "RoomDevice",
+    "RoomOutputDevice",
+    "RoomSatellite",
+    "UserBleDevice",
+    "PresenceEvent",
+    "PaperlessAuditResult",
+    "RadioFavorite",
+    # Device type constants
+    "DEVICE_TYPE_SATELLITE",
+    "DEVICE_TYPE_WEB_PANEL",
+    "DEVICE_TYPE_WEB_TABLET",
+    "DEVICE_TYPE_WEB_BROWSER",
+    "DEVICE_TYPE_WEB_KIOSK",
+    "DEVICE_TYPES",
+    "DEFAULT_CAPABILITIES",
+    # Output type constants
+    "OUTPUT_TYPE_AUDIO",
+    "OUTPUT_TYPE_VISUAL",
+    "OUTPUT_TYPES",
+]

--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -79,32 +79,6 @@ class Task(Base):
     completed_at = Column(DateTime, nullable=True)
     created_by = Column(String, nullable=True)
 
-class CameraEvent(Base):
-    """Kamera-Events"""
-    __tablename__ = "camera_events"
-
-    id = Column(Integer, primary_key=True, index=True)
-    camera_name = Column(String)
-    event_type = Column(String)  # 'person', 'car', 'animal'
-    confidence = Column(Integer)
-    timestamp = Column(DateTime, default=_utcnow)
-    snapshot_path = Column(String, nullable=True)
-    event_metadata = Column(JSON, nullable=True)  # Umbenannt von 'metadata'
-    notified = Column(Boolean, default=False)
-
-class HomeAssistantEntity(Base):
-    """Home Assistant Entities Cache"""
-    __tablename__ = "ha_entities"
-
-    id = Column(Integer, primary_key=True, index=True)
-    entity_id = Column(String, unique=True, index=True)
-    friendly_name = Column(String)
-    domain = Column(String)
-    state = Column(String, nullable=True)
-    attributes = Column(JSON, nullable=True)
-    last_updated = Column(DateTime, default=_utcnow)
-
-
 # --- Speaker Recognition Models ---
 
 class Speaker(Base):
@@ -139,269 +113,12 @@ class SpeakerEmbedding(Base):
     speaker = relationship("Speaker", back_populates="embeddings")
 
 
-# --- Room Management Models ---
-
-class Room(Base):
-    """Raum für Smart Home und Device-Zuordnung"""
-    __tablename__ = "rooms"
-
-    id = Column(Integer, primary_key=True, index=True)
-    name = Column(String(100), nullable=False, unique=True)  # "Wohnzimmer"
-    alias = Column(String(50), index=True)  # "wohnzimmer" (für Sprachbefehle, normalisiert)
-
-    # Home Assistant Sync
-    ha_area_id = Column(String(100), nullable=True, unique=True, index=True)
-    source = Column(String(20), default="renfield")  # renfield/homeassistant/satellite/device
-
-    # Room owner (for Media Follow Me conflict resolution)
-    owner_id = Column(Integer, ForeignKey("users.id"), nullable=True)
-    owner = relationship("User", foreign_keys="Room.owner_id")
-
-    # Metadata
-    icon = Column(String(50), nullable=True)  # "mdi:sofa"
-
-    # Timestamps
-    created_at = Column(DateTime, default=_utcnow)
-    updated_at = Column(DateTime, default=_utcnow, onupdate=_utcnow)
-    last_synced_at = Column(DateTime, nullable=True)
-
-    # Beziehungen
-    devices = relationship("RoomDevice", back_populates="room", cascade="all, delete-orphan")
-    output_devices = relationship(
-        "RoomOutputDevice",
-        back_populates="room",
-        cascade="all, delete-orphan",
-        order_by="RoomOutputDevice.priority"
-    )
-
-    @property
-    def satellites(self):
-        """Backward compatibility: Get only satellite-type devices"""
-        return [d for d in self.devices if d.device_type == "satellite"]
-
-    @property
-    def online_devices(self):
-        """Get all online devices in this room"""
-        return [d for d in self.devices if d.is_online]
-
-
-# Device Types
-DEVICE_TYPE_SATELLITE = "satellite"      # Physical Pi Zero + ReSpeaker
-DEVICE_TYPE_WEB_PANEL = "web_panel"      # Stationary web device (wall-mounted iPad)
-DEVICE_TYPE_WEB_TABLET = "web_tablet"    # Mobile web device (iPad, tablet)
-DEVICE_TYPE_WEB_BROWSER = "web_browser"  # Desktop browser
-DEVICE_TYPE_WEB_KIOSK = "web_kiosk"      # Touch kiosk terminal
-
-DEVICE_TYPES = [
-    DEVICE_TYPE_SATELLITE,
-    DEVICE_TYPE_WEB_PANEL,
-    DEVICE_TYPE_WEB_TABLET,
-    DEVICE_TYPE_WEB_BROWSER,
-    DEVICE_TYPE_WEB_KIOSK,
-]
-
-
-class RoomDevice(Base):
-    """
-    Unified Device Model for Room-based Input/Output Devices
-
-    Supports both physical satellites (Raspberry Pi) and web-based clients (iPad, Browser).
-    Capabilities are stored as JSON for flexibility.
-    """
-    __tablename__ = "room_devices"
-
-    id = Column(Integer, primary_key=True, index=True)
-    room_id = Column(Integer, ForeignKey("rooms.id"), nullable=False, index=True)
-    device_id = Column(String(100), nullable=False, unique=True, index=True)
-
-    # Device Classification
-    device_type = Column(String(20), nullable=False, default=DEVICE_TYPE_WEB_BROWSER)
-    device_name = Column(String(100), nullable=True)  # User-friendly name: "iPad Wohnzimmer"
-
-    # Capabilities (JSON for flexibility)
-    # Example: {"has_microphone": true, "has_speaker": true, "has_display": true, ...}
-    capabilities = Column(JSON, nullable=False, default=dict)
-
-    # Status
-    is_online = Column(Boolean, default=False)
-    is_stationary = Column(Boolean, default=True)  # Stationary vs. mobile device
-    last_connected_at = Column(DateTime, nullable=True)
-
-    # Connection Info
-    user_agent = Column(String(500), nullable=True)  # Browser/client info
-    ip_address = Column(String(45), nullable=True)   # IPv4 or IPv6
-
-    # Timestamps
-    created_at = Column(DateTime, default=_utcnow)
-    updated_at = Column(DateTime, default=_utcnow, onupdate=_utcnow)
-
-    # Beziehungen
-    room = relationship("Room", back_populates="devices")
-
-    def has_capability(self, capability: str) -> bool:
-        """Check if device has a specific capability"""
-        return self.capabilities.get(capability, False)
-
-    @property
-    def can_record_audio(self) -> bool:
-        return self.has_capability("has_microphone")
-
-    @property
-    def can_play_audio(self) -> bool:
-        return self.has_capability("has_speaker")
-
-    @property
-    def can_show_display(self) -> bool:
-        return self.has_capability("has_display")
-
-    @property
-    def has_wakeword(self) -> bool:
-        return self.has_capability("has_wakeword")
-
-
-# Default capabilities for different device types
-DEFAULT_CAPABILITIES = {
-    DEVICE_TYPE_SATELLITE: {
-        "has_microphone": True,
-        "has_speaker": True,
-        "has_wakeword": True,
-        "wakeword_method": "openwakeword",
-        "has_display": False,
-        "has_leds": True,
-        "led_count": 3,
-        "has_button": True,
-    },
-    DEVICE_TYPE_WEB_PANEL: {
-        "has_microphone": True,
-        "has_speaker": True,
-        "has_wakeword": True,
-        "wakeword_method": "browser_wasm",
-        "has_display": True,
-        "display_size": "large",
-        "supports_notifications": True,
-        "has_leds": False,
-        "has_button": False,
-    },
-    DEVICE_TYPE_WEB_TABLET: {
-        "has_microphone": True,
-        "has_speaker": True,
-        "has_wakeword": True,
-        "wakeword_method": "browser_wasm",
-        "has_display": True,
-        "display_size": "medium",
-        "supports_notifications": True,
-        "has_leds": False,
-        "has_button": False,
-    },
-    DEVICE_TYPE_WEB_BROWSER: {
-        "has_microphone": False,  # May need permission
-        "has_speaker": False,     # May need permission
-        "has_wakeword": False,
-        "has_display": True,
-        "display_size": "large",
-        "supports_notifications": True,
-        "has_leds": False,
-        "has_button": False,
-    },
-    DEVICE_TYPE_WEB_KIOSK: {
-        "has_microphone": True,
-        "has_speaker": True,
-        "has_wakeword": False,
-        "has_display": True,
-        "display_size": "large",
-        "supports_notifications": False,
-        "has_leds": False,
-        "has_button": False,
-    },
-}
-
-
-# Output Device Types
-OUTPUT_TYPE_AUDIO = "audio"
-OUTPUT_TYPE_VISUAL = "visual"
-
-OUTPUT_TYPES = [OUTPUT_TYPE_AUDIO, OUTPUT_TYPE_VISUAL]
-
-
-class RoomOutputDevice(Base):
-    """
-    Output device configuration for a room.
-
-    Defines which devices should be used for TTS audio output
-    in a room, with priority ordering and interruption settings.
-
-    Exactly one of renfield_device_id, ha_entity_id, or dlna_renderer_name must be set.
-    """
-    __tablename__ = "room_output_devices"
-
-    id = Column(Integer, primary_key=True, index=True)
-    room_id = Column(Integer, ForeignKey("rooms.id"), nullable=False, index=True)
-
-    # Device source: exactly one of Renfield device, HA entity, or DLNA renderer
-    renfield_device_id = Column(String(100), ForeignKey("room_devices.device_id"), nullable=True)
-    ha_entity_id = Column(String(255), nullable=True)  # e.g. "media_player.linn_dsm"
-    dlna_renderer_name = Column(String(255), nullable=True)  # e.g. "Arbeitszimmer"
-
-    # Output type
-    output_type = Column(String(20), nullable=False, default=OUTPUT_TYPE_AUDIO)
-
-    # Priority (1 = highest)
-    priority = Column(Integer, nullable=False, default=1)
-
-    # Interruption setting
-    allow_interruption = Column(Boolean, default=False)
-
-    # Volume setting (0.0 - 1.0, None = no change)
-    tts_volume = Column(Float, nullable=True, default=0.5)
-
-    # Device name (cached for display)
-    device_name = Column(String(255), nullable=True)
-
-    # Status
-    is_enabled = Column(Boolean, default=True)
-
-    # Timestamps
-    created_at = Column(DateTime, default=_utcnow)
-    updated_at = Column(DateTime, default=_utcnow, onupdate=_utcnow)
-
-    # Relationships
-    room = relationship("Room", back_populates="output_devices")
-    renfield_device = relationship("RoomDevice", foreign_keys=[renfield_device_id])
-
-    @property
-    def is_renfield_device(self) -> bool:
-        """Check if this output uses a Renfield device"""
-        return self.renfield_device_id is not None
-
-    @property
-    def is_ha_device(self) -> bool:
-        """Check if this output uses a Home Assistant entity"""
-        return self.ha_entity_id is not None
-
-    @property
-    def is_dlna_device(self) -> bool:
-        """Check if this output uses a DLNA renderer"""
-        return self.dlna_renderer_name is not None
-
-    @property
-    def target_id(self) -> str:
-        """Get the target device/entity ID"""
-        return self.renfield_device_id or self.ha_entity_id or self.dlna_renderer_name or ""
-
-    @property
-    def target_type(self) -> str:
-        """Get the device type string"""
-        if self.renfield_device_id:
-            return "renfield"
-        if self.ha_entity_id:
-            return "homeassistant"
-        if self.dlna_renderer_name:
-            return "dlna"
-        return "renfield"
-
-
-# Legacy alias for backward compatibility
-RoomSatellite = RoomDevice
+# --- Room management, device, and output-device models ---
+#
+# These moved to ha_glue/models/database.py as part of Phase 1 of the
+# Renfield open-source extraction. They are re-exported at the bottom of
+# this file for backwards compatibility during the Week 1-4 transition.
+# New code should import directly from ha_glue.models.database.
 
 
 # =============================================================================
@@ -824,7 +541,11 @@ class Notification(Base):
     title = Column(String(255), nullable=False)
     message = Column(Text, nullable=False)
     urgency = Column(String(20), default=URGENCY_INFO)
-    room_id = Column(Integer, ForeignKey("rooms.id"), nullable=True, index=True)
+    # room_id is a loose reference to ha_glue.rooms.id — no ForeignKey constraint
+    # so that platform-only deployments (without the ha_glue schema) can still
+    # create this table. Ha-glue code that needs the Room object does a runtime
+    # lookup via the hook system instead of a SQLAlchemy relationship.
+    room_id = Column(Integer, nullable=True, index=True)
     room_name = Column(String(100), nullable=True)
     source = Column(String(50), default="ha_automation")
     source_data = Column(JSON, nullable=True)
@@ -851,8 +572,9 @@ class Notification(Base):
     privacy = Column(String(20), default="public")
     target_user_id = Column(Integer, ForeignKey("users.id"), nullable=True, index=True)
 
-    # Relationships
-    room = relationship("Room", foreign_keys=[room_id])
+    # Relationships — room relationship removed (layering rule: platform
+    # must not depend on ha_glue). Use the hook system to resolve room_id
+    # to a Room object when ha_glue is loaded.
     target_user = relationship("User", foreign_keys=[target_user_id])
 
 
@@ -894,7 +616,9 @@ class Reminder(Base):
     id = Column(Integer, primary_key=True, index=True)
     message = Column(Text, nullable=False)
     trigger_at = Column(DateTime, nullable=False, index=True)
-    room_id = Column(Integer, ForeignKey("rooms.id"), nullable=True)
+    # room_id is a loose reference to ha_glue.rooms.id — see the Notification
+    # class for the rationale (no ForeignKey, no relationship).
+    room_id = Column(Integer, nullable=True)
     room_name = Column(String(100), nullable=True)
     user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
     session_id = Column(String(255), nullable=True)
@@ -903,7 +627,6 @@ class Reminder(Base):
     created_at = Column(DateTime, default=_utcnow)
     fired_at = Column(DateTime, nullable=True)
 
-    room = relationship("Room", foreign_keys=[room_id])
     user = relationship("User", foreign_keys=[user_id])
     notification = relationship("Notification", foreign_keys=[notification_id])
 
@@ -1134,40 +857,8 @@ class MemoryHistory(Base):
 
 
 # ==========================================================================
-# BLE Presence Detection
+# BLE Presence Detection (moved to ha_glue/models/database.py — re-exported below)
 # ==========================================================================
-
-class UserBleDevice(Base):
-    """Registered BLE device for room-level presence detection."""
-    __tablename__ = "user_ble_devices"
-
-    id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
-    mac_address = Column(String(17), unique=True, nullable=False, index=True)  # "AA:BB:CC:DD:EE:FF"
-    device_name = Column(String(100), nullable=False)   # "Emma's iPhone"
-    device_type = Column(String(50), default="phone")   # phone, watch, tracker
-    detection_method = Column(String(20), default="ble")  # "ble" | "classic_bt"
-    is_enabled = Column(Boolean, default=True)
-    created_at = Column(DateTime, default=_utcnow)
-
-    user = relationship("User", backref="ble_devices")
-
-
-class PresenceEvent(Base):
-    """Persisted presence event for analytics (heatmap, predictions)."""
-    __tablename__ = "presence_events"
-
-    id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
-    room_id = Column(Integer, ForeignKey("rooms.id"), nullable=False, index=True)
-    event_type = Column(String(20), nullable=False)  # "enter" | "leave"
-    source = Column(String(20), default="ble")        # "ble" | "voice" | "web"
-    confidence = Column(Float, nullable=True)
-    created_at = Column(DateTime, default=_utcnow, index=True)
-
-    __table_args__ = (
-        Index('ix_presence_events_analytics', 'user_id', 'room_id', 'created_at'),
-    )
 
 
 # System Setting Keys
@@ -1185,92 +876,65 @@ SYSTEM_SETTING_KEYS = [
 
 
 # ==========================================================================
-# Paperless Document Audit
+# Paperless Document Audit (moved to ha_glue/models/database.py)
+# Radio Favorites (moved to ha_glue/models/database.py)
 # ==========================================================================
-
-class PaperlessAuditResult(Base):
-    """Paperless document audit results from LLM analysis."""
-    __tablename__ = "paperless_audit_results"
-
-    id = Column(Integer, primary_key=True)
-    paperless_doc_id = Column(Integer, index=True, unique=True)
-
-    # Snapshot of current state
-    current_title = Column(String, nullable=True)
-    current_correspondent = Column(String, nullable=True)
-    current_document_type = Column(String, nullable=True)
-    current_tags = Column(JSON, nullable=True)
-
-    # LLM suggestions
-    suggested_title = Column(String, nullable=True)
-    suggested_correspondent = Column(String, nullable=True)
-    suggested_document_type = Column(String, nullable=True)
-    suggested_tags = Column(JSON, nullable=True)
-
-    # Document date
-    current_date = Column(String, nullable=True)          # Paperless 'created' (YYYY-MM-DD)
-    suggested_date = Column(String, nullable=True)        # LLM-extracted date
-
-    # Missing metadata detection
-    missing_fields = Column(JSON, nullable=True)          # ["correspondent", "document_type", ...]
-
-    # Duplicate detection
-    duplicate_group_id = Column(String, nullable=True, index=True)
-    duplicate_score = Column(Float, nullable=True)        # 0.0-1.0
-
-    # Custom fields
-    current_custom_fields = Column(JSON, nullable=True)
-    suggested_custom_fields = Column(JSON, nullable=True)
-
-    # Language detection
-    detected_language = Column(String(10), nullable=True) # "de", "en", etc.
-
-    # Storage path
-    current_storage_path = Column(String, nullable=True)
-    suggested_storage_path = Column(String, nullable=True)
-
-    # Content completeness
-    content_completeness = Column(Integer, nullable=True) # 1-5
-    completeness_issues = Column(String, nullable=True)
-
-    # Content hash for duplicate detection
-    content_hash = Column(String(32), nullable=True)      # MD5 of first 1000 chars
-
-    # Assessment
-    ocr_quality = Column(Integer, nullable=True)          # 1-5
-    ocr_issues = Column(String, nullable=True)
-    confidence = Column(Float, nullable=True)             # 0.0-1.0
-    changes_needed = Column(Boolean, default=False)
-    reasoning = Column(Text, nullable=True)               # LLM reasoning
-
-    # Status: pending → applied/skipped/failed
-    status = Column(String, default="pending")
-
-    # Re-OCR
-    renfield_ocr_text = Column(Text, nullable=True)
-
-    # Timestamps
-    audited_at = Column(DateTime, default=_utcnow)
-    applied_at = Column(DateTime, nullable=True)
-    audit_run_id = Column(String, nullable=True, index=True)
 
 
 # ==========================================================================
-# Radio Favorites
+# Backwards-compat re-exports from ha_glue.models.database
 # ==========================================================================
+#
+# Phase 1 Week 1 — the HA-specific models were moved to
+# `ha_glue/models/database.py` to establish a clean platform vs ha-glue
+# boundary for the open-source extraction. These re-exports keep the
+# legacy `from models.database import Room` import path working so
+# consumer files (api/routes/rooms.py, services/presence_service.py,
+# etc.) don't need to change in the same commit.
+#
+# TODO(phase1-week4): remove these re-exports once every consumer has
+# migrated to `from ha_glue.models.database import ...` AND the CI lint
+# rule that forbids platform → ha_glue imports is in place. See
+# `docs/architecture/renfield-platform-boundary.md` in the parent Reva
+# repo for the rollout plan.
+#
+# The try/except handles the platform-only deployment mode: if
+# `ha_glue` isn't installed (a future X-idra/renfield-only deploy),
+# the re-exports silently skip and `from models.database import Room`
+# raises ImportError at import time, which is the correct behavior.
 
-class RadioFavorite(Base):
-    """User's favorite radio stations (provider-agnostic, currently TuneIn)."""
-    __tablename__ = "radio_favorites"
-
-    id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=True, index=True)
-    station_id = Column(String(50), nullable=False)
-    station_name = Column(String(255), nullable=False)
-    station_image = Column(String(512), nullable=True)
-    genre = Column(String(100), nullable=True)
-    created_at = Column(DateTime, default=_utcnow)
-
-    __table_args__ = (
-        Index('ix_radio_favorites_user_station', 'user_id', 'station_id', unique=True),
+try:
+    from ha_glue.models.database import (  # noqa: F401 — re-export
+        DEFAULT_CAPABILITIES,
+        DEVICE_TYPE_SATELLITE,
+        DEVICE_TYPE_WEB_BROWSER,
+        DEVICE_TYPE_WEB_KIOSK,
+        DEVICE_TYPE_WEB_PANEL,
+        DEVICE_TYPE_WEB_TABLET,
+        DEVICE_TYPES,
+        OUTPUT_TYPE_AUDIO,
+        OUTPUT_TYPE_VISUAL,
+        OUTPUT_TYPES,
+        CameraEvent,
+        HomeAssistantEntity,
+        PaperlessAuditResult,
+        PresenceEvent,
+        RadioFavorite,
+        Room,
+        RoomDevice,
+        RoomOutputDevice,
+        RoomSatellite,
+        UserBleDevice,
     )
+except ImportError as _compat_err:
+    # Platform-only deployment — ha_glue not installed. Legacy consumer
+    # imports from models.database will fail at their import site with
+    # a clear ImportError, which is the desired behavior.
+    #
+    # Narrow catch: ONLY swallow the case where the top-level `ha_glue`
+    # package is missing. Any other ImportError (a typo inside
+    # `ha_glue.models.database`, a broken SQLAlchemy import, etc.) bubbles
+    # up immediately so it can't hide behind a confusing "cannot import
+    # name 'Room'" at the consumer site.
+    if _compat_err.name and _compat_err.name.split(".")[0] != "ha_glue":
+        raise


### PR DESCRIPTION
## Summary

Phase 1 Week 1.2 of the platform/ha-glue extraction. Tracks #342.

First concrete piece of the boundary. Moves SQLAlchemy models for HomeAssistant, camera, presence, paperless, and radio features into a new \`ha_glue/models/database.py\` while \`models/database.py\` keeps only platform-generic tables.

**Moved to \`ha_glue/models/database.py\` (9 classes + 2 constant blocks):**
- \`CameraEvent\`, \`HomeAssistantEntity\`, \`Room\`, \`RoomDevice\`, \`RoomOutputDevice\`, \`RoomSatellite\` (alias), \`UserBleDevice\`, \`PresenceEvent\`, \`PaperlessAuditResult\`, \`RadioFavorite\`
- \`DEVICE_TYPE_*\` / \`DEVICE_TYPES\` / \`DEFAULT_CAPABILITIES\`
- \`OUTPUT_TYPE_*\` / \`OUTPUT_TYPES\`

**Stays in \`models/database.py\`:** all 22 platform tables (Conversation, Message, Speaker, SpeakerEmbedding, User, Role, KBPermission, KnowledgeBase, Document, DocumentChunk, ChatUpload, SystemSetting, IntentCorrection, Notification, NotificationSuppression, Reminder, ConversationMemory, EpisodicMemory, KGEntity, KGRelation, MemoryHistory, Task).

## Layering rule fixes

Removed two platform → ha_glue hard dependencies that violated the Phase 1 boundary:

1. \`Notification.room_id\` had \`ForeignKey(\"rooms.id\")\` and \`relationship(\"Room\")\`. The relationship was declared but never read by application code (grep across all of \`src/backend\` for \`notification.room\` returns zero). Dropped both — the column is now a plain \`Integer\`. Runtime lookup via the hook system will happen in ha-glue.

2. \`Reminder.room_id\` had the same pattern. Same fix.

Neither change affects behavior because neither \`.room\` accessor was ever used; only \`room_id\` and \`room_name\` columns are read and written. The FK was also never enforced by ORM cascade — dangling room_ids already tolerated.

## Backwards compatibility

\`models/database.py\` ends with a try/except compat re-export block that pulls the HA classes back in from \`ha_glue.models.database\`, so existing consumer code (\`from models.database import Room\` in 11 files across \`services/\` and \`api/routes/\`) keeps working during the Week 2-4 transition. The re-exports will be removed in Week 4 once every consumer has been migrated AND the CI lint rule that forbids platform → ha_glue imports is in place.

The \`except ImportError\` is narrow — only swallows the case where the top-level \`ha_glue\` package is missing. Any typo or broken import INSIDE \`ha_glue.models.database\` bubbles up immediately so it can't hide behind a confusing \"cannot import name 'Room'\" at the consumer site.

## Verification

- ✅ AST parse clean on both split files
- ✅ \`configure_mappers()\` succeeds, 31 tables registered (identical to pristine main)
- ✅ \`from models.database import Room\` and \`from ha_glue.models.database import Room\` return the same class object (no duplicate mapping)
- ✅ 10/11 consumer files import successfully (11th fails only on missing \`redis\` in local dev env — pre-existing, unrelated)
- ✅ \`tests/backend/test_models.py\`: 2 passed, 21 errors — identical signature to pristine \`main\` (all errors are pre-existing SQLite/TSVECTOR incompat in the test fixture, unrelated to this change)
- ✅ Code review passed (no blocker/high/medium issues, one low-severity note about broadening the ImportError catch — addressed in this commit)

## What's next (not in this PR)

Phase 1 Week 1.2 continues in follow-up commits:

- [ ] Split \`utils/config.py\` (Pydantic HA settings into a nested submodel)
- [ ] Extract HA fallback from \`services/agent_router.py\` via a new \`on_intent_fallback\` hook
- [ ] Split \`api/lifecycle.py\` via hook registration
- [ ] Remove stray \`settings.ha_timeout\` import from \`services/ollama_service.py\`
- [ ] Clean docstrings in \`services/action_executor.py\`, \`services/agent_tools.py\`

Then Week 2 does the 28 ha-glue file moves into \`ha_glue/\` subtree, Week 3 handles the Alembic cutover, Week 4 adds the CI lint gate.

## Test plan

- [ ] CI green (ruff + pytest in the Renfield repo's existing workflows)
- [ ] Deploy to a running Renfield home-automation instance (if available) — verify rooms/presence/paperless still resolve
- [ ] Verify \`from models.database import Room\` still works from consumer files that haven't been migrated yet
- [ ] Verify \`alembic autogenerate\` still picks up HA tables (they should, because the compat re-export loads them into \`Base.metadata\`)

## References

- Parent Phase 1 tracking: #342
- Launch plan: [X-idra-Systems-GmbH/reva \`docs/architecture/renfield-open-source-launch.md\`](https://github.com/X-idra-Systems-GmbH/reva/blob/main/docs/architecture/renfield-open-source-launch.md)
- Boundary doc (per-file classification): [X-idra-Systems-GmbH/reva \`docs/architecture/renfield-platform-boundary.md\`](https://github.com/X-idra-Systems-GmbH/reva/blob/main/docs/architecture/renfield-platform-boundary.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)