### PR TITLE
refactor(intent): extract HA fallback to ha_glue via hook (#342)

### DIFF
--- a/src/backend/api/lifecycle.py
+++ b/src/backend/api/lifecycle.py
@@ -526,6 +526,27 @@ async def lifespan(app: "FastAPI"):
                 "Set CORS_ORIGINS to your frontend domain(s) in production."
             )
 
+    # Stage 0: Bootstrap ha_glue. Importing the package triggers
+    # `ha_glue/__init__.py::_register_hooks()` as a side effect, which
+    # registers all HA-flavored hook handlers (currently only
+    # `intent_fallback_resolve`) with the platform hook system.
+    #
+    # Gated on the smart_home feature flag so `RENFIELD_EDITION=pro`
+    # deployments don't activate HA behavior even though the package
+    # ships in the same monorepo. Wrapped in try/except so the eventual
+    # X-idra/renfield platform-only deploy (no ha_glue installed)
+    # degrades cleanly.
+    #
+    # This is the ONE structural platform -> ha_glue import line.
+    # Phase 2/3 will move it to a PLUGIN_MODULE entry point and remove
+    # it from this file.
+    if settings.features["smart_home"]:
+        try:
+            import ha_glue  # noqa: F401 — side-effect import, registers hooks
+            logger.info("✅ ha_glue bootstrap loaded")
+        except ImportError:
+            logger.info("ha_glue not installed — running platform-only")
+
     # Stage 1: Sequential (auth depends on database)
     await _init_database()
     await _init_auth()

--- a/src/backend/api/lifecycle.py
+++ b/src/backend/api/lifecycle.py
@@ -526,26 +526,33 @@ async def lifespan(app: "FastAPI"):
                 "Set CORS_ORIGINS to your frontend domain(s) in production."
             )
 
-    # Stage 0: Bootstrap ha_glue. Importing the package triggers
-    # `ha_glue/__init__.py::_register_hooks()` as a side effect, which
-    # registers all HA-flavored hook handlers (currently only
-    # `intent_fallback_resolve`) with the platform hook system.
+    # Stage 0: Bootstrap ha_glue. The ha_glue package itself is
+    # side-effect-free (the legacy compat re-export in models/database.py
+    # imports the package as part of attribute resolution, so any
+    # registration via __init__.py would bypass the smart_home gate
+    # below). Hook registration only happens when this explicit
+    # `bootstrap.register()` call fires.
     #
     # Gated on the smart_home feature flag so `RENFIELD_EDITION=pro`
     # deployments don't activate HA behavior even though the package
-    # ships in the same monorepo. Wrapped in try/except so the eventual
-    # X-idra/renfield platform-only deploy (no ha_glue installed)
-    # degrades cleanly.
+    # ships in the same monorepo. Wrapped in a broad try/except so the
+    # eventual X-idra/renfield platform-only deploy (no ha_glue
+    # installed) AND any future broken handler degrades cleanly.
     #
     # This is the ONE structural platform -> ha_glue import line.
     # Phase 2/3 will move it to a PLUGIN_MODULE entry point and remove
     # it from this file.
     if settings.features["smart_home"]:
         try:
-            import ha_glue  # noqa: F401 — side-effect import, registers hooks
+            from ha_glue.bootstrap import register as _ha_glue_register
+            _ha_glue_register()
             logger.info("✅ ha_glue bootstrap loaded")
         except ImportError:
             logger.info("ha_glue not installed — running platform-only")
+        except Exception:  # noqa: BLE001 — never break startup on plugin error
+            logger.opt(exception=True).warning(
+                "ha_glue bootstrap raised — HA fallback disabled, continuing startup"
+            )
 
     # Stage 1: Sequential (auth depends on database)
     await _init_database()

--- a/src/backend/ha_glue/__init__.py
+++ b/src/backend/ha_glue/__init__.py
@@ -28,44 +28,29 @@ imports.
 - `ha_glue.models.database` — 9 SQLAlchemy classes + constants. Compat
   re-export in `models/database.py` keeps legacy
   `from models.database import Room` working.
