### PR TITLE
feat(orchestrator,webchat): wire QueryOrchestrator + Adaptive Card protocol

### DIFF
--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -803,7 +803,67 @@ async def websocket_endpoint(
                 if hook_results:
                     session_state.conversation_history = hook_results[0]
 
-                if role.name == "conversation":
+                # === Cross-MCP Orchestrator (opt-in via agent_orchestrator_enabled) ===
+                # Detect multi-domain queries before falling through to single-role
+                # dispatch. When detected, sub-agents fan out in parallel and a
+                # synthesizer composes the combined answer. Plugins can build an
+                # Adaptive Card via the post_orchestration hook — the resulting
+                # `card` step lands on the WebSocket as `{"type": "card", ...}`.
+                orchestrated = False
+                if (
+                    settings.agent_orchestrator_enabled
+                    and mcp_manager is not None
+                    and role.name not in ("conversation", "knowledge")
+                ):
+                    try:
+                        from services.orchestrator import QueryOrchestrator
+                        orchestrator = QueryOrchestrator(agent_router, mcp_manager)
+                        sub_queries = await orchestrator.detect_multi_domain(
+                            content, ollama, lang=ollama.default_lang,
+                        )
+                    except Exception as _orch_err:
+                        logger.warning(f"Orchestrator detection failed, falling back to single-role: {_orch_err}")
+                        sub_queries = None
+
+                    if sub_queries and len(sub_queries) >= 2:
+                        agent_used = True
+                        orchestrated = True
+                        logger.info(f"🎼 Orchestrator: {len(sub_queries)} sub-queries → {[sq.get('role') for sq in sub_queries]}")
+                        executor = ActionExecutor(mcp_manager=mcp_manager)
+                        agent_tool_results = []
+                        async for step in orchestrator.run_orchestrated(
+                            sub_queries=sub_queries,
+                            message=content,
+                            ollama=ollama,
+                            executor=executor,
+                            lang=ollama.default_lang,
+                            conversation_history=session_state.conversation_history if session_state.conversation_history else None,
+                            room_context=room_context,
+                            memory_context=memory_context,
+                            document_context=document_context,
+                            personality_context=personality_context,
+                            user_permissions=user_permissions,
+                            user_id=user_id,
+                            context_vars_text=_context_vars_text,
+                            summary_text=_summary_text,
+                        ):
+                            await websocket.send_json(step_to_ws_message(step))
+                            if step.step_type == "final_answer":
+                                full_response = step.content
+                            if step.step_type == "tool_result" and step.success and step.data:
+                                agent_tool_results.append((step.tool, step.data))
+                            if step.step_type in ("tool_call", "tool_result"):
+                                agent_steps_count += 1
+
+                        if agent_tool_results:
+                            action_result = _build_agent_action_result(agent_tool_results)
+                        if not intent:
+                            intent = {"intent": "agent.orchestrated", "confidence": 1.0, "parameters": {}}
+                        logger.info(f"🎼 Orchestrator abgeschlossen: {agent_steps_count} Steps across {len(sub_queries)} sub-agents")
+
+                if orchestrated:
+                    pass  # Orchestrator handled the request — skip single-role dispatch
+                elif role.name == "conversation":
                     # Direct LLM response — no tools, no agent loop
                     intent = {"intent": "general.conversation", "parameters": {}, "confidence": 1.0}
 

--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -1632,6 +1632,14 @@ def step_to_ws_message(step: AgentStep) -> dict:
             "success": False,
             "message": _sanitize_credentials(step.content) if step.content else step.content,
         }
