### PR TITLE
feat(agent): expose token_budget_info and token_usage_info ContextVars for plugins

### DIFF
--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -13,6 +13,7 @@ import json
 import re
 import time
 from collections.abc import AsyncGenerator
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -29,6 +30,36 @@ if TYPE_CHECKING:
     from services.action_executor import ActionExecutor
     from services.agent_router import AgentRole
     from services.ollama_service import OllamaService
+
+
+# --- Plugin-observable ContextVars ------------------------------------------
+# Populated during AgentService.run(); consumed by plugins to read real
+# per-request state after the agent loop completes. Reset to None at the start
+# of each run so values never leak between requests.
+#
+# token_budget_info: {"utilization": float, "truncated": bool, "passes": list[str]}
+#   utilization  — fraction of context window used on the most recent
+#                  _enforce_token_budget call in the current run
+#   truncated    — whether that most recent call triggered at least one
+#                  reduction pass
+#   passes       — names of reduction passes that ran during that most recent
+#                  call (for debugging)
+#
+#   IMPORTANT — "last call wins" semantics: _enforce_token_budget runs once
+#   per agent step, and each invocation overwrites this ContextVar. If step 1
+#   truncated aggressively but step 3 stayed under threshold, plugins reading
+#   after run() returns see truncated=False (the step-3 state). Plugins that
+#   need cross-step aggregation must subscribe to the record_budget_reduction
+#   counter instead, which accumulates across the entire run.
+#   A future per-step list shape is tracked as tech debt upstream.
+#
+# token_usage_info: {"input_tokens": int, "output_tokens": int, "total_tokens": int}
+#   Real per-request totals from AgentContext.get_token_usage(), aggregated
+#   across all LLM calls in the run (budget enforcement, agent steps, summary).
+#   Unlike token_budget_info, these counts are cumulative over the whole run.
+
+token_budget_info: ContextVar[dict | None] = ContextVar("token_budget_info", default=None)
+token_usage_info: ContextVar[dict | None] = ContextVar("token_usage_info", default=None)
 
 
 def _compress_history_message(content: str, max_chars: int = 500) -> str:
@@ -657,82 +688,103 @@ class AgentService:
 
         prompt_tokens = token_counter.count(prompt)
         utilization = (prompt_tokens + reserved) / max_tokens
+        passes_run: list[str] = []
 
