### PR TITLE
fix(ws-auth): accept JWT access tokens on /ws

### DIFF
--- a/src/backend/services/websocket_auth.py
+++ b/src/backend/services/websocket_auth.py
@@ -141,6 +141,31 @@ async def authenticate_websocket(
     if not token:
         return None
 
+    # Strategy 1: Try JWT validation (web chat users authenticated via
+    # /api/auth/login). The React frontend reads `renfield_access_token`
+    # from localStorage and appends it directly to the WS URL as
+    # `?token=<JWT>`. Before this branch existed, the backend only
+    # accepted device tokens (from WSTokenStore) and rejected every
+    # web chat connection with 403.
+    try:
+        from services.auth_service import decode_token
+
+        payload = decode_token(token)
+        if payload and payload.get("type") == "access":
+            user_id = payload.get("sub")
+            logger.debug(f"WebSocket authenticated via JWT: user_id={user_id}")
+            return {
+                "authenticated": True,
+                "user_id": user_id,
+                "auth_method": "jwt",
+            }
+    except Exception:
+        # Not a valid JWT — fall through to device-token validation.
+        pass
+
+    # Strategy 2: Device token (satellites, devices) — the original
+    # flow. Used by hardware satellites that fetch a short-lived token
+    # via POST /api/ws/token at boot time.
     store = get_token_store()
     token_data = store.validate_token(token)
 

--- a/tests/backend/test_websocket.py
+++ b/tests/backend/test_websocket.py
@@ -434,6 +434,82 @@ class TestWebSocketAuthentication:
 
         assert device_id is None
 
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_authenticate_websocket_accepts_jwt(self):
+        """JWT access tokens from /api/auth/login must be accepted by /ws.
+
+        The React web chat reads `renfield_access_token` from localStorage
+        and appends it directly to the WS URL as `?token=<JWT>`. Before
+        this was supported, the backend only accepted device tokens and
+        rejected every web chat connection with 403. The dual-strategy
+        flow is: try JWT first, fall back to device token.
+        """
+        from unittest.mock import MagicMock, patch
+
+        from services.auth_service import create_access_token
+        from services.websocket_auth import authenticate_websocket
+        from utils.config import settings
+
+        # Mint a real JWT with the production helper so the structure
+        # and signing match exactly what /api/auth/login produces.
+        jwt = create_access_token(data={"sub": "7", "username": "testuser"})
+
+        ws = MagicMock()
+        ws.headers = {}
+
+        original = settings.ws_auth_enabled
+        settings.ws_auth_enabled = True
+        try:
+            result = await authenticate_websocket(ws, token=jwt)
+        finally:
+            settings.ws_auth_enabled = original
+
+        assert result is not None, "JWT must authenticate the WS connection"
+        assert result.get("auth_method") == "jwt"
+        assert result.get("user_id") == "7"
+        assert result.get("authenticated") is True
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_authenticate_websocket_jwt_falls_through_to_device_token(self):
+        """A non-JWT string must fall through to the device-token path.
+
+        Satellites use short-lived device tokens minted via POST
+        /api/ws/token. The JWT-first strategy must not break that flow:
+        if the token doesn't decode as a JWT, the device-token store
+        gets a chance to validate it.
+        """
+        from services.websocket_auth import (
+            WSTokenStore,
+            authenticate_websocket,
+            get_token_store,
+        )
+        from utils.config import settings
+        from unittest.mock import MagicMock
+
+        # Replace the module singleton with a fresh one for isolation.
+        import services.websocket_auth as ws_auth_mod
+        original_store = ws_auth_mod._token_store
+        ws_auth_mod._token_store = WSTokenStore()
+        try:
+            device_token = get_token_store().create_token(device_id="sat-001")
+
+            ws = MagicMock()
+            ws.headers = {}
+
+            original_enabled = settings.ws_auth_enabled
+            settings.ws_auth_enabled = True
+            try:
+                result = await authenticate_websocket(ws, token=device_token)
+            finally:
+                settings.ws_auth_enabled = original_enabled
+
+            assert result is not None, "device token must still authenticate"
+            assert result.get("device_id") == "sat-001"
+        finally:
+            ws_auth_mod._token_store = original_store
+
 
 # ============================================================================
 # WebSocket Protocol Edge Cases


### PR DESCRIPTION
**Half-merged feature from feat/web-chat-v2.** The frontend half shipped to production; the backend half never made it to main. Result: every web chat session authenticated by LDAP gets a 403 handshake storm on /ws.

## Background

Commit d033317 on feat/web-chat-v2 wired:
- Frontend: React web chat appends the JWT access token to the /ws URL as `?token=<JWT>`
- Backend: `services/websocket_auth.py` tries JWT validation before falling through to the device-token path

Only the frontend landed. The deployed Reva bundle has the token-append; the deployed backend only recognized device tokens from WSTokenStore.

## Discovery

Found via a Playwright E2E against Reva prod after fixing ebongard/renfield#364. With #364 in place, the frontend correctly shows the LoginPage, LDAP login mints a JWT, JWT is stored in localStorage — and then the WebSocket handshake instantly fails with 403. The 403 storm I tracked earlier today in the Reva prod logs was **this**, not ghost browser sessions.

## Fix

17-line JWT validation block lifted from feat/web-chat-v2 into main without pulling the rest of that branch's frontend changes (those are already deployed):

```python
# Strategy 1 — JWT validation
try:
    from services.auth_service import decode_token
    payload = decode_token(token)
    if payload and payload.get("type") == "access":
        return {
            "authenticated": True,
            "user_id": payload.get("sub"),
            "auth_method": "jwt",
        }
except Exception:
    pass

# Strategy 2 — Device token (original path, unchanged)
store = get_token_store()
token_data = store.validate_token(token)
```

Satellites keep working because the device-token flow is untouched. Web chat starts working because JWT validation runs first.

## Tests

Two new unit tests in `test_websocket.py::TestWebSocketAuthentication`:

1. `test_authenticate_websocket_accepts_jwt` — mints a real JWT with the production helper, asserts `auth_method=jwt`.
2. `test_authenticate_websocket_jwt_falls_through_to_device_token` — creates a device token, asserts the fallback path still works. Pins the contract so future JWT-side changes don't break satellites.

Both pass in the Reva prod pod against the real modules.

## Why this hid for weeks

The frontend was half-broken anyway due to ebongard/renfield#364 (fresh loads never rendered the LoginPage), so most sessions never got a JWT in the first place. Once #364 landed and LoginPage rendered, this second bug surfaced immediately.

## Test plan

- [x] Unit tests pass in prod pod
- [ ] Deploy to Reva prod, repeat Playwright E2E, verify WS connects and chat works end-to-end
- [ ] Observe `connection rejected (403)` log lines drop to zero

Refs ebongard/renfield#364