+    elif step.step_type == "card":
+        # Adaptive Card payload from a post_orchestration hook handler.
+        # Frontend renders via AdaptiveCardRenderer attached to the latest
+        # assistant message.
+        return {
+            "type": "card",
+            "card": (step.data or {}).get("card"),
+        }
     else:
         return {
             "type": "agent_thinking",

--- a/src/backend/services/orchestrator.py
+++ b/src/backend/services/orchestrator.py
@@ -129,14 +129,64 @@ class QueryOrchestrator:
         When agent_orchestrator_parallel is True, sub-agents run in parallel
         with isolated contexts. Otherwise falls back to sequential execution.
 
+        Fires `pre_orchestration` before sub-agents launch and
+        `post_orchestration` after synthesis. If any post_orchestration handler
+        returns a dict containing a `card` key, an additional AgentStep with
+        step_type="card" is yielded so the WebSocket layer can forward it to
+        the client. First well-shaped card wins.
+
         Yields AgentStep objects for real-time feedback.
         """
+        from services.agent_service import AgentStep
+        from utils.hooks import run_hooks
+
+        plan = {"sub_queries": list(sub_queries), "message": message, "lang": lang}
+        try:
+            await run_hooks("pre_orchestration", message=message, plan=plan, lang=lang)
+        except Exception as e:
+            # Hook failures must never break orchestration.
+            logger.warning(f"pre_orchestration hook raised, ignoring: {e}")
+
+        sub_results: list[dict] = []
+        final_answer: str | None = None
+
         if settings.agent_orchestrator_parallel:
-            async for step in self._run_parallel(sub_queries, message, ollama, executor, lang, **agent_kwargs):
-                yield step
+            inner = self._run_parallel(
+                sub_queries, message, ollama, executor, lang,
+                sub_results_out=sub_results, **agent_kwargs,
+            )
         else:
-            async for step in self._run_sequential(sub_queries, message, ollama, executor, lang, **agent_kwargs):
-                yield step
+            inner = self._run_sequential(
+                sub_queries, message, ollama, executor, lang,
+                sub_results_out=sub_results, **agent_kwargs,
+            )
+
+        async for step in inner:
+            if step.step_type == "final_answer":
+                final_answer = step.content
+            yield step
+
+        try:
+            hook_results = await run_hooks(
+                "post_orchestration",
+                message=message,
+                sub_results=sub_results,
+                final_answer=final_answer,
+                lang=lang,
+            )
+        except Exception as e:
+            logger.warning(f"post_orchestration hook raised, ignoring: {e}")
+            hook_results = []
+
+        for hr in hook_results:
+            if isinstance(hr, dict) and hr.get("card"):
+                yield AgentStep(
+                    step_number=100,
+                    step_type="card",
+                    content="",
+                    data={"card": hr["card"]},
+                )
+                break
 
     async def _run_sub_agent(
         self,
@@ -197,9 +247,15 @@ class QueryOrchestrator:
         ollama: "OllamaService",
         executor: "ActionExecutor",
         lang: str = "de",
+        sub_results_out: list[dict] | None = None,
         **agent_kwargs,
     ) -> AsyncGenerator["AgentStep", None]:
-        """Run all sub-agents in parallel, then synthesize."""
+        """Run all sub-agents in parallel, then synthesize.
+
+        `sub_results_out` (when provided) is appended to as sub-agents complete,
+        giving the caller access to the structured per-role answers needed for
+        the post_orchestration hook.
+        """
         from services.agent_service import AgentStep
 
         logger.info(f"⚡ Orchestrator: parallel execution of {len(sub_queries)} sub-agents")
@@ -212,7 +268,7 @@ class QueryOrchestrator:
         raw_results = await asyncio.gather(*tasks, return_exceptions=True)
 
         # Yield steps grouped by sub-agent + collect results for synthesis
-        sub_results: list[dict] = []
+        sub_results: list[dict] = sub_results_out if sub_results_out is not None else []
         for sq, result in zip(sub_queries, raw_results):
             if isinstance(result, Exception):
                 logger.error(f"Orchestrator: sub-agent [{sq['role']}] failed: {result}")
@@ -245,13 +301,19 @@ class QueryOrchestrator:
         ollama: "OllamaService",
         executor: "ActionExecutor",
         lang: str = "de",
+        sub_results_out: list[dict] | None = None,
         **agent_kwargs,
     ) -> AsyncGenerator["AgentStep", None]:
-        """Run sub-agents sequentially (original behavior)."""
+        """Run sub-agents sequentially (original behavior).
+
+        `sub_results_out` (when provided) is appended to as each sub-agent
+        completes, giving the caller access to the structured per-role answers
+        for the post_orchestration hook.
+        """
         from services.agent_service import AgentService, AgentStep
         from services.agent_tools import AgentToolRegistry
 
-        sub_results: list[dict] = []
+        sub_results: list[dict] = sub_results_out if sub_results_out is not None else []
 
         for i, sq in enumerate(sub_queries):
             role_name = sq["role"]

--- a/src/frontend/src/components/AdaptiveCardRenderer.jsx
+++ b/src/frontend/src/components/AdaptiveCardRenderer.jsx
@@ -1,0 +1,218 @@
+import React from 'react';
+import { ExternalLink } from 'lucide-react';
+
+/**
+ * Renders a subset of Microsoft Adaptive Card JSON used by Reva.
+ * Supports: TextBlock, ColumnSet/Column, Container, FactSet/Fact,
+ * Image, ActionSet, Action.OpenUrl, separator, spacing.
+ */
+
+const STYLE_COLORS = {
+  good: 'text-green-600 dark:text-green-400',
+  warning: 'text-yellow-600 dark:text-yellow-400',
+  attention: 'text-red-600 dark:text-red-400',
+  accent: 'text-blue-600 dark:text-blue-400',
+  default: 'text-gray-800 dark:text-gray-200',
+};
+
+const CONTAINER_STYLES = {
+  emphasis: 'bg-gray-100 dark:bg-gray-700/50',
+  good: 'bg-green-50 dark:bg-green-900/20',
+  warning: 'bg-yellow-50 dark:bg-yellow-900/20',
+  attention: 'bg-red-50 dark:bg-red-900/20',
+  accent: 'bg-blue-50 dark:bg-blue-900/20',
+};
+
+const SIZE_CLASSES = {
+  Small: 'text-xs',
+  Default: 'text-sm',
+  Medium: 'text-base',
+  Large: 'text-lg',
+  ExtraLarge: 'text-xl',
+};
+
+const SPACING = {
+  None: '',
+  Small: 'mt-1',
+  Default: 'mt-2',
+  Medium: 'mt-3',
+  Large: 'mt-4',
+  ExtraLarge: 'mt-6',
+};
+
+/** Parse **bold** and _italic_ into React elements (no dangerouslySetInnerHTML). */
+function renderFormattedText(text) {
+  if (!text) return null;
+  const parts = [];
+  let remaining = String(text);
+  let key = 0;
+
+  while (remaining.length > 0) {
+    const boldMatch = remaining.match(/\*\*(.+?)\*\*/);
+    const italicMatch = remaining.match(/_(.+?)_/);
+
+    const nextMatch = [boldMatch, italicMatch]
+      .filter(Boolean)
+      .sort((a, b) => a.index - b.index)[0];
+
+    if (!nextMatch) {
+      parts.push(remaining);
+      break;
+    }
+
+    if (nextMatch.index > 0) {
+      parts.push(remaining.substring(0, nextMatch.index));
+    }
+
+    if (nextMatch === boldMatch) {
+      parts.push(<strong key={key++}>{nextMatch[1]}</strong>);
+    } else {
+      parts.push(<em key={key++}>{nextMatch[1]}</em>);
+    }
+
+    remaining = remaining.substring(nextMatch.index + nextMatch[0].length);
+  }
+
+  return parts;
+}
+
+function renderElement(element, index = 0) {
+  if (!element || !element.type) return null;
+
+  const key = `ac-${index}`;
+  const spacing = element.spacing ? SPACING[element.spacing] || '' : '';
+  const separator = element.separator ? 'border-t border-gray-200 dark:border-gray-600 pt-1' : '';
+
+  switch (element.type) {
+    case 'TextBlock': {
+      const size = SIZE_CLASSES[element.size] || SIZE_CLASSES.Default;
+      const weight = element.weight === 'Bolder' ? 'font-semibold' : '';
+      const color = STYLE_COLORS[element.color] || STYLE_COLORS.default;
+      const subtle = element.isSubtle ? 'opacity-60' : '';
+      const wrap = element.wrap !== false ? '' : 'truncate';
+      const align = element.horizontalAlignment === 'Center' ? 'text-center'
+        : element.horizontalAlignment === 'Right' ? 'text-right' : '';
+
+      return (
+        <p
+          key={key}
+          className={`${size} ${weight} ${color} ${subtle} ${wrap} ${align} ${spacing} ${separator}`.trim()}
+        >
+          {renderFormattedText(element.text)}
+        </p>
+      );
+    }
+
+    case 'ColumnSet': {
+      const clickable = element.selectAction?.type === 'Action.OpenUrl';
+      const Wrapper = clickable ? 'a' : 'div';
+      const wrapperProps = clickable
+        ? { href: element.selectAction.url, target: '_blank', rel: 'noopener noreferrer' }
+        : {};
+
+      return (
+        <Wrapper
+          key={key}
+          {...wrapperProps}
+          className={`flex items-start gap-2 ${spacing} ${separator} ${clickable ? 'hover:bg-gray-50 dark:hover:bg-gray-700/30 rounded cursor-pointer' : ''}`.trim()}
+        >
+          {(element.columns || []).map((col, i) => renderElement({ ...col, type: 'Column' }, `${index}-col-${i}`))}
+        </Wrapper>
+      );
+    }
+
+    case 'Column': {
+      const width = element.width === 'stretch' ? 'flex-1 min-w-0'
+        : element.width === 'auto' ? 'flex-shrink-0'
+        : 'flex-shrink-0';
+      const style = element.width && String(element.width).match(/^\d+px$/)
+        ? { width: element.width } : {};
+
+      return (
+        <div key={key} className={width} style={style}>
+          {(element.items || []).map((item, i) => renderElement(item, `${index}-item-${i}`))}
+        </div>
+      );
+    }
+
+    case 'Container': {
+      const bg = CONTAINER_STYLES[element.style] || '';
+      const bleed = element.bleed ? '-mx-3 px-3 py-2' : 'py-1';
+
+      return (
+        <div key={key} className={`${bg} ${bleed} ${spacing} ${separator} rounded`}>
+          {(element.items || []).map((item, i) => renderElement(item, `${index}-citem-${i}`))}
+        </div>
+      );
+    }
+
+    case 'FactSet': {
+      return (
+        <div key={key} className={`grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm ${spacing} ${separator}`}>
+          {(element.facts || []).map((fact, i) => (
+            <React.Fragment key={`${key}-fact-${i}`}>
+              <span className="font-medium text-gray-600 dark:text-gray-400">{fact.title}</span>
+              <span className="text-gray-800 dark:text-gray-200">{fact.value}</span>
+            </React.Fragment>
+          ))}
+        </div>
+      );
+    }
+
+    case 'Image': {
+      const sizeMap = { Small: 'h-8', Medium: 'h-16', Large: 'h-24', Auto: '' };
+      const imgSize = sizeMap[element.size] || sizeMap.Medium;
+      return (
+        <img
+          key={key}
+          src={element.url}
+          alt={element.altText || ''}
+          className={`${imgSize} ${spacing} rounded`}
+        />
+      );
+    }
+
+    case 'ActionSet': {
+      return (
+        <div key={key} className={`flex flex-wrap gap-2 ${spacing} ${separator}`}>
+          {(element.actions || []).map((action, i) => {
+            if (action.type === 'Action.OpenUrl') {
+              return (
+                <a
+                  key={`${key}-action-${i}`}
+                  href={action.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium
+                    bg-blue-600 text-white rounded hover:bg-blue-700
+                    dark:bg-blue-500 dark:hover:bg-blue-600 transition-colors"
+                >
+                  <ExternalLink className="w-3 h-3" />
+                  {action.title}
+                </a>
+              );
+            }
+            return null;
+          })}
+        </div>
+      );
+    }
+
+    default:
+      return null;
+  }
+}
+
+export default function AdaptiveCardRenderer({ card }) {
+  if (!card) return null;
+
+  const body = card.body || [];
+
+  return (
+    <div className="rounded-lg border border-gray-200 dark:border-gray-600
+      bg-white dark:bg-gray-800 p-3 overflow-x-auto text-sm">
+      {body.map((element, i) => renderElement(element, i))}
+      {card.actions && renderElement({ type: 'ActionSet', actions: card.actions, spacing: 'Medium' }, 'actions')}
+    </div>
+  );
+}

--- a/src/frontend/src/pages/ChatPage/ChatMessages.jsx
+++ b/src/frontend/src/pages/ChatPage/ChatMessages.jsx
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Volume2, Loader, FileText, AlertCircle, CheckCircle, Search, CheckCircle2, XCircle, ChevronRight } from 'lucide-react';
+import AdaptiveCardRenderer from '../../components/AdaptiveCardRenderer';
 import IntentCorrectionButton from '../../components/IntentCorrectionButton';
 import AttachmentQuickActions from './AttachmentQuickActions';
 import EmailForwardDialog from './EmailForwardDialog';
@@ -206,6 +207,13 @@ export default function ChatMessages() {
             })()}
 
             {message.role === 'assistant' ? renderMessageContent(message.content) : <p className="whitespace-pre-wrap">{message.content}</p>}
+
+            {/* Adaptive Card (from WebSocket card message) */}
+            {message.card && (
+              <div className="mt-2">
+                <AdaptiveCardRenderer card={message.card} />
+              </div>
+            )}
 
             {/* Attachment chips */}
             {message.attachments && message.attachments.length > 0 && (

--- a/src/frontend/src/pages/ChatPage/context/ChatContext.jsx
+++ b/src/frontend/src/pages/ChatPage/context/ChatContext.jsx
@@ -432,6 +432,22 @@ export function ChatProvider({ children }) {
     }));
   }, []);
 
+  // Adaptive Card from server (sent after orchestrated/single-role response)
+  const handleCard = useCallback((data) => {
+    if (!data.card) return;
+    setMessages(prev => {
+      const updated = [...prev];
+      // Attach to most recent assistant message
+      for (let i = updated.length - 1; i >= 0; i--) {
+        if (updated[i].role === 'assistant') {
+          updated[i] = { ...updated[i], card: data.card };
+          break;
+        }
+      }
+      return updated;
+    });
+  }, []);
+
   // WebSocket hook
   const { wsConnected, sendMessage: wsSendMessage, isReady } = useChatWebSocket({
     onStreamChunk: handleStreamChunk,
@@ -445,6 +461,7 @@ export function ChatProvider({ children }) {
     onAgentThinking: handleAgentThinking,
     onAgentToolCall: handleAgentToolCall,
     onAgentToolResult: handleAgentToolResult,
+    onCard: handleCard,
   });
 
   // Handle transcription from audio recording

--- a/src/frontend/src/pages/ChatPage/hooks/useChatWebSocket.js
+++ b/src/frontend/src/pages/ChatPage/hooks/useChatWebSocket.js
@@ -25,6 +25,7 @@ export function useChatWebSocket({
   onAgentThinking,
   onAgentToolCall,
   onAgentToolResult,
+  onCard,
 } = {}) {
   const [wsConnected, setWsConnected] = useState(false);
   const wsRef = useRef(null);
@@ -37,7 +38,13 @@ export function useChatWebSocket({
       reconnectTimeoutRef.current = null;
     }
 
-    const wsUrl = import.meta.env.VITE_WS_URL || 'ws://localhost:8000/ws';
+    let wsUrl = import.meta.env.VITE_WS_URL || 'ws://localhost:8000/ws';
+    // Append JWT token for WebSocket authentication (falls back to device-token cookie if absent)
+    const accessToken = localStorage.getItem('renfield_access_token');
+    if (accessToken) {
+      const sep = wsUrl.includes('?') ? '&' : '?';
+      wsUrl = `${wsUrl}${sep}token=${accessToken}`;
+    }
     const ws = new WebSocket(wsUrl);
 
     ws.onopen = () => {
@@ -84,6 +91,9 @@ export function useChatWebSocket({
       } else if (data.type === 'agent_tool_result') {
         debug.log('Agent tool result:', data.tool, data.success ? 'success' : 'failed');
         onAgentToolResult?.(data);
+      } else if (data.type === 'card') {
+        debug.log('Card received');
+        onCard?.(data);
       }
     };
 
@@ -99,7 +109,7 @@ export function useChatWebSocket({
     };
 
     wsRef.current = ws;
-  }, [onStreamChunk, onStreamDone, onAction, onRagContext, onIntentFeedbackRequest, onDocumentProcessing, onDocumentReady, onDocumentError, onAgentThinking, onAgentToolCall, onAgentToolResult]);
+  }, [onStreamChunk, onStreamDone, onAction, onRagContext, onIntentFeedbackRequest, onDocumentProcessing, onDocumentReady, onDocumentError, onAgentThinking, onAgentToolCall, onAgentToolResult, onCard]);
 
   // Connect on mount, cleanup on unmount
   useEffect(() => {

--- a/tests/backend/test_orchestrator.py
+++ b/tests/backend/test_orchestrator.py
@@ -170,3 +170,194 @@ class TestDetectMultiDomain:
 
             result = await orchestrator.detect_multi_domain("test", ollama)
             assert result is None
+
+
+# ============================================================================
+# pre/post_orchestration hooks + card emission
+# ============================================================================
+
+class TestOrchestrationHooks:
+    """`run_orchestrated` must fire pre/post hooks and forward any card payload."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_hooks(self):
+        from utils.hooks import clear_hooks
+        clear_hooks()
+        yield
+        clear_hooks()
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_pre_and_post_hooks_fire(self):
+        """Both hook events fire with the expected kwargs."""
+        from utils.hooks import register_hook
+        from services.agent_service import AgentStep
+
+        captured = {"pre": [], "post": []}
+
+        async def pre_handler(**kw):
+            captured["pre"].append(kw)
+            return None
+
+        async def post_handler(**kw):
+            captured["post"].append(kw)
+            return None
+
+        register_hook("pre_orchestration", pre_handler)
+        register_hook("post_orchestration", post_handler)
+
+        orchestrator = QueryOrchestrator(_make_router([]), MagicMock())
+
+        async def _empty_runner(*args, **kwargs):
+            yield AgentStep(step_number=1, step_type="final_answer", content="ok")
+
+        with patch.object(orchestrator, "_run_parallel", _empty_runner), \
+             patch("services.orchestrator.settings") as s:
+            s.agent_orchestrator_parallel = True
+
+            steps = []
+            async for step in orchestrator.run_orchestrated(
+                sub_queries=[{"role": "smart_home", "query": "x"}],
+                message="Mach Licht an und spiel Musik",
+                ollama=_make_ollama("ok"),
+                executor=MagicMock(),
+                lang="de",
+            ):
+                steps.append(step)
+
+        assert len(captured["pre"]) == 1
+        assert captured["pre"][0]["message"] == "Mach Licht an und spiel Musik"
+        assert captured["pre"][0]["lang"] == "de"
+        assert "plan" in captured["pre"][0]
+
+        assert len(captured["post"]) == 1
+        assert captured["post"][0]["message"] == "Mach Licht an und spiel Musik"
+        assert captured["post"][0]["final_answer"] == "ok"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_post_hook_card_emitted_as_step(self):
+        """A post_orchestration handler returning {'card': ...} yields a card step."""
+        from utils.hooks import register_hook
+        from services.agent_service import AgentStep
+
+        card_payload = {"type": "AdaptiveCard", "version": "1.5", "body": [{"type": "TextBlock", "text": "hi"}]}
+
+        async def card_handler(**kw):
+            return {"card": card_payload}
+
+        register_hook("post_orchestration", card_handler)
+
+        orchestrator = QueryOrchestrator(_make_router([]), MagicMock())
+
+        async def _empty_runner(*args, **kwargs):
+            yield AgentStep(step_number=1, step_type="final_answer", content="done")
+
+        with patch.object(orchestrator, "_run_parallel", _empty_runner), \
+             patch("services.orchestrator.settings") as s:
+            s.agent_orchestrator_parallel = True
+
+            steps = []
+            async for step in orchestrator.run_orchestrated(
+                sub_queries=[{"role": "smart_home", "query": "x"}],
+                message="msg",
+                ollama=_make_ollama("ok"),
+                executor=MagicMock(),
+                lang="de",
+            ):
+                steps.append(step)
+
+        card_steps = [s for s in steps if s.step_type == "card"]
+        assert len(card_steps) == 1
+        assert card_steps[0].data == {"card": card_payload}
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_post_hook_first_card_wins(self):
+        """When multiple handlers return a card, only the first lands as a step."""
+        from utils.hooks import register_hook
+        from services.agent_service import AgentStep
+
+        async def first(**kw):
+            return {"card": {"version": "1.5", "marker": "first"}}
+
+        async def second(**kw):
+            return {"card": {"version": "1.5", "marker": "second"}}
+
+        register_hook("post_orchestration", first)
+        register_hook("post_orchestration", second)
+
+        orchestrator = QueryOrchestrator(_make_router([]), MagicMock())
+
+        async def _empty_runner(*args, **kwargs):
+            yield AgentStep(step_number=1, step_type="final_answer", content="x")
+
+        with patch.object(orchestrator, "_run_parallel", _empty_runner), \
+             patch("services.orchestrator.settings") as s:
+            s.agent_orchestrator_parallel = True
+
+            cards = []
+            async for step in orchestrator.run_orchestrated(
+                sub_queries=[{"role": "smart_home", "query": "x"}],
+                message="m", ollama=_make_ollama("x"),
+                executor=MagicMock(), lang="de",
+            ):
+                if step.step_type == "card":
+                    cards.append(step.data["card"])
+
+        assert len(cards) == 1
+        assert cards[0]["marker"] == "first"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_post_hook_failure_does_not_break_orchestration(self):
+        """A raising hook is logged and ignored, final_answer still streams."""
+        from utils.hooks import register_hook
+        from services.agent_service import AgentStep
+
+        async def broken_handler(**kw):
+            raise RuntimeError("boom")
+
+        register_hook("post_orchestration", broken_handler)
+
+        orchestrator = QueryOrchestrator(_make_router([]), MagicMock())
+
+        async def _empty_runner(*args, **kwargs):
+            yield AgentStep(step_number=1, step_type="final_answer", content="answered")
+
+        with patch.object(orchestrator, "_run_parallel", _empty_runner), \
+             patch("services.orchestrator.settings") as s:
+            s.agent_orchestrator_parallel = True
+
+            steps = []
+            async for step in orchestrator.run_orchestrated(
+                sub_queries=[{"role": "smart_home", "query": "x"}],
+                message="m", ollama=_make_ollama("x"),
+                executor=MagicMock(), lang="de",
+            ):
+                steps.append(step)
+
+        assert any(s.step_type == "final_answer" and s.content == "answered" for s in steps)
+        assert not any(s.step_type == "card" for s in steps)
+
+
+# ============================================================================
+# step_to_ws_message: card step -> WebSocket payload
+# ============================================================================
+
+class TestCardStepWsMessage:
+    @pytest.mark.unit
+    def test_card_step_serializes_to_card_ws_message(self):
+        from services.agent_service import AgentStep, step_to_ws_message
+        card = {"type": "AdaptiveCard", "version": "1.5", "body": []}
+        step = AgentStep(step_number=100, step_type="card", data={"card": card})
+
+        msg = step_to_ws_message(step)
+        assert msg == {"type": "card", "card": card}
+
+    @pytest.mark.unit
+    def test_card_step_with_no_data_yields_null_card(self):
+        """Defensive: a malformed card step should not raise."""
+        from services.agent_service import AgentStep, step_to_ws_message
+        msg = step_to_ws_message(AgentStep(step_number=100, step_type="card"))
+        assert msg == {"type": "card", "card": None}


### PR DESCRIPTION
## Summary

The cross-MCP orchestrator at `services/orchestrator.py` was dead code — `QueryOrchestrator` + `run_orchestrated()` were defined but nothing ever instantiated them. This PR wires it into the WebSocket chat handler and adds the Adaptive Card transport protocol so plugins (Reva) can render rich multi-domain answers in the web chat UI, matching what already worked on the Teams transport.

A user asking the web chat "Status of REL-100 and the related Jira tickets" used to fall through to the single-role agent loop and get a poor answer. Now the request fans out to the release + jira sub-agents in parallel, the synthesizer composes a combined answer, and Reva's post_orchestration hook returns an Adaptive Card that lands in the chat UI.

## Backend

- **`services/orchestrator.py`**: fire `pre_orchestration` before sub-agent fan-out and `post_orchestration` after synthesis. Both hooks were already declared in `HOOK_EVENTS` but never fired. Inner runners now accept `sub_results_out` so the caller can pass collected results to the post-hook. Hook failures are logged + ignored — orchestration must not break because a plugin handler raised.
- **`services/orchestrator.py`**: `post_orchestration` handlers may return `{"card": <ac_json>}`. The first well-shaped card is yielded as `AgentStep(step_type="card")` so the WebSocket layer forwards it.
- **`services/agent_service.py`**: `step_to_ws_message` now handles `step_type=="card"` and emits `{"type": "card", "card": <ac_json>}`.
- **`api/websocket/chat_handler.py`**: between `agent_router.classify_with_context` and the role-based dispatch, attempt `orchestrator.detect_multi_domain`. If it returns >=2 sub-queries (and `agent_orchestrator_enabled` is set), run the orchestrated path instead of the single-role agent loop. Falls back gracefully if detection fails.

## Frontend

Cherry-picked from commit `d033317` on `feat/web-chat-v2` (which never made it to main):

- **`components/AdaptiveCardRenderer.jsx`** (new, 218 LOC): hand-rolled React renderer for the Adaptive Card subset Reva uses (`TextBlock`, `ColumnSet/Column`, `Container`, `FactSet/Fact`, `Image`, `ActionSet`, `Action.OpenUrl`, separator, spacing). No npm dep — `adaptivecards` pulls in too much.
- **`useChatWebSocket.js`**: add `onCard` handler for `{type: "card"}` messages. Append JWT as `?token=` query param when connecting (required by the JWT-first auth path).
- **`ChatContext.jsx`**: `handleCard` attaches the AC JSON to the most recent assistant message via `setMessages`.
- **`ChatMessages.jsx`**: render `<AdaptiveCardRenderer card={...}>` underneath the message text when `message.card` is set.

## Hook contract (for plugin authors)

```python
async def my_handler(message: str, sub_results: list[dict],
                     final_answer: str | None, lang: str, **kwargs) -> dict | None:
    # sub_results items: {"role": str, "query": str, "answer": str, "steps": [AgentStep, ...]}
    return {"card": <adaptive_card_json>}  # or None to defer to other handlers
```

## Tests

`tests/backend/test_orchestrator.py` — 6 new cases (11 total pass):

- `TestOrchestrationHooks`:
  - `test_pre_and_post_hooks_fire`: both events fire with expected kwargs
  - `test_post_hook_card_emitted_as_step`: returned card lands as a card step
  - `test_post_hook_first_card_wins`: only the first handler's card is yielded
  - `test_post_hook_failure_does_not_break_orchestration`: raising handler is logged + swallowed
- `TestCardStepWsMessage`:
  - `test_card_step_serializes_to_card_ws_message`
  - `test_card_step_with_no_data_yields_null_card`

## Test plan

- [x] Orchestrator unit tests pass (11/11)
- [x] Hook firing fail-safe verified (raising handler doesn't break orchestration)
- [x] Frontend syntax check (bracket balance unchanged from baseline)
- [ ] Manual: web chat with `AGENT_ORCHESTRATOR_ENABLED=true` + Reva plugin shows card on cross-domain query
- [ ] Manual: opt-out path (`AGENT_ORCHESTRATOR_ENABLED=false`) still works — no card, single-role agent loop

## Companion PR

Reva's `_on_post_orchestration` handler is updated in a parallel reva PR to consume the dict-based contract this PR fires with. Without that, the hook is registered but returns None (no card), so this PR alone is safe to merge — it adds the protocol but won't change behavior until a plugin returns a card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)