### PR TITLE
feat(frontend): white-label branding via VITE_APP_NAME + VITE_APP_LOGO_URL

### DIFF
--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -47,10 +47,19 @@ FROM base AS build
 # Build arguments for environment configuration
 ARG VITE_API_URL=
 ARG VITE_WS_URL=/ws
+# White-label branding — defaults preserve the Renfield identity.
+# Plugins (e.g. Reva) override these at build time:
+#   docker build --build-arg VITE_APP_NAME=Reva \
+#                --build-arg VITE_APP_LOGO_URL=/reva-logo.png ...
+# The logo file must already be present under src/frontend/public/.
+ARG VITE_APP_NAME=Renfield
+ARG VITE_APP_LOGO_URL=
 
 # Set environment variables for build
 ENV VITE_API_URL=${VITE_API_URL}
 ENV VITE_WS_URL=${VITE_WS_URL}
+ENV VITE_APP_NAME=${VITE_APP_NAME}
+ENV VITE_APP_LOGO_URL=${VITE_APP_LOGO_URL}
 
 # App Code kopieren
 COPY . .

--- a/src/frontend/src/components/Layout.jsx
+++ b/src/frontend/src/components/Layout.jsx
@@ -225,7 +225,7 @@ export default function Layout({ children }) {
             </button>
 
             <Link to="/" className="flex items-center">
-              <img src="/renfield-logo-header.svg" alt="Renfield" className="h-12 w-auto" />
+              <img src={import.meta.env.VITE_APP_LOGO_URL || "/renfield-logo-header.svg"} alt={import.meta.env.VITE_APP_NAME || "Renfield"} className="h-12 w-auto" />
             </Link>
           </div>
 
@@ -299,7 +299,7 @@ export default function Layout({ children }) {
           {/* Full logo + close — shown on mobile + desktop hover */}
           <div className="flex items-center justify-between w-full lg:opacity-0 lg:group-hover/sidebar:opacity-100 transition-opacity duration-200">
             <Link to="/" onClick={handleNavClick} className="flex items-center overflow-hidden">
-              <img src="/renfield-logo-header.svg" alt="Renfield" className="h-11 w-auto" />
+              <img src={import.meta.env.VITE_APP_LOGO_URL || "/renfield-logo-header.svg"} alt={import.meta.env.VITE_APP_NAME || "Renfield"} className="h-11 w-auto" />
             </Link>
             <button
               ref={firstFocusableRef}

--- a/src/frontend/src/pages/LoginPage.jsx
+++ b/src/frontend/src/pages/LoginPage.jsx
@@ -83,7 +83,7 @@ export default function LoginPage() {
         {/* Logo/Title */}
         <div className="text-center mb-8">
           <img src="/logo-icon.svg" alt="" className="w-20 h-20 mx-auto mb-4" aria-hidden="true" />
-          <h1 className="text-4xl font-bold font-display text-cream">Renfield</h1>
+          <h1 className="text-4xl font-bold font-display text-cream">{import.meta.env.VITE_APP_NAME || 'Renfield'}</h1>
           <p className="text-gray-400 mt-2">{t('auth.signInToAccount')}</p>
         </div>
 
@@ -184,7 +184,7 @@ export default function LoginPage() {
 
         {/* Footer */}
         <p className="text-center text-gray-500 text-sm mt-8">
-          Renfield - {t('auth.personalAssistant')}
+          {import.meta.env.VITE_APP_NAME || 'Renfield'} - {t('auth.personalAssistant')}
         </p>
       </div>
     </div>

--- a/src/frontend/src/pages/RegisterPage.jsx
+++ b/src/frontend/src/pages/RegisterPage.jsx
@@ -107,7 +107,7 @@ export default function RegisterPage() {
         {/* Logo/Title */}
         <div className="text-center mb-8">
           <img src="/logo-icon.svg" alt="" className="w-20 h-20 mx-auto mb-4" aria-hidden="true" />
-          <h1 className="text-4xl font-bold font-display text-cream">Renfield</h1>
+          <h1 className="text-4xl font-bold font-display text-cream">{import.meta.env.VITE_APP_NAME || 'Renfield'}</h1>
           <p className="text-gray-400 mt-2">{t('auth.createYourAccount')}</p>
         </div>
 
@@ -257,7 +257,7 @@ export default function RegisterPage() {
 
         {/* Footer */}
         <p className="text-center text-gray-500 text-sm mt-8">
-          Renfield - {t('auth.personalAssistant')}
+          {import.meta.env.VITE_APP_NAME || 'Renfield'} - {t('auth.personalAssistant')}
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary

The platform-generic branding mechanism that landed in commit `d033317` on `feat/web-chat-v2` was inadvertently dropped during the cards/orchestrator cherry-pick (#374). Without it, plugin deployments (Reva) silently revert to the Renfield identity even when they bundle their own logo.

## Mechanism

Both build args default to `Renfield` + the bundled SVG, so the out-of-the-box build is identical for Renfield-only users. Plugins override them at docker build time:

```
docker build \
  --build-arg VITE_APP_NAME=Reva \
  --build-arg VITE_APP_LOGO_URL=/reva-logo.png \
  --target production \
  -t my-frontend:latest .
```

The logo file must be present under `src/frontend/public/` before the build (or copied into the build context).

## Files

- `Dockerfile`: declare `ARG` + `ENV` for `VITE_APP_NAME`, `VITE_APP_LOGO_URL`
- `Layout.jsx`: header + sidebar logos read `import.meta.env.VITE_APP_LOGO_URL`
- `LoginPage.jsx`, `RegisterPage.jsx`: title + footer read `VITE_APP_NAME`

## Test plan

- [x] No-arg build still shows `Renfield` (defaults preserved)
- [ ] Build with `--build-arg VITE_APP_NAME=Reva --build-arg VITE_APP_LOGO_URL=/reva-logo.png` shows Reva branding everywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)