### PR TITLE
fix(orchestrator): use agent model + tolerate prose-wrapped JSON

### DIFF
--- a/src/backend/prompts/agent.yaml
+++ b/src/backend/prompts/agent.yaml
@@ -530,14 +530,34 @@ de:
 
   # Cross-MCP orchestrator prompts
   orchestrator_detect_prompt: |
-    Benoetigt diese Anfrage mehrere unabhaengige Aktionen in verschiedenen Domaenen?
-    Anfrage: "{message}"
+    Du zerlegst Anfragen in Teilaufgaben fuer verschiedene Domaenen.
+    Antworte IMMER mit reinem JSON. Keine Erklaerungen, kein Prosa-Text.
 
-    Verfuegbare Domaenen:
+    Verfuegbare Domaenen (nutze GENAU diese Namen als "role"):
     {role_descriptions}
 
-    Falls ja, antworte mit JSON: [{{"role": "...", "query": "..."}}, ...]
-    Falls nein (eine einzelne Domaene genuegt), antworte mit: null
+    Regeln:
+    1. Wenn die Anfrage mindestens zwei unabhaengige Aktionen in verschiedenen
+       Domaenen braucht -> JSON-Array mit je einem Eintrag pro Domaene.
+    2. Wenn eine einzige Domaene ausreicht -> genau das Wort: null
+    3. "role" MUSS exakt einer der oben gelisteten Domaenen-Namen sein.
+    4. "query" ist ein knapper Satz, der diese Domaene allein erledigen kann.
+
+    Beispiele:
+
+    Anfrage: "Licht an und spiel Musik"
+    Antwort:
+    [{{"role":"smart_home","query":"Licht einschalten"}},{{"role":"media","query":"Musik abspielen"}}]
+
+    Anfrage: "Welche Release-Tickets gibt es zu REL-100?"
+    Antwort:
+    [{{"role":"release","query":"Details zu Release REL-100"}},{{"role":"jira","query":"Jira-Tickets verknuepft mit REL-100"}}]
+
+    Anfrage: "Mach das Licht im Wohnzimmer an"
+    Antwort: null
+
+    Anfrage: "{message}"
+    Antwort:
 
   orchestrator_synthesize_prompt: |
     Kombiniere diese Teilergebnisse zu einer natuerlichen Antwort auf die urspruengliche Frage.
@@ -1058,14 +1078,34 @@ en:
 
   # Cross-MCP orchestrator prompts
   orchestrator_detect_prompt: |
-    Does this request require multiple independent actions across different domains?
-    Request: "{message}"
+    You decompose a request into sub-tasks for different domains.
+    ALWAYS answer with pure JSON. No explanations, no prose.
 
-    Available domains:
+    Available domains (use EXACTLY these names as "role"):
     {role_descriptions}
 
-    If yes, reply with JSON: [{{"role": "...", "query": "..."}}, ...]
-    If no (a single domain suffices), reply with: null
+    Rules:
+    1. If the request needs at least two independent actions in different
+       domains -> JSON array with one entry per domain.
+    2. If a single domain is enough -> exactly the word: null
+    3. "role" MUST be exactly one of the listed domain names above.
+    4. "query" is a short sentence that domain alone can complete.
+
+    Examples:
+
+    Request: "Turn on the light and play music"
+    Answer:
+    [{{"role":"smart_home","query":"Turn on the light"}},{{"role":"media","query":"Play music"}}]
+
+    Request: "Which release tickets exist for REL-100?"
+    Answer:
+    [{{"role":"release","query":"Details for release REL-100"}},{{"role":"jira","query":"Jira tickets linked to REL-100"}}]
+
+    Request: "Turn on the living room light"
+    Answer: null
+
+    Request: "{message}"
+    Answer:
 
   orchestrator_synthesize_prompt: |
     Combine these partial results into a natural answer to the original question.

--- a/src/backend/services/orchestrator.py
+++ b/src/backend/services/orchestrator.py
@@ -64,45 +64,80 @@ class QueryOrchestrator:
         if not detect_prompt:
             return None
 
-        try:
-            router_url = settings.agent_router_url or settings.agent_ollama_url
-            router_model = settings.agent_router_model or settings.ollama_intent_model or settings.ollama_model
+        # Planner: use the primary role's agent model + URL. Small router
+        # models (e.g. llama3.2:3b) cannot reliably emit pure JSON for
+        # multi-domain decomposition — they wrap JSON in prose and invent
+        # role names. Reva ran qwen3.5:27b on llama-server as its planner
+        # in production for months; we mirror that here.
+        primary_role = next(
+            (r for r in self.router.roles.values() if r.has_agent_loop),
+            None,
+        )
+        planner_model: str | None = None
+        planner_url: str | None = None
+        if primary_role is not None:
+            planner_model = getattr(primary_role, "model", None)
+            planner_url = getattr(primary_role, "ollama_url", None)
+        planner_model = planner_model or settings.ollama_model
+        planner_url = planner_url or settings.agent_ollama_url
 
