### PR TITLE
fix(ws-auth): resolve JWT subject to Renfield User, return INT user_id

### DIFF
--- a/src/backend/services/websocket_auth.py
+++ b/src/backend/services/websocket_auth.py
@@ -144,24 +144,63 @@ async def authenticate_websocket(
     # Strategy 1: Try JWT validation (web chat users authenticated via
     # /api/auth/login). The React frontend reads `renfield_access_token`
     # from localStorage and appends it directly to the WS URL as
-    # `?token=<JWT>`. Before this branch existed, the backend only
-    # accepted device tokens (from WSTokenStore) and rejected every
-    # web chat connection with 403.
+    # `?token=<JWT>`. We mirror the User-resolution pattern from
+    # `auth_service.get_current_user`: decode → cast sub → look up the
+    # User → verify existence + active status → return the INT user.id
+    # from the DB column so downstream code never has to defensively
+    # cast a string.
+    #
+    # Why the DB lookup matters:
+    # - JWT `sub` claim is a string per the JWT spec (RFC 7519 §4.1.2).
+    #   Without the lookup we'd return that string directly and
+    #   downstream queries that expect int user_id crash asyncpg with
+    #   `DataError: str object cannot be interpreted as an integer`.
+    # - A revoked / deleted / disabled user whose JWT hasn't expired yet
+    #   must NOT be able to reconnect. The User row is the source of
+    #   truth for "can this person still use the system".
+    # - If the JWT is structurally valid but the User is gone, we return
+    #   None (reject) — we do NOT fall through to the device-token path,
+    #   because an attacker presenting a former user's JWT shouldn't get
+    #   a second chance at matching a satellite token.
+    payload = None
     try:
         from services.auth_service import decode_token
 
         payload = decode_token(token)
-        if payload and payload.get("type") == "access":
-            user_id = payload.get("sub")
-            logger.debug(f"WebSocket authenticated via JWT: user_id={user_id}")
-            return {
-                "authenticated": True,
-                "user_id": user_id,
-                "auth_method": "jwt",
-            }
-    except Exception:
-        # Not a valid JWT — fall through to device-token validation.
-        pass
+    except Exception as e:  # noqa: BLE001 — decode_token shouldn't raise, but defend
+        logger.debug(f"WebSocket JWT decode raised unexpectedly: {e}")
+
+    if payload and payload.get("type") == "access":
+        sub = payload.get("sub")
+        try:
+            user_id_int = int(sub)
+        except (TypeError, ValueError):
+            logger.debug(f"WebSocket JWT 'sub' is not an int-like string: {sub!r}")
+            return None
+
+        try:
+            from services.auth_service import get_user_by_id
+            from services.database import AsyncSessionLocal
+
+            async with AsyncSessionLocal() as db:
+                user = await get_user_by_id(db, user_id_int)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"WebSocket JWT user lookup failed: {e}")
+            return None
+
+        if user is None:
+            logger.debug(f"WebSocket JWT auth: user_id={user_id_int} not found")
+            return None
+        if not user.is_active:
+            logger.debug(f"WebSocket JWT auth: user_id={user_id_int} disabled")
+            return None
+
+        logger.debug(f"WebSocket authenticated via JWT: user_id={user.id}")
+        return {
+            "authenticated": True,
+            "user_id": user.id,  # int from the DB column, not the JWT string
+            "auth_method": "jwt",
+        }
 
     # Strategy 2: Device token (satellites, devices) — the original
     # flow. Used by hardware satellites that fetch a short-lived token

--- a/tests/backend/test_websocket.py
+++ b/tests/backend/test_websocket.py
@@ -11,6 +11,8 @@ Testet:
 
 import base64
 import json
+from contextlib import asynccontextmanager
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -27,6 +29,33 @@ from models.websocket_messages import (
     create_error_response,
     parse_ws_message,
 )
+
+# ============================================================================
+# Test helpers
+# ============================================================================
+
+
+def _fake_session_local():
+    """Return a `sessionmaker`-shaped mock suitable for `async with ... as db:`.
+
+    `authenticate_websocket` does:
+        async with AsyncSessionLocal() as db:
+            user = await get_user_by_id(db, user_id_int)
+
+    So we need:
+        - callable `AsyncSessionLocal` → returns an async context manager
+        - the context manager's `__aenter__` yields a mock db
+        - `get_user_by_id` itself is patched separately so the db mock
+          doesn't actually need to do anything
+    """
+    fake_db = MagicMock()
+
+    @asynccontextmanager
+    async def _cm():
+        yield fake_db
+
+    return MagicMock(side_effect=lambda: _cm())
+
 
 # ============================================================================
 # WebSocket Message Parsing Tests
