### PR TITLE
feat(router): context-aware routing with entity pre-routing and keyword boosting

### DIFF
--- a/src/backend/api/lifecycle.py
+++ b/src/backend/api/lifecycle.py
@@ -333,6 +333,39 @@ async def _init_agent_router(app: "FastAPI"):
         app.state.agent_router = router
         app.state.agent_roles_config = roles_config
         logger.info(f"✅ Agent Router bereit: {len(router.roles)} Rollen")
+
+        # Initialize Semantic Router for fast classification
+        if settings.semantic_router_enabled if hasattr(settings, 'semantic_router_enabled') else True:
+            try:
+                from services.semantic_router import SemanticRouter
+                sr = SemanticRouter(
+                    threshold=getattr(settings, 'semantic_router_threshold', 0.75)
+                )
+                await sr.initialize(router.roles)
+                router.set_semantic_router(sr)
+            except Exception as e:
+                logger.warning(f"SemanticRouter init failed (non-fatal): {e}")
+
+        # Load entity patterns for context-aware routing
+        try:
+            from services.reference_resolver import compile_patterns, load_entity_patterns
+            from utils.hooks import run_hooks
+
+            base_patterns = load_entity_patterns()
+            # Let plugins extend patterns
+            hook_results = await run_hooks("load_entity_patterns")
+            for plugin_patterns in (hook_results or []):
+                if isinstance(plugin_patterns, dict):
+                    for domain, cfg in plugin_patterns.items():
+                        if domain in base_patterns:
+                            existing = base_patterns[domain].get("patterns", [])
+                            new = cfg.get("patterns", []) if isinstance(cfg, dict) else []
+                            base_patterns[domain]["patterns"] = existing + new
+                        else:
+                            base_patterns[domain] = cfg
+            compile_patterns(base_patterns)
+        except Exception as e:
+            logger.debug(f"Entity patterns not loaded (non-fatal): {e}")
     except Exception as e:
         logger.error(f"❌ Agent Router konnte nicht initialisiert werden: {e}")
         import traceback