-- `ha_glue.services.intent_fallback` — HA-keyword intent fallback,
-  registered as an `intent_fallback_resolve` hook handler at import
-  time of this package.
+- `ha_glue.services.intent_fallback` — HA-keyword intent fallback
+  handler. Registered with the platform hook system by an explicit
+  call to `ha_glue.bootstrap.register()` from a platform startup file.
+- `ha_glue.bootstrap` — explicit hook-registration entry point.
 
 Service and route extractions for the rest of the ha-glue surface
 happen in Week 2; Alembic migration cutover in Week 3; CI lint gate
 in Week 4.
 
-## Hook registration
+## Hook registration — explicit, NOT side-effect-on-import
 
-This package's `__init__.py` registers all ha-glue hook handlers as a
-side effect of import. Trigger the bootstrap by adding `import ha_glue`
-to a platform startup file (currently `api/lifecycle.py` at the
-appropriate point), wrapped in a try/except so platform-only
-deployments (no ha_glue installed) degrade cleanly to "no HA fallback"
-without crashing.
+Importing this package is side-effect-free. Hook registration only
+happens when something explicitly calls `ha_glue.bootstrap.register()`.
+This is deliberate: the legacy compat re-export in
+`models/database.py::__getattr__` does `from ha_glue.models import
+database`, which imports the `ha_glue` package as part of attribute
+resolution. If `ha_glue/__init__.py` registered hooks as a side effect
+of import, every platform service that touched an ha-glue model
+through the compat shim would unconditionally activate HA behavior —
+even on `RENFIELD_EDITION=pro` deployments where the smart_home
+feature flag is False.
+
+Trigger the bootstrap explicitly from `api/lifecycle.py`, gated on
+`settings.features["smart_home"]`, and wrap in try/except so a
+missing `ha_glue` package degrades cleanly.
 """
-
-from loguru import logger as _logger
-
-
-def _register_hooks() -> None:
-    """Register all ha_glue hook handlers with the platform hook system.
-
-    Called once, at package import time. Failures are logged but never
-    propagate — a broken handler must not break Renfield startup.
-    """
-    try:
-        from utils.hooks import register_hook
-
-        from ha_glue.services.intent_fallback import ha_intent_fallback
-
-        register_hook("intent_fallback_resolve", ha_intent_fallback)
-        _logger.info("ha_glue: registered intent_fallback_resolve handler")
-    except Exception:  # noqa: BLE001 — startup must never break on plugin error
-        _logger.opt(exception=True).warning(
-            "ha_glue: hook registration failed — HA fallback disabled"
-        )
-
-
-_register_hooks()

--- a/src/backend/ha_glue/__init__.py
+++ b/src/backend/ha_glue/__init__.py
@@ -23,17 +23,49 @@ by a CI lint in Phase 1 Week 4. Platform files that need data from
 ha_glue should use the hook system (`utils.hooks`) instead of direct
 imports.
 
-## Current state (Phase 1 Week 1 — models split only)
+## Current state (Phase 1 Week 1.2)
 
-As of 2026-04-14, only `ha_glue.models.database` is populated. The
-service and route extractions happen in Week 2; Alembic migration
-cutover in Week 3; CI lint gate in Week 4.
+- `ha_glue.models.database` — 9 SQLAlchemy classes + constants. Compat
+  re-export in `models/database.py` keeps legacy
+  `from models.database import Room` working.
+- `ha_glue.services.intent_fallback` — HA-keyword intent fallback,
+  registered as an `intent_fallback_resolve` hook handler at import
+  time of this package.
 
-Consumers can already import from the new location:
+Service and route extractions for the rest of the ha-glue surface
+happen in Week 2; Alembic migration cutover in Week 3; CI lint gate
+in Week 4.
 
-    from ha_glue.models.database import Room, RoomDevice, PresenceEvent
+## Hook registration
 
-The legacy `from models.database import Room` path also still works
-via a compat re-export in `models/database.py`, which will be removed
-in Week 4 once every consumer has migrated.
+This package's `__init__.py` registers all ha-glue hook handlers as a
+side effect of import. Trigger the bootstrap by adding `import ha_glue`
+to a platform startup file (currently `api/lifecycle.py` at the
+appropriate point), wrapped in a try/except so platform-only
+deployments (no ha_glue installed) degrade cleanly to "no HA fallback"
+without crashing.
 """