@@ -444,8 +473,14 @@ class TestWebSocketAuthentication:
         this was supported, the backend only accepted device tokens and
         rejected every web chat connection with 403. The dual-strategy
         flow is: try JWT first, fall back to device token.
+
+        Critically, we assert `user_id` is an **int** (from the DB column)
+        and not the raw JWT `sub` string. Downstream code uses it in
+        asyncpg queries that expect an integer column — a string would
+        crash with `DataError: str object cannot be interpreted as an
+        integer`.
         """
-        from unittest.mock import MagicMock, patch
+        from unittest.mock import AsyncMock, MagicMock, patch
 
         from services.auth_service import create_access_token
         from services.websocket_auth import authenticate_websocket
@@ -455,20 +490,109 @@ class TestWebSocketAuthentication:
         # and signing match exactly what /api/auth/login produces.
         jwt = create_access_token(data={"sub": "7", "username": "testuser"})
 
+        # Stub the User lookup. `authenticate_websocket` now validates
+        # that the User row exists and is active before accepting the
+        # JWT; we don't want the test to require a real DB.
+        fake_user = MagicMock()
+        fake_user.id = 7  # int, as it would come from the DB column
+        fake_user.is_active = True
+
         ws = MagicMock()
         ws.headers = {}
 
         original = settings.ws_auth_enabled
         settings.ws_auth_enabled = True
         try:
-            result = await authenticate_websocket(ws, token=jwt)
+            with patch(
+                "services.auth_service.get_user_by_id",
+                new=AsyncMock(return_value=fake_user),
+            ), patch(
+                "services.database.AsyncSessionLocal",
+                new=_fake_session_local(),
+            ):
+                result = await authenticate_websocket(ws, token=jwt)
         finally:
             settings.ws_auth_enabled = original
 
         assert result is not None, "JWT must authenticate the WS connection"
         assert result.get("auth_method") == "jwt"
-        assert result.get("user_id") == "7"
+        assert result.get("user_id") == 7
+        assert isinstance(result.get("user_id"), int), (
+            "user_id must be INT from the DB column, not str from the JWT sub. "
+            "asyncpg rejects str for integer columns."
+        )
         assert result.get("authenticated") is True
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_authenticate_websocket_jwt_rejects_unknown_user(self):
+        """A well-formed JWT for a deleted user must be rejected.
+
+        An attacker with a former user's JWT must not:
+        - be accepted as if the user still exists, OR
+        - get a fall-through chance at the device-token path.
+        """
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from services.auth_service import create_access_token
+        from services.websocket_auth import authenticate_websocket
+        from utils.config import settings
+
+        jwt = create_access_token(data={"sub": "999", "username": "ghost"})
+
+        ws = MagicMock()
+        ws.headers = {}
+
+        original = settings.ws_auth_enabled
+        settings.ws_auth_enabled = True
+        try:
+            with patch(
+                "services.auth_service.get_user_by_id",
+                new=AsyncMock(return_value=None),  # user not found
+            ), patch(
+                "services.database.AsyncSessionLocal",
+                new=_fake_session_local(),
+            ):
+                result = await authenticate_websocket(ws, token=jwt)
+        finally:
+            settings.ws_auth_enabled = original
+
+        assert result is None, "deleted user's JWT must be rejected"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_authenticate_websocket_jwt_rejects_disabled_user(self):
+        """A well-formed JWT for a disabled user must be rejected."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from services.auth_service import create_access_token
+        from services.websocket_auth import authenticate_websocket
+        from utils.config import settings
+
+        jwt = create_access_token(data={"sub": "7", "username": "testuser"})
+
+        disabled = MagicMock()
+        disabled.id = 7
+        disabled.is_active = False
+
+        ws = MagicMock()
+        ws.headers = {}
+
+        original = settings.ws_auth_enabled
+        settings.ws_auth_enabled = True
+        try:
+            with patch(
+                "services.auth_service.get_user_by_id",
+                new=AsyncMock(return_value=disabled),
+            ), patch(
+                "services.database.AsyncSessionLocal",
+                new=_fake_session_local(),
+            ):
+                result = await authenticate_websocket(ws, token=jwt)
+        finally:
+            settings.ws_auth_enabled = original
+
+        assert result is None, "disabled user's JWT must be rejected"
 
     @pytest.mark.unit
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Follow-up to #365. The JWT strategy in `authenticate_websocket` returned `payload.get(\"sub\")` as-is — a string per JWT spec (RFC 7519 §4.1.2). Downstream code in `api/websocket/chat_handler.py` passes that value into asyncpg queries expecting an integer column. Every message triggered two exceptions in prod:

