### PR TITLE
fix(features): declare missing feature_* pydantic fields

### DIFF
--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -11,11 +11,26 @@ class Settings(BaseSettings):
     """Anwendungs-Einstellungen"""
 
     # Edition & Feature Flags
+    #
+    # Each `feature_*` field maps to a UI nav item / route guard. `None`
+    # means "fall through to the edition preset". Setting True or False
+    # via env (e.g. FEATURE_KNOWLEDGE_GRAPH=true) overrides the preset.
+    #
+    # If you add a feature key to the `features` property below, ALSO add
+    # the matching `feature_<name>: bool | None = None` field here —
+    # otherwise Pydantic Settings has nothing to bind the env var to and
+    # the override silently no-ops while the preset wins. (Cherry-pick
+    # 4f3344a originally added tasks/knowledge/knowledge_graph to the
+    # property without the fields, breaking per-deploy overrides until
+    # this commit.)
     renfield_edition: str = "community"  # "community" (full/home) or "pro" (business, no smart home)
-    feature_smart_home: bool | None = None   # None = use edition default
-    feature_cameras: bool | None = None      # None = use edition default
-    feature_satellites: bool | None = None   # None = use edition default
-    feature_voice: bool | None = None       # None = use edition default
+    feature_smart_home: bool | None = None       # None = use edition default
+    feature_cameras: bool | None = None          # None = use edition default
+    feature_satellites: bool | None = None       # None = use edition default
+    feature_voice: bool | None = None            # None = use edition default
+    feature_tasks: bool | None = None            # None = use edition default
+    feature_knowledge: bool | None = None        # None = use edition default
+    feature_knowledge_graph: bool | None = None  # None = use edition default
 
     # Datenbank - Einzelfelder für dynamischen DATABASE_URL-Aufbau
     database_url: str | None = None

--- a/tests/backend/test_feature_flags.py
+++ b/tests/backend/test_feature_flags.py
@@ -148,6 +148,55 @@ class TestFeatureOverrides:
         assert s.features["voice"] is False
         assert s.features["smart_home"] is True
 
+    def test_knowledge_graph_override_enables_on_pro(self):
+        """Explicit True enables knowledge_graph on pro edition.
+
+        Regression guard: cherry-pick 4f3344a added tasks/knowledge/
+        knowledge_graph to the `features` property without declaring
+        the matching `feature_*` Pydantic fields, so per-deploy
+        overrides (e.g. Reva needs the knowledge graph for chat-data
+        extraction) silently no-op'd. This test pins that the override
+        actually works.
+        """
+        s = Settings(
+            renfield_edition="pro",
+            feature_knowledge_graph=True,
+            _env_file=None,
+        )
+        assert s.features["knowledge_graph"] is True
+        # Other pro defaults still apply
+        assert s.features["tasks"] is False
+        assert s.features["knowledge"] is False
+        assert s.features["smart_home"] is False
+
+    def test_tasks_override_enables_on_pro(self):
+        """Explicit True enables tasks on pro edition."""
+        s = Settings(
+            renfield_edition="pro",
+            feature_tasks=True,
+            _env_file=None,
+        )
+        assert s.features["tasks"] is True
+
+    def test_knowledge_override_enables_on_pro(self):
+        """Explicit True enables knowledge on pro edition."""
+        s = Settings(
+            renfield_edition="pro",
+            feature_knowledge=True,
+            _env_file=None,
+        )
+        assert s.features["knowledge"] is True
+
+    def test_knowledge_graph_override_disables_on_community(self):
+        """Explicit False disables knowledge_graph on community edition."""
+        s = Settings(
+            renfield_edition="community",
+            feature_knowledge_graph=False,
+            _env_file=None,
+        )
+        assert s.features["knowledge_graph"] is False
+        assert s.features["smart_home"] is True
+
 
 # ============================================================================
 # Auth Status Endpoint Tests


### PR DESCRIPTION
Cherry-pick #369 (4f3344a) was incomplete — added the three new keys to the `features` property but forgot the matching Pydantic-declared fields. Result: `FEATURE_*=true` env vars bound to nothing, edition preset always won.

Surfaced when trying to re-enable the knowledge graph for Reva (pro deploy uses the KG for chat-data extraction). Patching ConfigMap had no effect because the field didn't exist.

## Fix

Add three missing fields:

```python
feature_tasks: bool | None = None
feature_knowledge: bool | None = None
feature_knowledge_graph: bool | None = None
```

Plus a docstring above the block warning contributors that adding a key to the `features` property without the matching field silently breaks per-deploy overrides.

## Behaviour

No change for any existing deploy (defaults stay None → edition preset wins). Only change: `FEATURE_*=true/false` ConfigMap entries now actually take effect.

## Tests

4 new in `TestFeatureOverrides`:

- `test_knowledge_graph_override_enables_on_pro` — pin-point guard for Reva use case
- `test_tasks_override_enables_on_pro` / `test_knowledge_override_enables_on_pro`
- `test_knowledge_graph_override_disables_on_community` — reverse direction

24 / 24 feature flag tests passing.
