### PR TITLE
test(ha_glue): update stale imports after Phase 1 W2 extraction (#361)

### DIFF
--- a/tests/backend/test_api_presence.py
+++ b/tests/backend/test_api_presence.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from services.presence_service import PresenceService
+from ha_glue.services.presence_service import PresenceService
 
 
 @pytest.fixture

--- a/tests/backend/test_audio_output_service.py
+++ b/tests/backend/test_audio_output_service.py
@@ -21,7 +21,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from services.audio_output_service import AudioOutputService, get_audio_output_service
+from ha_glue.services.audio_output_service import AudioOutputService, get_audio_output_service
 
 
 def _make_output_device(
@@ -55,8 +55,8 @@ def mock_settings():
 
 @pytest.fixture
 def service(mock_ha_client, mock_settings, tmp_path):
-    with patch("services.audio_output_service.HomeAssistantClient", return_value=mock_ha_client), \
-         patch("services.audio_output_service.settings", mock_settings):
+    with patch("ha_glue.services.audio_output_service.HomeAssistantClient", return_value=mock_ha_client), \
+         patch("ha_glue.services.audio_output_service.settings", mock_settings):
         svc = AudioOutputService()
         # Use tmp_path for cache to avoid filesystem side effects
         svc.TTS_CACHE_DIR = tmp_path
@@ -80,7 +80,7 @@ class TestPlayOnRenfieldDevice:
         mock_dm.get_device.return_value = mock_device
         mock_dm.send_tts_audio = AsyncMock()
 
-        with patch("services.audio_output_service.get_device_manager", return_value=mock_dm):
+        with patch("ha_glue.services.audio_output_service.get_device_manager", return_value=mock_dm):
             result = await service._play_on_renfield_device(
                 audio_bytes=b"fake-audio",
                 device_id="sat-kitchen",
@@ -100,7 +100,7 @@ class TestPlayOnRenfieldDevice:
         mock_dm = MagicMock()
         mock_dm.get_device.return_value = None
 
-        with patch("services.audio_output_service.get_device_manager", return_value=mock_dm):
+        with patch("ha_glue.services.audio_output_service.get_device_manager", return_value=mock_dm):
             result = await service._play_on_renfield_device(
                 audio_bytes=b"audio", device_id="sat-gone", session_id="sess-1"
             )
@@ -116,7 +116,7 @@ class TestPlayOnRenfieldDevice:
         mock_dm = MagicMock()
         mock_dm.get_device.return_value = mock_device
 
-        with patch("services.audio_output_service.get_device_manager", return_value=mock_dm):
+        with patch("ha_glue.services.audio_output_service.get_device_manager", return_value=mock_dm):
             result = await service._play_on_renfield_device(
                 audio_bytes=b"audio", device_id="sat-nospeaker", session_id="sess-1"
             )
@@ -133,7 +133,7 @@ class TestPlayOnRenfieldDevice:
         mock_dm.get_device.return_value = mock_device
         mock_dm.send_tts_audio = AsyncMock(side_effect=Exception("WS closed"))
 
-        with patch("services.audio_output_service.get_device_manager", return_value=mock_dm):
+        with patch("ha_glue.services.audio_output_service.get_device_manager", return_value=mock_dm):
             result = await service._play_on_renfield_device(
                 audio_bytes=b"audio", device_id="sat-err", session_id="sess-1"
             )
@@ -321,8 +321,8 @@ class TestBackendURL:
         mock_s.advertise_host = "renfield.local"
         mock_s.advertise_port = 8000
 
-        with patch("services.audio_output_service.settings", mock_s), \
-             patch("services.audio_output_service.HomeAssistantClient"):
+        with patch("ha_glue.services.audio_output_service.settings", mock_s), \
+             patch("ha_glue.services.audio_output_service.HomeAssistantClient"):
             svc = AudioOutputService()
             url = svc._get_backend_url()
 
@@ -334,8 +334,8 @@ class TestBackendURL:
         mock_s.advertise_host = None
         mock_s.backend_internal_url = "http://backend:8000"
 
-        with patch("services.audio_output_service.settings", mock_s), \
-             patch("services.audio_output_service.HomeAssistantClient"):
+        with patch("ha_glue.services.audio_output_service.settings", mock_s), \
+             patch("ha_glue.services.audio_output_service.HomeAssistantClient"):
             svc = AudioOutputService()
             url = svc._get_backend_url()
 
@@ -351,12 +351,12 @@ class TestSingleton:
 
     def test_get_audio_output_service_returns_instance(self):
         """get_audio_output_service returns an AudioOutputService."""
-        import services.audio_output_service as mod
+        import ha_glue.services.audio_output_service as mod
         # Reset singleton
         mod._audio_output_service = None
 
-        with patch("services.audio_output_service.HomeAssistantClient"), \
-             patch("services.audio_output_service.settings") as mock_s:
+        with patch("ha_glue.services.audio_output_service.HomeAssistantClient"), \
+             patch("ha_glue.services.audio_output_service.settings") as mock_s:
             mock_s.advertise_host = None
             mock_s.backend_internal_url = "http://backend:8000"
             svc = get_audio_output_service()
@@ -367,11 +367,11 @@ class TestSingleton:
 
     def test_get_audio_output_service_returns_same_instance(self):
         """Repeated calls return the same singleton instance."""
-        import services.audio_output_service as mod
+        import ha_glue.services.audio_output_service as mod
         mod._audio_output_service = None
 
-        with patch("services.audio_output_service.HomeAssistantClient"), \
-             patch("services.audio_output_service.settings") as mock_s:
+        with patch("ha_glue.services.audio_output_service.HomeAssistantClient"), \
+             patch("ha_glue.services.audio_output_service.settings") as mock_s:
             mock_s.advertise_host = None
             mock_s.backend_internal_url = "http://backend:8000"
             svc1 = get_audio_output_service()

--- a/tests/backend/test_integrations.py
+++ b/tests/backend/test_integrations.py
@@ -21,11 +21,11 @@ class TestHomeAssistantClient:
     @pytest.fixture
     def ha_client(self):
         """Create HomeAssistantClient with test settings"""
-        with patch('integrations.homeassistant.settings') as mock_settings:
+        with patch('ha_glue.integrations.homeassistant.settings') as mock_settings:
             mock_settings.home_assistant_url = "http://ha.local:8123"
             mock_settings.home_assistant_token = "test_token"
 
-            from integrations.homeassistant import HomeAssistantClient
+            from ha_glue.integrations.homeassistant import HomeAssistantClient
             return HomeAssistantClient()
 
     @pytest.mark.unit
@@ -216,10 +216,10 @@ class TestFrigateClient:
     @pytest.fixture
     def frigate_client(self):
         """Create FrigateClient with test settings"""
-        with patch('integrations.frigate.settings') as mock_settings:
+        with patch('ha_glue.integrations.frigate.settings') as mock_settings:
             mock_settings.frigate_url = "http://frigate.local:5000"
 
-            from integrations.frigate import FrigateClient
+            from ha_glue.integrations.frigate import FrigateClient
             return FrigateClient()
 
     @pytest.mark.unit
@@ -305,11 +305,11 @@ class TestIntegrationEdgeCases:
     @pytest.mark.unit
     async def test_ha_client_not_configured(self):
         """Test: HA Client ohne Konfiguration"""
-        with patch('integrations.homeassistant.settings') as mock_settings:
+        with patch('ha_glue.integrations.homeassistant.settings') as mock_settings:
             mock_settings.home_assistant_url = None
             mock_settings.home_assistant_token = None
 
-            from integrations.homeassistant import HomeAssistantClient
+            from ha_glue.integrations.homeassistant import HomeAssistantClient
             client = HomeAssistantClient()
 
             # Should return empty/False without throwing
@@ -319,11 +319,11 @@ class TestIntegrationEdgeCases:
     @pytest.mark.unit
     async def test_ha_client_timeout(self):
         """Test: HA Client Timeout"""
-        with patch('integrations.homeassistant.settings') as mock_settings:
+        with patch('ha_glue.integrations.homeassistant.settings') as mock_settings:
             mock_settings.home_assistant_url = "http://slow.server"
             mock_settings.home_assistant_token = "token"
 
-            from integrations.homeassistant import HomeAssistantClient
+            from ha_glue.integrations.homeassistant import HomeAssistantClient
             client = HomeAssistantClient()
 
             with patch.object(httpx.AsyncClient, 'get', new_callable=AsyncMock) as mock_get:
@@ -335,10 +335,10 @@ class TestIntegrationEdgeCases:
     @pytest.mark.unit
     async def test_frigate_client_not_configured(self):
         """Test: Frigate Client ohne Konfiguration"""
-        with patch('integrations.frigate.settings') as mock_settings:
+        with patch('ha_glue.integrations.frigate.settings') as mock_settings:
             mock_settings.frigate_url = None
 
-            from integrations.frigate import FrigateClient
+            from ha_glue.integrations.frigate import FrigateClient
             client = FrigateClient()
 
             result = await client.get_events()

--- a/tests/backend/test_intent_performance.py
+++ b/tests/backend/test_intent_performance.py
@@ -24,20 +24,20 @@ class TestEntityMapCache:
     @pytest.fixture(autouse=True)
     def reset_cache(self):
         """Clear class-level cache before each test."""
-        with patch('integrations.homeassistant.settings') as mock_settings:
+        with patch('ha_glue.integrations.homeassistant.settings') as mock_settings:
             mock_settings.home_assistant_url = "http://ha.local:8123"
             mock_settings.home_assistant_token = "test_token"
-            from integrations.homeassistant import HomeAssistantClient
+            from ha_glue.integrations.homeassistant import HomeAssistantClient
             HomeAssistantClient._entity_map_cache = None
             HomeAssistantClient._entity_map_cache_time = 0
         yield
 
     @pytest.fixture
     def ha_client(self):
-        with patch('integrations.homeassistant.settings') as mock_settings:
+        with patch('ha_glue.integrations.homeassistant.settings') as mock_settings:
             mock_settings.home_assistant_url = "http://ha.local:8123"
             mock_settings.home_assistant_token = "test_token"
-            from integrations.homeassistant import HomeAssistantClient
+            from ha_glue.integrations.homeassistant import HomeAssistantClient
             return HomeAssistantClient()
 
     @pytest.mark.unit
@@ -83,7 +83,7 @@ class TestEntityMapCache:
     @pytest.mark.asyncio
     async def test_entity_map_cache_expires(self, ha_client):
         """Cache should expire after TTL."""
-        from integrations.homeassistant import HomeAssistantClient
+        from ha_glue.integrations.homeassistant import HomeAssistantClient
 
         mock_states = [
             {
@@ -109,11 +109,11 @@ class TestEntityMapCache:
     @pytest.mark.asyncio
     async def test_entity_map_cache_shared_across_instances(self):
         """Cache should be shared across HomeAssistantClient instances."""
-        with patch('integrations.homeassistant.settings') as mock_settings:
+        with patch('ha_glue.integrations.homeassistant.settings') as mock_settings:
             mock_settings.home_assistant_url = "http://ha.local:8123"
             mock_settings.home_assistant_token = "test_token"
 
-            from integrations.homeassistant import HomeAssistantClient
+            from ha_glue.integrations.homeassistant import HomeAssistantClient
 
             client1 = HomeAssistantClient()
             client2 = HomeAssistantClient()
@@ -172,7 +172,7 @@ class TestEntityContextScoring:
                 }
             ]
 
-            with patch('integrations.homeassistant.HomeAssistantClient.get_entity_map',
+            with patch('ha_glue.integrations.homeassistant.HomeAssistantClient.get_entity_map',
                         new_callable=AsyncMock, return_value=mock_entities):
                 result = await service._build_entity_context(
                     "Schalte das Licht im Arbeitszimmer an",
@@ -211,7 +211,7 @@ class TestEntityContextScoring:
                 }
             ]
 
-            with patch('integrations.homeassistant.HomeAssistantClient.get_entity_map',
+            with patch('ha_glue.integrations.homeassistant.HomeAssistantClient.get_entity_map',
                         new_callable=AsyncMock, return_value=mock_entities):
                 # "Licht" should match light domain
                 result = await service._build_entity_context("Schalte das Licht ein")

--- a/tests/backend/test_internal_tools.py
+++ b/tests/backend/test_internal_tools.py
@@ -39,7 +39,7 @@ def _patch_resolve_deps(mock_room_service, mock_routing_service=None):
     # Ensure modules exist in sys.modules so patch() can resolve them.
     # The fake modules may not have the target attributes, so use create=True.
     _ensure_module = []
-    for mod_name in ["services.database", "services.room_service", "services.output_routing_service"]:
+    for mod_name in ["services.database", "ha_glue.services.room_service", "ha_glue.services.output_routing_service"]:
         if mod_name not in sys.modules:
             fake = ModuleType(mod_name)
             sys.modules[mod_name] = fake
@@ -49,8 +49,8 @@ def _patch_resolve_deps(mock_room_service, mock_routing_service=None):
     # top of the try block, even if the code returns before using them all.
     patches = [
         patch("services.database.AsyncSessionLocal", mock_session, create=True),
-        patch("services.room_service.RoomService", return_value=mock_room_service, create=True),
-        patch("services.output_routing_service.OutputRoutingService",
+        patch("ha_glue.services.room_service.RoomService", return_value=mock_room_service, create=True),
+        patch("ha_glue.services.output_routing_service.OutputRoutingService",
               return_value=mock_routing_service or MagicMock(), create=True),
     ]
 
@@ -334,7 +334,7 @@ class TestPlayInRoom:
         mock_ha_client.call_service = AsyncMock(return_value=True)
 
         with patch.object(internal_tools, "_resolve_room_player", new_callable=AsyncMock, return_value=resolve_result), \
-             patch("integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client):
+             patch("ha_glue.integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client):
             result = await internal_tools._play_in_room({
                 "media_url": "http://jellyfin:8096/Audio/abc123/universal",
                 "room_name": "Arbeitszimmer",
@@ -392,7 +392,7 @@ class TestPlayInRoom:
         mock_ha_client.call_service = AsyncMock(return_value=False)
 
         with patch.object(internal_tools, "_resolve_room_player", new_callable=AsyncMock, return_value=resolve_result), \
-             patch("integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client):
+             patch("ha_glue.integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client):
             result = await internal_tools._play_in_room({
                 "media_url": "http://jellyfin:8096/Audio/abc123/universal",
                 "room_name": "Arbeitszimmer",
@@ -419,7 +419,7 @@ class TestPlayInRoom:
         mock_ha_client.call_service = AsyncMock(side_effect=ConnectionError("HA unreachable"))
 
         with patch.object(internal_tools, "_resolve_room_player", new_callable=AsyncMock, return_value=resolve_result), \
-             patch("integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client):
+             patch("ha_glue.integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client):
             result = await internal_tools._play_in_room({
                 "media_url": "http://jellyfin:8096/Audio/abc123/universal",
                 "room_name": "Arbeitszimmer",
@@ -491,7 +491,7 @@ class TestPlayInRoom:
 
         with patch.object(internal_tools, "_resolve_room_player",
                           new_callable=AsyncMock, return_value=busy_result), \
-             patch("integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client):
+             patch("ha_glue.integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client):
             result = await internal_tools._play_in_room({
                 "media_url": "http://jellyfin:8096/Audio/abc/universal",
                 "room_name": "Arbeitszimmer",
@@ -520,7 +520,7 @@ class TestPlayInRoom:
         mock_ha_client.call_service = AsyncMock(return_value=True)
 
         with patch.object(internal_tools, "_resolve_room_player", new_callable=AsyncMock, return_value=resolve_result), \
-             patch("integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client):
+             patch("ha_glue.integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client):
             result = await internal_tools._play_in_room({
                 "media_url": "http://example.com/playlist.m3u",
                 "room_name": "Wohnzimmer",
@@ -560,7 +560,7 @@ class TestPlayInRoom:
         )
 
         with patch.object(internal_tools, "_resolve_room_player", new_callable=AsyncMock, return_value=resolve_result), \
-             patch("integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client), \
+             patch("ha_glue.integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client), \
              patch("asyncio.sleep", new_callable=AsyncMock):
             result = await internal_tools._play_in_room({
                 "media_url": static_url,
@@ -595,7 +595,7 @@ class TestPlayInRoom:
         mock_ha_client.get_state = AsyncMock(return_value={"state": "playing"})
 
         with patch.object(internal_tools, "_resolve_room_player", new_callable=AsyncMock, return_value=resolve_result), \
-             patch("integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client), \
+             patch("ha_glue.integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client), \
              patch("asyncio.sleep", new_callable=AsyncMock):
             result = await internal_tools._play_in_room({
                 "media_url": "http://jellyfin:8096/Audio/abc123/stream?static=true&api_key=k",
@@ -629,7 +629,7 @@ class TestPlayInRoom:
         mock_ha_client.get_state = AsyncMock(return_value={"state": "playing"})
 
         with patch.object(internal_tools, "_resolve_room_player", new_callable=AsyncMock, return_value=resolve_result), \
-             patch("integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client), \
+             patch("ha_glue.integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client), \
              patch("asyncio.sleep", new_callable=AsyncMock):
             result = await internal_tools._play_in_room({
                 "media_url": "http://jellyfin:8096/Audio/abc123/stream?static=true&api_key=k",
@@ -660,7 +660,7 @@ class TestPlayInRoom:
         mock_ha_client.get_state = AsyncMock(return_value={"state": "idle"})
 
         with patch.object(internal_tools, "_resolve_room_player", new_callable=AsyncMock, return_value=resolve_result), \
-             patch("integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client), \
+             patch("ha_glue.integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client), \
              patch("asyncio.sleep", new_callable=AsyncMock):
             result = await internal_tools._play_in_room({
                 "media_url": "http://example.com/audio.mp3",
@@ -743,7 +743,7 @@ class TestGetUserLocation:
     @pytest.mark.unit
     async def test_user_found_in_room(self, internal_tools):
         """User with active presence returns room info."""
-        from services.presence_service import UserPresence
+        from ha_glue.services.presence_service import UserPresence
         import time
 
         mock_presence_service = MagicMock()
@@ -757,7 +757,7 @@ class TestGetUserLocation:
             last_seen=time.time() - 30,
         )
 
-        with patch("services.presence_service.get_presence_service", return_value=mock_presence_service):
+        with patch("ha_glue.services.presence_service.get_presence_service", return_value=mock_presence_service):
             result = await internal_tools._get_user_location({"user_name": "Edi"})
 
         assert result["success"] is True
@@ -775,7 +775,7 @@ class TestGetUserLocation:
         mock_presence_service.get_display_name.return_value = "eve"
         mock_presence_service.get_user_presence.return_value = None
 
-        with patch("services.presence_service.get_presence_service", return_value=mock_presence_service):
+        with patch("ha_glue.services.presence_service.get_presence_service", return_value=mock_presence_service):
             result = await internal_tools._get_user_location({"user_name": "eve"})
 
         assert result["success"] is True
@@ -787,7 +787,7 @@ class TestGetUserLocation:
         mock_presence_service = MagicMock()
         mock_presence_service.find_user_by_name.return_value = None
 
-        with patch("services.presence_service.get_presence_service", return_value=mock_presence_service):
+        with patch("ha_glue.services.presence_service.get_presence_service", return_value=mock_presence_service):
             result = await internal_tools._get_user_location({"user_name": "nobody"})
 
         assert result["success"] is False
@@ -818,7 +818,7 @@ class TestGetAllPresence:
     @pytest.mark.unit
     async def test_users_present(self, internal_tools):
         """Returns all currently present users."""
-        from services.presence_service import UserPresence
+        from ha_glue.services.presence_service import UserPresence
         import time
 
         now = time.time()
@@ -829,7 +829,7 @@ class TestGetAllPresence:
         }
         mock_presence_service.get_display_name.side_effect = lambda uid: {1: "Edi", 2: "Alice"}[uid]
 
-        with patch("services.presence_service.get_presence_service", return_value=mock_presence_service):
+        with patch("ha_glue.services.presence_service.get_presence_service", return_value=mock_presence_service):
             result = await internal_tools._get_all_presence({})
 
         assert result["success"] is True
@@ -844,7 +844,7 @@ class TestGetAllPresence:
         mock_presence_service = MagicMock()
         mock_presence_service.get_all_presence.return_value = {}
 
-        with patch("services.presence_service.get_presence_service", return_value=mock_presence_service):
+        with patch("ha_glue.services.presence_service.get_presence_service", return_value=mock_presence_service):
             result = await internal_tools._get_all_presence({})
 
         assert result["success"] is True
@@ -1043,7 +1043,7 @@ class TestMediaControl:
 
         with patch.object(internal_tools, "_resolve_room_player",
                           new_callable=AsyncMock, return_value=resolve_result), \
-             patch("integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client):
+             patch("ha_glue.integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client):
             result = await internal_tools._media_control({
                 "action": "stop",
                 "room_name": "Arbeitszimmer",
@@ -1077,7 +1077,7 @@ class TestMediaControl:
 
         with patch.object(internal_tools, "_resolve_room_player",
                           new_callable=AsyncMock, return_value=resolve_result), \
-             patch("integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client):
+             patch("ha_glue.integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client):
             result = await internal_tools._media_control({
                 "action": "pause",
                 "room_name": "Wohnzimmer",
@@ -1110,7 +1110,7 @@ class TestMediaControl:
 
         with patch.object(internal_tools, "_resolve_room_player",
                           new_callable=AsyncMock, return_value=resolve_result), \
-             patch("integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client):
+             patch("ha_glue.integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client):
             result = await internal_tools._media_control({
                 "action": "resume",
                 "room_name": "Küche",
@@ -1143,7 +1143,7 @@ class TestMediaControl:
 
         with patch.object(internal_tools, "_resolve_room_player",
                           new_callable=AsyncMock, return_value=resolve_result), \
-             patch("integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client):
+             patch("ha_glue.integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client):
             result = await internal_tools._media_control({
                 "action": "next",
                 "room_name": "Arbeitszimmer",
@@ -1176,7 +1176,7 @@ class TestMediaControl:
 
         with patch.object(internal_tools, "_resolve_room_player",
                           new_callable=AsyncMock, return_value=resolve_result), \
-             patch("integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client):
+             patch("ha_glue.integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client):
             result = await internal_tools._media_control({
                 "action": "previous",
                 "room_name": "Arbeitszimmer",
@@ -1254,7 +1254,7 @@ class TestMediaControl:
 
         with patch.object(internal_tools, "_resolve_room_player",
                           new_callable=AsyncMock, return_value=resolve_result), \
-             patch("integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client):
+             patch("ha_glue.integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client):
             result = await internal_tools._media_control({
                 "action": "stop",
                 "room_name": "Arbeitszimmer",
@@ -1501,7 +1501,7 @@ class TestMediaControl:
 
         with patch.object(internal_tools, "_resolve_room_player",
                           new_callable=AsyncMock, return_value=resolve_result), \
-             patch("integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client):
+             patch("ha_glue.integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client):
             result = await internal_tools._media_control({
                 "action": "volume",
                 "room_name": "Wohnzimmer",
@@ -1629,7 +1629,7 @@ class TestMediaControl:
 
         with patch.object(internal_tools, "_resolve_room_player",
                           new_callable=AsyncMock, return_value=resolve_result), \
-             patch("integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client):
+             patch("ha_glue.integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client):
             result = await internal_tools._media_control({
                 "action": "volume",
                 "room_name": "Wohnzimmer",

--- a/tests/backend/test_media_follow_service.py
+++ b/tests/backend/test_media_follow_service.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from services.media_follow_service import (
+from ha_glue.services.media_follow_service import (
     MediaFollowService,
     MediaSession,
     MediaType,
@@ -190,7 +190,7 @@ class TestOnUserEnterRoom:
 
         mock_resume = AsyncMock()
         with patch.object(playing_session, "_resume_playback", mock_resume), \
-             patch("services.media_follow_service.settings") as mock_settings:
+             patch("ha_glue.services.media_follow_service.settings") as mock_settings:
             mock_settings.media_follow_suspend_timeout = 600.0
             mock_settings.media_follow_resume_delay = 0  # no delay in tests
             await playing_session.on_user_enter_room(
@@ -217,7 +217,7 @@ class TestOnUserEnterRoom:
 
         mock_resume = AsyncMock()
         with patch.object(playing_session, "_resume_playback", mock_resume), \
-             patch("services.media_follow_service.settings") as mock_settings:
+             patch("ha_glue.services.media_follow_service.settings") as mock_settings:
             mock_settings.media_follow_suspend_timeout = 600.0
             mock_settings.media_follow_resume_delay = 0
             await playing_session.on_user_enter_room(
@@ -327,7 +327,7 @@ class TestConflictDuringEnter:
         with patch.object(service, "_resume_playback", mock_resume), \
              patch.object(service, "_stop_playback", mock_stop), \
              patch.object(service, "_resolve_conflict", return_value=1), \
-             patch("services.media_follow_service.settings") as mock_settings:
+             patch("ha_glue.services.media_follow_service.settings") as mock_settings:
             mock_settings.media_follow_suspend_timeout = 600.0
             mock_settings.media_follow_resume_delay = 0
             await service.on_user_enter_room(
@@ -361,7 +361,7 @@ class TestConflictDuringEnter:
         mock_resume = AsyncMock()
         with patch.object(service, "_resume_playback", mock_resume), \
              patch.object(service, "_resolve_conflict", return_value=2), \
-             patch("services.media_follow_service.settings") as mock_settings:
+             patch("ha_glue.services.media_follow_service.settings") as mock_settings:
             mock_settings.media_follow_suspend_timeout = 600.0
             mock_settings.media_follow_resume_delay = 0
             await service.on_user_enter_room(
@@ -415,7 +415,7 @@ class TestSessionExpiry:
         session.state = SessionState.SUSPENDED
         session.suspended_at = time.time() - 700
 
-        with patch("services.media_follow_service.settings") as mock_settings:
+        with patch("ha_glue.services.media_follow_service.settings") as mock_settings:
             mock_settings.media_follow_suspend_timeout = 600.0
             service._cleanup_expired_sessions()
 
@@ -430,7 +430,7 @@ class TestSessionExpiry:
         session.state = SessionState.SUSPENDED
         session.suspended_at = time.time() - 100  # Not expired
 
-        with patch("services.media_follow_service.settings") as mock_settings:
+        with patch("ha_glue.services.media_follow_service.settings") as mock_settings:
             mock_settings.media_follow_suspend_timeout = 600.0
             service._cleanup_expired_sessions()
 
@@ -438,7 +438,7 @@ class TestSessionExpiry:
 
     def test_cleanup_keeps_playing_sessions(self, playing_session):
         """Playing sessions should never be cleaned up."""
-        with patch("services.media_follow_service.settings") as mock_settings:
+        with patch("ha_glue.services.media_follow_service.settings") as mock_settings:
             mock_settings.media_follow_suspend_timeout = 600.0
             playing_session._cleanup_expired_sessions()
 
@@ -507,7 +507,7 @@ class TestResumeVideoPlayback:
         session.suspended_at = time.time()
 
         mock_result = {"success": True, "message": "Playing"}
-        with patch("services.media_follow_service.settings") as mock_settings, \
+        with patch("ha_glue.services.media_follow_service.settings") as mock_settings, \
              patch("services.internal_tools.InternalToolService._play_video_on_dlna",
                    new_callable=AsyncMock, return_value=mock_result) as mock_play:
             mock_settings.media_follow_resume_delay = 0

--- a/tests/backend/test_memory_cleanup.py
+++ b/tests/backend/test_memory_cleanup.py
@@ -134,7 +134,7 @@ def _mock_lifecycle_modules():
     """Context manager to mock heavy dependencies for lifecycle import."""
     mocks = {
         "services.database": MagicMock(),
-        "services.device_manager": MagicMock(),
+        "ha_glue.services.device_manager": MagicMock(),
         "services.ollama_service": MagicMock(),
         "services.task_queue": MagicMock(),
         "redis": MagicMock(),

--- a/tests/backend/test_notification_privacy.py
+++ b/tests/backend/test_notification_privacy.py
@@ -1,14 +1,23 @@
 """
-Tests for privacy-aware TTS gating (should_play_tts).
+Tests for privacy-aware TTS gating (ha_should_play_tts_for_notification).
 
 Tests cover all privacy levels, presence states, and edge cases.
+
+After Phase 1 W2, this module moved from `services.notification_privacy`
+to `ha_glue.services.notification_privacy`. The function was renamed from
+`should_play_tts` to `ha_should_play_tts_for_notification` and its
+signature changed: keyword-only args and the database session is opened
+internally (not passed in) so the hook call site doesn't need to carry
+a session across the hook boundary.
 """
 
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from services.notification_privacy import should_play_tts
+from ha_glue.services.notification_privacy import ha_should_play_tts_for_notification
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -44,8 +53,19 @@ def _mock_db_returning_users(users: list):
     return db
 
 
-PATCH_SETTINGS = "services.notification_privacy.settings"
-PATCH_PRESENCE = "services.presence_service.get_presence_service"
+def _patch_session_local(db):
+    """Return a patch() for services.database.AsyncSessionLocal yielding `db`."""
+
+    @asynccontextmanager
+    async def _cm():
+        yield db
+
+    fake_sessionmaker = MagicMock(side_effect=lambda: _cm())
+    return patch("services.database.AsyncSessionLocal", fake_sessionmaker, create=True)
+
+
+PATCH_SETTINGS = "ha_glue.services.notification_privacy.ha_glue_settings"
+PATCH_PRESENCE = "ha_glue.services.presence_service.get_presence_service"
 
 
 # ---------------------------------------------------------------------------
@@ -57,18 +77,20 @@ class TestPublicPrivacy:
     @pytest.mark.asyncio
     async def test_public_always_allowed(self):
         """Public notifications always get TTS."""
-        db = AsyncMock()
-        result = await should_play_tts("public", None, None, db)
+        result = await ha_should_play_tts_for_notification(
+            privacy="public", target_user_id=None, room_id=None
+        )
         assert result is True
 
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_public_allowed_even_without_presence(self):
         """Public TTS works regardless of presence system state."""
-        db = AsyncMock()
         with patch(PATCH_SETTINGS) as mock_settings:
             mock_settings.presence_enabled = False
-            result = await should_play_tts("public", None, None, db)
+            result = await ha_should_play_tts_for_notification(
+                privacy="public", target_user_id=None, room_id=None
+            )
             assert result is True
 
 
@@ -84,11 +106,12 @@ class TestConfidentialPrivacy:
         presence = MagicMock()
         presence.is_user_alone_in_room.return_value = True
 
-        db = AsyncMock()
         with patch(PATCH_SETTINGS) as mock_settings, \
              patch(PATCH_PRESENCE, return_value=presence):
             mock_settings.presence_enabled = True
-            result = await should_play_tts("confidential", 1, 10, db)
+            result = await ha_should_play_tts_for_notification(
+                privacy="confidential", target_user_id=1, room_id=10
+            )
             assert result is True
             presence.is_user_alone_in_room.assert_called_once_with(1)
 
@@ -99,11 +122,12 @@ class TestConfidentialPrivacy:
         presence = MagicMock()
         presence.is_user_alone_in_room.return_value = False
 
-        db = AsyncMock()
         with patch(PATCH_SETTINGS) as mock_settings, \
              patch(PATCH_PRESENCE, return_value=presence):
             mock_settings.presence_enabled = True
-            result = await should_play_tts("confidential", 1, 10, db)
+            result = await ha_should_play_tts_for_notification(
+                privacy="confidential", target_user_id=1, room_id=10
+            )
             assert result is False
 
     @pytest.mark.unit
@@ -113,22 +137,24 @@ class TestConfidentialPrivacy:
         presence = MagicMock()
         presence.is_user_alone_in_room.return_value = None  # not tracked
 
-        db = AsyncMock()
         with patch(PATCH_SETTINGS) as mock_settings, \
              patch(PATCH_PRESENCE, return_value=presence):
             mock_settings.presence_enabled = True
-            result = await should_play_tts("confidential", 1, 10, db)
+            result = await ha_should_play_tts_for_notification(
+                privacy="confidential", target_user_id=1, room_id=10
+            )
             assert result is False
 
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_confidential_no_target_user(self):
         """Confidential TTS suppressed when no target_user_id specified."""
-        db = AsyncMock()
         with patch(PATCH_SETTINGS) as mock_settings, \
              patch(PATCH_PRESENCE):
             mock_settings.presence_enabled = True
-            result = await should_play_tts("confidential", None, 10, db)
+            result = await ha_should_play_tts_for_notification(
+                privacy="confidential", target_user_id=None, room_id=10
+            )
             assert result is False
 
     @pytest.mark.unit
@@ -138,11 +164,12 @@ class TestConfidentialPrivacy:
         presence = MagicMock()
         presence.is_user_alone_in_room.return_value = False
 
-        db = AsyncMock()
         with patch(PATCH_SETTINGS) as mock_settings, \
              patch(PATCH_PRESENCE, return_value=presence):
             mock_settings.presence_enabled = True
-            result = await should_play_tts("confidential", 1, 10, db)
+            result = await ha_should_play_tts_for_notification(
+                privacy="confidential", target_user_id=1, room_id=10
+            )
             assert result is False
 
 
@@ -164,10 +191,13 @@ class TestPersonalPrivacy:
         db = _mock_db_returning_users(users)
 
         with patch(PATCH_SETTINGS) as mock_settings, \
-             patch(PATCH_PRESENCE, return_value=presence):
+             patch(PATCH_PRESENCE, return_value=presence), \
+             _patch_session_local(db):
             mock_settings.presence_enabled = True
             mock_settings.presence_household_roles = "Admin,Familie"
-            result = await should_play_tts("personal", None, 10, db)
+            result = await ha_should_play_tts_for_notification(
+                privacy="personal", target_user_id=None, room_id=10
+            )
             assert result is True
 
     @pytest.mark.unit
@@ -183,10 +213,13 @@ class TestPersonalPrivacy:
         db = _mock_db_returning_users(users)
 
         with patch(PATCH_SETTINGS) as mock_settings, \
-             patch(PATCH_PRESENCE, return_value=presence):
+             patch(PATCH_PRESENCE, return_value=presence), \
+             _patch_session_local(db):
             mock_settings.presence_enabled = True
             mock_settings.presence_household_roles = "Admin,Familie"
-            result = await should_play_tts("personal", None, 10, db)
+            result = await ha_should_play_tts_for_notification(
+                privacy="personal", target_user_id=None, room_id=10
+            )
             assert result is False
 
     @pytest.mark.unit
@@ -196,22 +229,24 @@ class TestPersonalPrivacy:
         presence = MagicMock()
         presence.get_room_occupants.return_value = []
 
-        db = AsyncMock()
         with patch(PATCH_SETTINGS) as mock_settings, \
              patch(PATCH_PRESENCE, return_value=presence):
             mock_settings.presence_enabled = True
-            result = await should_play_tts("personal", None, 10, db)
+            result = await ha_should_play_tts_for_notification(
+                privacy="personal", target_user_id=None, room_id=10
+            )
             assert result is False
 
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_personal_no_room(self):
         """Personal TTS suppressed when no room_id is provided."""
-        db = AsyncMock()
         with patch(PATCH_SETTINGS) as mock_settings, \
              patch(PATCH_PRESENCE):
             mock_settings.presence_enabled = True
-            result = await should_play_tts("personal", None, None, db)
+            result = await ha_should_play_tts_for_notification(
+                privacy="personal", target_user_id=None, room_id=None
+            )
             assert result is False
 
 
@@ -224,11 +259,14 @@ class TestPresenceDisabled:
     @pytest.mark.asyncio
     async def test_presence_disabled_blocks_nonpublic(self):
         """When presence is disabled, non-public notifications don't get TTS."""
-        db = AsyncMock()
         with patch(PATCH_SETTINGS) as mock_settings:
             mock_settings.presence_enabled = False
-            assert await should_play_tts("personal", None, 10, db) is False
-            assert await should_play_tts("confidential", 1, 10, db) is False
+            assert await ha_should_play_tts_for_notification(
+                privacy="personal", target_user_id=None, room_id=10
+            ) is False
+            assert await ha_should_play_tts_for_notification(
+                privacy="confidential", target_user_id=1, room_id=10
+            ) is False
 
 
 # ---------------------------------------------------------------------------
@@ -240,9 +278,10 @@ class TestUnknownPrivacy:
     @pytest.mark.asyncio
     async def test_unknown_privacy_level_denied(self):
         """Unknown privacy levels are denied (fail-safe)."""
-        db = AsyncMock()
         with patch(PATCH_SETTINGS) as mock_settings, \
              patch(PATCH_PRESENCE):
             mock_settings.presence_enabled = True
-            result = await should_play_tts("secret", None, 10, db)
+            result = await ha_should_play_tts_for_notification(
+                privacy="secret", target_user_id=None, room_id=10
+            )
             assert result is False

--- a/tests/backend/test_notifications.py
+++ b/tests/backend/test_notifications.py
@@ -933,14 +933,13 @@ class TestPrivacyTtsGating:
         notification.room_id = 10
         notification.id = 99
 
-        with patch("services.notification_privacy.should_play_tts", new_callable=AsyncMock) as mock_gate:
+        with patch("ha_glue.services.notification_privacy.ha_should_play_tts_for_notification", new_callable=AsyncMock) as mock_gate:
             mock_gate.return_value = False
-            from services.notification_privacy import should_play_tts
-            result = await should_play_tts(
+            from ha_glue.services.notification_privacy import ha_should_play_tts_for_notification
+            result = await ha_should_play_tts_for_notification(
                 privacy=notification.privacy,
                 target_user_id=notification.target_user_id,
                 room_id=notification.room_id,
-                db=AsyncMock(),
             )
             assert result is False
 

--- a/tests/backend/test_output_routing_service.py
+++ b/tests/backend/test_output_routing_service.py
@@ -20,7 +20,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from services.output_routing_service import (
+from ha_glue.services.output_routing_service import (
     DeviceAvailability,
     OutputDecision,
     OutputRoutingService,
@@ -74,7 +74,7 @@ def mock_ha_client():
 
 @pytest.fixture
 def service(mock_db_session, mock_ha_client):
-    with patch("services.output_routing_service.HomeAssistantClient", return_value=mock_ha_client):
+    with patch("ha_glue.services.output_routing_service.HomeAssistantClient", return_value=mock_ha_client):
         svc = OutputRoutingService(mock_db_session)
     return svc
 
@@ -316,7 +316,7 @@ class TestDeviceAvailabilityChecks:
 
     @pytest.mark.asyncio
     async def test_renfield_device_idle_is_available(self, service):
-        from services.device_manager import DeviceState
+        from ha_glue.services.device_manager import DeviceState
         mock_device = MagicMock()
         mock_device.capabilities.has_speaker = True
         mock_device.state = DeviceState.IDLE
@@ -324,14 +324,14 @@ class TestDeviceAvailabilityChecks:
         mock_dm = MagicMock()
         mock_dm.get_device.return_value = mock_device
 
-        with patch("services.device_manager.get_device_manager", return_value=mock_dm):
+        with patch("ha_glue.services.device_manager.get_device_manager", return_value=mock_dm):
             result = await service._check_renfield_device_availability("sat-kitchen")
 
         assert result == DeviceAvailability.AVAILABLE
 
     @pytest.mark.asyncio
     async def test_renfield_device_speaking_is_busy(self, service):
-        from services.device_manager import DeviceState
+        from ha_glue.services.device_manager import DeviceState
         mock_device = MagicMock()
         mock_device.capabilities.has_speaker = True
         mock_device.state = DeviceState.SPEAKING
@@ -339,7 +339,7 @@ class TestDeviceAvailabilityChecks:
         mock_dm = MagicMock()
         mock_dm.get_device.return_value = mock_device
 
-        with patch("services.device_manager.get_device_manager", return_value=mock_dm):
+        with patch("ha_glue.services.device_manager.get_device_manager", return_value=mock_dm):
             result = await service._check_renfield_device_availability("sat-kitchen")
 
         assert result == DeviceAvailability.BUSY
@@ -349,7 +349,7 @@ class TestDeviceAvailabilityChecks:
         mock_dm = MagicMock()
         mock_dm.get_device.return_value = None
 
-        with patch("services.device_manager.get_device_manager", return_value=mock_dm):
+        with patch("ha_glue.services.device_manager.get_device_manager", return_value=mock_dm):
             result = await service._check_renfield_device_availability("sat-kitchen")
 
         assert result == DeviceAvailability.UNAVAILABLE
@@ -362,7 +362,7 @@ class TestDeviceAvailabilityChecks:
         mock_dm = MagicMock()
         mock_dm.get_device.return_value = mock_device
 
-        with patch("services.device_manager.get_device_manager", return_value=mock_dm):
+        with patch("ha_glue.services.device_manager.get_device_manager", return_value=mock_dm):
             result = await service._check_renfield_device_availability("sat-kitchen")
 
         assert result == DeviceAvailability.UNAVAILABLE

--- a/tests/backend/test_paperless_audit.py
+++ b/tests/backend/test_paperless_audit.py
@@ -23,7 +23,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from services.paperless_audit_service import PaperlessAuditService
+from ha_glue.services.paperless_audit_service import PaperlessAuditService
 
 
 # ============================================================================
@@ -947,7 +947,7 @@ class TestRunAudit:
         with patch.object(service, "_fetch_all_doc_ids", new_callable=AsyncMock) as mock_fetch, \
              patch.object(service, "_fetch_available_metadata", new_callable=AsyncMock) as mock_meta, \
              patch.object(service, "_analyze_document", new_callable=AsyncMock) as mock_analyze, \
-             patch("services.paperless_audit_service.settings") as mock_settings:
+             patch("ha_glue.services.paperless_audit_service.settings") as mock_settings:
 
             mock_settings.paperless_audit_fix_mode = "review"
             mock_settings.paperless_audit_confidence_threshold = 0.8
@@ -972,7 +972,7 @@ class TestRunAudit:
         with patch.object(service, "_fetch_all_doc_ids", new_callable=AsyncMock) as mock_fetch, \
              patch.object(service, "_fetch_available_metadata", new_callable=AsyncMock) as mock_meta, \
              patch.object(service, "_analyze_document", new_callable=AsyncMock) as mock_analyze, \
-             patch("services.paperless_audit_service.settings") as mock_settings:
+             patch("ha_glue.services.paperless_audit_service.settings") as mock_settings:
 
             mock_settings.paperless_audit_fix_mode = "review"
             mock_settings.paperless_audit_confidence_threshold = 0.8
@@ -1003,7 +1003,7 @@ class TestRunAudit:
              patch.object(service, "_fetch_available_metadata", new_callable=AsyncMock) as mock_meta, \
              patch.object(service, "_analyze_document", new_callable=AsyncMock) as mock_analyze, \
              patch.object(service, "_apply_fix", new_callable=AsyncMock) as mock_fix, \
-             patch("services.paperless_audit_service.settings") as mock_settings:
+             patch("ha_glue.services.paperless_audit_service.settings") as mock_settings:
 
             mock_settings.paperless_audit_fix_mode = "review"
             mock_settings.paperless_audit_confidence_threshold = 0.8
@@ -1029,7 +1029,7 @@ class TestRunAudit:
              patch.object(service, "_fetch_available_metadata", new_callable=AsyncMock) as mock_meta, \
              patch.object(service, "_analyze_document", new_callable=AsyncMock) as mock_analyze, \
              patch.object(service, "_apply_fix", new_callable=AsyncMock) as mock_fix, \
-             patch("services.paperless_audit_service.settings") as mock_settings:
+             patch("ha_glue.services.paperless_audit_service.settings") as mock_settings:
 
             mock_settings.paperless_audit_fix_mode = "review"
             mock_settings.paperless_audit_confidence_threshold = 0.8
@@ -1055,7 +1055,7 @@ class TestRunAudit:
              patch.object(service, "_fetch_available_metadata", new_callable=AsyncMock) as mock_meta, \
              patch.object(service, "_analyze_document", new_callable=AsyncMock) as mock_analyze, \
              patch.object(service, "_apply_fix", new_callable=AsyncMock) as mock_fix, \
-             patch("services.paperless_audit_service.settings") as mock_settings:
+             patch("ha_glue.services.paperless_audit_service.settings") as mock_settings:
 
             mock_settings.paperless_audit_fix_mode = "review"
             mock_settings.paperless_audit_confidence_threshold = 0.8
@@ -1079,7 +1079,7 @@ class TestRunAudit:
         """_running should be reset to False after audit completes."""
         with patch.object(service, "_fetch_all_doc_ids", new_callable=AsyncMock) as mock_fetch, \
              patch.object(service, "_fetch_available_metadata", new_callable=AsyncMock) as mock_meta, \
-             patch("services.paperless_audit_service.settings") as mock_settings:
+             patch("ha_glue.services.paperless_audit_service.settings") as mock_settings:
 
             mock_settings.paperless_audit_fix_mode = "review"
             mock_settings.paperless_audit_confidence_threshold = 0.8
@@ -1097,7 +1097,7 @@ class TestRunAudit:
         """_running should be reset even if an exception occurs."""
         with patch.object(service, "_fetch_all_doc_ids", new_callable=AsyncMock) as mock_fetch, \
              patch.object(service, "_fetch_available_metadata", new_callable=AsyncMock) as mock_meta, \
-             patch("services.paperless_audit_service.settings") as mock_settings:
+             patch("ha_glue.services.paperless_audit_service.settings") as mock_settings:
 
             mock_settings.paperless_audit_fix_mode = "review"
             mock_settings.paperless_audit_confidence_threshold = 0.8
@@ -1128,7 +1128,7 @@ class TestRunAudit:
         with patch.object(service, "_fetch_all_doc_ids", new_callable=AsyncMock) as mock_fetch, \
              patch.object(service, "_fetch_available_metadata", new_callable=AsyncMock) as mock_meta, \
              patch.object(service, "_analyze_document", side_effect=mock_analyze), \
-             patch("services.paperless_audit_service.settings") as mock_settings:
+             patch("ha_glue.services.paperless_audit_service.settings") as mock_settings:
 
             mock_settings.paperless_audit_fix_mode = "review"
             mock_settings.paperless_audit_confidence_threshold = 0.8

--- a/tests/backend/test_presence_analytics.py
+++ b/tests/backend/test_presence_analytics.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from models.database import PresenceEvent, Role, Room, User
-from services.presence_analytics import (
+from ha_glue.services.presence_analytics import (
     PresenceAnalyticsService,
     _on_enter_room,
 )
@@ -64,7 +64,7 @@ async def _insert_event(db, user_id, room_id, event_type="enter", source="ble",
 class TestHookHandlers:
     async def test_on_enter_room_creates_event(self, db_session):
         """_on_enter_room persists an 'enter' event."""
-        from services.presence_analytics import _persist_event
+        from ha_glue.services.presence_analytics import _persist_event
 
         await _seed_user_and_room(db_session, user_id=1, room_id=10)
 
@@ -93,7 +93,7 @@ class TestHookHandlers:
 
     async def test_on_leave_room_creates_event(self, db_session):
         """_on_leave_room persists a 'leave' event."""
-        from services.presence_analytics import _persist_event
+        from ha_glue.services.presence_analytics import _persist_event
 
         await _seed_user_and_room(db_session, user_id=1, room_id=10)
 

--- a/tests/backend/test_presence_service.py
+++ b/tests/backend/test_presence_service.py
@@ -13,7 +13,7 @@ with patch("utils.config.settings") as mock_settings:
     mock_settings.presence_stale_timeout = 120
     mock_settings.presence_hysteresis_scans = 2
     mock_settings.presence_rssi_threshold = -80
-    from services.presence_service import PresenceService
+    from ha_glue.services.presence_service import PresenceService
 
 
 @pytest.fixture

--- a/tests/backend/test_room_service.py
+++ b/tests/backend/test_room_service.py
@@ -13,7 +13,7 @@ Testet:
 import pytest
 
 from models.database import DEVICE_TYPE_SATELLITE, DEVICE_TYPE_WEB_BROWSER, DEVICE_TYPE_WEB_PANEL, Room, RoomDevice
-from services.room_service import RoomService, generate_device_id, normalize_room_name
+from ha_glue.services.room_service import RoomService, generate_device_id, normalize_room_name
 
 # ============================================================================
 # normalize_room_name Tests

--- a/tests/backend/test_satellites.py
+++ b/tests/backend/test_satellites.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from httpx import AsyncClient
 
-from services.satellite_manager import (
+from ha_glue.services.satellite_manager import (
     SatelliteCapabilities,
     SatelliteInfo,
     SatelliteManager,

--- a/tests/backend/test_voice.py
+++ b/tests/backend/test_voice.py
@@ -231,7 +231,7 @@ class TestTTSCacheAPI:
     @pytest.mark.integration
     async def test_tts_cache_not_found(self, async_client: AsyncClient):
         """Testet GET /api/voice/tts-cache für nicht-existentes Audio"""
-        with patch('services.audio_output_service.get_audio_output_service') as mock_service:
+        with patch('ha_glue.services.audio_output_service.get_audio_output_service') as mock_service:
             mock_instance = MagicMock()
             mock_instance.get_cached_audio.return_value = None
             mock_service.return_value = mock_instance
@@ -245,7 +245,7 @@ class TestTTSCacheAPI:
         """Testet GET /api/voice/tts-cache mit gecachtem Audio"""
         cached_audio = b'RIFF' + b'\x00' * 100
 
-        with patch('services.audio_output_service.get_audio_output_service') as mock_service:
+        with patch('ha_glue.services.audio_output_service.get_audio_output_service') as mock_service:
             mock_instance = MagicMock()
             mock_instance.get_cached_audio.return_value = cached_audio
             mock_service.return_value = mock_instance

--- a/tests/backend/test_zeroconf_service.py
+++ b/tests/backend/test_zeroconf_service.py
@@ -21,7 +21,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from services.zeroconf_service import (
+from ha_glue.services.zeroconf_service import (
     SERVICE_NAME,
     SERVICE_TYPE,
     ZeroconfService,
@@ -91,10 +91,10 @@ class TestStartLifecycle:
         mock_async_zc = MagicMock()
         mock_async_zc.async_register_service = AsyncMock()
 
-        with patch("services.zeroconf_service.ZEROCONF_AVAILABLE", True), \
-             patch("services.zeroconf_service.AsyncZeroconf", return_value=mock_async_zc), \
-             patch("services.zeroconf_service.ServiceInfo"), \
-             patch("services.zeroconf_service.get_advertise_address", return_value=("192.168.1.100", None)):
+        with patch("ha_glue.services.zeroconf_service.ZEROCONF_AVAILABLE", True), \
+             patch("ha_glue.services.zeroconf_service.AsyncZeroconf", return_value=mock_async_zc), \
+             patch("ha_glue.services.zeroconf_service.ServiceInfo"), \
+             patch("ha_glue.services.zeroconf_service.get_advertise_address", return_value=("192.168.1.100", None)):
             svc = ZeroconfService(port=8000)
             await svc.start()
 
@@ -105,7 +105,7 @@ class TestStartLifecycle:
     @pytest.mark.asyncio
     async def test_start_skips_when_not_available(self):
         """start() does nothing when zeroconf is not installed."""
-        with patch("services.zeroconf_service.ZEROCONF_AVAILABLE", False):
+        with patch("ha_glue.services.zeroconf_service.ZEROCONF_AVAILABLE", False):
             svc = ZeroconfService()
             await svc.start()
 
@@ -118,10 +118,10 @@ class TestStartLifecycle:
         mock_async_zc = MagicMock()
         mock_async_zc.async_register_service = AsyncMock()
 
-        with patch("services.zeroconf_service.ZEROCONF_AVAILABLE", True), \
-             patch("services.zeroconf_service.AsyncZeroconf", return_value=mock_async_zc), \
-             patch("services.zeroconf_service.ServiceInfo"), \
-             patch("services.zeroconf_service.get_advertise_address", return_value=("192.168.1.100", None)):
+        with patch("ha_glue.services.zeroconf_service.ZEROCONF_AVAILABLE", True), \
+             patch("ha_glue.services.zeroconf_service.AsyncZeroconf", return_value=mock_async_zc), \
+             patch("ha_glue.services.zeroconf_service.ServiceInfo"), \
+             patch("ha_glue.services.zeroconf_service.get_advertise_address", return_value=("192.168.1.100", None)):
             svc = ZeroconfService()
             await svc.start()
             mock_async_zc.async_register_service.reset_mock()
@@ -134,8 +134,8 @@ class TestStartLifecycle:
     @pytest.mark.asyncio
     async def test_start_handles_exception(self):
         """start() handles errors gracefully without raising."""
-        with patch("services.zeroconf_service.ZEROCONF_AVAILABLE", True), \
-             patch("services.zeroconf_service.get_advertise_address", side_effect=RuntimeError("network error")):
+        with patch("ha_glue.services.zeroconf_service.ZEROCONF_AVAILABLE", True), \
+             patch("ha_glue.services.zeroconf_service.get_advertise_address", side_effect=RuntimeError("network error")):
             svc = ZeroconfService()
             await svc.start()  # Should not raise
 
@@ -148,10 +148,10 @@ class TestStartLifecycle:
         mock_async_zc.async_register_service = AsyncMock()
         mock_service_info = MagicMock()
 
-        with patch("services.zeroconf_service.ZEROCONF_AVAILABLE", True), \
-             patch("services.zeroconf_service.AsyncZeroconf", return_value=mock_async_zc), \
-             patch("services.zeroconf_service.ServiceInfo", return_value=mock_service_info) as mock_si_cls, \
-             patch("services.zeroconf_service.get_advertise_address", return_value=(None, "renfield.local")):
+        with patch("ha_glue.services.zeroconf_service.ZEROCONF_AVAILABLE", True), \
+             patch("ha_glue.services.zeroconf_service.AsyncZeroconf", return_value=mock_async_zc), \
+             patch("ha_glue.services.zeroconf_service.ServiceInfo", return_value=mock_service_info) as mock_si_cls, \
+             patch("ha_glue.services.zeroconf_service.get_advertise_address", return_value=(None, "renfield.local")):
             svc = ZeroconfService(port=8000)
             await svc.start()
 
@@ -176,10 +176,10 @@ class TestStopLifecycle:
         mock_async_zc.async_unregister_service = AsyncMock()
         mock_async_zc.async_close = AsyncMock()
 
-        with patch("services.zeroconf_service.ZEROCONF_AVAILABLE", True), \
-             patch("services.zeroconf_service.AsyncZeroconf", return_value=mock_async_zc), \
-             patch("services.zeroconf_service.ServiceInfo"), \
-             patch("services.zeroconf_service.get_advertise_address", return_value=("192.168.1.100", None)):
+        with patch("ha_glue.services.zeroconf_service.ZEROCONF_AVAILABLE", True), \
+             patch("ha_glue.services.zeroconf_service.AsyncZeroconf", return_value=mock_async_zc), \
+             patch("ha_glue.services.zeroconf_service.ServiceInfo"), \
+             patch("ha_glue.services.zeroconf_service.get_advertise_address", return_value=("192.168.1.100", None)):
             svc = ZeroconfService()
             await svc.start()
             await svc.stop()
@@ -203,10 +203,10 @@ class TestStopLifecycle:
         mock_async_zc.async_unregister_service = AsyncMock(side_effect=RuntimeError("zc error"))
         mock_async_zc.async_close = AsyncMock()
 
-        with patch("services.zeroconf_service.ZEROCONF_AVAILABLE", True), \
-             patch("services.zeroconf_service.AsyncZeroconf", return_value=mock_async_zc), \
-             patch("services.zeroconf_service.ServiceInfo"), \
-             patch("services.zeroconf_service.get_advertise_address", return_value=("192.168.1.100", None)):
+        with patch("ha_glue.services.zeroconf_service.ZEROCONF_AVAILABLE", True), \
+             patch("ha_glue.services.zeroconf_service.AsyncZeroconf", return_value=mock_async_zc), \
+             patch("ha_glue.services.zeroconf_service.ServiceInfo"), \
+             patch("ha_glue.services.zeroconf_service.get_advertise_address", return_value=("192.168.1.100", None)):
             svc = ZeroconfService()
             await svc.start()
             await svc.stop()  # Should not raise
@@ -263,19 +263,19 @@ class TestSingleton:
 
     def test_get_zeroconf_service_returns_instance(self):
         """get_zeroconf_service returns a ZeroconfService."""
-        with patch("services.zeroconf_service._zeroconf_service", None):
+        with patch("ha_glue.services.zeroconf_service._zeroconf_service", None):
             svc = get_zeroconf_service()
         assert isinstance(svc, ZeroconfService)
 
     def test_get_zeroconf_service_uses_port(self):
         """get_zeroconf_service passes port to constructor."""
-        with patch("services.zeroconf_service._zeroconf_service", None):
+        with patch("ha_glue.services.zeroconf_service._zeroconf_service", None):
             svc = get_zeroconf_service(port=9090)
         assert svc.port == 9090
 
     def test_get_zeroconf_service_returns_same_instance(self):
         """get_zeroconf_service returns singleton."""
-        with patch("services.zeroconf_service._zeroconf_service", None):
+        with patch("ha_glue.services.zeroconf_service._zeroconf_service", None):
             svc1 = get_zeroconf_service()
             svc2 = get_zeroconf_service()
         assert svc1 is svc2


### PR DESCRIPTION
## Summary

Phase 1 W4.1 follow-up. After W2 moved 11 services and 2 integrations into `ha_glue/`, 17 test files in `tests/backend/` still imported from the old `services.X` / `integrations.X` paths. They never updated with the moves, so `pytest --collect-only` returned 0 tests with 18 collection errors in the ha-glue test tier.

This was the only **genuine** Phase 1 regression surfaced by the W4.1 test verification. Every other unit-test failure traced to pre-existing debt (test fixtures targeting SQLite for a PG-specific schema, missing local `redis` package, MagicMock/AsyncMock drift from unrelated production changes).

## What moved where

**Services** (11 modules now under `ha_glue.services.*`):

```
notification_privacy, audio_output_service, paperless_audit_service,
presence_analytics, zeroconf_service, output_routing_service,
room_service, media_follow_service, satellite_manager,
presence_service, device_manager
```

**Integrations** (2 modules now under `ha_glue.integrations.*`):

```
homeassistant, frigate
```

`services.database` stays unqualified — it is the platform DB session factory and lives in platform/, not ha_glue/.

## Sweep scope

- Direct `from services.X import Y` imports
- Lazy `import services.X as mod` imports
- `patch("services.X.Y")` / `patch('services.X.Y')` mocks
- `patch.dict(sys.modules, {"services.X": ...})` entries

17 files updated via perl sweep. One file (`test_notification_privacy.py`) needed a hand-written rewrite because the entry-point function was renamed *and* got a new signature — see below.

## `test_notification_privacy.py` — signature change

The module's entry point was renamed from `should_play_tts(privacy, target_user_id, room_id, db)` to `ha_should_play_tts_for_notification(*, privacy, target_user_id, room_id)` as part of the hook signature contract:

1. Renamed symbol reflects its role as a hook handler (`should_play_tts_for_notification` is the hook event name registered in `HOOK_EVENTS`).
2. Keyword-only args protect the call site from positional drift as hook kwargs grow over time.
3. The function now opens its own `AsyncSessionLocal()` via ``async with`` instead of accepting a `db` parameter, so the hook call site in `notification_service.py` doesn't have to carry a session across the hook boundary.

The test file is rewritten to:
- Import `ha_should_play_tts_for_notification` instead of `should_play_tts`.
- Drop the `db` positional argument from all call sites.
- Use keyword args.
- Patch `services.database.AsyncSessionLocal` via a small `_patch_session_local` helper (asynccontextmanager) for the two personal-privacy tests that hit `_all_household_members`.
- Update `PATCH_SETTINGS` to point at `ha_glue_settings` instead of the (now-missing) `settings` binding.

## Verification

```
Before: 0 tests collected, 18 errors
After:  538 tests collected
```

## Test plan

- [x] `python3 -m pytest tests/backend/test_*.py --collect-only -q` — 538 collected, 0 errors
- [x] Injected tests all parse and collect cleanly
- [ ] CI runs full ha-glue test tier and passes in PG/redis-equipped environment

Refs #342 (Phase 1 extraction), closes Phase 1 W4.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)