### PR TITLE
fix(models): use module __getattr__ for ha_glue compat re-exports (#342)

### DIFF
--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -898,43 +898,70 @@ SYSTEM_SETTING_KEYS = [
 # `docs/architecture/renfield-platform-boundary.md` in the parent Reva
 # repo for the rollout plan.
 #
-# The try/except handles the platform-only deployment mode: if
-# `ha_glue` isn't installed (a future X-idra/renfield-only deploy),
-# the re-exports silently skip and `from models.database import Room`
-# raises ImportError at import time, which is the correct behavior.
+# Implementation note — module-level `__getattr__` instead of a tail
+# try/except block. The earlier shape of this file used a top-level
+# `from ha_glue.models.database import Room, ...` wrapped in
+# try/except. That has a circular-init failure mode: if a consumer
+# imports `from ha_glue.models.database import X` BEFORE anything has
+# touched `models.database`, then ha_glue.models.database starts
+# loading, hits its own `from models.database import Base`, models.database
+# starts loading, hits the tail re-export, tries to import from a
+# half-loaded ha_glue.models.database, raises ImportError on the
+# missing class, the except swallows it, and models.database finishes
+# loading WITHOUT the re-exported names. Subsequent
+# `from models.database import Room` then fails.
+#
+# Module-level `__getattr__` (PEP 562) avoids this entirely. The
+# import from ha_glue.models.database happens lazily, on the first
+# attribute access — by which time both modules are fully loaded and
+# there's no partial-init state to trip over.
+#
+# Platform-only deployments (no ha_glue): a missing `ha_glue` package
+# raises a clean `ModuleNotFoundError` at the consumer's import site,
+# clearly naming the missing package. No silent failures.
 
-try:
-    from ha_glue.models.database import (  # noqa: F401 — re-export
-        DEFAULT_CAPABILITIES,
-        DEVICE_TYPE_SATELLITE,
-        DEVICE_TYPE_WEB_BROWSER,
-        DEVICE_TYPE_WEB_KIOSK,
-        DEVICE_TYPE_WEB_PANEL,
-        DEVICE_TYPE_WEB_TABLET,
-        DEVICE_TYPES,
-        OUTPUT_TYPE_AUDIO,
-        OUTPUT_TYPE_VISUAL,
-        OUTPUT_TYPES,
-        CameraEvent,
-        HomeAssistantEntity,
-        PaperlessAuditResult,
-        PresenceEvent,
-        RadioFavorite,
-        Room,
-        RoomDevice,
-        RoomOutputDevice,
-        RoomSatellite,
-        UserBleDevice,
-    )
-except ImportError as _compat_err:
-    # Platform-only deployment — ha_glue not installed. Legacy consumer
-    # imports from models.database will fail at their import site with
-    # a clear ImportError, which is the desired behavior.
-    #
-    # Narrow catch: ONLY swallow the case where the top-level `ha_glue`
-    # package is missing. Any other ImportError (a typo inside
-    # `ha_glue.models.database`, a broken SQLAlchemy import, etc.) bubbles
-    # up immediately so it can't hide behind a confusing "cannot import
-    # name 'Room'" at the consumer site.
-    if _compat_err.name and _compat_err.name.split(".")[0] != "ha_glue":
-        raise
+_HA_GLUE_REEXPORT_NAMES = frozenset({
+    "DEFAULT_CAPABILITIES",
+    "DEVICE_TYPE_SATELLITE",
+    "DEVICE_TYPE_WEB_BROWSER",
+    "DEVICE_TYPE_WEB_KIOSK",
+    "DEVICE_TYPE_WEB_PANEL",
+    "DEVICE_TYPE_WEB_TABLET",
+    "DEVICE_TYPES",
+    "OUTPUT_TYPE_AUDIO",
+    "OUTPUT_TYPE_VISUAL",
+    "OUTPUT_TYPES",
+    "CameraEvent",
+    "HomeAssistantEntity",
+    "PaperlessAuditResult",
+    "PresenceEvent",
+    "RadioFavorite",
+    "Room",
+    "RoomDevice",
+    "RoomOutputDevice",
+    "RoomSatellite",
+    "UserBleDevice",
+})
+
+
+def __getattr__(name: str):
+    """Lazily re-export ha-glue model classes for backwards compatibility.
+
+    Triggered only when a caller does `from models.database import X`
+    or `models.database.X` for a name that isn't already in the module
+    namespace. Defers the `from ha_glue.models.database import ...`
+    until both modules are fully loaded, sidestepping the partial-init
+    cycle that a tail-of-file try/except produces.
+    """
+    if name not in _HA_GLUE_REEXPORT_NAMES:
+        raise AttributeError(f"module 'models.database' has no attribute {name!r}")
+    from ha_glue.models import database as _hg
+    try:
+        return getattr(_hg, name)
+    except AttributeError as exc:
+        # ha_glue is loaded but the symbol isn't there — propagate as
+        # AttributeError, not as a misleading "package missing" error.
+        raise AttributeError(
+            f"models.database compat re-export: name {name!r} not found in "
+            f"ha_glue.models.database (module loaded but symbol missing)"
+        ) from exc


### PR DESCRIPTION
## Summary

Hotfix for a latent circular-init bug in the compat re-export block added by #343. Replaces the tail try/except with a module-level \`__getattr__\` (PEP 562) that lazily imports from \`ha_glue.models.database\` on first attribute access.

## The bug

The Phase 1 W1.2 models split (#343) added a tail try/except block to \`models/database.py\` that re-imports HA classes from \`ha_glue.models.database\`. That block has a circular-init failure mode discovered during post-deploy verification:

1. Consumer does \`from ha_glue.models.database import Room\` BEFORE anything has touched \`models.database\`
2. Python starts loading \`ha_glue.models.database\`
3. ha_glue does \`from models.database import Base, _utcnow\` → triggers \`models.database\` to load
4. \`models.database\` hits its tail try block
5. Tail try does \`from ha_glue.models.database import Room, ...\` — but ha_glue is **partially loaded** (only the \`from models.database\` line has executed; Room and friends aren't defined yet)
6. ImportError raised; the narrow \`except\` (added in #343 review to avoid hiding unrelated import errors) actually still catches this case because the failing module name starts with \"ha_glue\"
7. \`models.database\` finishes loading WITHOUT the re-exported names
8. Subsequent \`from models.database import Room\` then fails with a confusing \"cannot import name 'Room' from 'models.database'\"

## Production impact today: **none**

The bug is latent because Renfield's startup imports \`models.database\` very early, before anything could touch \`ha_glue.models.database\`. Verified live in the deployed pod: \`from models.database import Room\` works fine (legacy path), the layering fix (Notification/Reminder no longer have \`.room\`) is verified, all consumer files import clean.

The bug would bite **Week 2 consumer migrations** the moment a service file does \`from ha_glue.models.database import X\` first. This PR pre-empts that.

## The fix

Module-level \`__getattr__\` defers the ha_glue import until both modules are fully loaded:

\`\`\`python
_HA_GLUE_REEXPORT_NAMES = frozenset({\"Room\", \"RoomDevice\", ...})

def __getattr__(name: str):
    if name not in _HA_GLUE_REEXPORT_NAMES:
        raise AttributeError(f\"module 'models.database' has no attribute {name!r}\")
    from ha_glue.models import database as _hg
    try:
        return getattr(_hg, name)
    except AttributeError as exc:
        raise AttributeError(...) from exc
\`\`\`

No partial-init state to trip over because the \`from ha_glue.models import database\` only runs on the FIRST access to a re-exported name — by which time both modules have completed loading.

## Verification

- ✅ \`from ha_glue.models.database import Room\` first, then \`from models.database import Room as R2\` — same object
- ✅ \`from models.database import Room\` first, then \`from ha_glue.models.database import Room as Hg\` — same object
- ✅ \`configure_mappers()\` succeeds, 31 tables registered
- ✅ \`from models.database import NotARealClass\` raises ImportError (no silent typo swallowing)
- ✅ All 10 consumer files in \`services/\` and \`api/routes/\` import clean
- ✅ Platform-only deploy: missing \`ha_glue\` package raises clean \`ModuleNotFoundError\` at consumer import site

## Test plan

- [ ] CI green
- [ ] Smoke test: deploy to a Renfield instance and verify rooms / presence / paperless still resolve
- [ ] Verify legacy and new import paths from a Python REPL inside the running container

## References

- Parent: #342 (Phase 1 platform/ha-glue extraction)
- Original: #343 (the models split this fixes)
- Boundary doc: [X-idra-Systems-GmbH/reva docs/architecture/renfield-platform-boundary.md](https://github.com/X-idra-Systems-GmbH/reva/blob/main/docs/architecture/renfield-platform-boundary.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)