### PR TITLE
feat(federation): F3c — agent-loop integration + real Ollama synthesis

### DIFF
--- a/src/backend/api/lifecycle.py
+++ b/src/backend/api/lifecycle.py
@@ -299,6 +299,21 @@ async def _init_mcp(app: "FastAPI"):
         intent_registry.set_mcp_prompt_tools(prompt_tools)
 
         logger.info(f"✅ MCP Client bereit: {len(mcp_tools)} Tools registriert")
+
+        # Federation peer registry (F3c) — register paired PeerUsers as
+        # virtual FEDERATION-transport MCP servers so the agent loop sees
+        # `mcp.peer_<id>.query_brain` alongside every other MCP tool.
+        # Non-fatal on failure: an empty peer list or schema-migration-
+        # not-yet-applied DB should not block backend startup.
+        try:
+            from services.database import AsyncSessionLocal
+            from services.peer_mcp_registry import sync_peers
+            async with AsyncSessionLocal() as peer_session:
+                await sync_peers(manager, peer_session)
+        except Exception as peer_error:
+            logger.warning(
+                f"Federation peer registry sync skipped at startup: {peer_error}"
+            )
     except Exception as e:
         logger.error(f"MCP Client konnte nicht initialisiert werden: {e}")
         import traceback

--- a/src/backend/services/federation_query_responder.py
+++ b/src/backend/services/federation_query_responder.py
@@ -92,6 +92,7 @@ from services.mcp_streaming import (
     PROGRESS_LABEL_SYNTHESIZING,
 )
 from services.pairing_service import _canonical_bytes
+from utils.config import settings
 
 
 # Request lifecycle: pending rows live here for 60s (or until terminal).
@@ -415,28 +416,76 @@ class FederationQueryResponder:
     async def _synthesize(self, query: str, matches: list) -> str:
         """
         Ask the local LLM to turn retrieved matches into a natural-language
-        answer. Kept narrow: answer is short (<512 tokens) and must NOT
-        echo the asker's raw query back into other capture surfaces
-        (prompt-injection-as-capture defence — design doc § Synthesis
-        isolation).
+        answer.
 
-        F3c TODO: replace this stub with a proper Ollama prompt via
-        utils.llm_client. When wiring that up, revisit the synthesis-
-        isolation rules from the design doc: the asker's query MUST
-        NOT be fed into conversation_memory capture, notification
-        bodies, or any other surface that could persist the peer's
-        text into THIS responder's own atoms.
+        Synthesis isolation (design doc § Synthesis isolation):
+          - The asker's query passes through an LLM prompt ONLY for the
+            purpose of answering from the local snippets. It is NOT
+            persisted back into conversation_memory, notifications, or
+            any other capture surface on this responder. A malicious
+            peer crafting an "ignore previous instructions ..." query
+            therefore cannot coerce us to mutate our own atoms — they
+            only ever shape the answer we ship back to them, which they
+            already have full control over.
+          - Answer is capped at ≤512 tokens via a hard prompt limit AND
+            a 2000-char post-slice (defence in depth).
+
+        Fallback: if Ollama is unreachable or times out, degrade to
+        snippet concatenation so federation still returns SOMETHING
+        rather than a blank answer. Logged as warning for operator
+        visibility.
         """
         if not matches:
             return ""
-        # Minimal v1 synthesis — concatenate snippets + a short instruction.
-        # The snippet is sliced BEFORE the `- ` prefix so the 198-char
-        # cap is on actual content, not prefix+content.
-        snippets = "\n".join(f"- {(m.snippet or '')[:198]}" for m in matches[:5])
-        return (
-            f"Based on what I have: {query}\n"
-            f"Relevant snippets:\n{snippets}"
-        )[:2000]
+
+        # Build snippet context. Cap each to 400 chars so the prompt
+        # stays under typical context-window limits even for 10 matches.
+        snippets_text = "\n".join(
+            f"- {(m.snippet or '')[:400]}" for m in matches[:10]
+        )
+
+        system_msg = (
+            "You are answering a federated query from a trusted peer. "
+            "Answer ONLY from the provided snippets. "
+            "If the snippets do not contain the answer, say 'I don't know from what was shared with you.' "
+            "Do not fabricate details. Do not invent names, dates, or quantities not present in the snippets. "
+            "Keep your answer under 200 words and in the same language as the question."
+        )
+        user_msg = (
+            f"Question: {query}\n\n"
+            f"Snippets from the responder's atoms:\n{snippets_text}"
+        )
+
+        try:
+            from utils.llm_client import extract_response_content, get_default_client
+
+            client = get_default_client()
+            response = await asyncio.wait_for(
+                client.chat(
+                    model=settings.ollama_model,
+                    messages=[
+                        {"role": "system", "content": system_msg},
+                        {"role": "user", "content": user_msg},
+                    ],
+                    options={
+                        "temperature": 0.2,   # factual, low creativity
+                        "num_predict": 512,    # hard cap on generated tokens
+                    },
+                ),
+                timeout=30.0,  # responder TTL is 60s; synthesis + retrieval + poll-reply must fit
+            )
+            answer = extract_response_content(response) or ""
+        except Exception as e:
+            logger.warning(
+                f"Federation query_brain: Ollama synthesis failed ({e}); "
+                f"falling back to snippet concatenation"
+            )
+            # Fallback stub — same shape as the pre-F3c synthesis. Keeps
+            # federation functional when Ollama is down (a paired peer
+            # still gets provenance + raw snippets to work with).
+            answer = f"Relevant snippets:\n{snippets_text}"
+
+        return answer[:2000]
 
     # -------------------------------------------------------------------------
     # Serialization + signing of terminal responses

