### PR TITLE
chore(k8s): remove orphaned renfield-data PVC (#388)

### DIFF
--- a/docs/KUBERNETES_DEPLOYMENT.md
+++ b/docs/KUBERNETES_DEPLOYMENT.md
@@ -267,6 +267,16 @@ kubectl -n renfield create configmap renfield-mcp-config \
 kubectl -n renfield rollout restart deploy/backend
 ```
 
+When retiring a PVC that's attached to a running Deployment (e.g. the
+`renfield-data` removal post-#388), roll the Deployment first so the
+PVC becomes unbound, then delete it:
+
+```bash
+kubectl apply -k k8s/                         # manifest no longer mounts it
+kubectl -n renfield rollout status deploy/backend
+kubectl -n renfield delete pvc renfield-data  # now unbound
+```
+
 Ollama model pulls: drop the model into the NFS share at `192.168.1.9:/mnt/data/llm/.ollama/` and it becomes visible to both Ollama pods; the `ollama-model-prepull` Job can also be re-applied to pull a specific list.
 
 ## Not Yet Included

--- a/k8s/backend.yaml
+++ b/k8s/backend.yaml
@@ -14,22 +14,6 @@ spec:
       targetPort: 8000
 
 ---
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: renfield-data
-  namespace: renfield
-  labels:
-    app.kubernetes.io/name: backend
-    app.kubernetes.io/part-of: renfield
-spec:
-  accessModes: [ReadWriteOnce]
-  storageClassName: longhorn
-  resources:
-    requests:
-      storage: 10Gi
-
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -80,8 +64,6 @@ spec:
             limits:
               memory: 64Mi
           volumeMounts:
-            - name: data
-              mountPath: /app/data
             - name: cache-home
               mountPath: /app/data/cache-home
       containers:
@@ -164,8 +146,6 @@ spec:
                   name: renfield-secrets
                   key: mail-regfish-password
           volumeMounts:
-            - name: data
-              mountPath: /app/data
             # Shared with the document-worker pod (#388 cutover). The API
             # writes the uploaded file here, the worker reads it from the
             # same NFS-backed PVC. Must be mounted at the same path on
@@ -238,9 +218,6 @@ spec:
               # note referred to serving-path Docling — that's gone.
               memory: 8Gi
       volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: renfield-data
         # RWX NFS PVCs shared with document-worker — see k8s/shared-pvcs.yaml.
         - name: uploads
           persistentVolumeClaim:


### PR DESCRIPTION
## Summary

Post-cutover audit follow-up from PR #392 retro-review. The \`renfield-data\` Longhorn PVC at \`/app/data\` is unused — all actual writes land on overlaid subpaths (\`/app/data/uploads\` on NFS, \`/app/data/cache-home\` on NFS, \`/app/data/cache-home/.npm\` on emptyDir).

Evidence:
\`\`\`
$ kubectl exec backend -- find /app/data -not -path '*/uploads*' -not -path '*/cache-home*'
/app/data
/app/data/lost+found   # Longhorn ext4 default, empty
\`\`\`
\`\`\`
$ grep -r '/app/data' src/
src/backend/utils/config.py:218:    upload_dir: str = "/app/data/uploads"  # (NFS overlay)
\`\`\`

## Changes

- Drop \`PersistentVolumeClaim/renfield-data\` from \`k8s/backend.yaml\`.
- Drop \`data\` volume + mounts from main container and init container. Init's \`mkdir -p /app/data/cache-home/.cache\` writes to the cache-home overlay, so no behaviour change.
- Docs: add PVC-retirement procedure (roll first, then delete once unbound) to the Updating section.

## Test plan
- [ ] \`kubectl apply -k k8s/\` rolls backend cleanly, new pod doesn't attach renfield-data
- [ ] \`kubectl -n renfield delete pvc renfield-data\` succeeds (unbound)
- [ ] Smoke upload still works: 202 → completed
- [ ] No pod log errors on missing \`/app/data\` writes

Frees 10Gi of Longhorn storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)