### PR TITLE
fix: three post-cutover log issues (#388)

### DIFF
--- a/config/mail_accounts.default.yaml
+++ b/config/mail_accounts.default.yaml
@@ -1,0 +1,11 @@
+# Renfield mail accounts — shipped default (no accounts configured).
+#
+# This file is the k8s ConfigMap default so the renfield-mcp-mail server
+# starts without warnings when the operator hasn't set up real mail
+# accounts yet. Replace via a patched ConfigMap when ready — see
+# `config/mail_accounts.example.yaml` for the schema.
+#
+# Docker-compose users: copy mail_accounts.example.yaml to
+# mail_accounts.yaml (gitignored) and fill in real credentials.
+
+accounts: []

--- a/docs/KUBERNETES_DEPLOYMENT.md
+++ b/docs/KUBERNETES_DEPLOYMENT.md
@@ -251,6 +251,22 @@ kubectl -n renfield logs -f job/alembic-upgrade
 kubectl -n renfield delete job alembic-upgrade
 ```
 
+When the new version changes the MCP config set (new file in
+`config/`, new ConfigMap key referenced by a manifest), the
+`renfield-mcp-config` ConfigMap has to be rewritten before the
+manifests are applied — otherwise the pods get stuck in
+`ContainerCreating` on a missing subPath. The pattern:
+
+```bash
+kubectl -n renfield create configmap renfield-mcp-config \
+  --from-file=config/mcp_servers.yaml \
+  --from-file=config/agent_roles.yaml \
+  --from-file=config/kg_scopes.yaml \
+  --from-file=mail_accounts.yaml=config/mail_accounts.default.yaml \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n renfield rollout restart deploy/backend
+```
+
 Ollama model pulls: drop the model into the NFS share at `192.168.1.9:/mnt/data/llm/.ollama/` and it becomes visible to both Ollama pods; the `ollama-model-prepull` Job can also be re-applied to pull a specific list.
 
 ## Not Yet Included

--- a/docs/KUBERNETES_DEPLOYMENT.md
+++ b/docs/KUBERNETES_DEPLOYMENT.md
@@ -213,10 +213,14 @@ kubectl -n renfield create secret tls renfield-tls --cert=tls.crt --key=tls.key
 rm tls.{crt,key}
 
 # 5. MCP / agent config ConfigMap
+# `mail_accounts.default.yaml` is renamed to `mail_accounts.yaml` in the
+# ConfigMap — the mail MCP expects that exact filename. Swap in a real
+# accounts file here if you have one.
 kubectl -n renfield create configmap renfield-mcp-config \
   --from-file=config/mcp_servers.yaml \
   --from-file=config/agent_roles.yaml \
-  --from-file=config/kg_scopes.yaml
+  --from-file=config/kg_scopes.yaml \
+  --from-file=mail_accounts.yaml=config/mail_accounts.default.yaml
 
 # 6. Everything else via kustomize
 kubectl apply -k k8s/

--- a/k8s/backend.yaml
+++ b/k8s/backend.yaml
@@ -173,11 +173,19 @@ spec:
             - name: uploads
               mountPath: /app/data/uploads
             # Shared ML model cache (EasyOCR / HuggingFace / Docling).
-            # Not strictly required on the backend since Docling now runs
-            # in the worker, but keeps warm-cache behaviour for the
-            # legacy-inline rollback path (flag off).
+            # Backend still needs it because chat_upload.py runs Docling
+            # in-process; the worker reads from the same cache for the
+            # async upload path.
             - name: cache-home
               mountPath: /app/data/cache-home
+            # Overlay an ephemeral npm cache on top of the shared
+            # cache-home. The MCP stdio servers npx-install on startup,
+            # and backend + worker racing on the same .npm tree caused
+            # ENOTEMPTY rename errors that made MCP 'search' and 'news'
+            # fail on first connect (retries worked, just noisy). Pod-
+            # local emptyDir sidesteps the race entirely.
+            - name: npm-cache
+              mountPath: /app/data/cache-home/.npm
             - name: mcp-config
               mountPath: /app/config/mcp_servers.yaml
               subPath: mcp_servers.yaml
@@ -189,6 +197,14 @@ spec:
             - name: mcp-config
               mountPath: /app/config/kg_scopes.yaml
               subPath: kg_scopes.yaml
+              readOnly: true
+            # Silences the "Config file not found: /config/mail_accounts.yaml"
+            # WARN from renfield-mcp-mail on startup. The shipped default
+            # ships `accounts: []`; override by patching this entry in the
+            # renfield-mcp-config ConfigMap when real accounts are added.
+            - name: mcp-config
+              mountPath: /app/config/mail_accounts.yaml
+              subPath: mail_accounts.yaml
               readOnly: true
           livenessProbe:
             httpGet:
@@ -232,6 +248,11 @@ spec:
         - name: cache-home
           persistentVolumeClaim:
             claimName: renfield-cache-shared
+        # Pod-local npm cache (see mount comment). 2Gi is generous; npm
+        # + all MCP server dependencies typically land around 500 MB.
+        - name: npm-cache
+          emptyDir:
+            sizeLimit: 2Gi
         - name: mcp-config
           configMap:
             name: renfield-mcp-config

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -82,6 +82,12 @@ data:
   HOME: "/app/data/cache-home"
   HF_HOME: "/app/data/cache-home/.cache/huggingface"
 
+  # Mail MCP account config. Mounted into the backend pod via the
+  # renfield-mcp-config ConfigMap — see k8s/backend.yaml. The `/config/`
+  # default from config/mcp_servers.yaml doesn't exist in the pod;
+  # override to the actual mount path.
+  MAIL_ACCOUNTS_CONFIG: "/app/config/mail_accounts.yaml"
+
   # Logging
   LOG_LEVEL: "INFO"
   DO_NOT_TRACK: "1"

--- a/src/backend/services/rag_service.py
+++ b/src/backend/services/rag_service.py
@@ -123,8 +123,17 @@ class RAGService:
             "Kontext:"
         )
         try:
-            from services.llm_client import get_chat_client
-            client = get_chat_client()
+            # Previously imported from ``services.llm_client`` which
+            # never existed, and called ``get_chat_client()`` which
+            # was never implemented — both errors were swallowed by
+            # the broad except below, silently disabling contextual
+            # retrieval for every chunk indexed since the feature
+            # landed. Caught during post-cutover log inspection.
+            # ``get_default_client()`` returns the general LLM client
+            # (with fallback wiring) and exposes ``generate`` via the
+            # ollama.AsyncClient passthrough.
+            from utils.llm_client import get_default_client
+            client = get_default_client()
             model = settings.rag_contextual_model or settings.ollama_chat_model
             response = await asyncio.wait_for(
                 client.generate(model=model, prompt=prompt, options={"temperature": 0.1, "num_predict": 80}),


### PR DESCRIPTION
## Summary

Three issues surfaced while tailing the cluster logs right after the worker-split cutover. None are user-visible yet but all are real. One is a silent RAG quality regression that predates #388.

### 1. Contextual retrieval silently disabled *(pre-existing bug, high impact)*

\`rag_service.py:126\` imported \`from services.llm_client import get_chat_client\`. Neither path exists — the module is \`utils.llm_client\`, and there is no \`get_chat_client\` anywhere in the codebase. The broad \`except\` around the call swallowed the \`ModuleNotFoundError\` and logged a single WARN per chunk (\`Context-Prefix-Generierung fehlgeschlagen: No module named 'services.llm_client'\`). \`_generate_context_prefix\` always returned \`None\`. Every chunk indexed since the feature landed had no contextual prefix — Anthropic's ~49% retrieval-failure improvement was on the floor.

Fix: \`from utils.llm_client import get_default_client\`. \`_FallbackLLMClient\` exposes \`generate\` via pass-through so the existing call signature works unchanged.

### 2. MCP npm-install race on shared NFS cache

Backend and document-worker both mount \`renfield-cache-shared\` at \`/app/data/cache-home\` (so EasyOCR/HF weights are warm on both). \`HOME\` points there, so both pods write to the same \`.npm\` tree. \`npx\` installs on MCP stdio server startup raced → \`ENOTEMPTY\` rename → MCP \`search\` and \`news\` failed on first connect (retries succeeded, just WARN spam).

Fix: overlay a pod-local \`emptyDir\` at \`/app/data/cache-home/.npm\` on the backend. 2Gi cap. ML model caches stay shared.

### 3. \`renfield-mcp-mail\` WARN on missing config

\`mcp_servers.yaml\` defaults \`MAIL_ACCOUNTS_CONFIG\` to \`/config/mail_accounts.yaml\`, which doesn't exist in the pod — the ConfigMap mount is \`/app/config/\`. Fix three ways:
- Ship \`config/mail_accounts.default.yaml\` with \`accounts: []\` so fresh installs have a known-good default
- Add it to the \`renfield-mcp-config\` ConfigMap as \`mail_accounts.yaml\`
- Set \`MAIL_ACCOUNTS_CONFIG=/app/config/mail_accounts.yaml\` in \`renfield-env\` to override the stale \`/config/\` default

Docs updated to include the file in step 5 of \`docs/KUBERNETES_DEPLOYMENT.md\`.

## Test plan
- [x] Frontend + backend test suites still green locally
- [ ] After merge: rebuild backend image → apply manifests → recreate \`renfield-mcp-config\` ConfigMap with the 4th file → roll backend
- [ ] Verify no \`Context-Prefix-Generierung fehlgeschlagen\` WARNs in worker logs on next upload
- [ ] Verify no \`npm error code ENOTEMPTY\` on backend startup
- [ ] Verify no \`Config file not found: /config/mail_accounts.yaml\` on backend startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)