### PR TITLE
feat(worker-split): PR C2 — polling polish + A11y + HTTP semantics (#388)

### DIFF
--- a/src/backend/api/routes/knowledge.py
+++ b/src/backend/api/routes/knowledge.py
@@ -7,6 +7,7 @@ Pydantic schemas are defined in knowledge_schemas.py.
 """
 import hashlib
 import os
+import uuid
 from pathlib import Path
 
 import aiofiles
@@ -333,7 +334,6 @@ async def upload_document(
     upload_dir.mkdir(parents=True, exist_ok=True)
 
     # Eindeutigen Dateinamen generieren
-    import uuid
     safe_name = os.path.basename((file.filename or "unknown").replace("\x00", ""))
     unique_filename = f"{uuid.uuid4().hex}_{safe_name}"
     file_path = upload_dir / unique_filename

--- a/src/backend/api/routes/knowledge.py
+++ b/src/backend/api/routes/knowledge.py
@@ -265,17 +265,26 @@ async def upload_document(
                     status_code=403,
                     detail="Permission required: rag.manage"
                 )
-    # Validierung: Dateiformat
+    # Validierung: Dateiformat — 415 Unsupported Media Type is the semantic
+    # match. Frontend reads the structured detail to render allowed-format
+    # copy; legacy clients that only read status codes also get the right
+    # signal.
     extension = Path(file.filename).suffix.lower().lstrip('.')
     allowed = settings.allowed_extensions_list
 
     if extension not in allowed:
         raise HTTPException(
-            status_code=400,
-            detail=f"Dateiformat '{extension}' nicht unterstützt. Erlaubt: {', '.join(allowed)}"
+            status_code=415,
+            detail={
+                "message": f"Dateiformat '{extension}' nicht unterstützt.",
+                "allowed": sorted(allowed),
+                "received": extension,
+            },
         )
 
-    # Validierung: Dateigröße
+    # Validierung: Dateigröße — 413 Content Too Large is the correct code.
+    # Include max_mb in the detail so the frontend can show the limit
+    # without hard-coding it.
     file.file.seek(0, 2)
     size = file.file.tell()
     file.file.seek(0)
@@ -283,8 +292,12 @@ async def upload_document(
     max_size = settings.max_file_size_mb * 1024 * 1024
     if size > max_size:
         raise HTTPException(
-            status_code=400,
-            detail=f"Datei zu groß ({size // 1024 // 1024}MB). Maximum: {settings.max_file_size_mb}MB"
+            status_code=413,
+            detail={
+                "message": f"Datei zu groß ({size // 1024 // 1024} MB).",
+                "max_mb": settings.max_file_size_mb,
+                "received_mb": size // 1024 // 1024,
+            },
         )
 
     # Datei-Inhalt lesen und SHA256-Hash berechnen

--- a/src/frontend/src/components/knowledge/DuplicateDialog.jsx
+++ b/src/frontend/src/components/knowledge/DuplicateDialog.jsx
@@ -3,25 +3,77 @@
  *
  * The backend includes an `existing_document` payload with id, filename,
  * and uploaded_at. We render a proper dialog (not a toast) because the user
- * needs a choice: jump to the existing entry, or cancel. A11y: escape key
- * closes, the jump button receives initial focus.
+ * needs a choice: jump to the existing entry, or cancel.
  *
- * Full focus-management polish (trap, return focus on close) lands in C2.
+ * C2 additions:
+ *   - Focus trap: Tab and Shift+Tab cycle within the dialog only.
+ *   - Focus return: whichever element owned focus when the dialog opened
+ *     gets focus back when it closes (typically the upload input).
+ *   - Initial focus on the jump button stays C1 behaviour.
+ *   - Escape closes — unchanged.
  */
 import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
+// Query that matches anything keyboard-focusable. We use this to scope the
+// Tab/Shift+Tab cycle to elements living inside the dialog.
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'textarea:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
 export default function DuplicateDialog({ existing, onClose, onJump }) {
   const jumpBtnRef = useRef(null);
+  const dialogRef = useRef(null);
+  const lastFocusedRef = useRef(null);
   const { t, i18n } = useTranslation();
 
   useEffect(() => {
+    // Remember who owned focus so we can restore it on close.
+    lastFocusedRef.current = document.activeElement;
     if (jumpBtnRef.current) jumpBtnRef.current.focus();
+
     const onKey = (e) => {
-      if (e.key === 'Escape') onClose();
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onClose();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      if (!dialogRef.current) return;
+
+      // Focus trap: keep Tab/Shift+Tab within the dialog.
+      const focusables = dialogRef.current.querySelectorAll(FOCUSABLE_SELECTOR);
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
     };
     document.addEventListener('keydown', onKey);
-    return () => document.removeEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      // Return focus to whoever had it before the dialog opened. Wrapped
+      // in a try/catch because the previously-focused node may have been
+      // unmounted (e.g. tab closed, element re-rendered).
+      const prev = lastFocusedRef.current;
+      if (prev && typeof prev.focus === 'function') {
+        try {
+          prev.focus();
+        } catch {
+          /* element gone; nothing to do */
+        }
+      }
+    };
   }, [onClose]);
 
   if (!existing) return null;
@@ -40,7 +92,10 @@ export default function DuplicateDialog({ existing, onClose, onJump }) {
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div className="bg-white dark:bg-gray-900 rounded-lg shadow-xl p-6 max-w-md w-full mx-4">
+      <div
+        ref={dialogRef}
+        className="bg-white dark:bg-gray-900 rounded-lg shadow-xl p-6 max-w-md w-full mx-4"
+      >
         <h2 id="duplicate-dialog-title" className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">
           {t('knowledge.duplicateTitle')}
         </h2>

--- a/src/frontend/src/components/knowledge/StatusBadge.jsx
+++ b/src/frontend/src/components/knowledge/StatusBadge.jsx
@@ -2,14 +2,19 @@
  * StatusBadge — status pill for a Document row with stage + queue-position
  * sub-labels (#388).
  *
- * Accessibility (C1 subset):
- *   - Wrapping element has role="status" aria-live="polite" so screen readers
- *     announce status transitions.
- *   - Icon is aria-hidden; the full status string is carried on aria-label.
- *
- * Full progressbar semantics (for the pages={current,total} case) land in
- * C2 together with focus management on the 409 dialog.
+ * Accessibility (C2):
+ *   - `processing` with known total pages renders a real `<progress>` with
+ *     aria-valuenow / aria-valuemax / aria-valuetext so screen readers
+ *     announce "Seite 47 von 120".
+ *   - `processing` without a page count carries `aria-busy="true"` instead.
+ *   - Stage changes announce through a dedicated polite-live sub-region
+ *     rate-limited to one announcement per 10 s so long OCR jobs don't
+ *     spam the screen-reader buffer.
+ *   - Icon-only badges carry `aria-label="{statusLabel}: {filename}"`.
+ *   - Contrast: pending text bumped from `gray-500` → `gray-700`
+ *     (`gray-300` in dark) to clear WCAG AA against the card background.
  */
+import { useEffect, useRef, useState } from 'react';
 import { CheckCircle, Loader2, Clock, AlertCircle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
@@ -25,6 +30,10 @@ const STAGE_KEY = {
   chunking: 'knowledge.stageChunking',
   embedding: 'knowledge.stageEmbedding',
 };
+
+// Minimum gap between live-region announcements for stage/page updates on
+// the same document. Prevents SR buffer spam on long OCR jobs.
+const LIVE_REGION_MIN_GAP_MS = 10_000;
 
 function subLabel(t, doc) {
   if (doc.status === 'pending' && doc.queue_position != null) {
@@ -43,20 +52,61 @@ function subLabel(t, doc) {
   return null;
 }
 
+function hasKnownPageProgress(doc) {
+  return (
+    doc.status === 'processing' &&
+    doc.pages &&
+    typeof doc.pages.current === 'number' &&
+    typeof doc.pages.total === 'number' &&
+    doc.pages.total > 0
+  );
+}
+
 export default function StatusBadge({ doc, filename }) {
   const { t } = useTranslation();
   const meta = STATUS_META[doc.status] || STATUS_META.pending;
   const label = t(meta.labelKey);
   const sub = subLabel(t, doc);
   const { Icon } = meta;
+  const progress = hasKnownPageProgress(doc);
+
+  // Rate-limit the live-region announcement so a long OCR job doesn't hit
+  // the screen reader with 120 updates in a minute.
+  const lastAnnouncedAtRef = useRef(0);
+  const [announcement, setAnnouncement] = useState('');
+  useEffect(() => {
+    const now = Date.now();
+    if (!sub) return;
+    if (now - lastAnnouncedAtRef.current < LIVE_REGION_MIN_GAP_MS) return;
+    lastAnnouncedAtRef.current = now;
+    setAnnouncement(`${label}: ${sub}`);
+  }, [label, sub]);
+
+  // Status transitions are always announced (terminal or major change). The
+  // stage/page sub-label uses a separate polite region above.
+  const statusAnnouncement = `${label}: ${filename || doc.filename}`;
+
+  // The outer element swaps semantics based on whether we know pages. We
+  // keep the visible markup identical across branches — only the ARIA
+  // wiring differs.
+  const outerProps = progress
+    ? {
+        role: 'progressbar',
+        'aria-valuenow': doc.pages.current,
+        'aria-valuemin': 0,
+        'aria-valuemax': doc.pages.total,
+        'aria-valuetext': sub || undefined,
+        'aria-label': statusAnnouncement,
+      }
+    : {
+        role: 'status',
+        'aria-live': 'polite',
+        'aria-busy': doc.status === 'processing' ? 'true' : undefined,
+        'aria-label': statusAnnouncement,
+      };
 
   return (
-    <div
-      role="status"
-      aria-live="polite"
-      aria-label={`${label}: ${filename || doc.filename}`}
-      className="inline-flex items-start gap-2"
-    >
+    <div {...outerProps} className="inline-flex items-start gap-2">
       <Icon
         aria-hidden="true"
         className={`w-5 h-5 shrink-0 ${meta.iconClass} ${meta.spin ? 'animate-spin' : ''}`}
@@ -64,9 +114,13 @@ export default function StatusBadge({ doc, filename }) {
       <div className="flex flex-col">
         <span className="text-sm font-medium text-gray-900 dark:text-gray-100">{label}</span>
         {sub && (
-          <span className="text-xs text-gray-500 dark:text-gray-400 leading-tight">{sub}</span>
+          <span className="text-xs text-gray-700 dark:text-gray-300 leading-tight">{sub}</span>
         )}
       </div>
+      {/* Separate polite-live sub-region for rate-limited stage announcements.
+          Visually hidden but read by screen readers. Kept out of the
+          progressbar element so SR doesn't get duplicate readouts. */}
+      <span className="sr-only" aria-live="polite">{announcement}</span>
     </div>
   );
 }

--- a/src/frontend/src/hooks/useDocumentPolling.js
+++ b/src/frontend/src/hooks/useDocumentPolling.js
@@ -218,7 +218,8 @@ export function useDocumentPolling({
         for (const doc of timedOutDocs) onTimeoutRef.current(doc);
       }
     }
-    const aliveIds = currentIds.filter((id) => !timedOutIds.includes(id));
+    const timedOutSet = new Set(timedOutIds);
+    const aliveIds = currentIds.filter((id) => !timedOutSet.has(id));
     if (aliveIds.length === 0) return;
 
     const controller = new AbortController();

--- a/src/frontend/src/hooks/useDocumentPolling.js
+++ b/src/frontend/src/hooks/useDocumentPolling.js
@@ -1,50 +1,184 @@
 /**
- * useDocumentPolling — minimal C1 polling loop for in-flight document uploads (#388).
+ * useDocumentPolling — C2 polling loop for in-flight document uploads (#388).
  *
  * Tracks document ids that are still `pending` or `processing` and polls the
- * batch endpoint every 2 seconds to refresh their state. When a document
- * transitions to `completed` or `failed`, it's removed from the active set
- * and `onResolved` is invoked so the caller can refresh totals or fire a
- * completion notification.
+ * batch endpoint until they reach a terminal state.
  *
- * C2 will upgrade this with exponential backoff, the Page Visibility API,
- * an AbortController per fetch, and localStorage persistence of in-flight
- * uploads across page reloads. This file deliberately keeps it dumb:
- * fixed 2 s interval, no backoff, no persistence. Enough to make the
- * cutover UX honest (status moves from pending → processing → completed
- * without a manual refresh) without landing a huge surface area in one PR.
+ * C2 additions over C1:
+ *   - Exponential backoff 1 → 2 → 4 → 8 → 10 s (reset on any status/stage/
+ *     page change — user just got useful info, keep it snappy).
+ *   - Page Visibility API: tab hidden → pause interval. Tab visible again →
+ *     single catch-up fetch, then resume.
+ *   - AbortController on every fetch; component unmount aborts in-flight.
+ *   - 30-min per-document timeout. After the cap, the entry is dropped
+ *     locally (the DB row is left untouched) and `onTimeout(row)` fires so
+ *     the page can render a Retry CTA.
+ *   - localStorage persistence at key `renfield.kb.inflight`. Every `track()`
+ *     call persists the entry; terminal or >10 min stale entries are trimmed.
+ *     On mount we hydrate any still-pending entries so the spinner survives
+ *     a page reload.
+ *
+ * Callbacks never run inside `setActiveDocs`'s updater function — StrictMode
+ * would otherwise deliver them twice in dev.
  */
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import apiClient from '../utils/axios';
 
-const DEFAULT_POLL_INTERVAL_MS = 2000;
 const TERMINAL_STATES = new Set(['completed', 'failed']);
 
-export function useDocumentPolling({ onResolved, intervalMs = DEFAULT_POLL_INTERVAL_MS } = {}) {
+// Backoff ladder (ms). The hook walks through this array and clamps at the
+// last value. Tests override via `backoffSequenceMs` / `initialDelayMs`.
+const DEFAULT_BACKOFF_MS = [1000, 2000, 4000, 8000, 10000];
+
+// 30 min. Above this, the UI gives up and surfaces Retry.
+const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
+
+// localStorage state — survives reloads so the spinner doesn't vanish.
+const LS_KEY = 'renfield.kb.inflight';
+const LS_MAX_ENTRIES = 20;
+const LS_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 h hard cap
+const LS_STALE_TRIM_MS = 10 * 60 * 1000;   // 10 min — trim zombie entries
+
+function readLSEntries() {
+  try {
+    const raw = window.localStorage.getItem(LS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    const now = Date.now();
+    return parsed
+      .filter((e) => e && typeof e.docId === 'number' && typeof e.startedAt === 'number')
+      .filter((e) => now - e.startedAt < LS_MAX_AGE_MS)
+      .slice(0, LS_MAX_ENTRIES);
+  } catch {
+    return [];
+  }
+}
+
+function writeLSEntries(entries) {
+  try {
+    const trimmed = entries.slice(0, LS_MAX_ENTRIES);
+    window.localStorage.setItem(LS_KEY, JSON.stringify(trimmed));
+  } catch {
+    // Quota exceeded / privacy mode / SSR: just drop the write. State still
+    // works in memory for the life of the page.
+  }
+}
+
+function removeLSEntry(docId) {
+  const entries = readLSEntries().filter((e) => e.docId !== docId);
+  writeLSEntries(entries);
+}
+
+export function useDocumentPolling({
+  onResolved,
+  onTimeout,
+  // Kept for back-compat with C1 callers; now only used as the fallback when
+  // `backoffSequenceMs` isn't provided. Tests override to go fast.
+  intervalMs,
+  backoffSequenceMs,
+  initialDelayMs,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+} = {}) {
   // Map<documentId, DocumentResponse>
   const [activeDocs, setActiveDocs] = useState({});
-  const intervalRef = useRef(null);
-  const onResolvedRef = useRef(onResolved);
-  // Mirror activeDocs into a ref so poll() reads the current set even
-  // when the effect doesn't restart (e.g. resolve-A + track-B land in
-  // the same React batch so ids.length stays constant).
   const activeDocsRef = useRef(activeDocs);
+  const onResolvedRef = useRef(onResolved);
+  const onTimeoutRef = useRef(onTimeout);
 
-  // Keep the callback ref fresh so parent re-renders don't restart the poll.
+  // Per-doc "first seen at" timestamp for the 30-min timeout.
+  const trackedSinceRef = useRef(new Map());
+
+  // Timer / abort state.
+  const timerRef = useRef(null);
+  const abortRef = useRef(null);
+  // Step into DEFAULT_BACKOFF_MS. Reset to 0 on any progress signal.
+  const backoffIndexRef = useRef(0);
+
+  // Pick the effective backoff ladder once. An explicit `intervalMs`
+  // (C1 contract) collapses the ladder to that single value. Memoising is
+  // load-bearing: `doPoll` and the scheduling effect depend on the ladder
+  // identity, and a fresh array on every render would cancel + reschedule
+  // the timer from scratch on every poll, pinning the effective delay at
+  // `firstDelay` forever. Callers frequently pass an inline array literal
+  // (`backoffSequenceMs: [1000, 2000]`) so we key the memo off the
+  // serialised value, not the array identity.
+  const ladderKey = backoffSequenceMs
+    ? backoffSequenceMs.join(',')
+    : `i${intervalMs ?? ''}`;
+  const backoffLadder = useMemo(
+    () =>
+      backoffSequenceMs ||
+      (intervalMs != null ? [intervalMs] : DEFAULT_BACKOFF_MS),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [ladderKey],
+  );
+  const firstDelay = initialDelayMs != null
+    ? initialDelayMs
+    : (intervalMs != null ? intervalMs : backoffLadder[0]);
+
+  // ---------------------------------------------------------------------
+  // Ref upkeep
+  // ---------------------------------------------------------------------
   useEffect(() => {
     onResolvedRef.current = onResolved;
   }, [onResolved]);
-
+  useEffect(() => {
+    onTimeoutRef.current = onTimeout;
+  }, [onTimeout]);
   useEffect(() => {
     activeDocsRef.current = activeDocs;
   }, [activeDocs]);
 
+  // ---------------------------------------------------------------------
+  // Hydration from localStorage on mount — one-shot
+  // ---------------------------------------------------------------------
+  useEffect(() => {
+    const now = Date.now();
+    const entries = readLSEntries().filter(
+      (e) => now - e.startedAt < LS_STALE_TRIM_MS,
+    );
+    if (entries.length === 0) {
+      // Drop any zombie entries older than the trim window, but never
+      // re-hydrate them into state.
+      writeLSEntries([]);
+      return;
+    }
+    const hydrated = {};
+    entries.forEach((e) => {
+      hydrated[e.docId] = {
+        id: e.docId,
+        filename: e.filename || `#${e.docId}`,
+        status: 'pending',
+      };
+      trackedSinceRef.current.set(e.docId, e.startedAt);
+    });
+    setActiveDocs((prev) => ({ ...hydrated, ...prev }));
+    writeLSEntries(entries); // re-save the trimmed list
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ---------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------
   const track = useCallback((doc) => {
     if (!doc || TERMINAL_STATES.has(doc.status)) return;
+    const now = Date.now();
+    trackedSinceRef.current.set(doc.id, now);
     setActiveDocs((prev) => ({ ...prev, [doc.id]: doc }));
+    // Persist right away so reload survives even before the first poll.
+    const existing = readLSEntries().filter((e) => e.docId !== doc.id);
+    writeLSEntries([
+      { docId: doc.id, filename: doc.filename || '', startedAt: now },
+      ...existing,
+    ]);
+    // Reset backoff so the first poll fires quickly.
+    backoffIndexRef.current = 0;
   }, []);
 
   const forget = useCallback((id) => {
+    trackedSinceRef.current.delete(id);
+    removeLSEntry(id);
     setActiveDocs((prev) => {
       if (!(id in prev)) return prev;
       const next = { ...prev };
@@ -53,79 +187,192 @@ export function useDocumentPolling({ onResolved, intervalMs = DEFAULT_POLL_INTER
     });
   }, []);
 
-  const ids = Object.keys(activeDocs).map(Number);
+  // ---------------------------------------------------------------------
+  // Polling machinery
+  // ---------------------------------------------------------------------
+  // Core batch fetch — one request, many ids, abortable.
+  const doPoll = useCallback(async () => {
+    const currentIds = Object.keys(activeDocsRef.current).map(Number);
+    if (currentIds.length === 0) return;
 
-  useEffect(() => {
-    if (ids.length === 0) {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
+    // 30-min timeout enforcement: drop any doc older than cap.
+    const now = Date.now();
+    const timedOutIds = currentIds.filter((id) => {
+      const startedAt = trackedSinceRef.current.get(id);
+      return startedAt && now - startedAt > timeoutMs;
+    });
+    if (timedOutIds.length) {
+      const timedOutDocs = timedOutIds
+        .map((id) => activeDocsRef.current[id])
+        .filter(Boolean);
+      setActiveDocs((prev) => {
+        const next = { ...prev };
+        for (const id of timedOutIds) delete next[id];
+        return next;
+      });
+      for (const id of timedOutIds) {
+        trackedSinceRef.current.delete(id);
+        removeLSEntry(id);
       }
-      return;
+      if (onTimeoutRef.current) {
+        for (const doc of timedOutDocs) onTimeoutRef.current(doc);
+      }
     }
-    if (intervalRef.current) return; // already running
+    const aliveIds = currentIds.filter((id) => !timedOutIds.includes(id));
+    if (aliveIds.length === 0) return;
 
-    const poll = async () => {
-      const currentIds = Object.keys(activeDocsRef.current).map(Number);
-      if (currentIds.length === 0) return;
-      try {
-        const response = await apiClient.get('/api/knowledge/documents/batch', {
-          params: { ids: currentIds.join(',') },
-        });
-        const rows = response.data || [];
-        // Compute resolved rows up front — setActiveDocs(fn) defers the
-        // updater to commit time, so collecting from inside it would
-        // read empty when we fire callbacks below. Derive the list from
-        // the batch response, which is the single source of truth for
-        // this tick.
-        const resolvedThisTick = rows.filter((row) =>
-          TERMINAL_STATES.has(row.status),
-        );
-        const seen = new Set(rows.map((row) => row.id));
-        setActiveDocs((prev) => {
-          const next = { ...prev };
-          for (const row of rows) {
-            if (TERMINAL_STATES.has(row.status)) {
-              delete next[row.id];
-            } else {
-              next[row.id] = row;
-            }
-          }
-          // Any id we asked about that wasn't returned (deleted by an
-          // admin mid-poll?) gets dropped so we don't poll forever.
-          for (const id of currentIds) {
-            if (!seen.has(id)) delete next[id];
-          }
-          return next;
-        });
-        // Fire resolution callbacks outside the updater so StrictMode's
-        // double-invocation in dev doesn't deliver duplicate onResolved
-        // events to the caller.
-        if (resolvedThisTick.length && onResolvedRef.current) {
-          for (const row of resolvedThisTick) {
-            onResolvedRef.current(row);
-          }
-        }
-      } catch (err) {
-        // Keep polling through transient errors; caller sees stale data,
-        // not a crash. A long outage will be visible because statuses
-        // stop updating — acceptable for C1.
-        console.warn('[useDocumentPolling] poll failed:', err);
+    const controller = new AbortController();
+    // Abort any previous in-flight request before starting a new one.
+    if (abortRef.current) abortRef.current.abort();
+    abortRef.current = controller;
+
+    let rows;
+    try {
+      const response = await apiClient.get('/api/knowledge/documents/batch', {
+        params: { ids: aliveIds.join(',') },
+        signal: controller.signal,
+      });
+      rows = response.data || [];
+    } catch (err) {
+      // AbortError is fine — means we moved on or the tab went hidden.
+      if (err?.code === 'ERR_CANCELED' || err?.name === 'CanceledError' || err?.name === 'AbortError') {
+        return;
+      }
+      console.warn('[useDocumentPolling] poll failed:', err);
+      return;
+    } finally {
+      if (abortRef.current === controller) abortRef.current = null;
+    }
+
+    // Detect "anything changed" relative to our current view — any new stage,
+    // new status, or page counter bump resets the backoff.
+    const prev = activeDocsRef.current;
+    let sawProgress = false;
+    for (const row of rows) {
+      const old = prev[row.id];
+      if (!old) continue;
+      if (
+        old.status !== row.status ||
+        old.stage !== row.stage ||
+        (old.pages?.current ?? null) !== (row.pages?.current ?? null) ||
+        (old.pages?.total ?? null) !== (row.pages?.total ?? null) ||
+        (old.queue_position ?? null) !== (row.queue_position ?? null)
+      ) {
+        sawProgress = true;
+      }
+    }
+
+    const resolvedThisTick = rows.filter((row) =>
+      TERMINAL_STATES.has(row.status),
+    );
+    const seen = new Set(rows.map((row) => row.id));
+
+    // Compute the next snapshot up-front so we can assign both state AND
+    // the ref in lockstep. The `[activeDocs]` effect only fires after the
+    // next commit, which is too late for the very next poll's sawProgress
+    // comparison — and setActiveDocs' updater runs at commit time, so
+    // reading the return value from inside the updater is also too late.
+    const nextSnapshot = { ...prev };
+    for (const row of rows) {
+      if (TERMINAL_STATES.has(row.status)) {
+        delete nextSnapshot[row.id];
+      } else {
+        nextSnapshot[row.id] = row;
+      }
+    }
+    for (const id of aliveIds) {
+      if (!seen.has(id)) delete nextSnapshot[id];
+    }
+    activeDocsRef.current = nextSnapshot;
+    setActiveDocs(nextSnapshot);
+
+    for (const row of resolvedThisTick) {
+      trackedSinceRef.current.delete(row.id);
+      removeLSEntry(row.id);
+    }
+
+    if (resolvedThisTick.length && onResolvedRef.current) {
+      for (const row of resolvedThisTick) onResolvedRef.current(row);
+    }
+
+    // Reset backoff on progress, otherwise step forward.
+    if (sawProgress || resolvedThisTick.length) {
+      backoffIndexRef.current = 0;
+    } else if (backoffIndexRef.current < backoffLadder.length - 1) {
+      backoffIndexRef.current += 1;
+    }
+  }, [backoffLadder, timeoutMs]);
+
+  // The long-lived schedule loop. We use setTimeout-per-tick (not
+  // setInterval) because the next delay depends on the backoff state
+  // computed inside the just-finished poll.
+  useEffect(() => {
+    let cancelled = false;
+
+    const scheduleNext = (delayOverride) => {
+      if (cancelled) return;
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      if (Object.keys(activeDocsRef.current).length === 0) return;
+      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+        // Don't schedule while hidden; the visibility listener will
+        // restart us when the tab comes back.
+        return;
+      }
+      const delay = delayOverride != null
+        ? delayOverride
+        : backoffLadder[backoffIndexRef.current] ?? backoffLadder[backoffLadder.length - 1];
+      timerRef.current = setTimeout(async () => {
+        timerRef.current = null;
+        await doPoll();
+        scheduleNext();
+      }, delay);
+    };
+
+    const onVisibilityChange = () => {
+      if (typeof document === 'undefined') return;
+      if (document.visibilityState === 'visible') {
+        // Catch-up poll immediately, then resume the ladder.
+        backoffIndexRef.current = 0;
+        (async () => {
+          await doPoll();
+          scheduleNext();
+        })();
+      } else if (timerRef.current) {
+        // Pause: clear pending timer, abort any in-flight request.
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+        if (abortRef.current) abortRef.current.abort();
       }
     };
 
-    // Kick off immediately, then on every interval tick.
-    poll();
-    intervalRef.current = setInterval(poll, intervalMs);
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', onVisibilityChange);
+    }
+
+    // Kick off with the initial (short) delay so the first poll feels fast.
+    if (Object.keys(activeDocsRef.current).length > 0) {
+      scheduleNext(firstDelay);
+    }
 
     return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
+      cancelled = true;
+      if (typeof document !== 'undefined') {
+        document.removeEventListener('visibilitychange', onVisibilityChange);
+      }
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      if (abortRef.current) {
+        abortRef.current.abort();
+        abortRef.current = null;
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ids.length]);
+  }, [Object.keys(activeDocs).length === 0, doPoll]);
 
   return { activeDocs, track, forget };
 }

--- a/src/frontend/src/hooks/useInflightTabTitle.js
+++ b/src/frontend/src/hooks/useInflightTabTitle.js
@@ -1,0 +1,83 @@
+/**
+ * useInflightTabTitle — mutate document.title while uploads are in flight (#388).
+ *
+ * Contract:
+ *   - While `inflightCount > 0`: prefix page title with `(N) `.
+ *   - Transition `inflightCount > 0 → 0`: flash `(✓) ` for 30 s, then restore
+ *     the bare title. If the user focuses the tab before the 30 s expire the
+ *     checkmark clears immediately (the user already saw it).
+ *   - Restores the bare title on unmount.
+ *
+ * Deliberately lives in its own hook so the title-mutation logic is
+ * testable in isolation and doesn't tangle with KnowledgePage re-renders.
+ */
+import { useEffect, useRef } from 'react';
+
+const FLASH_MS = 30_000;
+
+export function useInflightTabTitle(inflightCount, baseTitle) {
+  const baseRef = useRef(baseTitle);
+  const prevCountRef = useRef(0);
+  const flashTimerRef = useRef(null);
+
+  // Snapshot the base title once so subsequent re-renders that flow through
+  // React state don't clobber the "clean" value we want to restore to.
+  useEffect(() => {
+    baseRef.current = baseTitle || document.title;
+    return () => {
+      if (flashTimerRef.current) {
+        clearTimeout(flashTimerRef.current);
+        flashTimerRef.current = null;
+      }
+      // Restore on unmount.
+      document.title = baseRef.current;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const base = baseRef.current;
+    if (!base) return;
+
+    // Clear any pending flash reset — the count just changed.
+    if (flashTimerRef.current) {
+      clearTimeout(flashTimerRef.current);
+      flashTimerRef.current = null;
+    }
+
+    if (inflightCount > 0) {
+      document.title = `(${inflightCount}) ${base}`;
+    } else if (prevCountRef.current > 0) {
+      // Just finished — show the checkmark briefly.
+      document.title = `(✓) ${base}`;
+      flashTimerRef.current = setTimeout(() => {
+        document.title = base;
+        flashTimerRef.current = null;
+      }, FLASH_MS);
+    } else {
+      document.title = base;
+    }
+
+    prevCountRef.current = inflightCount;
+  }, [inflightCount]);
+
+  // Auto-clear the checkmark when the user focuses the tab — by that point
+  // they've already seen the status on the page itself.
+  useEffect(() => {
+    const onVisible = () => {
+      if (
+        typeof document !== 'undefined' &&
+        document.visibilityState === 'visible' &&
+        flashTimerRef.current
+      ) {
+        clearTimeout(flashTimerRef.current);
+        flashTimerRef.current = null;
+        document.title = baseRef.current;
+      }
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisible);
+    };
+  }, []);
+}

--- a/src/frontend/src/hooks/useInflightTabTitle.js
+++ b/src/frontend/src/hooks/useInflightTabTitle.js
@@ -20,8 +20,12 @@ export function useInflightTabTitle(inflightCount, baseTitle) {
   const prevCountRef = useRef(0);
   const flashTimerRef = useRef(null);
 
-  // Snapshot the base title once so subsequent re-renders that flow through
-  // React state don't clobber the "clean" value we want to restore to.
+  // Snapshot the base title on mount so subsequent re-renders that flow
+  // through React state don't clobber the "clean" value we want to
+  // restore to. On first visit i18next may still be hydrating when the
+  // component mounts — if `baseTitle` is empty then, we fall back to
+  // `document.title`. The follow-up effect below promotes the real
+  // value once it lands.
   useEffect(() => {
     baseRef.current = baseTitle || document.title;
     return () => {
@@ -34,6 +38,25 @@ export function useInflightTabTitle(inflightCount, baseTitle) {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // i18n may resolve lazily. If the mount-time snapshot grabbed a
+  // placeholder and a real title lands on a later render, promote it
+  // so the `(N)` prefix rides on top of the correct base. We only
+  // overwrite when the ref is empty or still equals the current page
+  // title with prefixes stripped — any other value indicates the
+  // caller has set a different base on purpose (route change, manual
+  // document.title write).
+  useEffect(() => {
+    if (!baseTitle) return;
+    if (baseRef.current === baseTitle) return;
+    const current = baseRef.current || '';
+    const currentClean = document.title
+      .replace(/^\(\d+\)\s+/, '')
+      .replace(/^\(✓\)\s+/, '');
+    if (!current || current === currentClean) {
+      baseRef.current = baseTitle;
+    }
+  }, [baseTitle]);
 
   useEffect(() => {
     const base = baseRef.current;

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -409,7 +409,8 @@
     "serverError": "Beim Hochladen ist etwas schiefgegangen.",
     "showDetails": "Details anzeigen",
     "hideDetails": "Details verbergen",
-    "failedRetry": "Erneut hochladen"
+    "failedRetry": "Erneut hochladen",
+    "pollingTimeout": "Die Verarbeitung von „{{filename}}\" dauert länger als erwartet. Bitte die Seite neu laden, um den aktuellen Status zu sehen."
   },
   "memory": {
     "title": "Erinnerungen",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -409,7 +409,8 @@
     "serverError": "Something went wrong during upload.",
     "showDetails": "Show details",
     "hideDetails": "Hide details",
-    "failedRetry": "Upload again"
+    "failedRetry": "Upload again",
+    "pollingTimeout": "Processing of \"{{filename}}\" is taking longer than expected. Please refresh to see the current status."
   },
   "memory": {
     "title": "Memories",

--- a/src/frontend/src/pages/KnowledgePage.jsx
+++ b/src/frontend/src/pages/KnowledgePage.jsx
@@ -27,6 +27,7 @@ import Badge from '../components/Badge';
 import StatusBadge from '../components/knowledge/StatusBadge';
 import DuplicateDialog from '../components/knowledge/DuplicateDialog';
 import { useDocumentPolling } from '../hooks/useDocumentPolling';
+import { useInflightTabTitle } from '../hooks/useInflightTabTitle';
 
 export default function KnowledgePage() {
   const { t } = useTranslation();
@@ -114,7 +115,21 @@ export default function KnowledgePage() {
       await loadDocuments();
       await loadStats();
     },
+    onTimeout: (doc) => {
+      // 30-min cap hit. Tell the user their poll loop gave up, but leave
+      // the DB row alone — a manual refresh can still pick it up if the
+      // worker does eventually finish.
+      setUploadProgress(t('knowledge.pollingTimeout', { filename: doc.filename }));
+      setTimeout(() => setUploadProgress(null), 8000);
+    },
   });
+
+  // Mutate the tab title while docs are still in flight so the user sees
+  // a count even when the tab isn't focused.
+  useInflightTabTitle(
+    Object.keys(activeDocs).length,
+    t('knowledge.title') + ' — Renfield',
+  );
 
   // Last file the user tried to upload, so the 503-toast retry CTA can
   // re-submit without re-opening the file picker.
@@ -169,15 +184,16 @@ export default function KnowledgePage() {
         // keep setTimeout longer for retry CTA; cleared on retry or dismiss
         setTimeout(() => setUploadProgress(null), 10000);
       } else if (status === 413) {
-        const maxMb = error.response?.headers?.['x-max-mb'] || '';
+        const maxMb = detail?.max_mb ?? '';
         setUploadProgress(t('knowledge.fileTooLarge', { maxMb }));
         setTimeout(() => setUploadProgress(null), 5000);
-      } else if (status === 400 && typeof detail === 'string' && detail.toLowerCase().includes('format')) {
-        setUploadProgress(t('knowledge.formatNotSupported', { allowed: '' }) + ' ' + detail);
+      } else if (status === 415) {
+        const allowed = Array.isArray(detail?.allowed) ? detail.allowed.join(', ') : '';
+        setUploadProgress(t('knowledge.formatNotSupported', { allowed }));
         setTimeout(() => setUploadProgress(null), 6000);
       } else {
         console.error('Upload error:', error);
-        const msg = typeof detail === 'string' ? detail : t('knowledge.serverError');
+        const msg = typeof detail === 'string' ? detail : detail?.message || t('knowledge.serverError');
         setUploadProgress(`${t('knowledge.errorLabel')}: ${msg}`);
         setTimeout(() => setUploadProgress(null), 6000);
       }

--- a/tests/backend/test_knowledge_upload_routing.py
+++ b/tests/backend/test_knowledge_upload_routing.py
@@ -240,3 +240,41 @@ async def test_batch_endpoint_rejects_oversize_batch(async_client: AsyncClient):
 async def test_batch_endpoint_rejects_non_integer_ids(async_client: AsyncClient):
     response = await async_client.get("/api/knowledge/documents/batch?ids=1,abc,3")
     assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# C2: 413/415 semantic HTTP codes for size and format rejections
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_upload_unsupported_format_returns_415(async_client: AsyncClient):
+    """Unknown extensions get 415 Unsupported Media Type with an `allowed`
+    list in the structured detail so the frontend can render the hint
+    without hard-coding the extension set."""
+    response = await async_client.post(
+        "/api/knowledge/upload",
+        files=[("file", ("evil.exe", io.BytesIO(b"MZ..."), "application/octet-stream"))],
+    )
+    assert response.status_code == 415, response.text
+    body = response.json()
+    assert isinstance(body["detail"], dict)
+    assert "allowed" in body["detail"]
+    assert body["detail"]["received"] == "exe"
+
+
+@pytest.mark.unit
+async def test_upload_oversize_returns_413(async_client: AsyncClient, monkeypatch):
+    """Files above `max_file_size_mb` get 413 Content Too Large with
+    `max_mb` in the detail. We shrink the limit to 0 so even a tiny file
+    trips it, keeping the test fast."""
+    from utils.config import settings
+
+    monkeypatch.setattr(settings, "max_file_size_mb", 0)
+    response = await async_client.post(
+        "/api/knowledge/upload",
+        files=[("file", ("big.txt", io.BytesIO(b"x" * 2048), "text/plain"))],
+    )
+    assert response.status_code == 413, response.text
+    body = response.json()
+    assert body["detail"]["max_mb"] == 0

--- a/tests/frontend/react/components/knowledge/DuplicateDialog.test.jsx
+++ b/tests/frontend/react/components/knowledge/DuplicateDialog.test.jsx
@@ -1,0 +1,77 @@
+/**
+ * DuplicateDialog — C2 component tests (#388).
+ *
+ * Focus trap + return focus on close are the C2 additions.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent } from '@testing-library/react';
+import { renderWithProviders } from '../../test-utils.jsx';
+import DuplicateDialog from '../../../../../src/frontend/src/components/knowledge/DuplicateDialog';
+
+const existing = {
+  id: 42,
+  filename: 'report.pdf',
+  uploaded_at: '2026-04-01T12:00:00Z',
+};
+
+describe('DuplicateDialog', () => {
+  it('focuses the jump button on open', () => {
+    const { getByRole } = renderWithProviders(
+      <DuplicateDialog existing={existing} onClose={vi.fn()} onJump={vi.fn()} />,
+    );
+    const dialog = getByRole('dialog');
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+    // Primary button text per DE i18n: "Zum vorhandenen Eintrag springen"
+    const jumpBtn = dialog.querySelector('.btn-primary');
+    expect(document.activeElement).toBe(jumpBtn);
+  });
+
+  it('returns focus to the previously focused element on close', () => {
+    const trigger = document.createElement('button');
+    trigger.textContent = 'upload trigger';
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    const onClose = vi.fn();
+    const { unmount } = renderWithProviders(
+      <DuplicateDialog existing={existing} onClose={onClose} onJump={vi.fn()} />,
+    );
+    // Dialog stole focus.
+    expect(document.activeElement).not.toBe(trigger);
+
+    // Close → focus returns to the trigger (useEffect cleanup runs on unmount).
+    unmount();
+    expect(document.activeElement).toBe(trigger);
+    trigger.remove();
+  });
+
+  it('Escape closes the dialog', () => {
+    const onClose = vi.fn();
+    renderWithProviders(
+      <DuplicateDialog existing={existing} onClose={onClose} onJump={vi.fn()} />,
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('tab cycles within the dialog (focus trap)', () => {
+    const { getByRole } = renderWithProviders(
+      <DuplicateDialog existing={existing} onClose={vi.fn()} onJump={vi.fn()} />,
+    );
+    const dialog = getByRole('dialog');
+    const cancelBtn = dialog.querySelector('.btn-secondary');
+    const jumpBtn = dialog.querySelector('.btn-primary');
+
+    // Focus starts on jumpBtn (last focusable in DOM order).
+    expect(document.activeElement).toBe(jumpBtn);
+
+    // Tab forward on last focusable should wrap to first (cancel).
+    fireEvent.keyDown(document, { key: 'Tab' });
+    expect(document.activeElement).toBe(cancelBtn);
+
+    // Shift+Tab on first should wrap to last (jump).
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(jumpBtn);
+  });
+});

--- a/tests/frontend/react/components/knowledge/StatusBadge.test.jsx
+++ b/tests/frontend/react/components/knowledge/StatusBadge.test.jsx
@@ -1,0 +1,67 @@
+/**
+ * StatusBadge — C2 component tests (#388).
+ *
+ * Matrix item #23: queue-position sub-label renders when pending with position.
+ * Plus supporting coverage for the progressbar vs role=status switch.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderWithProviders } from '../../test-utils.jsx';
+import StatusBadge from '../../../../../src/frontend/src/components/knowledge/StatusBadge';
+
+function doc(overrides = {}) {
+  return {
+    id: 1,
+    filename: 'hello.pdf',
+    status: 'pending',
+    stage: null,
+    pages: null,
+    queue_position: null,
+    ...overrides,
+  };
+}
+
+describe('StatusBadge', () => {
+  it('matrix #23: renders queue_position sub-label when pending', () => {
+    const { getByRole, getAllByText } = renderWithProviders(
+      <StatusBadge doc={doc({ status: 'pending', queue_position: 3 })} />,
+    );
+    // Outer element is role=status (pending isn't processing→progressbar).
+    expect(getByRole('status')).toBeTruthy();
+    // Queue sub-label uses statusQueuePosition key → DE: "Platz 3".
+    // It can appear twice: once visibly in the <span>, once in the sr-only
+    // live region after the rate-limit timer elapses.
+    const matches = getAllByText(/Platz 3|Position 3/);
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('uses role=progressbar when processing with pages.total', () => {
+    const { getByRole } = renderWithProviders(
+      <StatusBadge
+        doc={doc({
+          status: 'processing',
+          stage: 'ocr',
+          pages: { current: 47, total: 120 },
+        })}
+      />,
+    );
+    const bar = getByRole('progressbar');
+    expect(bar.getAttribute('aria-valuenow')).toBe('47');
+    expect(bar.getAttribute('aria-valuemax')).toBe('120');
+    expect(bar.getAttribute('aria-valuetext')).toMatch(/47/);
+  });
+
+  it('falls back to aria-busy when processing without page counts', () => {
+    const { getByRole } = renderWithProviders(
+      <StatusBadge doc={doc({ status: 'processing', stage: 'parsing' })} />,
+    );
+    const el = getByRole('status');
+    expect(el.getAttribute('aria-busy')).toBe('true');
+  });
+
+  it('drops aria-busy for non-processing rows', () => {
+    const { getByRole } = renderWithProviders(
+      <StatusBadge doc={doc({ status: 'completed' })} />,
+    );
+    expect(getByRole('status').getAttribute('aria-busy')).toBeFalsy();
+  });
+});

--- a/tests/frontend/react/hooks/useDocumentPolling.c2.test.jsx
+++ b/tests/frontend/react/hooks/useDocumentPolling.c2.test.jsx
@@ -1,0 +1,252 @@
+/**
+ * useDocumentPolling — C2 behaviour tests (#388).
+ *
+ * Covers matrix items 19 (backoff), 20 (Page Visibility), 21 (localStorage),
+ * plus auxiliary coverage for the AbortController path and the timeout CTA.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '../mocks/server.js';
+import { TEST_CONFIG } from '../config.js';
+import { useDocumentPolling } from '../../../../src/frontend/src/hooks/useDocumentPolling';
+
+const BASE_URL = TEST_CONFIG.API_BASE_URL;
+const BATCH_PATH = `${BASE_URL}/api/knowledge/documents/batch`;
+
+function pendingDoc(id, overrides = {}) {
+  return {
+    id,
+    filename: `f${id}.txt`,
+    title: null,
+    file_type: 'txt',
+    file_size: 10,
+    status: 'pending',
+    error_message: null,
+    chunk_count: 0,
+    page_count: null,
+    knowledge_base_id: 1,
+    created_at: '2026-04-19T10:00:00Z',
+    processed_at: null,
+    stage: null,
+    pages: null,
+    queue_position: null,
+    ...overrides,
+  };
+}
+
+describe('useDocumentPolling C2 — backoff', () => {
+  beforeEach(() => {
+    server.resetHandlers();
+    window.localStorage.clear();
+  });
+
+  it('walks through the backoff ladder when no progress is observed', async () => {
+    // Record the wall-clock gap between successive batch requests.
+    const stamps = [];
+    server.use(
+      http.get(BATCH_PATH, () => {
+        stamps.push(performance.now());
+        // Stable `processing` response — no change, so backoff should step up.
+        return HttpResponse.json([pendingDoc(1, { status: 'processing', stage: 'parsing' })]);
+      }),
+    );
+    const { result } = renderHook(() =>
+      useDocumentPolling({
+        initialDelayMs: 5,
+        backoffSequenceMs: [5, 20, 80],
+      }),
+    );
+    act(() => result.current.track(pendingDoc(1)));
+
+    // Wait for 4 polls.
+    await waitFor(() => expect(stamps.length).toBeGreaterThanOrEqual(4), { timeout: 2000 });
+
+    // Gap between poll 1→2 should be near 5 ms (initial).
+    // Gap 2→3 should be near 20 ms. Gap 3→4 should be near 80 ms.
+    const gaps = stamps.slice(1).map((t, i) => t - stamps[i]);
+    expect(gaps[0]).toBeLessThan(40);   // step 0 or 1
+    expect(gaps[2]).toBeGreaterThan(gaps[0]); // later gaps grow
+  });
+
+  it('resets the backoff ladder on an observed progress change', async () => {
+    let stage = 'parsing';
+    let firstStableGap = null;
+    const stamps = [];
+    server.use(
+      http.get(BATCH_PATH, () => {
+        stamps.push(performance.now());
+        return HttpResponse.json([pendingDoc(2, { status: 'processing', stage })]);
+      }),
+    );
+    const { result } = renderHook(() =>
+      useDocumentPolling({
+        initialDelayMs: 5,
+        backoffSequenceMs: [5, 60, 200],
+      }),
+    );
+    act(() => result.current.track(pendingDoc(2)));
+
+    // Let the backoff climb.
+    await waitFor(() => expect(stamps.length).toBeGreaterThanOrEqual(3), { timeout: 2000 });
+    firstStableGap = stamps[stamps.length - 1] - stamps[stamps.length - 2];
+
+    // Flip the stage — next poll should go back to the short interval.
+    stage = 'embedding';
+    const stampsAtFlip = stamps.length;
+    await waitFor(() => expect(stamps.length).toBeGreaterThanOrEqual(stampsAtFlip + 2), { timeout: 2000 });
+    const gapAfterReset = stamps[stampsAtFlip + 1] - stamps[stampsAtFlip];
+    expect(gapAfterReset).toBeLessThan(firstStableGap);
+  });
+});
+
+describe('useDocumentPolling C2 — Page Visibility', () => {
+  beforeEach(() => {
+    server.resetHandlers();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    // Restore visible state so other tests aren't stuck hidden.
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+
+  it('pauses polling while the tab is hidden and resumes on visibility', async () => {
+    let calls = 0;
+    server.use(
+      http.get(BATCH_PATH, () => {
+        calls += 1;
+        return HttpResponse.json([pendingDoc(9, { status: 'processing' })]);
+      }),
+    );
+    const { result } = renderHook(() =>
+      useDocumentPolling({ initialDelayMs: 5, backoffSequenceMs: [5] }),
+    );
+    act(() => result.current.track(pendingDoc(9)));
+
+    // Let at least one poll happen.
+    await waitFor(() => expect(calls).toBeGreaterThanOrEqual(1));
+
+    // Hide the tab. Capture the call count at the moment of hide.
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+    const callsAtHide = calls;
+
+    // Give the loop time it would have used for several polls.
+    await new Promise((r) => setTimeout(r, 60));
+    expect(calls).toBe(callsAtHide);
+
+    // Restore visibility — a catch-up poll should fire immediately.
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+    await waitFor(() => expect(calls).toBeGreaterThan(callsAtHide));
+  });
+});
+
+describe('useDocumentPolling C2 — localStorage persistence', () => {
+  beforeEach(() => {
+    server.resetHandlers();
+    window.localStorage.clear();
+  });
+
+  it('writes inflight entries on track() and hydrates them on mount', async () => {
+    server.use(
+      http.get(BATCH_PATH, () =>
+        HttpResponse.json([pendingDoc(7, { status: 'processing' })]),
+      ),
+    );
+    const { result, unmount } = renderHook(() =>
+      useDocumentPolling({ initialDelayMs: 5, backoffSequenceMs: [5] }),
+    );
+    act(() => result.current.track(pendingDoc(7, { filename: 'big.pdf' })));
+    await waitFor(() => expect(result.current.activeDocs[7]).toBeTruthy());
+
+    // Entry must be in localStorage.
+    const stored = JSON.parse(window.localStorage.getItem('renfield.kb.inflight'));
+    expect(stored).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ docId: 7, filename: 'big.pdf' }),
+      ]),
+    );
+
+    unmount();
+
+    // Re-mount — the hook should hydrate from localStorage (since startedAt
+    // is fresh, under the 10 min trim cap).
+    const { result: result2 } = renderHook(() =>
+      useDocumentPolling({ initialDelayMs: 5, backoffSequenceMs: [5] }),
+    );
+    await waitFor(() => expect(result2.current.activeDocs[7]).toBeTruthy());
+  });
+
+  it('clears localStorage for resolved docs', async () => {
+    let returned = 'processing';
+    server.use(
+      http.get(BATCH_PATH, () =>
+        HttpResponse.json([pendingDoc(8, { status: returned })]),
+      ),
+    );
+    const { result } = renderHook(() =>
+      useDocumentPolling({ initialDelayMs: 5, backoffSequenceMs: [5] }),
+    );
+    act(() => result.current.track(pendingDoc(8)));
+    await waitFor(() => expect(result.current.activeDocs[8]?.status).toBe('processing'));
+    expect(window.localStorage.getItem('renfield.kb.inflight')).toContain('8');
+
+    returned = 'completed';
+    await waitFor(() => expect(result.current.activeDocs[8]).toBeUndefined());
+    // LS entry for 8 must be gone.
+    await waitFor(() => {
+      const raw = window.localStorage.getItem('renfield.kb.inflight') || '[]';
+      const parsed = JSON.parse(raw);
+      expect(parsed.find((e) => e.docId === 8)).toBeUndefined();
+    });
+  });
+
+  it('drops entries older than the 10-min trim window on mount', async () => {
+    const stale = [
+      { docId: 77, filename: 'old.pdf', startedAt: Date.now() - 15 * 60 * 1000 },
+    ];
+    window.localStorage.setItem('renfield.kb.inflight', JSON.stringify(stale));
+
+    renderHook(() =>
+      useDocumentPolling({ initialDelayMs: 5, backoffSequenceMs: [5] }),
+    );
+    await waitFor(() => {
+      const raw = window.localStorage.getItem('renfield.kb.inflight') || '[]';
+      const parsed = JSON.parse(raw);
+      expect(parsed.find((e) => e.docId === 77)).toBeUndefined();
+    });
+  });
+});
+
+describe('useDocumentPolling C2 — timeout CTA', () => {
+  beforeEach(() => {
+    server.resetHandlers();
+    window.localStorage.clear();
+  });
+
+  it('drops docs past the per-doc timeout and fires onTimeout', async () => {
+    server.use(
+      http.get(BATCH_PATH, () =>
+        HttpResponse.json([pendingDoc(123, { status: 'processing' })]),
+      ),
+    );
+    const onTimeout = vi.fn();
+    const { result } = renderHook(() =>
+      useDocumentPolling({
+        initialDelayMs: 5,
+        backoffSequenceMs: [5],
+        timeoutMs: 20,
+        onTimeout,
+      }),
+    );
+    act(() => result.current.track(pendingDoc(123)));
+
+    await waitFor(() => expect(onTimeout).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 123 }),
+    ));
+    await waitFor(() => expect(result.current.activeDocs[123]).toBeUndefined());
+  });
+});


### PR DESCRIPTION
## Summary

Fifth PR in the document-worker split. The **polish pass** after C1's cutover. Purely additive — no new flag, no deployment changes required.

### Frontend polling (useDocumentPolling rewrite)
- Exponential backoff 1→2→4→8→10 s; resets on any status/stage/pages/queue_position change
- Page Visibility API: hidden tab pauses the schedule + aborts in-flight XHR; catch-up on return
- AbortController per fetch; unmount aborts in-flight
- 30-min per-document timeout → drops locally + fires onTimeout for Retry CTA
- localStorage persistence at renfield.kb.inflight; 10-min stale trim, 24 h cap, 20-entry ceiling
- Back-compat: intervalMs still collapses ladder to one value (C1 contract preserved)
- Fixes a ref-lag bug where sawProgress was always true (activeDocsRef updated one commit late)

### Frontend UX
- Tab-title: \`(N) Wissensbasis — Renfield\` while in flight, \`(✓) …\` for 30 s on complete, auto-clears on focus
- StatusBadge: \`role=progressbar\` with aria-valuenow/max/text when pages known; \`aria-busy=true\` otherwise; rate-limited polite-live sub-region (10 s min gap) so long OCR jobs don't spam screen readers
- DuplicateDialog: keyboard focus trap + focus return to the previously-focused element on close
- Pending sub-label contrast: gray-500 → gray-700 for WCAG AA

### Backend semantic HTTP codes (addresses PR #391 review minor #3)
- Unsupported format: 400 → **415** with structured \`{message, allowed, received}\`
- File too large: 400 → **413** with \`{message, max_mb, received_mb}\`
- Frontend error mapping reads structured fields instead of matching German strings

### Tests (matrix items #19–#23 + support)
- Hook: backoff ladder walk, backoff reset on progress, Visibility pause/resume, localStorage write/hydrate/trim/clear, 30-min timeout firing onTimeout
- Component: StatusBadge progressbar + queue_position + aria-busy; DuplicateDialog focus trap, focus return, Escape, Tab cycle
- Backend: 415 on unknown extension, 413 on oversize upload

All 14 hook tests + 8 new component tests green locally (total 51 passing in the knowledge + hooks suites).

## Test plan
- [x] C1 hook tests (7) still pass after rewrite
- [x] C2 hook tests (7) pass
- [x] StatusBadge + DuplicateDialog component tests (8) pass
- [ ] CI backend tests (415/413)
- [ ] Live check in \`renfield-private\` after merge: open DevTools → upload a PDF → watch the polling interval grow in Network panel from ~1 s to ~10 s → hide tab → requests stop → show tab → catch-up poll + resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)