+
+from loguru import logger as _logger
+
+
+def _register_hooks() -> None:
+    """Register all ha_glue hook handlers with the platform hook system.
+
+    Called once, at package import time. Failures are logged but never
+    propagate — a broken handler must not break Renfield startup.
+    """
+    try:
+        from utils.hooks import register_hook
+
+        from ha_glue.services.intent_fallback import ha_intent_fallback
+
+        register_hook("intent_fallback_resolve", ha_intent_fallback)
+        _logger.info("ha_glue: registered intent_fallback_resolve handler")
+    except Exception:  # noqa: BLE001 — startup must never break on plugin error
+        _logger.opt(exception=True).warning(
+            "ha_glue: hook registration failed — HA fallback disabled"
+        )
+
+
+_register_hooks()

--- a/src/backend/ha_glue/bootstrap.py
+++ b/src/backend/ha_glue/bootstrap.py
@@ -1,0 +1,50 @@
+"""Explicit hook-registration entry point for ha_glue.
+
+This module exists so that registering ha-glue hook handlers requires
+an EXPLICIT call from platform startup code (currently
+`api/lifecycle.py`). Importing the `ha_glue` package itself is
+side-effect-free, which matters because the legacy compat re-export
+in `models/database.py::__getattr__` does `from ha_glue.models import
+database` to satisfy `from models.database import Room`. If hook
+registration lived in `ha_glue/__init__.py` as an import side effect,
+every platform service that touched an ha-glue model through the
+compat shim would unconditionally register HA behavior — bypassing
+the `settings.features["smart_home"]` gate that controls whether
+RENFIELD_EDITION=pro deployments activate HA features.
+
+The platform-side bootstrap is a single line:
+
+    from ha_glue.bootstrap import register
+    register()
+
+wrapped in try/except so a missing or broken ha_glue package degrades
+cleanly to "no HA fallback" without breaking Renfield startup.
+"""
+
+from __future__ import annotations
+
+from loguru import logger
+
+
+def register() -> None:
+    """Register all ha_glue hook handlers with the platform hook system.
+
+    Idempotent at the system level — calling twice would register the
+    same handlers twice, so the hook would fire twice with first-result
+    semantics still picking the same answer. We trust the caller to
+    only invoke this once during startup.
+
+    Failures are logged but never propagate. A broken handler module
+    must not break Renfield startup.
+    """
+    try:
+        from utils.hooks import register_hook
+
+        from ha_glue.services.intent_fallback import ha_intent_fallback
+
+        register_hook("intent_fallback_resolve", ha_intent_fallback)
+        logger.info("ha_glue.bootstrap: registered intent_fallback_resolve handler")
+    except Exception:  # noqa: BLE001 — startup must never break on plugin error
+        logger.opt(exception=True).warning(
+            "ha_glue.bootstrap: hook registration failed — HA fallback disabled"
+        )

--- a/src/backend/ha_glue/services/__init__.py
+++ b/src/backend/ha_glue/services/__init__.py
@@ -1,0 +1,11 @@
+"""Service-layer ha-glue modules.
+
+These services consume platform interfaces (LLM dispatch, hook system,
+SQLAlchemy models) and provide HomeAssistant-specific behavior on top.
+None of these modules should be imported by platform code.
+
+Phase 1 Week 1.2: only `intent_fallback` is populated. Week 2 will move
+the rest of the ha-glue services here (presence, room, audio output,
+satellites, paperless audit, etc.) per
+`docs/architecture/renfield-platform-boundary.md` in the parent Reva repo.
+"""

