### PR TITLE
feat(router,chat): sub_intent dispatch hook + orchestrator synthesis-only output

### DIFF
--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -805,6 +805,76 @@ async def websocket_endpoint(
                 if hook_results:
                     session_state.conversation_history = hook_results[0]
 
+                # === Sub-intent dispatch (plugin-owned deliverables) =============
+                # When the AgentRouter classifies a ``sub_intent`` with an
+                # explicit handler dispatch config, give plugins a chance
+                # to fully handle the turn before the orchestrator /
+                # single-role agent runs. This mirrors the Teams transport's
+                # _DISPATCH_HANDLERS table but works via the hook system so
+                # plugins don't need to monkey-patch the transport.
+                sub_intent_handled = False
+                if (
+                    role and role.sub_intent
+                    and role.sub_intent_definitions
+                ):
+                    si_config = role.sub_intent_definitions.get(role.sub_intent) or {}
+                    dispatch = si_config.get("dispatch") if isinstance(si_config, dict) else None
+                    if isinstance(dispatch, dict) and dispatch.get("type") == "handler":
+                        si_results = await run_hooks(
+                            "dispatch_sub_intent",
+                            role=role.name,
+                            sub_intent=role.sub_intent,
+                            handler_name=dispatch.get("handler", ""),
+                            message=content,
+                            lang=ollama.default_lang,
+                            session_id=msg_session_id,
+                            user_id=user_id,
+                            user_name=None,
+                            conversation_id=msg_session_id,
+                            mcp_manager=mcp_manager,
+                            ctx_vars=_ctx_vars,
+                        )
+                        # First plugin that returns a non-None dict wins
+                        si_result = next(
+                            (r for r in (si_results or []) if isinstance(r, dict)),
+                            None,
+                        )
+                        if si_result and si_result.get("handled"):
+                            agent_used = True
+                            sub_intent_handled = True
+                            full_response = si_result.get("answer", "") or ""
+                            card = si_result.get("card")
+                            intent = {
+                                "intent": f"sub_intent.{role.sub_intent}",
+                                "confidence": 1.0,
+                                "parameters": {},
+                            }
+
+                            # Stream the final answer so the web chat
+                            # renders it the same way as an agent response.
+                            # Order matters: stream the text first, attach
+                            # the card to the freshly-rendered assistant
+                            # bubble, THEN emit done. Some clients stop
+                            # listening after done (our python test
+                            # harness does), so card must land before it.
+                            if full_response:
+                                await websocket.send_json({
+                                    "type": "stream",
+                                    "content": full_response,
+                                })
+                            if card:
+                                await websocket.send_json({
+                                    "type": "card",
+                                    "card": card,
+                                })
+                            if full_response:
+                                await websocket.send_json({"type": "done"})
+                            logger.info(
+                                f"Sub-intent '{role.name}/{role.sub_intent}' "
+                                f"handled by plugin (answer_chars={len(full_response)}, "
+                                f"card={'yes' if card else 'no'})"
+                            )
+
                 # === Cross-MCP Orchestrator (opt-in via agent_orchestrator_enabled) ===
                 # Detect multi-domain queries before falling through to single-role
                 # dispatch. When detected, sub-agents fan out in parallel and a
@@ -813,7 +883,8 @@ async def websocket_endpoint(
                 # `card` step lands on the WebSocket as `{"type": "card", ...}`.
                 orchestrated = False
                 if (
-                    settings.agent_orchestrator_enabled
+                    not sub_intent_handled
+                    and settings.agent_orchestrator_enabled
                     and mcp_manager is not None
                     and role.name not in ("conversation", "knowledge")
                 ):
@@ -863,7 +934,9 @@ async def websocket_endpoint(
                             intent = {"intent": "agent.orchestrated", "confidence": 1.0, "parameters": {}}
                         logger.info(f"🎼 Orchestrator abgeschlossen: {agent_steps_count} Steps across {len(sub_queries)} sub-agents")
 
-                if orchestrated:
+                if sub_intent_handled:
+                    pass  # Sub-intent plugin fully handled the turn
+                elif orchestrated:
                     pass  # Orchestrator handled the request — skip single-role dispatch
                 elif role.name == "conversation":
                     # Direct LLM response — no tools, no agent loop

--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -850,13 +850,15 @@ async def websocket_endpoint(
                                 "parameters": {},
                             }
 
-                            # Stream the final answer so the web chat
-                            # renders it the same way as an agent response.
-                            # Order matters: stream the text first, attach
-                            # the card to the freshly-rendered assistant
-                            # bubble, THEN emit done. Some clients stop
-                            # listening after done (our python test
-                            # harness does), so card must land before it.
+                            # Stream the final answer + card so the web
+                            # chat renders the assistant bubble with the
+                            # adaptive card attached. The shared
+                            # persistence block below emits the ``done``
+                            # marker with ``intent`` / ``agent_steps``
+                            # metadata — do NOT emit a separate done
+                            # here, it would double-fire and clients that
+                            # stop listening after the first done would
+                            # miss the payload metadata.
                             if full_response:
                                 await websocket.send_json({
                                     "type": "stream",
@@ -867,8 +869,6 @@ async def websocket_endpoint(
                                     "type": "card",
                                     "card": card,
                                 })
-                            if full_response:
-                                await websocket.send_json({"type": "done"})
                             logger.info(
                                 f"Sub-intent '{role.name}/{role.sub_intent}' "
                                 f"handled by plugin (answer_chars={len(full_response)}, "

--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -820,6 +820,26 @@ async def websocket_endpoint(
                     si_config = role.sub_intent_definitions.get(role.sub_intent) or {}
                     dispatch = si_config.get("dispatch") if isinstance(si_config, dict) else None
                     if isinstance(dispatch, dict) and dispatch.get("type") == "handler":
+                        # Resolve the authenticated user's username once —
+                        # sub-intent handlers that need to query per-user
+                        # data (my_dashboard fetches the caller's releases
+                        # from Digital.ai Release by username) would
+                        # otherwise receive ``None`` and silently return
+                        # empty results.
+                        dispatch_user_name: str | None = None
+                        if user_id is not None:
+                            try:
+                                from services.auth_service import get_user_by_id
+                                from services.database import AsyncSessionLocal
+                                async with AsyncSessionLocal() as _db:
+                                    _user = await get_user_by_id(_db, user_id)
+                                    if _user is not None:
+                                        dispatch_user_name = _user.username
+                            except Exception as _e:
+                                logger.debug(
+                                    f"Sub-intent dispatch: username lookup "
+                                    f"for user_id={user_id} failed: {_e}"
+                                )
                         si_results = await run_hooks(
                             "dispatch_sub_intent",
                             role=role.name,
@@ -829,7 +849,7 @@ async def websocket_endpoint(
                             lang=ollama.default_lang,
                             session_id=msg_session_id,
                             user_id=user_id,
-                            user_name=None,
+                            user_name=dispatch_user_name,
                             conversation_id=msg_session_id,
                             mcp_manager=mcp_manager,
                             ctx_vars=_ctx_vars,

--- a/src/backend/services/agent_router.py
+++ b/src/backend/services/agent_router.py
@@ -14,11 +14,25 @@ Each role defines:
 import asyncio
 import json
 import os
+import re
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Optional
 
 import yaml
 from loguru import logger
+
+# Anti-dashboard guard: ``my_dashboard`` is the personal-overview
+# sub_intent. Messages that request a deliverable (status report,
+# release details, explicit list/fetch) must NOT be mis-classified as
+# my_dashboard just because those very words appear in the sub-intent's
+# "NOT for" description clause — the keyword matcher can't parse
+# negation. Shared across dispatch paths (Teams transport + web-chat
+# hook) via _infer_sub_intent.
+_ANTI_DASHBOARD = re.compile(
+    r"\b(erstell|bericht|report|status\s*bericht|details?\s+(zu|von|to|of)|"
+    r"suche|alle\s+releases|list|zeig\s+mir\s+alle|schick|sende|generate|deliveri)",
+    re.IGNORECASE,
+)
 
 from services.prompt_manager import prompt_manager
 from utils.config import settings
@@ -245,11 +259,16 @@ class AgentRouter:
             if domain in self.roles:
                 role = self.roles[domain]
                 ids = [m.id for m in resolved.entity_matches]
+                sub_intent = self._infer_sub_intent(
+                    message, role.sub_intent_definitions or {}, lang,
+                ) if role.sub_intent_definitions else None
                 logger.info(
                     f"Router entity-id: '{message[:60]}' -> "
-                    f"'{domain}' (entities={ids})"
+                    f"'{domain}"
+                    f"{'/' + sub_intent if sub_intent else ''}' "
+                    f"(entities={ids})"
                 )
-                return replace(role, sub_intent=None)
+                return replace(role, sub_intent=sub_intent)
 
         # Layer 2: Scored continuity — accumulate signals, penalize domain switches
         # Ported from Reva's context_router.py::_layer_continuity (proven in production)
@@ -336,11 +355,16 @@ class AgentRouter:
 
                 if score >= 0.6:
                     role = self.roles[active_domain]
+                    sub_intent = self._infer_sub_intent(
+                        message, role.sub_intent_definitions or {}, lang,
+                    ) if role.sub_intent_definitions else None
                     logger.info(
                         f"Router continuity: '{message[:60]}' -> "
-                        f"'{active_domain}' (score={score:.2f}: {', '.join(signals)})"
+                        f"'{active_domain}"
+                        f"{'/' + sub_intent if sub_intent else ''}' "
+                        f"(score={score:.2f}: {', '.join(signals)})"
                     )
-                    return replace(role, sub_intent=None)
+                    return replace(role, sub_intent=sub_intent)
                 elif signals:
                     logger.debug(
                         f"Router continuity below threshold: '{message[:60]}' "
@@ -500,8 +524,17 @@ class AgentRouter:
     ) -> str | None:
         """Infer sub_intent by matching user message words against description keywords.
 
-        Used as fallback when the router LLM returns prose instead of JSON.
-        Returns the sub_intent name with the most keyword hits, or None.
+        Called from (a) the LLM fallback path when the router returns
+        prose instead of JSON, (b) the entity-id and continuity fast-
+        paths to keep sub_intent hints across follow-ups. Returns the
+        sub_intent name with the most keyword hits, or None.
+
+        Guard: ``my_dashboard`` is a personal-dashboard intent; messages
+        that clearly request a deliverable ("Statusbericht erstellen",
+        "details zu Release X", "schicke den Bericht") are rejected for
+        my_dashboard even if keywords superficially match — most of
+        those words also appear in my_dashboard's "NOT for" description
+        clause and would otherwise cause false positives.
         """
         msg_lower = message.lower()
         best_name: str | None = None
@@ -514,6 +547,8 @@ class AgentRouter:
             if hits > best_hits:
                 best_hits = hits
                 best_name = si_name
+        if best_name == "my_dashboard" and _ANTI_DASHBOARD.search(message):
+            return None
         return best_name if best_hits > 0 else None
 
     def _parse_classification(self, response_text: str) -> tuple[str | None, str | None]:

--- a/src/backend/services/agent_router.py
+++ b/src/backend/services/agent_router.py
@@ -371,16 +371,28 @@ class AgentRouter:
         Returns:
             The classified AgentRole
         """
-        # Semantic fast path: try embedding-based classification first
+        # Semantic fast path: try embedding-based classification first.
+        # The router now also indexes sub_intent utterances, so a
+        # deliverable-style sub_intent (``my_dashboard``, ``status_report``)
+        # can win over the parent role and bypass the agent loop via the
+        # sub-intent dispatch hook.
         if self._semantic_router:
             try:
-                sem_role, sem_sim = await self._semantic_router.classify(message)
+                sem_role, sem_sub_intent, sem_sim = await self._semantic_router.classify(message)
                 if sem_role and sem_role in self.roles:
                     role = self.roles[sem_role]
+                    si_msg = f"/{sem_sub_intent}" if sem_sub_intent else ""
                     logger.info(
                         f"Router semantic fast-path: '{message[:60]}' -> "
-                        f"'{sem_role}' (sim={sem_sim:.3f})"
+                        f"'{sem_role}{si_msg}' (sim={sem_sim:.3f})"
                     )
+                    # Only propagate sub_intent when the parent role
+                    # actually defines it — otherwise silently drop to
+                    # avoid dispatching against a stale config.
+                    if sem_sub_intent and role.sub_intent_definitions and (
+                        sem_sub_intent in role.sub_intent_definitions
+                    ):
+                        return replace(role, sub_intent=sem_sub_intent)
                     return replace(role, sub_intent=None)
             except Exception as e:
                 logger.warning(f"Semantic router failed, falling back to LLM: {e}")

--- a/src/backend/services/agent_router.py
+++ b/src/backend/services/agent_router.py
@@ -29,8 +29,10 @@ from loguru import logger
 # negation. Shared across dispatch paths (Teams transport + web-chat
 # hook) via _infer_sub_intent.
 _ANTI_DASHBOARD = re.compile(
-    r"\b(erstell|bericht|report|status\s*bericht|details?\s+(zu|von|to|of)|"
-    r"suche|alle\s+releases|list|zeig\s+mir\s+alle|schick|sende|generate|deliveri)",
+    r"\b(erstell\w*|bericht\w*|report\w*|status[\s-]*bericht|"
+    r"details?\s+(?:zu|von|to|of)|suche\w*|alle\s+releases|"
+    r"list(?:|e|en|s|ing)|zeig\s+mir\s+alle|schick\w*|"
+    r"sende\w*|generate\w*|deliveri\w*)\b",
     re.IGNORECASE,
 )
 

--- a/src/backend/services/orchestrator.py
+++ b/src/backend/services/orchestrator.py
@@ -309,7 +309,15 @@ class QueryOrchestrator:
         ]
         raw_results = await asyncio.gather(*tasks, return_exceptions=True)
 
-        # Yield steps grouped by sub-agent + collect results for synthesis
+        # Yield steps grouped by sub-agent + collect results for synthesis.
+        # IMPORTANT: per-sub-agent `final_answer` steps are suppressed
+        # here — they are intermediate artifacts, not the combined
+        # response. The user sees exactly one final answer: either the
+        # synthesizer's output (for 2+ successful sub-agents) or the
+        # single surviving sub-agent's answer (1 sub-agent, or fallback).
+        # Without this filter, the web chat would render 1 + N answers
+        # (each with its own greeting), which duplicates content and
+        # confuses the user.
         sub_results: list[dict] = sub_results_out if sub_results_out is not None else []
         for sq, result in zip(sub_queries, raw_results):
             if isinstance(result, Exception):
@@ -323,18 +331,13 @@ class QueryOrchestrator:
                 continue
 
             for step in result["steps"]:
+                if step.step_type == "final_answer":
+                    continue  # see note above
                 yield step
             sub_results.append(result)
 
-        # Synthesize combined answer
-        if len([r for r in sub_results if r.get("answer")]) >= 2:
-            synthesized = await self._synthesize(message, sub_results, ollama, lang)
-            if synthesized:
-                yield AgentStep(
-                    step_number=99,
-                    step_type="final_answer",
-                    content=synthesized,
-                )
+        async for step in self._emit_combined_answer(message, sub_results, ollama, lang):
+            yield step
 
     async def _run_sequential(
         self,
@@ -375,6 +378,8 @@ class QueryOrchestrator:
             )
             agent = AgentService(tool_registry, role=role)
 
+            # Same suppression rule as _run_parallel — only the
+            # combined answer should be surfaced to the user.
             final_answer = None
             async for step in agent.run(
                 message=query,
@@ -383,9 +388,10 @@ class QueryOrchestrator:
                 lang=lang,
                 **agent_kwargs,
             ):
-                yield step
                 if step.step_type == "final_answer":
                     final_answer = step.content
+                    continue
+                yield step
 
             sub_results.append({
                 "role": role_name,
@@ -393,15 +399,43 @@ class QueryOrchestrator:
                 "answer": final_answer or "",
             })
 
-        # Synthesize combined answer
-        if len(sub_results) >= 2:
+        async for step in self._emit_combined_answer(message, sub_results, ollama, lang):
+            yield step
+
+    async def _emit_combined_answer(
+        self,
+        message: str,
+        sub_results: list[dict],
+        ollama: "OllamaService",
+        lang: str,
+    ) -> "AsyncGenerator[AgentStep, None]":
+        """Yield a single combined ``final_answer`` for the orchestrated turn.
+
+        Two-step logic:
+        1. Try the LLM synthesizer when at least two sub-agents returned
+           a non-empty answer — the combined deck usually needs the
+           narrative glue that the synthesizer produces.
+        2. Otherwise fall back to the first non-empty sub-agent answer.
+           This keeps single-successful-sub-agent runs from going
+           silent (which would happen if we kept the old ``>= 2`` gate
+           now that we suppress per-sub-agent final_answers).
+        """
+        from services.agent_service import AgentStep
+
+        non_empty = [r for r in sub_results if r.get("answer")]
+        synthesized: str | None = None
+        if len(non_empty) >= 2:
             synthesized = await self._synthesize(message, sub_results, ollama, lang)
-            if synthesized:
-                yield AgentStep(
-                    step_number=99,
-                    step_type="final_answer",
-                    content=synthesized,
-                )
+
+        final_text = synthesized or (non_empty[0]["answer"] if non_empty else "")
+        if not final_text:
+            return
+
+        yield AgentStep(
+            step_number=99,
+            step_type="final_answer",
+            content=final_text,
+        )
 
     async def _synthesize(
         self,

--- a/src/backend/services/orchestrator.py
+++ b/src/backend/services/orchestrator.py
@@ -411,30 +411,60 @@ class QueryOrchestrator:
     ) -> "AsyncGenerator[AgentStep, None]":
         """Yield a single combined ``final_answer`` for the orchestrated turn.
 
-        Two-step logic:
-        1. Try the LLM synthesizer when at least two sub-agents returned
-           a non-empty answer — the combined deck usually needs the
-           narrative glue that the synthesizer produces.
-        2. Otherwise fall back to the first non-empty sub-agent answer.
-           This keeps single-successful-sub-agent runs from going
-           silent (which would happen if we kept the old ``>= 2`` gate
-           now that we suppress per-sub-agent final_answers).
+        Logic:
+        1. Synthesize via LLM when ≥2 sub-agents returned a non-empty
+           answer — the combined deck needs narrative glue.
+        2. Fall back to the first non-empty sub-agent answer when only
+           one succeeded.
+        3. When *every* sub-agent failed (``non_empty`` is empty), emit
+           a visible error message so the user sees feedback and the
+           downstream chat_handler persists the turn. Returning silently
+           here would leave ``full_response=""``, which gates both the
+           WebSocket final bubble AND DB persistence — losing the whole
+           turn including the user's message.
         """
         from services.agent_service import AgentStep
 
         non_empty = [r for r in sub_results if r.get("answer")]
-        synthesized: str | None = None
+
         if len(non_empty) >= 2:
             synthesized = await self._synthesize(message, sub_results, ollama, lang)
+            if synthesized:
+                yield AgentStep(
+                    step_number=99,
+                    step_type="final_answer",
+                    content=synthesized,
+                )
+                return
+            # Synthesizer returned nothing — fall through to fallback.
 
-        final_text = synthesized or (non_empty[0]["answer"] if non_empty else "")
-        if not final_text:
+        if non_empty:
+            yield AgentStep(
+                step_number=99,
+                step_type="final_answer",
+                content=non_empty[0]["answer"],
+            )
             return
 
+        # Every sub-agent failed. Surface a localized error so the user
+        # isn't left staring at an empty reply.
+        failed_roles = [r.get("role", "?") for r in sub_results]
+        if lang.startswith("de"):
+            msg = (
+                "Keine der angefragten Integrationen hat eine Antwort "
+                f"geliefert (betroffen: {', '.join(failed_roles)}). "
+                "Bitte versuche es in einem Moment erneut."
+            )
+        else:
+            msg = (
+                "None of the requested integrations returned an answer "
+                f"(affected: {', '.join(failed_roles)}). "
+                "Please try again in a moment."
+            )
         yield AgentStep(
             step_number=99,
             step_type="final_answer",
-            content=final_text,
+            content=msg,
         )
 
     async def _synthesize(

--- a/src/backend/services/semantic_router.py
+++ b/src/backend/services/semantic_router.py
@@ -27,35 +27,69 @@ _KEYWORD_BOOST_AMOUNT = 0.15
 
 
 class SemanticRouter:
-    """Embedding-based fast classifier for agent routing."""
+    """Embedding-based fast classifier for agent routing.
+
+    Indexes both role-level utterances and per-role ``sub_intent``
+    utterances so deliverable-style sub-intents (``my_dashboard``,
+    ``status_report``, etc.) can win over the parent role when a user
+    message lexically resembles both.
+    """
 
     def __init__(self, threshold: float = 0.75):
         self.threshold = threshold
         self._role_embeddings: dict[str, list[list[float]]] = {}  # role_name -> list of embeddings
+        # Same shape as ``_role_embeddings`` but keyed by (role, sub_intent).
+        # Populated from ``role.sub_intent_definitions[*].utterances``.
+        self._sub_intent_embeddings: dict[tuple[str, str], list[list[float]]] = {}
         self._ollama_client = None
         self._initialized = False
 
     async def initialize(self, roles: dict[str, AgentRole]) -> None:
-        """Pre-compute embeddings for all role utterances."""
+        """Pre-compute embeddings for role + sub_intent utterances."""
         client = get_embed_client()
-        for name, role in roles.items():
-            if not role.utterances:
-                continue
-            embeddings = []
-            for utterance in role.utterances:
+
+        async def _embed_all(phrases: list[str], label: str) -> list[list[float]]:
+            out: list[list[float]] = []
+            for phrase in phrases:
                 try:
                     response = await client.embeddings(
                         model=settings.ollama_embed_model,
-                        prompt=utterance,
+                        prompt=phrase,
                     )
-                    embeddings.append(response.embedding)
+                    out.append(response.embedding)
                 except Exception as e:
-                    logger.warning(f"Failed to embed utterance for role {name}: {e}")
-            if embeddings:
-                self._role_embeddings[name] = embeddings
+                    logger.warning(f"Failed to embed utterance for {label}: {e}")
+            return out
+
+        for name, role in roles.items():
+            if role.utterances:
+                role_embs = await _embed_all(role.utterances, f"role {name}")
+                if role_embs:
+                    self._role_embeddings[name] = role_embs
+
+            # Sub-intent utterances — indexed separately so a matching
+            # sub_intent can override the parent role at classification
+            # time. We read the utterances directly off the config since
+            # AgentRole currently carries sub_intent_definitions as the
+            # raw description/dispatch dict.
+            for si_name, si_def in (role.sub_intent_definitions or {}).items():
+                if not isinstance(si_def, dict):
+                    continue
+                si_utters = si_def.get("utterances") or []
+                if not isinstance(si_utters, list) or not si_utters:
+                    continue
+                si_embs = await _embed_all(
+                    [str(u) for u in si_utters], f"sub_intent {name}/{si_name}",
+                )
+                if si_embs:
+                    self._sub_intent_embeddings[(name, si_name)] = si_embs
+
         self._ollama_client = client
         self._initialized = True
-        total_utterances = sum(len(v) for v in self._role_embeddings.values())
+        total_utterances = (
+            sum(len(v) for v in self._role_embeddings.values())
+            + sum(len(v) for v in self._sub_intent_embeddings.values())
+        )
 
         # Build keyword boost map from role descriptions.
         # If a role's description mentions domain-specific terms, those become
@@ -73,13 +107,24 @@ class SemanticRouter:
             + (f", {sum(len(v) for v in _KEYWORD_BOOST.values())} keyword boosts" if _KEYWORD_BOOST else "")
         )
 
-    async def classify(self, message: str) -> tuple[str | None, float]:
+    async def classify(
+        self, message: str,
+    ) -> tuple[str | None, str | None, float]:
         """Classify a message by cosine similarity to role utterances.
 
-        Returns (role_name, similarity) or (None, 0.0) if below threshold.
+        Returns ``(role_name, sub_intent_name_or_None, similarity)``.
+        Returns ``(None, None, best_sim)`` when the best match is below
+        the threshold.
+
+        Sub-intent utterances compete on equal footing with role
+        utterances, so a sub_intent matching closer than its parent role
+        wins — the caller can then bypass the agent loop via the
+        sub-intent dispatch hook.
         """
-        if not self._initialized or not self._role_embeddings:
-            return None, 0.0
+        if not self._initialized or (
+            not self._role_embeddings and not self._sub_intent_embeddings
+        ):
+            return None, None, 0.0
 
         try:
             response = await self._ollama_client.embeddings(
@@ -89,30 +134,55 @@ class SemanticRouter:
             query_emb = np.array(response.embedding)
         except Exception as e:
             logger.warning(f"SemanticRouter embed failed: {e}")
-            return None, 0.0
+            return None, None, 0.0
 
-        best_role = None
+        best_role: str | None = None
+        best_sub_intent: str | None = None
         best_sim = 0.0
 
         query_norm = np.linalg.norm(query_emb)
         if query_norm < 1e-10:
-            return None, 0.0
+            return None, None, 0.0
 
-        for role_name, embeddings in self._role_embeddings.items():
+        def _best_of(
+            embeddings: list, current_best_sim: float,
+        ) -> float:
+            """Return the best cosine similarity found in ``embeddings``."""
+            best = current_best_sim
             for emb in embeddings:
                 emb_arr = np.array(emb)
                 emb_norm = np.linalg.norm(emb_arr)
                 if emb_norm < 1e-10:
                     continue
                 sim = float(np.dot(query_emb, emb_arr) / (query_norm * emb_norm))
-                if sim > best_sim:
-                    best_sim = sim
-                    best_role = role_name
+                if sim > best:
+                    best = sim
+            return best
+
+        # Role-level utterances
+        for role_name, embeddings in self._role_embeddings.items():
+            sim = _best_of(embeddings, 0.0)
+            if sim > best_sim:
+                best_sim = sim
+                best_role = role_name
+                best_sub_intent = None
+
+        # Sub-intent utterances — can override a role-level match when
+        # the sub_intent phrasing is closer. Ties go to role level
+        # (compare strict ``>`` to preserve role match on equal sim).
+        for (role_name, si_name), embeddings in self._sub_intent_embeddings.items():
+            sim = _best_of(embeddings, 0.0)
+            if sim > best_sim:
+                best_sim = sim
+                best_role = role_name
+                best_sub_intent = si_name
 
         # Apply keyword boosting: if the message contains domain-specific
         # keywords, re-evaluate with boosted scores. This fixes cases where
         # "Zeige mir alle Releases" matches "Zeige mir alle Incidents" because
         # the sentence structure is identical but the domain keyword differs.
+        # Keyword boost operates on role-level only (sub_intents rely on
+        # their explicit utterances rather than keyword hints).
         if _KEYWORD_BOOST:
             msg_lower = message.lower()
             boosted_role = None
@@ -121,24 +191,17 @@ class SemanticRouter:
                 if role_name not in self._role_embeddings:
                     continue
                 if any(kw in msg_lower for kw in keywords):
-                    # Find best sim for this specific role
-                    for emb in self._role_embeddings[role_name]:
-                        emb_arr = np.array(emb)
-                        emb_norm = np.linalg.norm(emb_arr)
-                        if emb_norm < 1e-10:
-                            continue
-                        sim = float(np.dot(query_emb, emb_arr) / (query_norm * emb_norm))
-                        sim += _KEYWORD_BOOST_AMOUNT  # boost
-                        if sim > boosted_sim:
-                            boosted_sim = sim
-                            boosted_role = role_name
+                    sim = _best_of(self._role_embeddings[role_name], 0.0) + _KEYWORD_BOOST_AMOUNT
+                    if sim > boosted_sim:
+                        boosted_sim = sim
+                        boosted_role = role_name
             if boosted_role and boosted_sim >= self.threshold and boosted_role != best_role:
                 logger.info(
                     f"SemanticRouter keyword boost: '{best_role}' ({best_sim:.3f}) → "
                     f"'{boosted_role}' ({boosted_sim:.3f})"
                 )
-                return boosted_role, boosted_sim
+                return boosted_role, None, boosted_sim
 
         if best_sim >= self.threshold:
-            return best_role, best_sim
-        return None, best_sim
+            return best_role, best_sub_intent, best_sim
+        return None, None, best_sim

--- a/src/backend/utils/hooks.py
+++ b/src/backend/utils/hooks.py
@@ -171,6 +171,18 @@ HOOK_EVENTS: frozenset[str] = frozenset({
     "pre_sub_agent",
     "post_sub_agent",
     "check_output",
+    # Sub-intent dispatch — fired by chat_handler after AgentRouter
+    # classification when the matched role declares a sub_intent with a
+    # ``dispatch: {type: handler, handler: <name>}`` config. Handlers
+    # receive ``role: str, sub_intent: str, handler_name: str,
+    # message: str, lang: str, session_id, user_id, user_name,
+    # conversation_id, mcp_manager, ctx_vars`` and return either
+    # ``{"handled": True, "answer": str, "card": dict | None,
+    # "entry_mapping": list}`` to fully own the turn (bypassing the
+    # orchestrator and agent loop) or ``None`` to decline. First
+    # plugin returning ``handled=True`` wins. This is the web-chat
+    # equivalent of the Teams transport's ``_DISPATCH_HANDLERS`` table.
+    "dispatch_sub_intent",
 })
 
 HookFn = Callable[..., Coroutine[Any, Any, Any]]

--- a/tests/backend/test_agent_parallel.py
+++ b/tests/backend/test_agent_parallel.py
@@ -141,9 +141,11 @@ async def test_orchestrator_parallel_runs_both_agents():
             steps.append(step)
 
     final_answers = [s for s in steps if s.step_type == "final_answer"]
-    # 2 sub-agent finals + 1 synthesis = 3
-    assert len(final_answers) >= 2
-    assert any("Combined" in s.content for s in final_answers)
+    # Orchestrator now yields exactly ONE final_answer — the synthesized
+    # one. Per-sub-agent final_answer steps are suppressed so the web chat
+    # doesn't render multiple greetings / duplicated intro text.
+    assert len(final_answers) == 1
+    assert final_answers[0].content == "Combined answer"
 
 
 @pytest.mark.unit
@@ -188,7 +190,10 @@ async def test_orchestrator_error_isolation():
     finals = [s for s in steps if s.step_type == "final_answer"]
     assert len(errors) == 1
     assert "bad" in errors[0].content
-    assert len(finals) >= 1
+    # Even with synthesis returning None, exactly one final_answer is
+    # yielded — falling back to the surviving sub-agent's answer.
+    assert len(finals) == 1
+    assert finals[0].content == "Good result"
 
 
 @pytest.mark.unit

--- a/tests/backend/test_agent_parallel.py
+++ b/tests/backend/test_agent_parallel.py
@@ -238,3 +238,88 @@ async def test_orchestrator_step_tagging():
     for step in steps:
         if step.data and "sub_agent_role" in step.data:
             assert step.data["sub_agent_role"] == "smart_home"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_orchestrator_all_sub_agents_fail_emits_error_final_answer():
+    """When every sub-agent raises, the orchestrator must still yield a
+    final_answer so downstream message persistence runs. Regression test
+    for the silent-failure hole before PR #384 fix commit 51fb953."""
+    from services.orchestrator import QueryOrchestrator
+
+    mock_router = MagicMock()
+    mock_role = MagicMock()
+    mock_role.has_agent_loop = True
+    mock_role.mcp_servers = []
+    mock_role.internal_tools = []
+    mock_router.roles = {"release": mock_role, "jira": mock_role}
+
+    orch = QueryOrchestrator(mock_router, MagicMock())
+
+    async def mock_run_sub(sq, *args, **kwargs):
+        raise RuntimeError(f"{sq['role']} down")
+
+    orch._run_sub_agent = mock_run_sub
+    orch._synthesize = AsyncMock(return_value=None)
+
+    sub_queries = [
+        {"role": "release", "query": "a"},
+        {"role": "jira", "query": "b"},
+    ]
+
+    steps = []
+    with patch.object(settings, "agent_orchestrator_parallel", True):
+        async for step in orch._run_parallel(sub_queries, "test", MagicMock(), MagicMock()):
+            steps.append(step)
+
+    errors = [s for s in steps if s.step_type == "error"]
+    finals = [s for s in steps if s.step_type == "final_answer"]
+    assert len(errors) == 2
+    # Exactly one final_answer, localized error message
+    assert len(finals) == 1
+    assert "release" in finals[0].content and "jira" in finals[0].content
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_orchestrator_synthesis_none_falls_back_to_first_answer():
+    """If the synthesizer returns None despite having ≥2 non-empty
+    sub-agent results, the orchestrator must still emit a final_answer
+    (falling back to the first answer). Regression test for the
+    silent-return hole in the middle branch."""
+    from services.agent_service import AgentStep
+    from services.orchestrator import QueryOrchestrator
+
+    mock_router = MagicMock()
+    mock_role = MagicMock()
+    mock_role.has_agent_loop = True
+    mock_role.mcp_servers = []
+    mock_role.internal_tools = []
+    mock_router.roles = {"a": mock_role, "b": mock_role}
+
+    orch = QueryOrchestrator(mock_router, MagicMock())
+
+    async def mock_run_sub(sq, *args, **kwargs):
+        return {
+            "role": sq["role"],
+            "query": sq["query"],
+            "answer": f"answer-from-{sq['role']}",
+            "steps": [],
+        }
+
+    orch._run_sub_agent = mock_run_sub
+    orch._synthesize = AsyncMock(return_value=None)  # synthesizer fails
+
+    steps = []
+    with patch.object(settings, "agent_orchestrator_parallel", True):
+        async for step in orch._run_parallel(
+            [{"role": "a", "query": "q"}, {"role": "b", "query": "q"}],
+            "msg", MagicMock(), MagicMock(),
+        ):
+            steps.append(step)
+
+    finals = [s for s in steps if s.step_type == "final_answer"]
+    assert len(finals) == 1
+    # Falls back to the first non-empty answer
+    assert finals[0].content == "answer-from-a"

--- a/tests/backend/test_agent_router.py
+++ b/tests/backend/test_agent_router.py
@@ -1227,3 +1227,68 @@ class TestSetSemanticRouter:
             mock_sr.classify.assert_called_once_with("something")
             # LLM classification was attempted (get_agent_client was called)
             assert role.name == "general"
+
+
+# ---------------------------------------------------------------------------
+# Anti-dashboard guard + sub_intent inference on fast paths
+# (follow-up to PR #384 review findings)
+# ---------------------------------------------------------------------------
+
+
+class TestInferSubIntent:
+    """AgentRouter._infer_sub_intent: keyword-based sub_intent inference
+    used by the Layer-1 entity-id path, Layer-2 continuity path, and the
+    LLM prose-fallback path."""
+
+    @pytest.mark.unit
+    def test_status_report_wins_on_deliverable_query(self):
+        from services.agent_router import AgentRouter
+        defs = {
+            "my_dashboard": {
+                "de": "mein Dashboard, meine Aufgaben. NICHT verwenden fuer: Statusbericht erstellen",
+            },
+            "status_report": {
+                "de": "Statusbericht, Release-Bericht, status report",
+            },
+        }
+        assert AgentRouter._infer_sub_intent(
+            "Statusbericht für Product A 1.3.5", defs, "de",
+        ) == "status_report"
+
+    @pytest.mark.unit
+    def test_anti_dashboard_guard_rejects_false_positive(self):
+        """A message asking for a status report must NOT be classified
+        as my_dashboard even if 'Statusbericht' happens to appear in the
+        my_dashboard description's NICHT clause — the keyword matcher
+        can't parse negation."""
+        from services.agent_router import AgentRouter
+        defs = {
+            "my_dashboard": {
+                "de": "dashboard, meine aufgaben, NICHT fuer: Statusbericht erstellen, alle releases",
+            },
+        }
+        assert AgentRouter._infer_sub_intent(
+            "Statusbericht erstellen bitte", defs, "de",
+        ) is None
+
+    @pytest.mark.unit
+    def test_my_dashboard_still_matches_genuine_query(self):
+        from services.agent_router import AgentRouter
+        defs = {
+            "my_dashboard": {
+                "de": "dashboard, meine aufgaben, was liegt bei mir an",
+            },
+        }
+        assert AgentRouter._infer_sub_intent(
+            "Was liegt bei mir an?", defs, "de",
+        ) == "my_dashboard"
+
+    @pytest.mark.unit
+    def test_no_hits_returns_none(self):
+        from services.agent_router import AgentRouter
+        defs = {
+            "my_dashboard": {"de": "dashboard, tasks"},
+        }
+        assert AgentRouter._infer_sub_intent(
+            "Hello world", defs, "de",
+        ) is None

--- a/tests/backend/test_agent_router.py
+++ b/tests/backend/test_agent_router.py
@@ -1180,7 +1180,7 @@ class TestSetSemanticRouter:
         router = AgentRouter(config)
 
         mock_sr = AsyncMock()
-        mock_sr.classify.return_value = ("smart_home", 0.92)
+        mock_sr.classify.return_value = ("smart_home", None, 0.92)
         router.set_semantic_router(mock_sr)
 
         ollama = MagicMock()
@@ -1205,7 +1205,7 @@ class TestSetSemanticRouter:
         router = AgentRouter(config)
 
         mock_sr = AsyncMock()
-        mock_sr.classify.return_value = (None, 0.3)
+        mock_sr.classify.return_value = (None, None, 0.3)
         router.set_semantic_router(mock_sr)
 
         mock_client = AsyncMock()


### PR DESCRIPTION
## Summary

- **sub_intent dispatch parity between Teams & web chat**: lift the dispatch mechanism Reva's Teams transport already uses into Renfield's `chat_handler.py` via a new `dispatch_sub_intent` plugin hook. Deliverable sub-intents (`my_dashboard`, `status_report`, …) now bypass the orchestrator + agent loop uniformly across transports.
- **Semantic router sees sub_intents**: `SemanticRouter` now indexes sub_intent utterances alongside role utterances and returns `(role, sub_intent, sim)`, so a closer sub_intent match wins over the parent role. `AgentRouter` propagates the sub_intent.
- **Orchestrator emits exactly one final answer**: the parallel and sequential orchestrator paths suppressed per-sub-agent `final_answer` steps — the web chat was rendering *N + 1* greetings for a single multi-role query. New `_emit_combined_answer` synthesizes for ≥2 sub-agents, falls back to the first sub-agent's answer when synthesis is skipped.
- **Hook whitelist bug**: `register_hook("dispatch_sub_intent", …)` raised `ValueError: Unknown hook event` until the event name was added to `HOOK_EVENTS` (silent plugin-boot failure).

## Motivation

Downstream plugin (Reva) needs a deterministic deliverable-style query pattern (e.g. "Statusbericht für Release X") that guarantees a full parallel fetch across every connected integration, independent of the LLM planner's non-deterministic decisions. Sub-intent dispatch was the cleanest match for this — already used by `my_dashboard` — but only worked for the Teams transport. This PR makes it work for the web chat too, and fixes the duplicate-greeting bug that the orchestrator had regardless of whether a plugin handled the turn.

## Test plan

- [x] `test_agent_router.py` — semantic router mock updated to the 3-tuple return shape; both matching and below-threshold paths verified
- [x] `test_agent_parallel.py` — assert exactly one `final_answer` yielded (synthesized for ≥2 sub-agents, fallback for 1)
- [x] Live end-to-end via web chat (Reva): query classified as `release/status_report`, sub-intent handler fires, no orchestrator, exactly one stream chunk + one card + done
- [ ] Regression sweep against existing `my_dashboard` behavior (Teams + web chat)

## Notes

- Backwards-compat break: `SemanticRouter.classify` now returns `(role, sub_intent, sim)` instead of `(role, sim)`. Only one out-of-tree caller (`reva/routing/context_router.py`) — updated in the sibling Reva PR.
- Renfield swallows plugin-boot exceptions mid-chain, so the hook-whitelist bug was invisible until the dispatch code ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)