### PR TITLE
fix(chat): chat list shows truncated first user message instead of "New Conversation"

### DIFF
--- a/src/backend/api/routes/chat.py
+++ b/src/backend/api/routes/chat.py
@@ -328,30 +328,22 @@ async def list_conversations(
     db: AsyncSession = Depends(get_db),
     current_user: User | None = Depends(get_current_user),
 ):
-    """Liste aller Konversationen"""
+    """Liste aller Konversationen.
+
+    Authenticated users see only their own conversations; in single-user mode
+    (no auth) all conversations are returned. Both paths produce the same
+    shape so the frontend ChatSidebar can render `preview` (truncated first
+    user message) and `message_count` consistently.
+    """
     try:
-        if current_user is not None:
-            query = (
-                select(Conversation)
-                .where(Conversation.user_id == current_user.id)
-                .order_by(Conversation.updated_at.desc())
-                .offset(offset)
-                .limit(limit)
-            )
-            result = await db.execute(query)
-            convs = result.scalars().all()
-            conversations = [
-                {
-                    "session_id": c.session_id,
-                    "created_at": c.created_at.isoformat() if c.created_at else None,
-                    "updated_at": c.updated_at.isoformat() if c.updated_at else None,
-                }
-                for c in convs
-            ]
-        else:
-            from main import app
-            ollama: OllamaService = app.state.ollama
-            conversations = await ollama.get_all_conversations(db, limit, offset)
+        from services.conversation_service import ConversationService
+
+        service = ConversationService(db)
+        conversations = await service.list_all(
+            limit=limit,
+            offset=offset,
+            user_id=current_user.id if current_user is not None else None,
+        )
 
         return {
             "conversations": conversations,

--- a/src/backend/services/conversation_service.py
+++ b/src/backend/services/conversation_service.py
@@ -424,7 +424,8 @@ class ConversationService:
     async def list_all(
         self,
         limit: int = 50,
-        offset: int = 0
+        offset: int = 0,
+        user_id: int | None = None,
     ) -> list[dict]:
         """
         Hole Liste aller Konversationen.
@@ -432,9 +433,12 @@ class ConversationService:
         Args:
             limit: Maximale Anzahl
             offset: Pagination-Offset
+            user_id: Wenn gesetzt, nur Konversationen dieses Users (auth mode).
+                Wenn None, werden alle Konversationen zurueckgegeben (single-user mode).
 
         Returns:
-            Liste von Konversations-Zusammenfassungen
+            Liste von Konversations-Zusammenfassungen mit `preview` (gekuerzte
+            erste User-Nachricht) und `message_count`.
         """
         try:
             # Count subquery: message count per conversation
@@ -463,7 +467,7 @@ class ConversationService:
             first_msg = aliased(preview_subq)
 
             # Main query joining both subqueries
-            result = await self.db.execute(
+            stmt = (
                 select(
                     Conversation,
                     func.coalesce(count_subq.c.message_count, 0).label("message_count"),
@@ -475,6 +479,10 @@ class ConversationService:
                 .limit(limit)
                 .offset(offset)
             )
+            if user_id is not None:
+                stmt = stmt.where(Conversation.user_id == user_id)
+
+            result = await self.db.execute(stmt)
             rows = result.all()
 
             summaries = []

--- a/tests/backend/test_conversation_service.py
+++ b/tests/backend/test_conversation_service.py
@@ -255,6 +255,73 @@ class TestListAll:
         assert result[0]["session_id"] == "newer"
         assert result[1]["session_id"] == "older"
 
+    async def test_preview_is_first_user_message_truncated(
+        self, db_session: AsyncSession
+    ):
+        """Preview must be the first user message (not the last, not assistant)."""
+        service = ConversationService(db_session)
+        await service.save_message("with-preview", "user", "Mein erster Satz")
+        await service.save_message("with-preview", "assistant", "Eine Antwort")
+        await service.save_message("with-preview", "user", "Eine zweite Frage")
+
+        result = await service.list_all()
+        entry = next(r for r in result if r["session_id"] == "with-preview")
+        assert entry["preview"] == "Mein erster Satz"
+        assert entry["message_count"] == 3
+
+    async def test_preview_truncated_to_100_chars(self, db_session: AsyncSession):
+        service = ConversationService(db_session)
+        long_msg = "x" * 200
+        await service.save_message("long-msg", "user", long_msg)
+
+        result = await service.list_all()
+        entry = next(r for r in result if r["session_id"] == "long-msg")
+        assert len(entry["preview"]) == 100
+
+    async def test_user_id_filter_returns_only_user_conversations(
+        self, db_session: AsyncSession
+    ):
+        """When user_id is given, list_all returns only that user's conversations.
+
+        Regression: /api/conversations bypassed list_all when authenticated
+        and returned conversations without `preview`, so the sidebar showed
+        "New Conversation" for every entry. The fix unifies both paths
+        through list_all with an optional user_id filter.
+        """
+        service = ConversationService(db_session)
+        await service.save_message("user-1-conv", "user", "Hi from user 1")
+        await service.save_message("user-2-conv", "user", "Hi from user 2")
+        await service.save_message("orphan-conv", "user", "No owner")
+
+        # Manually assign user_id since save_message doesn't take it directly
+        result = await db_session.execute(
+            select(Conversation).where(
+                Conversation.session_id.in_(["user-1-conv", "user-2-conv"])
+            )
+        )
+        for conv in result.scalars().all():
+            conv.user_id = 1 if conv.session_id == "user-1-conv" else 2
+        await db_session.commit()
+
+        # User 1 sees only their own
+        only_user_1 = await service.list_all(user_id=1)
+        assert {c["session_id"] for c in only_user_1} == {"user-1-conv"}
+
+        # User 2 sees only their own
+        only_user_2 = await service.list_all(user_id=2)
+        assert {c["session_id"] for c in only_user_2} == {"user-2-conv"}
+
+        # No filter sees everything (single-user mode)
+        all_conv = await service.list_all()
+        assert {c["session_id"] for c in all_conv} == {
+            "user-1-conv", "user-2-conv", "orphan-conv",
+        }
+
+        # Each filtered entry still carries preview + message_count
+        entry = only_user_1[0]
+        assert entry["preview"] == "Hi from user 1"
+        assert entry["message_count"] == 1
+
 
 # ============================================================================
 # ConversationService.search Tests


### PR DESCRIPTION
## Summary

When auth is enabled, the `/api/conversations` endpoint bypassed `ConversationService.list_all()` and ran an inline minimal `SELECT` that returned only `{session_id, created_at, updated_at}`. The frontend's `ChatSidebar`/`ConversationItem` reads `conversation.preview` to render the chat title and falls back to `t('chat.newConversation')` when it's missing, so every authenticated user saw the same generic "Neue Konversation" title for every entry in the sidebar.

## Fix

Extend `list_all()` with an optional `user_id` filter and route both the auth path and single-user path through it. Both now return the same shape:

```
{session_id, created_at, updated_at, message_count, preview}
```

where `preview` is the truncated (100 chars) **first user message** of the conversation. The route shrinks from 30 lines of branchy code to 7.

## End-user effect

Before: every chat in the sidebar shows "Neue Konversation" / "New Conversation"
After: chats show their first user message, e.g. "Status von Release REL-100 und welche Jira-Tickets sind verknuepft?"

## Tests

`tests/backend/test_conversation_service.py::TestListAll` — 3 new cases:

- `test_preview_is_first_user_message_truncated`: pins that preview is the FIRST user message (ignores assistant + later user messages)
- `test_preview_truncated_to_100_chars`: length cap
- `test_user_id_filter_returns_only_user_conversations`: regression guard for the filter and the preview shape

## Test plan

- [x] Backend syntax + logic review
- [ ] Deploy to prod, log into web chat as evdb, verify sidebar shows real first-message titles for existing conversations
- [ ] Confirm cross-user isolation: user A doesn't see user B's chats

🤖 Generated with [Claude Code](https://claude.com/claude-code)