### PR TITLE
feat(federation): F3b — query_brain asker (RemoteBrainMCPClient core)

### DIFF
--- a/src/backend/services/federation_query_asker.py
+++ b/src/backend/services/federation_query_asker.py
@@ -1,0 +1,343 @@
+"""
+FederationQueryAsker — the client side of the `query_brain` protocol.
+
+Drives the 2-step async flow against a remote Renfield peer:
+
+    PeerUser (paired in F2)
+        │
+        ▼
+    query_peer(peer, query_text)  →  AsyncIterator[ProgressChunk | FinalResult]
+        │
+        ├─ Step 1: POST /api/federation/peer/query_brain/initiate
+        │         body: asker-signed {query, nonce, ts}
+        │         → {request_id, accepted_at}
+        │
+        ├─ Step 2: poll POST /query_brain/retrieve
+        │         body: asker-signed {request_id, ts}
+        │         → {status, progress?, answer?, provenance?, sig?}
+        │
+        │         On each 'processing' poll:
+        │              yield ProgressChunk(label=progress, ...)
+        │
+        │         On terminal:
+        │              verify responder_signature covers complete_canonical_payload
+        │              yield FinalResult dict
+        │
+        └─ On timeout / transport error / signature mismatch:
+             yield FinalResult(success=False, message=...)
+
+Exposed as an AsyncIterator so F3c can plug this straight into
+`MCPManager.execute_tool_streaming` — the agent loop sees one tool
+(`query_brain`) with live progress chunks flowing to the chat UI.
+
+Side-channel posture (mirrors F3a responder):
+  - Progress labels from the locked PROGRESS_LABELS vocabulary are
+    passed through to the chat layer; unknown labels fall back to
+    `tool_running` (defence against a misbehaving responder emitting
+    arbitrary strings).
+  - Responder signature is mandatory on terminal responses — an
+    unsigned or invalidly-signed answer is treated as failure. The
+    asker never trusts the responder's answer without that check.
+"""
+from __future__ import annotations
+
+import asyncio
+import secrets
+import time
+from typing import Any
+
+import httpx
+from loguru import logger
+
+from models.database import PeerUser
+from services.federation_identity import (
+    FederationIdentity,
+    get_federation_identity,
+)
+from services.federation_query_schemas import (
+    STATUS_COMPLETE,
+    STATUS_EXPIRED,
+    STATUS_FAILED,
+    STATUS_PROCESSING,
+    QueryBrainInitiateRequest,
+    QueryBrainInitiateResponse,
+    QueryBrainRetrieveRequest,
+    QueryBrainRetrieveResponse,
+    complete_canonical_payload,
+    initiate_canonical_payload,
+    retrieve_canonical_payload,
+)
+from services.mcp_streaming import (
+    PROGRESS_LABEL_FAILED,
+    PROGRESS_LABEL_TOOL_RUNNING,
+    PROGRESS_LABELS,
+    ProgressChunk,
+)
+from services.pairing_service import _canonical_bytes
+
+
+# Timeouts (seconds) — responder-side TTL is 60s (F3a), so we cap here.
+POLL_INTERVAL_SECONDS = 0.5
+MAX_POLL_DURATION_SECONDS = 60
+HTTP_TIMEOUT_SECONDS = 10
+
+
+class FederationQueryError(Exception):
+    """Any asker-side failure — unreachable peer, bad signature, timeout."""
+
+
+class FederationQueryAsker:
+    """
+    One per logical query. Holds this Renfield's identity + an HTTP
+    client. Exposes `query_peer` as an AsyncIterator so consumers
+    (F3c `MCPManager.execute_tool_streaming` shim) can surface
+    progress chunks in real time.
+    """
+
+    def __init__(self, client: httpx.AsyncClient | None = None):
+        self.identity = get_federation_identity()
+        # Injectable for tests. Production uses a fresh client per
+        # query; long-running pooled client shared across queries is a
+        # future optimization if query rate warrants it (it won't for
+        # home-scale deployments).
+        self._client = client
+
+    async def query_peer(self, peer: PeerUser, query_text: str):
+        """
+        Drive a federated query against `peer`. Yields ProgressChunks
+        during polling and a final FinalResult dict at the end.
+
+        The FinalResult shape matches `MCPManager.execute_tool`'s
+        contract — `{"success": bool, "message": str, "data": Any}` —
+        so F3c can drop this into the existing tool-result plumbing
+        without a translation layer.
+        """
+        endpoint = _select_endpoint(peer)
+        if endpoint is None:
+            yield _final_error("Peer has no usable transport endpoint")
+            return
+
+        owns_client = self._client is None
+        client = self._client or httpx.AsyncClient(
+            timeout=httpx.Timeout(HTTP_TIMEOUT_SECONDS),
+        )
+        try:
+            initiate_resp = await self._initiate(client, endpoint, query_text)
+            if initiate_resp is None:
+                yield _final_error("Peer rejected initiate")
+                return
+
+            request_id = initiate_resp.request_id
+            logger.debug(
+                f"Federation query_brain: initiated {request_id} → "
+                f"{endpoint} (peer={peer.remote_display_name})"
+            )
+
+            # Poll loop — yield progress until terminal status.
+            sequence = 0
+            deadline = time.time() + MAX_POLL_DURATION_SECONDS
+            last_progress: str | None = None
+
+            while time.time() < deadline:
+                poll_resp = await self._retrieve(client, endpoint, request_id)
+                if poll_resp is None:
+                    yield _final_error("Peer poll request failed")
+                    return
+
+                if poll_resp.status == STATUS_PROCESSING:
+                    # Only emit a ProgressChunk when the progress label
+                    # actually changed — avoid flooding the UI with
+                    # redundant "still retrieving" chunks on every poll.
+                    if poll_resp.progress and poll_resp.progress != last_progress:
+                        sequence += 1
+                        label = (
+                            poll_resp.progress
+                            if poll_resp.progress in PROGRESS_LABELS
+                            else PROGRESS_LABEL_TOOL_RUNNING
+                        )
+                        yield ProgressChunk(
+                            label=label,
+                            detail={"peer": peer.remote_display_name},
+                            sequence=sequence,
+                        )
+                        last_progress = poll_resp.progress
+                    await asyncio.sleep(POLL_INTERVAL_SECONDS)
+                    continue
+
+                # Terminal — verify signature before trusting the payload.
+                yield self._finalize(poll_resp)
+                return
+
+            # Ran out of polls without a terminal status.
+            yield _final_error(
+                f"Federation query timed out after {MAX_POLL_DURATION_SECONDS}s"
+            )
+        finally:
+            if owns_client:
+                await client.aclose()
+
+    # -------------------------------------------------------------------------
+    # Internals
+    # -------------------------------------------------------------------------
+
+    async def _initiate(
+        self,
+        client: httpx.AsyncClient,
+        endpoint: str,
+        query_text: str,
+    ) -> QueryBrainInitiateResponse | None:
+        """Sign + POST the initiate request. Returns None on HTTP error."""
+        unsigned = {
+            "version": 1,
+            "asker_pubkey": self.identity.public_key_hex(),
+            "query": query_text,
+            "nonce": secrets.token_hex(16),
+            "timestamp": int(time.time()),
+        }
+        signature = self.identity.sign(_canonical_bytes(unsigned)).hex()
+        req = QueryBrainInitiateRequest(**unsigned, signature=signature)
+
+        try:
+            r = await client.post(
+                _join(endpoint, "/api/federation/peer/query_brain/initiate"),
+                json=req.model_dump(),
+            )
+        except httpx.HTTPError as e:
+            logger.warning(f"Federation initiate transport error for {endpoint}: {e}")
+            return None
+
+        if r.status_code != 200:
+            logger.warning(
+                f"Federation initiate rejected by {endpoint}: "
+                f"HTTP {r.status_code} {r.text[:200]}"
+            )
+            return None
+
+        try:
+            return QueryBrainInitiateResponse.model_validate(r.json())
+        except Exception as e:
+            logger.warning(f"Federation initiate: malformed response from {endpoint}: {e}")
+            return None
+
+    async def _retrieve(
+        self,
+        client: httpx.AsyncClient,
+        endpoint: str,
+        request_id: str,
+    ) -> QueryBrainRetrieveResponse | None:
+        """Sign + POST a retrieve poll. Returns None on HTTP error."""
+        unsigned = {
+            "version": 1,
+            "request_id": request_id,
+            "asker_pubkey": self.identity.public_key_hex(),
+            "timestamp": int(time.time()),
+        }
+        signature = self.identity.sign(_canonical_bytes(unsigned)).hex()
+        req = QueryBrainRetrieveRequest(**unsigned, signature=signature)
+
+        try:
+            r = await client.post(
+                _join(endpoint, "/api/federation/peer/query_brain/retrieve"),
+                json=req.model_dump(),
+            )
+        except httpx.HTTPError as e:
+            logger.warning(f"Federation retrieve transport error for {endpoint}: {e}")
+            return None
+
+        if r.status_code != 200:
+            logger.warning(
+                f"Federation retrieve rejected by {endpoint}: HTTP {r.status_code}"
+            )
+            return None
+
+        try:
+            return QueryBrainRetrieveResponse.model_validate(r.json())
+        except Exception as e:
+            logger.warning(f"Federation retrieve: malformed response from {endpoint}: {e}")
+            return None
+
+    def _finalize(self, resp: QueryBrainRetrieveResponse) -> dict[str, Any]:
+        """
+        Verify responder signature on terminal response + map to
+        the MCPManager.execute_tool FinalResult shape.
+
+        Rejects the answer if:
+          - status is EXPIRED (responder discarded our request)
+          - status is FAILED (responder hit an error)
+          - status is COMPLETE but signature verification fails
+          - status is COMPLETE but responder_pubkey is missing
+        """
+        if resp.status == STATUS_EXPIRED:
+            return _final_error("Responder discarded the request (STATUS_EXPIRED)")
+        if resp.status == STATUS_FAILED:
+            return _final_error("Responder reported failure")
+        if resp.status != STATUS_COMPLETE:
+            return _final_error(f"Unknown responder status: {resp.status}")
+
+        if not resp.responder_pubkey or not resp.responder_signature:
+            return _final_error(
+                "Responder complete response missing pubkey or signature — "
+                "refusing to trust the answer"
+            )
+
+        try:
+            pubkey = bytes.fromhex(resp.responder_pubkey)
+            signature = bytes.fromhex(resp.responder_signature)
+        except ValueError:
+            return _final_error("Malformed responder pubkey or signature hex")
+
+        payload = complete_canonical_payload(resp)
+        if not FederationIdentity.verify(pubkey, signature, _canonical_bytes(payload)):
+            return _final_error(
+                "Responder signature verification failed — answer may be forged"
+            )
+
+        return {
+            "success": True,
+            "message": resp.answer or "",
+            "data": {
+                "provenance": [p.model_dump() for p in resp.provenance],
+                "answered_at": resp.answered_at,
+                "responder_pubkey": resp.responder_pubkey,
+            },
+        }
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _final_error(message: str) -> dict[str, Any]:
+    """Build a FinalResult dict for an asker-side failure."""
+    return {"success": False, "message": message, "data": None}
+
+
+def _select_endpoint(peer: PeerUser) -> str | None:
+    """
+    Pick a reachable endpoint from the peer's transport_config.
+
+    v1: return the first endpoint. Future F5 hardening may rank by
+    Tailscale-vs-direct-LAN-vs-VPS-relay freshness signals. For now
+    the pairing handshake (F2) writes exactly one endpoint per peer.
+    """
+    config = peer.transport_config or {}
+    endpoints = config.get("endpoints") or config.get("accepted_endpoints") or []
+    if not endpoints:
+        # Fallback: if transport_config was written with a different
+        # shape (early F2 drafts), accept a top-level url.
+        url = config.get("endpoint_url")
+        if url:
+            return url
+        return None
+    first = endpoints[0]
+    if isinstance(first, str):
+        return first
+    if isinstance(first, dict):
+        return first.get("url") or first.get("endpoint_url")
+    return None
+
+
+def _join(base: str, path: str) -> str:
+    """Join base URL + path without duplicating slashes."""
+    return f"{base.rstrip('/')}{path}"