--- a/src/backend/services/mcp_client.py
+++ b/src/backend/services/mcp_client.py
@@ -770,12 +770,23 @@ class MCPManager:
 
         for entry in raw["servers"]:
             try:
+                transport_str = _resolve_value(entry.get("transport", "streamable_http"))
+                transport = MCPTransportType(transport_str)
+                # FEDERATION is registry-managed (paired peers) — refuse
+                # YAML definitions so an admin can't accidentally register
+                # a federation entry without going through the pairing
+                # handshake, which would have no PeerUser row and crash
+                # at request time.
+                if transport == MCPTransportType.FEDERATION:
+                    raise ValueError(
+                        f"MCP server '{entry['name']}': transport='federation' is "
+                        f"registry-managed (paired peers only), not YAML-configured. "
+                        f"Remove this server from mcp_servers.yaml."
+                    )
                 config = MCPServerConfig(
                     name=entry["name"],
                     url=_resolve_value(entry.get("url")),
-                    transport=MCPTransportType(
-                        _resolve_value(entry.get("transport", "streamable_http"))
-                    ),
+                    transport=transport,
                     auth_token_env=entry.get("auth_token_env"),
                     headers={
                         k: _resolve_value(v)
@@ -1141,6 +1152,33 @@ class MCPManager:
             }
 
         state = self._servers.get(tool_info.server_name)
+
+        # Federation-transport branch (F3c): virtual servers have no MCP
+        # session at all — they route through HTTP federation. The agent
+        # loop dispatches through execute_tool (non-streaming), so we
+        # need the federation bridge here too. Collect the final
+        # FinalResult from _execute_federation_streaming; ProgressChunks
+        # are discarded on this path (non-streaming callers don't care,
+        # same shape as execute_tool's streaming-delegate fallback).
+        if state is not None and state.config.transport == MCPTransportType.FEDERATION:
+            final_result: dict | None = None
+            async for item in self._execute_federation_streaming(
+                state=state,
+                namespaced_name=namespaced_name,
+                arguments=arguments,
+                user_permissions=user_permissions,
+                user_id=user_id,
+            ):
+                if not isinstance(item, ProgressChunk):
+                    final_result = item
+            if final_result is None:
+                return {
+                    "success": False,
+                    "message": "Federation tool yielded no final result",
+                    "data": None,
+                }
+            return final_result
+
         if not state or not state.connected or not state.session:
             return {
                 "success": False,
@@ -1348,6 +1386,16 @@ class MCPManager:
         so revocation takes effect immediately. Opens its own AsyncSession
         because the request-scoped one was closed by FastAPI before this
         (agent-loop) call path — same pattern as the responder's bg task.
+
+        Permission enforcement (review BLOCKING #2): reads the tool from
+        _tool_index and calls _check_tool_permission just like the
+        non-federation paths. The agent loop picking the tool is not a
+        permission boundary — it's a tool-selection heuristic.
+
+        Schema note: federation tools bypass _coerce_arguments /
+        _validate_tool_input because the schema is intentionally
+        documentation-only (single `query: str` param). If query_brain
+        grows fields in F3d/F5, wire validation here.
         """
         from services.database import AsyncSessionLocal
         from services.federation_query_asker import FederationQueryAsker
@@ -1362,6 +1410,25 @@ class MCPManager:
                 "data": None,
             }
             return
+
+        # Permission check — same semantics as execute_tool's gate.
+        # Enforces whatever `permissions` the registry attached to the
+        # federation config (default: empty = no permission string
+        # required, i.e. any authenticated user can query any peer).
+        # F5 may tighten this to per-peer permission strings.
+        tool_info = self._tool_index.get(namespaced_name)
+        if tool_info is not None:
+            perm_error = self._check_tool_permission(tool_info, user_permissions)
+            if perm_error:
+                logger.warning(
+                    f"🔒 Federation permission denied: {namespaced_name} — {perm_error}"
+                )
+                yield {
+                    "success": False,
+                    "message": perm_error,
+                    "data": None,
+                }
+                return
 
         query_text = arguments.get("query") or arguments.get("text") or ""
         if not query_text:
@@ -1634,6 +1701,12 @@ class MCPManager:
     async def refresh_tools(self) -> None:
         """Refresh tool lists from all connected servers and reconnect failed ones."""
         for state in self._servers.values():
+            # Federation-transport servers have no MCP session; their
+            # single `query_brain` tool is managed by PeerMCPRegistry,
+            # not discovered via list_tools. Skip explicitly so future
+            # refactors don't accidentally include them.
+            if state.config.transport == MCPTransportType.FEDERATION:
+                continue
             if state.connected and state.session:
                 try:
                     tools_result = await asyncio.wait_for(

--- a/src/backend/services/mcp_client.py
+++ b/src/backend/services/mcp_client.py
@@ -598,6 +598,15 @@ class MCPTransportType(str, Enum):
     SSE = "sse"
     STDIO = "stdio"
 
+    # Federation peers (F3c) — not a real MCP transport; a virtual one.
+    # State rows with this transport are looked up at request time to find
+    # the underlying PeerUser row, and execute_tool_streaming routes them
+    # through FederationQueryAsker instead of session.call_tool. The
+    # only tool such servers expose is `query_brain`. Registry lives in
+    # services/peer_mcp_registry.py; it syncs peers into _servers at
+    # startup (and on pair/unpair events).
+    FEDERATION = "federation"
+
 
 class MCPPermissionError(Exception):
     """Raised when user lacks permission for an MCP tool."""
@@ -629,6 +638,12 @@ class MCPServerConfig:
                               # notifications and yield ProgressChunks. First consumer: federation
                               # query_brain (F3). Non-streaming servers ignore this flag — the
                               # progress queue stays empty and only the final result is yielded.
+
+    # Federation-transport only (F3c): the local PeerUser.id this virtual
+    # server represents. execute_tool_streaming looks up the peer row at
+    # request time (so revocation is picked up without needing a registry
+    # refresh). Unset for non-federation servers.
+    peer_user_id: int | None = None
 
 
 @dataclass
@@ -1275,6 +1290,23 @@ class MCPManager:
         if tool_info is not None:
             state = self._servers.get(tool_info.server_name)
 
+        # Federation-transport branch (F3c) — peers aren't real MCP
+        # servers; we route them through FederationQueryAsker which
+        # drives the initiate/retrieve HTTP protocol against the
+        # remote Renfield and yields ProgressChunks as progress labels
+        # transition. State machinery (rate limiter, validation, etc.)
+        # still applies via the helper.
+        if state is not None and state.config.transport == MCPTransportType.FEDERATION:
+            async for item in self._execute_federation_streaming(
+                state=state,
+                namespaced_name=namespaced_name,
+                arguments=arguments,
+                user_permissions=user_permissions,
+                user_id=user_id,
+            ):
+                yield item
+            return
+
         # Non-streaming path: yield once, same shape as execute_tool.
         if state is None or not state.config.streaming:
             result = await self.execute_tool(
@@ -1299,6 +1331,69 @@ class MCPManager:
             user_permissions=user_permissions,
             user_id=user_id,
         ):
+            yield item
+
+    async def _execute_federation_streaming(
+        self,
+        state: "MCPServerState",
+        namespaced_name: str,
+        arguments: dict,
+        user_permissions: list[str] | None,
+        user_id: int | None,
+    ) -> AsyncIterator[ProgressChunk | FinalResult]:
+        """
+        Route a federation-transport tool call to the remote Renfield peer.
+
+        Looks up the PeerUser row each call (not once-at-registration)
+        so revocation takes effect immediately. Opens its own AsyncSession
+        because the request-scoped one was closed by FastAPI before this
+        (agent-loop) call path — same pattern as the responder's bg task.
+        """
+        from services.database import AsyncSessionLocal
+        from services.federation_query_asker import FederationQueryAsker
+        from models.database import PeerUser
+        from sqlalchemy import select
+
+        peer_user_id = state.config.peer_user_id
+        if peer_user_id is None:
+            yield {
+                "success": False,
+                "message": f"Federation server {state.config.name} has no peer_user_id",
+                "data": None,
+            }
+            return
+
+        query_text = arguments.get("query") or arguments.get("text") or ""
+        if not query_text:
+            yield {
+                "success": False,
+                "message": "query_brain requires a 'query' argument",
+                "data": None,
+            }
+            return
+
+        async with AsyncSessionLocal() as session:
+            peer = (await session.execute(
+                select(PeerUser).where(
+                    PeerUser.id == peer_user_id,
+                    PeerUser.revoked_at.is_(None),
+                )
+            )).scalar_one_or_none()
+
+        if peer is None:
+            logger.warning(
+                f"Federation tool call: peer {peer_user_id} unknown or revoked "
+                f"(namespaced={namespaced_name}, user_id={user_id})"
+            )
+            yield {
+                "success": False,
+                "message": "Federation peer is unknown or has been revoked",
+                "data": None,
+            }
+            return
+
+        asker = FederationQueryAsker()
+        async for item in asker.query_peer(peer, query_text):
             yield item
 
     async def _execute_tool_streaming_impl(

--- a/src/backend/services/peer_mcp_registry.py
+++ b/src/backend/services/peer_mcp_registry.py
@@ -125,21 +125,24 @@ async def sync_peers(manager: MCPManager, db: AsyncSession) -> None:
 
     # 1. Register/update current peers.
     for server_name, peer in wanted.items():
-        manager._servers[server_name] = MCPServerState(
-            config=_build_federation_config(peer),
-        )
+        state = MCPServerState(config=_build_federation_config(peer))
         # `connected=True` is a lie — there's no MCP session — but
         # execute_tool_streaming's federation branch doesn't touch the
         # session at all, it goes straight to FederationQueryAsker.
         # We set it so `get_connected_server_names()` reports peers
         # as discoverable.
-        manager._servers[server_name].connected = True
+        state.connected = True
 
         tool_info = _build_query_brain_tool(peer)
         manager._tool_index[tool_info.namespaced_name] = tool_info
-        # Also register in the server's discovered-tools list so
-        # fuzzy fallback in execute_tool can find it.
-        manager._servers[server_name].all_discovered_tools = [tool_info]
+        # `tools` drives admin surfaces (`get_status()` tool_count);
+        # `all_discovered_tools` drives fuzzy fallback in execute_tool.
+        # Set both so dashboards report the peer correctly AND the
+        # agent-loop's tool-lookup path can find it by namespace or
+        # short name.
+        state.tools = [tool_info]
+        state.all_discovered_tools = [tool_info]
+        manager._servers[server_name] = state
 
     # 2. Drop entries for peers that have since been revoked or deleted.
     stale_server_names = [

--- a/src/backend/services/peer_mcp_registry.py
+++ b/src/backend/services/peer_mcp_registry.py
@@ -1,0 +1,157 @@
+"""
+PeerMCPRegistry — bridges paired PeerUser rows into the MCPManager.
+
+Each non-revoked peer becomes a "virtual" MCP server entry (transport
+= FEDERATION) exposing exactly one tool: `query_brain`. The agent loop
+then sees peers alongside every other MCP server and can route a
+query to `mcp.peer_<id>.query_brain` like any other tool. The actual
+transport (sign + HTTP initiate/retrieve + signature verify + peer-
+anchor binding) is handled by the F3c.1 federation branch in
+`MCPManager.execute_tool_streaming`.
+
+Sync lifecycle:
+
+    sync_peers(manager, db)          ← called at app startup
+        │
+        ├─ SELECT peer_users WHERE revoked_at IS NULL
+        │
+        ├─ For each peer: upsert MCPServerState in manager._servers
+        │                  + register query_brain in manager._tool_index
+        │
+        └─ Remove peer-entries whose PeerUser is gone/revoked
+
+F5 hardening will add event-driven refresh (on pair / unpair / revoke)
+instead of requiring a manual resync. For v1 we call this at startup
+only; `PairingService.complete_handshake` can opt to call it post-pair
+to make new peers immediately queryable without a restart.
+
+What we DON'T do here:
+  - Store PeerUser references. The registry keeps only `peer_user_id`
+    in the MCPServerConfig; the actual row is loaded per-request so
+    revocation propagates immediately (see F3c.1 branch).
+  - Touch the rate limiter or any other runtime state. Registry only
+    manages discovery shape.
+"""
+from __future__ import annotations
+
+from loguru import logger
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import PeerUser
+from services.mcp_client import (
+    MCPManager,
+    MCPServerConfig,
+    MCPServerState,
+    MCPToolInfo,
+    MCPTransportType,
+)
+
+
+# Namespace prefix for federation server entries. Using `peer_{id}` keeps
+# the name stable across display-name changes — the agent loop references
+# tools by namespace, not by display_name.
+FEDERATION_SERVER_PREFIX = "peer_"
+QUERY_BRAIN_TOOL_NAME = "query_brain"
+
+
+def _server_name_for(peer_user_id: int) -> str:
+    return f"{FEDERATION_SERVER_PREFIX}{peer_user_id}"
+
+
+def _namespaced_query_brain(peer_user_id: int) -> str:
+    return f"mcp.{_server_name_for(peer_user_id)}.{QUERY_BRAIN_TOOL_NAME}"
+
+
+def _build_query_brain_tool(peer: PeerUser) -> MCPToolInfo:
+    """
+    Build the MCPToolInfo for a peer's query_brain. Description is
+    personalised with the peer's display_name so the agent loop has a
+    natural-language signal ("ask Mom's brain") when selecting tools.
+    """
+    server_name = _server_name_for(peer.id)
+    return MCPToolInfo(
+        server_name=server_name,
+        original_name=QUERY_BRAIN_TOOL_NAME,
+        namespaced_name=f"mcp.{server_name}.{QUERY_BRAIN_TOOL_NAME}",
+        description=(
+            f"Ask {peer.remote_display_name}'s Renfield for information "
+            f"they've chosen to share with you through circles. "
+            f"Use when the user's question is about something "
+            f"{peer.remote_display_name} would know but you don't."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": (
+                        "Natural-language question to forward to the peer's Renfield. "
+                        "The peer's LLM will synthesize an answer from its own atoms."
+                    ),
+                },
+            },
+            "required": ["query"],
+        },
+    )
+
+
+def _build_federation_config(peer: PeerUser) -> MCPServerConfig:
+    """Build an MCPServerConfig flagging FEDERATION transport +
+    streaming so execute_tool_streaming takes the F3c.1 branch."""
+    return MCPServerConfig(
+        name=_server_name_for(peer.id),
+        transport=MCPTransportType.FEDERATION,
+        enabled=True,
+        streaming=True,
+        peer_user_id=peer.id,
+    )
+
+
+async def sync_peers(manager: MCPManager, db: AsyncSession) -> None:
+    """
+    Rebuild the federation-transport entries in MCPManager from the
+    current set of non-revoked PeerUser rows.
+
+    Idempotent: can be called at startup AND after a pair/unpair event
+    without accumulating duplicates. Any existing peer entries whose
+    PeerUser is revoked or deleted are removed from the manager.
+    """
+    rows = (await db.execute(
+        select(PeerUser).where(PeerUser.revoked_at.is_(None))
+    )).scalars().all()
+
+    wanted: dict[str, PeerUser] = {_server_name_for(p.id): p for p in rows}
+
+    # 1. Register/update current peers.
+    for server_name, peer in wanted.items():
+        manager._servers[server_name] = MCPServerState(
+            config=_build_federation_config(peer),
+        )
+        # `connected=True` is a lie — there's no MCP session — but
+        # execute_tool_streaming's federation branch doesn't touch the
+        # session at all, it goes straight to FederationQueryAsker.
+        # We set it so `get_connected_server_names()` reports peers
+        # as discoverable.
+        manager._servers[server_name].connected = True
+
+        tool_info = _build_query_brain_tool(peer)
+        manager._tool_index[tool_info.namespaced_name] = tool_info
+        # Also register in the server's discovered-tools list so
+        # fuzzy fallback in execute_tool can find it.
+        manager._servers[server_name].all_discovered_tools = [tool_info]
+
+    # 2. Drop entries for peers that have since been revoked or deleted.
+    stale_server_names = [
+        name for name in list(manager._servers.keys())
+        if name.startswith(FEDERATION_SERVER_PREFIX) and name not in wanted
+    ]
+    for server_name in stale_server_names:
+        manager._servers.pop(server_name, None)
+        stale_namespaced = f"mcp.{server_name}.{QUERY_BRAIN_TOOL_NAME}"
+        manager._tool_index.pop(stale_namespaced, None)
+
+    logger.info(
+        f"🔗 Federation peer registry synced: "
+        f"{len(wanted)} peer(s) active, {len(stale_server_names)} removed"
+    )

--- a/tests/backend/test_federation_agent_integration.py
+++ b/tests/backend/test_federation_agent_integration.py
@@ -1,0 +1,359 @@
+"""
+Tests for F3c — federation ↔ agent-loop integration.
+
+Coverage:
+- MCPManager.execute_tool_streaming routes FEDERATION-transport tools
+  to FederationQueryAsker (F3c.1)
+- Revoked/unknown peer surfaces as a FinalResult error, not an exception
+- Missing query argument yields a clear error FinalResult
+- PeerMCPRegistry.sync_peers upserts + removes stale entries (F3c.2)
+- Ollama synthesis happy path + fallback to snippet concatenation on
+  LLM failure (F3c.3)
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+from services.federation_identity import (
+    FederationIdentity,
+    init_federation_identity,
+    reset_federation_identity_for_tests,
+)
+from services.mcp_client import (
+    MCPManager,
+    MCPServerConfig,
+    MCPServerState,
+    MCPToolInfo,
+    MCPTransportType,
+)
+from services.mcp_streaming import ProgressChunk
+from services.peer_mcp_registry import (
+    FEDERATION_SERVER_PREFIX,
+    QUERY_BRAIN_TOOL_NAME,
+    _namespaced_query_brain,
+    _server_name_for,
+    sync_peers,
+)
+
+
+# =============================================================================
+# F3c.1 — federation routing in MCPManager
+# =============================================================================
+
+
+class TestFederationRouting:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_federation_transport_routes_to_query_asker(self, tmp_path, monkeypatch):
+        """An MCP tool call on a FEDERATION-transport server must go
+        through FederationQueryAsker.query_peer instead of
+        session.call_tool."""
+        reset_federation_identity_for_tests()
+        init_federation_identity(tmp_path / "key")
+
+        manager = MCPManager()
+        config = MCPServerConfig(
+            name="peer_7",
+            transport=MCPTransportType.FEDERATION,
+            streaming=True,
+            peer_user_id=7,
+        )
+        state = MCPServerState(config=config)
+        state.connected = True
+        manager._servers["peer_7"] = state
+        tool = MCPToolInfo(
+            server_name="peer_7",
+            original_name="query_brain",
+            namespaced_name="mcp.peer_7.query_brain",
+            description="",
+            input_schema={},
+        )
+        manager._tool_index["mcp.peer_7.query_brain"] = tool
+
+        # Stub the PeerUser lookup + FederationQueryAsker at import time.
+        fake_peer = SimpleNamespace(id=7, remote_display_name="Mom", revoked_at=None)
+        session_mock = AsyncMock()
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none = lambda: fake_peer
+        session_mock.execute = AsyncMock(return_value=result_mock)
+        session_mock.__aenter__ = AsyncMock(return_value=session_mock)
+        session_mock.__aexit__ = AsyncMock(return_value=False)
+
+        monkeypatch.setattr(
+            "services.database.AsyncSessionLocal", lambda: session_mock,
+        )
+
+        async def fake_query_peer(self, peer, text):
+            yield ProgressChunk(label="retrieving", sequence=1)
+            yield {"success": True, "message": f"answered {peer.remote_display_name}", "data": None}
+
+        monkeypatch.setattr(
+            "services.federation_query_asker.FederationQueryAsker.query_peer",
+            fake_query_peer,
+        )
+
+        items = []
+        async for item in manager.execute_tool_streaming(
+            "mcp.peer_7.query_brain", {"query": "what's for dinner?"},
+        ):
+            items.append(item)
+
+        progress = [i for i in items if isinstance(i, ProgressChunk)]
+        finals = [i for i in items if not isinstance(i, ProgressChunk)]
+        assert len(progress) == 1
+        assert finals[0]["success"] is True
+        assert "Mom" in finals[0]["message"]
+
+        reset_federation_identity_for_tests()
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_revoked_peer_returns_error_final_result(self, monkeypatch):
+        """If the PeerUser lookup returns None (revoked or deleted), the
+        federation branch yields a FinalResult error without invoking
+        FederationQueryAsker."""
+        manager = MCPManager()
+        config = MCPServerConfig(
+            name="peer_99", transport=MCPTransportType.FEDERATION,
+            streaming=True, peer_user_id=99,
+        )
+        state = MCPServerState(config=config)
+        state.connected = True
+        manager._servers["peer_99"] = state
+        manager._tool_index["mcp.peer_99.query_brain"] = MCPToolInfo(
+            server_name="peer_99", original_name="query_brain",
+            namespaced_name="mcp.peer_99.query_brain", description="", input_schema={},
+        )
+
+        session_mock = AsyncMock()
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none = lambda: None  # peer revoked/gone
+        session_mock.execute = AsyncMock(return_value=result_mock)
+        session_mock.__aenter__ = AsyncMock(return_value=session_mock)
+        session_mock.__aexit__ = AsyncMock(return_value=False)
+
+        monkeypatch.setattr(
+            "services.database.AsyncSessionLocal", lambda: session_mock,
+        )
+
+        asker_called = False
+
+        async def should_not_be_called(self, peer, text):
+            nonlocal asker_called
+            asker_called = True
+            yield {"success": True, "message": "", "data": None}
+
+        monkeypatch.setattr(
+            "services.federation_query_asker.FederationQueryAsker.query_peer",
+            should_not_be_called,
+        )
+
+        items = [i async for i in manager.execute_tool_streaming(
+            "mcp.peer_99.query_brain", {"query": "q"},
+        )]
+
+        assert not asker_called
+        assert items[-1]["success"] is False
+        assert "revoked" in items[-1]["message"].lower() or "unknown" in items[-1]["message"].lower()
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_missing_query_arg_returns_error(self):
+        """query_brain requires a 'query' argument. Missing = clear error."""
+        manager = MCPManager()
+        config = MCPServerConfig(
+            name="peer_1", transport=MCPTransportType.FEDERATION,
+            streaming=True, peer_user_id=1,
+        )
+        manager._servers["peer_1"] = MCPServerState(config=config)
+        manager._servers["peer_1"].connected = True
+        manager._tool_index["mcp.peer_1.query_brain"] = MCPToolInfo(
+            server_name="peer_1", original_name="query_brain",
+            namespaced_name="mcp.peer_1.query_brain", description="", input_schema={},
+        )
+
+        items = [i async for i in manager.execute_tool_streaming(
+            "mcp.peer_1.query_brain", {},  # no 'query' arg
+        )]
+
+        assert items[-1]["success"] is False
+        assert "query" in items[-1]["message"].lower()
+
+
+# =============================================================================
+# F3c.2 — PeerMCPRegistry.sync_peers
+# =============================================================================
+
+
+class TestSyncPeers:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_registers_non_revoked_peers(self):
+        manager = MCPManager()
+        db = AsyncMock()
+
+        peers = [
+            SimpleNamespace(id=1, remote_pubkey="a"*64, remote_display_name="Mom"),
+            SimpleNamespace(id=2, remote_pubkey="b"*64, remote_display_name="Dad"),
+        ]
+        result = MagicMock()
+        result.scalars = MagicMock(return_value=MagicMock(all=MagicMock(return_value=peers)))
+        db.execute = AsyncMock(return_value=result)
+
+        await sync_peers(manager, db)
+
+        assert _server_name_for(1) in manager._servers
+        assert _server_name_for(2) in manager._servers
+        assert _namespaced_query_brain(1) in manager._tool_index
+        assert _namespaced_query_brain(2) in manager._tool_index
+
+        # Config has the FEDERATION transport + peer_user_id wired.
+        peer1_config = manager._servers[_server_name_for(1)].config
+        assert peer1_config.transport == MCPTransportType.FEDERATION
+        assert peer1_config.streaming is True
+        assert peer1_config.peer_user_id == 1
+
+        # Tool description personalises with display_name.
+        tool1 = manager._tool_index[_namespaced_query_brain(1)]
+        assert "Mom" in tool1.description
+        # Tool schema requires a `query` parameter.
+        assert "query" in tool1.input_schema["properties"]
+        assert "query" in tool1.input_schema["required"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_removes_stale_entries_on_resync(self):
+        """If a peer is revoked between syncs, its registry entry is dropped."""
+        manager = MCPManager()
+
+        # First sync: two peers.
+        peers_initial = [
+            SimpleNamespace(id=1, remote_pubkey="a"*64, remote_display_name="Mom"),
+            SimpleNamespace(id=2, remote_pubkey="b"*64, remote_display_name="Dad"),
+        ]
+        db_a = AsyncMock()
+        r_a = MagicMock()
+        r_a.scalars = MagicMock(return_value=MagicMock(all=MagicMock(return_value=peers_initial)))
+        db_a.execute = AsyncMock(return_value=r_a)
+        await sync_peers(manager, db_a)
+        assert _server_name_for(2) in manager._servers
+
+        # Second sync: peer 2 revoked (not returned by the query).
+        peers_after = [peers_initial[0]]
+        db_b = AsyncMock()
+        r_b = MagicMock()
+        r_b.scalars = MagicMock(return_value=MagicMock(all=MagicMock(return_value=peers_after)))
+        db_b.execute = AsyncMock(return_value=r_b)
+        await sync_peers(manager, db_b)
+
+        assert _server_name_for(1) in manager._servers
+        assert _server_name_for(2) not in manager._servers
+        assert _namespaced_query_brain(2) not in manager._tool_index
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_does_not_touch_non_federation_servers(self):
+        """Non-federation servers (stdio n8n, streamable_http paperless,
+        etc.) must be unaffected by sync_peers — only entries with the
+        `peer_` prefix are managed."""
+        manager = MCPManager()
+        manager._servers["n8n"] = MCPServerState(
+            config=MCPServerConfig(name="n8n", transport=MCPTransportType.STDIO),
+        )
+
+        db = AsyncMock()
+        result = MagicMock()
+        result.scalars = MagicMock(return_value=MagicMock(all=MagicMock(return_value=[])))
+        db.execute = AsyncMock(return_value=result)
+
+        await sync_peers(manager, db)
+
+        assert "n8n" in manager._servers  # untouched
+
+
+# =============================================================================
+# F3c.3 — Ollama synthesis
+# =============================================================================
+
+
+class TestOllamaSynthesis:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_happy_path_uses_llm_output(self, tmp_path, monkeypatch):
+        """Synthesis calls the Ollama chat endpoint and returns the
+        model's answer."""
+        reset_federation_identity_for_tests()
+        init_federation_identity(tmp_path / "key")
+
+        from services.federation_query_responder import FederationQueryResponder
+
+        responder = FederationQueryResponder(db=MagicMock())
+
+        # Mock the llm client.
+        fake_response = MagicMock()
+        fake_response.message = MagicMock(content="Pasta with tomato sauce.")
+        mock_client = MagicMock()
+        mock_client.chat = AsyncMock(return_value=fake_response)
+
+        monkeypatch.setattr(
+            "utils.llm_client.get_default_client", lambda: mock_client,
+        )
+
+        matches = [
+            SimpleNamespace(snippet="Mom: 'the sauce is tomato + garlic'", atom=MagicMock(atom_id="a"*36, atom_type="conversation_memory"), score=0.9),
+        ]
+
+        answer = await responder._synthesize("What's Mom's sauce?", matches)
+        assert "Pasta" in answer
+        mock_client.chat.assert_awaited_once()
+
+        reset_federation_identity_for_tests()
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_ollama_failure_falls_back_to_snippets(self, tmp_path, monkeypatch):
+        """Ollama unreachable — synthesis must not raise; it returns the
+        snippet-concat fallback so federation still yields an answer."""
+        reset_federation_identity_for_tests()
+        init_federation_identity(tmp_path / "key")
+
+        from services.federation_query_responder import FederationQueryResponder
+
+        responder = FederationQueryResponder(db=MagicMock())
+
+        mock_client = MagicMock()
+        mock_client.chat = AsyncMock(side_effect=TimeoutError("ollama down"))
+        monkeypatch.setattr(
+            "utils.llm_client.get_default_client", lambda: mock_client,
+        )
+
+        matches = [
+            SimpleNamespace(snippet="snippet-1 from atoms", atom=MagicMock(), score=0.8),
+            SimpleNamespace(snippet="snippet-2", atom=MagicMock(), score=0.7),
+        ]
+        answer = await responder._synthesize("q", matches)
+
+        assert "snippet-1" in answer  # fallback ships the raw snippets
+        assert "snippet-2" in answer
+
+        reset_federation_identity_for_tests()
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_empty_matches_returns_empty(self, tmp_path):
+        """No retrieval results → empty answer (no LLM call needed)."""
+        reset_federation_identity_for_tests()
+        init_federation_identity(tmp_path / "key")
+
+        from services.federation_query_responder import FederationQueryResponder
+
+        responder = FederationQueryResponder(db=MagicMock())
+        answer = await responder._synthesize("q", [])
+        assert answer == ""
+
+        reset_federation_identity_for_tests()

--- a/tests/backend/test_federation_agent_integration.py
+++ b/tests/backend/test_federation_agent_integration.py
@@ -184,6 +184,114 @@ class TestFederationRouting:
         assert items[-1]["success"] is False
         assert "query" in items[-1]["message"].lower()
 
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_execute_tool_routes_federation_too(self, tmp_path, monkeypatch):
+        """CRITICAL #1 regression: the agent loop dispatches through
+        execute_tool (non-streaming), NOT execute_tool_streaming. The
+        federation branch must be present in BOTH methods so peers are
+        reachable from the agent loop."""
+        reset_federation_identity_for_tests()
+        init_federation_identity(tmp_path / "key")
+
+        manager = MCPManager()
+        config = MCPServerConfig(
+            name="peer_5", transport=MCPTransportType.FEDERATION,
+            streaming=True, peer_user_id=5,
+        )
+        state = MCPServerState(config=config)
+        state.connected = True
+        manager._servers["peer_5"] = state
+        manager._tool_index["mcp.peer_5.query_brain"] = MCPToolInfo(
+            server_name="peer_5", original_name="query_brain",
+            namespaced_name="mcp.peer_5.query_brain", description="", input_schema={},
+        )
+
+        fake_peer = SimpleNamespace(id=5, remote_display_name="Dad", revoked_at=None)
+        session_mock = AsyncMock()
+        r = MagicMock()
+        r.scalar_one_or_none = lambda: fake_peer
+        session_mock.execute = AsyncMock(return_value=r)
+        session_mock.__aenter__ = AsyncMock(return_value=session_mock)
+        session_mock.__aexit__ = AsyncMock(return_value=False)
+        monkeypatch.setattr(
+            "services.database.AsyncSessionLocal", lambda: session_mock,
+        )
+
+        async def fake_query_peer(self, peer, text):
+            yield ProgressChunk(label="retrieving", sequence=1)
+            yield {"success": True, "message": f"answered by {peer.remote_display_name}", "data": None}
+        monkeypatch.setattr(
+            "services.federation_query_asker.FederationQueryAsker.query_peer",
+            fake_query_peer,
+        )
+
+        # NON-STREAMING path — agent loop's entry point
+        result = await manager.execute_tool(
+            "mcp.peer_5.query_brain", {"query": "?"},
+        )
+
+        assert result["success"] is True
+        assert "Dad" in result["message"]
+        # ProgressChunks are discarded on the non-streaming path, only
+        # the final dict is returned.
+        assert "data" in result
+
+        reset_federation_identity_for_tests()
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_federation_branch_enforces_permissions(self, tmp_path, monkeypatch):
+        """BLOCKING #2 regression: federation tools go through
+        _check_tool_permission like every other path. A user without
+        the required permission gets a permission-denied FinalResult
+        BEFORE the peer is even looked up (no wasted HTTP)."""
+        reset_federation_identity_for_tests()
+        init_federation_identity(tmp_path / "key")
+
+        manager = MCPManager()
+        config = MCPServerConfig(
+            name="peer_9", transport=MCPTransportType.FEDERATION,
+            streaming=True, peer_user_id=9,
+            permissions=["federation.query"],  # requires this permission
+        )
+        manager._servers["peer_9"] = MCPServerState(config=config)
+        manager._servers["peer_9"].connected = True
+        manager._tool_index["mcp.peer_9.query_brain"] = MCPToolInfo(
+            server_name="peer_9", original_name="query_brain",
+            namespaced_name="mcp.peer_9.query_brain", description="", input_schema={},
+        )
+
+        # Track whether we reached the peer lookup (we shouldn't)
+        lookup_called = False
+        session_mock = AsyncMock()
+        r = MagicMock()
+
+        def _lookup():
+            nonlocal lookup_called
+            lookup_called = True
+            return None
+
+        r.scalar_one_or_none = _lookup
+        session_mock.execute = AsyncMock(return_value=r)
+        session_mock.__aenter__ = AsyncMock(return_value=session_mock)
+        session_mock.__aexit__ = AsyncMock(return_value=False)
+        monkeypatch.setattr(
+            "services.database.AsyncSessionLocal", lambda: session_mock,
+        )
+
+        # Caller has NO matching permission
+        items = [i async for i in manager.execute_tool_streaming(
+            "mcp.peer_9.query_brain", {"query": "?"},
+            user_permissions=["some.other.perm"],
+        )]
+
+        assert items[-1]["success"] is False
+        # Permission check fires before peer lookup
+        assert not lookup_called
+
+        reset_federation_identity_for_tests()
+
 
 # =============================================================================
 # F3c.2 — PeerMCPRegistry.sync_peers
@@ -260,11 +368,18 @@ class TestSyncPeers:
     async def test_does_not_touch_non_federation_servers(self):
         """Non-federation servers (stdio n8n, streamable_http paperless,
         etc.) must be unaffected by sync_peers — only entries with the
-        `peer_` prefix are managed."""
+        `peer_` prefix are managed. Both _servers and _tool_index must
+        be preserved so existing tools stay reachable after a resync."""
         manager = MCPManager()
         manager._servers["n8n"] = MCPServerState(
             config=MCPServerConfig(name="n8n", transport=MCPTransportType.STDIO),
         )
+        existing_tool = MCPToolInfo(
+            server_name="n8n", original_name="list_workflows",
+            namespaced_name="mcp.n8n.list_workflows",
+            description="", input_schema={},
+        )
+        manager._tool_index["mcp.n8n.list_workflows"] = existing_tool
 
         db = AsyncMock()
         result = MagicMock()
@@ -273,7 +388,31 @@ class TestSyncPeers:
 
         await sync_peers(manager, db)
 
-        assert "n8n" in manager._servers  # untouched
+        # Server entry preserved
+        assert "n8n" in manager._servers
+        # Tool entry preserved — regression guard for a future refactor
+        # that might mistakenly wipe the whole _tool_index.
+        assert "mcp.n8n.list_workflows" in manager._tool_index
+        assert manager._tool_index["mcp.n8n.list_workflows"] is existing_tool
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_registers_state_tools_for_admin_surfaces(self):
+        """`get_status()` reads state.tools for tool_count. sync_peers
+        must set it (not just all_discovered_tools) so admin UI reports
+        peer tool counts correctly."""
+        manager = MCPManager()
+        db = AsyncMock()
+        peers = [SimpleNamespace(id=1, remote_pubkey="a"*64, remote_display_name="Mom")]
+        result = MagicMock()
+        result.scalars = MagicMock(return_value=MagicMock(all=MagicMock(return_value=peers)))
+        db.execute = AsyncMock(return_value=result)
+
+        await sync_peers(manager, db)
+
+        state = manager._servers[_server_name_for(1)]
+        assert len(state.tools) == 1
+        assert state.tools[0].original_name == QUERY_BRAIN_TOOL_NAME
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Lane F3c of v2 federation. **Closes the loop:** the agent loop now sees paired peers as streaming MCP tools, and the responder synthesizes real answers from retrieved atoms via local Ollama. F4 (frontend UX) and F5 (hardening) remain.

## Three pieces

### F3c.1 — FEDERATION transport routing

- New `MCPTransportType.FEDERATION` enum value + `MCPServerConfig.peer_user_id: int | None`
- `execute_tool_streaming` branches on transport: federation entries route through `_execute_federation_streaming` → fresh `AsyncSessionLocal` → `PeerUser` lookup (revocation propagates immediately) → `FederationQueryAsker.query_peer` yielding `ProgressChunk | FinalResult`.
- Revoked/unknown peer yields a `FinalResult` error (no exception)
- Missing `query` arg yields a clear error

### F3c.2 — `PeerMCPRegistry`

- `services/peer_mcp_registry.py::sync_peers(manager, db)` — reads non-revoked `PeerUser` rows, upserts one `MCPServerState` per peer at `mcp.peer_<id>.query_brain`.
- Idempotent: re-running removes stale entries (revoked/deleted peers).
- Tool description personalises with `remote_display_name` so the agent loop has a natural-language signal ("ask Mom's brain").
- Schema requires a `query` parameter.
- Called from `api/lifecycle._init_mcp` at startup. Non-fatal on failure.
- F5 will upgrade to event-driven sync on pair/unpair/revoke.

### F3c.3 — Real Ollama synthesis

- `_synthesize` now calls `utils.llm_client.get_default_client().chat()` with a hard **answer-from-snippets-only** system prompt:
  - "Answer ONLY from provided snippets."
  - "Say 'I don't know' if snippets lack the answer."
  - "Do not fabricate names/dates/quantities."
  - Caps output at 200 words / 512 tokens / 2000 chars.
- Synthesis-isolation rule preserved: the asker's query never feeds into this responder's capture surfaces.
- 30s timeout (responder TTL is 60s — must fit retrieval + poll-reply budget).
- **Graceful fallback to snippet concatenation** on Ollama failure so federation stays functional rather than returning a blank answer.

## Tests (9 new)

| Category | Coverage |
|---|---|
| Federation routing | FEDERATION transport → FederationQueryAsker; revoked peer → FinalResult error (asker not invoked); missing query arg → clear error |
| PeerMCPRegistry | registers non-revoked peers with correct config + tool schema + personalised description; stale entries removed on resync; non-federation servers untouched |
| Ollama synthesis | happy path uses LLM output; Ollama failure → snippet-concat fallback; empty matches → empty answer (no LLM call) |

## What this unblocks

- **F4 frontend** — chat UI can show "asking Mom's brain..." live. ProgressChunks flow through `execute_tool_streaming` → agent loop → chat_handler; chat_handler → WebSocket relay is the last wire (either a small F3c.4 follow-up or rolled into F4).
- **F5 hardening** — per-peer rate limits, audit log, revocation UX scaffold on top of a complete protocol.

## Test plan

- [ ] `make test-backend tests/backend/test_federation_agent_integration.py` — expect 9 green
- [ ] Smoke: start two Renfields, pair via F2, invoke `query_brain` through the chat → expect a signed answer within 30s
- [ ] Restart responder → re-pair → issue query → answer still flows (registry picks up peers at boot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)