--- a/src/backend/ha_glue/services/intent_fallback.py
+++ b/src/backend/ha_glue/services/intent_fallback.py
@@ -1,0 +1,118 @@
+"""HA-keyword intent fallback for the platform's LLM intent classifier.
+
+Registered as an `intent_fallback_resolve` hook handler at ha_glue
+package import time (see `ha_glue/__init__.py`).
+
+When the platform's LLM intent classifier (`OllamaService._extract_intent`)
+fails to parse JSON from the model response — even after a retry — it
+fires the `intent_fallback_resolve` hook to give domain-specific
+consumers a last chance to recognize the intent before falling through
+to `general.unresolved`. This module's handler implements the legacy
+"detect German HA action keywords + look up entity in HA" path that
+used to live inline in `services/ollama_service.py`.
+
+Match algorithm
+---------------
+1. Lowercase the message.
+2. Check for an action keyword (`schalte`, `mach`, `stelle`, etc).
+3. Check for a device keyword (`licht`, `lampe`, `fenster`, etc).
+4. If both present, query the HA entity index via
+   `HomeAssistantClient.search_entities(message)` for a matching entity.
+5. Pick the first match and synthesize a `homeassistant.turn_on/off/get_state`
+   intent with `entity_id` as the parameter.
+
+This is a deliberately narrow fallback: it only fires when the primary
+classifier crashes on the JSON output AND the message looks unambiguously
+HA-shaped. False positives (a non-HA message accidentally hitting both
+keyword sets) get routed to a stale entity, which the downstream tool
+call will fail visibly. False negatives (an HA message that doesn't
+match the keyword sets) fall through to `general.unresolved` and the
+agent loop picks it up.
+
+Confidence
+----------
+Returned at 0.6 — lower than the primary classifier's typical 0.9 — so
+the agent loop / orchestrator can deprioritize it if other signals
+disagree.
+"""
+
+from __future__ import annotations
+
+from loguru import logger
+
+
+# German HA action keywords (verbs that indicate a smart-home command)
+_HA_ACTION_KEYWORDS = (
+    "schalte", "mach", "stelle", "ist", "zeige", "öffne", "schließe",
+)
+
+# German HA device keywords (nouns that indicate a smart-home target)
+_HA_DEVICE_KEYWORDS = (
+    "licht", "lampe", "fenster", "tür", "heizung", "rolladen",
+)
+
+# German "turn on" verbs
+_HA_TURN_ON_KEYWORDS = ("ein", "an", "schalte ein")
+
+# German "turn off" verbs
+_HA_TURN_OFF_KEYWORDS = ("aus", "schalte aus")
+
+# German "get state" verbs
+_HA_GET_STATE_KEYWORDS = ("ist", "status", "zustand")
+
+
+def _classify_action(message_lower: str) -> str:
+    """Pick the HA intent verb based on which keywords appear in the message."""
+    if any(word in message_lower for word in _HA_TURN_ON_KEYWORDS):
+        return "homeassistant.turn_on"
+    if any(word in message_lower for word in _HA_TURN_OFF_KEYWORDS):
+        return "homeassistant.turn_off"
+    if any(word in message_lower for word in _HA_GET_STATE_KEYWORDS):
+        return "homeassistant.get_state"
+    return "homeassistant.turn_on"  # default action
+
+
+async def ha_intent_fallback(*, message: str, lang: str) -> dict | None:
+    """Hook handler for `intent_fallback_resolve`.
+
+    Args:
+        message: The user's raw message text.
+        lang: Language code (currently unused — keyword sets are German-only,
+            English support would be a separate handler or an extended set).
+
+    Returns:
+        A dict with `{"intent": str, "parameters": dict, "confidence": float}`
+        when the fallback matched, or `None` to defer to other handlers /
+        the platform's `general.unresolved` default.
+    """
+    message_lower = message.lower()
+
+    has_action = any(keyword in message_lower for keyword in _HA_ACTION_KEYWORDS)
+    has_device = any(keyword in message_lower for keyword in _HA_DEVICE_KEYWORDS)
+    if not (has_action and has_device):
+        return None
+
+    logger.warning(
+        "⚠️  ha_glue intent_fallback: HA-shaped message detected, attempting "
+        "entity lookup via HomeAssistantClient"
+    )
+
+    # Late import — the platform side never touches `integrations.homeassistant`,
+    # so we keep all HA client imports inside ha_glue. If HA itself is offline
+    # this raises and the hook system catches + logs it; the fallback returns
+    # None and the platform falls through to general.unresolved cleanly.
+    from integrations.homeassistant import HomeAssistantClient
+    ha_client = HomeAssistantClient()
+    search_results = await ha_client.search_entities(message)
+
+    if not search_results:
+        return None
+
+    entity_id = search_results[0]["entity_id"]
+    intent = _classify_action(message_lower)
+    logger.info(f"✅ ha_glue intent_fallback: {intent} mit Entity: {entity_id}")
+    return {
+        "intent": intent,
+        "parameters": {"entity_id": entity_id},
+        "confidence": 0.6,
+    }

--- a/src/backend/ha_glue/services/intent_fallback.py
+++ b/src/backend/ha_glue/services/intent_fallback.py
@@ -3,7 +3,7 @@
 Registered as an `intent_fallback_resolve` hook handler at ha_glue
 package import time (see `ha_glue/__init__.py`).
 