-        if utilization <= threshold:
-            return prompt, memory_context, document_context, conversation_history
-
-        logger.warning(
-            f"Token budget over threshold: {utilization:.0%} "
-            f"({prompt_tokens} tokens + {reserved} reserved / {max_tokens} max)"
-        )
-        from utils.metrics import record_budget_reduction
-
-        # Pass 0: Adaptive tool result budgeting via _serialize_for_prompt
-        tool_result_steps = [
-            s for s in context.steps if s.step_type == "tool_result" and (s.data is not None or s.content)
-        ]
-        if tool_result_steps:
-            context.tool_result_budget_chars = 1  # minimal — just get the skeleton
-            prompt = await self._build_agent_prompt(
-                message, context, conversation_history,
-                memory_context=memory_context, document_context=document_context,
-                lang=lang, **build_kwargs,
-            )
-            skeleton_tokens = token_counter.count(prompt)
-            token_headroom = max(0, int(max_tokens * threshold) - reserved - skeleton_tokens)
-            total_chars_budget = int(token_headroom * 3.5)
-            n_results = len(tool_result_steps)
-            per_result_chars = max(200, total_chars_budget // max(1, n_results))
-            context.tool_result_budget_chars = per_result_chars
-            prompt = await self._build_agent_prompt(
-                message, context, conversation_history,
-                memory_context=memory_context, document_context=document_context,
-                lang=lang, **build_kwargs,
-            )
-            prompt_tokens = token_counter.count(prompt)
-            utilization = (prompt_tokens + reserved) / max_tokens
-            record_budget_reduction("adaptive_tool_budget")
-            logger.info(
-                f"Budget pass 0 (adaptive tool budget): {utilization:.0%} "
-                f"({per_result_chars} chars/result x {n_results} results)"
-            )
-            if utilization <= threshold:
-                return prompt, memory_context, document_context, conversation_history
-        context.tool_result_budget_chars = 0  # reset for fallback passes
-
-        # Pass 1: Halve conversation history
-        if conversation_history and len(conversation_history) > 3:
-            conversation_history = conversation_history[-3:]
-            prompt = await self._build_agent_prompt(
-                message, context, conversation_history,
-                memory_context=memory_context,
-                document_context=document_context,
-                lang=lang, **build_kwargs,
-            )
-            prompt_tokens = token_counter.count(prompt)
-            utilization = (prompt_tokens + reserved) / max_tokens
-            record_budget_reduction("halve_history")
-            logger.info(f"Budget pass 1 (halve history): {utilization:.0%}")
+        try:
             if utilization <= threshold:
                 return prompt, memory_context, document_context, conversation_history
 
-        # Pass 2: Drop memory context
-        if memory_context:
-            prompt = await self._build_agent_prompt(
-                message, context, conversation_history,
-                memory_context="",
-                document_context=document_context,
-                lang=lang, **build_kwargs,
+            logger.warning(
+                f"Token budget over threshold: {utilization:.0%} "
+                f"({prompt_tokens} tokens + {reserved} reserved / {max_tokens} max)"
             )
-            prompt_tokens = token_counter.count(prompt)
-            utilization = (prompt_tokens + reserved) / max_tokens
-            record_budget_reduction("drop_memory")
-            logger.info(f"Budget pass 2 (drop memory): {utilization:.0%}")
-            if utilization <= threshold:
-                return prompt, "", document_context, conversation_history
+            from utils.metrics import record_budget_reduction
 
-        # Pass 3: Drop document context
-        if document_context:
+            # Pass 0: Adaptive tool result budgeting via _serialize_for_prompt
+            tool_result_steps = [
+                s for s in context.steps if s.step_type == "tool_result" and (s.data is not None or s.content)
+            ]
+            if tool_result_steps:
+                context.tool_result_budget_chars = 1  # minimal — just get the skeleton
+                prompt = await self._build_agent_prompt(
+                    message, context, conversation_history,
+                    memory_context=memory_context, document_context=document_context,
+                    lang=lang, **build_kwargs,
+                )
+                skeleton_tokens = token_counter.count(prompt)
+                token_headroom = max(0, int(max_tokens * threshold) - reserved - skeleton_tokens)
+                total_chars_budget = int(token_headroom * 3.5)
+                n_results = len(tool_result_steps)
+                per_result_chars = max(200, total_chars_budget // max(1, n_results))
+                context.tool_result_budget_chars = per_result_chars
+                prompt = await self._build_agent_prompt(
+                    message, context, conversation_history,
+                    memory_context=memory_context, document_context=document_context,
+                    lang=lang, **build_kwargs,
+                )
+                prompt_tokens = token_counter.count(prompt)
+                utilization = (prompt_tokens + reserved) / max_tokens
+                record_budget_reduction("adaptive_tool_budget")
+                passes_run.append("adaptive_tool_budget")
+                logger.info(
+                    f"Budget pass 0 (adaptive tool budget): {utilization:.0%} "
+                    f"({per_result_chars} chars/result x {n_results} results)"
+                )
+                if utilization <= threshold:
+                    return prompt, memory_context, document_context, conversation_history
+            context.tool_result_budget_chars = 0  # reset for fallback passes
+
+            # Pass 1: Halve conversation history
+            if conversation_history and len(conversation_history) > 3:
+                conversation_history = conversation_history[-3:]
+                prompt = await self._build_agent_prompt(
+                    message, context, conversation_history,
+                    memory_context=memory_context,
+                    document_context=document_context,
+                    lang=lang, **build_kwargs,
+                )
+                prompt_tokens = token_counter.count(prompt)
+                utilization = (prompt_tokens + reserved) / max_tokens
+                record_budget_reduction("halve_history")
+                passes_run.append("halve_history")
+                logger.info(f"Budget pass 1 (halve history): {utilization:.0%}")
+                if utilization <= threshold:
+                    return prompt, memory_context, document_context, conversation_history
+
+            # Pass 2: Drop memory context
+            if memory_context:
+                prompt = await self._build_agent_prompt(
+                    message, context, conversation_history,
+                    memory_context="",
+                    document_context=document_context,
+                    lang=lang, **build_kwargs,
+                )
+                prompt_tokens = token_counter.count(prompt)
+                utilization = (prompt_tokens + reserved) / max_tokens
+                record_budget_reduction("drop_memory")
+                passes_run.append("drop_memory")
+                logger.info(f"Budget pass 2 (drop memory): {utilization:.0%}")
+                if utilization <= threshold:
+                    return prompt, "", document_context, conversation_history
+
+            # Pass 3: Drop document context
+            if document_context:
+                prompt = await self._build_agent_prompt(
+                    message, context, conversation_history,
+                    memory_context="",
+                    document_context="",
+                    lang=lang, **build_kwargs,
+                )
+                prompt_tokens = token_counter.count(prompt)
+                utilization = (prompt_tokens + reserved) / max_tokens
+                record_budget_reduction("drop_documents")
+                passes_run.append("drop_documents")
+                logger.info(f"Budget pass 3 (drop documents): {utilization:.0%}")
+                if utilization <= threshold:
+                    return prompt, "", "", conversation_history
+
+            # Pass 4: Truncate history results
+            context.truncate_history_results(max_chars=500)
             prompt = await self._build_agent_prompt(
                 message, context, conversation_history,
                 memory_context="",
@@ -741,24 +793,19 @@ class AgentService:
             )
             prompt_tokens = token_counter.count(prompt)
             utilization = (prompt_tokens + reserved) / max_tokens
-            record_budget_reduction("drop_documents")
-            logger.info(f"Budget pass 3 (drop documents): {utilization:.0%}")
-            if utilization <= threshold:
-                return prompt, "", "", conversation_history
-
-        # Pass 4: Truncate history results
-        context.truncate_history_results(max_chars=500)
-        prompt = await self._build_agent_prompt(
-            message, context, conversation_history,
-            memory_context="",
-            document_context="",
-            lang=lang, **build_kwargs,
-        )
-        prompt_tokens = token_counter.count(prompt)
-        utilization = (prompt_tokens + reserved) / max_tokens
-        record_budget_reduction("truncate_results")
-        logger.info(f"Budget pass 4 (truncate results): {utilization:.0%}")
-        return prompt, "", "", conversation_history
+            record_budget_reduction("truncate_results")
+            passes_run.append("truncate_results")
+            logger.info(f"Budget pass 4 (truncate results): {utilization:.0%}")
+            return prompt, "", "", conversation_history
+        finally:
+            # Expose final budget state to plugins via ContextVar.
+            # Fires even on early return (happy path, no reduction needed) so
+            # callers always see a value after _enforce_token_budget ran.
+            token_budget_info.set({
+                "utilization": round(utilization, 4),
+                "truncated": bool(passes_run),
+                "passes": list(passes_run),
+            })
 
     async def _build_agent_prompt(
         self,
@@ -892,10 +939,76 @@ class AgentService:
         context_vars_text: str = "",
         summary_text: str = "",
     ) -> AsyncGenerator[AgentStep, None]:
+        """Thin wrapper around _run_impl.
+
+        Resets plugin-observable ContextVars at the start of each request and
+        publishes the final per-request token usage via `token_usage_info`
+        after the loop finishes — whether by normal completion, early return,
+        or error. See module-level docstring on the ContextVars for the
+        expected payload shape.
+
+        Why the split into run() + _run_impl()?
+        The agent loop has many early-return paths (timeouts, circuit-breaker
+        trips, infinite-loop aborts, LLM failures). Publishing token_usage_info
+        on all of them requires a try/finally that sees the AgentContext. The
+        wrapper owns context creation so the `finally` can read
+        context.get_token_usage() regardless of where _run_impl returns.
+        Do not merge these back into a single method — it would require
+        wrapping ~500 lines of loop body in try/finally indentation.
+        """
+        # Reset per-request state so values never leak between requests.
+        token_budget_info.set(None)
+        token_usage_info.set(None)
+
+        context = AgentContext(original_message=message)
+        try:
+            async for step in self._run_impl(
+                context,
+                message=message,
+                ollama=ollama,
+                executor=executor,
+                conversation_history=conversation_history,
+                room_context=room_context,
+                lang=lang,
+                memory_context=memory_context,
+                document_context=document_context,
+                personality_context=personality_context,
+                user_permissions=user_permissions,
+                user_id=user_id,
+                context_vars_text=context_vars_text,
+                summary_text=summary_text,
+            ):
+                yield step
+        finally:
+            # Publish real token counts from the AgentContext — fires on every
+            # exit path including timeouts, circuit-breaker trips, and
+            # infinite-loop aborts.
+            token_usage_info.set(context.get_token_usage())
+
+    async def _run_impl(
+        self,
+        context: AgentContext,
+        *,
+        message: str,
+        ollama: "OllamaService",
+        executor: "ActionExecutor",
+        conversation_history: list[dict] | None = None,
+        room_context: dict | None = None,
+        lang: str | None = None,
+        memory_context: str = "",
+        document_context: str = "",
+        personality_context: str = "",
+        user_permissions: list[str] | None = None,
+        user_id: int | None = None,
+        context_vars_text: str = "",
+        summary_text: str = "",
+    ) -> AsyncGenerator[AgentStep, None]:
         """
         Run the Agent Loop. Yields AgentStep objects for real-time feedback.
 
         Args:
+            context: AgentContext created by the outer `run()` wrapper so the
+                wrapper can read final token usage even on early returns.
             message: The user's original message
             ollama: OllamaService instance for LLM calls
             executor: ActionExecutor for executing tool calls
@@ -912,7 +1025,6 @@ class AgentService:
         # Use ollama's default language if not specified
         lang = lang or ollama.default_lang
 
-        context = AgentContext(original_message=message)
         start_time = time.monotonic()
 
         # Ensure plugin tools (register_tools hook) are ready before we read

--- a/tests/backend/test_agent_service.py
+++ b/tests/backend/test_agent_service.py
@@ -1769,3 +1769,178 @@ class TestAgentBreaksOnRepeatedEmptyResults:
         # Should not have used many steps
         tool_calls = [s for s in steps if s.step_type == "tool_call"]
         assert len(tool_calls) == 2
+
+
+# ============================================================================
+# Plugin-observable ContextVars: token_budget_info, token_usage_info
+# ============================================================================
+
+
+class TestTokenContextVars:
+    """Plugin-observable ContextVars populated during AgentService.run().
+
+    Plugins (e.g. the Reva Teams transport) read these after the agent loop
+    to publish real per-request token metrics without needing access to the
+    internal AgentContext. See module-level docstring in agent_service.py.
+    """
+
+    def _make_registry(self):
+        from services.agent_tools import AgentToolRegistry
+        return AgentToolRegistry(mcp_manager=_make_mock_mcp_manager())
+
+    def _make_ollama_mock(self, responses):
+        ollama = MagicMock()
+        ollama.client = MagicMock()
+        call_count = 0
+
+        async def mock_chat(**kwargs):
+            nonlocal call_count
+            idx = min(call_count, len(responses) - 1)
+            call_count += 1
+            resp = MagicMock()
+            resp.message = MagicMock()
+            resp.message.content = responses[idx]
+            return resp
+
+        ollama.client.chat = mock_chat
+        _shared_agent_client.chat = mock_chat
+        return ollama
+
+    @pytest.mark.unit
+    async def test_token_usage_info_set_after_run(self):
+        """token_usage_info contains real input/output totals after run()."""
+        from services.agent_service import token_usage_info
+
+        registry = self._make_registry()
+        ollama = self._make_ollama_mock([
+            '{"action": "final_answer", "answer": "Hi", "reason": "Done"}'
+        ])
+        executor = AsyncMock()
+
+        agent = AgentService(registry, max_steps=3)
+        async for _ in agent.run(
+            message="Hallo", ollama=ollama, executor=executor
+        ):
+            pass
+
+        usage = token_usage_info.get()
+        assert usage is not None, "token_usage_info should be set after run()"
+        assert usage["input_tokens"] > 0, "input_tokens should be populated"
+        assert usage["output_tokens"] > 0, "output_tokens should be populated"
+        assert usage["total_tokens"] == usage["input_tokens"] + usage["output_tokens"]
+
+    @pytest.mark.unit
+    async def test_token_usage_info_reset_each_run(self):
+        """A fresh run() resets token_usage_info — no leak from prior request."""
+        from services.agent_service import token_usage_info
+
+        # Pre-seed a stale value
+        token_usage_info.set({"input_tokens": 999, "output_tokens": 999, "total_tokens": 1998})
+
+        registry = self._make_registry()
+        ollama = self._make_ollama_mock([
+            '{"action": "final_answer", "answer": "Hi", "reason": "Done"}'
+        ])
+        executor = AsyncMock()
+
+        agent = AgentService(registry, max_steps=3)
+        async for _ in agent.run(
+            message="Hallo", ollama=ollama, executor=executor
+        ):
+            pass
+
+        usage = token_usage_info.get()
+        assert usage is not None
+        # Stale 999 tokens should be gone — real counts are far smaller for
+        # a single-turn greeting
+        assert usage["input_tokens"] != 999, "stale input_tokens leaked"
+        assert usage["output_tokens"] != 999, "stale output_tokens leaked"
+
+    @pytest.mark.unit
+    async def test_token_usage_info_populated_on_early_error(self):
+        """Early error paths (e.g. LLM failure) still publish token usage."""
+        from services.agent_service import token_usage_info
+
+        registry = self._make_registry()
+        ollama = MagicMock()
+        ollama.client = MagicMock()
+
+        async def mock_chat_raises(**kwargs):
+            raise RuntimeError("LLM unreachable")
+
+        ollama.client.chat = mock_chat_raises
+        _shared_agent_client.chat = mock_chat_raises
+        executor = AsyncMock()
+
+        agent = AgentService(registry, max_steps=3)
+        steps = []
+        async for step in agent.run(
+            message="Hallo", ollama=ollama, executor=executor
+        ):
+            steps.append(step)
+
+        # Should have yielded an error and a fallback final_answer
+        assert any(s.step_type == "error" for s in steps)
+
+        # ContextVar should be set — the try/finally fires on early return
+        usage = token_usage_info.get()
+        assert usage is not None, "token_usage_info missing on error path"
+        # On this code path the chat call raises before track_tokens is invoked,
+        # and _build_fallback_answer does not call track_tokens either, so both
+        # counters must be exactly 0. If a future change introduces token
+        # tracking on the error path, update this assertion deliberately.
+        assert usage["input_tokens"] == 0, f"expected 0 input_tokens on error path, got {usage['input_tokens']}"
+        assert usage["output_tokens"] == 0, f"expected 0 output_tokens on error path, got {usage['output_tokens']}"
+
+    @pytest.mark.unit
+    async def test_token_budget_info_set_even_without_truncation(self):
+        """token_budget_info is set on the happy path (no reduction) too."""
+        from services.agent_service import token_budget_info
+
+        registry = self._make_registry()
+        ollama = self._make_ollama_mock([
+            '{"action": "final_answer", "answer": "Hi", "reason": "Done"}'
+        ])
+        executor = AsyncMock()
+
+        agent = AgentService(registry, max_steps=3)
+        async for _ in agent.run(
+            message="Hallo", ollama=ollama, executor=executor
+        ):
+            pass
+
+        budget = token_budget_info.get()
+        assert budget is not None, "token_budget_info should be set even when no truncation"
+        assert "utilization" in budget
+        assert "truncated" in budget
+        assert "passes" in budget
+        assert 0.0 <= budget["utilization"] <= 1.5  # typically <0.1 for a small prompt
+        assert budget["truncated"] is False
+        assert budget["passes"] == []
+
+    @pytest.mark.unit
+    async def test_token_budget_info_reset_each_run(self):
+        """A fresh run() resets token_budget_info — no leak from prior request."""
+        from services.agent_service import token_budget_info
+
+        token_budget_info.set({
+            "utilization": 0.95, "truncated": True, "passes": ["drop_memory"],
+        })
+
+        registry = self._make_registry()
+        ollama = self._make_ollama_mock([
+            '{"action": "final_answer", "answer": "Hi", "reason": "Done"}'
+        ])
+        executor = AsyncMock()
+
+        agent = AgentService(registry, max_steps=3)
+        async for _ in agent.run(
+            message="Hallo", ollama=ollama, executor=executor
+        ):
+            pass
+
+        budget = token_budget_info.get()
+        assert budget is not None
+        # Real budget for a greeting is well under threshold
+        assert budget["truncated"] is False
+        assert budget["passes"] == []


### PR DESCRIPTION
## Summary

Adds two plugin-observable `ContextVar`s at the module level of `services.agent_service`, populated during `AgentService.run()`:

- **`token_budget_info`** — `{utilization, truncated, passes}` from `_enforce_token_budget`, populated on every invocation (including the happy path where no reduction is needed)
- **`token_usage_info`** — `{input_tokens, output_tokens, total_tokens}` from `AgentContext.get_token_usage()`, populated at the end of every `run()` via `try/finally` so it fires on every exit path: normal completion, timeouts, circuit-breaker trips, LLM failures, infinite-loop aborts

Both are reset to `None` at the start of every `run()` so values never leak between requests.

## Why

Plugins (Reva today, others later) currently have no way to read real per-request token state after the agent loop. Reva's transport estimates tokens structurally from what the caller knows (system prompt, tools, user message, history, memory); the estimate is within ~2× of reality but still a proxy. Exposing the real counts turns it into an exact measurement and removes the structural-estimator code in the downstream plugin.

A stale import already exists in Reva — `from services.agent_service import token_budget_info` — gated by `try/except: pass` because the ContextVar didn't exist. This PR implements what Reva's code has been expecting for months. After this lands, `token_budget_info.get()` returns real data for the first time.

## Implementation notes

- `AgentService.run()` is now a thin wrapper around a new internal `_run_impl()`. The wrapper creates the `AgentContext` and passes it into `_run_impl()` so it remains accessible after any early return. Public signature unchanged — external callers (`api/routes/chat`, `websocket/chat_handler`, `services/orchestrator`) are unaffected
- `_enforce_token_budget` wraps its body in `try/finally` and publishes `token_budget_info` in `finally`, tracking `utilization` and `passes_run` across all branches

## Known gap (not addressed here)

The orchestrator in `services/orchestrator.py` runs multiple `AgentService` instances in parallel via `asyncio.gather`. Each sub-agent task has its own `contextvars.Context`, so sub-agent writes land in separate ContextVar slots. Plugins reading after `gather` see only the synthesizer sub-agent's counts, not a sum across all sub-agents. A follow-up can aggregate in the orchestrator — intentionally out of scope for this focused change.

## Test plan

- [x] 5 new tests in `TestTokenContextVars` covering normal run, reset between runs, early error paths, happy-path budget (no truncation), and budget reset
- [x] `python3 -c "import ast; ast.parse(open('src/backend/services/agent_service.py').read())"` — syntax clean
- [x] Existing callers (`agent.run(...)` in `chat_handler.py`, `routes/chat.py`, `orchestrator.py`) continue to match the public signature — confirmed via grep
- [ ] Full test suite run in CI
- [ ] Post-merge: Reva plugin PR switches from structural estimate to `token_usage_info.get()` for exact per-request counts, and `token_budget_info.get()` starts returning real data (currently silent-fails)

## Downstream

This unblocks two follow-ups in the Reva plugin:
1. Replace the structural token estimator in `src/reva/teams/transport.py` (merged in reva#173) with a read of `token_usage_info` — turns the Prometheus counters from approximations into exact counts
2. `reva_token_budget_truncations_total` starts incrementing for real (the ContextVar read was silently failing before this)