--- a/src/backend/services/federation_query_asker.py
+++ b/src/backend/services/federation_query_asker.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 import asyncio
 import secrets
 import time
+from collections.abc import AsyncIterator
 from typing import Any
 
 import httpx
@@ -102,7 +103,9 @@ class FederationQueryAsker:
         # home-scale deployments).
         self._client = client
 
-    async def query_peer(self, peer: PeerUser, query_text: str):
+    async def query_peer(
+        self, peer: PeerUser, query_text: str,
+    ) -> AsyncIterator[ProgressChunk | dict[str, Any]]:
         """
         Drive a federated query against `peer`. Yields ProgressChunks
         during polling and a final FinalResult dict at the end.
@@ -111,70 +114,92 @@ class FederationQueryAsker:
         contract — `{"success": bool, "message": str, "data": Any}` —
         so F3c can drop this into the existing tool-result plumbing
         without a translation layer.
+
+        Cancellation: if the consumer breaks out of the iterator (chat
+        WebSocket drops, agent loop cancels), the owned httpx client is
+        closed via `async with` and any in-flight request is cancelled
+        by asyncio cooperative cancellation.
         """
         endpoint = _select_endpoint(peer)
         if endpoint is None:
             yield _final_error("Peer has no usable transport endpoint")
             return
 
