### PR TITLE
docs: genericize HA-specific examples in docstrings (#342)

### DIFF
--- a/src/backend/services/action_executor.py
+++ b/src/backend/services/action_executor.py
@@ -26,7 +26,7 @@ class ActionExecutor:
 
         Args:
             intent_data: {
-                "intent": "mcp.homeassistant.turn_on",
+                "intent": "mcp.<namespace>.<tool>",
                 "parameters": {...},
                 "confidence": 0.9
             }

--- a/src/backend/services/agent_tools.py
+++ b/src/backend/services/agent_tools.py
@@ -150,9 +150,9 @@ class AgentToolRegistry:
     def resolve_tool_name(self, name: str) -> str | None:
         """Resolve a tool name, supporting short names without namespace prefix.
 
-        Small LLMs sometimes emit 'GetLiveContext' instead of
-        'mcp.homeassistant.GetLiveContext'. This tries exact match first,
-        then falls back to suffix match (must be unambiguous).
+        Small LLMs sometimes emit the bare tool name instead of the fully
+        qualified `mcp.<server>.<tool>` form. This tries exact match
+        first, then falls back to suffix match (must be unambiguous).
         """
         if name in self._tools:
             return name


### PR DESCRIPTION
## Summary

Tiny cosmetic cleanup. Two one-line changes in docstrings.

| File | Change |
|------|--------|
| \`services/action_executor.py:29\` | \`\"intent\": \"mcp.homeassistant.turn_on\"\` → \`\"intent\": \"mcp.<namespace>.<tool>\"\` |
| \`services/agent_tools.py:154\` | Example name \`mcp.homeassistant.GetLiveContext\` → \`mcp.<server>.<tool>\` |

Both files stay platform-side after the Phase 1 extraction (ref #342). The HA references were only used as illustration in docstrings, not as actual coupling or imports.

## Test plan

- [ ] Docstring render OK (no markdown breakage)
- [ ] No behavior change — CI should pass without any re-run beyond ruff/mypy/pytest that already run on PRs

## References

- Parent: #342 (Phase 1 platform/ha-glue extraction)
- Companion PR: #343 (models split — the bigger piece of Phase 1 Week 1.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)