### PR TITLE
feat(mcp): F1.3 — streaming wire for opt-in servers

### DIFF
--- a/src/backend/services/mcp_client.py
+++ b/src/backend/services/mcp_client.py
@@ -624,6 +624,11 @@ class MCPServerConfig:
     permissions: list[str] = field(default_factory=list)  # e.g. ["mcp.calendar.read", "mcp.calendar.manage"]
     tool_permissions: dict[str, str] = field(default_factory=dict)  # e.g. {"list_events": "mcp.calendar.read"}
     notifications: dict | None = None  # {"enabled": true, "poll_interval": 900, "tool": "get_pending_notifications"}
+    streaming: bool = False  # Opt-in: server emits progress notifications via MCP progress_callback.
+                              # When true, execute_tool_streaming wires an asyncio.Queue to capture
+                              # notifications and yield ProgressChunks. First consumer: federation
+                              # query_brain (F3). Non-streaming servers ignore this flag — the
+                              # progress queue stays empty and only the final result is yielded.
 
 
 @dataclass
@@ -782,6 +787,7 @@ class MCPManager:
                     permissions=entry.get("permissions", []),
                     tool_permissions=entry.get("tool_permissions", {}),
                     notifications=_parse_notifications(entry.get("notifications")),
+                    streaming=bool(_resolve_value(entry.get("streaming", False))),
                 )
 
                 if not config.enabled:
@@ -1254,21 +1260,201 @@ class MCPManager:
         Cancellation:
             If the consumer aborts the iterator (`break`, `aclose()`,
             GC) AFTER the first `__anext__()` but before the final yield,
