### PR TITLE
fix(webchat): pre_agent_context user_id + shadowed AsyncSessionLocal

### DIFF
--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -794,13 +794,19 @@ async def websocket_endpoint(
                 _background_tasks.add(_pr_task)
                 _pr_task.add_done_callback(_background_tasks.discard)
 
-                # Let plugins modify conversation history before the agent sees it
+                # Let plugins modify conversation history before the agent sees it.
+                # ``user_id`` is included so plugins can resolve the
+                # authenticated user before any Conversation row exists
+                # for this session — needed for cross-channel handoff,
+                # which has to look up the user's OTHER conversations
+                # on the very first turn.
                 from utils.hooks import run_hooks
                 hook_results = await run_hooks(
                     "pre_agent_context",
                     history=session_state.conversation_history or [],
                     session_id=msg_session_id or "",
                     lang=ollama.default_lang,
+                    user_id=user_id,
                 )
                 if hook_results:
                     session_state.conversation_history = hook_results[0]
@@ -829,8 +835,14 @@ async def websocket_endpoint(
                         dispatch_user_name: str | None = None
                         if user_id is not None:
                             try:
+                                # NOTE: do NOT reimport AsyncSessionLocal
+                                # here — a local import inside this
+                                # function scope shadows the
+                                # module-level binding (line 20) for
+                                # the rest of the function, causing
+                                # UnboundLocalError in later blocks
+                                # (e.g. the save_message path below).
                                 from services.auth_service import get_user_by_id
-                                from services.database import AsyncSessionLocal
                                 async with AsyncSessionLocal() as _db:
                                     _user = await get_user_by_id(_db, user_id)
                                     if _user is not None:

--- a/src/backend/services/conversation_service.py
+++ b/src/backend/services/conversation_service.py
@@ -136,6 +136,13 @@ class ConversationService:
             if not conversation:
                 conversation = Conversation(session_id=session_id, user_id=user_id)
                 self.db.add(conversation)
+                # Flush so ``conversation.id`` is populated before it's
+                # used as ``Message.conversation_id`` below — otherwise
+                # the first message of every brand-new session gets
+                # saved with ``conversation_id=NULL`` and becomes
+                # orphaned (invisible to any JOIN-based history or
+                # message-count query).
+                await self.db.flush()
             elif user_id and conversation.user_id is None:
                 conversation.user_id = user_id
                 await self.db.flush()


### PR DESCRIPTION
## Summary

Two small fixes that together unblock cross-channel conversation continuity on the Reva plugin side:

1. **`UnboundLocalError` in web-chat save_message path** — the sub-intent dispatch block (added in ebongard/renfield#384) re-imports `AsyncSessionLocal` inside a function-scoped `try:`, which promotes the name to a local variable for the entire function. Every later block that references the module-level `AsyncSessionLocal` hits `cannot access local variable 'AsyncSessionLocal' where it is not associated with a value`. The save_message path around line 1176 silently failed, so web-chat conversations were never persisted to the DB — invisible unless you grep for the one-line WARNING.

2. **`user_id` kwarg on `pre_agent_context`** — plugins that need to identify the authenticated user on the **first** turn of a session (before any `Conversation` row exists for the session_id) had no way to do so. Web-chat now passes `user_id=user_id` to the hook so plugins can look up cross-session state without racing the Conversation-row-creation that happens later in `save_message`.

## Motivation

Reva's bidirectional Teams ↔ Web Chat handoff feature needs to resolve the authenticated user on the first turn of a freshly-opened session to find their previous conversation. Without `user_id` on the hook, the current logic falls back to a Conversation-row lookup that won't find anything yet.

## Test plan

- [x] Verified locally: after the fix, web-chat conversations persist correctly (previously silent failure).
- [x] Live verification on production: `user_id` now reaches Reva's `pre_agent_context` hook, cross-channel import fires as expected.
- [ ] No regressions in existing `pre_agent_context` callers (ha_glue plugins, etc.) — `user_id` is an additive kwarg, existing handlers ignore it via `**kwargs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)