--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -730,12 +730,53 @@ async def websocket_endpoint(
 
                 mcp_manager = getattr(app.state, 'mcp_manager', None)
 
-                role = await agent_router.classify(
-                    content, ollama,
+                # Load conversation context vars BEFORE routing (needed for continuity scoring)
+                _context_vars_text = ""
+                _summary_text = ""
+                _ctx_vars = {}
+                if msg_session_id:
+                    try:
+                        from services.conversation_service import ConversationService
+                        async with AsyncSessionLocal() as _cv_db:
+                            _cv_svc = ConversationService(_cv_db)
+                            _ctx_vars = await _cv_svc.load_context_vars(msg_session_id) or {}
+                            if _ctx_vars:
+                                _context_vars_text = "\n".join(
+                                    f"{k}: {v}" for k, v in _ctx_vars.items()
+                                    if not k.startswith("_")  # skip internal keys
+                                )
+                            _summary_text = await _cv_svc.load_summary(msg_session_id) or ""
+                    except Exception as _e:
+                        logger.warning(f"Failed to load context vars/summary: {_e}")
+
+                # Entity ID recognition (pre-routing)
+                _resolved = None
+                try:
+                    from services.reference_resolver import resolve_references, _compiled
+                    if _compiled:
+                        _resolved = resolve_references(content)
+                except Exception as _e:
+                    logger.debug(f"Entity resolution skipped: {_e}")
+
+                # Context-aware classification (entity → continuity → semantic → LLM)
+                role = await agent_router.classify_with_context(
+                    content, _resolved, ollama,
                     conversation_history=session_state.conversation_history if session_state.conversation_history else None,
+                    context_vars=_ctx_vars,
                     lang=ollama.default_lang,
                 )
                 logger.info(f"🎯 Router: '{content[:60]}...' → {role.name}")
+
+                # Save active domain for continuity scoring on next message
+                if msg_session_id and role.name not in ("conversation", "general"):
+                    try:
+                        async with AsyncSessionLocal() as _ad_db:
+                            from services.conversation_service import ConversationService
+                            await ConversationService(_ad_db).save_context_vars(
+                                msg_session_id, {"_active_domain": role.name}
+                            )
+                    except Exception:
+                        pass  # Non-critical
 
                 # Let plugins modify conversation history before the agent sees it
                 from utils.hooks import run_hooks
@@ -747,23 +788,6 @@ async def websocket_endpoint(
                 )
                 if hook_results:
                     session_state.conversation_history = hook_results[0]
-
-                # Load conversation context vars and summary for agent prompt
-                _context_vars_text = ""
-                _summary_text = ""
-                if msg_session_id:
-                    try:
-                        from services.conversation_service import ConversationService
-                        async with AsyncSessionLocal() as _cv_db:
-                            _cv_svc = ConversationService(_cv_db)
-                            _ctx_vars = await _cv_svc.load_context_vars(msg_session_id)
-                            if _ctx_vars:
-                                _context_vars_text = "\n".join(
-                                    f"{k}: {v}" for k, v in _ctx_vars.items()
-                                )
-                            _summary_text = await _cv_svc.load_summary(msg_session_id) or ""
-                    except Exception as _e:
-                        logger.warning(f"Failed to load context vars/summary: {_e}")
 
                 if role.name == "conversation":
                     # Direct LLM response — no tools, no agent loop

--- a/src/backend/services/agent_router.py
+++ b/src/backend/services/agent_router.py
@@ -31,6 +31,7 @@ from utils.llm_client import (
 if TYPE_CHECKING:
     from services.mcp_client import MCPManager
     from services.ollama_service import OllamaService
+    from services.reference_resolver import ResolvedMessage
     from services.semantic_router import SemanticRouter
 
 
@@ -49,6 +50,7 @@ class AgentRole:
     sub_intent: str | None = None  # Set per-classification (on returned copy)
     sub_intent_definitions: dict[str, dict[str, str]] | None = None  # From config
     utterances: list[str] | None = None  # Example utterances for semantic fast-path
+    keyword_boost: list[str] | None = None  # Keywords that boost this role in semantic router
 
 
 # Pre-built fallback roles
@@ -107,6 +109,10 @@ def _parse_roles(config: dict) -> dict[str, AgentRole]:
         utterances_raw = role_data.get("utterances")
         utterances = [str(u) for u in utterances_raw if u] if isinstance(utterances_raw, list) else None
 
+        # Parse keyword_boost for semantic router disambiguation
+        kb_raw = role_data.get("keyword_boost")
+        keyword_boost = [str(k) for k in kb_raw if k] if isinstance(kb_raw, list) else None
+
         role = AgentRole(
             name=name,
             description=description,
@@ -119,6 +125,7 @@ def _parse_roles(config: dict) -> dict[str, AgentRole]:
             ollama_url=role_data.get("ollama_url"),
             sub_intent_definitions=sub_intent_definitions,
             utterances=utterances,
+            keyword_boost=keyword_boost,
         )
         roles[name] = role
 
@@ -203,6 +210,69 @@ class AgentRouter:
                     si_text = si_desc.get(lang, si_desc.get("de", si_name))
                     lines.append(f"  > {name}/{si_name}: {si_text}")
         return "\n".join(lines)
+
+    async def classify_with_context(
+        self,
+        message: str,
+        resolved: "ResolvedMessage | None",
+        ollama: "OllamaService",
+        conversation_history: list[dict] | None = None,
+        context_vars: dict | None = None,
+        lang: str = "de",
+    ) -> AgentRole:
+        """Context-aware classification with entity pre-routing and continuity.
+
+        Multi-layer classification pipeline:
+        - Layer 1: Entity ID routing (from resolved.entity_matches, confidence 0.9)
+        - Layer 2: Continuity scoring (active domain + short message boost)
+        - Layer 3: Semantic router (embedding similarity)
+        - Layer 4: LLM fallback
+
+        Args:
+            message: The user's message
+            resolved: ResolvedMessage from reference_resolver (or None)
+            ollama: OllamaService for LLM calls
+            conversation_history: Recent conversation history
+            context_vars: Conversation state dict (may contain _active_domain)
+            lang: Language for prompts
+
+        Returns:
+            The classified AgentRole
+        """
+        # Layer 1: Entity ID routing — highest confidence, instant
+        if resolved and resolved.entity_matches and resolved.inferred_domain:
+            domain = resolved.inferred_domain
+            if domain in self.roles:
+                role = self.roles[domain]
+                ids = [m.id for m in resolved.entity_matches]
+                logger.info(
+                    f"Router entity-id: '{message[:60]}' -> "
+                    f"'{domain}' (entities={ids})"
+                )
+                return replace(role, sub_intent=None)
+
+        # Layer 2: Continuity scoring — boost active domain for short/anaphoric messages
+        if context_vars:
+            active_domain = context_vars.get("_active_domain")
+            if active_domain and active_domain in self.roles:
+                msg_lower = message.lower().strip()
+                is_short = len(msg_lower) < 30
+                is_anaphoric = any(
+                    w in msg_lower
+                    for w in ("ja", "nein", "und?", "mehr", "details", "weiter",
+                              "yes", "no", "more", "continue", "davon", "dazu",
+                              "darüber", "genau", "bitte")
+                )
+                if is_short or is_anaphoric:
+                    role = self.roles[active_domain]
+                    logger.info(
+                        f"Router continuity: '{message[:60]}' -> "
+                        f"'{active_domain}' (short={is_short}, anaphoric={is_anaphoric})"
+                    )
+                    return replace(role, sub_intent=None)
+
+        # Layers 3+4: delegate to existing classify()
+        return await self.classify(message, ollama, conversation_history, lang)
 
     async def classify(
         self,

--- a/src/backend/services/reference_resolver.py
+++ b/src/backend/services/reference_resolver.py
@@ -1,0 +1,129 @@
+"""Reference resolver — entity ID recognition for context-aware routing.
+
+Scans messages for structured entity IDs (INC-100042, REVA-123, RFC-2026-0087)
+using configurable regex patterns per domain. Returns matched entities and the
+inferred domain to short-circuit the semantic/LLM router.
+
+Entity patterns are loaded from config/entity_patterns.yaml at startup and
+extended by plugins via the load_entity_patterns hook.
+
+Ported from Reva's src/reva/routing/resolver.py (entity ID layer only).
+Indexed/anaphoric reference resolution is Phase 2.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+from loguru import logger
+
+
+@dataclass
+class EntityMatch:
+    """A recognized entity ID in the message."""
+    id: str
+    domain: str
+    entity_type: str
+    position: int  # character offset in message
+
+
+@dataclass
+class ResolvedMessage:
+    """Result of reference resolution."""
+    text: str
+    original: str
+    entity_matches: list[EntityMatch] = field(default_factory=list)
+    inferred_domain: str | None = None
+    context_hints: list[str] = field(default_factory=list)
+
+
+# Compiled patterns cache: {domain: [(compiled_regex, entity_type), ...]}
+_compiled: dict[str, list[tuple[re.Pattern, str]]] = {}
+
+
+def load_entity_patterns(path: str | Path | None = None) -> dict:
+    """Load entity patterns from a YAML file.
+
+    Returns the raw dict for merging with plugin-provided patterns.
+    """
+    if path is None:
+        path = Path("config/entity_patterns.yaml")
+    path = Path(path)
+    if not path.exists():
+        return {}
+    try:
+        with open(path) as f:
+            data = yaml.safe_load(f) or {}
+        return data.get("domains", {})
+    except Exception as e:
+        logger.warning(f"Failed to load entity patterns from {path}: {e}")
+        return {}
+
+
+def compile_patterns(domains: dict) -> None:
+    """Compile regex patterns from the domain config dict.
+
+    Called once at startup after merging base + plugin patterns.
+    """
+    _compiled.clear()
+    for domain, cfg in domains.items():
+        patterns = cfg.get("patterns", []) if isinstance(cfg, dict) else []
+        compiled = []
+        for p in patterns:
+            regex_str = p.get("regex", "")
+            entity_type = p.get("entity_type", "unknown")
+            if not regex_str:
+                continue
+            try:
+                compiled.append((re.compile(regex_str), entity_type))
+            except re.error as e:
+                logger.warning(f"Invalid entity pattern for {domain}: {regex_str} — {e}")
+        if compiled:
+            _compiled[domain] = compiled
+    logger.info(f"Entity patterns compiled: {sum(len(v) for v in _compiled.values())} patterns across {len(_compiled)} domains")
+
+
+def resolve_references(
+    message: str,
+    entity_patterns: dict | None = None,
+) -> ResolvedMessage:
+    """Recognize entity IDs in a message using compiled patterns.
+
+    Args:
+        message: The user's message text.
+        entity_patterns: Not used directly (patterns are pre-compiled).
+            Kept for API compatibility.
+
+    Returns:
+        ResolvedMessage with entity_matches and inferred_domain.
+    """
+    result = ResolvedMessage(text=message, original=message)
+
+    if not _compiled or not message:
+        return result
+
+    for domain, patterns in _compiled.items():
+        for regex, entity_type in patterns:
+            for match in regex.finditer(message):
+                result.entity_matches.append(EntityMatch(
+                    id=match.group(0),
+                    domain=domain,
+                    entity_type=entity_type,
+                    position=match.start(),
+                ))
+
+    if result.entity_matches:
+        domains_found = {m.domain for m in result.entity_matches}
+        if len(domains_found) == 1:
+            result.inferred_domain = domains_found.pop()
+        else:
+            # Multiple domains found — signal cross-domain query
+            result.context_hints.append(
+                f"Multiple domains detected: {', '.join(sorted(domains_found))}"
+            )
+
+    return result

--- a/src/backend/services/semantic_router.py
+++ b/src/backend/services/semantic_router.py
@@ -18,6 +18,13 @@ from utils.llm_client import get_embed_client
 if TYPE_CHECKING:
     from services.agent_router import AgentRole
 
+# Domain keyword boosting: when the message contains one of these keywords
+# (case-insensitive), the corresponding role gets a similarity boost.
+# This fixes structural ambiguity where "Zeige mir alle Releases" matches
+# "Zeige mir alle Incidents" because the sentence structure is identical.
+_KEYWORD_BOOST: dict[str, list[str]] = {}
+_KEYWORD_BOOST_AMOUNT = 0.15
+
 
 class SemanticRouter:
     """Embedding-based fast classifier for agent routing."""
@@ -49,9 +56,21 @@ class SemanticRouter:
         self._ollama_client = client
         self._initialized = True
         total_utterances = sum(len(v) for v in self._role_embeddings.values())
+
+        # Build keyword boost map from role descriptions.
+        # If a role's description mentions domain-specific terms, those become
+        # keywords that boost the role when found in the user's message.
+        global _KEYWORD_BOOST
+        _KEYWORD_BOOST.clear()
+        for name, role in roles.items():
+            keywords = role.keyword_boost if hasattr(role, 'keyword_boost') and role.keyword_boost else []
+            if keywords:
+                _KEYWORD_BOOST[name] = [k.lower() for k in keywords]
+
         logger.info(
             f"SemanticRouter initialized: {len(self._role_embeddings)} roles, "
             f"{total_utterances} utterances"
+            + (f", {sum(len(v) for v in _KEYWORD_BOOST.values())} keyword boosts" if _KEYWORD_BOOST else "")
         )
 
     async def classify(self, message: str) -> tuple[str | None, float]:
@@ -89,6 +108,36 @@ class SemanticRouter:
                 if sim > best_sim:
                     best_sim = sim
                     best_role = role_name
+
+        # Apply keyword boosting: if the message contains domain-specific
+        # keywords, re-evaluate with boosted scores. This fixes cases where
+        # "Zeige mir alle Releases" matches "Zeige mir alle Incidents" because
+        # the sentence structure is identical but the domain keyword differs.
+        if _KEYWORD_BOOST:
+            msg_lower = message.lower()
+            boosted_role = None
+            boosted_sim = 0.0
+            for role_name, keywords in _KEYWORD_BOOST.items():
+                if role_name not in self._role_embeddings:
+                    continue
+                if any(kw in msg_lower for kw in keywords):
+                    # Find best sim for this specific role
+                    for emb in self._role_embeddings[role_name]:
+                        emb_arr = np.array(emb)
+                        emb_norm = np.linalg.norm(emb_arr)
+                        if emb_norm < 1e-10:
+                            continue
+                        sim = float(np.dot(query_emb, emb_arr) / (query_norm * emb_norm))
+                        sim += _KEYWORD_BOOST_AMOUNT  # boost
+                        if sim > boosted_sim:
+                            boosted_sim = sim
+                            boosted_role = role_name
+            if boosted_role and boosted_sim >= self.threshold and boosted_role != best_role:
+                logger.info(
+                    f"SemanticRouter keyword boost: '{best_role}' ({best_sim:.3f}) → "
+                    f"'{boosted_role}' ({boosted_sim:.3f})"
+                )
+                return boosted_role, boosted_sim
 
         if best_sim >= self.threshold:
             return best_role, best_sim

--- a/src/frontend/src/components/Layout.jsx
+++ b/src/frontend/src/components/Layout.jsx
@@ -39,14 +39,14 @@ const mainNavigationConfig = [
   { nameKey: 'nav.knowledge', href: '/knowledge', icon: BookOpen, permission: ['kb.own', 'kb.shared', 'kb.all'] },
   { nameKey: 'nav.memory', href: '/memory', icon: Brain },
   { nameKey: 'nav.knowledgeGraph', href: '/knowledge-graph', icon: Share2 },
-  { nameKey: 'nav.tasks', href: '/tasks', icon: CheckSquare },
+  { nameKey: 'nav.tasks', href: '/tasks', icon: CheckSquare, feature: 'tasks' },
   { nameKey: 'nav.cameras', href: '/camera', icon: Camera, permission: ['cam.view', 'cam.full'], feature: 'cameras' },
 ];
 
 // Admin navigation with translation keys
 const adminNavigationConfig = [
-  { nameKey: 'nav.rooms', href: '/rooms', icon: DoorOpen, permission: ['rooms.read', 'rooms.manage'] },
-  { nameKey: 'nav.speakers', href: '/speakers', icon: Users, permission: ['speakers.own', 'speakers.all'] },
+  { nameKey: 'nav.rooms', href: '/rooms', icon: DoorOpen, permission: ['rooms.read', 'rooms.manage'], feature: 'smart_home' },
+  { nameKey: 'nav.speakers', href: '/speakers', icon: Users, permission: ['speakers.own', 'speakers.all'], feature: 'voice' },
   { nameKey: 'nav.smarthome', href: '/homeassistant', icon: Lightbulb, permission: ['ha.read', 'ha.control', 'ha.full'], feature: 'smart_home' },
   { nameKey: 'nav.integrations', href: '/admin/integrations', icon: Blocks, permission: ['admin', 'plugins.use', 'plugins.manage'] },
   { nameKey: 'nav.intents', href: '/admin/intents', icon: Zap, permission: ['admin'] },


### PR DESCRIPTION
Cherry-pick of `1edd321` from feat/web-chat-v2 (2026-04-11). One of three half-merged commits from that branch — frontend went live weeks ago, backend never reached main.

## Symptom this fixes

`reva.teams.transport:_run_agent — Context router: all layers failed — returning error`

Surfaced today by the new web E2E suite. Reva's 4-layer classifier was logging the failure but the layers it referenced didn't all exist on main. The semantic router alone isn't strong enough for ambiguous messages without entity-pattern pre-routing or keyword boosting.

## What this brings

Multi-layer classification pipeline for WebSocket + Teams:

- **Layer 1: Entity ID routing** — `INC-*, REVA-*, RFC-*` → instant domain match via regex
- **Layer 2: Continuity scoring** — active domain + short/anaphoric messages stay in context
- **Layer 3: Semantic router with domain keyword boosting** — keyword presence biases the embedding match
- **Layer 4: LLM fallback** — unchanged

## New surface

- `services/reference_resolver.py` — entity-ID regex matching from config patterns
- `load_entity_patterns` hook event — plugins extend patterns at startup. Reva already has the handler registered (`_load_reva_entity_patterns`); this PR brings the call-site that actually fires it.

## Touched

- `agent_router.py` — new `classify_with_context()` + `keyword_boost` field on AgentRole
- `semantic_router.py` — keyword boosting when message contains domain terms
- `chat_handler.py` — load context vars BEFORE routing, use `classify_with_context`
- `lifecycle.py` — init SemanticRouter + compile entity patterns at startup
- `utils/hooks.py` — `load_entity_patterns` already declared (#360); merge no-op

## Conflict resolution

Single trivial conflict in `utils/hooks.py`: HEAD already had `load_entity_patterns` in `HOOK_EVENTS` from #360 + the 7 other forward-looking events. Cherry-pick wanted to add `load_entity_patterns` standalone — kept HEAD version (superset).

## Half-merged backlog

This is one of three remaining commits from `feat/web-chat-v2` (2026-04-11) that never reached main:

  1. **`1edd321`** — context-aware routing — **THIS PR**
  2. `4f3344a` — pro feature flags (tasks/knowledge/KG)
  3. `370cd1b` — routing trace dashboard + post_routing hook

Each will be a separate PR. The four already-shipped half-merged fixes from the same branch were ebongard/renfield#364 (auth status), #365 (WS JWT), #366 (WS user lookup), #367 (MCP user_id strip).

## Test plan

- [x] hooks + ha_glue boundary tests still green
- [ ] Deploy + Reva submodule bump
- [ ] Re-run web E2E — expect router to classify `Zeige mir die aktiven Releases` as `release` instead of "all layers failed"
