### PR TITLE
feat: document-worker split — PR B (RAGService refactor) (#388)

### DIFF
--- a/src/backend/services/rag_service.py
+++ b/src/backend/services/rag_service.py
@@ -326,11 +326,21 @@ class RAGService:
     ) -> Document:
         """Back-compat wrapper: create the Document row + process inline.
 
-        Pre-#388 behaviour. Still used by the legacy upload path (while
-        ``DOCUMENT_WORKER_ENABLED`` is false), the chat-upload routes, and
-        ``reindex_document``. In the worker world these are two separate
-        steps: the upload endpoint calls ``create_document_record`` and
-        enqueues; the worker calls ``process_existing_document``.
+        Used by the legacy upload path (while ``DOCUMENT_WORKER_ENABLED``
+        is false), the chat-upload routes, and ``reindex_document``. In
+        the worker world these are two separate steps: the upload
+        endpoint calls ``create_document_record`` and enqueues; the
+        worker calls ``process_existing_document``.
+
+        **Lifecycle note.** The returned Document is identical in shape
+        and final state to what the pre-split implementation produced.
+        Internally, however, the row now passes through two commits
+        (``pending`` → ``processing`` → ``completed``/``failed``)
+        instead of one (``processing`` → ``completed``/``failed``).
+        External observers polling mid-ingest may briefly see
+        ``status=pending`` where they previously would have seen
+        ``processing``. This is intentional: the same three-state
+        lifecycle serves both inline and worker paths.
         """
         doc = await self.create_document_record(
             file_path=file_path,

--- a/src/backend/services/rag_service.py
+++ b/src/backend/services/rag_service.py
@@ -8,7 +8,7 @@ import asyncio
 import os
 from collections import defaultdict
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 from sqlalchemy import delete, func, select, text
@@ -22,6 +22,7 @@ from sqlalchemy.orm import selectinload
 from models.database import (
     DOC_STATUS_COMPLETED,
     DOC_STATUS_FAILED,
+    DOC_STATUS_PENDING,
     DOC_STATUS_PROCESSING,
     EMBEDDING_DIMENSION,
     Document,
@@ -31,6 +32,9 @@ from models.database import (
 from services.document_processor import DocumentProcessor
 from utils.config import settings
 from utils.llm_client import get_embed_client
+
+if TYPE_CHECKING:  # pragma: no cover - imports only needed for type hints
+    from services.progress import DocumentProgress
 
 
 class RAGService:
@@ -158,60 +162,74 @@ class RAGService:
     # Document Ingestion
     # ==========================================================================
 
-    async def ingest_document(
+    async def create_document_record(
         self,
         file_path: str,
         knowledge_base_id: int | None = None,
         filename: str | None = None,
         file_hash: str | None = None,
-        user_id: int | None = None,
-        force_ocr: bool = False
     ) -> Document:
-        """
-        Verarbeitet und indexiert ein Dokument.
+        """Insert a ``Document`` row with status=pending and return it.
 
-        1. Dokument mit Docling parsen
-        2. Chunks erstellen
-        3. Embeddings generieren
-        4. In Datenbank speichern
-
-        Args:
-            file_path: Pfad zur Dokumentdatei
-            knowledge_base_id: Optional Knowledge Base ID
-            filename: Optional Dateiname (falls anders als file_path)
-            file_hash: Optional SHA256 hash for duplicate detection
-
-        Returns:
-            Document-Objekt mit Status
+        Used by the upload route to commit the row inside the HTTP request
+        so the client immediately has an id to poll. The actual Docling +
+        embedding work runs later, either inline (legacy, via the wrapper
+        ``ingest_document``) or asynchronously in the document-worker
+        (``process_existing_document``, #388).
         """
         actual_filename = filename or os.path.basename(file_path)
-
-        # Document-Eintrag erstellen
         doc = Document(
             file_path=file_path,
             filename=actual_filename,
             knowledge_base_id=knowledge_base_id,
             file_hash=file_hash,
-            status=DOC_STATUS_PROCESSING
+            status=DOC_STATUS_PENDING,
         )
         self.db.add(doc)
         await self.db.commit()
         await self.db.refresh(doc)
+        logger.info(f"Dokument erstellt: ID={doc.id}, Datei={actual_filename}, status=pending")
+        return doc
 
-        logger.info(f"Dokument erstellt: ID={doc.id}, Datei={actual_filename}")
+    async def process_existing_document(
+        self,
+        document_id: int,
+        force_ocr: bool = False,
+        user_id: int | None = None,
+        progress: "DocumentProgress | None" = None,
+    ) -> None:
+        """Run the ingestion pipeline on an already-persisted Document.
+
+        Transitions the row through pending → processing → completed/failed
+        and publishes optional live progress (stage + page counters) to
+        Redis via ``DocumentProgress`` for the frontend poll. Returns ``None``
+        on both success and a handled Docling failure (row is updated in
+        either case); re-raises for unexpected Python exceptions after
+        marking the row failed, so the caller can log and the task queue
+        can leave the entry un-ACKed for reclaim.
+        """
+        doc = await self.db.get(Document, document_id)
+        if doc is None:
+            raise ValueError(f"Document {document_id} not found")
+
+        doc.status = DOC_STATUS_PROCESSING
+        await self.db.commit()
 
         try:
-            # 1. Dokument verarbeiten
-            result = await self.processor.process_document(file_path, force_ocr=force_ocr)
+            # Stage 1: parsing — Docling reads the file, OCRs if needed,
+            # produces chunks and metadata.
+            if progress is not None:
+                await progress.set_stage("parsing")
+            result = await self.processor.process_document(doc.file_path, force_ocr=force_ocr)
 
             if result["status"] == "failed":
                 doc.status = DOC_STATUS_FAILED
                 doc.error_message = result.get("error", "Unbekannter Fehler")
                 await self.db.commit()
                 logger.error(f"Dokumentverarbeitung fehlgeschlagen: {doc.error_message}")
-                return doc
+                return
 
-            # 2. Metadaten aktualisieren
+            # Metadata from the parsed doc.
             metadata = result["metadata"]
             doc.title = metadata.get("title")
             doc.author = metadata.get("author")
@@ -219,16 +237,19 @@ class RAGService:
             doc.file_size = metadata.get("file_size")
             doc.page_count = metadata.get("page_count")
 
-            # 3. Contextual Retrieval: generate LLM context prefix per chunk
+            # Stage 2: chunking + contextual-retrieval prefix generation.
+            if progress is not None:
+                await progress.set_stage("chunking")
             chunks = result["chunks"]
-            doc_summary = f"{doc.title or actual_filename}"
+            doc_summary = f"{doc.title or doc.filename}"
             if chunks:
                 doc_summary += f" — {chunks[0]['text'][:300]}" if chunks[0].get("text") else ""
             chunks = await self._contextualize_chunks(chunks, doc_summary)
 
-            # 4. Chunks mit Embeddings erstellen (parallel, batch insert)
+            # Stage 3: embedding generation + DB inserts.
+            if progress is not None:
+                await progress.set_stage("embedding")
             sem = asyncio.Semaphore(5)
-
             if settings.rag_parent_child_enabled:
                 chunk_objects = await self._ingest_parent_child(doc.id, chunks, sem)
             else:
@@ -241,23 +262,23 @@ class RAGService:
             doc.chunk_count = chunk_count
             doc.status = DOC_STATUS_COMPLETED
             doc.processed_at = datetime.now(UTC).replace(tzinfo=None)
-
             await self.db.commit()
 
-            # Populate search_vector for Full-Text Search (bulk update)
+            # Populate search_vector for Full-Text Search (bulk update).
             fts_config = settings.rag_hybrid_fts_config
             await self.db.execute(
-                text("""
+                text(
+                    """
                     UPDATE document_chunks
                     SET search_vector = to_tsvector(:fts_config, content)
                     WHERE document_id = :doc_id
                     AND search_vector IS NULL
                     AND content IS NOT NULL
-                """),
-                {"doc_id": doc.id, "fts_config": fts_config}
+                    """
+                ),
+                {"doc_id": doc.id, "fts_config": fts_config},
             )
             await self.db.commit()
-
             await self.db.refresh(doc)
 
             # Fire KG extraction hook (fire-and-forget).
@@ -267,22 +288,25 @@ class RAGService:
             # (names, addresses, organisations) is in text/paragraph chunks.
             _KG_SKIP_TYPES = {"table", "code", "formula"}
             kg_chunks = [
-                co.content for co in chunk_objects
+                co.content
+                for co in chunk_objects
                 if co.content and co.chunk_type not in _KG_SKIP_TYPES
             ]
             if kg_chunks:
                 from utils.hooks import run_hooks
-                _task = asyncio.create_task(run_hooks(
-                    "post_document_ingest",
-                    chunks=kg_chunks,
-                    document_id=doc.id,
-                    user_id=user_id,
-                ))
+
+                _task = asyncio.create_task(
+                    run_hooks(
+                        "post_document_ingest",
+                        chunks=kg_chunks,
+                        document_id=doc.id,
+                        user_id=user_id,
+                    )
+                )
                 _background_tasks.add(_task)
                 _task.add_done_callback(_background_tasks.discard)
 
             logger.info(f"Dokument indexiert: ID={doc.id}, Chunks={chunk_count}")
-            return doc
 
         except Exception as e:
             doc.status = DOC_STATUS_FAILED
@@ -290,6 +314,37 @@ class RAGService:
             await self.db.commit()
             logger.error(f"Fehler beim Indexieren: {e}")
             raise
+
+    async def ingest_document(
+        self,
+        file_path: str,
+        knowledge_base_id: int | None = None,
+        filename: str | None = None,
+        file_hash: str | None = None,
+        user_id: int | None = None,
+        force_ocr: bool = False,
+    ) -> Document:
+        """Back-compat wrapper: create the Document row + process inline.
+
+        Pre-#388 behaviour. Still used by the legacy upload path (while
+        ``DOCUMENT_WORKER_ENABLED`` is false), the chat-upload routes, and
+        ``reindex_document``. In the worker world these are two separate
+        steps: the upload endpoint calls ``create_document_record`` and
+        enqueues; the worker calls ``process_existing_document``.
+        """
+        doc = await self.create_document_record(
+            file_path=file_path,
+            knowledge_base_id=knowledge_base_id,
+            filename=filename,
+            file_hash=file_hash,
+        )
+        await self.process_existing_document(
+            document_id=doc.id,
+            force_ocr=force_ocr,
+            user_id=user_id,
+        )
+        await self.db.refresh(doc)
+        return doc
 
     # --------------------------------------------------------------------------
     # Ingestion Strategies

--- a/src/backend/workers/document_processor_worker.py
+++ b/src/backend/workers/document_processor_worker.py
@@ -84,23 +84,17 @@ async def _process_entry(
         return
 
     force_ocr = bool(entry.params.get("force_ocr", False))
+    user_id = entry.params.get("user_id")
     progress = DocumentProgress(redis, doc_id)
     try:
         async with AsyncSessionLocal() as db:
             rag = RAGService(db)
-            # ``process_existing_document`` lands in PR B. Accessing it via
-            # getattr keeps PR A importable + runnable (the method just
-            # doesn't exist yet; the worker is idle while the feature flag
-            # stays off).
-            handler = getattr(rag, "process_existing_document", None)
-            if handler is None:
-                logger.error(
-                    "RAGService.process_existing_document is not available yet "
-                    "(PR B). Re-queue the task and ack to avoid a poison loop."
-                )
-                await queue.ack(entry.entry_id)
-                return
-            await handler(document_id=doc_id, force_ocr=force_ocr)
+            await rag.process_existing_document(
+                document_id=doc_id,
+                force_ocr=force_ocr,
+                user_id=user_id,
+                progress=progress,
+            )
         await queue.ack(entry.entry_id)
         logger.info(f"processed doc {doc_id} (entry {entry.entry_id})")
     except Exception as e:

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -14,8 +14,65 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy.dialects.postgresql import TSVECTOR
+from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
+
+# ---------------------------------------------------------------------------
+# Test-harness compatibility: production models declare Postgres-specific
+# column types (TSVECTOR for full-text search; pgvector's Vector for
+# embeddings) that SQLite can't compile. Register a dialect-specific
+# fallback so Base.metadata.create_all() succeeds against the in-memory
+# SQLite engine used by these fixtures. Production DDL on Postgres is
+# unaffected — the override only fires when dialect == sqlite.
+#
+# Scope: TEXT is not searchable and the Vector columns accept any payload
+# under SQLite; that's fine because unit tests that exercise similarity
+# search or to_tsvector() paths either mock those branches or mark
+# themselves @pytest.mark.database for a real Postgres integration run.
+# ---------------------------------------------------------------------------
+
+
+@compiles(TSVECTOR, "sqlite")
+def _tsvector_sqlite(element, compiler, **kw):
+    return "TEXT"
+
+
+try:  # pgvector is a soft dependency in the image; tolerate its absence.
+    from pgvector.sqlalchemy import Vector as _PgvectorVector
+except ImportError:  # pragma: no cover
+    _PgvectorVector = None
+else:
+
+    @compiles(_PgvectorVector, "sqlite")
+    def _pgvector_sqlite(element, compiler, **kw):
+        return "BLOB"
+
+
+def _register_postgres_shim_udfs(dbapi_conn, connection_record):
+    """Register pass-through Python implementations of the Postgres-only
+    SQL functions our production queries use, so SQLite can at least
+    execute the statements without error.
+
+    The stored values are not semantically meaningful for search — tests
+    that exercise actual FTS ranking should mark themselves for a real
+    Postgres integration run (`@pytest.mark.database`, driven against a
+    real Postgres fixture when available). What these shims buy us is:
+    unit tests exercising the code path can run without the queries
+    throwing `no such function` and aborting transactions.
+    """
+    def _to_tsvector(config: str | None, content: str | None) -> str:
+        # Real to_tsvector returns a tsvector; for SQLite we just keep the
+        # content as-is so downstream assertions on row existence still work.
+        return content or ""
+
+    try:
+        # aiosqlite 0.18+ exposes the underlying sqlite3 connection directly.
+        dbapi_conn.create_function("to_tsvector", 2, _to_tsvector)
+    except AttributeError:  # pragma: no cover - defensive
+        pass
+
 
 # Renfield Imports
 from models.database import (
@@ -45,12 +102,19 @@ TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
 @pytest.fixture
 async def async_engine():
     """Create async SQLite engine for tests"""
+    from sqlalchemy import event
+
     engine = create_async_engine(
         TEST_DATABASE_URL,
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
         echo=False
     )
+
+    # Hook is attached to the sync-engine side of the async wrapper. It runs
+    # once per raw sqlite3 connection, registering the to_tsvector shim
+    # defined above.
+    event.listen(engine.sync_engine, "connect", _register_postgres_shim_udfs)
 
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -61,10 +61,26 @@ def _register_postgres_shim_udfs(dbapi_conn, connection_record):
     real Postgres fixture when available). What these shims buy us is:
     unit tests exercising the code path can run without the queries
     throwing `no such function` and aborting transactions.
+
+    **Known blind spot:** the shim does not validate the ``config`` arg
+    to ``to_tsvector``. A production regression that passes a wrong
+    config value (None, empty, or an unknown language) will still pass
+    unit tests here because SQLite never looks at it. Catch those with
+    a ``@pytest.mark.database`` integration test running against real
+    Postgres.
     """
     def _to_tsvector(config: str | None, content: str | None) -> str:
         # Real to_tsvector returns a tsvector; for SQLite we just keep the
         # content as-is so downstream assertions on row existence still work.
+        # We do sanity-check the config so completely-empty arg regressions
+        # fail loudly rather than silently masking as "no rows matched".
+        if config is None or config == "":
+            raise ValueError(
+                "to_tsvector(config=<empty>): call sites must pass a non-empty "
+                "FTS config (e.g. 'german'). A None/empty config indicates a "
+                "regression in the caller — the SQLite shim cannot validate "
+                "language-level correctness, only presence."
+            )
         return content or ""
 
     try:

--- a/tests/backend/test_rag_service_split.py
+++ b/tests/backend/test_rag_service_split.py
@@ -1,0 +1,355 @@
+"""Tests for the RAGService ingest split (#388, PR B).
+
+Covers:
+
+- create_document_record: persists a Document row with status=pending
+- process_existing_document: happy path + handled Docling failure + unexpected exception
+- DocumentProgress: stage and page writes refresh TTL; clear() removes both keys
+
+The 409-duplicate behaviour (test #2 in the plan's matrix) lives in the
+upload route, not here; that's PR C1.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from models.database import (
+    DOC_STATUS_COMPLETED,
+    DOC_STATUS_FAILED,
+    DOC_STATUS_PENDING,
+    Document,
+    KnowledgeBase,
+)
+from services.progress import (
+    DEFAULT_TTL_S,
+    DocumentProgress,
+    _progress_key,
+    _stage_key,
+)
+from services.rag_service import RAGService
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def knowledge_base(db_session):
+    """A KnowledgeBase row for Document.knowledge_base_id to point at."""
+    kb = KnowledgeBase(name="test-kb", description="fixture")
+    db_session.add(kb)
+    await db_session.commit()
+    await db_session.refresh(kb)
+    return kb
+
+
+def _fake_docling_result(
+    num_chunks: int = 2,
+    title: str = "Testdokument",
+    page_count: int = 3,
+) -> dict:
+    """Build a Docling-shaped result dict, deterministic for tests."""
+    return {
+        "status": "ok",
+        "metadata": {
+            "title": title,
+            "author": "fixture",
+            "file_type": "txt",
+            "file_size": 100,
+            "page_count": page_count,
+        },
+        "chunks": [
+            {"text": f"Testabschnitt {i}", "chunk_index": i}
+            for i in range(num_chunks)
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# create_document_record
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.database
+async def test_create_document_record_persists_pending_row(db_session, knowledge_base):
+    rag = RAGService(db_session)
+    doc = await rag.create_document_record(
+        file_path="/tmp/foo.pdf",
+        knowledge_base_id=knowledge_base.id,
+        filename="foo.pdf",
+        file_hash="sha256:deadbeef",
+    )
+
+    assert doc.id is not None
+    assert doc.status == DOC_STATUS_PENDING
+    assert doc.filename == "foo.pdf"
+    assert doc.file_hash == "sha256:deadbeef"
+    assert doc.knowledge_base_id == knowledge_base.id
+    # No processing has happened yet.
+    assert doc.chunk_count is None or doc.chunk_count == 0
+    assert doc.processed_at is None
+
+
+@pytest.mark.unit
+@pytest.mark.database
+async def test_create_document_record_defaults_filename_from_path(db_session):
+    """When ``filename`` is omitted, it is derived from ``file_path``."""
+    rag = RAGService(db_session)
+    doc = await rag.create_document_record(file_path="/uploads/abc/report.txt")
+    assert doc.filename == "report.txt"
+    assert doc.status == DOC_STATUS_PENDING
+
+
+# ---------------------------------------------------------------------------
+# process_existing_document
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.database
+async def test_process_existing_document_happy_path(db_session, knowledge_base):
+    """Docling + embedding mocked; row transitions pending → completed."""
+    rag = RAGService(db_session)
+    doc = await rag.create_document_record(
+        file_path="/tmp/happy.txt",
+        knowledge_base_id=knowledge_base.id,
+        filename="happy.txt",
+    )
+
+    with patch.object(
+        rag.processor,
+        "process_document",
+        new=AsyncMock(return_value=_fake_docling_result(num_chunks=2)),
+    ), patch.object(
+        rag,
+        "_contextualize_chunks",
+        new=AsyncMock(side_effect=lambda chunks, summary: chunks),
+    ), patch.object(
+        rag,
+        "_ingest_flat",
+        new=AsyncMock(return_value=[]),
+    ), patch.object(
+        rag,
+        "_ingest_parent_child",
+        new=AsyncMock(return_value=[]),
+    ):
+        await rag.process_existing_document(document_id=doc.id)
+
+    await db_session.refresh(doc)
+    assert doc.status == DOC_STATUS_COMPLETED
+    assert doc.error_message is None
+    assert doc.title == "Testdokument"
+    assert doc.processed_at is not None
+
+
+@pytest.mark.unit
+@pytest.mark.database
+async def test_process_existing_document_handled_docling_failure(
+    db_session, knowledge_base
+):
+    """Docling returning status=failed must mark the row failed without raising."""
+    rag = RAGService(db_session)
+    doc = await rag.create_document_record(
+        file_path="/tmp/corrupt.pdf",
+        knowledge_base_id=knowledge_base.id,
+        filename="corrupt.pdf",
+    )
+
+    with patch.object(
+        rag.processor,
+        "process_document",
+        new=AsyncMock(return_value={"status": "failed", "error": "scan illegible"}),
+    ):
+        # Should NOT raise — handled Docling failures update the row and return.
+        await rag.process_existing_document(document_id=doc.id)
+
+    await db_session.refresh(doc)
+    assert doc.status == DOC_STATUS_FAILED
+    assert doc.error_message == "scan illegible"
+    assert doc.processed_at is None
+
+
+@pytest.mark.unit
+@pytest.mark.database
+async def test_process_existing_document_embedder_exception_rolls_status(
+    db_session, knowledge_base
+):
+    """An unexpected exception inside the pipeline must mark the row failed
+    AND re-raise so the task-queue caller leaves the PEL entry un-ACKed for
+    reclaim."""
+    rag = RAGService(db_session)
+    doc = await rag.create_document_record(
+        file_path="/tmp/crash.pdf",
+        knowledge_base_id=knowledge_base.id,
+        filename="crash.pdf",
+    )
+
+    boom = RuntimeError("embedder went boom")
+
+    # Mock both ingestion strategies so the test doesn't depend on the
+    # current default of `rag_parent_child_enabled` (which selects one).
+    with patch.object(
+        rag.processor,
+        "process_document",
+        new=AsyncMock(return_value=_fake_docling_result(num_chunks=1)),
+    ), patch.object(
+        rag,
+        "_contextualize_chunks",
+        new=AsyncMock(side_effect=lambda chunks, summary: chunks),
+    ), patch.object(
+        rag, "_ingest_flat", new=AsyncMock(side_effect=boom)
+    ), patch.object(
+        rag, "_ingest_parent_child", new=AsyncMock(side_effect=boom)
+    ):
+        with pytest.raises(RuntimeError, match="embedder went boom"):
+            await rag.process_existing_document(document_id=doc.id)
+
+    await db_session.refresh(doc)
+    assert doc.status == DOC_STATUS_FAILED
+    assert doc.error_message == "embedder went boom"
+
+
+@pytest.mark.unit
+@pytest.mark.database
+async def test_process_existing_document_missing_id_raises(db_session):
+    """Asking the worker to process a document that doesn't exist in the DB
+    must raise loudly — otherwise a corrupted payload silently acks and the
+    user never learns their upload vanished."""
+    rag = RAGService(db_session)
+    with pytest.raises(ValueError, match="not found"):
+        await rag.process_existing_document(document_id=999999)
+
+
+# ---------------------------------------------------------------------------
+# ingest_document back-compat wrapper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.database
+async def test_ingest_document_wrapper_creates_and_processes(
+    db_session, knowledge_base
+):
+    """The legacy wrapper must still create + process inline and return the
+    refreshed Document so existing callers (chat_upload, reindex_document)
+    keep working unchanged."""
+    rag = RAGService(db_session)
+
+    with patch.object(
+        rag.processor,
+        "process_document",
+        new=AsyncMock(return_value=_fake_docling_result(num_chunks=1)),
+    ), patch.object(
+        rag,
+        "_contextualize_chunks",
+        new=AsyncMock(side_effect=lambda chunks, summary: chunks),
+    ), patch.object(
+        rag,
+        "_ingest_flat",
+        new=AsyncMock(return_value=[]),
+    ), patch.object(
+        rag,
+        "_ingest_parent_child",
+        new=AsyncMock(return_value=[]),
+    ):
+        doc = await rag.ingest_document(
+            file_path="/tmp/legacy.txt",
+            knowledge_base_id=knowledge_base.id,
+            filename="legacy.txt",
+        )
+
+    assert doc.status == DOC_STATUS_COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# DocumentProgress
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_document_progress_stage_refreshes_ttl():
+    """Every set_stage must call SET with ex=TTL; no silent ttl-less writes."""
+    redis = AsyncMock()
+    redis.set = AsyncMock()
+    progress = DocumentProgress(redis, doc_id=42)
+
+    await progress.set_stage("ocr")
+
+    redis.set.assert_awaited_once_with(_stage_key(42), "ocr", ex=DEFAULT_TTL_S)
+
+
+@pytest.mark.unit
+async def test_document_progress_pages_clamps_and_refreshes_ttl():
+    """set_pages must clamp `current` into [0, total] and refresh TTL."""
+    redis = AsyncMock()
+    progress = DocumentProgress(redis, doc_id=7)
+
+    await progress.set_pages(current=5, total=10)
+    redis.set.assert_awaited_with(_progress_key(7), "5/10", ex=DEFAULT_TTL_S)
+
+    # Clamp negative current to 0
+    await progress.set_pages(current=-3, total=10)
+    redis.set.assert_awaited_with(_progress_key(7), "0/10", ex=DEFAULT_TTL_S)
+
+    # Clamp overshoot current to total
+    await progress.set_pages(current=15, total=10)
+    redis.set.assert_awaited_with(_progress_key(7), "10/10", ex=DEFAULT_TTL_S)
+
+
+@pytest.mark.unit
+async def test_document_progress_pages_ignores_zero_total():
+    """Non-paginated inputs (TXT, images) call set_pages(0, 0); nothing
+    should be written because "0/0" is meaningless in the UI."""
+    redis = AsyncMock()
+    progress = DocumentProgress(redis, doc_id=9)
+
+    await progress.set_pages(current=0, total=0)
+    redis.set.assert_not_called()
+
+
+@pytest.mark.unit
+async def test_document_progress_clear_removes_both_keys():
+    redis = AsyncMock()
+    progress = DocumentProgress(redis, doc_id=11)
+
+    await progress.clear()
+
+    redis.delete.assert_awaited_once_with(_stage_key(11), _progress_key(11))
+
+
+@pytest.mark.unit
+async def test_document_progress_read_returns_structured_view():
+    redis = AsyncMock()
+    redis.mget = AsyncMock(return_value=["ocr", "47/120"])
+    progress = DocumentProgress(redis, doc_id=3)
+
+    result = await progress.read()
+
+    assert result == {"stage": "ocr", "pages": {"current": 47, "total": 120}}
+
+
+@pytest.mark.unit
+async def test_document_progress_read_handles_missing_keys():
+    redis = AsyncMock()
+    redis.mget = AsyncMock(return_value=[None, None])
+    progress = DocumentProgress(redis, doc_id=3)
+
+    result = await progress.read()
+
+    assert result == {"stage": None, "pages": None}
+
+
+@pytest.mark.unit
+async def test_document_progress_read_tolerates_malformed_pages():
+    """A malformed progress string (log-noise, not a crash) maps to None."""
+    redis = AsyncMock()
+    redis.mget = AsyncMock(return_value=["chunking", "garbage"])
+    progress = DocumentProgress(redis, doc_id=3)
+
+    result = await progress.read()
+
+    assert result == {"stage": "chunking", "pages": None}

--- a/tests/backend/test_rag_service_split.py
+++ b/tests/backend/test_rag_service_split.py
@@ -284,20 +284,27 @@ async def test_document_progress_stage_refreshes_ttl():
 
 @pytest.mark.unit
 async def test_document_progress_pages_clamps_and_refreshes_ttl():
-    """set_pages must clamp `current` into [0, total] and refresh TTL."""
+    """set_pages must clamp `current` into [0, total] and refresh TTL.
+
+    Each sub-case uses ``reset_mock()`` so a silent-skip regression in
+    one clamp direction cannot be masked by the next correct call's
+    ``assert_awaited_with`` (which only sees the latest call).
+    """
     redis = AsyncMock()
     progress = DocumentProgress(redis, doc_id=7)
 
     await progress.set_pages(current=5, total=10)
-    redis.set.assert_awaited_with(_progress_key(7), "5/10", ex=DEFAULT_TTL_S)
+    redis.set.assert_awaited_once_with(_progress_key(7), "5/10", ex=DEFAULT_TTL_S)
+    redis.set.reset_mock()
 
     # Clamp negative current to 0
     await progress.set_pages(current=-3, total=10)
-    redis.set.assert_awaited_with(_progress_key(7), "0/10", ex=DEFAULT_TTL_S)
+    redis.set.assert_awaited_once_with(_progress_key(7), "0/10", ex=DEFAULT_TTL_S)
+    redis.set.reset_mock()
 
     # Clamp overshoot current to total
     await progress.set_pages(current=15, total=10)
-    redis.set.assert_awaited_with(_progress_key(7), "10/10", ex=DEFAULT_TTL_S)
+    redis.set.assert_awaited_once_with(_progress_key(7), "10/10", ex=DEFAULT_TTL_S)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Second of four PRs for #388. Behaviour-neutral refactor that sets up the
async split; the user-visible cutover still ships in PR C1.

## Scope

- `services/rag_service.py` — `ingest_document` is now a thin wrapper
  around two new entry points:
  - `create_document_record(file_path, kb_id, filename, file_hash) -> Document`
    persists a row with `status=pending`. Cheap, runs inside the upload
    request.
  - `process_existing_document(document_id, force_ocr, user_id, progress) -> None`
    runs the pipeline on an already-persisted row. Publishes live
    progress through the optional `DocumentProgress` sink for the
    frontend poll. Re-raises unexpected exceptions after marking the
    row failed; returns normally after handled Docling failures.
- `workers/document_processor_worker.py` — now calls
  `process_existing_document` directly. The `getattr`-stub from PR A
  is gone; `DocumentProgress` is wired through so stage + page counters
  land in Redis.
- `tests/backend/conftest.py` — SQLite shims so the pytest harness can
  build the Document/document_chunks schema and execute the FTS
  `UPDATE ... to_tsvector(...)` statement. Only the code path runs; real
  FTS ranking needs Postgres (marked `@pytest.mark.database` for a
  future integration run).
- `tests/backend/test_rag_service_split.py` — 14 unit tests covering
  matrix items 1/3/4/5/13 from `docs/DOCUMENT_WORKER_SPLIT.md`. Item 2
  (409 duplicate) is route-level and ships in PR C1.

## What this PR does NOT do

- Upload endpoint still calls `rag.ingest_document` inline; the branch
  on `document_worker_enabled` ships in PR C1.
- Frontend is untouched; polling is PR C1 (minimal) + C2 (polish).
- Backend memory limit stays at 12Gi until the cutover lands.

## Test plan

- [x] 14 new unit tests pass in-cluster (`pytest test_rag_service_split.py`)
- [x] `chat_upload.py:204` + `chat_upload.py:484` + `rag_service.py:reindex_document`
      still call the wrapper with their existing signature — no caller changes needed
- [x] Backend pod rolls out clean after the rebuild
- [x] Document-worker pod rolls out clean and stays idle (flag still off)
- [x] `https://renfield.local/health` stays 200
- [x] Heartbeat key `renfield:worker:document:heartbeat` still refreshed on
      consumer group `docworker`, Lag 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)