### PR TITLE
fix(k8s): mount shared uploads + cache on backend (#388)

### DIFF
--- a/k8s/backend.yaml
+++ b/k8s/backend.yaml
@@ -82,6 +82,8 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /app/data
+            - name: cache-home
+              mountPath: /app/data/cache-home
       containers:
         - name: backend
           image: registry.treehouse.x-idra.de/renfield/backend:latest
@@ -164,6 +166,18 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /app/data
+            # Shared with the document-worker pod (#388 cutover). The API
+            # writes the uploaded file here, the worker reads it from the
+            # same NFS-backed PVC. Must be mounted at the same path on
+            # both pods because the DB stores absolute file paths.
+            - name: uploads
+              mountPath: /app/data/uploads
+            # Shared ML model cache (EasyOCR / HuggingFace / Docling).
+            # Not strictly required on the backend since Docling now runs
+            # in the worker, but keeps warm-cache behaviour for the
+            # legacy-inline rollback path (flag off).
+            - name: cache-home
+              mountPath: /app/data/cache-home
             - name: mcp-config
               mountPath: /app/config/mcp_servers.yaml
               subPath: mcp_servers.yaml
@@ -208,6 +222,13 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: renfield-data
+        # RWX NFS PVCs shared with document-worker — see k8s/shared-pvcs.yaml.
+        - name: uploads
+          persistentVolumeClaim:
+            claimName: renfield-uploads-shared
+        - name: cache-home
+          persistentVolumeClaim:
+            claimName: renfield-cache-shared
         - name: mcp-config
           configMap:
             name: renfield-mcp-config


### PR DESCRIPTION
## Summary

Follow-up fix discovered during the PR C1 cluster cutover. PR A's `document-worker.yaml` comment read:

> Volumes intentionally mirror what the backend will mount post-cutover

But neither PR A nor PR C1 actually updated `k8s/backend.yaml`. At cutover (`DOCUMENT_WORKER_ENABLED=true`), the upload endpoint wrote the file to the backend's local Longhorn `renfield-data` PVC while the worker read from the shared NFS `renfield-uploads-shared` PVC — the file was invisible across pods, processing failed with *"Datei nicht gefunden"*.

## Change

Mount both shared PVCs on the backend Deployment at the same paths the worker uses:
- `renfield-uploads-shared` → `/app/data/uploads`
- `renfield-cache-shared` → `/app/data/cache-home`

`renfield-data` (Longhorn) stays for everything else under `/app/data`.

## Test plan
- [x] Live test on cluster: after applying this manifest, smoke upload went **202 → processing (stage=parsing → stage=embedding) → completed** in ~12 s, 2 chunks written
- [x] Existing doc 9 file migrated from Longhorn to NFS before manifest apply (one-time data move; future uploads land on NFS automatically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)