### PR TITLE
feat(federation): F3a — query_brain responder (backend)

### DIFF
--- a/src/backend/api/routes/federation_query.py
+++ b/src/backend/api/routes/federation_query.py
@@ -1,0 +1,65 @@
+"""
+Federation query_brain routes — peer-authenticated endpoints.
+
+Mounted under /api/federation/peer/. NO `get_current_user` dependency:
+these are peer-to-peer endpoints, authenticated entirely by the
+Ed25519 signature on each request (verified against peer_users rows).
+
+Uniform 400 "federation query failed" on every FederationQueryError —
+no oracle telegraphing signature-vs-nonce-vs-timestamp failure modes.
+Logs carry the specific reason for operator debugging.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from loguru import logger
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from services.database import get_db
+from services.federation_query_responder import (
+    FederationQueryError,
+    FederationQueryResponder,
+)
+from services.federation_query_schemas import (
+    QueryBrainInitiateRequest,
+    QueryBrainInitiateResponse,
+    QueryBrainRetrieveRequest,
+    QueryBrainRetrieveResponse,
+)
+
+
+router = APIRouter()
+
+
+@router.post("/peer/query_brain/initiate", response_model=QueryBrainInitiateResponse)
+async def peer_query_brain_initiate(
+    body: QueryBrainInitiateRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    """Responder step 1 — accept a signed query and enqueue background work."""
+    responder = FederationQueryResponder(db)
+    try:
+        return await responder.handle_initiate(body)
+    except FederationQueryError as e:
+        logger.warning(
+            f"Federation query_brain/initiate rejected "
+            f"(asker={body.asker_pubkey[:12]}...): {e}"
+        )
+        raise HTTPException(status_code=400, detail="Federation query failed")
+
+
+@router.post("/peer/query_brain/retrieve", response_model=QueryBrainRetrieveResponse)
+async def peer_query_brain_retrieve(
+    body: QueryBrainRetrieveRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    """Responder step 2 — return current state (or final signed answer)."""
+    responder = FederationQueryResponder(db)
+    try:
+        return await responder.handle_retrieve(body)
+    except FederationQueryError as e:
+        logger.warning(
+            f"Federation query_brain/retrieve rejected "
+            f"(asker={body.asker_pubkey[:12]}..., request_id={body.request_id}): {e}"
+        )
+        raise HTTPException(status_code=400, detail="Federation query failed")

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -25,6 +25,7 @@ from api.routes import (
     chat_upload,
     circles,
     federation_pairing,
+    federation_query,
     feedback,
     intents,
     knowledge,
@@ -179,6 +180,7 @@ app.include_router(kg_routes.router, prefix="/api/knowledge-graph", tags=["Knowl
 app.include_router(atoms.router, prefix="/api/atoms", tags=["Circles - Atoms"])
 app.include_router(circles.router, prefix="/api/circles", tags=["Circles - Membership"])
 app.include_router(federation_pairing.router, prefix="/api/federation", tags=["Federation - Pairing"])
+app.include_router(federation_query.router, prefix="/api/federation", tags=["Federation - Query"])
 
 # WebSocket Routers
 app.include_router(chat_router, tags=["WebSocket Chat"])

--- a/src/backend/services/federation_query_responder.py
+++ b/src/backend/services/federation_query_responder.py
@@ -1,0 +1,493 @@
+"""
+FederationQueryResponder — the server side of the `query_brain` protocol.
+
+Two HTTP endpoints under /api/federation/peer/ route here. There's NO
+`get_current_user` dependency: peers authenticate via the Ed25519
+signature bound to a `peer_users.remote_pubkey` row, not via local
+user sessions.
+
+Lifecycle:
+
+    handle_initiate()
+        │ verify signature over canonical(asker_pubkey, query, nonce, ts)
+        │ verify ±60s timestamp window
+        │ verify nonce not already seen (replay defence)
+        │ verify peer_users row exists + not revoked
+        │ look up asker's local user_id + max_visible_tier
+        │ mint request_id (UUID4)
+        │ enqueue background task
+        ▼
+      returns {request_id, accepted_at}
+
+    (background) _run_query()
+        │ status := 'processing', progress := 'retrieving'
+        │ run PolymorphicAtomStore.query(..., asker_id=..., max_visible_tier=...)
+        │ status := 'processing', progress := 'synthesizing'
+        │ call Ollama to turn top-k atoms into a natural-language answer
+        │ status := 'complete', answer, provenance[] (redacted_for_remote)
+        │   OR status := 'failed' on exception
+        ▼ (exposed via handle_retrieve polls)
+
+    handle_retrieve()
+        │ verify poll signature over (request_id, asker_pubkey, ts)
+        │ verify asker_pubkey matches the pubkey that called initiate
+        │   (stolen-request_id defence — two users from different peers
+        │    can't poll each other's requests)
+        │ return current state snapshot; if terminal, sign the response.
+        ▼
+      returns {status, progress?, answer?, provenance?, responder_signature?}
+
+Memory footprint: one `_PendingRequest` per in-flight query, purged on
+terminal status or 60s TTL. Single-process (Renfield ships one backend
+container); multi-process deploys would need Redis but that's F5.
+
+Side-channel mitigation (design doc § streaming-progress):
+  - Progress labels drawn from PROGRESS_LABELS (one of a locked set).
+  - Rate limit: max 4 progress transitions per request (responder can't
+    phase-by-phase telegraph timing for traffic analysis).
+  - Progress strings never carry per-query specifics (no "found 47
+    atoms"). A misbehaving responder can't leak that way because
+    FederationQueryResponder is the only code path emitting progress
+    in this flow.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from loguru import logger
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import PeerUser
+from services.atom_types import Provenance
+from services.federation_identity import (
+    FederationIdentity,
+    get_federation_identity,
+)
+from services.federation_query_schemas import (
+    STATUS_COMPLETE,
+    STATUS_EXPIRED,
+    STATUS_FAILED,
+    STATUS_PROCESSING,
+    FederationProvenance,
+    QueryBrainInitiateRequest,
+    QueryBrainInitiateResponse,
+    QueryBrainRetrieveRequest,
+    QueryBrainRetrieveResponse,
+    complete_canonical_payload,
+    initiate_canonical_payload,
+    retrieve_canonical_payload,
+)
+from services.mcp_streaming import (
+    PROGRESS_LABEL_COMPLETE,
+    PROGRESS_LABEL_FAILED,
+    PROGRESS_LABEL_RETRIEVING,
+    PROGRESS_LABEL_SYNTHESIZING,
+)
+from services.pairing_service import _canonical_bytes
+
+
+# Request lifecycle: pending rows live here for 60s (or until terminal).
+REQUEST_TTL_SECONDS = 60
+# Replay defence: nonces remembered for the ±60s window + a grace period.
+NONCE_WINDOW_SECONDS = 60
+NONCE_CACHE_MAX = 4096
+
+# Max progress transitions per request (traffic-analysis defence).
+MAX_PROGRESS_UPDATES = 4
+
+
+# =============================================================================
+# Errors (mapped to HTTP 400 uniformly by the route layer — no oracle)
+# =============================================================================
+
+
+class FederationQueryError(Exception):
+    """Any signature/timestamp/nonce/peer lookup failure during query_brain."""
+
+
+# =============================================================================
+# In-memory state
+# =============================================================================
+
+
+@dataclass
+class _PendingRequest:
+    """One in-flight federated query, kept until terminal or TTL expiry."""
+    request_id: str
+    asker_pubkey: str
+    peer_user_id: int              # PeerUser.id (the responder-side row)
+    asker_local_user_id: int | None  # membership.member_user_id (None if not member)
+    max_visible_tier: int           # how deep the asker can reach
+    query: str
+    initiated_at: float
+    status: str = STATUS_PROCESSING
+    progress_label: str = PROGRESS_LABEL_RETRIEVING
+    progress_count: int = 0
+    answer: str | None = None
+    provenance: list[Provenance] = field(default_factory=list)
+    answered_at: float | None = None
+    error_message: str | None = None
+
+
+# Single process scope. F5 hardening task: persist to Redis for multi-worker.
+_pending_requests: dict[str, _PendingRequest] = {}
+_nonce_cache: OrderedDict[str, float] = OrderedDict()
+
+
+def _clear_state_for_tests() -> None:
+    """Test-only reset — every test starts with a clean in-memory view."""
+    _pending_requests.clear()
+    _nonce_cache.clear()
+
+
+def _prune_expired(now: float | None = None) -> None:
+    """Drop pending requests past TTL. Called on every initiate/retrieve."""
+    t = now if now is not None else time.time()
+    expired = [rid for rid, pr in _pending_requests.items()
+               if t - pr.initiated_at > REQUEST_TTL_SECONDS and pr.status == STATUS_PROCESSING]
+    for rid in expired:
+        pr = _pending_requests[rid]
+        pr.status = STATUS_EXPIRED
+        logger.debug(f"Federation query_brain: expired {rid} (peer={pr.peer_user_id})")
+
+
+def _record_nonce(nonce: str, now: float) -> bool:
+    """
+    Returns True iff the nonce is new. Evicts old entries past the
+    window so the cache stays bounded. LRU-ordered by insertion time.
+    """
+    # Drop entries outside the timestamp window — they're outside the
+    # replay-rejection window anyway.
+    while _nonce_cache:
+        oldest_nonce, oldest_at = next(iter(_nonce_cache.items()))
+        if now - oldest_at > NONCE_WINDOW_SECONDS:
+            _nonce_cache.pop(oldest_nonce, None)
+        else:
+            break
+
+    if nonce in _nonce_cache:
+        return False
+    if len(_nonce_cache) >= NONCE_CACHE_MAX:
+        # Shouldn't happen in practice; evict oldest to make room.
+        _nonce_cache.popitem(last=False)
+    _nonce_cache[nonce] = now
+    return True
+
+
+# =============================================================================
+# Responder service
+# =============================================================================
+
+
+class FederationQueryResponder:
+    """
+    One per AsyncSession. Holds the DB handle + identity; the in-flight
+    request map is module-level since background tasks outlive the
+    HTTP session that created them.
+    """
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+        self.identity = get_federation_identity()
+
+    # -------------------------------------------------------------------------
+    # Step 1 — initiate
+    # -------------------------------------------------------------------------
+
+    async def handle_initiate(
+        self,
+        req: QueryBrainInitiateRequest,
+    ) -> QueryBrainInitiateResponse:
+        """
+        Verify asker signature + freshness + peer authorization, mint a
+        request_id, and kick off the background query+synthesis work.
+        """
+        self._verify_signature(
+            pubkey_hex=req.asker_pubkey,
+            signature_hex=req.signature,
+            payload=initiate_canonical_payload(req),
+        )
+
+        now = time.time()
+        if abs(now - req.timestamp) > NONCE_WINDOW_SECONDS:
+            raise FederationQueryError(
+                "Timestamp outside ±60s window (clock skew or replay)"
+            )
+
+        if not _record_nonce(req.nonce, now=now):
+            raise FederationQueryError("Nonce already seen (replay detected)")
+
+        peer = await self._lookup_peer(req.asker_pubkey)
+
+        # Resolve the asker's local visible tier. The responder granted
+        # the asker a tier via CircleMembership when they paired (F2).
+        # Use that as `max_visible_tier`. The asker's own user_id on
+        # OUR side is the PeerUser.remote_user_id echo (cosmetic), but
+        # the actual membership lookup keys on (circle_owner_id, member_user_id).
+        # We don't have a stable remote-user-id ↔ local-user-id map, so
+        # the membership is keyed on peer.remote_user_id directly: the
+        # pairing flow wrote CircleMembership(
+        #   circle_owner_id=responder, member_user_id=remote_user_id
+        # ). Look that up.
+        asker_local_user_id = peer.remote_user_id
+        max_visible_tier = await self._resolve_asker_tier(
+            owner_user_id=peer.circle_owner_id,
+            member_user_id=peer.remote_user_id,
+        )
+
+        request_id = str(uuid.uuid4())
+        _prune_expired(now=now)
+        _pending_requests[request_id] = _PendingRequest(
+            request_id=request_id,
+            asker_pubkey=req.asker_pubkey,
+            peer_user_id=peer.id,
+            asker_local_user_id=asker_local_user_id,
+            max_visible_tier=max_visible_tier,
+            query=req.query,
+            initiated_at=now,
+        )
+
+        # Schedule the background work. The task is fire-and-forget —
+        # asker polls via handle_retrieve.
+        asyncio.create_task(self._run_query(request_id))
+
+        return QueryBrainInitiateResponse(
+            request_id=request_id,
+            accepted_at=int(now),
+        )
+
+    # -------------------------------------------------------------------------
+    # Step 2 — retrieve (poll)
+    # -------------------------------------------------------------------------
+
+    async def handle_retrieve(
+        self,
+        req: QueryBrainRetrieveRequest,
+    ) -> QueryBrainRetrieveResponse:
+        """Verify poll signature + pubkey binding, return current state."""
+        self._verify_signature(
+            pubkey_hex=req.asker_pubkey,
+            signature_hex=req.signature,
+            payload=retrieve_canonical_payload(req),
+        )
+
+        now = time.time()
+        if abs(now - req.timestamp) > NONCE_WINDOW_SECONDS:
+            raise FederationQueryError("Poll timestamp outside window")
+
+        _prune_expired(now=now)
+        pending = _pending_requests.get(req.request_id)
+        if pending is None:
+            # Uniform: treat unknown + expired identically — no
+            # existence-oracle on request_ids.
+            return QueryBrainRetrieveResponse(status=STATUS_EXPIRED)
+
+        # Binding check — a stolen request_id cannot be polled by a
+        # different pubkey. Forges a uniform-expired response rather
+        # than revealing "wrong user polled".
+        if pending.asker_pubkey != req.asker_pubkey:
+            logger.warning(
+                f"Federation query_brain: pubkey mismatch on retrieve "
+                f"(request_id={req.request_id}, expected={pending.asker_pubkey[:12]}..., "
+                f"got={req.asker_pubkey[:12]}...)"
+            )
+            return QueryBrainRetrieveResponse(status=STATUS_EXPIRED)
+
+        return self._serialize_pending(pending)
+
+    # -------------------------------------------------------------------------
+    # Background work
+    # -------------------------------------------------------------------------
+
+    async def _run_query(self, request_id: str) -> None:
+        """Execute retrieval + synthesis in the background. Never raises —
+        exceptions transition the request to STATUS_FAILED instead."""
+        pending = _pending_requests.get(request_id)
+        if pending is None:
+            return
+
+        try:
+            # Transition: retrieving (chunk+KG+memory RRF).
+            self._emit_progress(pending, PROGRESS_LABEL_RETRIEVING)
+            matches = await self._retrieve(pending)
+
+            # Transition: synthesizing (Ollama call).
+            self._emit_progress(pending, PROGRESS_LABEL_SYNTHESIZING)
+            answer = await self._synthesize(pending.query, matches)
+
+            # Build redacted provenance list for the response.
+            provenance = [
+                Provenance(
+                    atom_id=m.atom.atom_id,
+                    atom_type=m.atom.atom_type,
+                    display_label=m.snippet[:120] if m.snippet else f"atom {m.atom.atom_id[:8]}",
+                    score=m.score,
+                ).redacted_for_remote()
+                for m in matches[:5]
+            ]
+
+            pending.answer = answer
+            pending.provenance = provenance
+            pending.answered_at = time.time()
+            pending.status = STATUS_COMPLETE
+            pending.progress_label = PROGRESS_LABEL_COMPLETE
+        except Exception as e:
+            logger.error(
+                f"Federation query_brain: background work failed "
+                f"(request_id={request_id}): {e}"
+            )
+            pending.error_message = str(e)
+            pending.status = STATUS_FAILED
+            pending.progress_label = PROGRESS_LABEL_FAILED
+
+    async def _retrieve(self, pending: _PendingRequest):
+        """Run the polymorphic atom query, scoped to what the asker can see."""
+        from services.polymorphic_atom_store import PolymorphicAtomStore
+        store = PolymorphicAtomStore(self.db)
+        return await store.query(
+            query_text=pending.query,
+            asker_id=pending.asker_local_user_id or 0,
+            max_visible_tier=pending.max_visible_tier,
+            top_k=10,
+        )
+
+    async def _synthesize(self, query: str, matches: list) -> str:
+        """
+        Ask the local LLM to turn retrieved matches into a natural-language
+        answer. Kept narrow: answer is short (<512 tokens) and must NOT
+        echo the asker's raw query back into other capture surfaces
+        (prompt-injection-as-capture defence — design doc § Synthesis
+        isolation).
+        """
+        if not matches:
+            return ""
+        # Minimal v1 synthesis — concatenate snippets + a short instruction.
+        # F3c will replace this with a proper prompt that calls the local
+        # chat model through utils.llm_client. For F3a the shape of the
+        # answer matters more than its polish.
+        snippets = "\n".join(f"- {m.snippet or ''}"[:200] for m in matches[:5])
+        return (
+            f"Based on what I have: {query}\n"
+            f"Relevant snippets:\n{snippets}"
+        )[:2000]
+
+    # -------------------------------------------------------------------------
+    # Serialization + signing of terminal responses
+    # -------------------------------------------------------------------------
+
+    def _serialize_pending(self, pending: _PendingRequest) -> QueryBrainRetrieveResponse:
+        if pending.status == STATUS_PROCESSING:
+            return QueryBrainRetrieveResponse(
+                status=STATUS_PROCESSING,
+                progress=pending.progress_label,
+            )
+
+        if pending.status == STATUS_FAILED:
+            resp = QueryBrainRetrieveResponse(
+                status=STATUS_FAILED,
+                answered_at=int(pending.answered_at or time.time()),
+                responder_pubkey=self.identity.public_key_hex(),
+            )
+            resp.responder_signature = self._sign_response(resp)
+            return resp
+
+        if pending.status == STATUS_EXPIRED:
+            return QueryBrainRetrieveResponse(status=STATUS_EXPIRED)
+
+        # STATUS_COMPLETE
+        resp = QueryBrainRetrieveResponse(
+            status=STATUS_COMPLETE,
+            answer=pending.answer,
+            provenance=[
+                FederationProvenance(
+                    atom_id=p.atom_id,
+                    atom_type=p.atom_type,
+                    display_label=p.display_label,
+                    score=p.score,
+                )
+                for p in pending.provenance
+            ],
+            answered_at=int(pending.answered_at or time.time()),
+            responder_pubkey=self.identity.public_key_hex(),
+        )
+        resp.responder_signature = self._sign_response(resp)
+        return resp
+
+    def _sign_response(self, resp: QueryBrainRetrieveResponse) -> str:
+        payload = complete_canonical_payload(resp)
+        return self.identity.sign(_canonical_bytes(payload)).hex()
+
+    # -------------------------------------------------------------------------
+    # Helpers
+    # -------------------------------------------------------------------------
+
+    @staticmethod
+    def _verify_signature(
+        *,
+        pubkey_hex: str,
+        signature_hex: str,
+        payload: dict[str, Any],
+    ) -> None:
+        """Verify the asker's Ed25519 signature over the canonical payload.
+        Raises FederationQueryError on any failure — uniform error at route."""
+        try:
+            pubkey = bytes.fromhex(pubkey_hex)
+            signature = bytes.fromhex(signature_hex)
+        except ValueError as e:
+            raise FederationQueryError("Malformed pubkey or signature hex") from e
+        if not FederationIdentity.verify(pubkey, signature, _canonical_bytes(payload)):
+            raise FederationQueryError("Signature verification failed")
+
+    async def _lookup_peer(self, asker_pubkey: str) -> PeerUser:
+        """Find the PeerUser row that matches this remote pubkey. Must be
+        not-revoked; pairing must have succeeded in F2 first."""
+        peer = (await self.db.execute(
+            select(PeerUser).where(
+                PeerUser.remote_pubkey == asker_pubkey,
+                PeerUser.revoked_at.is_(None),
+            )
+        )).scalar_one_or_none()
+        if peer is None:
+            raise FederationQueryError("Unknown or revoked peer")
+        # Update last_seen_at as a side effect of a successful auth.
+        peer.last_seen_at = datetime.now(UTC).replace(tzinfo=None)
+        await self.db.commit()
+        return peer
+
+    async def _resolve_asker_tier(
+        self,
+        owner_user_id: int,
+        member_user_id: int | None,
+    ) -> int:
+        """Look up what tier the responder granted the asker on pairing."""
+        if member_user_id is None:
+            return 0  # No membership — treat as self-only view (empty)
+        from models.database import CircleMembership
+        row = (await self.db.execute(
+            select(CircleMembership).where(
+                CircleMembership.circle_owner_id == owner_user_id,
+                CircleMembership.member_user_id == member_user_id,
+                CircleMembership.dimension == "tier",
+            )
+        )).scalar_one_or_none()
+        if row is None:
+            return 0
+        try:
+            return int(row.value)
+        except (TypeError, ValueError):
+            return 0
+
+    @staticmethod
+    def _emit_progress(pending: _PendingRequest, label: str) -> None:
+        """Update progress label (rate-limited to MAX_PROGRESS_UPDATES)."""
+        if pending.progress_count >= MAX_PROGRESS_UPDATES:
+            return
+        pending.progress_label = label
+        pending.progress_count += 1

--- a/src/backend/services/federation_query_responder.py
+++ b/src/backend/services/federation_query_responder.py
@@ -66,6 +66,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.database import PeerUser
 from services.atom_types import Provenance
+from services.database import AsyncSessionLocal
 from services.federation_identity import (
     FederationIdentity,
     get_federation_identity,
@@ -140,20 +141,39 @@ class _PendingRequest:
 _pending_requests: dict[str, _PendingRequest] = {}
 _nonce_cache: OrderedDict[str, float] = OrderedDict()
 
+# Strong references to in-flight background tasks. Without this set the
+# asyncio GC can collect the task mid-run; with it, we also have somewhere
+# to join on shutdown (F5 will add graceful-drain support).
+_background_tasks: set[asyncio.Task] = set()
+
 
 def _clear_state_for_tests() -> None:
     """Test-only reset — every test starts with a clean in-memory view."""
     _pending_requests.clear()
     _nonce_cache.clear()
+    # Cancel any lingering bg tasks from a prior test so they don't
+    # later write to the cleared `_pending_requests` dict.
+    for task in list(_background_tasks):
+        task.cancel()
+    _background_tasks.clear()
 
 
 def _prune_expired(now: float | None = None) -> None:
-    """Drop pending requests past TTL. Called on every initiate/retrieve."""
+    """Drop pending requests past TTL. Called on every initiate/retrieve.
+
+    Iterates over a `list(items())` snapshot so a concurrent initiate
+    that adds a new entry mid-iteration can't raise `RuntimeError:
+    dictionary changed size during iteration` (two coroutines can
+    interleave at any await boundary — not today's call path, but an
+    easy foot-gun to leave).
+    """
     t = now if now is not None else time.time()
-    expired = [rid for rid, pr in _pending_requests.items()
+    expired = [rid for rid, pr in list(_pending_requests.items())
                if t - pr.initiated_at > REQUEST_TTL_SECONDS and pr.status == STATUS_PROCESSING]
     for rid in expired:
-        pr = _pending_requests[rid]
+        pr = _pending_requests.get(rid)
+        if pr is None:
+            continue
         pr.status = STATUS_EXPIRED
         logger.debug(f"Federation query_brain: expired {rid} (peer={pr.peer_user_id})")
 
@@ -255,8 +275,12 @@ class FederationQueryResponder:
         )
 
         # Schedule the background work. The task is fire-and-forget —
-        # asker polls via handle_retrieve.
-        asyncio.create_task(self._run_query(request_id))
+        # asker polls via handle_retrieve. We keep a strong reference
+        # in `_background_tasks` so asyncio's GC doesn't collect it
+        # mid-run (add_done_callback removes the ref on completion).
+        task = asyncio.create_task(self._run_query(request_id))
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
 
         return QueryBrainInitiateResponse(
             request_id=request_id,
@@ -308,7 +332,16 @@ class FederationQueryResponder:
 
     async def _run_query(self, request_id: str) -> None:
         """Execute retrieval + synthesis in the background. Never raises —
-        exceptions transition the request to STATUS_FAILED instead."""
+        the outer try/except catches everything (including AttributeError
+        on a None pending or ImportError inside _retrieve) and transitions
+        to STATUS_FAILED, so the asker always sees a terminal status
+        before TTL rather than polling into a timeout.
+
+        CRITICAL: opens its OWN AsyncSession. The request-scoped session
+        that `handle_initiate` used is closed by FastAPI's `get_db`
+        dependency when the route returns, long before this bg task
+        runs. Using `self.db` here would hit a closed session every time.
+        """
         pending = _pending_requests.get(request_id)
         if pending is None:
             return
@@ -316,7 +349,10 @@ class FederationQueryResponder:
         try:
             # Transition: retrieving (chunk+KG+memory RRF).
             self._emit_progress(pending, PROGRESS_LABEL_RETRIEVING)
-            matches = await self._retrieve(pending)
+
+            # Fresh session scoped to this bg task only.
+            async with AsyncSessionLocal() as session:
+                matches = await self._retrieve(session, pending)
 
             # Transition: synthesizing (Ollama call).
             self._emit_progress(pending, PROGRESS_LABEL_SYNTHESIZING)
@@ -336,21 +372,39 @@ class FederationQueryResponder:
             pending.answer = answer
             pending.provenance = provenance
             pending.answered_at = time.time()
-            pending.status = STATUS_COMPLETE
+            # Status set LAST so a concurrent retrieve observing
+            # status=COMPLETE is guaranteed to see answer/provenance.
             pending.progress_label = PROGRESS_LABEL_COMPLETE
+            pending.status = STATUS_COMPLETE
+        except asyncio.CancelledError:
+            # Propagate cancellation (from _clear_state_for_tests or
+            # graceful shutdown). Don't mark failed.
+            raise
         except Exception as e:
             logger.error(
                 f"Federation query_brain: background work failed "
                 f"(request_id={request_id}): {e}"
             )
             pending.error_message = str(e)
-            pending.status = STATUS_FAILED
+            # Fill in answered_at on failure too so _serialize_pending's
+            # `int(pending.answered_at or time.time())` reports the
+            # actual failure moment instead of the poll moment.
+            pending.answered_at = time.time()
             pending.progress_label = PROGRESS_LABEL_FAILED
+            pending.status = STATUS_FAILED
 
-    async def _retrieve(self, pending: _PendingRequest):
-        """Run the polymorphic atom query, scoped to what the asker can see."""
+    async def _retrieve(
+        self,
+        session: AsyncSession,
+        pending: _PendingRequest,
+    ):
+        """Run the polymorphic atom query, scoped to what the asker can see.
+
+        Takes a session parameter rather than reading `self.db` — the bg
+        task opens its own session (see _run_query docstring).
+        """
         from services.polymorphic_atom_store import PolymorphicAtomStore
-        store = PolymorphicAtomStore(self.db)
+        store = PolymorphicAtomStore(session)
         return await store.query(
             query_text=pending.query,
             asker_id=pending.asker_local_user_id or 0,
@@ -365,14 +419,20 @@ class FederationQueryResponder:
         echo the asker's raw query back into other capture surfaces
         (prompt-injection-as-capture defence — design doc § Synthesis
         isolation).
+
+        F3c TODO: replace this stub with a proper Ollama prompt via
+        utils.llm_client. When wiring that up, revisit the synthesis-
+        isolation rules from the design doc: the asker's query MUST
+        NOT be fed into conversation_memory capture, notification
+        bodies, or any other surface that could persist the peer's
+        text into THIS responder's own atoms.
         """
         if not matches:
             return ""
         # Minimal v1 synthesis — concatenate snippets + a short instruction.
-        # F3c will replace this with a proper prompt that calls the local
-        # chat model through utils.llm_client. For F3a the shape of the
-        # answer matters more than its polish.
-        snippets = "\n".join(f"- {m.snippet or ''}"[:200] for m in matches[:5])
+        # The snippet is sliced BEFORE the `- ` prefix so the 198-char
+        # cap is on actual content, not prefix+content.
+        snippets = "\n".join(f"- {(m.snippet or '')[:198]}" for m in matches[:5])
         return (
             f"Based on what I have: {query}\n"
             f"Relevant snippets:\n{snippets}"
@@ -447,7 +507,14 @@ class FederationQueryResponder:
 
     async def _lookup_peer(self, asker_pubkey: str) -> PeerUser:
         """Find the PeerUser row that matches this remote pubkey. Must be
-        not-revoked; pairing must have succeeded in F2 first."""
+        not-revoked; pairing must have succeeded in F2 first.
+
+        last_seen_at is updated as a side effect of a successful auth,
+        but its commit failure is NON-FATAL — a transient DB hiccup here
+        must not surface to the caller as an auth failure. A spammy-but-
+        signed peer could also exploit this path to amplify writes;
+        debouncing is a future F5 task.
+        """
         peer = (await self.db.execute(
             select(PeerUser).where(
                 PeerUser.remote_pubkey == asker_pubkey,
@@ -456,9 +523,15 @@ class FederationQueryResponder:
         )).scalar_one_or_none()
         if peer is None:
             raise FederationQueryError("Unknown or revoked peer")
-        # Update last_seen_at as a side effect of a successful auth.
-        peer.last_seen_at = datetime.now(UTC).replace(tzinfo=None)
-        await self.db.commit()
+        try:
+            peer.last_seen_at = datetime.now(UTC).replace(tzinfo=None)
+            await self.db.commit()
+        except Exception as e:
+            logger.warning(
+                f"Federation query_brain: last_seen_at update failed "
+                f"(peer_id={peer.id}, non-fatal): {e}"
+            )
+            await self.db.rollback()
         return peer
 
     async def _resolve_asker_tier(

--- a/src/backend/services/federation_query_schemas.py
+++ b/src/backend/services/federation_query_schemas.py
@@ -1,0 +1,191 @@
+"""
+Federation query_brain wire-format schemas.
+
+Split from the responder service so the asker-side client (F3b) can
+import the same shapes without pulling in the responder's runtime
+dependencies (Ollama, AtomStore, etc.).
+
+Protocol summary (design doc § query_brain MCP tool, Two-step protocol):
+
+    ASKER                                     RESPONDER
+      │                                           │
+      │   POST /peer/query_brain/initiate         │
+      │   {asker_pubkey, query, nonce,            │
+      │    timestamp, signature}                  │
+      │──────────────────────────────────────────▶│
+      │                                           │
+      │                                           │ verify sig + ± window
+      │                                           │ + peer_users lookup
+      │                                           │ + mint request_id (UUID4)
+      │                                           │ + enqueue background
+      │                                           │   work
+      │                                           │
+      │◀──────────────────────────────────────────│
+      │   {request_id, accepted_at}               │
+      │                                           │
+      │   (poll loop)                             │
+      │   POST /peer/query_brain/retrieve         │
+      │   {request_id, asker_pubkey, signature}   │
+      │──────────────────────────────────────────▶│
+      │                                           │ verify sig + pubkey
+      │                                           │ BOUND to initiator
+      │                                           │ + return progress
+      │                                           │ label (one of a
+      │                                           │ locked vocabulary —
+      │                                           │ see mcp_streaming)
+      │                                           │
+      │◀──────────────────────────────────────────│
+      │   {status: 'processing', progress: str}   │
+      │   ... (repeat until complete/failed/      │
+      │        expired) ...                       │
+      │   {status: 'complete', answer,            │
+      │    provenance[], responder_signature}     │
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+# =============================================================================
+# Status discriminator for retrieve responses
+# =============================================================================
+
+STATUS_PROCESSING = "processing"
+STATUS_COMPLETE = "complete"
+STATUS_FAILED = "failed"
+STATUS_EXPIRED = "expired"
+
+STATUS_VALUES = frozenset({STATUS_PROCESSING, STATUS_COMPLETE, STATUS_FAILED, STATUS_EXPIRED})
+
+
+# =============================================================================
+# Initiate
+# =============================================================================
+
+
+class QueryBrainInitiateRequest(BaseModel):
+    """
+    Asker-signed request to kick off a federated query.
+
+    Signature covers the canonical-JSON encoding of every non-signature
+    field (asker_pubkey, query, nonce, timestamp). Responder MUST
+    reject requests whose timestamp falls outside a ±60s window and
+    must remember the nonce to reject replays.
+    """
+    version: int = 1
+    asker_pubkey: str = Field(..., min_length=64, max_length=64)  # hex
+    query: str = Field(..., max_length=4000)
+    nonce: str = Field(..., min_length=16)  # 128-bit, hex-encoded
+    timestamp: int  # unix seconds; responder rejects > ±60s from its clock
+    signature: str = Field(..., min_length=128, max_length=128)  # hex
+
+
+class QueryBrainInitiateResponse(BaseModel):
+    """Responder acknowledgement — opaque request_id the asker polls with."""
+    request_id: str  # UUID4
+    accepted_at: int  # unix seconds
+
+
+# =============================================================================
+# Retrieve (poll)
+# =============================================================================
+
+
+class QueryBrainRetrieveRequest(BaseModel):
+    """
+    Asker-signed poll for an in-flight request. Signature covers
+    (request_id, asker_pubkey, timestamp) so a stolen request_id
+    alone can't be polled by an eavesdropper.
+    """
+    version: int = 1
+    request_id: str
+    asker_pubkey: str = Field(..., min_length=64, max_length=64)
+    timestamp: int
+    signature: str = Field(..., min_length=128, max_length=128)
+
+
+class FederationProvenance(BaseModel):
+    """
+    Redacted source attribution — matches `Provenance.redacted_for_remote()`
+    output. Responder runs that redaction before serializing. Asker stores
+    these alongside the answer for display ("from Mom's recipes") but
+    cannot correlate them back to the responder's atom IDs (UUID4 per
+    call, not stable).
+    """
+    atom_id: str
+    atom_type: str
+    display_label: str
+    score: float
+
+
+class QueryBrainRetrieveResponse(BaseModel):
+    """
+    Poll response. Status discriminator controls which other fields
+    are populated. Every terminal status (complete/failed/expired)
+    also carries `responder_signature` over the full response body
+    so the asker can verify the responder actually produced it.
+    """
+    version: int = 1
+    status: str  # one of STATUS_VALUES
+    progress: str | None = None  # present when status='processing'
+    answer: str | None = None    # present when status='complete'
+    provenance: list[FederationProvenance] = Field(default_factory=list)
+    answered_at: int | None = None
+    responder_pubkey: str | None = None
+    responder_signature: str | None = None  # terminal statuses only
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def initiate_canonical_payload(req: QueryBrainInitiateRequest) -> dict[str, Any]:
+    """
+    Return the dict over which `signature` is Ed25519-signed by the asker.
+    Shared by signer and verifier to avoid byte drift (same pattern as
+    pairing_service._canonical_bytes).
+    """
+    return {
+        "version": req.version,
+        "asker_pubkey": req.asker_pubkey,
+        "query": req.query,
+        "nonce": req.nonce,
+        "timestamp": req.timestamp,
+    }
+
+
+def retrieve_canonical_payload(req: QueryBrainRetrieveRequest) -> dict[str, Any]:
+    """Dict over which the asker signs their poll request."""
+    return {
+        "version": req.version,
+        "request_id": req.request_id,
+        "asker_pubkey": req.asker_pubkey,
+        "timestamp": req.timestamp,
+    }
+
+
+def complete_canonical_payload(resp: QueryBrainRetrieveResponse) -> dict[str, Any]:
+    """
+    Dict over which the RESPONDER signs a terminal retrieve response.
+    Asker verifies this signature against responder_pubkey before
+    accepting the answer into their agent loop.
+    """
+    return {
+        "version": resp.version,
+        "status": resp.status,
+        "answer": resp.answer,
+        "provenance": [
+            {
+                "atom_id": p.atom_id,
+                "atom_type": p.atom_type,
+                "display_label": p.display_label,
+                "score": p.score,
+            }
+            for p in resp.provenance
+        ],
+        "answered_at": resp.answered_at,
+        "responder_pubkey": resp.responder_pubkey,
+    }

--- a/tests/backend/test_federation_query_responder.py
+++ b/tests/backend/test_federation_query_responder.py
@@ -345,6 +345,99 @@ class TestHandleRetrieve:
 # =============================================================================
 
 
+class TestBackgroundTaskSession:
+    """Regression guard for CRITICAL review finding #1 — bg task MUST
+    open its own AsyncSession. Using the request-scoped session would
+    hit a closed-session error after the initiate HTTP handler returns."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_run_query_opens_fresh_session_via_AsyncSessionLocal(
+        self, responder_identity, asker_identity, monkeypatch,
+    ):
+        """Patch AsyncSessionLocal to track whether _run_query opened
+        its own session — if it reuses self.db, the patched factory
+        is never called."""
+        from services import federation_query_responder as fqr
+
+        factory_calls = 0
+        real_factory = fqr.AsyncSessionLocal
+
+        class _TrackedSession:
+            """Minimal async-ctx-mgr stand-in for AsyncSession."""
+            async def __aenter__(self):
+                return MagicMock()
+            async def __aexit__(self, *a):
+                return False
+
+        def factory():
+            nonlocal factory_calls
+            factory_calls += 1
+            return _TrackedSession()
+
+        monkeypatch.setattr(fqr, "AsyncSessionLocal", factory)
+
+        # Inject a ready-to-run pending entry.
+        pending = _PendingRequest(
+            request_id="bg-test-1",
+            asker_pubkey=asker_identity.public_key_hex(),
+            peer_user_id=1,
+            asker_local_user_id=2,
+            max_visible_tier=2,
+            query="q",
+            initiated_at=time.time(),
+        )
+        fqr._pending_requests[pending.request_id] = pending
+
+        responder = FederationQueryResponder(db=MagicMock())
+        # Stub _retrieve + _synthesize so we only exercise the session-
+        # acquisition path.
+        responder._retrieve = AsyncMock(return_value=[])
+        responder._synthesize = AsyncMock(return_value="answer")
+
+        await responder._run_query(pending.request_id)
+
+        assert factory_calls == 1, (
+            "bg task did not open its own session via AsyncSessionLocal — "
+            "the request-scoped session from handle_initiate would already "
+            "be closed. CRITICAL regression."
+        )
+        # And the pending should be marked COMPLETE by the full run.
+        assert pending.status == STATUS_COMPLETE
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_run_query_outer_try_catches_everything(
+        self, responder_identity, asker_identity,
+    ):
+        """If _retrieve raises any Exception (ImportError, KeyError,
+        anything), the outer try/except must still mark the pending
+        as STATUS_FAILED + set answered_at so the asker sees a
+        terminal status instead of polling into TTL."""
+        from services import federation_query_responder as fqr
+
+        pending = _PendingRequest(
+            request_id="bg-test-fail",
+            asker_pubkey=asker_identity.public_key_hex(),
+            peer_user_id=1,
+            asker_local_user_id=2,
+            max_visible_tier=2,
+            query="q",
+            initiated_at=time.time(),
+        )
+        fqr._pending_requests[pending.request_id] = pending
+
+        responder = FederationQueryResponder(db=MagicMock())
+        responder._retrieve = AsyncMock(side_effect=RuntimeError("boom"))
+
+        # Must not raise out of the bg task.
+        await responder._run_query(pending.request_id)
+
+        assert pending.status == STATUS_FAILED
+        assert pending.error_message == "boom"
+        assert pending.answered_at is not None  # set on failure per fix
+
+
 class TestProgressRateLimit:
     @pytest.mark.unit
     def test_emit_progress_caps_at_max_updates(

--- a/tests/backend/test_federation_query_responder.py
+++ b/tests/backend/test_federation_query_responder.py
@@ -1,0 +1,366 @@
+"""
+Tests for F3a — federation query_brain responder.
+
+Coverage:
+- initiate happy path (verified peer → request_id minted → background task kicked)
+- signature mismatch rejected
+- stale timestamp rejected
+- nonce replay rejected
+- unknown peer rejected (or revoked peer)
+- retrieve pubkey-binding (stolen request_id can't be polled by another peer)
+- retrieve unknown request → STATUS_EXPIRED (not an oracle)
+- progress rate-limited to MAX_PROGRESS_UPDATES
+- terminal response is signed by responder
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+from services.federation_identity import (
+    FederationIdentity,
+    get_federation_identity,
+    init_federation_identity,
+    reset_federation_identity_for_tests,
+)
+from services.federation_query_responder import (
+    FederationQueryError,
+    FederationQueryResponder,
+    MAX_PROGRESS_UPDATES,
+    _PendingRequest,
+    _clear_state_for_tests,
+    _pending_requests,
+)
+from services.federation_query_schemas import (
+    STATUS_COMPLETE,
+    STATUS_EXPIRED,
+    STATUS_FAILED,
+    STATUS_PROCESSING,
+    QueryBrainInitiateRequest,
+    QueryBrainRetrieveRequest,
+    complete_canonical_payload,
+    initiate_canonical_payload,
+    retrieve_canonical_payload,
+)
+from services.mcp_streaming import (
+    PROGRESS_LABEL_COMPLETE,
+    PROGRESS_LABEL_RETRIEVING,
+    PROGRESS_LABEL_SYNTHESIZING,
+)
+from services.pairing_service import _canonical_bytes
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def responder_identity(tmp_path):
+    """Fresh federation identity for the responder side + reset state."""
+    reset_federation_identity_for_tests()
+    init_federation_identity(tmp_path / "responder_key")
+    _clear_state_for_tests()
+    yield get_federation_identity()
+    reset_federation_identity_for_tests()
+    _clear_state_for_tests()
+
+
+@pytest.fixture
+def asker_identity():
+    """Independent asker identity — not the responder's singleton."""
+    priv = ed25519.Ed25519PrivateKey.generate()
+    return FederationIdentity(priv)
+
+
+@pytest.fixture
+def mock_db_with_peer(asker_identity):
+    """AsyncSession mock that returns a matching PeerUser for the asker."""
+    db = MagicMock()
+    peer = MagicMock()
+    peer.id = 77
+    peer.circle_owner_id = 1  # responder's local user
+    peer.remote_pubkey = asker_identity.public_key_hex()
+    peer.remote_user_id = 42
+    peer.revoked_at = None
+
+    db.execute = AsyncMock()
+    # Default: first execute returns peer, subsequent return membership tier
+    membership = MagicMock(value=2)  # responder granted asker tier=2 (household)
+
+    async def execute_side(stmt):
+        result = MagicMock()
+        if "peer_users" in str(stmt):
+            result.scalar_one_or_none = lambda: peer
+        elif "circle_memberships" in str(stmt):
+            result.scalar_one_or_none = lambda: membership
+        else:
+            result.scalar_one_or_none = lambda: None
+        return result
+
+    db.execute.side_effect = execute_side
+    db.commit = AsyncMock()
+    return db
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _sign_initiate(
+    asker: FederationIdentity,
+    query: str = "what is mom's recipe?",
+    nonce: str | None = None,
+    timestamp: int | None = None,
+) -> QueryBrainInitiateRequest:
+    import secrets
+
+    unsigned = {
+        "version": 1,
+        "asker_pubkey": asker.public_key_hex(),
+        "query": query,
+        "nonce": nonce or secrets.token_hex(16),
+        "timestamp": timestamp if timestamp is not None else int(time.time()),
+    }
+    sig = asker.sign(_canonical_bytes(unsigned)).hex()
+    return QueryBrainInitiateRequest(**unsigned, signature=sig)
+
+
+def _sign_retrieve(
+    asker: FederationIdentity,
+    request_id: str,
+    timestamp: int | None = None,
+) -> QueryBrainRetrieveRequest:
+    unsigned = {
+        "version": 1,
+        "request_id": request_id,
+        "asker_pubkey": asker.public_key_hex(),
+        "timestamp": timestamp if timestamp is not None else int(time.time()),
+    }
+    sig = asker.sign(_canonical_bytes(unsigned)).hex()
+    return QueryBrainRetrieveRequest(**unsigned, signature=sig)
+
+
+# =============================================================================
+# Initiate
+# =============================================================================
+
+
+class TestHandleInitiate:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_happy_path_mints_request_id(
+        self, responder_identity, asker_identity, mock_db_with_peer,
+    ):
+        responder = FederationQueryResponder(db=mock_db_with_peer)
+
+        # Stub out _run_query so we don't need Ollama/PolymorphicAtomStore.
+        responder._run_query = AsyncMock()
+
+        req = _sign_initiate(asker_identity)
+        resp = await responder.handle_initiate(req)
+
+        assert resp.request_id  # UUID-shaped
+        assert len(resp.request_id) == 36  # UUID4 with hyphens
+        assert resp.accepted_at >= 0
+
+        # Pending entry exists with the correct asker_pubkey binding.
+        pending = _pending_requests[resp.request_id]
+        assert pending.asker_pubkey == asker_identity.public_key_hex()
+        assert pending.peer_user_id == 77
+        assert pending.max_visible_tier == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_tampered_signature_rejected(
+        self, responder_identity, asker_identity, mock_db_with_peer,
+    ):
+        responder = FederationQueryResponder(db=mock_db_with_peer)
+        req = _sign_initiate(asker_identity)
+        # Flip one byte in the signature
+        bad = bytearray(bytes.fromhex(req.signature))
+        bad[0] ^= 0xFF
+        tampered = QueryBrainInitiateRequest(**{**req.model_dump(), "signature": bad.hex()})
+
+        with pytest.raises(FederationQueryError, match="Signature"):
+            await responder.handle_initiate(tampered)
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_stale_timestamp_rejected(
+        self, responder_identity, asker_identity, mock_db_with_peer,
+    ):
+        responder = FederationQueryResponder(db=mock_db_with_peer)
+        # 2 minutes in the past — outside ±60s window
+        req = _sign_initiate(asker_identity, timestamp=int(time.time()) - 120)
+        with pytest.raises(FederationQueryError, match="window"):
+            await responder.handle_initiate(req)
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_nonce_replay_rejected(
+        self, responder_identity, asker_identity, mock_db_with_peer,
+    ):
+        responder = FederationQueryResponder(db=mock_db_with_peer)
+        responder._run_query = AsyncMock()
+
+        req1 = _sign_initiate(asker_identity, nonce="deadbeefdeadbeef" * 2)
+        await responder.handle_initiate(req1)
+
+        # Build a second request reusing the same nonce (signer would need
+        # to resign since timestamp changed; we simulate by re-signing the
+        # same nonce at a new moment).
+        req2 = _sign_initiate(asker_identity, nonce="deadbeefdeadbeef" * 2)
+        with pytest.raises(FederationQueryError, match="replay"):
+            await responder.handle_initiate(req2)
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_unknown_peer_rejected(self, responder_identity, asker_identity):
+        """Asker whose pubkey isn't in peer_users must be rejected."""
+        db = MagicMock()
+        async def no_peer(stmt):
+            r = MagicMock()
+            r.scalar_one_or_none = lambda: None
+            return r
+        db.execute = AsyncMock(side_effect=no_peer)
+        db.commit = AsyncMock()
+
+        responder = FederationQueryResponder(db=db)
+        req = _sign_initiate(asker_identity)
+        with pytest.raises(FederationQueryError, match="Unknown or revoked"):
+            await responder.handle_initiate(req)
+
+
+# =============================================================================
+# Retrieve
+# =============================================================================
+
+
+class TestHandleRetrieve:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_returns_processing_state(
+        self, responder_identity, asker_identity, mock_db_with_peer,
+    ):
+        responder = FederationQueryResponder(db=mock_db_with_peer)
+        responder._run_query = AsyncMock()
+
+        init_req = _sign_initiate(asker_identity)
+        init_resp = await responder.handle_initiate(init_req)
+
+        poll = _sign_retrieve(asker_identity, init_resp.request_id)
+        resp = await responder.handle_retrieve(poll)
+        assert resp.status == STATUS_PROCESSING
+        assert resp.progress == PROGRESS_LABEL_RETRIEVING
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_unknown_request_id_returns_expired(
+        self, responder_identity, asker_identity, mock_db_with_peer,
+    ):
+        """No oracle — non-existent request_id returns the same status
+        as an actually-expired one. An attacker can't enumerate valid ids."""
+        responder = FederationQueryResponder(db=mock_db_with_peer)
+        poll = _sign_retrieve(asker_identity, "not-a-real-request-id")
+        resp = await responder.handle_retrieve(poll)
+        assert resp.status == STATUS_EXPIRED
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_stolen_request_id_rejected_with_different_pubkey(
+        self, responder_identity, asker_identity, mock_db_with_peer,
+    ):
+        """A paired peer who somehow observed another peer's request_id
+        cannot poll it — the pubkey binding closes that hole."""
+        responder = FederationQueryResponder(db=mock_db_with_peer)
+        responder._run_query = AsyncMock()
+
+        init_req = _sign_initiate(asker_identity)
+        init_resp = await responder.handle_initiate(init_req)
+
+        # A different asker tries to poll (valid signature with THEIR key).
+        attacker = FederationIdentity(ed25519.Ed25519PrivateKey.generate())
+        poll = _sign_retrieve(attacker, init_resp.request_id)
+        resp = await responder.handle_retrieve(poll)
+        assert resp.status == STATUS_EXPIRED  # uniform — no oracle
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_terminal_response_is_signed(
+        self, responder_identity, asker_identity, mock_db_with_peer,
+    ):
+        """A completed request returns a response signed with responder
+        identity over `complete_canonical_payload`."""
+        responder = FederationQueryResponder(db=mock_db_with_peer)
+        # Inject a completed pending entry manually (skip the bg task).
+        from services.federation_query_responder import _pending_requests
+        from services.atom_types import Provenance
+
+        pending = _PendingRequest(
+            request_id="test-req-1",
+            asker_pubkey=asker_identity.public_key_hex(),
+            peer_user_id=77,
+            asker_local_user_id=42,
+            max_visible_tier=2,
+            query="q",
+            initiated_at=time.time(),
+            status=STATUS_COMPLETE,
+            progress_label=PROGRESS_LABEL_COMPLETE,
+            answer="Mom said pasta.",
+            provenance=[Provenance(
+                atom_id="AAAA-1111",
+                atom_type="conversation_memory",
+                display_label="from mom's recipes",
+                score=0.87,
+            ).redacted_for_remote()],
+            answered_at=time.time(),
+        )
+        _pending_requests[pending.request_id] = pending
+
+        poll = _sign_retrieve(asker_identity, pending.request_id)
+        resp = await responder.handle_retrieve(poll)
+        assert resp.status == STATUS_COMPLETE
+        assert resp.answer == "Mom said pasta."
+        assert resp.responder_pubkey == responder_identity.public_key_hex()
+        assert resp.responder_signature is not None
+
+        # Asker (a third party holding the responder's pubkey) MUST be
+        # able to verify the signature.
+        ok = FederationIdentity.verify(
+            bytes.fromhex(resp.responder_pubkey),
+            bytes.fromhex(resp.responder_signature),
+            _canonical_bytes(complete_canonical_payload(resp)),
+        )
+        assert ok
+
+
+# =============================================================================
+# Progress rate limiting
+# =============================================================================
+
+
+class TestProgressRateLimit:
+    @pytest.mark.unit
+    def test_emit_progress_caps_at_max_updates(
+        self, responder_identity, asker_identity,
+    ):
+        """Traffic-analysis defence: responder can't phase-by-phase
+        telegraph timing beyond a fixed chunk count."""
+        pending = _PendingRequest(
+            request_id="x",
+            asker_pubkey=asker_identity.public_key_hex(),
+            peer_user_id=1,
+            asker_local_user_id=2,
+            max_visible_tier=2,
+            query="q",
+            initiated_at=time.time(),
+        )
+        for i in range(10):
+            FederationQueryResponder._emit_progress(pending, PROGRESS_LABEL_SYNTHESIZING)
+        assert pending.progress_count == MAX_PROGRESS_UPDATES


### PR DESCRIPTION
## Summary

Lane F3a of v2 federation. Ships the **responder side** of the federated `query_brain` protocol. Paired peers (from F2) can now submit signed queries and poll for answers. Asker side (RemoteBrainMCPClient) lands in F3b.

## Endpoints

Mounted under `/api/federation/peer/`. **No `get_current_user`** — peers authenticate entirely via Ed25519 signature verified against `peer_users.remote_pubkey`.

| Method | Path | Purpose |
|---|---|---|
| POST | `/query_brain/initiate` | Verify sig + window + nonce + peer lookup → mint UUID4 request_id → enqueue bg work |
| POST | `/query_brain/retrieve` | Verify sig + pubkey binding → return current state (terminal responses signed) |

## Security posture

Adversary model: paired peer is trusted to render truthfully but not trusted absolutely.

- **Signature verification** on every request, bound to `peer_users.remote_pubkey`.
- **±60s timestamp window** — rejects clock-skewed replays.
- **Nonce replay defence** — LRU of 4096 recent nonces, rolling ±60s window.
- **Request-ID binding** — `retrieve` verifies the polling pubkey matches the initiating pubkey. Stolen request_ids returned from one peer to another yield `STATUS_EXPIRED` (uniform — no oracle).
- **Revoked peers** (`revoked_at != NULL`) rejected at lookup time — revocation is immediate.
- **Uniform HTTP 400** "federation query failed" at the route layer. Operator logs have the real reason; wire doesn't.
- **Progress labels** drawn from `PROGRESS_LABELS` locked vocabulary (can't leak "found 47 atoms" strings).
- **Progress rate limit**: `MAX_PROGRESS_UPDATES=4` caps phase-by-phase traffic-analysis leakage.
- **Redacted provenance** via `Provenance.redacted_for_remote()` — atom_ids re-randomized per call (no cross-query correlation).

## Flow

```
ASKER                              RESPONDER
  │ sign(query, nonce, ts)             │
  │─────POST /initiate────────────────▶│ verify sig + window + nonce
  │                                    │ peer_users lookup
  │                                    │ resolve max_visible_tier from
  │                                    │   CircleMembership (set at pairing)
  │                                    │ mint request_id (UUID4)
  │                                    │ asyncio.create_task(_run_query)
  │                                    │    ├─ PolymorphicAtomStore.query()
  │                                    │    ├─ _synthesize (stub — F3c
  │                                    │    │                wires Ollama)
  │                                    │    └─ sign response
  │◀────{request_id, accepted_at}──────│
  │                                    │
  │ poll loop                          │
  │─────POST /retrieve─────────────────▶│ verify sig + pubkey binding
  │◀────{status: processing,           │
  │      progress: 'retrieving'}       │
  │                                    │
  │─────POST /retrieve (later)─────────▶│
  │◀────{status: complete, answer,     │
  │      provenance, responder_sig}    │
```

## Tests (9)

Initiate:
- happy path — request_id minted + pending bound to pubkey
- tampered signature rejected
- stale timestamp rejected
- nonce replay rejected
- unknown/revoked peer rejected

Retrieve:
- processing state returns current progress label
- unknown request_id → `STATUS_EXPIRED` (no existence oracle)
- stolen request_id polled with different pubkey → `STATUS_EXPIRED` (binding)
- terminal `complete` carries a responder signature that verifies against `complete_canonical_payload`

Progress:
- `_emit_progress` caps at `MAX_PROGRESS_UPDATES` (traffic analysis defence)

## Deferred to F3b / F3c / F5

- **F3b**: asker-side `RemoteBrainMCPClient` — registers each `PeerUser` as an MCP server, drives the initiate/retrieve poll loop, streams progress chunks via the F1 streaming surface.
- **F3c**: replaces `_synthesize` stub with real Ollama prompt through `utils.llm_client`. Wires ProgressChunks through `MCPManager.execute_tool_streaming` so chat UI shows "asking Mom's brain... synthesizing..." live.
- **F5**: per-peer rate limiting, audit log, revocation UX, multi-process state (Redis).

## Test plan

- [ ] `make test-backend tests/backend/test_federation_query_responder.py` — expect 9 green
- [ ] Manual: `POST /api/federation/peer/query_brain/initiate` with a signed payload on `.159` — expect `request_id` response
- [ ] Manual: follow-up `retrieve` returns `STATUS_PROCESSING` then `STATUS_COMPLETE` within the 60s TTL

🤖 Generated with [Claude Code](https://claude.com/claude-code)