-            if router_url:
-                client, _ = get_agent_client(fallback_url=router_url)
+        if not planner_model:
+            logger.debug("Orchestrator: no planner model configured, skipping detection")
+            return None
+
+        try:
+            if planner_url:
+                client, _ = get_agent_client(fallback_url=planner_url)
             else:
                 client = ollama.client
 
-            classification_kwargs = get_classification_chat_kwargs(router_model)
+            classification_kwargs = get_classification_chat_kwargs(planner_model)
+            # num_predict=800 matches Reva's production planner budget — enough
+            # for a 4-sub-agent plan with localized query strings.
             raw_response = await asyncio.wait_for(
                 client.chat(
-                    model=router_model,
+                    model=planner_model,
                     messages=[{"role": "user", "content": detect_prompt}],
-                    options={"temperature": 0, "num_predict": 256, "num_ctx": 4096},
+                    options={"temperature": 0, "num_predict": 800, "num_ctx": 4096},
                     **classification_kwargs,
                 ),
                 timeout=settings.agent_router_timeout,
             )
-            response_text = extract_response_content(raw_response) or ""
+            response_text = (extract_response_content(raw_response) or "").strip()
 
-            # Parse response — either JSON array or "null"
-            response_text = response_text.strip()
+            # Accept the explicit "null" sentinel (single-domain signal).
             if response_text.lower() in ("null", "none", ""):
                 return None
 
-            sub_queries = json.loads(response_text)
+            # Extract the JSON array from a potentially-prose response.
+            # Even large models occasionally wrap the array in explanation.
+            start = response_text.find("[")
+            end = response_text.rfind("]") + 1
+            if start < 0 or end <= start:
+                logger.info(f"Orchestrator: no JSON array in response, single-role. Raw: {response_text[:200]}")
+                return None
+
+            try:
+                sub_queries = json.loads(response_text[start:end])
+            except json.JSONDecodeError as e:
+                logger.info(f"Orchestrator: JSON parse failed ({e}), single-role. Raw: {response_text[start:end][:200]}")
+                return None
+
             if not isinstance(sub_queries, list) or len(sub_queries) < 2:
                 return None
 
-            # Validate each sub-query has role and query
+            # Validate each sub-query has role + query and the role exists.
             valid = []
             for sq in sub_queries:
                 if isinstance(sq, dict) and sq.get("role") and sq.get("query"):
-                    # Verify role exists
                     if sq["role"] in self.router.roles:
                         valid.append(sq)
 
             if len(valid) < 2:
