### PR TITLE
fix(orchestrator): tolerate list-shaped step.data in sub-agents

### DIFF
--- a/src/backend/services/orchestrator.py
+++ b/src/backend/services/orchestrator.py
@@ -265,9 +265,16 @@ class QueryOrchestrator:
             lang=lang,
             **agent_kwargs,
         ):
-            # Tag step with sub-agent role for frontend grouping
-            step.data = step.data or {}
-            step.data["sub_agent_role"] = role_name
+            # Tag step with sub-agent role for frontend grouping. Some MCP
+            # tools return list-shaped step.data (e.g. JQL search results) —
+            # only inject the marker when data is dict-shaped or unset, never
+            # convert a list into a dict (would lose the result payload).
+            if step.data is None:
+                step.data = {"sub_agent_role": role_name}
+            elif isinstance(step.data, dict):
+                step.data["sub_agent_role"] = role_name
+            # list/scalar data stays as-is; sub_agent_role is then unavailable
+            # for frontend grouping on that step but the data itself survives.
             steps.append(step)
             if step.step_type == "final_answer":
                 final_answer = step.content

--- a/tests/backend/test_orchestrator.py
+++ b/tests/backend/test_orchestrator.py
@@ -435,3 +435,97 @@ class TestCardStepWsMessage:
         from services.agent_service import AgentStep, step_to_ws_message
         msg = step_to_ws_message(AgentStep(step_number=100, step_type="card"))
         assert msg == {"type": "card", "card": None}
+
+
+# ============================================================================
+# _run_sub_agent: handle list-shaped step.data
+# ============================================================================
+
+class TestRunSubAgentListData:
+    """Sub-agent step tagging must survive list/scalar step.data payloads.
+
+    Real prod failure: JQL search returns step.data as a list, sub-agent
+    crashed with `list indices must be integers or slices, not str` because
+    the tag injection assumed dict.
+    """
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_list_step_data_does_not_crash_sub_agent(self):
+        from services.agent_service import AgentStep
+        from services.orchestrator import QueryOrchestrator
+
+        # Build a sub-agent that yields one list-data step + a final_answer
+        async def _fake_run(*args, **kwargs):
+            yield AgentStep(
+                step_number=1, step_type="tool_result",
+                tool="jira_search", success=True,
+                data=[{"key": "REVA-42"}, {"key": "REVA-43"}],  # LIST not dict
+            )
+            yield AgentStep(
+                step_number=2, step_type="final_answer",
+                content="Found 2 tickets",
+            )
+
+        primary = _make_role("jira", servers=["jira"])
+        primary.has_agent_loop = True
+        router = _make_router([primary])
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        with patch("services.agent_service.AgentService") as MockAS, \
+             patch("services.agent_tools.AgentToolRegistry") as MockReg:
+            mock_agent = MagicMock()
+            mock_agent.run = _fake_run
+            MockAS.return_value = mock_agent
+            MockReg.return_value = MagicMock()
+
+            result = await orchestrator._run_sub_agent(
+                {"role": "jira", "query": "find tickets"},
+                _make_ollama("ok"),
+                MagicMock(),
+                "de",
+            )
+
+        # Sub-agent completed, list-shaped data preserved as-is
+        assert result["role"] == "jira"
+        assert result["answer"] == "Found 2 tickets"
+        assert len(result["steps"]) == 2
+        assert result["steps"][0].data == [{"key": "REVA-42"}, {"key": "REVA-43"}]
+        # Dict-shaped final_answer step got tagged
+        assert result["steps"][1].data == {"sub_agent_role": "jira"}
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_dict_step_data_still_tagged(self):
+        """Regression: dict-shaped data must still get sub_agent_role injected."""
+        from services.agent_service import AgentStep
+        from services.orchestrator import QueryOrchestrator
+
+        async def _fake_run(*args, **kwargs):
+            yield AgentStep(
+                step_number=1, step_type="tool_result",
+                tool="get_release", success=True,
+                data={"id": "REL-100", "status": "QA"},
+            )
+
+        primary = _make_role("release", servers=["release"])
+        primary.has_agent_loop = True
+        router = _make_router([primary])
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        with patch("services.agent_service.AgentService") as MockAS, \
+             patch("services.agent_tools.AgentToolRegistry") as MockReg:
+            mock_agent = MagicMock()
+            mock_agent.run = _fake_run
+            MockAS.return_value = mock_agent
+            MockReg.return_value = MagicMock()
+
+            result = await orchestrator._run_sub_agent(
+                {"role": "release", "query": "status"},
+                _make_ollama("ok"),
+                MagicMock(),
+                "de",
+            )
+
+        assert result["steps"][0].data["sub_agent_role"] == "release"
+        assert result["steps"][0].data["id"] == "REL-100"


### PR DESCRIPTION
## Summary

Third bug found while smoke-testing the orchestrator uplift end-to-end in prod.

`_run_sub_agent` tags every step with `sub_agent_role` for frontend grouping:

\`\`\`python
step.data = step.data or {}
step.data["sub_agent_role"] = role_name
\`\`\`

This assumes \`step.data\` is a dict (or None). But MCP tools commonly return list-shaped payloads — JQL searches, list_releases, etc. When \`step.data\` is a list, \`step.data or {}\` returns the list (truthy), and \`list[str_key] = value\` raises TypeError.

Real prod traceback:

\`\`\`
ERROR | services.orchestrator:_run_parallel:309
       Orchestrator: sub-agent [release] failed: list indices must be integers or slices, not str
ERROR | services.orchestrator:_run_parallel:309
       Orchestrator: sub-agent [jira] failed: list indices must be integers or slices, not str
\`\`\`

Both sub-agents died on their first list-returning tool result.

## Fix

Check shape before tagging:
- \`None\` → create \`{"sub_agent_role": role_name}\`
- \`dict\` → inject marker
- \`list\`/scalar → leave untouched (payload preserved; marker unavailable for frontend grouping on that step, acceptable vs losing the data entirely)

## Tests

\`tests/backend/test_orchestrator.py\` — 2 new cases (15 total pass):

- \`test_list_step_data_does_not_crash_sub_agent\`: reproduces the prod failure with JQL-style list result, asserts sub-agent completes and list payload survives
- \`test_dict_step_data_still_tagged\`: regression guard that dict data still gets the marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)