### PR TITLE
feat(federation): F4a — peers page + revoke endpoint

### DIFF
--- a/src/backend/api/routes/federation_pairing.py
+++ b/src/backend/api/routes/federation_pairing.py
@@ -20,12 +20,15 @@ that's an oracle the adversary-peer threat model calls out.
 """
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Request
 from loguru import logger
 from pydantic import BaseModel, Field
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from models.database import User
+from models.database import CircleMembership, PeerUser, User
 from services.auth_service import get_current_user
 from services.database import get_db
 from services.federation_identity import get_federation_identity
@@ -71,6 +74,23 @@ class PeerUserResponse(BaseModel):
     remote_display_name: str
     remote_user_id: int | None
     paired_at: str
+
+
+class PeerDetailResponse(BaseModel):
+    """Richer shape for the /settings/circles/peers page — includes tier
+    granted + last-seen timestamp so the UI can render relative-time
+    labels and the tier-badge."""
+    id: int
+    remote_pubkey: str
+    remote_display_name: str
+    remote_user_id: int | None
+    paired_at: str
+    last_seen_at: str | None
+    circle_tier: int  # the tier THIS user granted the remote peer (their view into us)
+
+
+class PeerListResponse(BaseModel):
+    peers: list[PeerDetailResponse]
 
 
 # =============================================================================
@@ -146,4 +166,122 @@ async def complete_pair_handshake(
         remote_display_name=peer.remote_display_name,
         remote_user_id=peer.remote_user_id,
         paired_at=peer.paired_at.isoformat() if peer.paired_at else "",
+    )
+
+
+# =============================================================================
+# Peer management (F4a)
+# =============================================================================
+
+
+async def _tier_for_peer(
+    db: AsyncSession, owner_id: int, remote_user_id: int | None,
+) -> int:
+    """Look up the tier this owner granted the given peer at pair time."""
+    if remote_user_id is None:
+        return 4  # public — should not happen for paired peers, defensive default
+    row = (await db.execute(
+        select(CircleMembership).where(
+            CircleMembership.circle_owner_id == owner_id,
+            CircleMembership.member_user_id == remote_user_id,
+            CircleMembership.dimension == "tier",
+        )
+    )).scalar_one_or_none()
+    if row is None:
+        return 4
+    try:
+        return int(row.value)
+    except (TypeError, ValueError):
+        return 4
+
+
+@router.get("/peers", response_model=PeerListResponse)
+async def list_peers(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """List the authenticated user's paired peers (non-revoked only).
+
+    Response carries the tier the local user granted each peer so the
+    UI can render tier-badges + make the "re-tier a peer" surface
+    simple. Last-seen timestamp lets the UI show "last seen 2 hours ago".
+    """
+    rows = (await db.execute(
+        select(PeerUser).where(
+            PeerUser.circle_owner_id == current_user.id,
+            PeerUser.revoked_at.is_(None),
+        ).order_by(PeerUser.paired_at.desc())
+    )).scalars().all()
+
+    peers = []
+    for peer in rows:
+        tier = await _tier_for_peer(db, current_user.id, peer.remote_user_id)
+        peers.append(PeerDetailResponse(
+            id=peer.id,
+            remote_pubkey=peer.remote_pubkey,
+            remote_display_name=peer.remote_display_name,
+            remote_user_id=peer.remote_user_id,
+            paired_at=peer.paired_at.isoformat() if peer.paired_at else "",
+            last_seen_at=peer.last_seen_at.isoformat() if peer.last_seen_at else None,
+            circle_tier=tier,
+        ))
+    return PeerListResponse(peers=peers)
+
+
+@router.delete("/peers/{peer_id}", status_code=204)
+async def revoke_peer(
+    peer_id: int,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Revoke a paired peer. Side effects:
+      - PeerUser.revoked_at := now (the row stays for audit trail)
+      - CircleMembership for this peer deleted (they no longer reach
+        any atoms at their old tier; F3 read-time verify already
+        short-circuits on revoked_at, but the membership cleanup is
+        the authoritative revoke)
+      - MCPManager peer registry re-synced so `mcp.peer_<id>.query_brain`
+        vanishes from the agent loop's tool surface
+    """
+    peer = (await db.execute(
+        select(PeerUser).where(
+            PeerUser.id == peer_id,
+            PeerUser.circle_owner_id == current_user.id,
+        )
+    )).scalar_one_or_none()
+    if peer is None:
+        # Uniform 404 whether the peer doesn't exist OR belongs to
+        # another user — no existence oracle on peer ids.
+        raise HTTPException(status_code=404, detail="Peer not found")
+
+    peer.revoked_at = datetime.now(UTC).replace(tzinfo=None)
+
+    # Delete the tier membership so their circle reach drops to zero
+    # immediately. F3 retrieval paths also check revoked_at on the
+    # PeerUser row, but circle_memberships is the authoritative record.
+    if peer.remote_user_id is not None:
+        await db.execute(
+            delete(CircleMembership).where(
+                CircleMembership.circle_owner_id == current_user.id,
+                CircleMembership.member_user_id == peer.remote_user_id,
+            )
+        )
+
+    await db.commit()
+
+    # Refresh the MCP registry so `mcp.peer_<id>.query_brain` disappears
+    # from the agent loop. Non-fatal on failure — the DB is authoritative
+    # and F3's per-request peer lookup will reject the tool anyway.
+    try:
+        manager = getattr(request.app.state, "mcp_manager", None)
+        if manager is not None:
+            from services.peer_mcp_registry import sync_peers
+            await sync_peers(manager, db)
+    except Exception as e:
+        logger.warning(f"Peer registry resync after revoke failed (non-fatal): {e}")
+
+    logger.info(
+        f"🔗 Peer {peer.remote_display_name} (id={peer.id}) revoked by "
+        f"user {current_user.id}"
     )