+                logger.info(
+                    f"Orchestrator: parsed {len(sub_queries)} entries but only "
+                    f"{len(valid)} had valid roles, single-role"
+                )
                 return None
 
             logger.info(

--- a/tests/backend/test_orchestrator.py
+++ b/tests/backend/test_orchestrator.py
@@ -171,6 +171,80 @@ class TestDetectMultiDomain:
             result = await orchestrator.detect_multi_domain("test", ollama)
             assert result is None
 
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_extracts_json_array_from_prose_response(self):
+        """3B router models often wrap JSON in prose — the extractor must cope.
+
+        Real failure observed in prod (renfield#374): llama3.2:3b returned a
+        German explanation paragraph with the JSON array embedded mid-text
+        followed by another sentence. The detector previously crashed on
+        json.loads(). Now we find the first `[` and last `]` and parse that
+        slice.
+        """
+        roles = [_make_role("smart_home", servers=["homeassistant"]), _make_role("media", servers=["jellyfin"])]
+        router = _make_router(roles)
+        prose_wrapped = (
+            'Die Anfrage benoetigt mehrere Aktionen:\n\n'
+            '[{"role":"smart_home","query":"Licht an"},'
+            '{"role":"media","query":"Musik spielen"}]\n\n'
+            'Bitte beachten Sie diese Aufteilung.'
+        )
+        ollama = _make_ollama(prose_wrapped)
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        with patch("services.orchestrator.prompt_manager") as pm, \
+             patch("services.orchestrator.settings") as s, \
+             patch("services.orchestrator.get_classification_chat_kwargs", return_value={}):
+            pm.get.return_value = "detect prompt"
+            s.agent_ollama_url = None
+            s.ollama_model = "test-model"
+            s.agent_router_timeout = 10.0
+            s.agent_orchestrator_parallel = True
+
+            result = await orchestrator.detect_multi_domain("Mach Licht an und spiel Musik", ollama)
+            assert result is not None
+            assert len(result) == 2
+            assert {sq["role"] for sq in result} == {"smart_home", "media"}
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_planner_uses_primary_role_model(self):
+        """Detection must call the heavy agent model, not the small router.
+
+        Reva ran qwen3.5:27b (the role model) as planner in production. Small
+        router models can't reliably emit pure JSON. This test pins that the
+        first agent-loop role's `model` is what gets passed to client.chat.
+        """
+        primary = _make_role("smart_home", servers=["homeassistant"])
+        primary.model = "qwen3.5:27b"
+        primary.ollama_url = "http://cuda.local:8081/v1"
+        roles = [primary, _make_role("media", servers=["jellyfin"])]
+        router = _make_router(roles)
+        ollama = _make_ollama("null")
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        with patch("services.orchestrator.prompt_manager") as pm, \
+             patch("services.orchestrator.settings") as s, \
+             patch("services.orchestrator.get_classification_chat_kwargs", return_value={}), \
+             patch("services.orchestrator.get_agent_client") as gac:
+            pm.get.return_value = "detect prompt"
+            s.ollama_model = "fallback-model"
+            s.agent_ollama_url = "http://fallback:1234"
+            s.agent_router_timeout = 10.0
+
+            mock_client = MagicMock()
+            mock_resp = MagicMock()
+            mock_resp.message.content = "null"
+            mock_client.chat = AsyncMock(return_value=mock_resp)
+            gac.return_value = (mock_client, "http://cuda.local:8081/v1")
+
+            await orchestrator.detect_multi_domain("test", ollama)
+
+            gac.assert_called_once_with(fallback_url="http://cuda.local:8081/v1")
+            mock_client.chat.assert_called_once()
+            assert mock_client.chat.call_args.kwargs["model"] == "qwen3.5:27b"
+
 
 # ============================================================================
 # pre/post_orchestration hooks + card emission


### PR DESCRIPTION
## Summary

#374 wired the orchestrator into the WebSocket chat handler but detection failed end-to-end against a real router model. Two production bugs found while smoke-testing in prod (cards never rendered, response was always single-role):

### 1. Wrong model

`detect_multi_domain` used `settings.agent_router_model` which resolves to `llama3.2:3b` on Ollama. A 3B model can't reliably produce pure JSON for multi-domain decomposition with the minimal prompt — observed real prod failure:

```
"Die Anfrage benoetigt mehrere unabhaengige Aktionen...
[
  {"role": "Release-Manager", "query": "..."},
  {"role": "Jira-Nutzer", "query": "..."}
]
Die Anfrage kann also nicht..."
```

Note: invented role names (`Release-Manager` instead of `release`), prose wrapper, and trailing explanation.

Reva's pre-uplift orchestrator used the **primary role's agent model** (qwen3.5:27b on llama-server) and ran reliably in production for months. We now mirror that — pick the first `has_agent_loop` role and use its `model` + `ollama_url`. Falls back to `settings.ollama_model` / `agent_ollama_url` if the role doesn't override.

### 2. Brittle JSON parser

Even a heavier model may occasionally wrap output in prose. Mirror Reva's robust extraction: find the first `[` and last `]`, parse the slice. Empty/null/none strings still short-circuit early.

## Other changes

- Bumped `num_predict` 256 → 800 (matches Reva's planner budget, fits 4 sub-agents with localized query strings).
- Improved prompt (DE + EN) with few-shot examples and explicit rule that `role` MUST be one of the listed domain names verbatim.

## Tests

`tests/backend/test_orchestrator.py` — 2 new cases (13 total pass):

- `test_extracts_json_array_from_prose_response`: real prod failure reproduced as a fixture (German prose wrapping the JSON array)
- `test_planner_uses_primary_role_model`: pins that the heavy role model is what reaches `client.chat`, not a settings fallback

## Test plan

- [x] Unit tests pass (13/13)
- [ ] Deploy to prod, send multi-domain web chat query, verify Adaptive Card renders
- [ ] Confirm single-domain queries still take the single-role path (no orchestration overhead)

## Why now

Found while running the post-merge browser verification of #374. The orchestrator was wiring fine but `detect_multi_domain` returned None on every query because the router model couldn't parse its own output. Without this fix, #374 ships dead-on-arrival on the web chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)