### PR TITLE
feat: document-worker split — PR A (infra) (#388)

### DIFF
--- a/docs/DOCUMENT_WORKER_SPLIT.md
+++ b/docs/DOCUMENT_WORKER_SPLIT.md
@@ -3,149 +3,461 @@
 Plan to extract document ingestion (Docling + EasyOCR + layout detection) from the
 backend pod into a dedicated worker deployment.
 
+Revision history:
+- v1 (2026-04-18): initial draft, inline feature flag, hostPath NFS, existing Redis-list TaskQueue.
+- **v2 (2026-04-19)**: pressure-tested in `/plan-eng-review`. Six changes incorporated:
+  (1) TaskQueue replaced by Redis Streams for at-least-once durability;
+  (2) shared storage via NFS-CSI driver, not hostPath;
+  (3) worker heartbeat gates the upload route's fast-path;
+  (4) test matrix made mandatory (worker-crash recovery is blocking);
+  (5) frontend polling ships in the cutover PR, not a follow-up;
+  (6) worker entrypoint audited for module isolation.
+
 ## Status
 
-- **Current**: the backend runs document processing inline in the upload
-  request. The first real PDF upload after boot triggered an `OOMKilled`
-  (exit 137) at 6 GiB — Docling initialises RT-DETR layout detection plus
-  EasyOCR detection + recognition models (770 weights) on top of the already
-  resident Whisper+Transformers footprint.
-- **Short-term mitigation** (shipped): backend memory limit raised from 6 GiB
-  to 8 GiB. Eliminates the crash for the current `WHISPER_MODEL=small` +
-  Docling workload with headroom.
-- **Long-term plan** (this document): extract document processing into a
-  separate worker deployment so the backend's footprint stays around 3–4 GiB
-  regardless of upload traffic.
+- **Current**: backend runs document processing inline in the upload request.
+  First real PDF upload OOMKilled at 6 GiB — Docling boots RT-DETR layout +
+  EasyOCR detection/recognition models (770 weights) on top of the resident
+  Whisper + transformers footprint.
+- **Short-term mitigation** (shipped in PR #387): backend memory limit 12 GiB.
+  Works, but still a landmine for scanned multi-hundred-page PDFs.
+- **Long-term plan** (this document): separate worker deployment, backend
+  drops back to ~5 GiB.
 
 ## Why a separate deployment
 
-- Isolates a heavyweight, spiky memory consumer (Docling easily peaks at
-  1.5–2 GiB on large PDFs) from the steady-state API serving path.
-- Survives `WHISPER_MODEL` being bumped to `medium`/`large-v3` without having
-  to re-budget the backend every time.
+- Isolates a heavyweight, spiky memory consumer from the steady-state API path.
+- Survives `WHISPER_MODEL` being bumped to `medium`/`large-v3` without re-budgeting.
 - Lets document ingestion scale horizontally without scaling FastAPI replicas.
-- Aligns with the pattern already used for Ollama (separate GPU-bound pods
-  behind a ClusterIP Service) and matches the Celery/Redis dependencies
-  already declared in `requirements.txt`.
+- Aligns with the pattern already used for Ollama (separate pods behind a
+  Service) and uses the Redis instance already in the cluster.
 
 ## Architecture target
 
 ```
-    upload request                                  poll / WS notify
-    ─────────────►  ┌─────────────┐                ◄───────────────
-                    │   Backend   │                     Client
-                    │  (FastAPI)  │
-                    └──────┬──────┘
-         create Doc         │
-      record(status=queued) │
-         enqueue task       ▼
-                    ┌────────────┐                  ┌──────────────┐
-                    │   Redis    │◄────dequeue──────│  Doc-Worker  │
-                    │  (queue)   │                  │  (Celery /   │
-                    └────────────┘                  │  TaskQueue)  │
-                                                    │  — Docling — │
-                           read/write                │  — EasyOCR — │
-                                                    │  — Embedder  │
-                                                    └──────┬───────┘
-                                                           │
-                                                           ▼
-                                                    shared upload storage
-                                                    (NFS /mnt/data/renfield-uploads)
-                                                           │
-                                                    ┌──────▼───────┐
-                                                    │ Postgres DB  │
-                                                    │  (chunks +   │
-                                                    │  embeddings) │
-                                                    └──────────────┘
+    upload request                                     poll / WS notify
+    ─────────────►  ┌────────────────┐               ◄──────────────────
+                    │    Backend     │                       Client
+                    │   (FastAPI)    │
+                    └────────┬───────┘
+     1. create Doc          │
+        record(queued)      │   4. check worker heartbeat
+     2. XADD on stream      │      → 503 if stale (> 90s)
+                            ▼
+                    ┌───────────────┐              ┌────────────────┐
+                    │     Redis     │              │   Doc-Worker   │
+                    │ stream+group: │◄──XREADGROUP─│  (1 replica)   │
+                    │ renfield:doc  │──XACK──      │                │
+                    │ heartbeat key │              │   Docling      │
+                    └───────┬───────┘              │   EasyOCR      │
+                            │ heartbeat            │   → embedder   │
+                            │ SET renfield:        │     (Ollama)   │
+                            │ worker:hb EX 90s     └────────┬───────┘
+                            │  ◄─────────────────── every 30s
+                            │
+                            │  read/write PDFs
+                            ▼
+                    ┌──────────────────────┐         ┌──────────────┐
+                    │ RWX PVC via NFS-CSI  │         │ Postgres DB  │
+                    │ uploads-shared       │         │ chunks +     │
+                    │ NFS: 192.168.1.9:    │         │ embeddings   │
+                    │  /mnt/data/          │         └──────────────┘
+                    │  renfield-uploads    │
+                    └──────────────────────┘
 ```
 
-## Changes required
+## Queue durability — Redis Streams
 
-### Backend code
+The existing `services/task_queue.py` uses `LPUSH` + `RPOP`. `RPOP` is destructive:
+the task leaves the queue before the worker acknowledges it. A worker crash
+mid-processing loses the task, the Document row stays `status=processing`
+forever, and the user sees a hung spinner with no recovery path. This pattern
+is fine for "fire-and-forget" but unsafe for document ingestion where every
+request must eventually succeed or fail visibly.
 
-1. `src/backend/services/rag_service.py`
-   - Split `ingest_document()` into two entry points:
-     - `create_document_record(file_path, kb_id, filename, hash) → Document`
-       creates the row with `status=queued`, returns its id.
-     - `process_existing_document(document_id, force_ocr) → None` runs the
-       pipeline for a record already in the DB (Docling, chunking, embedding,
-       FTS population, status transitions).
-   - The current `ingest_document()` can remain as a thin wrapper that calls
-     both in sequence, to avoid breaking callers outside the upload path.
+**Replace with Redis Streams** (`XADD`, `XREADGROUP`, `XACK`, `XPENDING`).
+Streams give us:
 
-2. `src/backend/api/routes/knowledge.py`
-   - `POST /api/knowledge/upload`:
-     - After duplicate check + file save → `create_document_record(...)`
-     - Enqueue `{"type": "document_process", "parameters": {"document_id": …,
-       "force_ocr": …}}` via `TaskQueue.enqueue(...)`
-     - Return `202 Accepted` with the document metadata (status = queued).
-   - `GET /api/knowledge/documents/{id}` already exposes the live status —
-     no new endpoint needed.
+- Single atomic `XADD` (no LPUSH+SET race).
+- `XREADGROUP` reads without removing — the entry stays in the Pending Entries
+  List (PEL) until ACKed.
+- `XACK` on successful completion removes it from the PEL.
+- Worker crash → entry stays pending → next worker (or the same worker after
+  restart) reads it via `XPENDING` + `XCLAIM` after a visibility timeout.
+- Consumer-group semantics for free horizontal scale (post-MVP).
 
-3. New module `src/backend/workers/document_processor_worker.py`
-   - Async main loop:
-     - `redis = TaskQueue()`
-     - forever: `dequeue()` (with BRPOP-backed blocking or sleep fallback)
-     - on `document_process` type: open a fresh SQLAlchemy session, call
-       `process_existing_document(doc_id, force_ocr)`, update task status.
-     - graceful shutdown on SIGTERM (finish current task, then exit).
-   - Entry point: `python -m workers.document_processor_worker`.
+No Celery needed. `redis.asyncio` already ships XREADGROUP support.
 
-### K8s
+Changes in `services/task_queue.py`:
 
-4. `k8s/document-worker.yaml`
-   - Deployment, 1 replica, same backend image (`registry.treehouse.x-idra.de/renfield/backend:latest`)
-   - `command: ["python", "-m", "workers.document_processor_worker"]`
-   - Memory `requests: 1Gi, limits: 6Gi` (owns the Docling peak alone)
-   - Mounts the shared uploads volume + ConfigMap like backend
-   - `imagePullSecrets: harbor-pull-secret`
-   - No Service — worker is a pure consumer.
+```
+class DocumentTaskQueue:
+    stream_key   = "renfield:tasks:document"
+    group_name   = "docworker"
+    consumer     = f"worker-{pod_name}"  # unique per pod
+    visibility_s = 600  # 10 min, covers worst-case PDF
 
-5. `k8s/backend.yaml`
-   - Drop memory limit from `8Gi` back to `4Gi` once the worker takes over
-     document ingestion.
-   - Drop `renfield-data` PVC if the only consumers of `/app/data` were
-     uploads (otherwise keep it; migrate only the uploads subdir).
+    enqueue(params)          → XADD, returns stream entry id
+    read_one(block_ms=5000)  → XREADGROUP BLOCK 5000 COUNT 1
+    ack(entry_id)            → XACK
+    reclaim_stale()          → XPENDING + XCLAIM for entries idle > visibility_s
+    close()
+```
 
-6. Shared uploads storage
-   - The current Longhorn PVC `renfield-data` is `ReadWriteOnce` — backend
-     and worker on different nodes can't both mount it.
-   - Two options:
-     - **A** hostPath `/mnt/data/renfield-uploads` on the NFS mount
-       (`192.168.1.9:/mnt/data`) available on both GPU workers. Simplest; same
-       pattern as Ollama's `/mnt/llm`. Requires the directory to exist on both
-       nodes (one-time setup).
-     - **B** Longhorn RWX PVC (via RWX engine). More moving parts, not yet
-       enabled in the cluster.
-   - Recommendation: start with A. Migration of existing files is a `cp -r`
-     step during rollout.
+The old `TaskQueue` class stays for any non-document fire-and-forget uses
+(none currently, but `ensure_admin_user` or cleanup scheduling might adopt
+it later). We rename the module carefully to avoid breaking imports.
 
-### Frontend (optional, follow-up)
+## Shared uploads storage — NFS-CSI driver
 
-7. `src/frontend/src/pages/KnowledgePage.tsx`
-   - After upload (now returns `status=queued`), poll `/api/knowledge/documents/{id}`
-     until `status in {completed, failed}` and surface progress in the UI.
-   - Without this change the user experiences a "completed" badge only after
-     the next list refresh — acceptable, but unpolished.
+The uploads directory must be visible to both the backend (for save) and the
+worker (for read). Longhorn is `ReadWriteOnce` — multi-node access is not
+possible. `hostPath` was ruled out: `/mnt/data/renfield-uploads` is **not**
+exported from `192.168.1.9` today (only `/mnt/data/llm` is), and any
+hostPath-based solution requires per-node manual mount management that
+silently breaks on node replacement. That violates our "no per-host patches"
+rule.
+
+### Chosen approach: CSI Driver NFS
+
+Install the official Kubernetes CSI driver for NFS (kubernetes-csi/csi-driver-nfs).
+This is a standard, well-maintained k8s addon that speaks to any NFSv3/v4
+server and exposes ReadWriteMany PersistentVolumes declaratively.
+
+**Server-side prep** (one-time, on `192.168.1.9`):
+
+```
+sudo mkdir /mnt/data/renfield-uploads
+sudo chown nobody:nogroup /mnt/data/renfield-uploads
+sudo chmod 0770 /mnt/data/renfield-uploads
+# /etc/exports — add a line for each worker node subnet:
+/mnt/data/renfield-uploads  192.168.1.0/24(rw,sync,no_subtree_check,no_root_squash)
+sudo exportfs -ra
+```
+
+**Cluster-side** (tracked in `../private_k8s/nfs-csi/`):
+
+1. Install the driver via the upstream manifests (vendor pinned copy under
+   `../private_k8s/nfs-csi/driver-v4.x.y.yaml`).
+2. Create a `StorageClass` `nfs-csi`:
+   ```yaml
+   apiVersion: storage.k8s.io/v1
+   kind: StorageClass
+   metadata:
+     name: nfs-csi
+   provisioner: nfs.csi.k8s.io
+   parameters:
+     server: 192.168.1.9
+     share: /mnt/data/renfield-uploads
+   reclaimPolicy: Retain
+   volumeBindingMode: Immediate
+   mountOptions:
+     - nfsvers=4.2
+     - hard
+     - timeo=600
+   ```
+3. In `k8s/backend.yaml` and `k8s/document-worker.yaml`, mount a
+   `PersistentVolumeClaim` with `accessModes: [ReadWriteMany]` and
+   `storageClassName: nfs-csi` at `/app/data/uploads`.
+
+This puts the NFS mount **inside** the Kubernetes object model. Node
+replacement is transparent — the CSI driver re-attaches on whatever node
+the pod lands on. No `/etc/fstab`, no per-node `mkdir`, no drift.
+
+### Data migration
+
+Existing uploads live on the Longhorn RWO PVC under `/app/data/uploads/`. The
+migration is a one-shot `rsync` executed with the backend in a read-only window:
+
+1. Create the new NFS-CSI PVC `renfield-uploads-shared`.
+2. Spin up a migrator Job that mounts **both** the old PVC and the new PVC and
+   runs `rsync -a --delete /old/uploads/ /new/uploads/`.
+3. Scale backend to 0 briefly (or set it to respond 503 on `/api/knowledge/upload`
+   during the cutover).
+4. Re-run rsync to capture last-second deltas.
+5. Redeploy backend with the new PVC mounted, worker deployment up, flag flipped.
+6. Keep the old PVC with `reclaimPolicy: Retain` for 30 days in case of rollback.
+
+## Worker heartbeat gates the upload route
+
+If `DOCUMENT_WORKER_ENABLED=true` but no worker is consuming (e.g. image-pull
+stalled, worker crash-looping, ConfigMap out of sync), the upload endpoint
+would enqueue tasks into a stream no one reads. Users see permanent spinners.
+
+Solution: worker publishes a liveness key every 30 s:
+
+```
+SET renfield:worker:document:heartbeat <pod_name> EX 90
+```
+
+Upload endpoint checks it before enqueuing:
+
+```python
+async def _worker_is_alive(redis) -> bool:
+    return await redis.get("renfield:worker:document:heartbeat") is not None
+```
+
+If the key is missing **and** `DOCUMENT_WORKER_ENABLED=true`, the upload
+endpoint returns `503 Service Unavailable` with a clear message. The client
+can retry. We do **not** fall back to inline — that would silently hide the
+infrastructure outage. Fail loudly, escalate to ops.
+
+If `DOCUMENT_WORKER_ENABLED=false`, the old inline path runs, heartbeat is
+ignored.
+
+## Worker entrypoint — module isolation
+
+`python -m workers.document_processor_worker` must **not** import or boot
+the FastAPI app, or it pulls the MCP client (connecting to 10 servers on
+startup), Whisper, Speechbrain, Ollama clients, the full lifecycle init —
+exactly what we're trying to excise from the worker.
+
+The worker module imports only:
+
+- `services.database` (engine + session factory)
+- `services.rag_service` (`RAGService`, specifically the new
+  `process_existing_document` entry point)
+- `services.document_processor` (Docling)
+- `services.task_queue` (new `DocumentTaskQueue`)
+- `utils.config.settings`
+- `utils.llm_client.get_embed_client` (Ollama calls from Docling's chunk loop)
+
+Explicit test: `importlib.import_module("workers.document_processor_worker")`
+must not trigger `main.app` instantiation or MCP-connect.
+
+## Backend code changes
+
+### 1. `src/backend/services/rag_service.py`
+
+Split `ingest_document` into two entry points, keep the existing function as
+a thin wrapper so non-upload callers don't break:
+
+```python
+async def create_document_record(
+    self,
+    file_path: str,
+    knowledge_base_id: int | None,
+    filename: str,
+    file_hash: str,
+    user_id: int | None,
+) -> Document:
+    """Insert the Document row with status=queued; returns the persisted row."""
+
+async def process_existing_document(
+    self,
+    document_id: int,
+    force_ocr: bool = False,
+) -> None:
+    """Run Docling → chunking → embedding → FTS on a pre-existing row.
+    Transitions status queued → processing → completed/failed.
+    Commits a final error_message on any unhandled exception."""
+
+# Back-compat wrapper (non-upload callers, test fixtures):
+async def ingest_document(self, *args, **kwargs) -> Document:
+    doc = await self.create_document_record(...)
+    await self.process_existing_document(doc.id, kwargs.get("force_ocr", False))
+    return await self.db.get(Document, doc.id)
+```
+
+Audit required: grep for existing callers of `ingest_document` before merging.
+
+### 2. `src/backend/api/routes/knowledge.py`
+
+Upload endpoint branches on `settings.document_worker_enabled`:
+
+```python
+if settings.document_worker_enabled:
+    if not await _worker_is_alive(redis):
+        raise HTTPException(503, "Document worker unavailable")
+    doc = await rag.create_document_record(...)
+    await queue.enqueue({"document_id": doc.id, "force_ocr": force_ocr})
+    return DocumentResponse(id=doc.id, status="queued", ...)  # 202
+else:
+    # Legacy inline path — unchanged.
+    doc = await rag.ingest_document(...)
+    return DocumentResponse(...)
+```
+
+HTTP status code for the new path is `202 Accepted`, not `200`.
+
+### 3. New module `src/backend/workers/document_processor_worker.py`
+
+Async main loop:
+
+```python
+async def main():
+    redis = await aioredis.from_url(settings.redis_url)
+    queue = DocumentTaskQueue(redis, consumer_id=pod_name())
+    await queue.ensure_group()
+
+    # Reclaim entries from dead consumers on startup
+    await queue.reclaim_stale()
+
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, stop_event.set)
+
+    heartbeat_task = asyncio.create_task(_heartbeat_loop(redis, stop_event))
+
+    try:
+        while not stop_event.is_set():
+            entry = await queue.read_one(block_ms=5000)
+            if not entry:
+                continue
+            entry_id, params = entry
+            async with AsyncSessionLocal() as db:
+                rag = RAGService(db)
+                try:
+                    await rag.process_existing_document(
+                        document_id=params["document_id"],
+                        force_ocr=params.get("force_ocr", False),
+                    )
+                    await queue.ack(entry_id)
+                except Exception as e:
+                    logger.exception(f"Task {entry_id} failed: {e}")
+                    # Do NOT ack — entry stays in PEL, reclaim_stale picks it
+                    # up after visibility timeout. Document row already has
+                    # status=failed and error_message from process_existing_document.
+    finally:
+        heartbeat_task.cancel()
+        await queue.close()
+        await redis.aclose()
+```
+
+### 4. `src/frontend/src/pages/KnowledgePage.tsx`
+
+After upload returns 202, poll `/api/knowledge/documents/{id}` every 2 s
+until `status ∈ {completed, failed}`. Surface per-document progress (queued,
+processing, completed, failed) with a spinner and a clear error path.
+
+This is **not** a follow-up — it ships in the cutover PR. Without it, users
+see a silent hung spinner immediately after upload, which is a UX regression
+vs. the synchronous `200` today.
+
+## K8s changes
+
+### `k8s/document-worker.yaml` (new)
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: document-worker
+  namespace: renfield
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels: {app.kubernetes.io/name: document-worker}
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: document-worker, app.kubernetes.io/part-of: renfield}
+    spec:
+      imagePullSecrets: [{name: harbor-pull-secret}]
+      containers:
+        - name: worker
+          image: registry.treehouse.x-idra.de/renfield/backend:latest
+          imagePullPolicy: Always
+          command: ["python", "-m", "workers.document_processor_worker"]
+          envFrom: [{configMapRef: {name: renfield-env}}]
+          env:
+            - name: POD_NAME
+              valueFrom: {fieldRef: {fieldPath: metadata.name}}
+            # Postgres, Redis, Ollama URLs come from renfield-env; secrets as in backend
+          volumeMounts:
+            - {name: uploads, mountPath: /app/data/uploads}
+            - {name: cache-home, mountPath: /app/data/cache-home}  # shared HF+EasyOCR cache
+            - {name: mcp-config, mountPath: /app/config/...}
+          resources:
+            requests: {cpu: 500m, memory: 1Gi}
+            limits:   {cpu: "2",  memory: 6Gi}
+      volumes:
+        - name: uploads
+          persistentVolumeClaim: {claimName: renfield-uploads-shared}
+        - name: cache-home
+          persistentVolumeClaim: {claimName: renfield-cache-shared}
+        - name: mcp-config
+          configMap: {name: renfield-mcp-config}
+```
+
+No Service — worker is a pure stream consumer.
+
+### `k8s/backend.yaml` (modified)
+
+- Replace `renfield-data` PVC mount at `/app/data` with two PVCs:
+  `renfield-uploads-shared` (RWX, NFS-CSI) at `/app/data/uploads`, and
+  `renfield-cache-shared` (RWX, NFS-CSI) at `/app/data/cache-home`.
+- After cutover: memory limit `12Gi → 5Gi`.
+
+### `k8s/configmap.yaml`
+
+- Add `DOCUMENT_WORKER_ENABLED: "false"` (default off, flipped in rollout).
+
+### `../private_k8s/nfs-csi/` (new, cluster-wide)
+
+- Pinned copy of `csi-driver-nfs` manifests (version tracked in the README).
+- Two `StorageClass` objects: `nfs-csi` for uploads, shared by namespaces as
+  they need RWX NFS.
+
+## Test matrix (mandatory, blocking)
+
+| # | Path | Kind | Tool |
+|---|------|------|------|
+| 1 | `create_document_record` happy path | unit | pytest + async |
+| 2 | `create_document_record` with duplicate hash → 409 | unit | pytest |
+| 3 | `process_existing_document` happy path (stubbed Docling) | unit | pytest |
+| 4 | `process_existing_document` Docling failure → `status=failed` with error_message | unit | pytest |
+| 5 | `process_existing_document` embedder raises → `status=failed`, DB rolled back | unit | pytest |
+| 6 | Upload endpoint 202 with flag=on, worker heartbeat present | API | httpx + test client |
+| 7 | Upload endpoint 503 with flag=on, heartbeat missing | API | httpx |
+| 8 | Upload endpoint legacy 200 with flag=off | API | httpx |
+| 9 | Worker loop: successful processing → XACK called | integration | testcontainers redis |
+| 10 | **Worker crash recovery: SIGKILL mid-task → next worker reclaims via XCLAIM** | **integration, blocking** | testcontainers redis |
+| 11 | Worker SIGTERM: finishes current task, exits cleanly | integration | subprocess + signal |
+| 12 | Worker module import does NOT instantiate FastAPI app | unit | importlib + introspection |
+| 13 | Frontend: upload → 202 → polling → completed badge shown | e2e | vitest + MSW |
+| 14 | Frontend: upload → 202 → polling sees `status=failed` → error surface | e2e | vitest + MSW |
+
+Test 10 is the reason we're switching to Streams. Without it, the whole
+redesign is lipstick.
 
 ## Migration plan
 
-1. Ship the code split (new RAGService entry points + worker module) + K8s
-   manifest + shared-storage mount, behind a feature flag
-   `DOCUMENT_WORKER_ENABLED=false` — existing inline path still works.
-2. Create the NFS upload directory on gpu-1 and gpu-2, `cp -r` the existing
-   uploads from the Longhorn PVC into it.
-3. Flip the flag on in the ConfigMap, roll out.
-4. Backfill the frontend polling (separate PR).
-5. Once stable, drop the feature flag and the inline code path; lower the
-   backend memory limit to 4 GiB.
+Sequenced, each step independently revertable:
+
+1. **Cluster prep** — install NFS-CSI driver, create StorageClass, verify
+   provisioning with a throwaway test PVC.
+2. **Server prep** — create `/mnt/data/renfield-uploads` on `192.168.1.9`,
+   add `/etc/exports` entry, `exportfs -ra`.
+3. **PR A (infra)** — add `DocumentTaskQueue` (Streams) alongside existing
+   `TaskQueue`; add `k8s/document-worker.yaml` + PVC manifests + worker
+   module; `DOCUMENT_WORKER_ENABLED=false`. Nothing behaviourally changes.
+4. **PR B (refactor)** — split `RAGService.ingest_document`; unit tests 1–5.
+5. **PR C (cutover-ready)** — upload endpoint branch on flag; heartbeat
+   gating; frontend polling; tests 6–14.
+6. **Rollout** — deploy PR C with flag still off. Run migrator Job.
+   `docker compose up` cutover check:
+   1. Scale backend to 0, run final rsync.
+   2. Scale backend to 1 with flag still off — verify new PVC mounts read/write.
+   3. Apply ConfigMap with `DOCUMENT_WORKER_ENABLED=true`.
+   4. Restart backend + worker. Smoke-test an upload end-to-end.
+7. **Cleanup** — drop backend memory `12Gi → 5Gi` in a follow-up commit once
+   the stack has been stable 48 h. Remove legacy inline path once flag has
+   been on for a week.
 
 ## Out of scope
 
-- Task retries / DLQ semantics (worker will just log + mark `failed` on
-  unhandled exceptions, same behaviour as today).
-- Horizontal autoscaling of the worker.
-- Celery — the existing `TaskQueue` in `services/task_queue.py` is already
-  Redis-backed and fit for purpose; pulling in Celery adds more moving parts
-  without a concrete need right now. Can be revisited if we need richer
-  features (priorities, periodic tasks, scheduled retries).
+- Celery migration — Streams covers everything we need.
+- Worker horizontal autoscaling — 1 replica holds current load.
+- Multi-tenant priority queues (e.g. premium uploads first) — single stream.
+- PDF-level progress reporting (per-page %) — status=processing is enough.
+
+## Open questions
+
+- **NFS-CSI version pin.** Current stable is v4.10.x — check against K8s
+  v1.35 compatibility before ingesting.
+- **Migration-window tolerance.** How long can uploads be 503 during rsync?
+  Current estimate: 2 min for today's payload. If unacceptable, we can
+  double-write during the transition and cut over lazily.

--- a/docs/DOCUMENT_WORKER_SPLIT.md
+++ b/docs/DOCUMENT_WORKER_SPLIT.md
@@ -5,13 +5,23 @@ backend pod into a dedicated worker deployment.
 
 Revision history:
 - v1 (2026-04-18): initial draft, inline feature flag, hostPath NFS, existing Redis-list TaskQueue.
-- **v2 (2026-04-19)**: pressure-tested in `/plan-eng-review`. Six changes incorporated:
-  (1) TaskQueue replaced by Redis Streams for at-least-once durability;
+- v2 (2026-04-19, morning): pressure-tested in `/plan-eng-review`. Six changes:
+  (1) TaskQueue → Redis Streams for at-least-once durability;
   (2) shared storage via NFS-CSI driver, not hostPath;
-  (3) worker heartbeat gates the upload route's fast-path;
-  (4) test matrix made mandatory (worker-crash recovery is blocking);
+  (3) worker heartbeat gates the upload route;
+  (4) test matrix mandatory (worker-crash recovery is blocking);
   (5) frontend polling ships in the cutover PR, not a follow-up;
   (6) worker entrypoint audited for module isolation.
+- **v3 (2026-04-19, afternoon)**: pressure-tested in `/plan-design-review`.
+  Eight UX decisions adopted:
+  (1) reuse existing `pending` status, don't invent `queued`;
+  (2) full polling strategy (1 s start, 10 s cap, 30 min timeout, Visibility API, AbortController);
+  (3) full DE copy map for all response states;
+  (4) tab-title mutation + localStorage optimistic persistence;
+  (5) per-page progress via stage + page counters;
+  (6) queue-position always shown when ≥ 1;
+  (7) full A11y spec (ARIA live, progressbar, focus management, contrast);
+  (8) cutover PR split into C1 (minimal cutover) + C2 (polish).
 
 ## Status
 
@@ -29,19 +39,19 @@ Revision history:
 - Isolates a heavyweight, spiky memory consumer from the steady-state API path.
 - Survives `WHISPER_MODEL` being bumped to `medium`/`large-v3` without re-budgeting.
 - Lets document ingestion scale horizontally without scaling FastAPI replicas.
-- Aligns with the pattern already used for Ollama (separate pods behind a
-  Service) and uses the Redis instance already in the cluster.
+- Aligns with the pattern already used for Ollama and uses the Redis instance
+  already in the cluster.
 
 ## Architecture target
 
 ```
-    upload request                                     poll / WS notify
+    upload request                                     poll / tab badge
     ─────────────►  ┌────────────────┐               ◄──────────────────
                     │    Backend     │                       Client
                     │   (FastAPI)    │
                     └────────┬───────┘
      1. create Doc          │
-        record(queued)      │   4. check worker heartbeat
+        record(pending)     │   4. check worker heartbeat
      2. XADD on stream      │      → 503 if stale (> 90s)
                             ▼
                     ┌───────────────┐              ┌────────────────┐
@@ -49,20 +59,22 @@ Revision history:
                     │ stream+group: │◄──XREADGROUP─│  (1 replica)   │
                     │ renfield:doc  │──XACK──      │                │
                     │ heartbeat key │              │   Docling      │
-                    └───────┬───────┘              │   EasyOCR      │
-                            │ heartbeat            │   → embedder   │
-                            │ SET renfield:        │     (Ollama)   │
-                            │ worker:hb EX 90s     └────────┬───────┘
+                    │ stage key     │              │   EasyOCR      │
+                    │ progress key  │──SET─────────│   → embedder   │
+                    └───────┬───────┘              │     (Ollama)   │
+                            │ heartbeat            └────────┬───────┘
+                            │ SET renfield:                 │
+                            │ worker:hb EX 90s              │
                             │  ◄─────────────────── every 30s
                             │
                             │  read/write PDFs
                             ▼
                     ┌──────────────────────┐         ┌──────────────┐
                     │ RWX PVC via NFS-CSI  │         │ Postgres DB  │
-                    │ uploads-shared       │         │ chunks +     │
+                    │ renfield-uploads     │         │ chunks +     │
                     │ NFS: 192.168.1.9:    │         │ embeddings   │
-                    │  /mnt/data/          │         └──────────────┘
-                    │  renfield-uploads    │
+                    │ /mnt/data/k8s/       │         └──────────────┘
+                    │ renfield/uploads     │
                     └──────────────────────┘
 ```
 
@@ -79,14 +91,14 @@ request must eventually succeed or fail visibly.
 Streams give us:
 
 - Single atomic `XADD` (no LPUSH+SET race).
-- `XREADGROUP` reads without removing — the entry stays in the Pending Entries
+- `XREADGROUP` reads without removing; entry stays in the Pending Entries
   List (PEL) until ACKed.
 - `XACK` on successful completion removes it from the PEL.
-- Worker crash → entry stays pending → next worker (or the same worker after
-  restart) reads it via `XPENDING` + `XCLAIM` after a visibility timeout.
+- Worker crash → entry stays pending → next worker (or the same after restart)
+  reads it via `XPENDING` + `XCLAIM` after a visibility timeout.
 - Consumer-group semantics for free horizontal scale (post-MVP).
 
-No Celery needed. `redis.asyncio` already ships XREADGROUP support.
+No Celery. `redis.asyncio` already ships XREADGROUP support.
 
 Changes in `services/task_queue.py`:
 
@@ -101,88 +113,62 @@ class DocumentTaskQueue:
     read_one(block_ms=5000)  → XREADGROUP BLOCK 5000 COUNT 1
     ack(entry_id)            → XACK
     reclaim_stale()          → XPENDING + XCLAIM for entries idle > visibility_s
+    xlen_pending()           → XLEN + PEL depth for queue-position calculation
     close()
 ```
 
-The old `TaskQueue` class stays for any non-document fire-and-forget uses
-(none currently, but `ensure_admin_user` or cleanup scheduling might adopt
-it later). We rename the module carefully to avoid breaking imports.
+The old `TaskQueue` class stays for any non-document fire-and-forget uses.
 
 ## Shared uploads storage — NFS-CSI driver
 
-The uploads directory must be visible to both the backend (for save) and the
-worker (for read). Longhorn is `ReadWriteOnce` — multi-node access is not
-possible. `hostPath` was ruled out: `/mnt/data/renfield-uploads` is **not**
-exported from `192.168.1.9` today (only `/mnt/data/llm` is), and any
-hostPath-based solution requires per-node manual mount management that
-silently breaks on node replacement. That violates our "no per-host patches"
-rule.
+Install kubernetes-csi/csi-driver-nfs. RWX PVCs are then declarative; the
+driver mounts pod-local on-demand. Node replacement is transparent.
 
-### Chosen approach: CSI Driver NFS
+**Server-side state** (already verified 2026-04-19):
 
-Install the official Kubernetes CSI driver for NFS (kubernetes-csi/csi-driver-nfs).
-This is a standard, well-maintained k8s addon that speaks to any NFSv3/v4
-server and exposes ReadWriteMany PersistentVolumes declaratively.
-
-**Server-side prep** (one-time, on `192.168.1.9`):
-
-```
-sudo mkdir /mnt/data/renfield-uploads
-sudo chown nobody:nogroup /mnt/data/renfield-uploads
-sudo chmod 0770 /mnt/data/renfield-uploads
-# /etc/exports — add a line for each worker node subnet:
-/mnt/data/renfield-uploads  192.168.1.0/24(rw,sync,no_subtree_check,no_root_squash)
-sudo exportfs -ra
-```
+- `/mnt/data/k8s` is exported `*` from `192.168.1.9` and world-writable
+  (`drwxrwxrwx`). Subdirectories created by the CSI provisioner land as
+  `nobody:root 755`, which backend + worker (both container-root) can
+  read/write through root_squash.
+- Subdirectory convention: `/mnt/data/k8s/<namespace>/<purpose>/`.
+  For Renfield: `/mnt/data/k8s/renfield/uploads/` and
+  `/mnt/data/k8s/renfield/cache-home/`.
 
 **Cluster-side** (tracked in `../private_k8s/nfs-csi/`):
 
-1. Install the driver via the upstream manifests (vendor pinned copy under
-   `../private_k8s/nfs-csi/driver-v4.x.y.yaml`).
-2. Create a `StorageClass` `nfs-csi`:
+1. Install csi-driver-nfs v4.13.2 (latest stable, released 2026-04-16).
+2. Two StorageClasses:
    ```yaml
-   apiVersion: storage.k8s.io/v1
-   kind: StorageClass
-   metadata:
-     name: nfs-csi
+   # nfs-csi-renfield-uploads
    provisioner: nfs.csi.k8s.io
    parameters:
      server: 192.168.1.9
-     share: /mnt/data/renfield-uploads
+     share: /mnt/data/k8s/renfield/uploads
    reclaimPolicy: Retain
-   volumeBindingMode: Immediate
-   mountOptions:
-     - nfsvers=4.2
-     - hard
-     - timeo=600
+   mountOptions: [nfsvers=4.2, hard, timeo=600]
    ```
-3. In `k8s/backend.yaml` and `k8s/document-worker.yaml`, mount a
-   `PersistentVolumeClaim` with `accessModes: [ReadWriteMany]` and
-   `storageClassName: nfs-csi` at `/app/data/uploads`.
+3. PVCs in `k8s/` reference these classes with `accessModes: [ReadWriteMany]`.
 
-This puts the NFS mount **inside** the Kubernetes object model. Node
-replacement is transparent — the CSI driver re-attaches on whatever node
-the pod lands on. No `/etc/fstab`, no per-node `mkdir`, no drift.
+The NFS mount lives inside the Kubernetes object model. No `/etc/fstab`, no
+per-node `mkdir`, no drift.
 
 ### Data migration
 
-Existing uploads live on the Longhorn RWO PVC under `/app/data/uploads/`. The
-migration is a one-shot `rsync` executed with the backend in a read-only window:
+Existing uploads live on the Longhorn RWO PVC under `/app/data/uploads/`.
+One-shot rsync with a short read-only window:
 
-1. Create the new NFS-CSI PVC `renfield-uploads-shared`.
-2. Spin up a migrator Job that mounts **both** the old PVC and the new PVC and
-   runs `rsync -a --delete /old/uploads/ /new/uploads/`.
-3. Scale backend to 0 briefly (or set it to respond 503 on `/api/knowledge/upload`
-   during the cutover).
-4. Re-run rsync to capture last-second deltas.
-5. Redeploy backend with the new PVC mounted, worker deployment up, flag flipped.
-6. Keep the old PVC with `reclaimPolicy: Retain` for 30 days in case of rollback.
+1. Create NFS-CSI PVC `renfield-uploads-shared`.
+2. Migrator Job mounts both old + new, runs `rsync -a --delete old/ new/`.
+3. Backend scale-to-0 briefly (or `/api/knowledge/upload` returns 503).
+4. Re-rsync to capture deltas.
+5. Redeploy backend with new PVC, worker up, flag flipped.
+6. Old PVC kept with `reclaimPolicy: Retain` for 30 days.
 
 ## Worker heartbeat gates the upload route
 
-If `DOCUMENT_WORKER_ENABLED=true` but no worker is consuming (e.g. image-pull
-stalled, worker crash-looping, ConfigMap out of sync), the upload endpoint
-would enqueue tasks into a stream no one reads. Users see permanent spinners.
+If `DOCUMENT_WORKER_ENABLED=true` but no worker is consuming (image-pull
+stall, crash-loop, ConfigMap drift), the upload endpoint would enqueue
+tasks into a stream no one reads. Users see permanent spinners.
 
 Solution: worker publishes a liveness key every 30 s:
 
@@ -190,46 +176,178 @@ Solution: worker publishes a liveness key every 30 s:
 SET renfield:worker:document:heartbeat <pod_name> EX 90
 ```
 
-Upload endpoint checks it before enqueuing:
-
-```python
-async def _worker_is_alive(redis) -> bool:
-    return await redis.get("renfield:worker:document:heartbeat") is not None
-```
-
-If the key is missing **and** `DOCUMENT_WORKER_ENABLED=true`, the upload
-endpoint returns `503 Service Unavailable` with a clear message. The client
-can retry. We do **not** fall back to inline — that would silently hide the
-infrastructure outage. Fail loudly, escalate to ops.
-
-If `DOCUMENT_WORKER_ENABLED=false`, the old inline path runs, heartbeat is
-ignored.
+Upload endpoint checks before enqueuing; if missing and the flag is on,
+return **503** with the copy specified below. The client shows a Retry CTA.
+We do **not** fall back to inline — that silently hides the infrastructure
+outage. Fail loudly, escalate to ops.
 
 ## Worker entrypoint — module isolation
 
 `python -m workers.document_processor_worker` must **not** import or boot
-the FastAPI app, or it pulls the MCP client (connecting to 10 servers on
-startup), Whisper, Speechbrain, Ollama clients, the full lifecycle init —
-exactly what we're trying to excise from the worker.
+the FastAPI app. Otherwise it pulls MCP-connect, Whisper, Speechbrain, Ollama
+clients, full lifecycle init — exactly what we're excising from the worker.
 
-The worker module imports only:
+Worker imports only:
 
 - `services.database` (engine + session factory)
-- `services.rag_service` (`RAGService`, specifically the new
-  `process_existing_document` entry point)
+- `services.rag_service` (`RAGService`, `process_existing_document`)
 - `services.document_processor` (Docling)
-- `services.task_queue` (new `DocumentTaskQueue`)
+- `services.task_queue` (`DocumentTaskQueue`)
+- `services.progress` (new, see below)
 - `utils.config.settings`
-- `utils.llm_client.get_embed_client` (Ollama calls from Docling's chunk loop)
+- `utils.llm_client.get_embed_client`
 
 Explicit test: `importlib.import_module("workers.document_processor_worker")`
-must not trigger `main.app` instantiation or MCP-connect.
+must not trigger `main.app` or MCP connect.
+
+## Processing stage + per-page progress
+
+During `process_existing_document`, the worker writes two Redis keys so the
+frontend can show granular progress. Keys are TTL-bound to 30 min to avoid
+leaking state for dead tasks.
+
+```
+renfield:doc:{doc_id}:stage     → "parsing" | "ocr" | "chunking" | "embedding"
+renfield:doc:{doc_id}:progress  → "47/120"  (current/total pages, or "" for non-paginated)
+```
+
+New module `src/backend/services/progress.py`:
+
+```python
+class DocumentProgress:
+    def __init__(self, redis, doc_id: int): ...
+    async def set_stage(self, stage: str) -> None: ...
+    async def set_pages(self, current: int, total: int) -> None: ...
+    async def clear(self) -> None: ...
+    async def read(self) -> dict: ...  # used by GET /api/knowledge/documents/{id}
+```
+
+Docling's `DocumentConverter` already accepts progress callbacks in newer
+versions; worker wires them to `DocumentProgress.set_pages`. Non-paginated
+inputs (TXT, PNG) skip the page counter; stage alone is meaningful.
+
+`GET /api/knowledge/documents/{id}` surfaces both fields alongside `status`:
+
+```json
+{
+  "id": 42,
+  "status": "processing",
+  "stage": "ocr",
+  "pages": { "current": 47, "total": 120 },
+  "queue_position": null,
+  "error_message": null
+}
+```
+
+When status is `pending`: `queue_position` is set to the 1-indexed position in
+the stream (via `XPENDING` + PEL depth). When status transitions to
+`processing`, `queue_position` clears.
+
+## Upload lifecycle UX
+
+This is the complete user-facing contract for the new flow.
+
+### Status taxonomy (reuses existing `pending`)
+
+| Status | Label (DE) | Icon | Color | Meaning |
+|---|---|---|---|---|
+| `pending` | „In Warteschlange" | `Clock` | gray-500 | Enqueued, worker hasn't picked it up |
+| `processing` | „Wird verarbeitet…" | `Loader2` (spin) | primary-500 | Active, with stage + page sub-label |
+| `completed` | „Fertig" | `CheckCircle2` | green-500 | Indexed and searchable |
+| `failed` | „Fehlgeschlagen" | `AlertCircle` | red-500 | Unhandled exception; error_message set |
+
+**No new backend status.** `queued` is not introduced. `pending` (already in
+the frontend's `statusFilters`) covers the enqueued-but-not-yet-read state.
+
+### Sub-labels during `processing`
+
+The badge sub-label reads the `stage` + `pages` fields:
+
+| Stage | Sub-label |
+|---|---|
+| parsing | „Dokument wird gelesen…" |
+| ocr | „Text wird erkannt… Seite `{current}` von `{total}`" (only shown when pages present) |
+| chunking | „Abschnitte werden erstellt…" |
+| embedding | „Wird in die Wissensbasis aufgenommen…" |
+
+If `processing` persists > 30 s without stage progression, an additional
+muted line reads: „Das kann bei großen PDFs eine Minute dauern."
+
+### Queue position
+
+When `status=pending` and `queue_position` is set, the badge sub-label reads
+„Platz `{queue_position}`". Always shown when present; hidden when position
+can't be computed (e.g., stream lookup failed — we don't show "Platz —").
+
+### Polling strategy
+
+- **First poll** 1 s after upload response.
+- **Interval** doubles after each poll until capped at 10 s: 1, 2, 4, 8, 10, 10, …
+- **Reset to 1 s** on every status/stage/page change (user just got useful info,
+  keep it snappy).
+- **Timeout** after 30 min continuous polling per document → mark locally as
+  „Zeitüberschreitung", show Retry CTA. Remote state in DB unchanged; a manual
+  refresh can pick it up if the worker eventually finishes.
+- **Page Visibility API**: tab hidden → pause interval; tab visible → single
+  catch-up fetch + resume interval.
+- **AbortController** on every fetch; component unmount aborts in-flight requests.
+- **Per-tab singleton**: one polling loop per page instance, not per document.
+  Batch lookups via `GET /api/knowledge/documents?ids=1,2,3` (new query param)
+  when > 1 document is active.
+
+### HTTP response copy (DE)
+
+| Code | Situation | UI surface | Message |
+|---|---|---|---|
+| **202** | Upload accepted, enqueued | Inline on upload zone + new row appears in list as `pending` | „Hochgeladen. Die Verarbeitung startet gleich." |
+| **409** | Duplicate hash (existing_document in body) | Modal dialog | Title: „Dieses Dokument gibt es schon". Body: „`{existing.filename}` wurde am `{existing.uploaded_at|date('de')}` bereits hochgeladen." Primary: „Zum vorhandenen Eintrag springen" (anchor link). Secondary: „Abbrechen". |
+| **413** | File too large | Toast (red) | „Datei zu groß. Maximum: `{max_mb}` MB." |
+| **415 / 400** | Format not allowed | Toast (red) | „Dateiformat nicht unterstützt. Erlaubt: `{allowed}`." |
+| **503** | Worker heartbeat missing | Toast (amber) with Retry CTA | „Die Dokumentverarbeitung ist gerade nicht erreichbar. Bitte in einer Minute erneut versuchen." Button: „Erneut versuchen" → re-POST the same file. |
+| **500** | Unknown server error | Toast (red) with Details expander | „Beim Hochladen ist etwas schiefgegangen." Expander reveals raw `detail`. |
+| `status=failed` from poll | Processing exception | Inline in the document row, replacing the spinner | „Fehlgeschlagen". Expander reveals `error_message`. Button: „Erneut hochladen" → re-POST (old document row is left alone). |
+
+### Tab-title + localStorage optimistic state
+
+- **Tab title** mutates while own uploads are `pending` or `processing`:
+  `(2) Wissensbasis — Renfield`. On all complete: `(✓) Wissensbasis — Renfield`
+  until the user focuses the tab or 30 s pass.
+- **localStorage key**: `renfield.kb.inflight` = array of
+  `{docId, filename, startedAt}` (max 20 entries, capped at 24 h age).
+  Written on 202-response, trimmed after `completed|failed` is observed or the
+  entry is older than 10 min (belt-and-suspenders against zombie entries).
+- **On page load**: hydrate from localStorage. Any entry whose `docId` matches
+  the server's list and is still `pending`/`processing` gets a subtle „Gerade
+  hochgeladen" hairline over its row for 5 min.
+- **No OS notifications** (`Notification.requestPermission()` is invasive for a
+  household context and doesn't add enough on top of title mutation).
+
+### Accessibility
+
+- Status region on the document list is wrapped in `<div role="status"
+  aria-live="polite">`. Screen readers announce status transitions as they
+  happen. A dedicated polite-live sub-region for stage changes so users aren't
+  spammed with page-counter updates (rate-limit: at most every 10 s).
+- Progress bar on `processing` rows with `pages.total` present:
+  `<progress role="progressbar" aria-valuenow={current} aria-valuemax={total}
+  aria-valuetext="Seite 47 von 120">`. Without pages, use `aria-busy="true"`
+  on the row instead.
+- Icon-only status badges carry `aria-label="{statusLabel}: {filename}"`.
+  The visible icon is `aria-hidden="true"`.
+- 409 dialog: focus moves to „Zum vorhandenen Eintrag springen" on open.
+  `Esc` closes the dialog. Focus returns to the upload trigger on close.
+- Touch targets on Retry, Details expander, and row-level buttons ≥ 44×44 px.
+- Keyboard path: Tab from upload zone → status filter → each document row's
+  primary action → pagination. Enter/Space activate.
+- Color contrast: every status color tested against WCAG AA in both Tailwind
+  `dark:` and light mode. `gray-500` on `gray-100` fails AA — use `gray-700`
+  for the pending label, only the icon carries the lighter tone.
 
 ## Backend code changes
 
 ### 1. `src/backend/services/rag_service.py`
 
-Split `ingest_document` into two entry points, keep the existing function as
+Split `ingest_document` into two entry points; keep the legacy function as
 a thin wrapper so non-upload callers don't break:
 
 ```python
@@ -241,7 +359,7 @@ async def create_document_record(
     file_hash: str,
     user_id: int | None,
 ) -> Document:
-    """Insert the Document row with status=queued; returns the persisted row."""
+    """Insert the Document row with status=pending; returns the persisted row."""
 
 async def process_existing_document(
     self,
@@ -249,14 +367,12 @@ async def process_existing_document(
     force_ocr: bool = False,
 ) -> None:
     """Run Docling → chunking → embedding → FTS on a pre-existing row.
-    Transitions status queued → processing → completed/failed.
-    Commits a final error_message on any unhandled exception."""
+    Reports progress via DocumentProgress. Transitions
+    pending → processing → completed/failed. Always commits a final
+    error_message on any unhandled exception."""
 
 # Back-compat wrapper (non-upload callers, test fixtures):
-async def ingest_document(self, *args, **kwargs) -> Document:
-    doc = await self.create_document_record(...)
-    await self.process_existing_document(doc.id, kwargs.get("force_ocr", False))
-    return await self.db.get(Document, doc.id)
+async def ingest_document(self, *args, **kwargs) -> Document: ...
 ```
 
 Audit required: grep for existing callers of `ingest_document` before merging.
@@ -271,14 +387,14 @@ if settings.document_worker_enabled:
         raise HTTPException(503, "Document worker unavailable")
     doc = await rag.create_document_record(...)
     await queue.enqueue({"document_id": doc.id, "force_ocr": force_ocr})
-    return DocumentResponse(id=doc.id, status="queued", ...)  # 202
+    return DocumentResponse(id=doc.id, status="pending", ...)  # 202
 else:
-    # Legacy inline path — unchanged.
     doc = await rag.ingest_document(...)
-    return DocumentResponse(...)
+    return DocumentResponse(...)  # 200, legacy
 ```
 
-HTTP status code for the new path is `202 Accepted`, not `200`.
+New: `GET /api/knowledge/documents?ids=1,2,3` batch endpoint for the polling
+client. Keeps Redis+DB load O(1) regardless of how many docs are in flight.
 
 ### 3. New module `src/backend/workers/document_processor_worker.py`
 
@@ -289,8 +405,6 @@ async def main():
     redis = await aioredis.from_url(settings.redis_url)
     queue = DocumentTaskQueue(redis, consumer_id=pod_name())
     await queue.ensure_group()
-
-    # Reclaim entries from dead consumers on startup
     await queue.reclaim_stale()
 
     stop_event = asyncio.Event()
@@ -306,8 +420,9 @@ async def main():
             if not entry:
                 continue
             entry_id, params = entry
+            progress = DocumentProgress(redis, params["document_id"])
             async with AsyncSessionLocal() as db:
-                rag = RAGService(db)
+                rag = RAGService(db, progress=progress)
                 try:
                     await rag.process_existing_document(
                         document_id=params["document_id"],
@@ -316,28 +431,40 @@ async def main():
                     await queue.ack(entry_id)
                 except Exception as e:
                     logger.exception(f"Task {entry_id} failed: {e}")
-                    # Do NOT ack — entry stays in PEL, reclaim_stale picks it
-                    # up after visibility timeout. Document row already has
-                    # status=failed and error_message from process_existing_document.
+                    # Do NOT ack — reclaim_stale reaps after visibility timeout.
+                finally:
+                    await progress.clear()
     finally:
         heartbeat_task.cancel()
         await queue.close()
         await redis.aclose()
 ```
 
-### 4. `src/frontend/src/pages/KnowledgePage.tsx`
+### 4. `src/frontend/src/pages/KnowledgePage.jsx`
 
-After upload returns 202, poll `/api/knowledge/documents/{id}` every 2 s
-until `status ∈ {completed, failed}`. Surface per-document progress (queued,
-processing, completed, failed) with a spinner and a clear error path.
+Two sub-phases, matching the PR split below:
 
-This is **not** a follow-up — it ships in the cutover PR. Without it, users
-see a silent hung spinner immediately after upload, which is a UX regression
-vs. the synchronous `200` today.
+**C1 (cutover):**
+- Upload handler accepts 202 response. Inserts optimistic row with
+  `status=pending` while waiting for server list refresh.
+- Basic polling loop (fixed 2 s) until `completed`/`failed`.
+- Status badges use the full taxonomy above. Copy map applied for all six
+  response codes. 409 uses a real modal, not a toast.
+- Basic A11y: `role="status" aria-live="polite"` on the status column,
+  `aria-label` on icon-only badges, 44 px touch targets.
+
+**C2 (polish):**
+- Polling strategy upgraded: 1 s start, 10 s cap, Visibility API, AbortController,
+  batch endpoint.
+- Stage + page sub-labels; progressbar on rows with pages.
+- Tab-title mutation + localStorage optimistic persistence.
+- Queue-position sub-label when `pending`.
+- Full A11y: progressbar semantics, focus management on 409 dialog, keyboard
+  path audit, contrast review.
 
 ## K8s changes
 
-### `k8s/document-worker.yaml` (new)
+### `k8s/document-worker.yaml` (new, PR A)
 
 ```yaml
 apiVersion: apps/v1
@@ -347,10 +474,8 @@ metadata:
   namespace: renfield
 spec:
   replicas: 1
-  strategy:
-    type: Recreate
-  selector:
-    matchLabels: {app.kubernetes.io/name: document-worker}
+  strategy: {type: Recreate}
+  selector: {matchLabels: {app.kubernetes.io/name: document-worker}}
   template:
     metadata:
       labels: {app.kubernetes.io/name: document-worker, app.kubernetes.io/part-of: renfield}
@@ -365,11 +490,9 @@ spec:
           env:
             - name: POD_NAME
               valueFrom: {fieldRef: {fieldPath: metadata.name}}
-            # Postgres, Redis, Ollama URLs come from renfield-env; secrets as in backend
           volumeMounts:
             - {name: uploads, mountPath: /app/data/uploads}
-            - {name: cache-home, mountPath: /app/data/cache-home}  # shared HF+EasyOCR cache
-            - {name: mcp-config, mountPath: /app/config/...}
+            - {name: cache-home, mountPath: /app/data/cache-home}
           resources:
             requests: {cpu: 500m, memory: 1Gi}
             limits:   {cpu: "2",  memory: 6Gi}
@@ -378,86 +501,91 @@ spec:
           persistentVolumeClaim: {claimName: renfield-uploads-shared}
         - name: cache-home
           persistentVolumeClaim: {claimName: renfield-cache-shared}
-        - name: mcp-config
-          configMap: {name: renfield-mcp-config}
 ```
 
-No Service — worker is a pure stream consumer.
+No Service — worker is a pure consumer.
 
-### `k8s/backend.yaml` (modified)
+### `k8s/backend.yaml` (modified across PRs)
 
-- Replace `renfield-data` PVC mount at `/app/data` with two PVCs:
-  `renfield-uploads-shared` (RWX, NFS-CSI) at `/app/data/uploads`, and
-  `renfield-cache-shared` (RWX, NFS-CSI) at `/app/data/cache-home`.
-- After cutover: memory limit `12Gi → 5Gi`.
+- **PR A**: add new PVC mounts alongside Longhorn (dual-write window).
+- **PR C1 cutover**: drop Longhorn `renfield-data`, keep NFS-CSI PVCs.
+- **Post-cutover**: memory limit `12Gi → 5Gi`.
 
 ### `k8s/configmap.yaml`
 
-- Add `DOCUMENT_WORKER_ENABLED: "false"` (default off, flipped in rollout).
+Add `DOCUMENT_WORKER_ENABLED: "false"` in PR A; flip during rollout.
 
 ### `../private_k8s/nfs-csi/` (new, cluster-wide)
 
-- Pinned copy of `csi-driver-nfs` manifests (version tracked in the README).
-- Two `StorageClass` objects: `nfs-csi` for uploads, shared by namespaces as
-  they need RWX NFS.
+- Pinned `csi-driver-nfs` v4.13.2 manifests.
+- `StorageClass nfs-csi-renfield-uploads` and `StorageClass nfs-csi-renfield-cache`.
 
 ## Test matrix (mandatory, blocking)
 
-| # | Path | Kind | Tool |
-|---|------|------|------|
-| 1 | `create_document_record` happy path | unit | pytest + async |
-| 2 | `create_document_record` with duplicate hash → 409 | unit | pytest |
-| 3 | `process_existing_document` happy path (stubbed Docling) | unit | pytest |
-| 4 | `process_existing_document` Docling failure → `status=failed` with error_message | unit | pytest |
-| 5 | `process_existing_document` embedder raises → `status=failed`, DB rolled back | unit | pytest |
-| 6 | Upload endpoint 202 with flag=on, worker heartbeat present | API | httpx + test client |
-| 7 | Upload endpoint 503 with flag=on, heartbeat missing | API | httpx |
-| 8 | Upload endpoint legacy 200 with flag=off | API | httpx |
-| 9 | Worker loop: successful processing → XACK called | integration | testcontainers redis |
-| 10 | **Worker crash recovery: SIGKILL mid-task → next worker reclaims via XCLAIM** | **integration, blocking** | testcontainers redis |
-| 11 | Worker SIGTERM: finishes current task, exits cleanly | integration | subprocess + signal |
-| 12 | Worker module import does NOT instantiate FastAPI app | unit | importlib + introspection |
-| 13 | Frontend: upload → 202 → polling → completed badge shown | e2e | vitest + MSW |
-| 14 | Frontend: upload → 202 → polling sees `status=failed` → error surface | e2e | vitest + MSW |
+| # | Path | Kind |
+|---|------|------|
+| 1 | `create_document_record` happy path | unit |
+| 2 | `create_document_record` with duplicate hash → 409 | unit |
+| 3 | `process_existing_document` happy path (stubbed Docling) | unit |
+| 4 | `process_existing_document` Docling failure → `status=failed` with error_message | unit |
+| 5 | `process_existing_document` embedder raises → `status=failed`, DB rolled back | unit |
+| 6 | Upload endpoint 202 with flag=on, worker heartbeat present | API |
+| 7 | Upload endpoint 503 with flag=on, heartbeat missing | API |
+| 8 | Upload endpoint legacy 200 with flag=off | API |
+| 9 | Worker loop: successful processing → XACK called | integration |
+| 10 | **Worker crash recovery: SIGKILL mid-task → next worker reclaims via XCLAIM** | **integration, blocking** |
+| 11 | Worker SIGTERM: finishes current task, exits cleanly | integration |
+| 12 | Worker module import does NOT instantiate FastAPI app | unit |
+| 13 | DocumentProgress stage + page writes + TTL expiry | unit |
+| 14 | `GET /api/knowledge/documents?ids=1,2,3` batch endpoint returns all three | API |
+| 15 | Frontend (C1): upload → 202 → row appears `pending` → polling → `completed` | e2e |
+| 16 | Frontend (C1): upload → 202 → polling sees `failed` → error surface with Retry | e2e |
+| 17 | Frontend (C1): upload → 503 → toast + Retry CTA | e2e |
+| 18 | Frontend (C1): duplicate upload → 409 dialog → anchor jumps to existing | e2e |
+| 19 | Frontend (C2): backoff observed 1 → 2 → 4 → 8 → 10 s | unit (hook test) |
+| 20 | Frontend (C2): Visibility API pauses polling in hidden tab | unit |
+| 21 | Frontend (C2): localStorage round-trip on reload during `processing` | unit |
+| 22 | Frontend (C2): screen-reader announces status transitions (RTL + axe-core) | e2e |
+| 23 | Frontend (C2): queue position sub-label renders when pending with position | unit |
 
 Test 10 is the reason we're switching to Streams. Without it, the whole
-redesign is lipstick.
+redesign is cosmetic.
 
-## Migration plan
+## Migration plan (revised after UX review)
 
-Sequenced, each step independently revertable:
+Five sequenced PRs:
 
-1. **Cluster prep** — install NFS-CSI driver, create StorageClass, verify
-   provisioning with a throwaway test PVC.
-2. **Server prep** — create `/mnt/data/renfield-uploads` on `192.168.1.9`,
-   add `/etc/exports` entry, `exportfs -ra`.
-3. **PR A (infra)** — add `DocumentTaskQueue` (Streams) alongside existing
-   `TaskQueue`; add `k8s/document-worker.yaml` + PVC manifests + worker
-   module; `DOCUMENT_WORKER_ENABLED=false`. Nothing behaviourally changes.
-4. **PR B (refactor)** — split `RAGService.ingest_document`; unit tests 1–5.
-5. **PR C (cutover-ready)** — upload endpoint branch on flag; heartbeat
-   gating; frontend polling; tests 6–14.
-6. **Rollout** — deploy PR C with flag still off. Run migrator Job.
-   `docker compose up` cutover check:
-   1. Scale backend to 0, run final rsync.
-   2. Scale backend to 1 with flag still off — verify new PVC mounts read/write.
-   3. Apply ConfigMap with `DOCUMENT_WORKER_ENABLED=true`.
-   4. Restart backend + worker. Smoke-test an upload end-to-end.
-7. **Cleanup** — drop backend memory `12Gi → 5Gi` in a follow-up commit once
-   the stack has been stable 48 h. Remove legacy inline path once flag has
-   been on for a week.
+1. **PR A (Infra)** — NFS-CSI installation (vendored in `private_k8s/`),
+   StorageClasses, PVC manifests, `DocumentTaskQueue` (Streams) alongside
+   existing TaskQueue, `DocumentProgress`, `workers/document_processor_worker.py`,
+   `k8s/document-worker.yaml`, `DOCUMENT_WORKER_ENABLED=false`. Nothing behaviourally
+   changes from a user perspective.
+2. **PR B (Refactor)** — `RAGService` split into `create_document_record` +
+   `process_existing_document`. Unit tests 1–5, 13.
+3. **PR C1 (Cutover, backend + minimal frontend)** — upload endpoint branches on
+   flag; heartbeat gate; batch `?ids=` endpoint; DocumentProgress wired from
+   Docling callbacks; minimal frontend (badges + copy map + basic polling +
+   409 dialog + basic A11y). Tests 6–12, 14–18. After merge: run migrator Job,
+   flip flag, verify.
+4. **PR C2 (Polish)** — frontend UX additions: polling backoff, Visibility API,
+   localStorage, tab-title mutation, progressbar, queue-position sub-label,
+   full A11y audit, contrast review. Tests 19–23.
+5. **Cleanup** — backend memory limit `12Gi → 5Gi`. Remove legacy inline path
+   once C1 has been flag-on for a week without incident.
 
 ## Out of scope
 
 - Celery migration — Streams covers everything we need.
 - Worker horizontal autoscaling — 1 replica holds current load.
-- Multi-tenant priority queues (e.g. premium uploads first) — single stream.
-- PDF-level progress reporting (per-page %) — status=processing is enough.
+- Multi-tenant priority queues — single stream.
+- Per-user upload quotas / retention — tracked separately.
+- Native OS notifications (`Notification.requestPermission()`) — invasive for
+  household context; tab-title + localStorage covers the need.
 
 ## Open questions
 
-- **NFS-CSI version pin.** Current stable is v4.10.x — check against K8s
-  v1.35 compatibility before ingesting.
-- **Migration-window tolerance.** How long can uploads be 503 during rsync?
-  Current estimate: 2 min for today's payload. If unacceptable, we can
-  double-write during the transition and cut over lazily.
+- **Migration window tolerance.** How long can uploads be 503 during rsync?
+  Estimate: ~2 min for today's payload. If unacceptable, double-write during
+  the transition.
+- **NFS-CSI pinning.** Using v4.13.2 (released 2026-04-16). Verify compatibility
+  with K8s v1.35 before PR A merges.

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -77,9 +77,15 @@ data:
 
   # Persist ML model caches (EasyOCR ~/.EasyOCR, HuggingFace ~/.cache/huggingface,
   # Torch ~/.cache/torch, whisper ~/.cache/whisper) across pod restarts by
-  # pointing HOME at the /app/data mount (Longhorn PVC).
+  # pointing HOME at the /app/data mount (Longhorn PVC today; NFS-CSI RWX
+  # PVC after cutover — same path, shared with the document-worker).
   HOME: "/app/data/cache-home"
   HF_HOME: "/app/data/cache-home/.cache/huggingface"
+
+  # Document worker split (#388). When false, /api/knowledge/upload runs
+  # Docling inline in the request. When true, the endpoint enqueues on the
+  # Redis Stream and the document-worker pod owns the processing.
+  DOCUMENT_WORKER_ENABLED: "false"
 
   # Logging
   LOG_LEVEL: "INFO"

--- a/k8s/document-worker.yaml
+++ b/k8s/document-worker.yaml
@@ -1,0 +1,117 @@
+# Document processor worker (#388).
+#
+# Runs the Docling + EasyOCR + embedding pipeline out-of-process from the
+# backend so a large PDF upload doesn't OOM the API serving path. Consumes
+# from the `renfield:tasks:document` Redis Stream; heartbeats to
+# `renfield:worker:document:heartbeat` so the API can 503 gracefully if the
+# worker is down.
+#
+# PR A ships this Deployment but it sits idle: DOCUMENT_WORKER_ENABLED stays
+# `false` in the backend ConfigMap so /api/knowledge/upload continues the
+# inline code path. When the flag flips in PR C1 cutover, this pod picks up
+# the enqueued tasks.
+#
+# Volumes intentionally mirror what the backend will mount post-cutover —
+# same uploads directory (so the backend writes the file, the worker reads
+# it), same cache-home (so Docling/HuggingFace/EasyOCR weights are shared).
+# Both are RWX via NFS-CSI (see k8s/shared-pvcs.yaml).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: document-worker
+  namespace: renfield
+  labels:
+    app.kubernetes.io/name: document-worker
+    app.kubernetes.io/part-of: renfield
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: document-worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: document-worker
+        app.kubernetes.io/part-of: renfield
+    spec:
+      imagePullSecrets:
+        - name: harbor-pull-secret
+      initContainers:
+        # Ensure infra deps are reachable before we start consuming.
+        - name: wait-for-deps
+          image: busybox:1.36
+          command: ["sh", "-c"]
+          args:
+            - |
+              echo "waiting for postgres..."; until nc -z postgres 5432; do sleep 1; done
+              echo "waiting for redis...";    until nc -z redis 6379;    do sleep 1; done
+              echo "waiting for ollama...";   until nc -z ollama 11434;  do sleep 1; done
+              echo "deps ready"
+              mkdir -p /app/data/cache-home/.cache /app/data/cache-home/.EasyOCR
+          resources:
+            requests: {cpu: 10m, memory: 16Mi}
+            limits:   {memory: 64Mi}
+          volumeMounts:
+            - {name: cache-home, mountPath: /app/data/cache-home}
+      containers:
+        - name: worker
+          image: registry.treehouse.x-idra.de/renfield/backend:latest
+          imagePullPolicy: Always
+          workingDir: /app
+          command: ["python", "-m", "workers.document_processor_worker"]
+          envFrom:
+            - configMapRef: {name: renfield-env}
+          env:
+            - name: POD_NAME
+              valueFrom: {fieldRef: {fieldPath: metadata.name}}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef: {name: renfield-secrets, key: postgres-password}
+            - name: DATABASE_URL
+              value: postgresql+asyncpg://renfield:$(POSTGRES_PASSWORD)@postgres:5432/renfield
+            # Integration secrets mirror the backend so Docling/RAG code paths
+            # that eventually call out (e.g. contextual retrieval LLM) work.
+            - name: HOME_ASSISTANT_TOKEN
+              valueFrom:
+                secretKeyRef: {name: renfield-secrets, key: home-assistant-token}
+          volumeMounts:
+            - {name: uploads,    mountPath: /app/data/uploads}
+            - {name: cache-home, mountPath: /app/data/cache-home}
+            - name: mcp-config
+              mountPath: /app/config/mcp_servers.yaml
+              subPath: mcp_servers.yaml
+              readOnly: true
+            - name: mcp-config
+              mountPath: /app/config/agent_roles.yaml
+              subPath: agent_roles.yaml
+              readOnly: true
+            - name: mcp-config
+              mountPath: /app/config/kg_scopes.yaml
+              subPath: kg_scopes.yaml
+              readOnly: true
+          # No livenessProbe here. The worker's real liveness signal is the
+          # Redis heartbeat key (`renfield:worker:document:heartbeat`) which
+          # the upload endpoint checks before enqueuing. If the Python
+          # process dies, the pod exits non-zero and Kubernetes restarts it;
+          # if the process deadlocks in a C extension, the heartbeat stops
+          # refreshing and the upload endpoint 503s — failure is visible end
+          # to end without an in-pod probe. A probe that uses `pgrep` would
+          # need the `procps` package in the runtime image, which we don't
+          # ship to keep the image lean.
+          resources:
+            requests: {cpu: 500m, memory: 1Gi}
+            # 6Gi owns the Docling/EasyOCR peak alone. Backend can drop to
+            # ~5Gi post-cutover (PR C1) since it no longer runs this pipeline.
+            limits:   {cpu: "2",  memory: 6Gi}
+      volumes:
+        - name: uploads
+          persistentVolumeClaim:
+            claimName: renfield-uploads-shared
+        - name: cache-home
+          persistentVolumeClaim:
+            claimName: renfield-cache-shared
+        - name: mcp-config
+          configMap:
+            name: renfield-mcp-config

--- a/k8s/document-worker.yaml
+++ b/k8s/document-worker.yaml
@@ -36,6 +36,12 @@ spec:
         app.kubernetes.io/name: document-worker
         app.kubernetes.io/part-of: renfield
     spec:
+      # Default is 30s, which is short compared to Docling+OCR on a big PDF
+      # (15–120s). Set 120s so SIGTERM has a realistic chance to finish the
+      # in-flight task and XACK it. If the task exceeds 120s the pod gets
+      # SIGKILLed anyway; the Stream PEL + reclaim_stale recovers it on the
+      # next boot (design invariant, covered by integration test #10).
+      terminationGracePeriodSeconds: 120
       imagePullSecrets:
         - name: harbor-pull-secret
       initContainers:

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -16,6 +16,8 @@ resources:
   - frontend.yaml
   - middleware-https-redirect.yaml
   - ingress.yaml
+  - shared-pvcs.yaml
+  - document-worker.yaml
 
 labels:
   - pairs:

--- a/k8s/shared-pvcs.yaml
+++ b/k8s/shared-pvcs.yaml
@@ -1,0 +1,46 @@
+# Shared ReadWriteMany PVCs for the document worker split (#388).
+#
+# These PVCs back storage that both the backend and the document-worker pods
+# need to read/write simultaneously. Longhorn's default StorageClass is
+# ReadWriteOnce, which cannot span two nodes. NFS-CSI v4.13.2 provisions
+# backed by the household NFS export at 192.168.1.9:/mnt/data/k8s/renfield/.
+#
+# Mounted by:
+#   renfield-uploads-shared → backend + worker at /app/data/uploads
+#                             (document files served to /api/settings/wakeword/models
+#                              unrelated; this is /api/knowledge/upload payload storage)
+#   renfield-cache-shared   → backend + worker at /app/data/cache-home
+#                             (HuggingFace + EasyOCR + Whisper model caches)
+#
+# These manifests are shipped in PR A (infrastructure) but NOT yet mounted by
+# any deployment. Actual mounts follow in PR C1 (cutover), after the migrator
+# Job has copied existing uploads off the Longhorn renfield-data PVC.
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: renfield-uploads-shared
+  namespace: renfield
+  labels:
+    app.kubernetes.io/part-of: renfield
+spec:
+  accessModes: [ReadWriteMany]
+  storageClassName: nfs-csi-renfield-uploads
+  resources:
+    requests:
+      storage: 50Gi
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: renfield-cache-shared
+  namespace: renfield
+  labels:
+    app.kubernetes.io/part-of: renfield
+spec:
+  accessModes: [ReadWriteMany]
+  storageClassName: nfs-csi-renfield-cache
+  resources:
+    requests:
+      storage: 20Gi

--- a/src/backend/services/progress.py
+++ b/src/backend/services/progress.py
@@ -1,0 +1,110 @@
+"""
+DocumentProgress — live per-document processing progress in Redis (#388).
+
+Why in Redis, not Postgres:
+  Docling/EasyOCR emit progress callbacks at sub-second intervals while a
+  multi-page PDF is being OCR'd. Writing those into the ``documents`` table
+  would generate hundreds of UPDATEs per ingestion and defeat the Postgres
+  connection pool. Redis is the right tool for ephemeral, write-heavy,
+  TTL-bound state. The ``Document`` row only tracks terminal status
+  (``pending``/``processing``/``completed``/``failed``); stage + page counts
+  live here.
+
+Key shape:
+    renfield:doc:{doc_id}:stage       → "parsing" | "ocr" | "chunking" | "embedding"
+    renfield:doc:{doc_id}:progress    → "<current>/<total>" (empty for non-paginated)
+
+Both keys use the same 30-minute TTL so a dead task can't leak state
+forever. The frontend reads these via ``GET /api/knowledge/documents/{id}``
+alongside the DB status. ``clear()`` is called on both success and failure
+so the UI doesn't flash stale progress against a ``completed`` row.
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+import redis.asyncio as aioredis
+from loguru import logger
+
+Stage = Literal["parsing", "ocr", "chunking", "embedding"]
+
+KEY_PREFIX = "renfield:doc"
+STAGE_SUFFIX = "stage"
+PROGRESS_SUFFIX = "progress"
+DEFAULT_TTL_S = 30 * 60  # 30 minutes; matches worker visibility + UI polling timeout
+
+
+def _stage_key(doc_id: int) -> str:
+    return f"{KEY_PREFIX}:{doc_id}:{STAGE_SUFFIX}"
+
+
+def _progress_key(doc_id: int) -> str:
+    return f"{KEY_PREFIX}:{doc_id}:{PROGRESS_SUFFIX}"
+
+
+class DocumentProgress:
+    """Live progress publisher for a single Document being ingested.
+
+    Instances are cheap. Typically constructed per-task inside the worker
+    and passed down into ``DocumentProcessor`` as a callback sink.
+    """
+
+    def __init__(
+        self,
+        redis_client: aioredis.Redis,
+        doc_id: int,
+        ttl_s: int = DEFAULT_TTL_S,
+    ):
+        self.redis = redis_client
+        self.doc_id = doc_id
+        self.ttl_s = ttl_s
+
+    async def set_stage(self, stage: Stage) -> None:
+        """Advance the stage label. Refreshes the TTL on the stage key."""
+        await self.redis.set(_stage_key(self.doc_id), stage, ex=self.ttl_s)
+
+    async def set_pages(self, current: int, total: int) -> None:
+        """Record ``current/total`` page progress. Only meaningful for paginated
+        formats (PDF, DOCX). Non-paginated flows just call ``set_stage``.
+        """
+        if total <= 0:
+            return
+        if current < 0:
+            current = 0
+        if current > total:
+            current = total
+        value = f"{current}/{total}"
+        await self.redis.set(_progress_key(self.doc_id), value, ex=self.ttl_s)
+
+    async def clear(self) -> None:
+        """Remove both keys. Called from the worker's ``finally`` block so a
+        completed/failed document doesn't keep advertising stage info."""
+        await self.redis.delete(
+            _stage_key(self.doc_id),
+            _progress_key(self.doc_id),
+        )
+
+    async def read(self) -> dict:
+        """Read the current stage + pages. Returned dict has shape:
+
+            {"stage": "ocr" | None, "pages": {"current": 47, "total": 120} | None}
+
+        Used by the ``/api/knowledge/documents/{id}`` response to surface
+        progress to the frontend. Missing keys map to ``None`` rather than
+        raising so the API can safely call ``read()`` for any document.
+        """
+        stage_raw, progress_raw = await self.redis.mget(
+            _stage_key(self.doc_id),
+            _progress_key(self.doc_id),
+        )
+        pages = None
+        if progress_raw:
+            try:
+                current_str, total_str = progress_raw.split("/", 1)
+                pages = {"current": int(current_str), "total": int(total_str)}
+            except ValueError:
+                logger.warning(
+                    f"DocumentProgress: malformed value for doc {self.doc_id}: "
+                    f"{progress_raw!r}"
+                )
+        return {"stage": stage_raw, "pages": pages}

--- a/src/backend/services/task_queue.py
+++ b/src/backend/services/task_queue.py
@@ -1,7 +1,19 @@
 """
-Task Queue Service mit Redis (async)
+Task Queue Service mit Redis (async).
+
+Two implementations live here:
+
+- ``TaskQueue`` (original): fire-and-forget list-based queue using LPUSH/RPOP.
+  Destructive read — a crashing consumer loses the in-flight task. Fine for
+  tasks that can be dropped silently.
+- ``DocumentTaskQueue`` (#388): Redis Streams with a consumer group. Entries
+  stay in the Pending Entries List until ACKed, so a crash leaves the task
+  recoverable. Used by the document-processor worker so that an OOM-kill
+  mid-OCR does not silently orphan a Document row in ``status=processing``.
 """
 import json
+from dataclasses import dataclass
+from typing import Any
 
 import redis.asyncio as aioredis
 from loguru import logger
@@ -80,3 +92,189 @@ class TaskQueue:
     async def close(self):
         """Close Redis connection gracefully."""
         await self.redis_client.close()
+
+
+# ---------------------------------------------------------------------------
+# DocumentTaskQueue — Redis Streams with consumer group + reclaim.
+# ---------------------------------------------------------------------------
+
+@dataclass
+class StreamEntry:
+    """One document-processing task pulled from the stream."""
+
+    entry_id: str
+    params: dict[str, Any]
+
+
+class DocumentTaskQueue:
+    """Durable task queue for document ingestion using Redis Streams.
+
+    Why Streams (not a Redis list): the list-based ``TaskQueue`` uses RPOP
+    which removes the entry on read. If the worker crashes between RPOP and
+    finishing the task, the work is silently lost and the Document row is
+    stuck in ``status=processing`` forever. Streams keep the entry in the
+    Pending Entries List (PEL) until ``XACK`` is called; a reboot or a
+    separate consumer can pick it up via ``XCLAIM`` once the visibility
+    window has elapsed.
+
+    Contract:
+      * One stream (``renfield:tasks:document``) and one consumer group
+        (``docworker``). Each worker pod is a consumer identified by its
+        pod name so ``XPENDING`` can attribute stuck entries.
+      * ``enqueue`` is a single ``XADD`` — atomic on the Redis side.
+      * ``read_one`` uses ``XREADGROUP BLOCK`` for efficient long-polling;
+        returns ``None`` if the timeout fires with no new entry.
+      * ``ack`` is called after the task finishes successfully. If an
+        exception propagates out of the handler, the entry stays in the PEL
+        and ``reclaim_stale`` moves it to the current consumer on the next
+        start-up (or whenever the caller decides to reap).
+    """
+
+    DEFAULT_STREAM = "renfield:tasks:document"
+    DEFAULT_GROUP = "docworker"
+    DEFAULT_VISIBILITY_MS = 600_000  # 10 min, covers worst-case OCR
+
+    def __init__(
+        self,
+        redis_client: aioredis.Redis | None = None,
+        consumer_id: str = "worker-local",
+        stream_key: str = DEFAULT_STREAM,
+        group_name: str = DEFAULT_GROUP,
+        visibility_ms: int = DEFAULT_VISIBILITY_MS,
+    ):
+        self.redis_client = redis_client or aioredis.from_url(
+            settings.redis_url, decode_responses=True
+        )
+        self.consumer_id = consumer_id
+        self.stream_key = stream_key
+        self.group_name = group_name
+        self.visibility_ms = visibility_ms
+        self._owns_client = redis_client is None
+
+    async def ensure_group(self) -> None:
+        """Create the consumer group if it doesn't exist.
+
+        ``MKSTREAM`` creates the stream on the fly, which is what we want on
+        a fresh Redis. If the group already exists Redis returns
+        ``BUSYGROUP`` — we treat that as success.
+        """
+        try:
+            await self.redis_client.xgroup_create(
+                name=self.stream_key,
+                groupname=self.group_name,
+                id="$",
+                mkstream=True,
+            )
+            logger.info(
+                f"DocumentTaskQueue: created consumer group {self.group_name!r} "
+                f"on stream {self.stream_key!r}"
+            )
+        except aioredis.ResponseError as e:
+            if "BUSYGROUP" not in str(e):
+                raise
+            # Group already existed — normal on subsequent starts.
+
+    async def enqueue(self, params: dict[str, Any]) -> str:
+        """Add a task to the stream. Returns the stream entry id (ms-seq)."""
+        entry_id = await self.redis_client.xadd(
+            self.stream_key,
+            {"payload": json.dumps(params)},
+        )
+        logger.info(f"DocumentTaskQueue: enqueued {entry_id} params={params}")
+        return entry_id
+
+    async def read_one(self, block_ms: int = 5_000) -> StreamEntry | None:
+        """Block for up to ``block_ms`` ms waiting for a task. Returns
+        ``None`` if the window closed with no new entry."""
+        result = await self.redis_client.xreadgroup(
+            groupname=self.group_name,
+            consumername=self.consumer_id,
+            streams={self.stream_key: ">"},
+            count=1,
+            block=block_ms,
+        )
+        if not result:
+            return None
+        # XREADGROUP returns [(stream_name, [(entry_id, {field: value}), ...])]
+        _stream, entries = result[0]
+        entry_id, fields = entries[0]
+        try:
+            params = json.loads(fields.get("payload", "{}"))
+        except json.JSONDecodeError as e:
+            logger.error(
+                f"DocumentTaskQueue: bad payload for {entry_id}: {e}. "
+                "Acking to prevent poison-pill loop."
+            )
+            await self.ack(entry_id)
+            return None
+        return StreamEntry(entry_id=entry_id, params=params)
+
+    async def ack(self, entry_id: str) -> None:
+        """Acknowledge successful processing. Removes the entry from the PEL."""
+        await self.redis_client.xack(self.stream_key, self.group_name, entry_id)
+
+    async def reclaim_stale(self, min_idle_ms: int | None = None) -> list[StreamEntry]:
+        """Claim entries from dead consumers whose idle time exceeds the
+        visibility window. Typically called once on worker startup so the
+        current pod adopts anything a previous (now-gone) pod was working on
+        when it died.
+        """
+        min_idle = min_idle_ms if min_idle_ms is not None else self.visibility_ms
+        # XAUTOCLAIM returns (next_cursor, claimed_entries, deleted_ids)
+        cursor = "0-0"
+        claimed: list[StreamEntry] = []
+        while True:
+            result = await self.redis_client.xautoclaim(
+                name=self.stream_key,
+                groupname=self.group_name,
+                consumername=self.consumer_id,
+                min_idle_time=min_idle,
+                start_id=cursor,
+                count=100,
+            )
+            # redis.asyncio returns a 3-tuple (next_cursor, items, deleted)
+            next_cursor, items, _deleted = result
+            for entry_id, fields in items:
+                try:
+                    params = json.loads(fields.get("payload", "{}"))
+                except json.JSONDecodeError:
+                    # Poison entry — ack to drop, log.
+                    logger.error(
+                        f"DocumentTaskQueue: reclaimed {entry_id} has bad payload; dropping"
+                    )
+                    await self.ack(entry_id)
+                    continue
+                claimed.append(StreamEntry(entry_id=entry_id, params=params))
+            if next_cursor == "0-0" or not items:
+                break
+            cursor = next_cursor
+        if claimed:
+            logger.warning(
+                f"DocumentTaskQueue: reclaimed {len(claimed)} stale entries "
+                f"from previous consumers"
+            )
+        return claimed
+
+    async def pending_count(self) -> int:
+        """Number of entries currently in the consumer group's PEL.
+
+        Combined with ``stream_length`` this lets the API compute a user-facing
+        queue position for a pending Document row.
+        """
+        summary = await self.redis_client.xpending(self.stream_key, self.group_name)
+        # xpending with no args returns either a dict or a positional list
+        # depending on the Redis library version. Normalise defensively.
+        if isinstance(summary, dict):
+            return int(summary.get("pending", 0))
+        if isinstance(summary, list) and summary:
+            return int(summary[0])
+        return 0
+
+    async def stream_length(self) -> int:
+        """Total length of the stream (includes already-acked entries that
+        haven't been trimmed)."""
+        return int(await self.redis_client.xlen(self.stream_key))
+
+    async def close(self) -> None:
+        if self._owns_client:
+            await self.redis_client.aclose()

--- a/src/backend/services/task_queue.py
+++ b/src/backend/services/task_queue.py
@@ -245,7 +245,12 @@ class DocumentTaskQueue:
                     await self.ack(entry_id)
                     continue
                 claimed.append(StreamEntry(entry_id=entry_id, params=params))
-            if next_cursor == "0-0" or not items:
+            # XAUTOCLAIM returns "0-0" as next_cursor when the scan has
+            # completed a full loop. An empty items batch with a non-"0-0"
+            # cursor just means "no entries matched the min_idle filter in
+            # this window"; later windows may still have entries, so we
+            # must keep iterating.
+            if next_cursor == "0-0":
                 break
             cursor = next_cursor
         if claimed:

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -46,6 +46,12 @@ class Settings(BaseSettings):
     # Redis
     redis_url: str = "redis://redis:6379"
 
+    # Document worker (#388). Flag gates whether /api/knowledge/upload runs
+    # Docling inline (False, legacy) or enqueues the task for the async worker
+    # pod (True). Defaults off; flipped in PR C1 after the worker is verified
+    # in the target cluster.
+    document_worker_enabled: bool = False
+
     # Ollama - Multi-Modell Konfiguration
     ollama_url: str = "http://ollama:11434"
     ollama_model: str = "llama3.2:3b"  # Legacy fallback; recommended: qwen3:14b (see docs/LLM_MODEL_GUIDE.md)

--- a/src/backend/workers/__init__.py
+++ b/src/backend/workers/__init__.py
@@ -1,0 +1,7 @@
+"""Renfield worker processes (#388).
+
+Each worker module is runnable via ``python -m workers.<name>`` and must not
+import or instantiate the FastAPI app (``main.app``). Worker pods exist to
+stay lean — pulling the whole API lifecycle would negate the memory budget
+that motivated the split.
+"""

--- a/src/backend/workers/document_processor_worker.py
+++ b/src/backend/workers/document_processor_worker.py
@@ -121,6 +121,15 @@ async def main() -> None:
     queue = DocumentTaskQueue(redis_client=redis, consumer_id=consumer)
     await queue.ensure_group()
 
+    # Heartbeat MUST start before reclaim_stale. On restart, the PEL may
+    # contain several entries left over from the previous consumer; each
+    # reclaimed entry runs through _process_entry (Docling: 15–120 s).
+    # Posting the heartbeat during that window keeps /api/knowledge/upload
+    # green instead of 503'ing for minutes while the worker is in fact
+    # alive and catching up.
+    stop_event = asyncio.Event()
+    heartbeat_task = asyncio.create_task(_heartbeat_loop(redis, stop_event, consumer))
+
     # Reclaim anything a previous consumer started but didn't finish.
     reclaimed = await queue.reclaim_stale()
     if reclaimed:
@@ -131,12 +140,9 @@ async def main() -> None:
         for entry in reclaimed:
             await _process_entry(redis, queue, entry)
 
-    stop_event = asyncio.Event()
     loop = asyncio.get_running_loop()
     for sig in (signal.SIGTERM, signal.SIGINT):
         loop.add_signal_handler(sig, stop_event.set)
-
-    heartbeat_task = asyncio.create_task(_heartbeat_loop(redis, stop_event, consumer))
 
     try:
         while not stop_event.is_set():

--- a/src/backend/workers/document_processor_worker.py
+++ b/src/backend/workers/document_processor_worker.py
@@ -1,0 +1,164 @@
+"""
+Document-processor worker (#388).
+
+Consumes tasks from the ``renfield:tasks:document`` Redis Stream and runs
+the Docling/EasyOCR/embedding pipeline out-of-process from the backend.
+
+Entry point::
+
+    python -m workers.document_processor_worker
+
+Design constraints:
+
+- Must NOT import ``main`` or instantiate the FastAPI app. Test
+  ``test_worker_module_isolation`` asserts this; adding such an import
+  would pull the entire lifecycle (MCP clients connecting to 10 servers,
+  Whisper download, Speechbrain, …) into the worker pod and defeat the
+  memory budget that motivated the split.
+- Graceful shutdown on SIGTERM/SIGINT: finish the current task, ack it,
+  then exit. Kubernetes gives ~30 s grace-period; an in-flight OCR on a
+  large PDF may exceed that, in which case Kubernetes escalates to
+  SIGKILL. The Streams PEL + reclaim_stale on next boot recovers the task.
+- Heartbeat key ``renfield:worker:document:heartbeat`` lets the API
+  short-circuit enqueue when no worker is alive. See
+  ``_worker_is_alive`` in ``api/routes/knowledge.py``.
+
+Not wired into ``/api/knowledge/upload`` yet. PR A ships the worker as
+runnable infra; the upload endpoint still takes the inline code path
+until ``DOCUMENT_WORKER_ENABLED`` is flipped in PR C1.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+
+import redis.asyncio as aioredis
+from loguru import logger
+
+from services.database import AsyncSessionLocal
+from services.progress import DocumentProgress
+from services.rag_service import RAGService
+from services.task_queue import DocumentTaskQueue, StreamEntry
+from utils.config import settings
+
+HEARTBEAT_KEY = "renfield:worker:document:heartbeat"
+HEARTBEAT_INTERVAL_S = 30
+HEARTBEAT_TTL_S = 90
+
+
+def _pod_name() -> str:
+    """Identify this worker instance. In k8s the env var ``POD_NAME`` is set
+    via downward API; outside k8s we fall back to hostname for dev runs."""
+    return os.environ.get("POD_NAME") or os.environ.get("HOSTNAME", "worker-local")
+
+
+async def _heartbeat_loop(
+    redis: aioredis.Redis,
+    stop_event: asyncio.Event,
+    consumer_id: str,
+) -> None:
+    """Refresh the liveness key while the worker is up."""
+    while not stop_event.is_set():
+        try:
+            await redis.set(HEARTBEAT_KEY, consumer_id, ex=HEARTBEAT_TTL_S)
+        except Exception as e:
+            logger.warning(f"heartbeat write failed: {e}")
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=HEARTBEAT_INTERVAL_S)
+        except asyncio.TimeoutError:
+            continue
+
+
+async def _process_entry(
+    redis: aioredis.Redis,
+    queue: DocumentTaskQueue,
+    entry: StreamEntry,
+) -> None:
+    """Handle a single stream entry. On success the entry is XACKed; on
+    exception we leave it in the PEL so the next reclaim picks it up."""
+    doc_id = entry.params.get("document_id")
+    if doc_id is None:
+        logger.error(f"skipping entry {entry.entry_id}: missing document_id")
+        await queue.ack(entry.entry_id)
+        return
+
+    force_ocr = bool(entry.params.get("force_ocr", False))
+    progress = DocumentProgress(redis, doc_id)
+    try:
+        async with AsyncSessionLocal() as db:
+            rag = RAGService(db)
+            # ``process_existing_document`` lands in PR B. Accessing it via
+            # getattr keeps PR A importable + runnable (the method just
+            # doesn't exist yet; the worker is idle while the feature flag
+            # stays off).
+            handler = getattr(rag, "process_existing_document", None)
+            if handler is None:
+                logger.error(
+                    "RAGService.process_existing_document is not available yet "
+                    "(PR B). Re-queue the task and ack to avoid a poison loop."
+                )
+                await queue.ack(entry.entry_id)
+                return
+            await handler(document_id=doc_id, force_ocr=force_ocr)
+        await queue.ack(entry.entry_id)
+        logger.info(f"processed doc {doc_id} (entry {entry.entry_id})")
+    except Exception as e:
+        logger.exception(f"task {entry.entry_id} for doc {doc_id} failed: {e}")
+        # Deliberately NOT ack'ing — reclaim_stale picks it up next time.
+    finally:
+        try:
+            await progress.clear()
+        except Exception as e:
+            logger.warning(f"progress clear failed for doc {doc_id}: {e}")
+
+
+async def main() -> None:
+    consumer = _pod_name()
+    logger.info(f"document-worker starting (consumer={consumer!r})")
+
+    redis = aioredis.from_url(settings.redis_url, decode_responses=True)
+    queue = DocumentTaskQueue(redis_client=redis, consumer_id=consumer)
+    await queue.ensure_group()
+
+    # Reclaim anything a previous consumer started but didn't finish.
+    reclaimed = await queue.reclaim_stale()
+    if reclaimed:
+        logger.warning(
+            f"reclaimed {len(reclaimed)} pending entries on startup; "
+            "processing them before reading new tasks"
+        )
+        for entry in reclaimed:
+            await _process_entry(redis, queue, entry)
+
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, stop_event.set)
+
+    heartbeat_task = asyncio.create_task(_heartbeat_loop(redis, stop_event, consumer))
+
+    try:
+        while not stop_event.is_set():
+            entry = await queue.read_one(block_ms=5_000)
+            if entry is None:
+                continue
+            await _process_entry(redis, queue, entry)
+    finally:
+        logger.info("document-worker shutting down")
+        heartbeat_task.cancel()
+        try:
+            await heartbeat_task
+        except asyncio.CancelledError:
+            pass
+        try:
+            await redis.delete(HEARTBEAT_KEY)
+        except Exception:
+            pass
+        await queue.close()
+        await redis.aclose()
+        logger.info("document-worker exited cleanly")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/backend/test_document_worker_isolation.py
+++ b/tests/backend/test_document_worker_isolation.py
@@ -1,0 +1,58 @@
+"""Verify the document-worker module is isolated from the FastAPI app (#388).
+
+The worker pod's memory budget (6 GiB) assumes it only loads Docling +
+EasyOCR + embedding clients. If ``import workers.document_processor_worker``
+transitively pulls ``main.app``, the worker boots the full lifecycle
+(MCP-connect to 10 servers, Whisper download, Speechbrain, …) and the
+budget is fiction.
+
+This test guards against that regression. Run it in a fresh subprocess so
+the global module cache is clean.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+@pytest.mark.unit
+def test_worker_import_does_not_load_fastapi_app():
+    """Importing the worker must not load ``main`` (where FastAPI's ``app``
+    is instantiated) or any MCP client module."""
+    script = textwrap.dedent(
+        """
+        import sys
+        import workers.document_processor_worker as w  # noqa: F401
+
+        loaded_main = 'main' in sys.modules
+        loaded_mcp = [m for m in sys.modules if m.startswith('services.mcp')]
+        loaded_lifecycle = 'api.lifecycle' in sys.modules
+        loaded_chat_handler = 'api.websocket.chat_handler' in sys.modules
+
+        print(f'main={loaded_main}')
+        print(f'mcp_modules={loaded_mcp}')
+        print(f'lifecycle={loaded_lifecycle}')
+        print(f'chat_handler={loaded_chat_handler}')
+
+        assert not loaded_main, 'worker transitively loaded main (FastAPI app)'
+        assert not loaded_lifecycle, 'worker transitively loaded api.lifecycle'
+        assert not loaded_chat_handler, 'worker transitively loaded chat_handler'
+        # mcp_client is imported by rag_service only through the agent path;
+        # if it sneaks in here we've broken the worker budget.
+        assert not loaded_mcp, f'worker loaded MCP modules: {loaded_mcp}'
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"worker import test failed.\nstdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )

--- a/tests/backend/test_document_worker_isolation.py
+++ b/tests/backend/test_document_worker_isolation.py
@@ -11,9 +11,11 @@ the global module cache is clean.
 """
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import textwrap
+from pathlib import Path
 
 import pytest
 
@@ -46,11 +48,24 @@ def test_worker_import_does_not_load_fastapi_app():
         """
     )
 
+    # The subprocess gets a fresh Python and does NOT inherit sys.path
+    # modifications made by conftest.py. Inject PYTHONPATH explicitly so
+    # ``import workers.document_processor_worker`` resolves both in the
+    # container (where PYTHONPATH is unset but CWD=/app works) and on CI
+    # runners (where CWD is the repo root and only PYTHONPATH helps).
+    backend_root = Path(__file__).resolve().parents[2] / "src" / "backend"
+    env = os.environ.copy()
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        str(backend_root) + (os.pathsep + existing if existing else "")
+    )
+
     result = subprocess.run(
         [sys.executable, "-c", script],
         capture_output=True,
         text=True,
         timeout=30,
+        env=env,
     )
     assert result.returncode == 0, (
         f"worker import test failed.\nstdout:\n{result.stdout}\n"


### PR DESCRIPTION
First of four PRs for #388. **Zero user-visible behaviour change.**
Ships the infra the async document-ingestion split needs, leaves the flag off.

## Scope

- **Redis Streams task queue** (`services/task_queue.py`): new
  `DocumentTaskQueue` class next to the existing list-based `TaskQueue`.
  At-least-once delivery via `XREADGROUP` + `XACK` + `XAUTOCLAIM`. The
  existing queue stays for fire-and-forget callers.
- **Progress publisher** (`services/progress.py`): `DocumentProgress`
  writes `renfield:doc:{id}:stage` and `renfield:doc:{id}:progress` so
  the frontend can render stage + page counters without hammering
  Postgres. 30-min TTL.
- **Worker module** (`workers/document_processor_worker.py`): async main
  loop, heartbeat key `renfield:worker:document:heartbeat` (30 s refresh,
  90 s TTL), graceful SIGTERM, reclaim_stale on startup. Isolation test
  guards against transitively importing `main` / `api.lifecycle` /
  `services.mcp_*`.
- **K8s**: `shared-pvcs.yaml` (RWX PVCs on new nfs-csi-renfield-* StorageClasses),
  `document-worker.yaml` (same backend image, different command, 6Gi
  limit, no Service), `DOCUMENT_WORKER_ENABLED=false` in the ConfigMap.
- **Cluster-wide infra** (outside this repo, in `../private_k8s/nfs-csi/`):
  csi-driver-nfs v4.13.2 manifests + two StorageClasses pointing at
  `192.168.1.9:/mnt/data/k8s/renfield/{uploads,cache-home}`.

## What this PR does NOT do

Entirely by design — PR A is verhaltensneutral.

- `/api/knowledge/upload` still runs Docling inline (flag is off)
- `RAGService.ingest_document` is untouched (refactor is PR B)
- Frontend is untouched (polling + UX are PR C1/C2)
- Backend memory limit stays at 12Gi (will drop to ~5Gi after cutover)

## Deployment verification

```
kubectl -n kube-system get csidriver nfs.csi.k8s.io          # registered
kubectl get sc nfs-csi-renfield-uploads nfs-csi-renfield-cache
kubectl -n renfield get pvc renfield-uploads-shared renfield-cache-shared   # Bound, RWX
kubectl -n renfield get pod -l app.kubernetes.io/name=document-worker       # Running 0 restarts
# Heartbeat check:
kubectl -n renfield exec deploy/backend -c backend -- python3 -c "
import asyncio, redis.asyncio as r
async def m():
    c = r.from_url('redis://redis:6379')
    print(await c.get('renfield:worker:document:heartbeat'))
asyncio.run(m())"
```

All verified against the renfield-private cluster:

- csi-driver-nfs v4.13.2 installed, pods Running
- Both StorageClasses provision, PVCs Bound RWX
- document-worker Running, 0 restarts after the liveness-probe fix (the
  slim Python image has no `pgrep`, so the probe was removed — the Redis
  heartbeat is the real liveness signal anyway).
- Consumer group `docworker` created on stream `renfield:tasks:document`,
  Lag 0.

## Next PRs

- PR B: refactor `RAGService.ingest_document` into
  `create_document_record` + `process_existing_document`.
- PR C1: upload endpoint switches to 202/enqueue behind the flag; minimal
  frontend with copy map + 409 dialog + basic polling; cutover.
- PR C2: polling backoff, Visibility API, localStorage, progressbar,
  queue-position, full A11y audit.

## Test plan

- [x] Syntax + AST parse clean for the new modules.
- [x] `test_document_worker_isolation.py` asserts no FastAPI/MCP transitive imports.
- [x] Worker pod Running in cluster, heartbeat refreshed, stream group created.
- [x] No change to existing `/api/knowledge/upload` flow (flag off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)