### PR TITLE
feat(alembic): discover plugin metadata via PLUGIN_METADATA_MODULES (#363)

### DIFF
--- a/src/backend/alembic/env.py
+++ b/src/backend/alembic/env.py
@@ -49,8 +49,11 @@ smart-home tables are EMPTY in the Reva production database. So (a)
 is safe for X-IDRA's single pro deploy.
 """
 import asyncio
+import importlib
+import os
 from logging.config import fileConfig
 
+from loguru import logger
 from sqlalchemy import pool
 from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import async_engine_from_config
@@ -78,6 +81,58 @@ except ImportError:
     # will see only the 22 platform tables in Base.metadata.
     pass
 
+# ---------------------------------------------------------------------------
+# Plugin metadata discovery (X-idra/reva#151)
+# ---------------------------------------------------------------------------
+#
+# Plugins like Reva declare their own SQLAlchemy `Base = declarative_base()`
+# so their tables live on a separate MetaData instance from Renfield's core
+# `Base.metadata`. Without this block, `alembic revision --autogenerate`
+# sees those tables in the live DB but not in `target_metadata`, and emits
+# `drop_table` for every one of them — a latent footgun waiting for the
+# day someone blindly applies that diff.
+#
+# Fix: each plugin can set `PLUGIN_METADATA_MODULES` to a comma-separated
+# list of dotted module paths. Each module is imported for its side effects
+# and, if it exposes a top-level `Base` attribute, that Base's metadata is
+# appended to Alembic's `target_metadata` list. Alembic natively supports
+# multiple MetaData objects via a list.
+#
+# Example (Reva):
+#   PLUGIN_METADATA_MODULES=reva.metadata
+#
+# Reva's `reva.metadata` module imports every Reva model submodule as a
+# side effect and re-exports `reva.core.models.Base`, which owns the full
+# set of reva_* tables.
+#
+# If the env var is unset or the module fails to import, target_metadata
+# stays exactly what it would have been — zero behaviour change for
+# platform-only deploys or deploys without the env var set.
+_plugin_metadatas: list = []
+_plugin_modules_env = os.getenv("PLUGIN_METADATA_MODULES", "")
+for _mod_spec in _plugin_modules_env.split(","):
+    _spec = _mod_spec.strip()
+    if not _spec:
+        continue
+    try:
+        _plugin_mod = importlib.import_module(_spec)
+    except ImportError as _exc:
+        logger.warning(
+            f"alembic/env.py: plugin metadata module {_spec!r} not importable: {_exc}"
+        )
+        continue
+    _plugin_base = getattr(_plugin_mod, "Base", None)
+    if _plugin_base is None:
+        logger.warning(
+            f"alembic/env.py: plugin metadata module {_spec!r} has no top-level 'Base' attribute"
+        )
+        continue
+    _plugin_metadatas.append(_plugin_base.metadata)
+    logger.info(
+        f"alembic/env.py: registered plugin metadata from {_spec} "
+        f"({len(_plugin_base.metadata.tables)} tables)"
+    )
+
 # Alembic Config object
 config = context.config
 
@@ -91,8 +146,12 @@ config.set_main_option(
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-# Model's MetaData object for 'autogenerate' support
-target_metadata = Base.metadata
+# Model's MetaData object(s) for 'autogenerate' support.
+# Alembic accepts a single MetaData or a list of them. When no plugin
+# metadata modules are configured we pass the bare MetaData to preserve
+# the pre-#151 shape; when any are registered we pass a list so each
+# plugin's tables are considered independently.
+target_metadata = [Base.metadata, *_plugin_metadatas] if _plugin_metadatas else Base.metadata
 
 
 def run_migrations_offline() -> None:

--- a/tests/backend/test_alembic_plugin_metadata.py
+++ b/tests/backend/test_alembic_plugin_metadata.py
@@ -1,0 +1,148 @@
+"""
+Tests for `alembic/env.py` plugin metadata discovery (X-idra/reva#151).
+
+The env.py reads `PLUGIN_METADATA_MODULES` at import time and appends
+each plugin's `Base.metadata` to Alembic's `target_metadata` list so
+autogenerate doesn't emit spurious `drop_table` statements for plugin-
+owned tables that live on a separate SQLAlchemy Base.
+
+These tests avoid actually importing `alembic/env.py` (which has
+side effects on Alembic context). Instead they exercise the same
+discovery logic via a small helper that mirrors the env.py block.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import types
+
+import pytest
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import declarative_base
+
+
+def _discover_plugin_metadatas(env_value: str) -> list:
+    """Mirror the env.py discovery logic for unit testing.
+
+    Keep this in lockstep with the corresponding block in `alembic/env.py`.
+    If that block changes shape, update this helper and the tests will
+    still pin the contract.
+    """
+    result: list = []
+    for spec in env_value.split(","):
+        spec = spec.strip()
+        if not spec:
+            continue
+        try:
+            mod = importlib.import_module(spec)
+        except ImportError:
+            continue
+        plugin_base = getattr(mod, "Base", None)
+        if plugin_base is None:
+            continue
+        result.append(plugin_base.metadata)
+    return result
+
+
+@pytest.fixture
+def _fake_plugin_module(request):
+    """Install a fake plugin module in sys.modules and yield its dotted name."""
+    mod_name = f"test_fake_plugin_{os.getpid()}_{id(request)}"
+    mod = types.ModuleType(mod_name)
+
+    FakeBase = declarative_base()
+
+    class FakeTable(FakeBase):
+        __tablename__ = "reva_fake_plugin_test_table"
+        id = Column(Integer, primary_key=True)
+        name = Column(String)
+
+    mod.Base = FakeBase
+    sys.modules[mod_name] = mod
+
+    yield mod_name
+
+    sys.modules.pop(mod_name, None)
+
+
+def test_empty_env_var_returns_no_plugins():
+    """No PLUGIN_METADATA_MODULES → empty list."""
+    assert _discover_plugin_metadatas("") == []
+
+
+def test_whitespace_only_entries_are_ignored():
+    """`,,, ,,` expands to nothing."""
+    assert _discover_plugin_metadatas(",, ,, ") == []
+
+
+def test_nonexistent_module_is_ignored_silently():
+    """ImportError → skipped, not raised. Platform-only deploy compat."""
+    metadatas = _discover_plugin_metadatas("definitely.not.a.real.module")
+    assert metadatas == []
+
+
+def test_module_without_base_attribute_is_skipped(monkeypatch):
+    """A module that imports successfully but has no `Base` is not added."""
+    mod_name = f"test_no_base_plugin_{os.getpid()}"
+    mod = types.ModuleType(mod_name)
+    sys.modules[mod_name] = mod
+    try:
+        assert _discover_plugin_metadatas(mod_name) == []
+    finally:
+        sys.modules.pop(mod_name, None)
+
+
+def test_single_plugin_module_is_registered(_fake_plugin_module):
+    """A well-formed plugin module gets its MetaData added."""
+    metadatas = _discover_plugin_metadatas(_fake_plugin_module)
+    assert len(metadatas) == 1
+    tables = set(metadatas[0].tables.keys())
+    assert "reva_fake_plugin_test_table" in tables
+
+
+def test_multiple_plugin_modules_are_all_registered(_fake_plugin_module):
+    """Comma-separated list, first entry good, second entry broken."""
+    env = f"{_fake_plugin_module}, definitely.not.real"
+    metadatas = _discover_plugin_metadatas(env)
+    # Broken one is silently skipped, good one is kept.
+    assert len(metadatas) == 1
+    tables = set(metadatas[0].tables.keys())
+    assert "reva_fake_plugin_test_table" in tables
+
+
+def test_target_metadata_shape_matches_env_py_contract(_fake_plugin_module):
+    """When plugin metadatas are present, env.py builds a list.
+
+    When none are present, env.py passes a bare MetaData. Alembic
+    accepts both shapes; we just pin the contract so the env.py block
+    doesn't regress to always-list or always-scalar.
+    """
+    # Bare platform
+    target_empty = _compute_target_metadata([], _platform_metadata())
+    assert not isinstance(target_empty, list)
+
+    # With one plugin
+    plugin_mds = _discover_plugin_metadatas(_fake_plugin_module)
+    target_with_plugin = _compute_target_metadata(plugin_mds, _platform_metadata())
+    assert isinstance(target_with_plugin, list)
+    assert len(target_with_plugin) == 2
+
+
+# ----- shape helpers (mirror env.py) ---------------------------------------
+
+
+def _platform_metadata():
+    FakeBase = declarative_base()
+
+    class PlatformTable(FakeBase):
+        __tablename__ = "platform_test_table"
+        id = Column(Integer, primary_key=True)
+
+    return FakeBase.metadata
+
+
+def _compute_target_metadata(plugin_metadatas: list, platform_metadata):
+    """Mirror the `target_metadata = ...` line at the bottom of env.py."""
+    return [platform_metadata, *plugin_metadatas] if plugin_metadatas else platform_metadata


### PR DESCRIPTION
## Summary

Fixes the latent footgun filed as [X-idra-Systems-GmbH/reva#151](https://github.com/X-idra-Systems-GmbH/reva/issues/151). Plugins like Reva declare their own SQLAlchemy `declarative_base()` so plugin tables live on a separate `MetaData` instance from Renfield's core `Base.metadata`. Without this block, `alembic revision --autogenerate` sees those tables in the live DB but not in `target_metadata`, and emits `drop_table` for every one of them.

During Phase 1 W3 verification, a `compare_metadata` run on Reva prod surfaced 29 spurious diffs — all `reva_*` tables (reva_user_projections, reva_subscriptions, reva_routing_log, reva_channel_references, reva_user_references, reva_kpi_daily_users, reva_canonical_users, reva_user_audit_log, reva_kpi_evaluations, plus their indexes). Empty tables, yes, but still a wrong diff that could silently merge and drop Reva's data layer.

## Mechanism

Alembic's `target_metadata` natively accepts a list of MetaData instances. We use a new env var `PLUGIN_METADATA_MODULES` to let plugins hook into the autogenerate diff without Renfield having any hardcoded plugin knowledge.

```python
_plugin_metadatas: list = []
for _mod_spec in os.getenv("PLUGIN_METADATA_MODULES", "").split(","):
    _spec = _mod_spec.strip()
    if not _spec:
        continue
    try:
        _plugin_mod = importlib.import_module(_spec)
    except ImportError:
        continue
    _plugin_base = getattr(_plugin_mod, "Base", None)
    if _plugin_base is not None:
        _plugin_metadatas.append(_plugin_base.metadata)

target_metadata = (
    [Base.metadata, *_plugin_metadatas]
    if _plugin_metadatas
    else Base.metadata
)
```

Format: comma-separated dotted module paths. Each module is imported for its side effects; if it exposes a top-level `Base` attribute, that Base's metadata is appended to the target list.

**Zero behaviour change** for deploys that don't set the env var. The `target_metadata` stays the same scalar `Base.metadata` it was before. Pure-additive contract.

## Reva-side follow-up

This PR does not change Reva. Reva will add `src/reva/metadata.py` (a single-file entry point that imports every Reva model submodule for side-effect registration and re-exports `reva.core.models.Base`) and set `PLUGIN_METADATA_MODULES=reva.metadata` in the Reva K8s `reva-env` ConfigMap. That lands in a separate Reva PR after this one ships.

## Tests

`tests/backend/test_alembic_plugin_metadata.py` — 7 tests:

- Empty env var → empty list (platform default)
- Whitespace-only entries ignored
- Nonexistent module silently skipped (X-idra/renfield compat path)
- Module without top-level `Base` is skipped
- Single well-formed plugin module registers its MetaData
- Comma-separated list with one broken entry keeps the good one
- `target_metadata` shape contract: scalar when empty, list when any plugin is present

All passing.

## Does not solve

This PR fixes autogenerate SEEING the plugin tables. It does NOT migrate Reva to use alembic as its table lifecycle manager — Reva still does `RevaBase.metadata.create_all()` at startup. Those two things are independent concerns. A future Reva PR can generate an initial alembic migration from the existing schema and stop using create_all, but that's out of scope here.

## Test plan

- [x] `python3 -m pytest tests/backend/test_alembic_plugin_metadata.py -v` → 7 passed
- [ ] Deploy to Reva prod with `PLUGIN_METADATA_MODULES=reva.metadata` set, rerun `compare_metadata` — expect the 29 spurious `reva_*` diffs to disappear

Refs X-idra-Systems-GmbH/reva#151

🤖 Generated with [Claude Code](https://claude.com/claude-code)