-When the platform's LLM intent classifier (`OllamaService._extract_intent`)
+When the platform's LLM intent classifier (`OllamaService.extract_intent`)
 fails to parse JSON from the model response — even after a retry — it
 fires the `intent_fallback_resolve` hook to give domain-specific
 consumers a last chance to recognize the intent before falling through

--- a/src/backend/services/ollama_service.py
+++ b/src/backend/services/ollama_service.py
@@ -544,21 +544,28 @@ WICHTIGE REGELN FÜR ANTWORTEN:
                     # JSON parsing of the LLM response failed even after retry.
                     # Fire the `intent_fallback_resolve` hook so domain-specific
                     # consumers (e.g. ha_glue's HA-keyword fallback) can still
-                    # recognize the intent. First handler that returns a non-None
-                    # result wins. If no handler matches, fall through to
-                    # general.unresolved and let the agent loop pick it up.
+                    # recognize the intent. First handler that returns a
+                    # well-shaped non-None result wins. If no handler matches,
+                    # fall through to general.unresolved and let the agent loop
+                    # pick it up.
                     from utils.hooks import run_hooks
                     fallback_results = await run_hooks(
                         "intent_fallback_resolve",
                         message=message,
                         lang=lang,
                     )
-                    if fallback_results:
-                        logger.info(
-                            f"✅ Intent fallback resolved by hook: "
-                            f"{fallback_results[0].get('intent')!r}"
+                    for candidate in fallback_results:
+                        if isinstance(candidate, dict) and "intent" in candidate:
+                            logger.info(
+                                f"✅ Intent fallback resolved by hook: "
+                                f"{candidate.get('intent')!r}"
+                            )
+                            return candidate
+                        logger.warning(
+                            f"⚠️  intent_fallback_resolve handler returned "
+                            f"unexpected shape (type={type(candidate).__name__}); "
+                            f"ignoring and trying next handler"
                         )
-                        return fallback_results[0]
 
                     # Fallback: unresolved intent (agent loop can pick this up)
                     return {

--- a/src/backend/services/ollama_service.py
+++ b/src/backend/services/ollama_service.py
@@ -541,40 +541,24 @@ WICHTIGE REGELN FÜR ANTWORTEN:
                         logger.warning(f"⚠️ Retry also failed: {retry_err}")
 
                 if intent_data is None:
-                    # Letzter Versuch: Prüfe ob wir einen Home Assistant Intent vermuten können
-                    message_lower = message.lower()
-                    ha_action_keywords = ["schalte", "mach", "stelle", "ist", "zeige", "öffne", "schließe"]
-
-                    has_action = any(keyword in message_lower for keyword in ha_action_keywords)
-                    has_device = any(keyword in message_lower for keyword in ["licht", "lampe", "fenster", "tür", "heizung", "rolladen"])
-
-                    if has_action and has_device:
-                        logger.warning("⚠️  Vermute Home Assistant Intent - verwende Fallback mit Entity-Suche")
-                        # Versuche zumindest die Entity zu finden
-                        from integrations.homeassistant import HomeAssistantClient
-                        ha_client = HomeAssistantClient()
-                        search_results = await ha_client.search_entities(message)
-
-                        if search_results:
-                            # Nehme erste gefundene Entity
-                            entity_id = search_results[0]["entity_id"]
-
-                            # Bestimme Intent basierend auf Aktion
-                            if any(word in message_lower for word in ["ein", "an", "schalte ein"]):
-                                intent = "homeassistant.turn_on"
-                            elif any(word in message_lower for word in ["aus", "schalte aus"]):
-                                intent = "homeassistant.turn_off"
-                            elif any(word in message_lower for word in ["ist", "status", "zustand"]):
-                                intent = "homeassistant.get_state"
-                            else:
-                                intent = "homeassistant.turn_on"  # Default
-
-                            logger.info(f"✅ Fallback Intent: {intent} mit Entity: {entity_id}")
-                            return {
-                                "intent": intent,
-                                "parameters": {"entity_id": entity_id},
-                                "confidence": 0.6  # Niedrigere Confidence für Fallback
-                            }
+                    # JSON parsing of the LLM response failed even after retry.
+                    # Fire the `intent_fallback_resolve` hook so domain-specific
+                    # consumers (e.g. ha_glue's HA-keyword fallback) can still
+                    # recognize the intent. First handler that returns a non-None
+                    # result wins. If no handler matches, fall through to
+                    # general.unresolved and let the agent loop pick it up.
+                    from utils.hooks import run_hooks
+                    fallback_results = await run_hooks(
+                        "intent_fallback_resolve",
+                        message=message,
+                        lang=lang,
+                    )
+                    if fallback_results:
+                        logger.info(
+                            f"✅ Intent fallback resolved by hook: "
+                            f"{fallback_results[0].get('intent')!r}"
+                        )
+                        return fallback_results[0]
 
                     # Fallback: unresolved intent (agent loop can pick this up)
                     return {

--- a/src/backend/utils/hooks.py
+++ b/src/backend/utils/hooks.py
@@ -29,6 +29,13 @@ HOOK_EVENTS: frozenset[str] = frozenset({
     "presence_last_left",
     "compact_mcp_result",
     "authenticate",
+    # Intent classification fallback — fired by the LLM intent dispatcher
+    # when JSON parsing fails and a domain-specific consumer (e.g. HA via
+    # ha_glue) might still recognize the user's intent from raw keywords.
+    # Handlers receive `message: str, lang: str` and return a dict
+    # `{"intent": str, "parameters": dict, "confidence": float}` on success
+    # or None to fall through. First non-None result wins.
+    "intent_fallback_resolve",
 })
 
 HookFn = Callable[..., Coroutine[Any, Any, Any]]

--- a/src/backend/utils/hooks.py
+++ b/src/backend/utils/hooks.py
@@ -34,7 +34,11 @@ HOOK_EVENTS: frozenset[str] = frozenset({
     # ha_glue) might still recognize the user's intent from raw keywords.
     # Handlers receive `message: str, lang: str` and return a dict
     # `{"intent": str, "parameters": dict, "confidence": float}` on success
-    # or None to fall through. First non-None result wins.
+    # or None to fall through. First well-shaped non-None result wins —
+    # registration order determines precedence, so earlier-registered
+    # handlers shadow later ones for the same input. The call site
+    # validates each candidate is a dict with an "intent" key before
+    # accepting it.
     "intent_fallback_resolve",
 })
 


### PR DESCRIPTION
## Summary

Phase 1 W1.2 Day 4. First hook-based platform/ha_glue extraction. Removes the HomeAssistantClient import + HA-keyword fallback block from \`services/ollama_service.py\` (a platform file) and reroutes it through a new \`intent_fallback_resolve\` hook event. The actual HA keyword-detection logic moves to \`ha_glue/services/intent_fallback.py\`, registered with the platform hook system via an explicit \`ha_glue.bootstrap.register()\` call from \`api/lifecycle.py\`.

Establishes a hook-bootstrap pattern that Day 5 (lifecycle split) and follow-up cleanups (the two remaining HA blocks in ollama_service.py around \`_get_relevant_entities\` and \`_get_ha_keywords\`) will reuse.

## What this fixes

\`services/ollama_service.py\` had a 40-line block (lines 543-577 of the pre-fix version) that fired when the LLM intent classifier crashed on JSON output. The block:

1. Detected German HA action verbs (\`schalte\`, \`mach\`, \`licht\`, etc.)
2. Imported \`from integrations.homeassistant import HomeAssistantClient\`
3. Called \`ha_client.search_entities(message)\` to find a matching entity
4. Synthesized a \`homeassistant.turn_on/off/get_state\` intent

That entire block was a structural platform → ha_glue dependency that the boundary doc had originally misclassified as a \"stray ha_timeout import\" 1-line cleanup. The actual fix is a hook extraction.

## Hook design

- **New event** \`intent_fallback_resolve\` in \`utils/hooks.py::HOOK_EVENTS\`. Handlers receive \`message: str, lang: str\` and return either \`{\"intent\": str, \"parameters\": dict, \"confidence\": float}\` or None. First well-shaped non-None result wins. Registration order determines precedence (documented in the inline comment).
- **Platform side** \`OllamaService.extract_intent\` now calls \`await run_hooks(\"intent_fallback_resolve\", message=..., lang=...)\` from inside its \`if intent_data is None:\` branch. Iterates the result list, validates each candidate is \`isinstance(dict)\` with an \`\"intent\"\` key, picks the first valid one. Skips bad-shape candidates with a WARNING log so a future buggy handler can't AttributeError the call site.
- **ha_glue side** \`ha_glue/services/intent_fallback.py::ha_intent_fallback\` is a pure async function. Late-imports \`HomeAssistantClient\` inside its body so platform files never touch HA. Returns None for non-HA-shaped messages.
- **Bootstrap** \`ha_glue/bootstrap.py::register()\` is the explicit entry point. \`ha_glue/__init__.py\` is **side-effect-free** (see the HIGH fix below).

## Bootstrap correctness — side-effect-free package import

The first version of this branch had \`ha_glue/__init__.py::_register_hooks()\` running as a side effect of import. Code review caught that this bypasses the \`settings.features[\"smart_home\"]\` gate: the legacy compat re-export in \`models/database.py::__getattr__\` does \`from ha_glue.models import database as _hg\` to satisfy \`from models.database import Room\`, and importlib resolves that by first importing the \`ha_glue\` package — running the side effect unconditionally. Many platform services (rag_service, episodic_memory, device_manager, knowledge_graph) hit the compat shim, so on \`RENFIELD_EDITION=pro\` deploys the HA fallback handler would silently register itself and fire on every JSON-parse failure, eating HomeAssistantClient timeouts on machines with no HA running.

Fix (commit \`238ff36\`):
- \`ha_glue/__init__.py\` is now docstring-only with zero side effects
- New module \`ha_glue/bootstrap.py\` exposes \`register()\` as the explicit entry point
- \`api/lifecycle.py\` Stage 0 calls \`from ha_glue.bootstrap import register; register()\`, gated on \`settings.features[\"smart_home\"]\`, wrapped in \`except (ImportError, BLE001)\` so missing OR broken ha_glue degrades cleanly

Verified locally:
- \`import ha_glue\` registers **zero** hooks
- \`from models.database import Room\` (compat-shim path) registers **zero** hooks
- Explicit \`from ha_glue.bootstrap import register; register()\` registers exactly **one** hook (the intent_fallback handler)

## Layering

The ONE structural platform → ha_glue import line is the \`from ha_glue.bootstrap import register\` in \`api/lifecycle.py\`. Everything else uses the hook system. Phase 2/3 will move that bootstrap to a \`PLUGIN_MODULE\` entry point and remove the import from lifecycle.py — at which point the W4 CI lint can forbid platform → ha_glue imports completely.

## Verification

- ✅ AST parse clean on all 6 files (4 modified + 2 new)
- ✅ \`intent_fallback_resolve\` event present in HOOK_EVENTS
- ✅ \`import ha_glue\` is side-effect-free (zero hooks registered)
- ✅ Compat re-export path is side-effect-free (zero hooks registered)
- ✅ Explicit \`bootstrap.register()\` registers exactly one handler
- ✅ Bad-shape candidates (returning string instead of dict) are skipped with warning
- ✅ Well-shaped candidates are accepted
- ✅ Handler returns None for non-HA messages (\"Wie ist das Wetter heute?\")
- ✅ \`services.ollama_service\` still imports cleanly after the patch
- ✅ All 31 SQLAlchemy tables still register (no model regression)

## What's still in ollama_service.py

\`ollama_service.py\` still has TWO more HA blocks that need similar hook extractions in follow-up commits:

1. \`_get_relevant_entities\` (lines ~735+) — fetches HA entities filtered by message keywords for prompt context
2. \`_get_ha_keywords\` (lines ~893+) — fetches the dynamic HA keyword list with hardcoded German fallback

Out of scope for this PR. Each gets its own focused extraction once Day 5 (lifecycle split) is in.

## Test plan

- [ ] CI green on the renfield repo
- [ ] Deploy to a Renfield home-automation instance — verify HA voice commands still resolve via the hook path when the LLM intent classifier crashes on JSON
- [ ] Deploy to a \`RENFIELD_EDITION=pro\` instance — verify no \`ha_glue\` log noise, no HomeAssistantClient timeouts on intent-parse failures

## References

- Tracking: #342 (Phase 1 parent)
- Boundary doc: [X-idra-Systems-GmbH/reva docs/architecture/renfield-platform-boundary.md](https://github.com/X-idra-Systems-GmbH/reva/blob/main/docs/architecture/renfield-platform-boundary.md)
- Builds on: #343 (models split), #344 (docstring cleanup), #345 (lazy compat re-exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)