### PR TITLE
refactor(config): split HA settings into ha_glue.utils.config (#342)

### DIFF
--- a/src/backend/api/lifecycle.py
+++ b/src/backend/api/lifecycle.py
@@ -18,6 +18,7 @@ from services.device_manager import get_device_manager
 from services.ollama_service import OllamaService
 from services.task_queue import TaskQueue
 from utils.config import settings
+from ha_glue.utils.config import ha_glue_settings
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
@@ -255,7 +256,7 @@ def _schedule_presence_event_cleanup():
     _startup_tasks.append(task)
     logger.info(
         f"Presence Event Cleanup Scheduler gestartet "
-        f"(retention={settings.presence_analytics_retention_days}d, täglich)"
+        f"(retention={ha_glue_settings.presence_analytics_retention_days}d, täglich)"
     )
 
 
@@ -265,7 +266,7 @@ async def _init_paperless_audit(app: "FastAPI") -> None:
     Routes, service, and imports only happen inside this function.
     If Paperless MCP is not configured, nothing is imported, no routes exist.
     """
-    if not settings.paperless_audit_enabled:
+    if not ha_glue_settings.paperless_audit_enabled:
         return
 
     mcp_manager = getattr(app.state, "mcp_manager", None)
@@ -584,7 +585,7 @@ async def lifespan(app: "FastAPI"):
     zeroconf_service = await _init_zeroconf(app)
 
     # Presence webhooks + analytics
-    if settings.presence_enabled:
+    if ha_glue_settings.presence_enabled:
         from services.presence_webhook import register_presence_webhooks
 
         register_presence_webhooks()
@@ -612,7 +613,7 @@ async def lifespan(app: "FastAPI"):
                 presence_svc.set_room_name(room.id, room.name)
 
     # Conversation handoff hook (requires presence for room-change detection)
-    if settings.presence_enabled:
+    if ha_glue_settings.presence_enabled:
         from services.conversation_handoff import on_presence_enter_room
         from utils.hooks import register_hook
 
@@ -620,7 +621,7 @@ async def lifespan(app: "FastAPI"):
         logger.info("✅ Conversation handoff hook registered")
 
     # Media Follow Me hooks (requires both presence and media_follow enabled)
-    if settings.media_follow_enabled and settings.presence_enabled:
+    if ha_glue_settings.media_follow_enabled and ha_glue_settings.presence_enabled:
         from services.media_follow_service import get_media_follow_service
         from utils.hooks import register_hook
 

--- a/src/backend/api/routes/presence.py
+++ b/src/backend/api/routes/presence.py
@@ -16,6 +16,7 @@ from services.auth_service import require_permission
 from services.database import get_db
 from services.presence_service import get_presence_service
 from utils.config import settings
+from ha_glue.utils.config import ha_glue_settings
 
 router = APIRouter(prefix="/api/presence")
 
@@ -70,7 +71,7 @@ class PresenceStatusResponse(BaseModel):
 @router.get("/status", response_model=PresenceStatusResponse)
 async def get_presence_status():
     """Check whether presence detection is enabled."""
-    return PresenceStatusResponse(enabled=settings.presence_enabled)
+    return PresenceStatusResponse(enabled=ha_glue_settings.presence_enabled)
 
 
 # --- Room occupancy ---
@@ -78,7 +79,7 @@ async def get_presence_status():
 @router.get("/rooms", response_model=list[RoomOccupancyResponse])
 async def get_rooms_presence():
     """Get all rooms with their current occupants."""
-    if not settings.presence_enabled:
+    if not ha_glue_settings.presence_enabled:
         return []
 
     presence = get_presence_service()
@@ -110,7 +111,7 @@ async def get_rooms_presence():
 @router.get("/room/{room_id}", response_model=RoomOccupancyResponse)
 async def get_room_presence(room_id: int):
     """Get occupants of a specific room."""
-    if not settings.presence_enabled:
+    if not ha_glue_settings.presence_enabled:
         return RoomOccupancyResponse(room_id=room_id)
 
     presence = get_presence_service()
@@ -140,7 +141,7 @@ async def get_room_presence(room_id: int):
 @router.get("/user/{user_id}", response_model=UserPresenceResponse)
 async def get_user_presence(user_id: int):
     """Get current room and alone-status for a user."""
-    if not settings.presence_enabled:
+    if not ha_glue_settings.presence_enabled:
         return UserPresenceResponse(user_id=user_id)
 
     presence = get_presence_service()

--- a/src/backend/api/routes/satellites.py
+++ b/src/backend/api/routes/satellites.py
@@ -16,6 +16,7 @@ from models.permissions import Permission
 from services.auth_service import require_permission
 from services.satellite_manager import get_satellite_manager
 from utils.config import settings
+from ha_glue.utils.config import ha_glue_settings
 
 router = APIRouter()
 
@@ -163,7 +164,7 @@ def _satellite_to_response(sat_id: str, sat_data: dict[str, Any]) -> SatelliteRe
 
     # Get version info
     version = sat_data.get("version", "unknown")
-    update_available = _is_update_available(version, settings.satellite_latest_version)
+    update_available = _is_update_available(version, ha_glue_settings.satellite_latest_version)
 
     return SatelliteResponse(
         satellite_id=sat_id,
@@ -218,7 +219,7 @@ async def list_satellites(_user: User = Depends(require_permission(Permission.AD
         total_count=len(responses),
         online_count=len(responses),  # All returned are online
         active_sessions=active_sessions,
-        latest_version=settings.satellite_latest_version
+        latest_version=ha_glue_settings.satellite_latest_version
     )
 
 

--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -22,6 +22,7 @@ from services.input_guard import detect_injection
 from services.websocket_auth import WSAuthError, authenticate_websocket
 from services.websocket_rate_limiter import get_rate_limiter
 from utils.config import settings
+from ha_glue.utils.config import ha_glue_settings
 
 from .shared import (
     ConversationSessionState,
@@ -649,7 +650,7 @@ async def websocket_endpoint(
                     logger.warning(f"⚠️ Failed to load user permissions: {e}")
 
             # Register voice/auth presence if user is authenticated in a known room
-            if (user_id and settings.presence_enabled
+            if (user_id and ha_glue_settings.presence_enabled
                     and room_context and room_context.get("room_id")):
                 try:
                     from services.presence_service import get_presence_service

--- a/src/backend/api/websocket/satellite_handler.py
+++ b/src/backend/api/websocket/satellite_handler.py
@@ -22,6 +22,7 @@ from services.wakeword_config_manager import get_wakeword_config_manager
 from services.websocket_auth import WSAuthError, authenticate_websocket
 from services.websocket_rate_limiter import get_connection_limiter, get_rate_limiter
 from utils.config import settings
+from ha_glue.utils.config import ha_glue_settings
 
 from .shared import get_whisper_service, send_ws_error
 
@@ -177,7 +178,7 @@ async def satellite_websocket(
 
                 # Persist room assignment to database
                 room_id = None
-                if success and settings.rooms_auto_create_from_satellite:
+                if success and ha_glue_settings.rooms_auto_create_from_satellite:
                     try:
                         from services.room_service import RoomService
 
@@ -222,7 +223,7 @@ async def satellite_websocket(
                 logger.info(f"📡 Satellite {satellite_id} registered from {room}")
 
                 # Push known BLE + Classic BT MACs to satellite for presence scanning
-                if settings.presence_enabled:
+                if ha_glue_settings.presence_enabled:
                     try:
                         from services.presence_service import get_presence_service
                         presence_svc = get_presence_service()
@@ -462,7 +463,7 @@ async def satellite_websocket(
                     # Load user permissions from speaker recognition
                     sat_user_permissions = None
                     sat_user_id = None
-                    if speaker_name and (settings.auth_enabled or settings.presence_enabled):
+                    if speaker_name and (settings.auth_enabled or ha_glue_settings.presence_enabled):
                         try:
                             from sqlalchemy import select
 
@@ -497,7 +498,7 @@ async def satellite_websocket(
                             logger.warning(f"⚠️ Failed to associate speaker with conversation: {e}")
 
                     # Register voice presence if speaker was recognized
-                    if sat_user_id and settings.presence_enabled and satellite and satellite.room_id:
+                    if sat_user_id and ha_glue_settings.presence_enabled and satellite and satellite.room_id:
                         try:
                             from services.presence_service import get_presence_service
                             presence_svc = get_presence_service()
@@ -632,7 +633,7 @@ Gib eine kurze, natürliche Antwort. KEIN JSON, nur Text."""
 
             # Handle BLE presence scan results
             elif msg_type == "ble_presence":
-                if satellite_id and settings.presence_enabled:
+                if satellite_id and ha_glue_settings.presence_enabled:
                     ble_devices = data.get("devices", [])
                     satellite = satellite_manager.get_satellite(satellite_id)
                     ble_room_id = satellite.room_id if satellite else None

--- a/src/backend/ha_glue/utils/__init__.py
+++ b/src/backend/ha_glue/utils/__init__.py
@@ -1,0 +1,6 @@
+"""Utility modules for the ha_glue layer.
+
+`ha_glue.utils.config` — dedicated Pydantic BaseSettings class holding
+all HomeAssistant / satellite / presence / media / paperless / radio /
+jellyfin / frigate configuration. See `config.py` for rationale.
+"""

--- a/src/backend/ha_glue/utils/config.py
+++ b/src/backend/ha_glue/utils/config.py
@@ -1,0 +1,130 @@
+"""HA-glue Pydantic settings class.
+
+Phase 1 Week 1.2 Day 3 of the platform/ha-glue extraction. This module
+owns all HomeAssistant-flavored configuration (home_assistant_*,
+frigate_*, paperless_*, presence_*, media_follow_*, ha_*, radio_*,
+jellyfin_*, satellite_*) that used to live inline in the platform
+`utils/config.py::Settings` class.
+
+## Why a separate BaseSettings class
+
+Pydantic's `BaseSettings` reads env vars into class fields at
+instantiation time. Multiple `BaseSettings` subclasses can coexist in
+the same Python process, each reading from the same env space — the
+only constraint is that field names don't conflict. Since this class
+and `utils.config.Settings` declare a disjoint set of fields, both can
+load from the same `.env` file / K8s ConfigMap / Docker secrets dir
+without interference.
+
+Critically, this means env var names **stay exactly as they are**.
+`HOME_ASSISTANT_URL`, `PAPERLESS_API_URL`, `PRESENCE_WEBHOOK_SECRET`,
+etc. all map to `HaGlueSettings` fields with no prefix change. No
+existing deploy breaks. The only migration is updating the consumer
+import path from `from utils.config import settings` to
+`from ha_glue.utils.config import ha_glue_settings` — one line per
+consumer file, and most consumers will move to `ha_glue/` anyway in
+Week 2.
+
+## When is HaGlueSettings loaded
+
+Lazy — the module-level instance `ha_glue_settings = HaGlueSettings()`
+is constructed on first import of this module. Platform-only
+deployments (future `X-idra/renfield`) simply don't have this module
+on disk; consumers that try to `from ha_glue.utils.config import ...`
+get a clean `ModuleNotFoundError` at import time, naming the missing
+package.
+
+Platform code that currently leaks HA references (see
+`docs/architecture/renfield-platform-boundary.md` in the parent Reva
+repo) can either:
+
+1. Import `ha_glue_settings` directly with a try/except guard for
+   platform-only deploys (transitional — Week 4 CI lint catches this)
+2. Call into ha-glue via a hook and have ha_glue check its own settings
+   (the clean long-term answer — planned for Week 2/Day 5)
+
+## Fields owned by this module
+
+See the `HaGlueSettings` class below. Total: 39 fields, mapping 1:1
+to what was removed from `utils.config.Settings` in the same commit.
+"""
+
+from __future__ import annotations
+
+from pydantic import Field, SecretStr
+from pydantic_settings import BaseSettings
+
+
+class HaGlueSettings(BaseSettings):
+    """HomeAssistant / consumer-hardware configuration for ha_glue."""
+
+    # === Home Assistant ===
+    home_assistant_url: str | None = None
+    home_assistant_token: SecretStr | None = None
+
+    # === Frigate (cameras / NVR) ===
+    frigate_url: str | None = None
+    frigate_timeout: float = Field(default=10.0, ge=1.0, le=120.0)
+
+    # === HA integration cache / timeout ===
+    ha_timeout: float = Field(default=10.0, ge=1.0, le=120.0)
+    ha_cache_ttl: int = Field(default=300, ge=10, le=86400)
+    ha_mcp_enabled: bool = False
+
+    # === Paperless-NGX ===
+    paperless_enabled: bool = False
+    paperless_api_url: str | None = None
+    paperless_api_token: SecretStr | None = None
+
+    # === Paperless Audit ===
+    paperless_audit_enabled: bool = False
+    paperless_audit_model: str = ""              # Empty = use default model
+    paperless_audit_schedule: str = "02:00"      # Daily at 02:00
+    paperless_audit_fix_mode: str = "review"     # review | auto_threshold | auto_all
+    paperless_audit_confidence_threshold: float = 0.9
+    paperless_audit_ocr_threshold: int = 2       # OCR <= 2 → suggest re-OCR
+    paperless_audit_batch_delay: float = 2.0     # Seconds between documents
+
+    # === Presence Detection (BLE-based room-level) ===
+    presence_enabled: bool = False                      # Master-Switch for BLE presence detection
+    presence_stale_timeout: int = 120                   # Seconds before user marked absent
+    presence_hysteresis_scans: int = 2                  # Consecutive scans before room change
+    presence_rssi_threshold: int = -80                  # dBm, signals weaker than this are ignored
+    presence_household_roles: str = "Admin,Familie"     # Roles considered household members for privacy TTS
+    presence_webhook_url: str = ""                      # URL to POST presence events (empty = disabled)
+    presence_webhook_secret: str = ""                   # Shared secret for webhook auth (X-Webhook-Secret header)
+    presence_analytics_retention_days: int = 90         # Days to keep presence events for analytics
+
+    # === Media Follow Me (playback follows user between rooms) ===
+    media_follow_enabled: bool = False                         # Master switch (requires presence_enabled)
+    media_follow_suspend_timeout: float = 600.0                # Seconds before suspended session expires
+    media_follow_resume_delay: float = 2.0                     # Delay before resuming in new room
+
+    # === Radio (TuneIn) ===
+    radio_enabled: bool = False
+    tunein_partner_id: str = ""
+
+    # === Jellyfin ===
+    jellyfin_enabled: bool = False
+    jellyfin_url: str | None = None
+    jellyfin_base_url: str | None = None
+    jellyfin_api_key: SecretStr | None = None
+    jellyfin_token: SecretStr | None = None
+    jellyfin_user_id: str | None = None
+
+    # === Satellite OTA Updates ===
+    satellite_latest_version: str = "1.0.0"  # Latest available satellite version
+    satellite_package_cache_ttl: int = Field(default=300, ge=10, le=86400)
+
+    # === Rooms ===
+    rooms_auto_create_from_satellite: bool = True  # Auto-create rooms when satellites register
+
+    class Config:
+        env_file = ".env"
+        secrets_dir = "/run/secrets"
+        case_sensitive = False
+        extra = "ignore"  # Allow platform fields to coexist in the same env space
+
+
+# Module-level singleton. Constructed once, on first import of this module.
+ha_glue_settings = HaGlueSettings()

--- a/src/backend/integrations/frigate.py
+++ b/src/backend/integrations/frigate.py
@@ -9,6 +9,7 @@ import paho.mqtt.client as mqtt
 from loguru import logger
 
 from utils.config import settings
+from ha_glue.utils.config import ha_glue_settings
 
 _shared_frigate_client: httpx.AsyncClient | None = None
 
@@ -17,9 +18,9 @@ async def get_frigate_http_client() -> httpx.AsyncClient:
     global _shared_frigate_client
     if _shared_frigate_client is None or _shared_frigate_client.is_closed:
         _shared_frigate_client = httpx.AsyncClient(
-            base_url=settings.frigate_url or "",
+            base_url=ha_glue_settings.frigate_url or "",
             limits=httpx.Limits(max_connections=10, max_keepalive_connections=5),
-            timeout=httpx.Timeout(settings.frigate_timeout),
+            timeout=httpx.Timeout(ha_glue_settings.frigate_timeout),
         )
     return _shared_frigate_client
 
@@ -35,7 +36,7 @@ class FrigateClient:
     """Client für Frigate NVR"""
 
     def __init__(self):
-        self.base_url = settings.frigate_url
+        self.base_url = ha_glue_settings.frigate_url
         self.mqtt_client = None
         self.event_callbacks = []
 
@@ -57,7 +58,7 @@ class FrigateClient:
             response = await client.get(
                 "/api/events",
                 params=params,
-                timeout=settings.frigate_timeout
+                timeout=ha_glue_settings.frigate_timeout
             )
             response.raise_for_status()
             return response.json()
@@ -71,7 +72,7 @@ class FrigateClient:
             client = await get_frigate_http_client()
             response = await client.get(
                 f"/api/events/{event_id}/snapshot.jpg",
-                timeout=settings.frigate_timeout
+                timeout=ha_glue_settings.frigate_timeout
             )
             response.raise_for_status()
             return response.content
@@ -85,7 +86,7 @@ class FrigateClient:
             client = await get_frigate_http_client()
             response = await client.get(
                 "/api/config",
-                timeout=settings.frigate_timeout
+                timeout=ha_glue_settings.frigate_timeout
             )
             response.raise_for_status()
             config = response.json()

--- a/src/backend/integrations/homeassistant.py
+++ b/src/backend/integrations/homeassistant.py
@@ -13,6 +13,7 @@ import httpx
 from loguru import logger
 
 from utils.config import settings
+from ha_glue.utils.config import ha_glue_settings
 
 _shared_http_client: httpx.AsyncClient | None = None
 
@@ -20,15 +21,15 @@ _shared_http_client: httpx.AsyncClient | None = None
 async def get_ha_http_client() -> httpx.AsyncClient:
     global _shared_http_client
     if _shared_http_client is None or _shared_http_client.is_closed:
-        token = settings.home_assistant_token.get_secret_value() if settings.home_assistant_token else ""
+        token = ha_glue_settings.home_assistant_token.get_secret_value() if ha_glue_settings.home_assistant_token else ""
         _shared_http_client = httpx.AsyncClient(
-            base_url=settings.home_assistant_url or "",
+            base_url=ha_glue_settings.home_assistant_url or "",
             headers={
                 "Authorization": f"Bearer {token}",
                 "Content-Type": "application/json",
             },
             limits=httpx.Limits(max_connections=20, max_keepalive_connections=10),
-            timeout=httpx.Timeout(settings.ha_timeout),
+            timeout=httpx.Timeout(ha_glue_settings.ha_timeout),
         )
     return _shared_http_client
 
@@ -49,18 +50,18 @@ class HomeAssistantClient:
     _ENTITY_MAP_TTL: float = 60.0  # seconds
 
     def __init__(self):
-        self.base_url = settings.home_assistant_url
-        self.token = settings.home_assistant_token.get_secret_value() if settings.home_assistant_token else None
+        self.base_url = ha_glue_settings.home_assistant_url
+        self.token = ha_glue_settings.home_assistant_token.get_secret_value() if ha_glue_settings.home_assistant_token else None
         # Keyword Cache
         self._keywords_cache = None
         self._keywords_last_updated = None
-        self._cache_ttl = settings.ha_cache_ttl
+        self._cache_ttl = ha_glue_settings.ha_cache_ttl
 
     async def get_states(self) -> list[dict]:
         """Alle Entity States abrufen"""
         try:
             client = await get_ha_http_client()
-            response = await client.get("/api/states", timeout=settings.ha_timeout)
+            response = await client.get("/api/states", timeout=ha_glue_settings.ha_timeout)
             response.raise_for_status()
             return response.json()
         except Exception as e:
@@ -71,7 +72,7 @@ class HomeAssistantClient:
         """State einer bestimmten Entity abrufen"""
         try:
             client = await get_ha_http_client()
-            response = await client.get(f"/api/states/{entity_id}", timeout=settings.ha_timeout)
+            response = await client.get(f"/api/states/{entity_id}", timeout=ha_glue_settings.ha_timeout)
             response.raise_for_status()
             return response.json()
         except Exception as e:
@@ -96,7 +97,7 @@ class HomeAssistantClient:
             response = await client.post(
                 f"/api/services/{domain}/{service}",
                 json=data,
-                timeout=timeout or settings.ha_timeout
+                timeout=timeout or ha_glue_settings.ha_timeout
             )
             response.raise_for_status()
             logger.info(f"✅ Service {domain}.{service} für {entity_id} aufgerufen")
@@ -485,7 +486,7 @@ class HomeAssistantClient:
             client = await get_ha_http_client()
             response = await client.get(
                 "/api/config/area_registry",
-                timeout=settings.ha_timeout
+                timeout=ha_glue_settings.ha_timeout
             )
 
             if response.status_code == 200:

--- a/src/backend/services/intent_registry.py
+++ b/src/backend/services/intent_registry.py
@@ -18,6 +18,7 @@ Usage:
 from dataclasses import dataclass, field
 
 from utils.config import settings
+from ha_glue.utils.config import ha_glue_settings
 
 
 @dataclass
@@ -96,7 +97,7 @@ PRESENCE_INTENTS = IntegrationIntents(
     integration_name="presence",
     title_de="ANWESENHEIT",
     title_en="PRESENCE",
-    is_enabled_func=lambda: settings.presence_enabled,
+    is_enabled_func=lambda: ha_glue_settings.presence_enabled,
     intents=[
         IntentDef(
             name="internal.get_user_location",

--- a/src/backend/services/internal_tools.py
+++ b/src/backend/services/internal_tools.py
@@ -570,7 +570,7 @@ class InternalToolService:
 
         # Clear media follow session on explicit stop
         if action == "stop" and result.get("success"):
-            from utils.config import settings as _settings
+            from ha_glue.utils.config import ha_glue_settings as _settings
             if _settings.media_follow_enabled:
                 try:
                     from services.media_follow_service import get_media_follow_service

--- a/src/backend/services/internal_tools.py
+++ b/src/backend/services/internal_tools.py
@@ -291,7 +291,7 @@ class InternalToolService:
         self, params: dict, room_name: str, media_type, **kwargs
     ) -> None:
         """Register playback with MediaFollowService if enabled (async version)."""
-        from utils.config import settings as _settings
+        from ha_glue.utils.config import ha_glue_settings as _settings
 
         if not _settings.media_follow_enabled:
             return

--- a/src/backend/services/media_follow_service.py
+++ b/src/backend/services/media_follow_service.py
@@ -16,6 +16,7 @@ from enum import Enum
 from loguru import logger
 
 from utils.config import settings
+from ha_glue.utils.config import ha_glue_settings
 
 
 class MediaType(str, Enum):
@@ -189,8 +190,8 @@ class MediaFollowService:
             f"'{session.title or session.station_name or session.album_name}'"
         )
 
-        if settings.media_follow_resume_delay > 0:
-            await asyncio.sleep(settings.media_follow_resume_delay)
+        if ha_glue_settings.media_follow_resume_delay > 0:
+            await asyncio.sleep(ha_glue_settings.media_follow_resume_delay)
 
         await self._resume_playback(session, room_id, room_name)
 
@@ -397,7 +398,7 @@ class MediaFollowService:
     def _cleanup_expired_sessions(self) -> None:
         """Remove suspended sessions that have exceeded the timeout."""
         now = time.time()
-        timeout = settings.media_follow_suspend_timeout
+        timeout = ha_glue_settings.media_follow_suspend_timeout
         expired = [
             uid for uid, s in self._sessions.items()
             if s.state == SessionState.SUSPENDED

--- a/src/backend/services/notification_privacy.py
+++ b/src/backend/services/notification_privacy.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from utils.config import settings
+from ha_glue.utils.config import ha_glue_settings
 
 
 async def should_play_tts(
@@ -39,7 +40,7 @@ async def should_play_tts(
     if privacy == "public":
         return True
 
-    if not settings.presence_enabled:
+    if not ha_glue_settings.presence_enabled:
         logger.debug("Presence disabled — suppressing non-public TTS (privacy=%s)", privacy)
         return False
 
@@ -74,7 +75,7 @@ async def _all_household_members(user_ids: list[int], db: AsyncSession) -> bool:
     """Check whether all given user IDs belong to household roles."""
     from models.database import User
 
-    household_roles = {r.strip() for r in settings.presence_household_roles.split(",") if r.strip()}
+    household_roles = {r.strip() for r in ha_glue_settings.presence_household_roles.split(",") if r.strip()}
 
     result = await db.execute(
         select(User).options(selectinload(User.role)).where(User.id.in_(user_ids))

--- a/src/backend/services/notification_service.py
+++ b/src/backend/services/notification_service.py
@@ -28,6 +28,7 @@ from models.database import (
     SystemSetting,
 )
 from utils.config import settings
+from ha_glue.utils.config import ha_glue_settings
 
 
 class NotificationService:
@@ -501,7 +502,7 @@ class NotificationService:
         logger.info(f"📨 Notification #{notification.id} erstellt: {title} (urgency={urgency})")
 
         # Resolve target user's room from presence if no room specified
-        if target_user_id and not room_id and settings.presence_enabled:
+        if target_user_id and not room_id and ha_glue_settings.presence_enabled:
             try:
                 from services.presence_service import get_presence_service
                 presence = get_presence_service()

--- a/src/backend/services/paperless_audit_service.py
+++ b/src/backend/services/paperless_audit_service.py
@@ -21,6 +21,7 @@ from uuid import uuid4
 from sqlalchemy import func, select
 
 from utils.config import settings
+from ha_glue.utils.config import ha_glue_settings
 
 logger = logging.getLogger(__name__)
 
@@ -99,8 +100,8 @@ class PaperlessAuditService:
         Returns:
             {"run_id": str, "total": int, "processed": int, "changes_found": int}
         """
-        fix_mode = fix_mode or settings.paperless_audit_fix_mode
-        confidence_threshold = confidence_threshold or settings.paperless_audit_confidence_threshold
+        fix_mode = fix_mode or ha_glue_settings.paperless_audit_fix_mode
+        confidence_threshold = confidence_threshold or ha_glue_settings.paperless_audit_confidence_threshold
         run_id = str(uuid4())
 
         # State is set by run_audit_background() when called via API.
@@ -162,7 +163,7 @@ class PaperlessAuditService:
                     logger.error(f"Audit failed for doc {doc_id}: {e}")
 
                 # Throttle
-                await asyncio.sleep(settings.paperless_audit_batch_delay)
+                await asyncio.sleep(ha_glue_settings.paperless_audit_batch_delay)
 
             return {
                 "run_id": run_id,
@@ -442,7 +443,7 @@ class PaperlessAuditService:
             get_default_client,
         )
 
-        model = settings.paperless_audit_model or settings.ollama_model
+        model = ha_glue_settings.paperless_audit_model or settings.ollama_model
         content = (doc.get("content") or "")[:_MAX_CONTENT_LENGTH]
 
         # Build custom fields schema string

--- a/src/backend/services/presence_analytics.py
+++ b/src/backend/services/presence_analytics.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.database import PresenceEvent, Room
 from utils.config import settings
+from ha_glue.utils.config import ha_glue_settings
 from utils.hooks import register_hook
 
 # ---------------------------------------------------------------------------
@@ -196,7 +197,7 @@ class PresenceAnalyticsService:
 
     async def cleanup_old_events(self, retention_days: int | None = None) -> int:
         """Delete events older than retention_days. Returns count deleted."""
-        retention = retention_days or settings.presence_analytics_retention_days
+        retention = retention_days or ha_glue_settings.presence_analytics_retention_days
         cutoff = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=retention)
 
         result = await self.db.execute(

--- a/src/backend/services/presence_service.py
+++ b/src/backend/services/presence_service.py
@@ -14,6 +14,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from utils.config import settings
+from ha_glue.utils.config import ha_glue_settings
 
 
 @dataclass
@@ -51,9 +52,9 @@ class PresenceService:
         self._mac_to_method: dict[str, str] = {}         # MAC → detection_method cache
         self._presence: dict[int, UserPresence] = {}     # user_id → presence
         self._sightings: dict[str, list[DeviceSighting]] = {}  # MAC → recent sightings
-        self._hysteresis_threshold: int = settings.presence_hysteresis_scans
-        self._stale_timeout: float = float(settings.presence_stale_timeout)
-        self._rssi_threshold: int = settings.presence_rssi_threshold
+        self._hysteresis_threshold: int = ha_glue_settings.presence_hysteresis_scans
+        self._stale_timeout: float = float(ha_glue_settings.presence_stale_timeout)
+        self._rssi_threshold: int = ha_glue_settings.presence_rssi_threshold
         self._room_names: dict[int, str] = {}            # room_id → name cache
         self._user_names: dict[int, str] = {}            # user_id → username
         self._user_first_names: dict[int, str] = {}      # user_id → first_name

--- a/src/backend/services/presence_webhook.py
+++ b/src/backend/services/presence_webhook.py
@@ -4,6 +4,7 @@ import httpx
 from loguru import logger
 
 from utils.config import settings
+from ha_glue.utils.config import ha_glue_settings
 from utils.hooks import register_hook
 
 _client: httpx.AsyncClient | None = None
@@ -16,12 +17,12 @@ async def _dispatch(event: str, **kwargs):
         _client = httpx.AsyncClient(timeout=10.0)
 
     headers = {"Content-Type": "application/json"}
-    if settings.presence_webhook_secret:
-        headers["X-Webhook-Secret"] = settings.presence_webhook_secret
+    if ha_glue_settings.presence_webhook_secret:
+        headers["X-Webhook-Secret"] = ha_glue_settings.presence_webhook_secret
 
     payload = {"event": event, **kwargs}
     try:
-        resp = await _client.post(settings.presence_webhook_url, json=payload, headers=headers)
+        resp = await _client.post(ha_glue_settings.presence_webhook_url, json=payload, headers=headers)
         resp.raise_for_status()
         logger.debug(f"Presence webhook: {event} → {resp.status_code}")
     except Exception:
@@ -30,7 +31,7 @@ async def _dispatch(event: str, **kwargs):
 
 def register_presence_webhooks():
     """Register hook handlers for all presence events."""
-    if not settings.presence_webhook_url:
+    if not ha_glue_settings.presence_webhook_url:
         return
 
     for event in (
@@ -44,4 +45,4 @@ def register_presence_webhooks():
 
         register_hook(event, handler)
 
-    logger.info(f"Presence webhooks registered → {settings.presence_webhook_url}")
+    logger.info(f"Presence webhooks registered → {ha_glue_settings.presence_webhook_url}")

--- a/src/backend/services/satellite_update_service.py
+++ b/src/backend/services/satellite_update_service.py
@@ -16,6 +16,7 @@ from loguru import logger
 
 from services.satellite_manager import UpdateStatus, get_satellite_manager
 from utils.config import settings
+from ha_glue.utils.config import ha_glue_settings
 
 
 class SatelliteUpdateService:
@@ -35,13 +36,13 @@ class SatelliteUpdateService:
         # Cache for built packages
         self._package_cache: dict[str, Any] | None = None
         self._package_cache_time: float = 0
-        self._package_cache_ttl: float = settings.satellite_package_cache_ttl
+        self._package_cache_ttl: float = ha_glue_settings.satellite_package_cache_ttl
 
         logger.info("📦 SatelliteUpdateService initialized")
 
     def get_latest_version(self) -> str:
         """Get the latest available satellite version from config"""
-        return settings.satellite_latest_version
+        return ha_glue_settings.satellite_latest_version
 
     def is_update_available(self, current_version: str) -> bool:
         """

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -46,15 +46,14 @@ class Settings(BaseSettings):
     ollama_vision_url: str | None = None         # Separate Ollama URL for vision model (default: ollama_url)
     ollama_embed_url: str | None = None          # Separate Ollama URL for embeddings (default: ollama_url)
 
-    # Home Assistant
-    home_assistant_url: str | None = None
-    home_assistant_token: SecretStr | None = None
+    # Home Assistant / Frigate settings moved to ha_glue/utils/config.py
+    # (see `HaGlueSettings`). Access via:
+    #     from ha_glue.utils.config import ha_glue_settings
+    # Env var names (HOME_ASSISTANT_URL, HOME_ASSISTANT_TOKEN, FRIGATE_URL,
+    # FRIGATE_TIMEOUT) are unchanged.
 
     # n8n — field exists so .env can set N8N_API_URL for the n8n-mcp stdio subprocess
     n8n_api_url: str | None = None
-
-    # Frigate
-    frigate_url: str | None = None
 
     # MCP integration toggles (used by mcp_servers.yaml)
     weather_enabled: bool = False
@@ -83,8 +82,7 @@ class Settings(BaseSettings):
     speaker_auto_enroll: bool = True             # Auto-create unknown speakers and save embeddings
     speaker_continuous_learning: bool = True     # Add embeddings to known speakers on each interaction
 
-    # Room Management
-    rooms_auto_create_from_satellite: bool = True  # Auto-create rooms when satellites register
+    # Room Management / Satellite OTA moved to ha_glue/utils/config.py.
 
     # Output Routing
     advertise_host: str | None = None  # Hostname/IP that external services (like HA) can reach
@@ -97,8 +95,7 @@ class Settings(BaseSettings):
     wake_word_threshold: float = 0.5
     wake_word_cooldown_ms: int = 2000
 
-    # Satellite OTA Updates
-    satellite_latest_version: str = "1.0.0"  # Latest available satellite version
+    # Satellite OTA Updates — moved to ha_glue/utils/config.py.
 
     # Agent (ReAct Loop)
     agent_enabled: bool = False           # Opt-in, disabled by default
@@ -223,27 +220,8 @@ class Settings(BaseSettings):
     secret_key: SecretStr = "changeme-in-production-use-strong-random-key"
     trusted_proxies: str = ""  # Comma-separated CIDRs, e.g. "172.18.0.0/16,127.0.0.1"
 
-    # Jellyfin
-    jellyfin_enabled: bool = False
-    jellyfin_url: str | None = None
-    jellyfin_base_url: str | None = None
-    jellyfin_api_key: SecretStr | None = None
-    jellyfin_token: SecretStr | None = None
-    jellyfin_user_id: str | None = None
-
-    # Paperless-NGX
-    paperless_enabled: bool = False
-    paperless_api_url: str | None = None
-    paperless_api_token: SecretStr | None = None
-
-    # Paperless Audit
-    paperless_audit_enabled: bool = False
-    paperless_audit_model: str = ""              # Empty = use default model
-    paperless_audit_schedule: str = "02:00"      # Daily at 02:00
-    paperless_audit_fix_mode: str = "review"     # review | auto_threshold | auto_all
-    paperless_audit_confidence_threshold: float = 0.9
-    paperless_audit_ocr_threshold: int = 2       # OCR <= 2 → suggest re-OCR
-    paperless_audit_batch_delay: float = 2.0     # Seconds between documents
+    # Jellyfin / Paperless / Paperless Audit settings moved to
+    # ha_glue/utils/config.py.
 
     # Email MCP
     email_mcp_enabled: bool = False
@@ -258,12 +236,7 @@ class Settings(BaseSettings):
     n8n_api_key: SecretStr | None = None
     n8n_mcp_enabled: bool = False
 
-    # Radio (TuneIn)
-    radio_enabled: bool = False
-    tunein_partner_id: str = ""
-
-    # Home Assistant MCP
-    ha_mcp_enabled: bool = False
+    # Radio (TuneIn) / HA MCP settings moved to ha_glue/utils/config.py.
 
     # === Plugin / Extension System ===
     plugin_module: str = ""  # e.g. "renfield_twin.hooks:register"
@@ -324,9 +297,7 @@ class Settings(BaseSettings):
     device_session_timeout: float = 30.0  # Max voice session duration in seconds
     device_heartbeat_timeout: float = 60.0  # Disconnect after no heartbeat for this duration
 
-    # Integration Timeouts
-    ha_timeout: float = Field(default=10.0, ge=1.0, le=120.0)
-    frigate_timeout: float = Field(default=10.0, ge=1.0, le=120.0)
+    # HA / Frigate integration timeouts moved to ha_glue/utils/config.py.
     n8n_timeout: float = Field(default=30.0, ge=1.0, le=300.0)
 
     # Agent LLM Defaults (fallback when prompt_manager has no config)
@@ -338,9 +309,8 @@ class Settings(BaseSettings):
     cb_llm_recovery_timeout: float = Field(default=30.0, ge=1.0, le=600.0)
     cb_agent_recovery_timeout: float = Field(default=60.0, ge=1.0, le=600.0)
 
-    # Cache TTLs (seconds)
-    ha_cache_ttl: int = Field(default=300, ge=10, le=86400)
-    satellite_package_cache_ttl: int = Field(default=300, ge=10, le=86400)
+    # Cache TTLs (seconds) — ha_cache_ttl and satellite_package_cache_ttl
+    # moved to ha_glue/utils/config.py.
     intent_feedback_cache_ttl: int = Field(default=300, ge=10, le=86400)
 
     # === Proactive Notifications ===
@@ -358,20 +328,8 @@ class Settings(BaseSettings):
     proactive_feedback_learning_enabled: bool = False
     proactive_feedback_similarity_threshold: float = 0.80
 
-    # Presence Detection (BLE-based room-level)
-    presence_enabled: bool = False                      # Master-Switch for BLE presence detection
-    presence_stale_timeout: int = 120                   # Seconds before user marked absent
-    presence_hysteresis_scans: int = 2                  # Consecutive scans before room change
-    presence_rssi_threshold: int = -80                     # dBm, signals weaker than this are ignored
-    presence_household_roles: str = "Admin,Familie"        # Roles considered household members for privacy TTS
-    presence_webhook_url: str = ""                           # URL to POST presence events (empty = disabled)
-    presence_webhook_secret: str = ""                        # Shared secret for webhook auth (X-Webhook-Secret header)
-    presence_analytics_retention_days: int = 90              # Days to keep presence events for analytics
-
-    # Media Follow Me (playback follows user between rooms)
-    media_follow_enabled: bool = False                         # Master switch (requires presence_enabled)
-    media_follow_suspend_timeout: float = 600.0                # Seconds before suspended session expires
-    media_follow_resume_delay: float = 2.0                     # Delay before resuming in new room
+    # Presence Detection / Media Follow Me settings moved to
+    # ha_glue/utils/config.py.
 
     # Notification Polling (generic MCP server polling)
     notification_poller_enabled: bool = False           # Master-Switch for MCP notification polling


### PR DESCRIPTION
## Summary

Phase 1 W1.2 Day 3 — second structural piece of the platform/ha-glue boundary. Moves 39 HomeAssistant-flavored Pydantic Settings fields (home_assistant_*, frigate_*, paperless_*, presence_*, media_follow_*, ha_*, radio_*, jellyfin_*, satellite_*, rooms_auto_create_from_satellite) out of the platform \`utils/config.py::Settings\` class into a new dedicated \`ha_glue.utils.config::HaGlueSettings\` class.

Two commits on the branch (squash-merge will combine):
- \`daadb1a refactor(config): split HA settings into ha_glue.utils.config\`
- \`ae841aa fix(config-split): catch second _settings alias in internal_tools.py\` — self-review caught an orphan that the initial \`replace_all\` pass missed due to indent divergence

## Why two BaseSettings classes

Pydantic BaseSettings subclasses can coexist in the same process, each reading the same env space but only claiming fields it declares. Since \`HaGlueSettings\` and \`Settings\` declare disjoint field sets, both instances can load from the same \`.env\` / K8s ConfigMap / Docker secrets dir without interference. **Env var names stay unchanged** — \`HOME_ASSISTANT_URL\` still maps to the same value, \`PAPERLESS_API_TOKEN\` still maps to a \`SecretStr\`, etc. No existing deploy breaks, no config migration needed.

## Consumer migration

17 files had references to the moved fields. Each file now imports \`HaGlueSettings\` alongside the existing \`Settings\`:

\`\`\`python
from utils.config import settings
from ha_glue.utils.config import ha_glue_settings
\`\`\`

Platform fields stay on \`settings\`; HA fields read from \`ha_glue_settings\`.

**12 files destined for \`ha_glue/\` in Week 2** (the import move travels with the file):
- \`integrations/frigate.py\`, \`integrations/homeassistant.py\`
- \`api/routes/presence.py\`, \`api/routes/satellites.py\`
- \`api/websocket/satellite_handler.py\`
- \`services/internal_tools.py\` (uses a local \`from ha_glue.utils.config import ha_glue_settings as _settings\` alias at two call sites)
- \`services/media_follow_service.py\`
- \`services/paperless_audit_service.py\`
- \`services/presence_analytics.py\`
- \`services/presence_service.py\`
- \`services/presence_webhook.py\`
- \`services/satellite_update_service.py\`

**5 platform files with HA leakage** — these are the layering violations the Week 4 CI lint will flag. Follow-up commits use the hook pattern from #346 to extract the HA logic:
- \`api/lifecycle.py\` — presence/paperless/media_follow background task scheduling → startup hook
- \`api/websocket/chat_handler.py\` — presence gating on incoming chat → hook
- \`services/intent_registry.py\` — presence intent availability → hook
- \`services/notification_privacy.py\` — household-role TTS privacy → hook
- \`services/notification_service.py\` — presence gating on notification delivery → hook

## Platform Settings impact

| | Before | After |
|---|---:|---:|
| Total fields | 239 | 200 |
| HA-flavored fields | ~39 | **0** |
| Net file change | — | −72 lines |

## Verification

- ✅ Field completeness 39/39: types, defaults, \`SecretStr\` wrappers, \`Field(ge=, le=)\` bounds all preserved
- ✅ Zero orphan references: regex sweep for \`\\bsettings\\.FIELD\\b\` across 39 names returns nothing
- ✅ 17/17 consumer files have matching \`ha_glue_settings\` imports
- ✅ Exactly 5 platform-side ha_glue imports (matches the commit message, known and deferred)
- ✅ Platform \`Settings\` regex check confirms zero remaining HA fields; \`features\` property still wired to \`feature_smart_home/cameras/satellites/voice\`
- ✅ \`SecretStr\` import still needed + present (used by \`postgres_password\`, \`secret_key\`, \`mail_primary_password\`, \`n8n_api_key\`, \`default_admin_password\`)
- ✅ Both Settings classes share \`.env\` / \`secrets_dir\` / env space with \`extra=\"ignore\"\`
- ✅ E2E env var loading: \`HOME_ASSISTANT_URL=http://test-ha:8123\` → \`ha_glue_settings.home_assistant_url\` correctly
- ✅ AST parse clean on all 19 files
- ✅ 16/16 consumer modules import without errors
- ✅ Independent code review (confidence-based, 1 pass): no blocker/high/medium/low issues

## Not in this PR

- **Does not extract** the HA logic from platform files — that's Week 2 / Day 5 hook work. This commit only moves setting definitions; the 5 leaky platform files still read HA state via the new import path. The Week 4 CI lint will flag those reads as layering violations, at which point follow-up commits extract each to a hook.
- **Does not rename** env vars. Existing deploys continue to work unchanged.
- **Does not affect** the 200 platform fields in \`Settings\`.

## Test plan

- [ ] CI green
- [ ] Deploy to a Renfield home-automation instance — verify presence/paperless/media_follow features still work via the new settings location
- [ ] Deploy to a \`RENFIELD_EDITION=pro\` instance — verify no regressions (Reva doesn't touch these fields at all)

## References

- Parent tracking: #342 (Phase 1 parent)
- Boundary doc: [X-idra-Systems-GmbH/reva docs/architecture/renfield-platform-boundary.md](https://github.com/X-idra-Systems-GmbH/reva/blob/main/docs/architecture/renfield-platform-boundary.md)
- Builds on: #343 (models split), #344 (docstrings), #345 (lazy compat), #346 (intent fallback hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)