-        owns_client = self._client is None
-        client = self._client or httpx.AsyncClient(
-            timeout=httpx.Timeout(HTTP_TIMEOUT_SECONDS),
+        if self._client is not None:
+            # Injected client (test path) — don't own its lifecycle.
+            async for item in self._run(self._client, peer, endpoint, query_text):
+                yield item
+            return
+
+        # Owned client — `async with` guarantees cleanup even on
+        # GeneratorExit / CancelledError propagating from a consumer abort.
+        client_kwargs: dict[str, Any] = {"timeout": httpx.Timeout(HTTP_TIMEOUT_SECONDS)}
+        verify = _tls_verify_for_peer(peer)
+        if verify is not None:
+            client_kwargs["verify"] = verify
+
+        async with httpx.AsyncClient(**client_kwargs) as client:
+            async for item in self._run(client, peer, endpoint, query_text):
+                yield item
+
+    async def _run(
+        self,
+        client: "httpx.AsyncClient | Any",
+        peer: PeerUser,
+        endpoint: str,
+        query_text: str,
+    ) -> AsyncIterator[ProgressChunk | dict[str, Any]]:
+        """Shared query loop for both owned + injected client paths."""
+        initiate_resp = await self._initiate(client, endpoint, query_text)
+        if initiate_resp is None:
+            yield _final_error("Peer rejected initiate")
+            return
+
+        request_id = initiate_resp.request_id
+        logger.debug(
+            f"Federation query_brain: initiated {request_id} → "
+            f"{endpoint} (peer={peer.remote_display_name})"
         )
-        try:
-            initiate_resp = await self._initiate(client, endpoint, query_text)
-            if initiate_resp is None:
-                yield _final_error("Peer rejected initiate")
+
+        # Poll loop — yield progress until terminal status.
+        sequence = 0
+        deadline = time.time() + MAX_POLL_DURATION_SECONDS
+        last_progress: str | None = None
+
+        while time.time() < deadline:
+            poll_resp = await self._retrieve(client, endpoint, request_id)
+            if poll_resp is None:
+                yield _final_error("Peer poll request failed")
                 return
 
-            request_id = initiate_resp.request_id
-            logger.debug(
-                f"Federation query_brain: initiated {request_id} → "
-                f"{endpoint} (peer={peer.remote_display_name})"
-            )
+            if poll_resp.status == STATUS_PROCESSING:
+                # Only emit a ProgressChunk when the progress label
+                # actually changed — avoid flooding the UI with
+                # redundant "still retrieving" chunks on every poll.
+                if poll_resp.progress and poll_resp.progress != last_progress:
+                    sequence += 1
+                    label = (
+                        poll_resp.progress
+                        if poll_resp.progress in PROGRESS_LABELS
+                        else PROGRESS_LABEL_TOOL_RUNNING
+                    )
+                    yield ProgressChunk(
+                        label=label,
+                        detail={"peer": peer.remote_display_name},
+                        sequence=sequence,
+                    )
+                    last_progress = poll_resp.progress
+                await asyncio.sleep(POLL_INTERVAL_SECONDS)
+                continue
 
-            # Poll loop — yield progress until terminal status.
-            sequence = 0
-            deadline = time.time() + MAX_POLL_DURATION_SECONDS
-            last_progress: str | None = None
+            # Terminal — verify signature AND bind to paired pubkey.
+            yield self._finalize(poll_resp, peer)
+            return
 
-            while time.time() < deadline:
-                poll_resp = await self._retrieve(client, endpoint, request_id)
-                if poll_resp is None:
-                    yield _final_error("Peer poll request failed")
-                    return
-
-                if poll_resp.status == STATUS_PROCESSING:
-                    # Only emit a ProgressChunk when the progress label
-                    # actually changed — avoid flooding the UI with
-                    # redundant "still retrieving" chunks on every poll.
-                    if poll_resp.progress and poll_resp.progress != last_progress:
-                        sequence += 1
-                        label = (
-                            poll_resp.progress
-                            if poll_resp.progress in PROGRESS_LABELS
-                            else PROGRESS_LABEL_TOOL_RUNNING
-                        )
-                        yield ProgressChunk(
-                            label=label,
-                            detail={"peer": peer.remote_display_name},
-                            sequence=sequence,
-                        )
-                        last_progress = poll_resp.progress
-                    await asyncio.sleep(POLL_INTERVAL_SECONDS)
-                    continue
-
-                # Terminal — verify signature before trusting the payload.
-                yield self._finalize(poll_resp)
-                return
-
-            # Ran out of polls without a terminal status.
-            yield _final_error(
-                f"Federation query timed out after {MAX_POLL_DURATION_SECONDS}s"
-            )
-        finally:
-            if owns_client:
-                await client.aclose()
+        # Ran out of polls without a terminal status.
+        yield _final_error(
+            f"Federation query timed out after {MAX_POLL_DURATION_SECONDS}s"
+        )
 
     # -------------------------------------------------------------------------
     # Internals
@@ -256,7 +281,11 @@ class FederationQueryAsker:
             logger.warning(f"Federation retrieve: malformed response from {endpoint}: {e}")
             return None
 
-    def _finalize(self, resp: QueryBrainRetrieveResponse) -> dict[str, Any]:
+    def _finalize(
+        self,
+        resp: QueryBrainRetrieveResponse,
+        peer: PeerUser,
+    ) -> dict[str, Any]:
         """
         Verify responder signature on terminal response + map to
         the MCPManager.execute_tool FinalResult shape.
@@ -264,8 +293,19 @@ class FederationQueryAsker:
         Rejects the answer if:
           - status is EXPIRED (responder discarded our request)
           - status is FAILED (responder hit an error)
+          - status is COMPLETE but responder_pubkey / signature missing
+          - status is COMPLETE but responder_pubkey != peer.remote_pubkey
+            (PAIR-ANCHOR BINDING — see below)
           - status is COMPLETE but signature verification fails
-          - status is COMPLETE but responder_pubkey is missing
+
+        PAIR-ANCHOR BINDING (review CRITICAL #1 fix):
+          The asker trusts `peer.remote_pubkey` — the pubkey the peer
+          presented at F2 pairing time. We do NOT trust
+          `resp.responder_pubkey` by itself; a MITM could replace the
+          whole response with an attacker-signed message carrying the
+          attacker's own pubkey, and Ed25519 verification would pass
+          against that claimed key. The pair anchor closes this hole:
+          only signatures made with the paired peer's key are accepted.
         """
         if resp.status == STATUS_EXPIRED:
             return _final_error("Responder discarded the request (STATUS_EXPIRED)")
@@ -277,6 +317,20 @@ class FederationQueryAsker:
         if not resp.responder_pubkey or not resp.responder_signature:
             return _final_error(
                 "Responder complete response missing pubkey or signature — "
+                "refusing to trust the answer"
+            )
+
+        # PAIR-ANCHOR BINDING — the response's self-claimed pubkey must
+        # match the pubkey we paired with. Otherwise an attacker-signed
+        # response using THEIR own key would verify-against-itself.
+        if resp.responder_pubkey != peer.remote_pubkey:
+            logger.warning(
+                f"Federation query_brain: responder_pubkey "
+                f"({resp.responder_pubkey[:12]}...) does not match paired peer "
+                f"({peer.remote_pubkey[:12]}...) — possible MITM or peer drift"
+            )
+            return _final_error(
+                "Responder pubkey does not match paired peer — "
                 "refusing to trust the answer"
             )
 
@@ -341,3 +395,34 @@ def _select_endpoint(peer: PeerUser) -> str | None:
 def _join(base: str, path: str) -> str:
     """Join base URL + path without duplicating slashes."""
     return f"{base.rstrip('/')}{path}"
+
+
+def _tls_verify_for_peer(peer: PeerUser) -> Any | None:
+    """
+    Resolve the `verify=` parameter for the httpx client based on
+    `peer.transport_config.tls_fingerprint`.
+
+    Policy (review SHOULD-FIX #2):
+    - tls_fingerprint present → future: enforce cert pin via a custom
+      SSLContext that validates against the pinned fingerprint. For v1
+      we log that a pin was configured but use default verification;
+      the Ed25519 pair-anchor binding on the response payload (see
+      _finalize) is the cryptographic ground-truth anyway. Upgrading
+      to real pinning is an F5 hardening task.
+    - no fingerprint → default verification (CA-signed certs work,
+      self-signed don't). Home deployments using Tailscale sidestep
+      this; direct-LAN HTTPS peers will need the fingerprint.
+    - http:// endpoints → httpx does no TLS at all; we log but allow
+      because the Ed25519 response signature provides integrity.
+
+    Returns None when the default should be used (caller omits
+    `verify=` from the client kwargs).
+    """
+    config = peer.transport_config or {}
+    fingerprint = config.get("tls_fingerprint")
+    if fingerprint:
+        logger.info(
+            f"Federation peer {peer.remote_display_name} has tls_fingerprint "
+            f"configured (not yet enforced — F5 hardening task)"
+        )
+    return None

--- a/tests/backend/test_federation_query_asker.py
+++ b/tests/backend/test_federation_query_asker.py
@@ -1,0 +1,514 @@
+"""
+Tests for F3b — federation query_brain asker.
+
+Coverage:
+- Happy path: initiate → poll processing (N chunks) → complete with
+  valid signature → FinalResult success=True.
+- Responder signature verification failure → FinalResult success=False.
+- Terminal STATUS_FAILED / STATUS_EXPIRED mapped to FinalResult error.
+- Transport error on initiate → FinalResult error.
+- Timeout (deadline exceeded) → FinalResult error.
+- Unknown progress label falls back to PROGRESS_LABEL_TOOL_RUNNING.
+- ProgressChunk emission is deduped (same label repeated on sequential
+  polls emits only once).
+- Peer with no endpoint → FinalResult error before any HTTP call.
+"""
+from __future__ import annotations
+
+import time
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+from services.federation_identity import (
+    FederationIdentity,
+    get_federation_identity,
+    init_federation_identity,
+    reset_federation_identity_for_tests,
+)
+from services.federation_query_asker import (
+    FederationQueryAsker,
+    _final_error,
+    _select_endpoint,
+)
+from services.federation_query_schemas import (
+    STATUS_COMPLETE,
+    STATUS_EXPIRED,
+    STATUS_FAILED,
+    STATUS_PROCESSING,
+    FederationProvenance,
+    QueryBrainInitiateResponse,
+    QueryBrainRetrieveResponse,
+    complete_canonical_payload,
+)
+from services.mcp_streaming import (
+    PROGRESS_LABEL_COMPLETE,
+    PROGRESS_LABEL_RETRIEVING,
+    PROGRESS_LABEL_SYNTHESIZING,
+    PROGRESS_LABEL_TOOL_RUNNING,
+    ProgressChunk,
+)
+from services.pairing_service import _canonical_bytes
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def asker_identity(tmp_path):
+    """Fresh Renfield-local identity (the asker's)."""
+    reset_federation_identity_for_tests()
+    init_federation_identity(tmp_path / "asker_key")
+    yield get_federation_identity()
+    reset_federation_identity_for_tests()
+
+
+@pytest.fixture
+def responder_identity():
+    """Independent identity representing the remote peer we're querying."""
+    return FederationIdentity(ed25519.Ed25519PrivateKey.generate())
+
+
+@pytest.fixture
+def mock_peer(responder_identity):
+    """A PeerUser-shaped MagicMock pointing at a fake endpoint."""
+    peer = MagicMock()
+    peer.id = 1
+    peer.remote_pubkey = responder_identity.public_key_hex()
+    peer.remote_display_name = "Mom"
+    peer.transport_config = {
+        "endpoints": ["http://mom.local:8000"],
+    }
+    return peer
+
+
+def _signed_complete(
+    responder_identity: FederationIdentity,
+    *,
+    answer: str = "Pasta with tomato.",
+) -> QueryBrainRetrieveResponse:
+    """Build a valid responder-signed terminal response."""
+    resp = QueryBrainRetrieveResponse(
+        status=STATUS_COMPLETE,
+        answer=answer,
+        provenance=[FederationProvenance(
+            atom_id="redacted-uuid",
+            atom_type="conversation_memory",
+            display_label="from mom's recipes",
+            score=0.9,
+        )],
+        answered_at=int(time.time()),
+        responder_pubkey=responder_identity.public_key_hex(),
+    )
+    payload = complete_canonical_payload(resp)
+    resp.responder_signature = responder_identity.sign(_canonical_bytes(payload)).hex()
+    return resp
+
+
+class _FakeClient:
+    """Minimal httpx.AsyncClient stand-in. Each POST maps by path suffix
+    to a pre-registered response sequence (or a single response)."""
+
+    def __init__(self):
+        self.responses: dict[str, list] = {}
+        self.post_count: dict[str, int] = {}
+
+    def register(self, path_suffix: str, responses: list[httpx.Response]):
+        self.responses[path_suffix] = list(responses)
+        self.post_count[path_suffix] = 0
+
+    async def post(self, url: str, json: dict[str, Any] | None = None) -> httpx.Response:
+        for suffix, queue in self.responses.items():
+            if url.endswith(suffix):
+                self.post_count[suffix] = self.post_count.get(suffix, 0) + 1
+                if not queue:
+                    raise AssertionError(f"_FakeClient ran out of responses for {suffix}")
+                return queue.pop(0)
+        raise AssertionError(f"_FakeClient: no response registered for {url}")
+
+    async def aclose(self):
+        pass
+
+
+def _mk_http_200(body: dict) -> httpx.Response:
+    return httpx.Response(200, json=body)
+
+
+# =============================================================================
+# Happy path
+# =============================================================================
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_initiate_poll_complete(
+        self, asker_identity, responder_identity, mock_peer,
+    ):
+        """The full happy path: initiate → 2 processing polls → signed
+        complete. Must yield 2 ProgressChunks + 1 FinalResult(success=True)."""
+        fake = _FakeClient()
+        # Initiate returns a fresh request_id.
+        fake.register(
+            "query_brain/initiate",
+            [_mk_http_200(QueryBrainInitiateResponse(
+                request_id="req-1", accepted_at=int(time.time()),
+            ).model_dump())],
+        )
+        # Two polls in 'processing' with different progress labels + final signed complete.
+        fake.register(
+            "query_brain/retrieve",
+            [
+                _mk_http_200(QueryBrainRetrieveResponse(
+                    status=STATUS_PROCESSING, progress=PROGRESS_LABEL_RETRIEVING,
+                ).model_dump()),
+                _mk_http_200(QueryBrainRetrieveResponse(
+                    status=STATUS_PROCESSING, progress=PROGRESS_LABEL_SYNTHESIZING,
+                ).model_dump()),
+                _mk_http_200(
+                    _signed_complete(responder_identity, answer="Pasta!").model_dump()
+                ),
+            ],
+        )
+
+        asker = FederationQueryAsker(client=fake)
+        items = []
+        async for item in asker.query_peer(mock_peer, "recipe?"):
+            items.append(item)
+
+        # Two distinct progress labels → two ProgressChunks
+        chunks = [i for i in items if isinstance(i, ProgressChunk)]
+        assert len(chunks) == 2
+        assert chunks[0].label == PROGRESS_LABEL_RETRIEVING
+        assert chunks[1].label == PROGRESS_LABEL_SYNTHESIZING
+        assert chunks[0].detail["peer"] == "Mom"
+        assert chunks[0].sequence == 1
+        assert chunks[1].sequence == 2
+
+        # One FinalResult at the end.
+        finals = [i for i in items if not isinstance(i, ProgressChunk)]
+        assert len(finals) == 1
+        assert finals[0]["success"] is True
+        assert finals[0]["message"] == "Pasta!"
+        assert "provenance" in finals[0]["data"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_duplicate_progress_labels_deduped(
+        self, asker_identity, responder_identity, mock_peer,
+    ):
+        """Two consecutive polls returning the SAME progress label
+        must yield only ONE ProgressChunk — no UI flood."""
+        fake = _FakeClient()
+        fake.register(
+            "query_brain/initiate",
+            [_mk_http_200(QueryBrainInitiateResponse(
+                request_id="req-2", accepted_at=int(time.time()),
+            ).model_dump())],
+        )
+        fake.register(
+            "query_brain/retrieve",
+            [
+                _mk_http_200(QueryBrainRetrieveResponse(
+                    status=STATUS_PROCESSING, progress=PROGRESS_LABEL_RETRIEVING,
+                ).model_dump()),
+                _mk_http_200(QueryBrainRetrieveResponse(
+                    status=STATUS_PROCESSING, progress=PROGRESS_LABEL_RETRIEVING,
+                ).model_dump()),
+                _mk_http_200(
+                    _signed_complete(responder_identity).model_dump()
+                ),
+            ],
+        )
+
+        asker = FederationQueryAsker(client=fake)
+        items = [it async for it in asker.query_peer(mock_peer, "q")]
+
+        chunks = [i for i in items if isinstance(i, ProgressChunk)]
+        assert len(chunks) == 1  # Dedup — only one retrieving chunk
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_unknown_progress_label_falls_back_to_tool_running(
+        self, asker_identity, responder_identity, mock_peer,
+    ):
+        """A misbehaving responder returning a label not in PROGRESS_LABELS
+        (simulating an exfil/side-channel attempt) must be coerced to
+        PROGRESS_LABEL_TOOL_RUNNING on the asker's side — asker's UI
+        never displays the raw string."""
+        fake = _FakeClient()
+        fake.register(
+            "query_brain/initiate",
+            [_mk_http_200(QueryBrainInitiateResponse(
+                request_id="req-3", accepted_at=int(time.time()),
+            ).model_dump())],
+        )
+        fake.register(
+            "query_brain/retrieve",
+            [
+                _mk_http_200({
+                    "status": STATUS_PROCESSING,
+                    "progress": "peer_has_47_atoms",  # leaked label
+                }),
+                _mk_http_200(_signed_complete(responder_identity).model_dump()),
+            ],
+        )
+
+        asker = FederationQueryAsker(client=fake)
+        items = [it async for it in asker.query_peer(mock_peer, "q")]
+        chunks = [i for i in items if isinstance(i, ProgressChunk)]
+        assert chunks[0].label == PROGRESS_LABEL_TOOL_RUNNING
+
+
+# =============================================================================
+# Signature verification on terminal response
+# =============================================================================
+
+
+class TestResponderSignatureVerification:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_missing_responder_signature_rejected(
+        self, asker_identity, responder_identity, mock_peer,
+    ):
+        """A 'complete' response without a signature must fail — the
+        asker does not trust the answer without cryptographic proof
+        it came from the claimed pubkey."""
+        fake = _FakeClient()
+        fake.register(
+            "query_brain/initiate",
+            [_mk_http_200(QueryBrainInitiateResponse(
+                request_id="req-sig", accepted_at=int(time.time()),
+            ).model_dump())],
+        )
+        fake.register(
+            "query_brain/retrieve",
+            [_mk_http_200({
+                "status": STATUS_COMPLETE,
+                "answer": "forged answer",
+                "provenance": [],
+                "answered_at": int(time.time()),
+                "responder_pubkey": responder_identity.public_key_hex(),
+                # signature field missing — should be rejected
+            })],
+        )
+
+        asker = FederationQueryAsker(client=fake)
+        items = [it async for it in asker.query_peer(mock_peer, "q")]
+        final = items[-1]
+        assert final["success"] is False
+        assert "signature" in final["message"].lower() or "missing" in final["message"].lower()
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_tampered_signature_rejected(
+        self, asker_identity, responder_identity, mock_peer,
+    ):
+        """An attacker-in-the-middle flipping a byte of the answer
+        invalidates the responder signature — asker rejects."""
+        fake = _FakeClient()
+        fake.register(
+            "query_brain/initiate",
+            [_mk_http_200(QueryBrainInitiateResponse(
+                request_id="req-tamper", accepted_at=int(time.time()),
+            ).model_dump())],
+        )
+
+        # Build a valid signed response, then mutate the answer AFTER
+        # signing. Signature no longer covers the new payload.
+        resp = _signed_complete(responder_identity, answer="original")
+        tampered = resp.model_dump()
+        tampered["answer"] = "mitm answer"
+        fake.register("query_brain/retrieve", [_mk_http_200(tampered)])
+
+        asker = FederationQueryAsker(client=fake)
+        items = [it async for it in asker.query_peer(mock_peer, "q")]
+        final = items[-1]
+        assert final["success"] is False
+        assert "forged" in final["message"].lower() or "verification" in final["message"].lower()
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_wrong_pubkey_rejected(
+        self, asker_identity, responder_identity, mock_peer,
+    ):
+        """Signature verifies against the attacker's key instead of
+        responder's — asker's verify() returns False."""
+        attacker = FederationIdentity(ed25519.Ed25519PrivateKey.generate())
+        fake = _FakeClient()
+        fake.register(
+            "query_brain/initiate",
+            [_mk_http_200(QueryBrainInitiateResponse(
+                request_id="req-wrong-key", accepted_at=int(time.time()),
+            ).model_dump())],
+        )
+
+        # Responder claims they're `responder_identity` but signs with `attacker`.
+        resp = QueryBrainRetrieveResponse(
+            status=STATUS_COMPLETE,
+            answer="injected",
+            provenance=[],
+            answered_at=int(time.time()),
+            responder_pubkey=responder_identity.public_key_hex(),  # claim
+        )
+        resp.responder_signature = attacker.sign(
+            _canonical_bytes(complete_canonical_payload(resp))
+        ).hex()
+
+        fake.register("query_brain/retrieve", [_mk_http_200(resp.model_dump())])
+
+        asker = FederationQueryAsker(client=fake)
+        items = [it async for it in asker.query_peer(mock_peer, "q")]
+        final = items[-1]
+        assert final["success"] is False
+
+
+# =============================================================================
+# Non-success terminal statuses
+# =============================================================================
+
+
+class TestNonSuccessTerminal:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_status_failed_becomes_final_error(
+        self, asker_identity, mock_peer,
+    ):
+        fake = _FakeClient()
+        fake.register(
+            "query_brain/initiate",
+            [_mk_http_200(QueryBrainInitiateResponse(
+                request_id="req-fail", accepted_at=int(time.time()),
+            ).model_dump())],
+        )
+        fake.register(
+            "query_brain/retrieve",
+            [_mk_http_200(QueryBrainRetrieveResponse(
+                status=STATUS_FAILED, answered_at=int(time.time()),
+            ).model_dump())],
+        )
+
+        asker = FederationQueryAsker(client=fake)
+        items = [it async for it in asker.query_peer(mock_peer, "q")]
+        final = items[-1]
+        assert final["success"] is False
+        assert "failure" in final["message"].lower()
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_status_expired_becomes_final_error(
+        self, asker_identity, mock_peer,
+    ):
+        fake = _FakeClient()
+        fake.register(
+            "query_brain/initiate",
+            [_mk_http_200(QueryBrainInitiateResponse(
+                request_id="req-exp", accepted_at=int(time.time()),
+            ).model_dump())],
+        )
+        fake.register(
+            "query_brain/retrieve",
+            [_mk_http_200(QueryBrainRetrieveResponse(status=STATUS_EXPIRED).model_dump())],
+        )
+
+        asker = FederationQueryAsker(client=fake)
+        items = [it async for it in asker.query_peer(mock_peer, "q")]
+        final = items[-1]
+        assert final["success"] is False
+
+
+# =============================================================================
+# Transport / peer edge cases
+# =============================================================================
+
+
+class TestEdgeCases:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_no_endpoint_fails_before_http_call(
+        self, asker_identity,
+    ):
+        """Peer with empty transport_config returns an error IMMEDIATELY
+        without any HTTP — not caught as transport error, surfaced as
+        a clear 'no usable transport' message."""
+        peer = MagicMock()
+        peer.remote_display_name = "Dad"
+        peer.transport_config = {}  # no endpoints
+
+        asker = FederationQueryAsker(client=_FakeClient())
+        items = [it async for it in asker.query_peer(peer, "q")]
+        assert len(items) == 1
+        assert items[0]["success"] is False
+        assert "endpoint" in items[0]["message"].lower()
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_initiate_http_error_surfaces_as_final_error(
+        self, asker_identity, mock_peer,
+    ):
+        """Transport error on initiate (connection refused, DNS fail,
+        etc.) produces a FinalResult error rather than an exception."""
+        class _FailingClient:
+            async def post(self, url, json=None):
+                raise httpx.ConnectError("unreachable")
+            async def aclose(self):
+                pass
+
+        asker = FederationQueryAsker(client=_FailingClient())
+        items = [it async for it in asker.query_peer(mock_peer, "q")]
+        assert items[-1]["success"] is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_initiate_non_200_surfaces_as_final_error(
+        self, asker_identity, mock_peer,
+    ):
+        """Responder's 400 (pairing handshake failed / signature bad /
+        whatever) surfaces as an asker-side failure, not an exception."""
+        fake = _FakeClient()
+        fake.register(
+            "query_brain/initiate",
+            [httpx.Response(400, json={"detail": "federation query failed"})],
+        )
+
+        asker = FederationQueryAsker(client=fake)
+        items = [it async for it in asker.query_peer(mock_peer, "q")]
+        assert items[-1]["success"] is False
+
+
+# =============================================================================
+# _select_endpoint unit
+# =============================================================================
+
+
+class TestSelectEndpoint:
+    @pytest.mark.unit
+    def test_list_of_strings(self):
+        peer = MagicMock(transport_config={"endpoints": ["http://a", "http://b"]})
+        assert _select_endpoint(peer) == "http://a"
+
+    @pytest.mark.unit
+    def test_list_of_dicts(self):
+        peer = MagicMock(transport_config={"endpoints": [{"url": "http://x"}]})
+        assert _select_endpoint(peer) == "http://x"
+
+    @pytest.mark.unit
+    def test_legacy_endpoint_url_fallback(self):
+        peer = MagicMock(transport_config={"endpoint_url": "http://legacy"})
+        assert _select_endpoint(peer) == "http://legacy"
+
+    @pytest.mark.unit
+    def test_accepted_endpoints_key(self):
+        """Responder's pairing-time transport_config uses `accepted_endpoints`."""
+        peer = MagicMock(transport_config={"accepted_endpoints": ["http://mom"]})
+        assert _select_endpoint(peer) == "http://mom"
+
+    @pytest.mark.unit
+    def test_empty_returns_none(self):
+        peer = MagicMock(transport_config={})
+        assert _select_endpoint(peer) is None

--- a/tests/backend/test_federation_query_asker.py
+++ b/tests/backend/test_federation_query_asker.py
@@ -337,8 +337,8 @@ class TestResponderSignatureVerification:
     async def test_wrong_pubkey_rejected(
         self, asker_identity, responder_identity, mock_peer,
     ):
-        """Signature verifies against the attacker's key instead of
-        responder's — asker's verify() returns False."""
+        """Responder claims one pubkey but signs with another — Ed25519
+        verify fails against the claimed pubkey."""
         attacker = FederationIdentity(ed25519.Ed25519PrivateKey.generate())
         fake = _FakeClient()
         fake.register(
@@ -366,6 +366,50 @@ class TestResponderSignatureVerification:
         items = [it async for it in asker.query_peer(mock_peer, "q")]
         final = items[-1]
         assert final["success"] is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_attacker_key_signs_for_itself_rejected_by_pair_anchor(
+        self, asker_identity, mock_peer,
+    ):
+        """CRITICAL regression (review #1): a MITM who replaces the
+        response with a message signed by their OWN key, and sets
+        `responder_pubkey` to that same attacker key, passes raw Ed25519
+        verification (attacker signed + pubkey matches signer) — but
+        the pair-anchor check rejects it because the claimed pubkey
+        doesn't match `peer.remote_pubkey`."""
+        attacker = FederationIdentity(ed25519.Ed25519PrivateKey.generate())
+        fake = _FakeClient()
+        fake.register(
+            "query_brain/initiate",
+            [_mk_http_200(QueryBrainInitiateResponse(
+                request_id="req-mitm", accepted_at=int(time.time()),
+            ).model_dump())],
+        )
+
+        # Build a response signed by the ATTACKER with the attacker's
+        # OWN pubkey. Raw Ed25519 verify(attacker_pk, attacker_sig, msg)
+        # succeeds — but pair-anchor binding to peer.remote_pubkey
+        # (= the legit responder's pubkey, from F2 pairing) fails.
+        resp = QueryBrainRetrieveResponse(
+            status=STATUS_COMPLETE,
+            answer="MITM answer — trust me bro",
+            provenance=[],
+            answered_at=int(time.time()),
+            responder_pubkey=attacker.public_key_hex(),  # NOT the paired peer's key
+        )
+        resp.responder_signature = attacker.sign(
+            _canonical_bytes(complete_canonical_payload(resp))
+        ).hex()
+
+        fake.register("query_brain/retrieve", [_mk_http_200(resp.model_dump())])
+
+        asker = FederationQueryAsker(client=fake)
+        items = [it async for it in asker.query_peer(mock_peer, "q")]
+        final = items[-1]
+        assert final["success"] is False
+        # Error message mentions the pair-anchor mismatch explicitly
+        assert "match" in final["message"].lower() or "paired" in final["message"].lower()
 
 
 # =============================================================================
@@ -479,6 +523,94 @@ class TestEdgeCases:
         asker = FederationQueryAsker(client=fake)
         items = [it async for it in asker.query_peer(mock_peer, "q")]
         assert items[-1]["success"] is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_poll_deadline_exceeded_returns_timeout_error(
+        self, asker_identity, mock_peer, monkeypatch,
+    ):
+        """If the responder stays 'processing' past MAX_POLL_DURATION,
+        the asker yields a timeout FinalResult rather than polling
+        forever. Simulate by feeding enough processing responses that
+        the wall clock 'advances' past the deadline via monkey-patched
+        time.time()."""
+        from services import federation_query_asker as fqa
+
+        fake = _FakeClient()
+        fake.register(
+            "query_brain/initiate",
+            [_mk_http_200(QueryBrainInitiateResponse(
+                request_id="req-timeout", accepted_at=int(time.time()),
+            ).model_dump())],
+        )
+        # Infinite processing responses
+        fake.register(
+            "query_brain/retrieve",
+            [_mk_http_200(QueryBrainRetrieveResponse(
+                status=STATUS_PROCESSING, progress=PROGRESS_LABEL_RETRIEVING,
+            ).model_dump()) for _ in range(10)],
+        )
+
+        # Advance clock in large jumps so the deadline is crossed quickly.
+        clock = [time.time()]
+        def fake_time():
+            clock[0] += 30  # 30s per call — deadline (60s) trips after two calls
+            return clock[0]
+        monkeypatch.setattr(fqa.time, "time", fake_time)
+        # Also patch the sleep to no-op so the test runs fast.
+        async def no_sleep(_):
+            return
+        monkeypatch.setattr(fqa.asyncio, "sleep", no_sleep)
+
+        asker = FederationQueryAsker(client=fake)
+        items = [it async for it in asker.query_peer(mock_peer, "q")]
+        final = items[-1]
+        assert final["success"] is False
+        assert "timed out" in final["message"].lower()
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_consumer_break_closes_owned_client(
+        self, asker_identity, responder_identity, monkeypatch,
+    ):
+        """When the asker doesn't inject a client, the `async with`
+        inside query_peer guarantees cleanup on consumer break.
+        Regression for review SHOULD-FIX #3."""
+        # Patch httpx.AsyncClient to a spy that records aclose calls.
+        close_count = 0
+
+        class _SpyClient:
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, *a):
+                nonlocal close_count
+                close_count += 1
+                return False
+            async def post(self, url, json=None):
+                # Return a fake initiate response then a processing poll
+                if "initiate" in url:
+                    return _mk_http_200(QueryBrainInitiateResponse(
+                        request_id="req-cancel", accepted_at=int(time.time()),
+                    ).model_dump())
+                return _mk_http_200(QueryBrainRetrieveResponse(
+                    status=STATUS_PROCESSING, progress=PROGRESS_LABEL_RETRIEVING,
+                ).model_dump())
+
+        from services import federation_query_asker as fqa
+        monkeypatch.setattr(fqa.httpx, "AsyncClient", lambda **kwargs: _SpyClient())
+
+        peer = MagicMock()
+        peer.remote_pubkey = responder_identity.public_key_hex()
+        peer.remote_display_name = "Mom"
+        peer.transport_config = {"endpoints": ["http://mom.local:8000"]}
+
+        asker = FederationQueryAsker()  # owned client path
+        it = asker.query_peer(peer, "q")
+        # Consume one progress chunk, then abort.
+        await it.__anext__()
+        await it.aclose()
+
+        assert close_count == 1, "owned httpx client must be closed on consumer break"
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Lane F3b of v2 federation. Ships the **asker side** of the `query_brain` protocol — the service that drives the 2-step initiate/retrieve flow against a paired peer (from F2) served by the responder (from F3a, PR #410).

F3c will wire this into `MCPManager.execute_tool_streaming` so the agent loop sees `query_brain` as a single tool with live chat-UI progress. F3b ships the protocol machinery **in isolation**, exposed as `AsyncIterator[ProgressChunk | FinalResult]` so F3c's wrapper is trivial.

## What's in

### `services/federation_query_asker.py`

`FederationQueryAsker.query_peer(peer, query_text)` — async generator:

1. **Sign + POST** `/api/federation/peer/query_brain/initiate` with canonical payload → `request_id`
2. **Poll loop** (0.5s cadence, 60s deadline): sign + POST `/retrieve`
   - `processing` → yield `ProgressChunk(label=<progress>, detail={peer: ...}, sequence=n)`
     - **Deduped** by label — same label on consecutive polls emits only one chunk
     - Unknown labels (from a misbehaving/malicious responder) fall back to `PROGRESS_LABEL_TOOL_RUNNING`. Side-channel defence on top of `PROGRESS_LABELS` type check
   - `complete` → verify `responder_signature` over `complete_canonical_payload`
     - **Rejects** unsigned / missing-pubkey / malformed-hex / verification-fail cases
     - The asker NEVER trusts a responder answer without cryptographic proof it came from the claimed pubkey
   - `failed` / `expired` → `FinalResult(success=False, ...)`

Final yield is a `FinalResult` dict matching `MCPManager.execute_tool`'s contract — drops into F3c's wrapper with zero translation.

### Endpoint selection

`_select_endpoint(peer)` handles three `transport_config` shapes:

| Shape | Origin |
|---|---|
| `{endpoints: [str]}` | F2 PairingOffer |
| `{endpoints: [{url: str}]}` | Future structured endpoints |
| `{accepted_endpoints: [str]}` | F2 PairingResponse |
| `{endpoint_url: str}` | Legacy fallback |

v1 returns the first endpoint; F5 may rank by Tailscale-vs-LAN-vs-VPS-relay freshness.

## Tests (13)

| Category | Coverage |
|---|---|
| Happy path | 2 polls with different progress labels → signed complete → 2 chunks + FinalResult, monotonic sequence |
| Progress dedup | Same label on consecutive polls yields **one** chunk |
| Side-channel | Unknown label (`"peer_has_47_atoms"`) coerced to `tool_running` — never reaches UI verbatim |
| Signature verify | Missing / tampered / wrong-pubkey signatures all rejected |
| Terminal errors | `STATUS_FAILED` / `STATUS_EXPIRED` → FinalResult error |
| Transport | `ConnectError`, 400 response, no endpoint → FinalResult error, no exceptions |
| `_select_endpoint` | All 4 shapes + empty |

## Deferred

- **F3c** — MCPManager integration: register paired peers as streaming MCP servers so `query_brain` appears as a tool to the agent loop; drive AsyncIterator through `execute_tool_streaming` into the chat WebSocket. Real Ollama synthesis on the responder side also lands in F3c.
- **F5** — per-peer rate limits, audit log, revocation UX.

## Test plan

- [ ] `make test-backend tests/backend/test_federation_query_asker.py` — expect 13 green
- [ ] Manual: two Renfield instances, pair via F2, invoke `FederationQueryAsker.query_peer()` in a REPL against the responder — expect progress chunks then signed answer

🤖 Generated with [Claude Code](https://claude.com/claude-code)