-            the underlying tool call is allowed to complete in the
-            background but its result is discarded. If `aclose()` is
+            the underlying tool call is cancelled. If `aclose()` is
             called BEFORE the first `__anext__()`, the underlying tool
             is never invoked — creating the generator does not start
             work, the first `__anext__()` does.
         """
-        # F1.2: thin wrapper. F1.3 will detect streaming-capable tools and
-        # yield real ProgressChunks before the final dict.
-        result = await self.execute_tool(
+        # Resolve the server first so we can branch on the streaming flag.
+        # Tool lookup happens inside execute_tool anyway, so for the
+        # non-streaming path we just wrap that single call. For the
+        # streaming path we need to duplicate the lookup because we want
+        # the state object to check `config.streaming` on.
+        tool_info = self._tool_index.get(namespaced_name)
+        state = None
+        if tool_info is not None:
+            state = self._servers.get(tool_info.server_name)
+
+        # Non-streaming path: yield once, same shape as execute_tool.
+        if state is None or not state.config.streaming:
+            result = await self.execute_tool(
+                namespaced_name=namespaced_name,
+                arguments=arguments,
+                user_permissions=user_permissions,
+                user_id=user_id,
+            )
+            yield result
+            return
+
+        # Streaming path — progress_callback → asyncio.Queue → consumer.
+        # Shares the prep machinery (perm/rate/validation/timeout/format)
+        # with execute_tool via the code below; kept inline rather than in
+        # a helper because the streaming concurrency shape is distinct
+        # enough that extracting it obscures more than it saves.
+        async for item in self._execute_tool_streaming_impl(
+            tool_info=tool_info,
+            state=state,
             namespaced_name=namespaced_name,
             arguments=arguments,
             user_permissions=user_permissions,
             user_id=user_id,
+        ):
+            yield item
+
+    async def _execute_tool_streaming_impl(
+        self,
+        tool_info: "MCPToolInfo",
+        state: "MCPServerState",
+        namespaced_name: str,
+        arguments: dict,
+        user_permissions: list[str] | None,
+        user_id: int | None,
+    ) -> AsyncIterator[ProgressChunk | FinalResult]:
+        """Streaming-path implementation for F1.3.
+
+        Runs the tool call in a background task with an asyncio.Queue-backed
+        progress_callback. Yields ProgressChunks as they arrive, then the
+        final FinalResult dict (same shape execute_tool returns).
+        """
+        from services.mcp_streaming import (
+            PROGRESS_LABEL_FAILED,
+            PROGRESS_LABEL_TOOL_RUNNING,
+            PROGRESS_LABELS,
         )
-        yield result
+
+        # === Permission check ===
+        perm_error = self._check_tool_permission(tool_info, user_permissions)
+        if perm_error:
+            logger.warning(f"🔒 MCP permission denied: {namespaced_name} — {perm_error}")
+            yield {"success": False, "message": perm_error, "data": None}
+            return
+
+        if not state.connected or not state.session:
+            yield {
+                "success": False,
+                "message": f"MCP Server '{tool_info.server_name}' nicht verbunden",
+                "data": None,
+            }
+            return
+
+        # === Rate limiting ===
+        if state.rate_limiter and not await state.rate_limiter.acquire():
+            logger.warning(f"MCP rate limit exceeded for server '{tool_info.server_name}'")
+            yield {
+                "success": False,
+                "message": f"Rate limit exceeded for MCP server '{tool_info.server_name}'",
+                "data": None,
+            }
+            return
+
+        # === Argument coercion + validation ===
+        arguments = _coerce_arguments(arguments, tool_info.input_schema)
+        arguments = await _geocode_location_arguments(arguments, tool_info.input_schema)
+        try:
+            _validate_tool_input(arguments, tool_info.input_schema)
+        except MCPValidationError as e:
+            logger.warning(f"MCP input validation failed for {namespaced_name}: {e}")
+            yield {"success": False, "message": str(e), "data": None}
+            return
+
+        # === Set up progress queue + callback ===
+        progress_queue: asyncio.Queue = asyncio.Queue()
+        sequence_counter = 0
+
+        async def progress_cb(progress: float, total: float | None, message: str | None) -> None:
+            """MCP SDK passes (progress, total, message). `message` carries the
+            progress label; we validate it against PROGRESS_LABELS and fall
+            back to TOOL_RUNNING for unknown labels (defence against a
+            misbehaving or malicious responder emitting arbitrary strings)."""
+            nonlocal sequence_counter
+            sequence_counter += 1
+            label = message if message in PROGRESS_LABELS else PROGRESS_LABEL_TOOL_RUNNING
+            detail: dict[str, Any] = {"progress": float(progress)}
+            if total is not None:
+                detail["total"] = float(total)
+            await progress_queue.put(ProgressChunk(
+                label=label, detail=detail, sequence=sequence_counter,
+            ))
+
+        # === Run the tool call as a background task ===
+        try:
+            call_coro = state.session.call_tool(
+                tool_info.original_name, arguments, progress_callback=progress_cb,
+            )
+        except TypeError:
+            # Older MCP SDK without progress_callback kwarg — degrade gracefully.
+            logger.debug(
+                f"MCP SDK call_tool has no progress_callback kwarg; "
+                f"{namespaced_name} runs without streaming."
+            )
+            call_coro = state.session.call_tool(tool_info.original_name, arguments)
+
+        user_info = f" (user_id={user_id})" if user_id is not None else ""
+        logger.debug(f"MCP streaming call: {namespaced_name}{user_info}")
+
+        call_task = asyncio.create_task(
+            asyncio.wait_for(call_coro, timeout=settings.mcp_call_timeout)
+        )
+
+        # === Drain progress chunks while task runs ===
+        try:
+            while not call_task.done():
+                try:
+                    chunk = await asyncio.wait_for(progress_queue.get(), timeout=0.05)
+                    yield chunk
+                except TimeoutError:
+                    continue
+            # Flush anything that arrived after the last poll.
+            while not progress_queue.empty():
+                yield progress_queue.get_nowait()
+        except (asyncio.CancelledError, GeneratorExit):
+            # Consumer closed the generator — cancel the tool call.
+            call_task.cancel()
+            raise
+
+        # === Yield the final result (same format as execute_tool) ===
+        try:
+            result = await call_task
+        except TimeoutError:
+            logger.error(f"MCP tool call timeout: {namespaced_name}")
+            yield {
+                "success": False,
+                "message": f"Tool-Aufruf Timeout: {namespaced_name}",
+                "data": None,
+            }
+            return
+        except Exception as e:
+            logger.error(f"MCP tool call failed: {namespaced_name}: {e}")
+            state.connected = False
+            state.last_error = str(e)
+            yield {
+                "success": False,
+                "message": f"Tool-Aufruf fehlgeschlagen: {e}",
+                "data": None,
+            }
+            return
+
+        # Convert CallToolResult → FinalResult dict (same logic as execute_tool).
+        is_error = getattr(result, "isError", False)
+        content_parts = []
+        raw_data = []
+        for item in result.content:
+            text = getattr(item, "text", None)
+            if text:
+                content_parts.append(_truncate_response(text))
+            raw_data.append({"type": getattr(item, "type", "unknown"), "text": text})
+
+        message_text = "\n".join(content_parts) if content_parts else "Tool executed"
+        message_text = _truncate_response(message_text)
+
+        if not is_error:
+            is_error = _detect_inner_error(message_text)
+
+        yield {
+            "success": not is_error,
+            "message": message_text,
+            "data": raw_data if raw_data else None,
+        }
 
     def get_all_tools(self) -> list[MCPToolInfo]:
         """Return all discovered MCP tools."""

--- a/src/backend/services/mcp_client.py
+++ b/src/backend/services/mcp_client.py
@@ -19,7 +19,7 @@ import random
 import re
 import time
 from collections.abc import AsyncIterator
-from contextlib import AsyncExitStack
+from contextlib import AsyncExitStack, suppress
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -1317,7 +1317,6 @@ class MCPManager:
         final FinalResult dict (same shape execute_tool returns).
         """
         from services.mcp_streaming import (
-            PROGRESS_LABEL_FAILED,
             PROGRESS_LABEL_TOOL_RUNNING,
             PROGRESS_LABELS,
         )
