### PR TITLE
fix(features): add tasks/knowledge/knowledge_graph feature flags

### DIFF
--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -343,8 +343,8 @@ class Settings(BaseSettings):
     def features(self) -> dict[str, bool]:
         """Resolve feature flags: explicit override > edition preset."""
         presets = {
-            "community": {"smart_home": True, "cameras": True, "satellites": True, "voice": True},
-            "pro": {"smart_home": False, "cameras": False, "satellites": False, "voice": False},
+            "community": {"smart_home": True, "cameras": True, "satellites": True, "voice": True, "tasks": True, "knowledge": True, "knowledge_graph": True},
+            "pro": {"smart_home": False, "cameras": False, "satellites": False, "voice": False, "tasks": False, "knowledge": False, "knowledge_graph": False},
         }
         defaults = presets.get(self.renfield_edition, presets["pro"])
         return {
@@ -352,6 +352,9 @@ class Settings(BaseSettings):
             "cameras": self.feature_cameras if self.feature_cameras is not None else defaults["cameras"],
             "satellites": self.feature_satellites if self.feature_satellites is not None else defaults["satellites"],
             "voice": self.feature_voice if self.feature_voice is not None else defaults["voice"],
+            "tasks": getattr(self, 'feature_tasks', None) if getattr(self, 'feature_tasks', None) is not None else defaults.get("tasks", True),
+            "knowledge": getattr(self, 'feature_knowledge', None) if getattr(self, 'feature_knowledge', None) is not None else defaults.get("knowledge", True),
+            "knowledge_graph": getattr(self, 'feature_knowledge_graph', None) if getattr(self, 'feature_knowledge_graph', None) is not None else defaults.get("knowledge_graph", True),
         }
 
     @property

--- a/src/frontend/src/components/Layout.jsx
+++ b/src/frontend/src/components/Layout.jsx
@@ -36,9 +36,9 @@ import { useAuth } from '../context/AuthContext';
 // Navigation items with translation keys
 const mainNavigationConfig = [
   { nameKey: 'nav.chat', href: '/', icon: MessageSquare },
-  { nameKey: 'nav.knowledge', href: '/knowledge', icon: BookOpen, permission: ['kb.own', 'kb.shared', 'kb.all'] },
+  { nameKey: 'nav.knowledge', href: '/knowledge', icon: BookOpen, permission: ['kb.own', 'kb.shared', 'kb.all'], feature: 'knowledge' },
   { nameKey: 'nav.memory', href: '/memory', icon: Brain },
-  { nameKey: 'nav.knowledgeGraph', href: '/knowledge-graph', icon: Share2 },
+  { nameKey: 'nav.knowledgeGraph', href: '/knowledge-graph', icon: Share2, feature: 'knowledge_graph' },
   { nameKey: 'nav.tasks', href: '/tasks', icon: CheckSquare, feature: 'tasks' },
   { nameKey: 'nav.cameras', href: '/camera', icon: Camera, permission: ['cam.view', 'cam.full'], feature: 'cameras' },
 ];

--- a/tests/backend/test_feature_flags.py
+++ b/tests/backend/test_feature_flags.py
@@ -25,16 +25,28 @@ class TestEditionPresets:
             "cameras": True,
             "satellites": True,
             "voice": True,
+            "tasks": True,
+            "knowledge": True,
+            "knowledge_graph": True,
         }
 
     def test_pro_edition_disables_home_features(self):
-        """Pro (business) edition disables smart home features by default."""
+        """Pro (business) edition disables smart home + auxiliary features.
+
+        `tasks`, `knowledge`, `knowledge_graph` are also off in pro because
+        the frontend's `isFeatureEnabled()` returns true for `undefined`
+        — without explicit False values the nav items would render even on
+        pro deploys (Reva, X-IDRA enterprise).
+        """
         s = Settings(renfield_edition="pro", _env_file=None)
         assert s.features == {
             "smart_home": False,
             "cameras": False,
             "satellites": False,
             "voice": False,
+            "tasks": False,
+            "knowledge": False,
+            "knowledge_graph": False,
         }
 
     def test_unknown_edition_falls_back_to_pro(self):
