### PR TITLE
refactor: sweep remaining platform->ha_glue leaks via hooks (#342)

### DIFF
--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -22,7 +22,6 @@ from services.input_guard import detect_injection
 from services.websocket_auth import WSAuthError, authenticate_websocket
 from services.websocket_rate_limiter import get_rate_limiter
 from utils.config import settings
-from ha_glue.utils.config import ha_glue_settings
 
 from .shared import (
     ConversationSessionState,
@@ -649,19 +648,20 @@ async def websocket_endpoint(
                 except Exception as e:
                     logger.warning(f"⚠️ Failed to load user permissions: {e}")
 
-            # Register voice/auth presence if user is authenticated in a known room
-            if (user_id and ha_glue_settings.presence_enabled
-                    and room_context and room_context.get("room_id")):
-                try:
-                    from services.presence_service import get_presence_service
-                    presence_svc = get_presence_service()
-                    await presence_svc.register_voice_presence(
-                        user_id=int(user_id),
-                        room_id=room_context["room_id"],
-                        room_name=room_context.get("room_name"),
-                    )
-                except Exception as e:
-                    logger.warning(f"⚠️ Auth presence update failed: {e}")
+            # Fire chat_context_established hook so domain-specific consumers
+            # (e.g. ha_glue's BLE voice-presence registration) can react to
+            # an authenticated user speaking from a known room. Platform
+            # default: no handler → no-op. Exceptions in handlers are caught
+            # by run_hooks and logged.
+            if user_id and room_context and room_context.get("room_id"):
+                from utils.hooks import run_hooks
+                await run_hooks(
+                    "chat_context_established",
+                    user_id=int(user_id),
+                    room_id=room_context["room_id"],
+                    room_name=room_context.get("room_name"),
+                    lang=lang,
+                )
 
             # === Media Transport Shortcut (pre-memory, pre-router) ===
             # Detect simple stop/pause/resume/next/previous BEFORE memory retrieval

--- a/src/backend/ha_glue/bootstrap.py
+++ b/src/backend/ha_glue/bootstrap.py
@@ -70,17 +70,28 @@ def register() -> None:
             ha_validate_classified_intent,
         )
         from ha_glue.services.intent_fallback import ha_intent_fallback
+        from ha_glue.services.notification_privacy import (
+            ha_should_play_tts_for_notification,
+        )
+        from ha_glue.services.sweep_handlers import (
+            ha_chat_context_established,
+            ha_resolve_user_current_room,
+        )
 
         register_hook("intent_fallback_resolve", ha_intent_fallback)
         register_hook("build_entity_context", ha_build_entity_context)
         register_hook("validate_classified_intent", ha_validate_classified_intent)
+        register_hook("chat_context_established", ha_chat_context_established)
+        register_hook("should_play_tts_for_notification", ha_should_play_tts_for_notification)
+        register_hook("resolve_user_current_room", ha_resolve_user_current_room)
         register_hook("startup", ha_glue_on_startup)
         register_hook("shutdown", ha_glue_on_shutdown)
         register_hook("shutdown_finalize", ha_glue_on_shutdown_finalize)
         logger.info(
-            "ha_glue.bootstrap: registered 6 handlers — intent_fallback_resolve, "
-            "build_entity_context, validate_classified_intent, startup, "
-            "shutdown, shutdown_finalize"
+            "ha_glue.bootstrap: registered 9 handlers — intent_fallback_resolve, "
+            "build_entity_context, validate_classified_intent, "
+            "chat_context_established, should_play_tts_for_notification, "
+            "resolve_user_current_room, startup, shutdown, shutdown_finalize"
         )
     except Exception:  # noqa: BLE001 — startup must never break on plugin error
         logger.opt(exception=True).warning(
@@ -111,6 +122,25 @@ async def ha_glue_on_startup(*, app: Any) -> None:
     not prevent the others from initializing.
     """
     from ha_glue.utils.config import ha_glue_settings
+
+    # --- Register presence intents with the platform IntentRegistry ---
+    # The `PRESENCE_INTENTS` definition used to live inline in
+    # `services/intent_registry.py` with an `is_enabled_func` lambda
+    # reading `ha_glue_settings`. Moved to ha_glue and registered here
+    # via the new `intent_registry.add_integration()` method. The
+    # lambda still reads `ha_glue_settings.presence_enabled`, so the
+    # intents only appear in the prompt when presence is actually on.
+    try:
+        from services.intent_registry import intent_registry
+
+        from ha_glue.services.presence_intents import PRESENCE_INTENTS
+
+        intent_registry.add_integration(PRESENCE_INTENTS)
+        logger.info("✅ ha_glue: registered PRESENCE_INTENTS with intent_registry")
+    except Exception:  # noqa: BLE001
+        logger.opt(exception=True).warning(
+            "ha_glue.bootstrap: PRESENCE_INTENTS registration failed"
+        )
 
     # --- Paperless audit ---
     try:

--- a/src/backend/ha_glue/services/notification_privacy.py
+++ b/src/backend/ha_glue/services/notification_privacy.py
@@ -1,5 +1,10 @@
-"""
-Privacy-aware TTS gating for notifications.
+"""Privacy-aware TTS gating for notifications.
+
+Moved from platform `services/notification_privacy.py` to ha_glue in
+Phase 1 W2 because this file is 100% HomeAssistant-flavored — the
+entire privacy decision depends on BLE presence data, household-role
+classification, and room-occupancy tracking that only exist in
+ha_glue's presence subsystem.
 
 Determines whether a notification should be played via TTS based on
 its privacy level and room occupancy from the BLE presence system.
@@ -8,43 +13,61 @@ Privacy levels:
   - public: always play TTS
   - personal: play only when all room occupants are household members
   - confidential: play only when the target user is completely alone
+
+## Wired via hook
+
+Registered as a `should_play_tts_for_notification` handler by
+`ha_glue/bootstrap.py::register()`. Platform `notification_service.py`
+fires the hook when delivering a non-public notification; this
+handler returns the presence-aware decision. On platform-only deploys
+where ha_glue isn't loaded, the hook has no handler and the call site
+fails safe to "suppress non-public TTS."
 """
+
+from __future__ import annotations
 
 from loguru import logger
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from utils.config import settings
 from ha_glue.utils.config import ha_glue_settings
 
 
-async def should_play_tts(
+async def ha_should_play_tts_for_notification(
+    *,
     privacy: str,
     target_user_id: int | None,
     room_id: int | None,
-    db: AsyncSession,
-) -> bool:
-    """
-    Decide whether TTS should play for a notification.
+) -> bool | None:
+    """Decide whether TTS should play for a notification.
+
+    Opens its own database session so the call site doesn't need to
+    pass one across the hook boundary.
 
     Args:
         privacy: Privacy level ("public", "personal", "confidential").
-        target_user_id: The user this notification is intended for (if any).
+        target_user_id: The user this notification is intended for.
         room_id: The room where TTS would play (if known).
-        db: Database session for querying user roles.
 
     Returns:
         True if TTS is allowed, False if it should be suppressed.
+        Never returns None (platform default when no handler).
     """
+    # public always passes — but the platform shouldn't fire this hook
+    # for public notifications at all. Handle defensively anyway.
     if privacy == "public":
         return True
 
     if not ha_glue_settings.presence_enabled:
-        logger.debug("Presence disabled — suppressing non-public TTS (privacy=%s)", privacy)
+        logger.debug(
+            "ha_glue notification_privacy: presence disabled — "
+            f"suppressing non-public TTS (privacy={privacy})"
+        )
         return False
 
+    from services.database import AsyncSessionLocal
     from services.presence_service import get_presence_service
+
     presence = get_presence_service()
 
     if privacy == "confidential":
@@ -64,18 +87,25 @@ async def should_play_tts(
             return False
 
         occupant_ids = [o.user_id for o in occupants]
-        return await _all_household_members(occupant_ids, db)
+        async with AsyncSessionLocal() as db:
+            return await _all_household_members(occupant_ids, db)
 
     # Unknown privacy level — fail-safe
-    logger.warning("Unknown privacy level '%s' — suppressing TTS", privacy)
+    logger.warning(
+        f"ha_glue notification_privacy: unknown privacy level {privacy!r} — suppressing TTS"
+    )
     return False
 
 
-async def _all_household_members(user_ids: list[int], db: AsyncSession) -> bool:
+async def _all_household_members(user_ids: list[int], db) -> bool:
     """Check whether all given user IDs belong to household roles."""
     from models.database import User
 
-    household_roles = {r.strip() for r in ha_glue_settings.presence_household_roles.split(",") if r.strip()}
+    household_roles = {
+        r.strip()
+        for r in ha_glue_settings.presence_household_roles.split(",")
+        if r.strip()
+    }
 
     result = await db.execute(
         select(User).options(selectinload(User.role)).where(User.id.in_(user_ids))

--- a/src/backend/ha_glue/services/presence_intents.py
+++ b/src/backend/ha_glue/services/presence_intents.py
@@ -1,0 +1,49 @@
+"""HA presence intent definitions.
+
+Defines the `PRESENCE_INTENTS` integration that used to live inline in
+platform `services/intent_registry.py`. Registered with the platform's
+IntentRegistry via `intent_registry.add_integration()` during
+ha_glue's startup hook.
+
+The `is_enabled_func` reads `ha_glue_settings.presence_enabled`, which
+is resolved at the time `get_enabled_integrations()` is called — so
+the presence intents appear in the prompt only when ha_glue is loaded
+AND presence is enabled.
+"""
+
+from __future__ import annotations
+
+from services.intent_registry import IntegrationIntents, IntentDef, IntentParam
+
+from ha_glue.utils.config import ha_glue_settings
+
+
+PRESENCE_INTENTS = IntegrationIntents(
+    integration_name="presence",
+    title_de="ANWESENHEIT",
+    title_en="PRESENCE",
+    is_enabled_func=lambda: ha_glue_settings.presence_enabled,
+    intents=[
+        IntentDef(
+            name="internal.get_user_location",
+            description_de="Aktuellen oder letzten bekannten Aufenthaltsort eines Benutzers abfragen",
+            description_en="Get current or last known room location of a user",
+            parameters=[
+                IntentParam(
+                    "user_name",
+                    "Name des Benutzers (Username, Vorname oder Nachname)",
+                    required=True,
+                ),
+            ],
+            examples_de=["Wo ist Alex?", "In welchem Raum ist Alex?"],
+            examples_en=["Where is Alex?", "Which room is Alex in?"],
+        ),
+        IntentDef(
+            name="internal.get_all_presence",
+            description_de="Alle aktuell anwesenden Benutzer und ihre Räume anzeigen",
+            description_en="Get all currently present users and their room locations",
+            examples_de=["Wer ist zuhause?", "Wo sind alle?"],
+            examples_en=["Who is home?", "Where is everyone?"],
+        ),
+    ],
+)

--- a/src/backend/ha_glue/services/sweep_handlers.py
+++ b/src/backend/ha_glue/services/sweep_handlers.py
@@ -1,0 +1,92 @@
+"""Small hook handlers for the Phase 1 W2 platform-leak sweep.
+
+These handlers replace direct `ha_glue_settings` imports that used to
+live in platform files:
+
+- `ha_chat_context_established` — replaces the BLE voice-presence
+  registration block in `api/websocket/chat_handler.py`. Fires on the
+  `chat_context_established` hook and calls
+  `presence_service.register_voice_presence()` when presence is enabled.
+
+- `ha_resolve_user_current_room` — replaces the room-lookup block in
+  `services/notification_service.py::_persist`. Fires on the
+  `resolve_user_current_room` hook and returns the user's current
+  room from the BLE presence service, or None if unknown.
+
+Both handlers early-return None (hook fall-through) when
+`ha_glue_settings.presence_enabled` is False, so pro deploys don't
+activate any presence-dependent behavior even though the handlers
+are registered in the same `register()` call.
+"""
+
+from __future__ import annotations
+
+from loguru import logger
+
+
+async def ha_chat_context_established(
+    *,
+    user_id: int,
+    room_id: int,
+    room_name: str | None = None,
+    lang: str = "de",
+) -> None:
+    """Register BLE voice-auth presence when a user speaks from a known room.
+
+    The platform chat handler fires this hook whenever an authenticated
+    user's message starts processing with a known room context. If
+    presence is enabled, record that the user is (now) in that room
+    so presence-derived features (media follow, privacy gating,
+    notifications) see the updated location.
+    """
+    from ha_glue.utils.config import ha_glue_settings
+
+    if not ha_glue_settings.presence_enabled:
+        return
+
+    try:
+        from services.presence_service import get_presence_service
+        presence_svc = get_presence_service()
+        await presence_svc.register_voice_presence(
+            user_id=user_id,
+            room_id=room_id,
+            room_name=room_name,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"⚠️  ha_glue chat_context_established: voice presence update failed: {e}")
+
+
+async def ha_resolve_user_current_room(
+    *,
+    user_id: int,
+) -> dict | None:
+    """Return the user's current room from BLE presence, or None.
+
+    Used by `notification_service` to target a notification at the
+    user's actual room when no explicit room was specified by the
+    caller. Returns `None` when:
+
+    - Presence is disabled at the ha_glue level
+    - The user isn't tracked by BLE
+    - The presence service raises for any reason
+    """
+    from ha_glue.utils.config import ha_glue_settings
+
+    if not ha_glue_settings.presence_enabled:
+        return None
+
+    try:
+        from services.presence_service import get_presence_service
+        presence = get_presence_service()
+        user_p = presence.get_user_presence(user_id)
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"ha_glue resolve_user_current_room: presence lookup failed: {e}")
+        return None
+
+    if not user_p or not user_p.room_id:
+        return None
+
+    return {
+        "room_id": user_p.room_id,
+        "room_name": user_p.room_name or "",
+    }

--- a/src/backend/services/intent_registry.py
+++ b/src/backend/services/intent_registry.py
@@ -18,7 +18,6 @@ Usage:
 from dataclasses import dataclass, field
 
 from utils.config import settings
-from ha_glue.utils.config import ha_glue_settings
 
 
 @dataclass
@@ -93,30 +92,6 @@ KNOWLEDGE_INTENTS = IntegrationIntents(
     ],
 )
 
-PRESENCE_INTENTS = IntegrationIntents(
-    integration_name="presence",
-    title_de="ANWESENHEIT",
-    title_en="PRESENCE",
-    is_enabled_func=lambda: ha_glue_settings.presence_enabled,
-    intents=[
-        IntentDef(
-            name="internal.get_user_location",
-            description_de="Aktuellen oder letzten bekannten Aufenthaltsort eines Benutzers abfragen",
-            description_en="Get current or last known room location of a user",
-            parameters=[IntentParam("user_name", "Name des Benutzers (Username, Vorname oder Nachname)", required=True)],
-            examples_de=["Wo ist Alex?", "In welchem Raum ist Alex?"],
-            examples_en=["Where is Alex?", "Which room is Alex in?"],
-        ),
-        IntentDef(
-            name="internal.get_all_presence",
-            description_de="Alle aktuell anwesenden Benutzer und ihre Räume anzeigen",
-            description_en="Get all currently present users and their room locations",
-            examples_de=["Wer ist zuhause?", "Wo sind alle?"],
-            examples_en=["Who is home?", "Where is everyone?"],
-        ),
-    ],
-)
-
 GENERAL_INTENTS = IntegrationIntents(
     integration_name="general",
     title_de="ALLGEMEIN",
@@ -133,10 +108,12 @@ GENERAL_INTENTS = IntegrationIntents(
     ],
 )
 
-# All core integrations (HA, n8n, camera are now MCP-only)
+# All core integrations (HA, n8n, camera are now MCP-only).
+# Domain-specific integrations (e.g. ha_glue's PRESENCE_INTENTS) are
+# registered at startup via `intent_registry.add_integration()` rather
+# than declared here, so platform code doesn't depend on ha_glue.
 CORE_INTEGRATIONS = [
     KNOWLEDGE_INTENTS,
-    PRESENCE_INTENTS,
     GENERAL_INTENTS,
 ]
 
@@ -154,9 +131,26 @@ class IntentRegistry:
         self._mcp_tools: list[dict] = []
         self._mcp_examples: dict[str, dict[str, list[str]]] = {}  # server_name → {"de": [...], "en": [...]}
         self._mcp_prompt_tools: dict[str, list[str]] = {}  # server_name → [tool_name, ...]
+        # Plugin-registered integrations (e.g. ha_glue's PRESENCE_INTENTS).
+        # Extends CORE_INTEGRATIONS at runtime without platform code
+        # knowing about specific domain integrations. Populated via
+        # `add_integration()` during plugin startup hooks.
+        self._plugin_integrations: list[IntegrationIntents] = []
         # Prompt cache: invalidated when tools/plugins change
         self._prompt_cache: dict[str, str] = {}  # key → cached output
         self._examples_cache: dict[str, str] = {}  # key → cached output
+
+    def add_integration(self, integration: IntegrationIntents) -> None:
+        """Register a plugin-provided integration.
+
+        Called by domain-specific plugins (e.g. ha_glue) during startup
+        to contribute their own `IntegrationIntents` to the registry.
+        The integration's own `is_enabled_func` is queried on every
+        `get_enabled_integrations()` call, so plugins can gate on
+        their own settings without platform knowing about them.
+        """
+        self._plugin_integrations.append(integration)
+        self._invalidate_prompt_cache()
 
     def _invalidate_prompt_cache(self) -> None:
         """Clear cached prompt outputs when configuration changes."""
@@ -189,8 +183,9 @@ class IntentRegistry:
         self._invalidate_prompt_cache()
 
     def get_enabled_integrations(self) -> list[IntegrationIntents]:
-        """Get list of enabled core integrations."""
-        return [i for i in CORE_INTEGRATIONS if i.is_enabled_func()]
+        """Get list of enabled core + plugin-registered integrations."""
+        all_integrations = CORE_INTEGRATIONS + self._plugin_integrations
+        return [i for i in all_integrations if i.is_enabled_func()]
 
     def is_intent_available(self, intent_name: str) -> bool:
         """Check if an intent is currently available."""
@@ -379,7 +374,7 @@ class IntentRegistry:
             "mcp_tools": 0,
         }
 
-        for integration in CORE_INTEGRATIONS:
+        for integration in CORE_INTEGRATIONS + self._plugin_integrations:
             if integration.is_enabled_func():
                 status["enabled_integrations"].append({
                     "name": integration.integration_name,

--- a/src/backend/services/notification_service.py
+++ b/src/backend/services/notification_service.py
@@ -28,7 +28,6 @@ from models.database import (
     SystemSetting,
 )
 from utils.config import settings
-from ha_glue.utils.config import ha_glue_settings
 
 
 class NotificationService:
@@ -501,17 +500,29 @@ class NotificationService:
 
         logger.info(f"📨 Notification #{notification.id} erstellt: {title} (urgency={urgency})")
 
-        # Resolve target user's room from presence if no room specified
-        if target_user_id and not room_id and ha_glue_settings.presence_enabled:
+        # Resolve target user's room via hook — domain-specific consumers
+        # (e.g. ha_glue's BLE presence service) can respond with the user's
+        # current room. Platform default: no handler → notification stays
+        # un-roomed, and the targeted broadcast falls back to the generic
+        # channel.
+        if target_user_id and not room_id:
             try:
-                from services.presence_service import get_presence_service
-                presence = get_presence_service()
-                user_p = presence.get_user_presence(target_user_id)
-                if user_p and user_p.room_id:
-                    notification.room_id = user_p.room_id
-                    notification.room_name = user_p.room_name or ""
+                from utils.hooks import run_hooks
+                results = await run_hooks(
+                    "resolve_user_current_room",
+                    user_id=target_user_id,
+                )
+                for result in results:
+                    if isinstance(result, dict) and "room_id" in result:
+                        notification.room_id = result["room_id"]
+                        notification.room_name = result.get("room_name", "")
+                        break
+                    logger.warning(
+                        f"⚠️  resolve_user_current_room handler returned "
+                        f"unexpected shape (type={type(result).__name__}); ignoring"
+                    )
             except Exception as e:
-                logger.debug("Could not resolve target user room: %s", e)
+                logger.debug("Could not resolve target user room via hook: %s", e)
 
         # Store embedding in background
         if embedding:
@@ -582,22 +593,33 @@ class NotificationService:
 
         logger.info(f"📤 Notification #{notification.id} an {len(delivered_ids)} Geräte gesendet")
 
-        # TTS delivery (with privacy gate)
+        # TTS delivery (with privacy gate via hook)
         if tts:
             tts_allowed = True
             if notification.privacy and notification.privacy != "public":
+                # Non-public privacy levels require a domain-specific handler
+                # to decide whether TTS is safe. ha_glue's handler uses BLE
+                # presence to check room occupancy. Platform default (no
+                # handler) fails safe: non-public TTS is suppressed.
                 try:
-                    from services.database import AsyncSessionLocal
-                    from services.notification_privacy import should_play_tts
-                    async with AsyncSessionLocal() as privacy_db:
-                        tts_allowed = await should_play_tts(
-                            privacy=notification.privacy,
-                            target_user_id=notification.target_user_id,
-                            room_id=notification.room_id,
-                            db=privacy_db,
+                    from utils.hooks import run_hooks
+                    results = await run_hooks(
+                        "should_play_tts_for_notification",
+                        privacy=notification.privacy,
+                        target_user_id=notification.target_user_id,
+                        room_id=notification.room_id,
+                    )
+                    tts_allowed = False  # fail-safe default
+                    for result in results:
+                        if isinstance(result, bool):
+                            tts_allowed = result
+                            break
+                        logger.warning(
+                            f"⚠️  should_play_tts_for_notification handler returned "
+                            f"unexpected shape (type={type(result).__name__}); ignoring"
                         )
                 except Exception as e:
-                    logger.warning("Privacy gate error, suppressing TTS: %s", e)
+                    logger.warning("Privacy gate hook error, suppressing TTS: %s", e)
                     tts_allowed = False
             if tts_allowed:
                 tts_delivered = await self._deliver_tts(notification)

--- a/src/backend/utils/hooks.py
+++ b/src/backend/utils/hooks.py
@@ -69,6 +69,28 @@ HOOK_EVENTS: frozenset[str] = frozenset({
     # `general.conversation` when the message doesn't actually contain
     # HA-shaped words.
     "validate_classified_intent",
+    # Chat message context established — fired by the WebSocket chat
+    # handler when an authenticated user's message starts processing and
+    # a room context is known. Kwargs: `user_id: int, room_id: int,
+    # room_name: str | None, lang: str`. Handlers return nothing. Used
+    # by ha_glue to register BLE voice-auth presence when a user speaks
+    # from a known room. Platform default (no handler) is a no-op.
+    "chat_context_established",
+    # Privacy-aware TTS gate for notifications — fired by the notification
+    # service when delivering a non-public notification that may require
+    # suppression based on room occupancy. Kwargs: `privacy: str,
+    # target_user_id: int | None, room_id: int | None`. Handlers return
+    # `bool` — True if TTS allowed, False to suppress. First well-shaped
+    # non-None result wins. Platform default (no handler) falls back to
+    # "suppress non-public TTS" as fail-safe.
+    "should_play_tts_for_notification",
+    # Resolve a user's current room — fired by the notification service
+    # when a notification has a target user but no explicit room. Kwargs:
+    # `user_id: int`. Handlers return a dict
+    # `{"room_id": int, "room_name": str}` or None. First well-shaped
+    # non-None result wins. Platform default (no handler) leaves the
+    # notification un-roomed.
+    "resolve_user_current_room",
 })
 
 HookFn = Callable[..., Coroutine[Any, Any, Any]]


### PR DESCRIPTION
## Summary

Phase 1 W2 follow-up. Removes the last 4 platform files that had direct \`from ha_glue.utils.config import ha_glue_settings\` imports, plus relocates the only purely-HA file that lived in \`services/\` (\`notification_privacy.py\`) into ha_glue.

**After this PR:** ZERO platform files import from \`ha_glue.utils.config\` in live code. The ONLY structural platform → ha_glue import in the whole codebase is the Stage 0 bootstrap (\`from ha_glue.bootstrap import register\`) in \`api/lifecycle.py\`.

## Four leak fixes

### 1. \`api/websocket/chat_handler.py\` — voice-auth presence registration

Removed the inline \`if ha_glue_settings.presence_enabled and room_context and room_context.get(\"room_id\"):\` block that imported \`services.presence_service\` and called \`register_voice_presence()\`. Replaced with a single \`run_hooks(\"chat_context_established\", ...)\` call.

ha_glue's new handler (\`ha_chat_context_established\`) gates on \`presence_enabled\` internally and calls the presence service from inside ha_glue. Platform-only deploys: no-op.

### 2. \`services/intent_registry.py\` — \`PRESENCE_INTENTS\` definition

The \`PRESENCE_INTENTS\` \`IntegrationIntents\` dataclass was declared inline in a platform file with \`is_enabled_func=lambda: ha_glue_settings.presence_enabled\`. Moved to \`ha_glue/services/presence_intents.py\`.

Added a new \`IntentRegistry.add_integration()\` method for runtime registration of plugin-provided integrations. \`get_enabled_integrations()\` now returns \`CORE_INTEGRATIONS + self._plugin_integrations\`, filtered per-integration by \`is_enabled_func()\` at query time. \`ha_glue_on_startup\` calls \`intent_registry.add_integration(PRESENCE_INTENTS)\` during the \`startup\` hook.

### 3. \`services/notification_privacy.py\` — whole file moved

The file is 100% HomeAssistant-flavored — every decision depends on BLE presence, household-role classification, and room-occupancy tracking that only exist in ha_glue's presence subsystem. Called from exactly one place (\`notification_service.py\`), so: move the file, rename the function to \`ha_should_play_tts_for_notification\`, wire via the new \`should_play_tts_for_notification\` hook. The handler opens its own DB session so the call site doesn't need to pass one across the hook boundary.

### 4. \`services/notification_service.py\` — two leaks, two hooks

- **Room lookup** — \`if target_user_id and not room_id and ha_glue_settings.presence_enabled:\` → \`run_hooks(\"resolve_user_current_room\", user_id=...)\`. ha_glue returns \`{room_id, room_name}\` from presence. Platform default: room stays unresolved.
- **TTS privacy gate** — direct \`from services.notification_privacy import should_play_tts\` call → \`run_hooks(\"should_play_tts_for_notification\", ...)\`. Platform default: non-public TTS suppressed (fail-safe).

## Three new hook events

| Event | Purpose | Platform default |
|---|---|---|
| \`chat_context_established\` | Authenticated chat message with known room | No-op |
| \`should_play_tts_for_notification\` | Non-public TTS privacy gate | Suppress (fail-safe) |
| \`resolve_user_current_room\` | Look up user's current room by user_id | Room unresolved |

## ha_glue handlers (9 total, up from 6)

| Event | Handler | Since |
|---|---|---|
| intent_fallback_resolve | ha_intent_fallback | #346 |
| build_entity_context | ha_build_entity_context | #349 |
| validate_classified_intent | ha_validate_classified_intent | #349 |
| chat_context_established | ha_chat_context_established | **this PR** |
| should_play_tts_for_notification | ha_should_play_tts_for_notification | **this PR** |
| resolve_user_current_room | ha_resolve_user_current_room | **this PR** |
| startup | ha_glue_on_startup | #348 |
| shutdown | ha_glue_on_shutdown | #348 |
| shutdown_finalize | ha_glue_on_shutdown_finalize | #349 |

Plus one non-hook side effect: \`ha_glue_on_startup\` calls \`intent_registry.add_integration(PRESENCE_INTENTS)\`.

## Layering state

**Before this PR:** 5 platform files with \`ha_glue_settings\` imports (api/lifecycle.py + the 4 fixed here). api/lifecycle.py already had only comment references (no live use) after #348.

**After this PR:** **0 platform files with \`ha_glue_settings\` imports in live code.** Two platform files still have the name in COMMENTS (\`utils/config.py\` and \`api/lifecycle.py\` explain the split). The only structural platform → ha_glue import anywhere is \`from ha_glue.bootstrap import register\` in \`api/lifecycle.py\` Stage 0.

The 16 files that still reference \`ha_glue_settings\` are all ha-glue-destined files scheduled to move in the Week 2 file-move sweep. The imports travel with the files.

## Verification

- ✅ AST parse clean on all 8 files (4 modified platform + 4 new/moved ha_glue)
- ✅ \`import ha_glue\` remains side-effect-free
- ✅ \`register()\` wires 9 handlers across 9 events
- ✅ \`IntentRegistry.add_integration()\` correctly extends CORE_INTEGRATIONS
- ✅ \`get_enabled_integrations()\` returns \`['knowledge', 'general']\` with presence off, \`['knowledge', 'general', 'presence']\` with presence on (runtime gating preserved)
- ✅ \`chat_context_established\` handler early-returns when presence off
- ✅ \`resolve_user_current_room\` returns empty results list when presence off
- ✅ \`should_play_tts_for_notification\` fail-safe default: returns False
- ✅ Grep sweep: zero \`ha_glue_settings\` imports in platform code outside ha_glue/

## Not in this PR

- The 16 ha-glue-destined files that still reference \`ha_glue_settings\` (Week 2 file move)
- \`main.py:409\` \`/admin/refresh-keywords\` admin endpoint (needs new \`ha_glue/api/\` + \`register_routes\` hook)
- Platform \`IntentRegistry.CORE_INTEGRATIONS\` still has \`KNOWLEDGE_INTENTS\` + \`GENERAL_INTENTS\` — those are platform-appropriate

## Test plan

- [ ] CI green
- [ ] Deploy to Renfield HA instance — verify voice auth presence, notification privacy gate, and PRESENCE_INTENTS all still work via the hook path
- [ ] Deploy to \`RENFIELD_EDITION=pro\` (Reva) — verify no regressions, no new log noise, notification flow still works

## References

- Parent: #342 (Phase 1 tracking)
- Dependency: #347 (config split), #348 (lifecycle hook)
- Pattern: #346 (intent fallback), #349 (ollama hooks)
- Boundary doc: [X-idra-Systems-GmbH/reva docs/architecture/renfield-platform-boundary.md](https://github.com/X-idra-Systems-GmbH/reva/blob/main/docs/architecture/renfield-platform-boundary.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)