### PR TITLE
feat(alembic): make env.py ha_glue-aware for autogenerate (#342)

### DIFF
--- a/src/backend/alembic/env.py
+++ b/src/backend/alembic/env.py
@@ -2,6 +2,51 @@
 Alembic Environment Configuration
 
 Async SQLAlchemy support for PostgreSQL migrations.
+
+## Target metadata and the ha_glue split (Phase 1 W3)
+
+`target_metadata = Base.metadata` drives Alembic's autogenerate diff.
+After the Phase 1 Week 1-2 ha_glue extraction, HA-specific tables
+(Room, RoomDevice, RoomOutputDevice, UserBleDevice, PresenceEvent,
+PaperlessAuditResult, HomeAssistantEntity, CameraEvent, RadioFavorite)
+live in `ha_glue.models.database` and only register with `Base.metadata`
+when that module is imported.
+
+This env.py runs on two deployment flavors:
+
+1. **Home-automation (`ebongard/renfield`, current monorepo HA deploys)** —
+   ha_glue is on disk, HA tables are in use. We want autogenerate to
+   SEE the HA tables so it doesn't produce "drop tables" diffs.
+2. **Platform-only (future `X-idra/renfield`, `RENFIELD_EDITION=pro`
+   deploys like Reva)** — ha_glue may or may not be on disk. Pro
+   deploys today have it (monorepo), but Phase 3 extracts it into a
+   separate repo. We want autogenerate to ignore HA tables so the
+   platform schema stays lean.
+
+The pragmatic answer: **import ha_glue.models.database inside a
+try/except**. If it's available, its classes register with Base.metadata
+as a side effect and autogenerate sees them. If it's not on disk
+(future platform-only repo), ImportError is swallowed and only
+platform tables drive autogenerate. No env var gate needed — presence
+of the package IS the flavor signal.
+
+## Phase 3 cutover plan
+
+When the platform repo splits from ebongard/renfield (Phase 3), the
+X-idra/renfield repo will NOT have ha_glue/ on disk. The try/except
+below will silently skip and target_metadata will be lean. At that
+point, existing platform-only deploys that had the HA tables lingering
+from monorepo history should either:
+- (a) drop the 9 HA tables via a one-shot cleanup migration (cutover
+  path — recommended for X-IDRA because the tables are empty per
+  J2.3 audit)
+- (b) accept the drift and let the HA tables sit there (no-op path —
+  lowest risk, highest cruft)
+
+The J2.3 audit (X-idra-Systems-GmbH/reva
+docs/architecture/renfield-open-source-readiness.md) verified all 11
+smart-home tables are EMPTY in the Reva production database. So (a)
+is safe for X-IDRA's single pro deploy.
 """
 import asyncio
 from logging.config import fileConfig
@@ -12,9 +57,26 @@ from sqlalchemy.ext.asyncio import async_engine_from_config
 
 from alembic import context
 
-# Import your models
+# Import platform models (the 22-class Base.metadata after W1.2).
 from models.database import Base
 from utils.config import settings
+
+# Conditionally register ha_glue models with Base.metadata. If ha_glue
+# is on disk (monorepo or ha-glue flavor deploy), importing
+# `ha_glue.models.database` as a side effect registers its 9 HA classes
+# with the shared Base.metadata. If ha_glue is absent (future X-idra/
+# renfield platform repo), the ImportError is swallowed and
+# target_metadata stays platform-only.
+#
+# This single line is the Phase 1 W3 deliverable — it makes
+# `alembic revision --autogenerate` and `alembic upgrade` produce the
+# correct diff for each deployment flavor without any env var gating.
+try:
+    from ha_glue.models import database as _ha_glue_db  # noqa: F401 — side-effect registration
+except ImportError:
+    # Platform-only deploy — ha_glue package not installed. Autogenerate
+    # will see only the 22 platform tables in Base.metadata.
+    pass
 
 # Alembic Config object
 config = context.config


### PR DESCRIPTION
## Summary

Phase 1 Week 3 of the open-source extraction. After W1.2 moved the 9 HA-specific tables into `ha_glue/models/database.py`, Alembic's `target_metadata = Base.metadata` in `env.py` only saw the 22 platform tables at import time. Running `alembic revision --autogenerate` on a ha-glue deploy would produce a spurious "drop 9 HA tables" diff.

This PR adds a conditional side-effect import so `env.py` picks up the HA model classes automatically when ha_glue is on disk, and falls through cleanly when it is not.

```python
try:
    from ha_glue.models import database as _ha_glue_db  # noqa: F401
except ImportError:
    pass
```

- **HA-flavored deploy (ebongard/renfield, monorepo):** ha_glue imports, 9 HA classes register with Base.metadata as side effect, autogenerate sees all 31 tables. No spurious drops.
- **Platform-only deploy (future X-idra/renfield):** ImportError swallowed, Base.metadata stays lean at 22 tables, autogenerate produces a platform-only diff.

No env var gate needed. Presence of the package IS the flavor signal.

## Why this matters

Without this, the first `alembic revision --autogenerate` run on a ha-glue deploy after the W1.2 extraction would emit drop statements for Room, RoomDevice, RoomOutputDevice, UserBleDevice, PresenceEvent, PaperlessAuditResult, HomeAssistantEntity, CameraEvent, RadioFavorite. Merging that migration would wipe live HA data.

## Phase 3 cutover plan

When the platform repo splits from ebongard/renfield (Phase 3), X-idra/renfield will not have ha_glue/ on disk. The try/except silently skips, target_metadata stays lean. Existing platform-only deploys with lingering HA tables from monorepo history can either drop the 9 empty HA tables via a one-shot cleanup migration (recommended, verified empty per the J2.3 audit) or accept the drift.

The 60-line module docstring in `env.py` documents both deploy flavors and the Phase 3 cutover options for the next maintainer.

## Test plan

- [x] Mode 1 verified — ha_glue present: `Base.metadata` contains 31 tables after import, all 9 HA classes registered
- [x] Mode 2 verified — ha_glue blocked via `sys.meta_path`: `Base.metadata` contains 22 platform tables, zero HA leakage
- [ ] `alembic upgrade head` on a fresh DB produces no errors
- [ ] `alembic revision --autogenerate` on live prod produces an empty diff (no spurious drops)

Refs #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)