@@ -45,6 +57,9 @@ class TestEditionPresets:
             "cameras": False,
             "satellites": False,
             "voice": False,
+            "tasks": False,
+            "knowledge": False,
+            "knowledge_graph": False,
         }
 
     def test_default_edition_is_community(self):
@@ -99,6 +114,9 @@ class TestFeatureOverrides:
             "cameras": True,
             "satellites": True,
             "voice": False,
+            "tasks": False,
+            "knowledge": False,
+            "knowledge_graph": False,
         }
 
     def test_none_means_use_default(self):
@@ -147,6 +165,9 @@ class TestAuthStatusFeatures:
             "cameras": True,
             "satellites": True,
             "voice": True,
+            "tasks": True,
+            "knowledge": True,
+            "knowledge_graph": True,
         }
 
     def test_pro_features_for_status(self):
@@ -158,6 +179,9 @@ class TestAuthStatusFeatures:
             "cameras": False,
             "satellites": False,
             "voice": False,
+            "tasks": False,
+            "knowledge": False,
+            "knowledge_graph": False,
         }
 
     def test_override_in_features_for_status(self):
@@ -209,10 +233,29 @@ class TestFeaturesPropertyConsistency:
     """Test that features property is always consistent."""
 
     def test_features_returns_all_keys(self):
-        """Features dict always contains all four keys."""
+        """Features dict always contains every known feature key.
+
+        The frontend's `isFeatureEnabled()` returns True for `undefined`,
+        so the API contract is "every feature is explicitly named in the
+        response". If a new feature is added, it must appear in the
+        response for ALL editions even if its value is False — otherwise
+        `undefined` lets it leak on into the UI.
+        """
+        expected_keys = {
+            "smart_home",
+            "cameras",
+            "satellites",
+            "voice",
+            "tasks",
+            "knowledge",
+            "knowledge_graph",
+        }
         for edition in ["community", "pro", "enterprise"]:
             s = Settings(renfield_edition=edition, _env_file=None)
-            assert set(s.features.keys()) == {"smart_home", "cameras", "satellites", "voice"}
+            assert set(s.features.keys()) == expected_keys, (
+                f"edition={edition!r}: features keys drift — got "
+                f"{set(s.features.keys()) ^ expected_keys}"
+            )
 
     def test_features_values_are_bool(self):
         """All feature values are booleans."""


### PR DESCRIPTION
Cherry-pick of `4f3344a` from feat/web-chat-v2 (2026-04-11). Two of three remaining half-merged commits.

## What this fixes

Frontend's `isFeatureEnabled()` returns `true` for `undefined` (since `undefined !== false`). Without explicit feature flags for `tasks`, `knowledge`, and `knowledge_graph` in the pro preset, these nav items rendered on Reva even though Reva is `RENFIELD_EDITION=pro`.

## Changes

- `utils/config.py` — pro preset now sets all three new flags to `False`; community keeps them `True`
- `Layout.jsx` — Wissen + Wissensgraph nav items now gated on the new flags
- `tests/backend/test_feature_flags.py` — extended to assert the new keys exist for all editions and that pro disables them

## Why the test changes are part of THIS PR

The original cherry-pick `4f3344a` did not update `test_feature_flags.py` — that test was either added later on main or never updated to match the production reality. Six existing test cases failed against the new feature dict shape because they did exact-equality on the old 4-key set. Updated all of them to assert the 7-key superset, plus added a clarifying docstring on `test_features_returns_all_keys` explaining why the frontend's `undefined !== false` quirk demands the explicit-False values.

## Half-merged backlog

Two down, one to go from `feat/web-chat-v2` (2026-04-11):

  ✅ `1edd321` — context-aware routing — ebongard/renfield#368 (merged)
  ✅ `4f3344a` — pro feature flags — **THIS PR**
  ⬜ `370cd1b` — routing trace dashboard + post_routing hook
