### PR TITLE
chore(worker-split): housekeeping — docs + C2 review nits (#388)

### DIFF
--- a/docs/DOCUMENT_WORKER_SPLIT.md
+++ b/docs/DOCUMENT_WORKER_SPLIT.md
@@ -25,14 +25,39 @@ Revision history:
 
 ## Status
 
-- **Current**: backend runs document processing inline in the upload request.
-  First real PDF upload OOMKilled at 6 GiB — Docling boots RT-DETR layout +
-  EasyOCR detection/recognition models (770 weights) on top of the resident
-  Whisper + transformers footprint.
-- **Short-term mitigation** (shipped in PR #387): backend memory limit 12 GiB.
-  Works, but still a landmine for scanned multi-hundred-page PDFs.
-- **Long-term plan** (this document): separate worker deployment, backend
-  drops back to ~5 GiB.
+**Shipped 2026-04-19.** The `/api/knowledge/upload` path is now fully async
+— creates a pending Document, enqueues to the Redis Stream, returns 202,
+polling frontend drives it to `completed`. Backend memory limit dropped
+12 GiB → 8 GiB (would be 5 GiB if not for chat_upload, which still runs
+Docling inline — follow-up).
+
+Merged PRs:
+
+- **PR A** (infra) — `4cb5800`: NFS-CSI, shared PVCs, DocumentTaskQueue
+  (Streams), DocumentProgress, worker Deployment, `DOCUMENT_WORKER_ENABLED=false`.
+- **PR B** (refactor) — `cf7ea1e`: RAGService split into
+  `create_document_record` + `process_existing_document` + back-compat
+  `ingest_document` wrapper.
+- **PR C1** (cutover) — `dc46060`: upload endpoint branches on flag,
+  heartbeat gate, batch endpoint, live progress, minimal frontend.
+- **#392** (fix) — `a3c5162`: backend missed the shared PVC mounts at
+  cutover; added them, migrated doc 9 via `kubectl cp`.
+- **PR C2** (polish) — `fe48f24`: polling backoff + Visibility API +
+  localStorage + tab-title + progressbar A11y + 413/415 semantics.
+- **#394** (cleanup) — `65e39b7`: removed legacy inline path,
+  `DOCUMENT_WORKER_ENABLED` config, 12 GiB → 8 GiB.
+- **#395** (follow-up) — `5f702a3`: silent RAG regression
+  (`services.llm_client` → `utils.llm_client`), npm cache NFS race,
+  mail MCP default config.
+- **#396** (race fix) — `fbc9b63`: unique `(file_hash, knowledge_base_id)`
+  constraint + route IntegrityError handler → 409 not 500.
+
+Still open:
+
+- `chat_upload.py` Docling path migration — would drop backend memory to
+  ~5 GiB as originally planned.
+- `renfield-data` Longhorn PVC audit — may be orphaned after the shared
+  NFS mounts took over `/app/data/uploads` and `/app/data/cache-home`.
 
 ## Why a separate deployment
 

--- a/src/frontend/src/components/knowledge/StatusBadge.jsx
+++ b/src/frontend/src/components/knowledge/StatusBadge.jsx
@@ -71,16 +71,20 @@ export default function StatusBadge({ doc, filename }) {
   const progress = hasKnownPageProgress(doc);
 
   // Rate-limit the live-region announcement so a long OCR job doesn't hit
-  // the screen reader with 120 updates in a minute.
+  // the screen reader with 120 updates in a minute. Key the effect on
+  // `sub` only — a language switch changes `label` but shouldn't reset
+  // the rate-limit window (user already heard the equivalent phrase in
+  // the old language).
   const lastAnnouncedAtRef = useRef(0);
   const [announcement, setAnnouncement] = useState('');
   useEffect(() => {
-    const now = Date.now();
     if (!sub) return;
+    const now = Date.now();
     if (now - lastAnnouncedAtRef.current < LIVE_REGION_MIN_GAP_MS) return;
     lastAnnouncedAtRef.current = now;
     setAnnouncement(`${label}: ${sub}`);
-  }, [label, sub]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps — see above
+  }, [sub]);
 
   // Status transitions are always announced (terminal or major change). The
   // stage/page sub-label uses a separate polite region above.
@@ -119,8 +123,12 @@ export default function StatusBadge({ doc, filename }) {
       </div>
       {/* Separate polite-live sub-region for rate-limited stage announcements.
           Visually hidden but read by screen readers. Kept out of the
-          progressbar element so SR doesn't get duplicate readouts. */}
-      <span className="sr-only" aria-live="polite">{announcement}</span>
+          progressbar element so SR doesn't get duplicate readouts. Only
+          rendered when we actually have something to announce — an
+          always-present empty live region is noise in the DOM. */}
+      {announcement && (
+        <span className="sr-only" aria-live="polite">{announcement}</span>
+      )}
     </div>
   );
 }

--- a/src/frontend/src/hooks/useDocumentPolling.js
+++ b/src/frontend/src/hooks/useDocumentPolling.js
@@ -39,6 +39,10 @@ const LS_MAX_ENTRIES = 20;
 const LS_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 h hard cap
 const LS_STALE_TRIM_MS = 10 * 60 * 1000;   // 10 min — trim zombie entries
 
+// SSR / jsdom without document guard. Hoisted so the four call sites
+// inside the scheduling effect don't have to repeat the `typeof` check.
+const HAS_DOCUMENT = typeof document !== 'undefined';
+
 function readLSEntries() {
   try {
     const raw = window.localStorage.getItem(LS_KEY);
@@ -317,7 +321,7 @@ export function useDocumentPolling({
         timerRef.current = null;
       }
       if (Object.keys(activeDocsRef.current).length === 0) return;
-      if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+      if (HAS_DOCUMENT && document.visibilityState === 'hidden') {
         // Don't schedule while hidden; the visibility listener will
         // restart us when the tab comes back.
         return;
@@ -333,7 +337,7 @@ export function useDocumentPolling({
     };
 
     const onVisibilityChange = () => {
-      if (typeof document === 'undefined') return;
+      if (!HAS_DOCUMENT) return;
       if (document.visibilityState === 'visible') {
         // Catch-up poll immediately, then resume the ladder.
         backoffIndexRef.current = 0;
@@ -349,7 +353,7 @@ export function useDocumentPolling({
       }
     };
 
-    if (typeof document !== 'undefined') {
+    if (HAS_DOCUMENT) {
       document.addEventListener('visibilitychange', onVisibilityChange);
     }
 
@@ -360,7 +364,7 @@ export function useDocumentPolling({
 
     return () => {
       cancelled = true;
-      if (typeof document !== 'undefined') {
+      if (HAS_DOCUMENT) {
         document.removeEventListener('visibilitychange', onVisibilityChange);
       }
       if (timerRef.current) {


### PR DESCRIPTION
## Summary

Three non-blocking items from C2 + cleanup reviewers.

1. \`docs/DOCUMENT_WORKER_SPLIT.md\` status was still "Planning". Rewrote to reflect shipped state with PR references and remaining open items.
2. \`useDocumentPolling.js\`: four duplicated \`typeof document !== 'undefined'\` guards → single module-level \`HAS_DOCUMENT\` const.
3. \`StatusBadge.jsx\`:
   - Don't render the sr-only live-region span when announcement is empty.
   - Rate-limit effect dep was \`[label, sub]\` — language switch reset the 10 s window and spammed screen readers with the translated phrase. Narrowed to \`[sub]\`.

All 51 hook + component tests still pass.

## Test plan
- [x] Frontend tests green locally
- [ ] CI green