@@ -1381,8 +1380,14 @@ class MCPManager:
             call_coro = state.session.call_tool(
                 tool_info.original_name, arguments, progress_callback=progress_cb,
             )
-        except TypeError:
-            # Older MCP SDK without progress_callback kwarg — degrade gracefully.
+        except TypeError as e:
+            # Narrow catch: only swallow the "unexpected keyword argument
+            # 'progress_callback'" case (pre-ProgressFnT MCP SDK). Any other
+            # TypeError (bad arguments type, missing positional, ...) must
+            # bubble up as a FinalResult error so the consumer sees a real
+            # diagnostic instead of a silent retry that re-raises.
+            if "progress_callback" not in str(e):
+                raise
             logger.debug(
                 f"MCP SDK call_tool has no progress_callback kwarg; "
                 f"{namespaced_name} runs without streaming."
@@ -1408,8 +1413,13 @@ class MCPManager:
             while not progress_queue.empty():
                 yield progress_queue.get_nowait()
         except (asyncio.CancelledError, GeneratorExit):
-            # Consumer closed the generator — cancel the tool call.
+            # Consumer closed the generator — cancel the tool call AND await
+            # it (via suppress) so the task-destroyed-but-pending warning
+            # doesn't fire and any transport-level cleanup runs before we
+            # re-raise.
             call_task.cancel()
+            with suppress(BaseException):
+                await call_task
             raise
 
         # === Yield the final result (same format as execute_tool) ===

--- a/tests/backend/test_mcp_streaming.py
+++ b/tests/backend/test_mcp_streaming.py
@@ -2,17 +2,25 @@
 Tests for the MCP streaming surface (services/mcp_streaming.py types +
 MCPManager.execute_tool_streaming).
 
-Lane F1 of the second-brain-circles federation plan. F1 ships the surface
-+ types + non-streaming default yield-once behavior. F1.3 (follow-up)
-adds the streaming wire for streamable_http transports.
+Lane F1 of the second-brain-circles federation plan.
+- F1.1/F1.2 ship types + yield-once default.
+- F1.3 adds the streaming wire for servers flagged `streaming: true`.
 """
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from services.mcp_client import MCPManager
+from services.mcp_client import (
+    MCPManager,
+    MCPServerConfig,
+    MCPServerState,
+    MCPToolInfo,
+    MCPTransportType,
+)
 from services.mcp_streaming import (
     FEDERATION_PROGRESS_LABELS,
     PROGRESS_LABEL_COMPLETE,
@@ -180,3 +188,199 @@ class TestExecuteToolStreamingYieldOnce:
         # Equality (not identity) — lets future wrappers add envelope
         # metadata (trace_id, timing) without breaking this regression guard.
         assert chunks[0] == full_shape
+
+
+# =============================================================================
+# F1.3 — actual streaming wire (servers flagged `streaming: true`)
+# =============================================================================
+
+
+def _streaming_manager(session_call_tool):
+    """Build an MCPManager with one streaming-capable mock server + tool.
+
+    `session_call_tool` is the coroutine function used as session.call_tool —
+    it receives (name, arguments, progress_callback=...) and returns the
+    CallToolResult mock.
+    """
+    manager = MCPManager()
+
+    # Fake server state
+    config = MCPServerConfig(
+        name="peer1",
+        url="http://peer1.local/mcp",
+        transport=MCPTransportType.STREAMABLE_HTTP,
+        streaming=True,
+    )
+    session = MagicMock()
+    session.call_tool = session_call_tool
+    state = MCPServerState(config=config)
+    state.session = session
+    state.connected = True
+    manager._servers["peer1"] = state
+
+    # Register a tool on it
+    tool = MCPToolInfo(
+        server_name="peer1",
+        original_name="query_brain",
+        namespaced_name="mcp.peer1.query_brain",
+        description="federated peer query",
+        input_schema={"type": "object", "properties": {}},
+    )
+    manager._tool_index["mcp.peer1.query_brain"] = tool
+    return manager
+
+
+class TestExecuteToolStreamingWire:
+    """F1.3 — real streaming path (server opts in via streaming: true)."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_streaming_yields_progress_chunks_then_final(self):
+        """The progress_callback is exposed via MCP SDK call_tool kwarg.
+        Invoking it N times should produce N ProgressChunks before the
+        final dict."""
+        async def fake_call_tool(name, arguments, progress_callback=None, **kwargs):
+            # Simulate a responder emitting three progress notifications.
+            if progress_callback:
+                await progress_callback(0.1, 1.0, PROGRESS_LABEL_WAKING_UP)
+                await progress_callback(0.5, 1.0, PROGRESS_LABEL_RETRIEVING)
+                await progress_callback(0.9, 1.0, PROGRESS_LABEL_SYNTHESIZING)
+            # Final CallToolResult shape
+            return SimpleNamespace(
+                isError=False,
+                content=[SimpleNamespace(type="text", text="Mom's favorite recipe is pasta.")],
+            )
+
+        manager = _streaming_manager(fake_call_tool)
+
+        items = [item async for item in manager.execute_tool_streaming(
+            "mcp.peer1.query_brain", {}, user_permissions=None,
+        )]
+
+        progress = [i for i in items if isinstance(i, ProgressChunk)]
+        finals = [i for i in items if not isinstance(i, ProgressChunk)]
+        assert len(progress) == 3
+        assert [p.label for p in progress] == [
+            PROGRESS_LABEL_WAKING_UP,
+            PROGRESS_LABEL_RETRIEVING,
+            PROGRESS_LABEL_SYNTHESIZING,
+        ]
+        assert [p.sequence for p in progress] == [1, 2, 3]
+        # Sequence is monotonic, starting at 1.
+        assert len(finals) == 1
+        assert finals[0]["success"] is True
+        assert "pasta" in finals[0]["message"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_unknown_progress_label_falls_back_to_tool_running(self):
+        """A misbehaving responder emitting a label not in PROGRESS_LABELS
+        must not crash the asker. The callback maps unknown labels to
+        PROGRESS_LABEL_TOOL_RUNNING."""
+        async def fake_call_tool(name, arguments, progress_callback=None, **kwargs):
+            if progress_callback:
+                await progress_callback(0.5, 1.0, "peer_has_47_atoms")  # leak attempt
+            return SimpleNamespace(isError=False, content=[])
+
+        manager = _streaming_manager(fake_call_tool)
+        items = [item async for item in manager.execute_tool_streaming(
+            "mcp.peer1.query_brain", {},
+        )]
+
+        progress = [i for i in items if isinstance(i, ProgressChunk)]
+        assert len(progress) == 1
+        assert progress[0].label == PROGRESS_LABEL_TOOL_RUNNING
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_zero_progress_notifications_still_yields_final(self):
+        """A streaming-capable server that never emits progress should still
+        produce a FinalResult — streaming path handles silent tools too."""
+        async def fake_call_tool(name, arguments, progress_callback=None, **kwargs):
+            return SimpleNamespace(isError=False, content=[SimpleNamespace(type="text", text="ok")])
+
+        manager = _streaming_manager(fake_call_tool)
+        items = [item async for item in manager.execute_tool_streaming(
+            "mcp.peer1.query_brain", {},
+        )]
+
+        assert len(items) == 1
+        assert items[0]["success"] is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_call_tool_without_progress_callback_kwarg_falls_back(self):
+        """Older MCP SDK versions don't accept progress_callback. The
+        streaming path must retry without the kwarg instead of crashing."""
+        call_count = 0
+
+        async def fake_call_tool(name, arguments, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if "progress_callback" in kwargs:
+                # Simulate older SDK: reject the kwarg
+                raise TypeError("call_tool() got unexpected keyword argument 'progress_callback'")
+            return SimpleNamespace(isError=False, content=[SimpleNamespace(type="text", text="legacy ok")])
+
+        # The SDK raises TypeError at call_tool() invocation. To simulate
+        # that accurately with the eager vs lazy split in our wrapper, we
+        # use a callable whose first call raises.
+        outer_calls = []
+
+        def eager_call_tool(name, arguments, progress_callback=None):
+            outer_calls.append(progress_callback)
+            if progress_callback is not None:
+                raise TypeError("unexpected kwarg progress_callback")
+            # Return a coroutine that yields the mock result
+            async def _run():
+                return SimpleNamespace(
+                    isError=False, content=[SimpleNamespace(type="text", text="legacy ok")],
+                )
+            return _run()
+
+        manager = _streaming_manager(eager_call_tool)
+        items = [item async for item in manager.execute_tool_streaming(
+            "mcp.peer1.query_brain", {},
+        )]
+        assert len(items) == 1
+        assert items[0]["success"] is True
+        assert items[0]["message"] == "legacy ok"
+        # First attempt used progress_callback, fallback without it succeeded.
+        assert len(outer_calls) == 2
+        assert outer_calls[0] is not None  # first try
+        assert outer_calls[1] is None      # fallback
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_non_streaming_server_uses_yield_once_path(self):
+        """Servers without `streaming: true` take the existing execute_tool
+        wrapper path — no progress callback is wired, no chunks emitted."""
+        manager = MCPManager()
+        config = MCPServerConfig(name="plain", streaming=False)
+        state = MCPServerState(config=config)
+        state.session = MagicMock()
+        state.connected = True
+        manager._servers["plain"] = state
+        manager._tool_index["mcp.plain.t"] = MCPToolInfo(
+            server_name="plain", original_name="t", namespaced_name="mcp.plain.t",
+            description="", input_schema={},
+        )
+
+        sentinel = {"success": True, "message": "fast path", "data": None}
+        with patch.object(manager, "execute_tool", new=AsyncMock(return_value=sentinel)) as mock:
+            items = [i async for i in manager.execute_tool_streaming("mcp.plain.t", {})]
+
+        mock.assert_awaited_once()
+        assert items == [sentinel]
+
+
+class TestMCPServerConfigStreaming:
+    @pytest.mark.unit
+    def test_default_is_false(self):
+        config = MCPServerConfig(name="x")
+        assert config.streaming is False
+
+    @pytest.mark.unit
+    def test_explicit_true(self):
+        config = MCPServerConfig(name="x", streaming=True)
+        assert config.streaming is True

--- a/tests/backend/test_mcp_streaming.py
+++ b/tests/backend/test_mcp_streaming.py
@@ -352,6 +352,22 @@ class TestExecuteToolStreamingWire:
 
     @pytest.mark.asyncio
     @pytest.mark.unit
+    async def test_unrelated_typeerror_is_not_swallowed(self):
+        """Narrow catch: only the 'unexpected keyword progress_callback'
+        TypeError triggers the fallback. Other TypeErrors (e.g. bad
+        arguments type) must propagate instead of silently retrying."""
+        def bad_call_tool(name, arguments, progress_callback=None):
+            # Simulates a genuinely broken call (e.g. arguments type mismatch)
+            # that happens to raise TypeError without mentioning progress_callback.
+            raise TypeError("arguments must be a dict, got list")
+
+        manager = _streaming_manager(bad_call_tool)
+        with pytest.raises(TypeError, match="must be a dict"):
+            async for _ in manager.execute_tool_streaming("mcp.peer1.query_brain", []):
+                pass
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
     async def test_non_streaming_server_uses_yield_once_path(self):
         """Servers without `streaming: true` take the existing execute_tool
         wrapper path — no progress callback is wired, no chunks emitted."""


### PR DESCRIPTION
## Summary

Lane F1.3 of v2 federation. Wires the actual **progress_callback → asyncio.Queue → yield** path for MCP servers that opt in with `streaming: true`. Federation `query_brain` (F3) will be the first consumer.

**Zero behavior change for the existing fleet.** Every current MCP server (weather, search, news, jellyfin, etc.) has `streaming: false` (default), so `execute_tool_streaming` falls through to the F1.2 yield-once wrapper for them.

## Implementation

- **`MCPServerConfig.streaming: bool = False`** — new field; YAML parser reads `streaming: true` per server entry.
- **`execute_tool_streaming` branches** on `state.config.streaming`. Non-streaming → F1.2 wrapper (unchanged). Streaming → `_execute_tool_streaming_impl`.
- **`_execute_tool_streaming_impl`** runs `session.call_tool(..., progress_callback=cb)` in a background task and drains a local `asyncio.Queue` of ProgressChunks while the task runs.
- **Side-channel defence in depth:** the queue callback maps unknown progress labels to `PROGRESS_LABEL_TOOL_RUNNING`. A misbehaving peer cannot leak arbitrary strings to the asker's UI, on top of the `PROGRESS_LABELS` type-layer check.
- **Older-SDK fallback:** if `call_tool()` raises `TypeError` on the `progress_callback=` kwarg, retry without it. Some Renfield deployments may be running pre-`ProgressFnT` MCP SDK.
- **Consumer-close cancels the background task** via `except (CancelledError, GeneratorExit)`.

## Tests

| Case | Assertion |
|---|---|
| 3 progress notifications + result | 3 ProgressChunks (monotonic sequence 1/2/3, correct labels) + 1 FinalResult |
| Unknown label | Falls through to `tool_running` (side-channel defence) |
| Zero notifications on streaming server | Yields exactly one FinalResult |
| Older SDK without `progress_callback` kwarg | TypeError fallback triggers; call count = 2 |
| Non-streaming server | Uses F1.2 wrapper path (unchanged) |
| `MCPServerConfig.streaming` | Default False, explicit True |

## What this unblocks

F3 (federation `query_brain`) can now write:

```python
async for chunk in manager.execute_tool_streaming("mcp.mom.query_brain", args):
    if isinstance(chunk, ProgressChunk):
        await ws.send_json({"type": "federation_progress", "label": chunk.label})
    else:
        return chunk  # FinalResult
```

…and the frontend chat gets `"asking Mom's brain... retrieving... synthesizing..."` live.

## Test plan

- [ ] `make test-backend tests/backend/test_mcp_streaming.py` — expect all (~15) green
- [ ] Existing MCP servers still work (none flag `streaming: true`, so they take the wrapper path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)