```
Memory retrieval failed: (asyncpg.DataError) invalid input for
query argument $2: '7' ('str' object cannot be interpreted as an integer)
Memory extraction failed: (same)
```

The chat itself worked (responses still arrived) but memory retrieval + background extraction silently failed on every single message.

## Why a proper User lookup, not a cast

A raw `int(sub)` at the consumer would suppress the crash but mask three real problems:

1. **Revoked/deleted users** — a JWT outlives its owner if the User is deleted or disabled before expiration. Without a lookup, the WS treats a ghost user as authenticated until the JWT TTL runs out.
2. **is_active gate** — `get_current_user` (the REST path) rejects disabled users with 403. The WS path skipped that check entirely.
3. **Silent corruption** — casting at the consumer fixes one symptom; the auth layer still returns the wrong type. Every future consumer repeats the cast defensively.

The canonical pattern already lives in `auth_service.py::get_current_user` (lines 242-264):

```python
user_id = payload.get(\"sub\")                  # string from JWT
user = await get_user_by_id(db, int(user_id))   # DB lookup
if not user:          raise 401                 # deleted → reject
if not user.is_active: raise 403                # disabled → reject
return user                                     # ORM object; downstream reads user.id as int
```

This PR mirrors that pattern inside `authenticate_websocket`. Downstream code keeps its defensive `int(user_id)` casts but they become no-ops because `auth_result[\"user_id\"]` is now int from the DB column.

## Behavior changes

| Scenario | Before | After |
|---|---|---|
| Valid JWT, active User | Accepted with str user_id → asyncpg crash on memory queries | Accepted with int user_id, memory queries work |
| Deleted User, valid JWT | Accepted silently | 403 |
| Disabled User, valid JWT | Accepted silently | 403 |
| Non-JWT token (device) | Device-token path | Device-token path (unchanged) |
| JWT with non-int `sub` | Would crash downstream | Explicit reject at auth |
| DB lookup fails during auth | — | Rejected, logged WARNING, no fall-through |

## Important non-fall-through

If the JWT is structurally valid but the User is gone/disabled, we return None immediately rather than falling through to the device-token strategy. An attacker presenting a former user's JWT must not also get a second chance at matching a satellite token.

## Tests

4 unit tests in `test_websocket.py::TestWebSocketAuthentication`:

1. `test_authenticate_websocket_accepts_jwt` — asserts `user_id == 7` (int) AND `isinstance(user_id, int)` with a message pointing to asyncpg. Stubs `get_user_by_id` returning an active User.
2. `test_authenticate_websocket_jwt_rejects_unknown_user` — `get_user_by_id` → None; auth returns None (no fall-through).
3. `test_authenticate_websocket_jwt_rejects_disabled_user` — User with `is_active=False`; rejected.
4. `test_authenticate_websocket_jwt_falls_through_to_device_token` (kept from #365) — non-JWT string still hits the device-token path.

Shared `_fake_session_local` helper provides a `sessionmaker`-shaped async context manager so tests don't need a real asyncpg DB. All 4 pass in the Reva prod pod.

## Out of scope

`chat_handler.py:622-634` does a redundant `select(User).where(User.id == int(user_id))` per connection to load permissions/personality. Now that `authenticate_websocket` already has the User, a future refactor can hoist that state into the auth result and save one DB roundtrip per connection. Not doing it here to keep the fix surgical.

## Test plan

- [x] 4 unit tests pass in prod pod
- [ ] Deploy to Reva prod, resend queries via Playwright, verify the two \"Memory ... failed\" WARNINGs drop to zero
- [ ] Verify memory retrieval actually works for the logged-in user (future query should see memories from current session)

Refs ebongard/renfield#364, ebongard/renfield#365