### PR TITLE
feat(theming): voice-gate wake word UI + configurable chat starters

### DIFF
--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -54,12 +54,18 @@ ARG VITE_WS_URL=/ws
 # The logo file must already be present under src/frontend/public/.
 ARG VITE_APP_NAME=Renfield
 ARG VITE_APP_LOGO_URL=
+# JSON array of starter prompts shown on an empty chat page. Plugins
+# override per deployment, e.g.
+#   --build-arg VITE_CHAT_STARTERS='["Status REL-100","Open Jira tickets"]'
+# Defaults to i18n examples (weather/light/music) when unset.
+ARG VITE_CHAT_STARTERS=
 
 # Set environment variables for build
 ENV VITE_API_URL=${VITE_API_URL}
 ENV VITE_WS_URL=${VITE_WS_URL}
 ENV VITE_APP_NAME=${VITE_APP_NAME}
 ENV VITE_APP_LOGO_URL=${VITE_APP_LOGO_URL}
+ENV VITE_CHAT_STARTERS=${VITE_CHAT_STARTERS}
 
 # App Code kopieren
 COPY . .

--- a/src/frontend/src/pages/ChatPage/ChatHeader.jsx
+++ b/src/frontend/src/pages/ChatPage/ChatHeader.jsx
@@ -1,11 +1,14 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Loader, Ear, EarOff, Settings } from 'lucide-react';
+import { useAuth } from '../../context/AuthContext';
 import { useChatContext } from './context/ChatContext';
 
 export default function ChatHeader() {
   const { t } = useTranslation();
+  const { isFeatureEnabled } = useAuth();
   const { wsConnected, wakeWord, recording } = useChatContext();
+  const voiceEnabled = isFeatureEnabled('voice');
   const [showWakeWordSettings, setShowWakeWordSettings] = useState(false);
 
   const {
@@ -30,8 +33,8 @@ export default function ChatHeader() {
           <p className="text-gray-500 dark:text-gray-400">{t('chat.subtitle')}</p>
         </div>
         <div className="flex items-center space-x-2 sm:space-x-4">
-          {/* Wake Word Controls */}
-          <div className="flex items-center space-x-2">
+          {/* Wake Word Controls (voice feature only) */}
+          {voiceEnabled && <div className="flex items-center space-x-2">
             <button
               onClick={toggleWakeWord}
               disabled={wakeWordLoading || recording}
@@ -68,7 +71,7 @@ export default function ChatHeader() {
                 <Settings className="w-4 h-4" />
               </button>
             )}
-          </div>
+          </div>}
 
           {/* Connection Status */}
           <div className="flex items-center space-x-2">
@@ -81,7 +84,7 @@ export default function ChatHeader() {
       </div>
 
       {/* Wake Word Error Message */}
-      {wakeWordError && !wakeWordEnabled && (
+      {voiceEnabled && wakeWordError && !wakeWordEnabled && (
         <div className="mt-3 flex items-center px-3 py-2 bg-red-100 dark:bg-red-900/30 rounded-lg border border-red-300 dark:border-red-700/50">
           <div className="flex items-center space-x-2">
             <div className="w-2 h-2 rounded-full bg-red-500" />
@@ -96,7 +99,7 @@ export default function ChatHeader() {
       )}
 
       {/* Wake Word Listening Indicator */}
-      {wakeWordEnabled && !recording && (
+      {voiceEnabled && wakeWordEnabled && !recording && (
         <div className="mt-3 flex items-center justify-between px-3 py-2 bg-green-100 dark:bg-green-900/30 rounded-lg border border-green-300 dark:border-green-700/50">
           <div className="flex items-center space-x-2">
             <div className={`w-2 h-2 rounded-full ${wakeWordListening ? 'bg-green-500 animate-pulse' : 'bg-yellow-500'}`} />

--- a/src/frontend/src/pages/ChatPage/ChatMessages.jsx
+++ b/src/frontend/src/pages/ChatPage/ChatMessages.jsx
@@ -113,11 +113,13 @@ export default function ChatMessages() {
             {t('chat.useTextOrMic')}
           </p>
           <div className="flex flex-wrap justify-center gap-2">
-            {[
-              t('chat.exampleWeather'),
-              t('chat.exampleLight'),
-              t('chat.exampleMusic'),
-            ].map((example) => (
+            {(() => {
+              try {
+                const custom = import.meta.env.VITE_CHAT_STARTERS;
+                if (custom) return JSON.parse(custom);
+              } catch {}
+              return [t('chat.exampleWeather'), t('chat.exampleLight'), t('chat.exampleMusic')];
+            })().map((example) => (
               <button
                 key={example}
                 onClick={() => sendMessage?.(example, false)}


### PR DESCRIPTION
## Summary

Two small frontend fixes from orphan PR #338 that are still missing on main and visibly broken for non-voice plugin deploys (Reva).

### 1. Wake word UI gated on `voice` feature flag (24460d4)

`ChatHeader.jsx` unconditionally renders the "Hey Renfield" wake word controls + listening indicator + error banner. On a Reva deploy (voice=false) these show but don't work — confusing UX.

Fix: wrap the wake word block in `{voiceEnabled && ...}` using `isFeatureEnabled('voice')` from auth context. Renfield/community deploys (voice=true by default) are unchanged.

### 2. Configurable chat starter prompts via `VITE_CHAT_STARTERS` (e3ba067)

The empty-chat suggestion buttons are hardcoded to weather / light / music examples. On Reva these render as "Wie wird das Wetter?" / "Mach das Licht an" / "Spiele Musik" — completely off-brand for a release-management assistant.

Fix: parse `VITE_CHAT_STARTERS` (JSON array string) at build time. Defaults to the existing i18n examples when unset, so Renfield-default builds are unchanged.

```
docker build \
  --build-arg VITE_CHAT_STARTERS='["Status REL-100","Open Jira tickets","Confluence release notes"]' \
  ...
```

## Scope notes

Cherry-picked just these two from #338. Skipped:
- `VITE_APP_ICON_URL` + `VITE_THEME_COLORS` env-var args — separate concern (favicon vs the header logo we already configured in #378). Out of scope; can ship separately if needed.
- All other commits on #338 already triaged as superseded by #374-#380.

## Test plan

- [x] No-arg build: wake word visible (Renfield default), starters show i18n weather/light/music examples
- [ ] Build with `VITE_APP_NAME=Reva` (no VITE_CHAT_STARTERS): wake word HIDDEN (voice=false on Reva), starters fall back to weather/light/music — should override starters too in companion Reva PR
- [ ] Build with `VITE_CHAT_STARTERS='[...]'`: starters reflect the override

## Cleans up

This is the surviving content of orphan PR #338 (`feat/white-label-theming`). The branding/logo/i18n bits already shipped via #378 + #379. Will close #338 after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)