### PR TITLE
feat(nav): add admin routing dashboard nav link

### DIFF
--- a/src/frontend/src/components/Layout.jsx
+++ b/src/frontend/src/components/Layout.jsx
@@ -25,7 +25,8 @@ import {
   MapPin,
   Wrench,
   FileSearch,
-  Share2
+  Share2,
+  GitBranch
 } from 'lucide-react';
 import DeviceStatus from './DeviceStatus';
 import ThemeToggle from './ThemeToggle';
@@ -50,6 +51,7 @@ const adminNavigationConfig = [
   { nameKey: 'nav.smarthome', href: '/homeassistant', icon: Lightbulb, permission: ['ha.read', 'ha.control', 'ha.full'], feature: 'smart_home' },
   { nameKey: 'nav.integrations', href: '/admin/integrations', icon: Blocks, permission: ['admin', 'plugins.use', 'plugins.manage'] },
   { nameKey: 'nav.intents', href: '/admin/intents', icon: Zap, permission: ['admin'] },
+  { nameKey: 'nav.routingDashboard', href: '/admin/routing', icon: GitBranch, permission: ['admin'] },
   { nameKey: 'nav.users', href: '/admin/users', icon: UserCog, permission: ['admin'] },
   { nameKey: 'nav.roles', href: '/admin/roles', icon: Shield, permission: ['admin'] },
   { nameKey: 'nav.satellites', href: '/admin/satellites', icon: Satellite, permission: ['admin'], feature: 'satellites' },

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -42,6 +42,7 @@
     "knowledgeGraph": "Wissensgraph",
     "memory": "Erinnerungen",
     "intents": "Intents",
+    "routingDashboard": "Routing Dashboard",
     "maintenance": "Wartung",
     "paperlessAudit": "Paperless Audit",
     "settings": "Einstellungen",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -42,6 +42,7 @@
     "knowledgeGraph": "Knowledge Graph",
     "memory": "Memories",
     "intents": "Intents",
+    "routingDashboard": "Routing Dashboard",
     "maintenance": "Maintenance",
     "paperlessAudit": "Paperless Audit",
     "settings": "Settings",


### PR DESCRIPTION
## Summary

The `/admin/routing` page is registered in `App.jsx` and the backend endpoints (`/api/admin/routing-traces`, `/api/admin/routing-stats` — provided by Reva via plugin) respond, but there's no sidebar entry — making the page unreachable from the UI for admins.

This PR adds a `GitBranch` nav item under the Admin section, gated by `permission: ['admin']` so it only appears for admin users (and is hidden entirely when auth is disabled doesn't matter — the auth filter passes everything through in that case, which is consistent with the other admin items).

## Changes

- `Layout.jsx`: import `GitBranch` from lucide-react, add `nav.routingDashboard` entry to `adminNavigationConfig` between `intents` and `users`
- `i18n/locales/en.json`: add `nav.routingDashboard` = "Routing Dashboard"
- `i18n/locales/de.json`: add `nav.routingDashboard` = "Routing Dashboard"

## Test plan

- [x] Visual: nav link appears for admin user under Admin section
- [x] Visual: nav link hidden for non-admin user
- [ ] Click nav link → navigates to `/admin/routing` (route already wired in App.jsx)

## Context

Cherry-pick #370 (`feat(admin): routing trace dashboard + post_routing hook`) added the page + route + lazy-load wiring but missed the nav link. Found during a follow-up audit of recent cherry-picks from `feat/web-chat-v2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)