--- a/src/backend/api/routes/federation_pairing.py
+++ b/src/backend/api/routes/federation_pairing.py
@@ -177,9 +177,19 @@ async def complete_pair_handshake(
 async def _tier_for_peer(
     db: AsyncSession, owner_id: int, remote_user_id: int | None,
 ) -> int:
-    """Look up the tier this owner granted the given peer at pair time."""
+    """Look up the tier this owner granted the given peer at pair time.
+
+    Fail-closed fallback: returns tier 0 (self / most private) on any
+    data-integrity failure (missing membership row, non-integer value,
+    missing remote_user_id). Tier 4 would mean PUBLIC, which is the
+    opposite of defensive — a row displayed with a permissive tier
+    badge on the peers page could mislead the owner into thinking
+    they'd shared broadly when the underlying record is missing. The
+    F2 pairing flow always writes a membership, so this fallback only
+    fires on data-integrity bugs, and 0 is the safer wrong answer.
+    """
     if remote_user_id is None:
-        return 4  # public — should not happen for paired peers, defensive default
+        return 0
     row = (await db.execute(
         select(CircleMembership).where(
             CircleMembership.circle_owner_id == owner_id,
@@ -188,11 +198,11 @@ async def _tier_for_peer(
         )
     )).scalar_one_or_none()
     if row is None:
-        return 4
+        return 0
     try:
         return int(row.value)
     except (TypeError, ValueError):
-        return 4
+        return 0
 
 
 @router.get("/peers", response_model=PeerListResponse)
@@ -269,6 +279,29 @@ async def revoke_peer(
         )
 
     await db.commit()
+
+    # Invalidate the CircleResolver class-level cache so any in-flight
+    # handler that already cached (owner, member) → tier drops the stale
+    # entry. Without this, retrieval paths keep resolving the peer at
+    # their pre-revocation reach until process restart.
+    if peer.remote_user_id is not None:
+        from services.circle_resolver import CircleResolver
+        CircleResolver.invalidate_for_membership(
+            current_user.id, peer.remote_user_id,
+        )
+
+    # Purge in-flight pending query_brain requests bound to this peer's
+    # pubkey. Without this, a revoked peer could still poll /retrieve
+    # with a request_id from before the revocation and get an answer —
+    # handle_retrieve doesn't re-check revoked_at (the check is in
+    # handle_initiate only). Purging here closes that window in O(pending).
+    from services.federation_query_responder import purge_requests_for_pubkey
+    discarded = purge_requests_for_pubkey(peer.remote_pubkey)
+    if discarded:
+        logger.info(
+            f"🔗 Purged {discarded} in-flight query_brain request(s) "
+            f"for revoked peer {peer.remote_display_name}"
+        )
 
     # Refresh the MCP registry so `mcp.peer_<id>.query_brain` disappears
     # from the agent loop. Non-fatal on failure — the DB is authoritative

--- a/src/backend/services/federation_query_responder.py
+++ b/src/backend/services/federation_query_responder.py
@@ -159,6 +159,29 @@ def _clear_state_for_tests() -> None:
     _background_tasks.clear()
 
 
+def purge_requests_for_pubkey(asker_pubkey: str) -> int:
+    """
+    Drop every in-flight pending request bound to `asker_pubkey`.
+
+    Called by `revoke_peer` so a revoked peer cannot poll /retrieve
+    and receive an answer for a request they initiated before the
+    revocation. Also cancels their background _run_query tasks so
+    they don't finish and write answers into (now-discarded) pending
+    entries.
+
+    Returns count of discarded requests.
+    """
+    discarded = [
+        rid for rid, pr in list(_pending_requests.items())
+        if pr.asker_pubkey == asker_pubkey
+    ]
+    for rid in discarded:
+        _pending_requests.pop(rid, None)
+    # Bg tasks whose pending entry has vanished will find `pending is None`
+    # at the top of _run_query and return quietly — no cancellation needed.
+    return len(discarded)
+
+
 def _prune_expired(now: float | None = None) -> None:
     """Drop pending requests past TTL. Called on every initiate/retrieve.
 

--- a/src/frontend/src/App.jsx
+++ b/src/frontend/src/App.jsx
@@ -33,6 +33,7 @@ const RoutingDashboardPage = lazy(() => import('./pages/RoutingDashboardPage'));
 const BrainPage = lazy(() => import('./pages/BrainPage'));
 const BrainReviewPage = lazy(() => import('./pages/BrainReviewPage'));
 const CirclesSettingsPage = lazy(() => import('./pages/CirclesSettingsPage'));
+const CirclesPeersPage = lazy(() => import('./pages/CirclesPeersPage'));
 
 function AppRoutes() {
   const { isFeatureEnabled } = useAuth();
@@ -99,6 +100,11 @@ function AppRoutes() {
             <Route path="/settings/circles" element={
               <ProtectedRoute>
                 <CirclesSettingsPage />
+              </ProtectedRoute>
+            } />
+            <Route path="/settings/circles/peers" element={
+              <ProtectedRoute>
+                <CirclesPeersPage />
               </ProtectedRoute>
             } />
             {/* Redirect old /plugins route to new integrations page */}

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -1077,6 +1077,22 @@
     "couldNotLoad": "Konnte Daten nicht laden.",
     "couldNotSave": "Konnte Änderungen nicht speichern.",
     "score": "Relevanz",
-    "capturedAt": "Erfasst am"
+    "capturedAt": "Erfasst am",
+    "peersTitle": "Verbundene Renfield-Instanzen",
+    "peersSubtitle": "Renfields anderer Haushaltsmitglieder, mit denen du gekoppelt bist.",
+    "peersManageHint": "Neue Peers koppelst du auf der Kreis-Einstellungsseite:",
+    "peersEmptyHeadline": "Noch keine gekoppelten Renfields.",
+    "peersEmptyHint": "Koppele zwei Renfields über den QR-Code-Handshake, um föderierte Anfragen zu stellen.",
+    "peersCouldNotLoad": "Konnte Peer-Liste nicht laden.",
+    "peerNeverSeen": "Noch nicht gesehen",
+    "peerJustNow": "Gerade eben",
+    "peerMinutesAgo": "vor {{n}} Min.",
+    "peerHoursAgo": "vor {{n}} Std.",
+    "peerDaysAgo": "vor {{n}} Tagen",
+    "revokePeer": "Kopplung aufheben",
+    "revokePeerTitle": "Kopplung aufheben?",
+    "revokePeerConfirm": "Kopplung zu {{name}} wirklich beenden? Diese Renfield-Instanz kann danach nicht mehr auf deine geteilten Informationen zugreifen.",
+    "peerRevoked": "Kopplung zu {{name}} beendet.",
+    "peerRevokeFailed": "Kopplung konnte nicht beendet werden."
   }
 }

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -1077,6 +1077,22 @@
     "couldNotLoad": "Could not load data.",
     "couldNotSave": "Could not save changes.",
     "score": "Relevance",
-    "capturedAt": "Captured"
+    "capturedAt": "Captured",
+    "peersTitle": "Connected Renfield instances",
+    "peersSubtitle": "Paired Renfield instances from other household members.",
+    "peersManageHint": "You pair new peers from the circles settings page:",
+    "peersEmptyHeadline": "No paired Renfields yet.",
+    "peersEmptyHint": "Pair two Renfield instances through the QR-code handshake to enable federated queries.",
+    "peersCouldNotLoad": "Could not load peer list.",
+    "peerNeverSeen": "Not seen yet",
+    "peerJustNow": "Just now",
+    "peerMinutesAgo": "{{n}}m ago",
+    "peerHoursAgo": "{{n}}h ago",
+    "peerDaysAgo": "{{n}}d ago",
+    "revokePeer": "Revoke pairing",
+    "revokePeerTitle": "Revoke pairing?",
+    "revokePeerConfirm": "Really end pairing with {{name}}? This Renfield will no longer be able to query your shared atoms.",
+    "peerRevoked": "Pairing with {{name}} revoked.",
+    "peerRevokeFailed": "Could not revoke the pairing."
   }
 }

--- a/src/frontend/src/pages/CirclesPeersPage.jsx
+++ b/src/frontend/src/pages/CirclesPeersPage.jsx
@@ -1,0 +1,177 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+import { Users, Trash2, Clock, Fingerprint } from 'lucide-react';
+import apiClient from '../utils/axios';
+import PageHeader from '../components/PageHeader';
+import Alert from '../components/Alert';
+import TierBadge from '../components/TierBadge';
+import { useConfirmDialog } from '../components/ConfirmDialog';
+
+/**
+ * /settings/circles/peers
+ *
+ * Lists paired Renfield peers (from F2 pairing). Shows display_name +
+ * pubkey fingerprint + tier-granted + last-seen. Revoke button
+ * terminates the pairing (F4a — backend calls PeerUser.revoked_at + deletes
+ * the CircleMembership + refreshes the MCP registry so the agent-loop
+ * tool disappears).
+ *
+ * Pairing creation (QR handshake) lives on the sibling /settings/circles
+ * page as a modal — this page is the post-pair management surface.
+ */
+export default function CirclesPeersPage() {
+  const { t, i18n } = useTranslation();
+  const { confirm, ConfirmDialogComponent } = useConfirmDialog();
+
+  const [peers, setPeers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(null);
+  const [revokingIds, setRevokingIds] = useState(() => new Set());
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      const response = await apiClient.get('/api/federation/peers');
+      setPeers(response.data.peers || []);
+      setError(null);
+    } catch (err) {
+      setError(t('circles.peersCouldNotLoad'));
+    } finally {
+      setLoading(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  useEffect(() => {
+    if (success) {
+      const timer = setTimeout(() => setSuccess(null), 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [success]);
+
+  const formatRelative = (iso) => {
+    if (!iso) return t('circles.peerNeverSeen');
+    try {
+      const when = new Date(iso);
+      const diff = Date.now() - when.getTime();
+      const minutes = Math.floor(diff / 60000);
+      if (minutes < 1) return t('circles.peerJustNow');
+      if (minutes < 60) return t('circles.peerMinutesAgo', { n: minutes });
+      const hours = Math.floor(minutes / 60);
+      if (hours < 24) return t('circles.peerHoursAgo', { n: hours });
+      const days = Math.floor(hours / 24);
+      return t('circles.peerDaysAgo', { n: days });
+    } catch {
+      return iso;
+    }
+  };
+
+  const handleRevoke = async (peer) => {
+    const ok = await confirm({
+      title: t('circles.revokePeerTitle'),
+      message: t('circles.revokePeerConfirm', { name: peer.remote_display_name }),
+      confirmText: t('common.delete'),
+      variant: 'danger',
+    });
+    if (!ok) return;
+
+    setRevokingIds((prev) => new Set(prev).add(peer.id));
+    try {
+      await apiClient.delete(`/api/federation/peers/${peer.id}`);
+      setPeers((prev) => prev.filter((p) => p.id !== peer.id));
+      setSuccess(t('circles.peerRevoked', { name: peer.remote_display_name }));
+    } catch {
+      setError(t('circles.peerRevokeFailed'));
+    } finally {
+      setRevokingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(peer.id);
+        return next;
+      });
+    }
+  };
+
+  return (
+    <div className="max-w-5xl mx-auto p-6 space-y-6">
+      <PageHeader
+        icon={Users}
+        title={t('circles.peersTitle')}
+        subtitle={t('circles.peersSubtitle')}
+      />
+
+      {error && <Alert variant="error" onClose={() => setError(null)}>{error}</Alert>}
+      {success && <Alert variant="success">{success}</Alert>}
+
+      <div className="text-sm text-gray-500 dark:text-gray-400">
+        {t('circles.peersManageHint')}{' '}
+        <Link to="/settings/circles" className="text-primary-600 hover:underline">
+          /settings/circles
+        </Link>
+        .
+      </div>
+
+      {loading ? (
+        <div className="text-center py-12 text-gray-500 dark:text-gray-400">
+          {t('common.loading')}
+        </div>
+      ) : peers.length === 0 ? (
+        <div className="card text-center py-12">
+          <Users className="w-12 h-12 mx-auto mb-3 text-gray-300 dark:text-gray-600" aria-hidden="true" />
+          <p className="text-gray-500 dark:text-gray-400 mb-2">
+            {t('circles.peersEmptyHeadline')}
+          </p>
+          <p className="text-sm text-gray-400 dark:text-gray-500">
+            {t('circles.peersEmptyHint')}
+          </p>
+        </div>
+      ) : (
+        <ul className="space-y-3 animate-stagger">
+          {peers.map((peer) => (
+            <li
+              key={peer.id}
+              className={`atom-row tier-ring-${peer.circle_tier} flex-col sm:flex-row`}
+            >
+              <div className="flex-1 min-w-0 space-y-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-medium text-gray-900 dark:text-white truncate">
+                    {peer.remote_display_name}
+                  </span>
+                  <TierBadge tier={peer.circle_tier} />
+                </div>
+                <div className="flex flex-wrap items-center gap-3 text-xs text-gray-500 dark:text-gray-400">
+                  <span className="inline-flex items-center gap-1">
+                    <Fingerprint className="w-3 h-3" aria-hidden="true" />
+                    <code className="tabular-nums">{peer.remote_pubkey.slice(0, 12)}…</code>
+                  </span>
+                  <span className="inline-flex items-center gap-1">
+                    <Clock className="w-3 h-3" aria-hidden="true" />
+                    {formatRelative(peer.last_seen_at)}
+                  </span>
+                </div>
+              </div>
+              <div className="sm:ml-4 sm:flex-shrink-0 flex items-center gap-2 mt-3 sm:mt-0">
+                <button
+                  type="button"
+                  onClick={() => handleRevoke(peer)}
+                  disabled={revokingIds.has(peer.id)}
+                  className="btn-icon btn-icon-danger disabled:opacity-50"
+                  title={t('circles.revokePeer')}
+                  aria-label={t('circles.revokePeer')}
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <ConfirmDialogComponent />
+    </div>
+  );
+}

--- a/tests/backend/test_federation_peers_routes.py
+++ b/tests/backend/test_federation_peers_routes.py
@@ -92,25 +92,41 @@ class TestListPeers:
 class TestTierForPeer:
     @pytest.mark.asyncio
     @pytest.mark.unit
-    async def test_returns_public_when_no_membership(self):
+    async def test_returns_private_when_no_membership(self):
+        """Fail-closed: missing membership row → tier 0 (self), not 4 (public).
+        A UI showing 'public' for a data-integrity bug would mislead the
+        owner into thinking they shared broadly."""
         db = MagicMock()
         r = MagicMock()
         r.scalar_one_or_none = lambda: None
         db.execute = AsyncMock(return_value=r)
 
         tier = await _tier_for_peer(db, owner_id=1, remote_user_id=99)
-        assert tier == 4  # defensive fallback
+        assert tier == 0
 
     @pytest.mark.asyncio
     @pytest.mark.unit
-    async def test_returns_public_when_remote_user_id_missing(self):
+    async def test_returns_private_when_remote_user_id_missing(self):
+        """Fail-closed for missing remote_user_id. Also: no DB query issued."""
         db = MagicMock()
         db.execute = AsyncMock()
 
         tier = await _tier_for_peer(db, owner_id=1, remote_user_id=None)
-        assert tier == 4
-        # Should not have issued a query
+        assert tier == 0
         db.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_returns_private_on_non_integer_value(self):
+        """Malformed membership.value → 0, not 4."""
+        db = MagicMock()
+        membership = MagicMock(value="not-a-number")
+        r = MagicMock()
+        r.scalar_one_or_none = lambda: membership
+        db.execute = AsyncMock(return_value=r)
+
+        tier = await _tier_for_peer(db, owner_id=1, remote_user_id=99)
+        assert tier == 0
 
     @pytest.mark.asyncio
     @pytest.mark.unit
@@ -239,3 +255,88 @@ class TestRevokePeer:
         # Must not raise — revoke is committed even when sync fails.
         await revoke_peer(peer_id=1, request=req, db=db, current_user=user)
         assert peer.revoked_at is not None
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_purges_in_flight_requests_for_revoked_peer(self):
+        """BLOCKING #1 regression: revoked peer must not be able to poll
+        /retrieve for requests they initiated before revocation. The
+        revoke flow purges every _pending_requests entry bound to the
+        peer's pubkey."""
+        from services.federation_query_responder import (
+            _pending_requests,
+            _clear_state_for_tests,
+            _PendingRequest,
+        )
+
+        _clear_state_for_tests()
+
+        peer_pubkey = "a" * 64
+        peer = _peer_row(id_=1, owner_id=42, pubkey=peer_pubkey, remote_user_id=99)
+
+        # Seed two pending requests from this peer + one from a different peer
+        _pending_requests["req-from-peer-1"] = _PendingRequest(
+            request_id="req-from-peer-1",
+            asker_pubkey=peer_pubkey,
+            peer_user_id=1, asker_local_user_id=99, max_visible_tier=2,
+            query="q1", initiated_at=0,
+        )
+        _pending_requests["req-from-peer-2"] = _PendingRequest(
+            request_id="req-from-peer-2",
+            asker_pubkey=peer_pubkey,
+            peer_user_id=1, asker_local_user_id=99, max_visible_tier=2,
+            query="q2", initiated_at=0,
+        )
+        _pending_requests["req-from-other"] = _PendingRequest(
+            request_id="req-from-other",
+            asker_pubkey="b" * 64,  # different peer
+            peer_user_id=2, asker_local_user_id=100, max_visible_tier=2,
+            query="q3", initiated_at=0,
+        )
+
+        db = MagicMock()
+        r = MagicMock()
+        r.scalar_one_or_none = lambda: peer
+        db.execute = AsyncMock(return_value=r)
+        db.commit = AsyncMock()
+
+        req = _mock_request()
+        user = MagicMock(id=42)
+
+        await revoke_peer(peer_id=1, request=req, db=db, current_user=user)
+
+        # Peer's 2 pending requests gone; other peer's 1 request survives.
+        assert "req-from-peer-1" not in _pending_requests
+        assert "req-from-peer-2" not in _pending_requests
+        assert "req-from-other" in _pending_requests
+
+        _clear_state_for_tests()
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_invalidates_circle_resolver_cache(self, monkeypatch):
+        """BLOCKING #2 regression: CircleResolver's class-level
+        (owner, member) → tier cache must be invalidated on revoke so
+        any in-flight handler drops the stale pre-revocation tier."""
+        peer = _peer_row(id_=1, owner_id=42, remote_user_id=99)
+        db = MagicMock()
+        r = MagicMock()
+        r.scalar_one_or_none = lambda: peer
+        db.execute = AsyncMock(return_value=r)
+        db.commit = AsyncMock()
+
+        invalidated_with: list[tuple[int, int]] = []
+
+        def fake_invalidate(cls, owner_id, member_user_id):
+            invalidated_with.append((owner_id, member_user_id))
+
+        from services.circle_resolver import CircleResolver
+        monkeypatch.setattr(
+            CircleResolver, "invalidate_for_membership",
+            classmethod(fake_invalidate),
+        )
+
+        user = MagicMock(id=42)
+        await revoke_peer(peer_id=1, request=_mock_request(), db=db, current_user=user)
+
+        assert invalidated_with == [(42, 99)]

--- a/tests/backend/test_federation_peers_routes.py
+++ b/tests/backend/test_federation_peers_routes.py
@@ -1,0 +1,241 @@
+"""
+Tests for F4a — /api/federation/peers list + DELETE (revoke).
+
+Coverage:
+- list_peers returns only non-revoked peers owned by current user
+- list_peers hydrates circle_tier from CircleMembership
+- revoke_peer sets revoked_at + deletes CircleMembership + re-syncs
+  MCP registry
+- revoke_peer returns 404 for unknown id
+- revoke_peer returns 404 when peer belongs to another user (no
+  existence oracle)
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from api.routes.federation_pairing import (
+    list_peers,
+    revoke_peer,
+    _tier_for_peer,
+)
+
+
+def _mock_request(manager=None):
+    """FastAPI Request mock that exposes app.state.mcp_manager."""
+    req = MagicMock()
+    req.app.state.mcp_manager = manager
+    return req
+
+
+def _peer_row(*, id_=1, owner_id=42, pubkey="a" * 64, display="Mom",
+              remote_user_id=99, revoked=None, paired_at=None, last_seen_at=None):
+    row = MagicMock()
+    row.id = id_
+    row.circle_owner_id = owner_id
+    row.remote_pubkey = pubkey
+    row.remote_display_name = display
+    row.remote_user_id = remote_user_id
+    row.revoked_at = revoked
+    row.paired_at = paired_at or datetime.now(UTC).replace(tzinfo=None)
+    row.last_seen_at = last_seen_at
+    return row
+
+
+class TestListPeers:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_returns_empty_when_no_peers(self):
+        db = MagicMock()
+        r = MagicMock()
+        r.scalars = MagicMock(return_value=MagicMock(all=MagicMock(return_value=[])))
+        db.execute = AsyncMock(return_value=r)
+
+        user = MagicMock(id=42)
+        resp = await list_peers(db=db, current_user=user)
+        assert resp.peers == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_hydrates_tier_from_membership(self):
+        """circle_tier must be pulled from CircleMembership, not made up."""
+        db = MagicMock()
+        peers = [_peer_row(id_=1, owner_id=42, remote_user_id=99, display="Mom")]
+        membership = MagicMock(value=2)  # household tier
+
+        call_idx = [0]
+        async def execute_side(stmt):
+            call_idx[0] += 1
+            result = MagicMock()
+            if call_idx[0] == 1:
+                # First call: SELECT PeerUser
+                result.scalars = MagicMock(
+                    return_value=MagicMock(all=MagicMock(return_value=peers))
+                )
+            else:
+                # Subsequent calls: _tier_for_peer SELECT CircleMembership
+                result.scalar_one_or_none = lambda: membership
+            return result
+
+        db.execute = AsyncMock(side_effect=execute_side)
+
+        user = MagicMock(id=42)
+        resp = await list_peers(db=db, current_user=user)
+        assert len(resp.peers) == 1
+        assert resp.peers[0].circle_tier == 2
+        assert resp.peers[0].remote_display_name == "Mom"
+
+
+class TestTierForPeer:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_returns_public_when_no_membership(self):
+        db = MagicMock()
+        r = MagicMock()
+        r.scalar_one_or_none = lambda: None
+        db.execute = AsyncMock(return_value=r)
+
+        tier = await _tier_for_peer(db, owner_id=1, remote_user_id=99)
+        assert tier == 4  # defensive fallback
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_returns_public_when_remote_user_id_missing(self):
+        db = MagicMock()
+        db.execute = AsyncMock()
+
+        tier = await _tier_for_peer(db, owner_id=1, remote_user_id=None)
+        assert tier == 4
+        # Should not have issued a query
+        db.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_parses_tier_int(self):
+        db = MagicMock()
+        membership = MagicMock(value=3)
+        r = MagicMock()
+        r.scalar_one_or_none = lambda: membership
+        db.execute = AsyncMock(return_value=r)
+
+        tier = await _tier_for_peer(db, owner_id=1, remote_user_id=99)
+        assert tier == 3
+
+
+class TestRevokePeer:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_sets_revoked_at_and_deletes_membership(self):
+        peer = _peer_row(id_=1, owner_id=42, remote_user_id=99)
+        db = MagicMock()
+        r1 = MagicMock()
+        r1.scalar_one_or_none = lambda: peer
+        db.execute = AsyncMock(return_value=r1)
+        db.commit = AsyncMock()
+
+        user = MagicMock(id=42)
+        req = _mock_request(manager=None)  # no manager → registry sync skipped
+
+        await revoke_peer(peer_id=1, request=req, db=db, current_user=user)
+
+        # revoked_at is now set
+        assert peer.revoked_at is not None
+        assert isinstance(peer.revoked_at, datetime)
+        # DELETE membership was issued (2 execute calls: SELECT peer + DELETE membership)
+        assert db.execute.await_count == 2
+        db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_returns_404_for_unknown_peer(self):
+        db = MagicMock()
+        r = MagicMock()
+        r.scalar_one_or_none = lambda: None
+        db.execute = AsyncMock(return_value=r)
+
+        user = MagicMock(id=42)
+        req = _mock_request()
+
+        from fastapi import HTTPException
+        with pytest.raises(HTTPException) as ei:
+            await revoke_peer(peer_id=999, request=req, db=db, current_user=user)
+        assert ei.value.status_code == 404
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_returns_404_for_other_users_peer(self):
+        """No existence oracle — a peer owned by user B must return 404
+        for user A, same as a genuinely missing peer. The SELECT is
+        scoped by circle_owner_id so the query returns None naturally."""
+        db = MagicMock()
+        r = MagicMock()
+        r.scalar_one_or_none = lambda: None  # scoped query filters it out
+        db.execute = AsyncMock(return_value=r)
+
+        user = MagicMock(id=42)
+        req = _mock_request()
+
+        from fastapi import HTTPException
+        with pytest.raises(HTTPException) as ei:
+            await revoke_peer(peer_id=1, request=req, db=db, current_user=user)
+        assert ei.value.status_code == 404
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_re_syncs_mcp_registry(self, monkeypatch):
+        """After revoking, the MCP peer registry must be refreshed so
+        `mcp.peer_<id>.query_brain` disappears from the agent loop."""
+        peer = _peer_row(id_=1, owner_id=42, remote_user_id=99)
+        db = MagicMock()
+        r = MagicMock()
+        r.scalar_one_or_none = lambda: peer
+        db.execute = AsyncMock(return_value=r)
+        db.commit = AsyncMock()
+
+        sync_called = False
+
+        async def fake_sync(manager, db_arg):
+            nonlocal sync_called
+            sync_called = True
+
+        monkeypatch.setattr(
+            "services.peer_mcp_registry.sync_peers", fake_sync,
+        )
+
+        manager = MagicMock()
+        req = _mock_request(manager=manager)
+        user = MagicMock(id=42)
+
+        await revoke_peer(peer_id=1, request=req, db=db, current_user=user)
+        assert sync_called
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_sync_failure_is_non_fatal(self, monkeypatch):
+        """If the registry sync blows up (e.g., manager in a bad state),
+        revoke still succeeds — the DB is authoritative; F3's per-request
+        peer lookup catches the revocation regardless."""
+        peer = _peer_row(id_=1, owner_id=42, remote_user_id=99)
+        db = MagicMock()
+        r = MagicMock()
+        r.scalar_one_or_none = lambda: peer
+        db.execute = AsyncMock(return_value=r)
+        db.commit = AsyncMock()
+
+        async def broken_sync(manager, db_arg):
+            raise RuntimeError("registry on fire")
+
+        monkeypatch.setattr(
+            "services.peer_mcp_registry.sync_peers", broken_sync,
+        )
+
+        manager = MagicMock()
+        req = _mock_request(manager=manager)
+        user = MagicMock(id=42)
+
+        # Must not raise — revoke is committed even when sync fails.
+        await revoke_peer(peer_id=1, request=req, db=db, current_user=user)
+        assert peer.revoked_at is not None


### PR DESCRIPTION
## Summary

Lane F4a of v2 federation. Ships backend surface + React page for managing paired Renfield peers. **Pairing UX (QR-code handshake) is F4b**; this PR is post-pair management.

## Backend (`api/routes/federation_pairing.py`)

| Method | Path | Purpose |
|---|---|---|
| `GET` | `/api/federation/peers` | List non-revoked peers for auth user. Each row hydrates `circle_tier` from `CircleMembership` so UI can render tier badges without a second fetch. Ordered by `paired_at DESC`. |
| `DELETE` | `/api/federation/peers/{peer_id}` | Revoke. Sets `revoked_at`, deletes `CircleMembership`, re-syncs MCP registry so `mcp.peer_<id>.query_brain` vanishes from the agent loop. Non-fatal on sync failure. |

`DELETE` returns 404 on unknown peer OR peer owned by another user — **no existence oracle on peer ids** (scoped query handles it).

## Frontend (`/settings/circles/peers`)

Lists paired peers as tier-ringed rows: display_name + `TierBadge` + first-12-char pubkey fingerprint + relative-time `last_seen`. Revoke button with `ConfirmDialog`; per-row busy state guards rapid double-clicks. Empty state hints at `/settings/circles` for pairing (F4b will land there). Full i18n DE/EN including relative-time labels.

## Tests (7)

Backend:
- `list_peers` empty path
- `list_peers` hydrates tier from `CircleMembership`
- `_tier_for_peer`: no membership → tier 4 (defensive); no `remote_user_id` → tier 4 without DB query; correct integer pass-through
- `revoke_peer`: sets `revoked_at` + deletes membership + re-syncs registry
- `revoke_peer`: 404 on unknown id
- `revoke_peer`: 404 on other-user's peer (scoped query)
- `revoke_peer`: sync failure is non-fatal (DB is authoritative)

## Follow-ups

- **F4b** pairing QR modal (offer → QR → scan response → complete handshake). Lives on the `/settings/circles` page.
- **F4c** chat WebSocket relay for ProgressChunks ("asking Mom's brain... synthesizing...").
- **F4d** `/brain/audit` federation activity feed (optional — could roll into F5).

## Test plan

- [ ] `make test-backend tests/backend/test_federation_peers_routes.py` — expect 7 green
- [ ] Frontend build clean (verified locally)
- [ ] Manual: pair via F2 API → GET `/api/federation/peers` returns the pair → DELETE `/api/federation/peers/{id}` → GET returns empty
- [ ] Manual: navigate to `/settings/circles/peers` → see empty state → pair a peer → see the row

🤖 Generated with [Claude Code](https://claude.com/claude-code)