### PR TITLE
feat(federation): F4d — asker-side audit feed at /brain/audit

### DIFF
--- a/src/backend/alembic/versions/pc20260422_federation_audit.py
+++ b/src/backend/alembic/versions/pc20260422_federation_audit.py
@@ -77,18 +77,17 @@ def upgrade() -> None:
             ix["name"] for ix in inspector.get_indexes("federation_query_log")
         }
 
-    if not _has_idx("ix_federation_query_log_user_id"):
-        op.create_index(
-            "ix_federation_query_log_user_id",
-            "federation_query_log",
-            ["user_id"],
-        )
-    if not _has_idx("ix_federation_query_log_initiated_at"):
-        op.create_index(
-            "ix_federation_query_log_initiated_at",
-            "federation_query_log",
-            ["initiated_at"],
-        )
+    # Index choices:
+    #   idx_fed_audit_user_initiated covers the primary list query
+    #     (user_id = ? ORDER BY initiated_at DESC) AND any WHERE user_id = ?
+    #     by leading-column rule. No separate single-column user_id index.
+    #   idx_fed_audit_user_peer covers the ?peer= filter in the API.
+    #   ix_federation_query_log_request_id serves debug lookups by
+    #     request_id (cross-user — admin-tool query).
+    # The retention prune (WHERE initiated_at < cutoff) has no user_id
+    # prefix and will scan; at expected row counts (<10k per user,
+    # 90-day retention) the scan cost is negligible. If that changes,
+    # add a dedicated single-column `initiated_at` index then.
     if not _has_idx("ix_federation_query_log_request_id"):
         op.create_index(
             "ix_federation_query_log_request_id",
@@ -113,6 +112,4 @@ def downgrade() -> None:
     op.drop_index("idx_fed_audit_user_peer", table_name="federation_query_log")
     op.drop_index("idx_fed_audit_user_initiated", table_name="federation_query_log")
     op.drop_index("ix_federation_query_log_request_id", table_name="federation_query_log")
-    op.drop_index("ix_federation_query_log_initiated_at", table_name="federation_query_log")
-    op.drop_index("ix_federation_query_log_user_id", table_name="federation_query_log")
     op.drop_table("federation_query_log")

--- a/src/backend/alembic/versions/pc20260422_federation_audit.py
+++ b/src/backend/alembic/versions/pc20260422_federation_audit.py
@@ -1,0 +1,118 @@
+"""Add federation_query_log table (F4d of v2 federation)
+
+Revision ID: pc20260422_federation_audit
+Revises: pc20260421_peer_users
+Create Date: 2026-04-22
+
+Asker-side audit row for each federated query. One row per
+`FederationQueryAsker.query_peer` lifecycle. Kept separate from
+`peer_users` (audit-vs-config separation, different retention).
+
+FK on peer_users uses ON DELETE SET NULL so unpairing doesn't
+cascade-delete historical rows; we also denormalize the pubkey +
+display name as snapshots for cases where the peer row was deleted
+before we render the audit page.
+
+Idempotency: guarded like pc20260421 — tolerates Base.metadata
+create_all having already made the table on a dev box.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers
+revision = "pc20260422_federation_audit"
+down_revision = "pc20260421_peer_users"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "federation_query_log" not in existing_tables:
+        op.create_table(
+            "federation_query_log",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "user_id",
+                sa.Integer(),
+                sa.ForeignKey("users.id"),
+                nullable=False,
+            ),
+            sa.Column(
+                "peer_user_id",
+                sa.Integer(),
+                sa.ForeignKey("peer_users.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("peer_pubkey_snapshot", sa.String(64), nullable=False),
+            sa.Column("peer_display_name_snapshot", sa.String(255), nullable=False),
+            sa.Column("request_id", sa.String(64), nullable=True),
+            sa.Column("query_text", sa.Text(), nullable=False),
+            sa.Column(
+                "initiated_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column("finalized_at", sa.DateTime(), nullable=True),
+            sa.Column("final_status", sa.String(16), nullable=False),
+            sa.Column(
+                "verified_signature",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            ),
+            sa.Column("answer_excerpt", sa.Text(), nullable=True),
+            sa.Column("error_message", sa.Text(), nullable=True),
+        )
+
+    def _has_idx(idx_name: str) -> bool:
+        if "federation_query_log" not in existing_tables:
+            return False
+        return idx_name in {
+            ix["name"] for ix in inspector.get_indexes("federation_query_log")
+        }
+
+    if not _has_idx("ix_federation_query_log_user_id"):
+        op.create_index(
+            "ix_federation_query_log_user_id",
+            "federation_query_log",
+            ["user_id"],
+        )
+    if not _has_idx("ix_federation_query_log_initiated_at"):
+        op.create_index(
+            "ix_federation_query_log_initiated_at",
+            "federation_query_log",
+            ["initiated_at"],
+        )
+    if not _has_idx("ix_federation_query_log_request_id"):
+        op.create_index(
+            "ix_federation_query_log_request_id",
+            "federation_query_log",
+            ["request_id"],
+        )
+    if not _has_idx("idx_fed_audit_user_initiated"):
+        op.create_index(
+            "idx_fed_audit_user_initiated",
+            "federation_query_log",
+            ["user_id", "initiated_at"],
+        )
+    if not _has_idx("idx_fed_audit_user_peer"):
+        op.create_index(
+            "idx_fed_audit_user_peer",
+            "federation_query_log",
+            ["user_id", "peer_pubkey_snapshot"],
+        )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_fed_audit_user_peer", table_name="federation_query_log")
+    op.drop_index("idx_fed_audit_user_initiated", table_name="federation_query_log")
+    op.drop_index("ix_federation_query_log_request_id", table_name="federation_query_log")
+    op.drop_index("ix_federation_query_log_initiated_at", table_name="federation_query_log")
+    op.drop_index("ix_federation_query_log_user_id", table_name="federation_query_log")
+    op.drop_table("federation_query_log")

--- a/src/backend/api/lifecycle.py
+++ b/src/backend/api/lifecycle.py
@@ -234,6 +234,30 @@ def _schedule_upload_cleanup():
     )
 
 
+def _schedule_federation_audit_cleanup():
+    """F4d — periodic retention prune of the federation query audit log.
+
+    Pivots on `initiated_at`; hourly cadence matches the upload cleanup
+    pattern. Swallows exceptions the same way so the poller keeps
+    running across transient DB hiccups.
+    """
+    async def cleanup_loop():
+        while True:
+            try:
+                await asyncio.sleep(3600)  # 1 hour
+                from services.federation_audit import prune_old_audit_rows
+
+                await prune_old_audit_rows()
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.warning(f"Federation audit cleanup failed: {e}")
+
+    task = asyncio.create_task(cleanup_loop())
+    _startup_tasks.append(task)
+    logger.info("Federation Audit Cleanup Scheduler gestartet (stündlich, retention=90d)")
+
+
 def _schedule_notification_poller(app):
     """Start the MCP notification poller for servers with notifications enabled."""
     if not settings.notification_poller_enabled:
@@ -526,6 +550,7 @@ async def lifespan(app: "FastAPI"):
     _schedule_notification_poller(app)
     _schedule_memory_cleanup()
     _schedule_upload_cleanup()
+    _schedule_federation_audit_cleanup()
 
     # Presence / paperless audit / media follow / conversation handoff /
     # Zeroconf satellite discovery are bootstrapped by ha_glue via its

--- a/src/backend/api/routes/federation_audit.py
+++ b/src/backend/api/routes/federation_audit.py
@@ -1,0 +1,91 @@
+"""
+Federation audit API — asker-side "what did I ask, when, what came back".
+
+Mounted under `/api/federation/audit`. Authenticated — always scoped
+to the caller's own `user_id`. There is no admin escape hatch: even
+an admin cannot read another user's audit log, because the federation
+query trail is as sensitive as the conversation history itself.
+
+Retention is handled out-of-band by `services.federation_audit.prune_old_audit_rows`
+scheduled from `api.lifecycle`.
+
+Design ref: F4d of the v2 federation lanes.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, Field
+
+from models.database import User
+from services.auth_service import get_current_user
+from services.federation_audit import list_audit_for_user
+
+
+router = APIRouter()
+
+
+class FederationAuditEntry(BaseModel):
+    id: int
+    peer_user_id: int | None
+    peer_pubkey: str
+    peer_display_name: str
+    query_text: str
+    initiated_at: str
+    finalized_at: str | None
+    final_status: str
+    verified_signature: bool
+    answer_excerpt: str | None
+    error_message: str | None
+
+
+class FederationAuditListResponse(BaseModel):
+    entries: list[FederationAuditEntry] = Field(default_factory=list)
+    # Echo back the filter the caller used, so a paginated UI can
+    # reconstruct the "next page" URL without re-parsing params.
+    limit: int
+    offset: int
+    peer_pubkey: str | None
+
+
+@router.get("/audit", response_model=FederationAuditListResponse)
+async def list_federation_audit(
+    limit: int = Query(50, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    peer_pubkey: str | None = Query(None, min_length=64, max_length=64),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Return this user's own federation query audit, newest first.
+
+    `peer_pubkey` (optional) filters to queries against a single peer.
+    Must be the full 64-char hex — partial prefixes are not supported
+    here so the UI must round-trip the exact key from the peers page.
+    """
+    rows = await list_audit_for_user(
+        user_id=current_user.id,
+        limit=limit,
+        offset=offset,
+        peer_pubkey=peer_pubkey,
+    )
+    entries = [
+        FederationAuditEntry(
+            id=row.id,
+            peer_user_id=row.peer_user_id,
+            peer_pubkey=row.peer_pubkey_snapshot,
+            peer_display_name=row.peer_display_name_snapshot,
+            query_text=row.query_text,
+            initiated_at=row.initiated_at.isoformat() if row.initiated_at else "",
+            finalized_at=row.finalized_at.isoformat() if row.finalized_at else None,
+            final_status=row.final_status,
+            verified_signature=row.verified_signature,
+            answer_excerpt=row.answer_excerpt,
+            error_message=row.error_message,
+        )
+        for row in rows
+    ]
+    return FederationAuditListResponse(
+        entries=entries,
+        limit=limit,
+        offset=offset,
+        peer_pubkey=peer_pubkey,
+    )

--- a/src/backend/api/routes/federation_audit.py
+++ b/src/backend/api/routes/federation_audit.py
@@ -51,7 +51,12 @@ class FederationAuditListResponse(BaseModel):
 async def list_federation_audit(
     limit: int = Query(50, ge=1, le=500),
     offset: int = Query(0, ge=0),
-    peer_pubkey: str | None = Query(None, min_length=64, max_length=64),
+    peer_pubkey: str | None = Query(
+        None,
+        min_length=64,
+        max_length=64,
+        pattern="^[0-9a-fA-F]{64}$",
+    ),
     current_user: User = Depends(get_current_user),
 ):
     """

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -24,6 +24,7 @@ from api.routes import (
     chat,
     chat_upload,
     circles,
+    federation_audit,
     federation_pairing,
     federation_query,
     feedback,
@@ -181,6 +182,7 @@ app.include_router(atoms.router, prefix="/api/atoms", tags=["Circles - Atoms"])
 app.include_router(circles.router, prefix="/api/circles", tags=["Circles - Membership"])
 app.include_router(federation_pairing.router, prefix="/api/federation", tags=["Federation - Pairing"])
 app.include_router(federation_query.router, prefix="/api/federation", tags=["Federation - Query"])
+app.include_router(federation_audit.router, prefix="/api/federation", tags=["Federation - Audit"])
 
 # WebSocket Routers
 app.include_router(chat_router, tags=["WebSocket Chat"])

--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -1134,7 +1134,10 @@ class FederationQueryLog(Base):
     __tablename__ = "federation_query_log"
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    # No single-column index on user_id — the composite
+    # `idx_fed_audit_user_initiated` covers `WHERE user_id = ?` queries
+    # via the leading-column rule.
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
 
     # Nullable because peer_users can be deleted while audit survives.
     peer_user_id = Column(
@@ -1152,7 +1155,7 @@ class FederationQueryLog(Base):
     # The user's question. Truncated at write to MAX_QUERY_TEXT_LEN chars.
     query_text = Column(Text, nullable=False)
 
-    initiated_at = Column(DateTime, default=_utcnow, nullable=False, index=True)
+    initiated_at = Column(DateTime, default=_utcnow, nullable=False)
     finalized_at = Column(DateTime, nullable=True)
 
     # Locked vocabulary: success | expired | failed | unknown. Wider than

--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -1108,6 +1108,78 @@ class PeerUser(Base):
     owner = relationship("User", foreign_keys=[circle_owner_id])
 
 
+class FederationQueryLog(Base):
+    """
+    Asker-side audit row for each federated query.
+
+    One row per `FederationQueryAsker.query_peer` lifecycle: initiate →
+    poll → finalize. Written by `_execute_federation_streaming` in
+    mcp_client after the asker's terminal yield, so revoked peers,
+    HTTP errors, and signature failures are all captured.
+
+    Privacy: rows are strictly scoped to `user_id` (the asker). The
+    responder has no visibility into this log — responder-side audit
+    (who asked me) is a separate future feature. `query_text` and
+    `answer_excerpt` are stored because a user-facing "what did I ask"
+    feed needs them; both are truncated at write to bound row size.
+
+    Retention: a lifecycle task prunes rows older than
+    `FEDERATION_AUDIT_RETENTION_DAYS` (default 90). `peer_user_id` is
+    nullable + FK-ON-DELETE-SET-NULL so unpairing doesn't cascade-delete
+    historical queries; `peer_pubkey_snapshot` + `peer_display_name_snapshot`
+    preserve who we asked even after the peer_users row is gone.
+
+    Design ref: F4d of the v2 federation lanes.
+    """
+    __tablename__ = "federation_query_log"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+
+    # Nullable because peer_users can be deleted while audit survives.
+    peer_user_id = Column(
+        Integer, ForeignKey("peer_users.id", ondelete="SET NULL"), nullable=True,
+    )
+    # Snapshots — the peer's identity AT THE TIME of the query. If the
+    # display name changes later or the row is deleted, this still shows
+    # what the user saw when they asked.
+    peer_pubkey_snapshot = Column(String(64), nullable=False)
+    peer_display_name_snapshot = Column(String(255), nullable=False)
+
+    # The asker's own request_id (uuid-ish string from /initiate).
+    request_id = Column(String(64), nullable=True, index=True)
+
+    # The user's question. Truncated at write to MAX_QUERY_TEXT_LEN chars.
+    query_text = Column(Text, nullable=False)
+
+    initiated_at = Column(DateTime, default=_utcnow, nullable=False, index=True)
+    finalized_at = Column(DateTime, nullable=True)
+
+    # Locked vocabulary: success | expired | failed | unknown. Wider than
+    # FEDERATION_PROGRESS_LABELS on purpose — this captures the asker's
+    # terminal determination, not the responder's progress label.
+    final_status = Column(String(16), nullable=False)
+    # Whether the responder's Ed25519 signature AND pair-anchor both
+    # validated. False on terminal paths that never reached verification
+    # (HTTP error, revoked peer, timeout) as well as on explicit failure.
+    verified_signature = Column(Boolean, nullable=False, default=False)
+
+    # Truncated final answer for at-a-glance display. None on failure paths.
+    answer_excerpt = Column(Text, nullable=True)
+    # Error text on non-success paths. None on success.
+    error_message = Column(Text, nullable=True)
+
+    __table_args__ = (
+        # Primary list query: "my queries, newest first".
+        Index("idx_fed_audit_user_initiated", "user_id", "initiated_at"),
+        # Per-peer filter: "show me everything I've asked Mom".
+        Index("idx_fed_audit_user_peer", "user_id", "peer_pubkey_snapshot"),
+    )
+
+    user = relationship("User", foreign_keys=[user_id])
+    peer = relationship("PeerUser", foreign_keys=[peer_user_id])
+
+
 # ==========================================================================
 # Backwards-compat re-exports from ha_glue.models.database
 # ==========================================================================

--- a/src/backend/services/federation_audit.py
+++ b/src/backend/services/federation_audit.py
@@ -102,7 +102,12 @@ async def write_federation_audit(
     audit rows unambiguously).
     """
     if user_id is None:
-        # Auth-disabled deploys: no asker identity to pin the row to.
+        # Auth-disabled / single-user deploys: no asker identity to pin
+        # the row to. Debug-log once per call so operators can see why
+        # `/brain/audit` stays empty on their deploy.
+        logger.debug(
+            "Federation audit write skipped (user_id=None — auth-disabled deploy)"
+        )
         return
 
     final_status, verified, answer_excerpt, error_message = _classify_final(final_item)

--- a/src/backend/services/federation_audit.py
+++ b/src/backend/services/federation_audit.py
@@ -1,0 +1,194 @@
+"""
+Federation query audit (F4d).
+
+Writes one `FederationQueryLog` row per asker-side federated query
+lifecycle. Called by `MCPManager._execute_federation_streaming` after
+the asker yields its terminal result.
+
+Privacy:
+    Rows are scoped strictly to the asker's `user_id`. Responder-side
+    audit (who asked me) is a separate future feature with its own
+    privacy boundary — do not conflate.
+
+Truncation:
+    `query_text` + `answer_excerpt` + `error_message` are all truncated
+    at write time to bound row size and keep list-page queries fast.
+    Users who want the full answer re-run the query (federation is
+    idempotent per `request_id`).
+
+Retention:
+    `prune_old_audit_rows()` deletes rows older than
+    `FEDERATION_AUDIT_RETENTION_DAYS` (default 90). Called from the
+    lifecycle hourly loop.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from loguru import logger
+from sqlalchemy import delete, select
+
+from models.database import FederationQueryLog
+from services.database import AsyncSessionLocal
+
+# Per-column truncation caps. Chosen to keep a single audit row well
+# under 4 KB on disk (Postgres TOAST threshold, though TEXT isn't
+# strictly bounded by this — the cap is a UX choice, not a storage one).
+MAX_QUERY_TEXT_LEN = 1000
+MAX_ANSWER_EXCERPT_LEN = 2000
+MAX_ERROR_MESSAGE_LEN = 500
+
+FEDERATION_AUDIT_RETENTION_DAYS = 90
+
+
+def _truncate(s: str | None, max_len: int) -> str | None:
+    if s is None:
+        return None
+    if len(s) <= max_len:
+        return s
+    # Ellipsis marker is included in the budget.
+    return s[: max_len - 1] + "…"
+
+
+def _classify_final(final: dict[str, Any] | None) -> tuple[str, bool, str | None, str | None]:
+    """
+    Map a FederationQueryAsker terminal dict to (final_status,
+    verified_signature, answer_excerpt, error_message).
+
+    - success=True from the asker implies the pair-anchored Ed25519
+      signature verified — asker.py's `_finalize` returns success=True
+      only on that path. We pivot `verified_signature` on that flag.
+    - final=None means the generator was aborted before yielding a
+      terminal item (e.g., agent loop cancellation). Record as
+      `unknown` so the audit row isn't dishonest.
+    """
+    if final is None:
+        return "unknown", False, None, "No terminal result (query cancelled or aborted)"
+
+    if final.get("success"):
+        return (
+            "success",
+            True,
+            _truncate(final.get("message") or "", MAX_ANSWER_EXCERPT_LEN),
+            None,
+        )
+
+    # Failure path. The message carries the asker's reason text.
+    msg = final.get("message") or "Unknown failure"
+    return "failed", False, None, _truncate(msg, MAX_ERROR_MESSAGE_LEN)
+
+
+async def write_federation_audit(
+    *,
+    user_id: int | None,
+    peer_user_id: int | None,
+    peer_pubkey_snapshot: str,
+    peer_display_name_snapshot: str,
+    query_text: str,
+    initiated_at: datetime,
+    final_item: dict[str, Any] | None,
+) -> None:
+    """
+    Write one audit row for a completed federated query.
+
+    Best-effort: any exception is swallowed + logged. The user has
+    already received their answer by the time this is called; a DB
+    blip here is not allowed to surface as a tool failure.
+
+    user_id=None skips the write entirely — single-user / auth-disabled
+    deploys don't have a meaningful asker identity to attribute, and
+    the `user_id` column on the table is NOT NULL by design (scoping
+    audit rows unambiguously).
+    """
+    if user_id is None:
+        # Auth-disabled deploys: no asker identity to pin the row to.
+        return
+
+    final_status, verified, answer_excerpt, error_message = _classify_final(final_item)
+
+    try:
+        async with AsyncSessionLocal() as session:
+            row = FederationQueryLog(
+                user_id=user_id,
+                peer_user_id=peer_user_id,
+                peer_pubkey_snapshot=peer_pubkey_snapshot,
+                peer_display_name_snapshot=peer_display_name_snapshot,
+                query_text=_truncate(query_text, MAX_QUERY_TEXT_LEN),
+                initiated_at=initiated_at,
+                finalized_at=datetime.now(UTC).replace(tzinfo=None),
+                final_status=final_status,
+                verified_signature=verified,
+                answer_excerpt=answer_excerpt,
+                error_message=error_message,
+            )
+            session.add(row)
+            await session.commit()
+    except Exception as e:  # noqa: BLE001 — best-effort write
+        logger.warning(
+            f"Federation audit write failed (peer={peer_pubkey_snapshot[:12]}…, "
+            f"status={final_status}): {e}"
+        )
+
+
+async def prune_old_audit_rows(
+    retention_days: int = FEDERATION_AUDIT_RETENTION_DAYS,
+) -> int:
+    """
+    Delete audit rows older than `retention_days`. Returns the number
+    of rows removed. Called from the lifecycle hourly cleanup loop.
+
+    Pivots on `initiated_at` rather than `finalized_at` so rows that
+    never finalized (cancelled queries, bugs) are also eventually
+    pruned.
+    """
+    cutoff = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=retention_days)
+    try:
+        async with AsyncSessionLocal() as session:
+            result = await session.execute(
+                delete(FederationQueryLog).where(
+                    FederationQueryLog.initiated_at < cutoff
+                )
+            )
+            await session.commit()
+            deleted = result.rowcount or 0
+            if deleted > 0:
+                logger.info(
+                    f"Federation audit retention: pruned {deleted} row(s) "
+                    f"older than {retention_days} days"
+                )
+            return deleted
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"Federation audit retention prune failed: {e}")
+        return 0
+
+
+async def list_audit_for_user(
+    *,
+    user_id: int,
+    limit: int = 50,
+    offset: int = 0,
+    peer_pubkey: str | None = None,
+) -> list[FederationQueryLog]:
+    """
+    Return the user's own audit rows, newest first. Filter by peer if
+    `peer_pubkey` is given.
+
+    Never returns rows for other users — the `WHERE user_id = ...`
+    clause is mandatory. Callers pass `user_id` from `get_current_user`;
+    there is no admin escape hatch.
+    """
+    async with AsyncSessionLocal() as session:
+        stmt = (
+            select(FederationQueryLog)
+            .where(FederationQueryLog.user_id == user_id)
+            .order_by(FederationQueryLog.initiated_at.desc())
+            .limit(min(max(limit, 1), 500))
+            .offset(max(offset, 0))
+        )
+        if peer_pubkey:
+            stmt = stmt.where(
+                FederationQueryLog.peer_pubkey_snapshot == peer_pubkey
+            )
+        result = await session.execute(stmt)
+        return list(result.scalars().all())

--- a/src/backend/services/mcp_client.py
+++ b/src/backend/services/mcp_client.py
@@ -1489,43 +1489,47 @@ class MCPManager:
 
         asker = FederationQueryAsker()
         final_item: dict | None = None
-        async for item in asker.query_peer(peer, query_text):
-            # F4c — relay ProgressChunks to the chat WS sink if one was
-            # threaded in. Enrich with stable peer identity (remote_pubkey)
-            # so the frontend can key status lines per-peer even when the
-            # display name changes or collides. Sink failures must not
-            # abort the tool call — log and continue.
-            if progress_sink is not None and isinstance(item, ProgressChunk):
-                try:
-                    await progress_sink({
-                        "peer_pubkey": peer.remote_pubkey,
-                        "peer_display_name": peer.remote_display_name,
-                        "label": item.label,
-                        "detail": item.detail,
-                        "sequence": item.sequence,
-                    })
-                except Exception as sink_err:  # pragma: no cover — sink is best-effort
-                    logger.warning(
-                        f"Federation progress_sink raised (continuing): {sink_err}"
-                    )
-            if not isinstance(item, ProgressChunk):
-                final_item = item
-            yield item
-
-        # F4d — one audit row per asker.query_peer lifecycle. Write AFTER
-        # the last yield so partial consumers (agent loop aborted mid-
-        # iteration) still get a row. Write failures are swallowed in
-        # write_federation_audit — the user already has their answer.
-        from services.federation_audit import write_federation_audit
-        await write_federation_audit(
-            user_id=user_id,
-            peer_user_id=peer_id_snapshot,
-            peer_pubkey_snapshot=peer_pubkey_snapshot,
-            peer_display_name_snapshot=peer_display_snapshot,
-            query_text=query_text,
-            initiated_at=initiated_at,
-            final_item=final_item,
-        )
+        try:
+            async for item in asker.query_peer(peer, query_text):
+                # F4c — relay ProgressChunks to the chat WS sink if one was
+                # threaded in. Enrich with stable peer identity (remote_pubkey)
+                # so the frontend can key status lines per-peer even when the
+                # display name changes or collides. Sink failures must not
+                # abort the tool call — log and continue.
+                if progress_sink is not None and isinstance(item, ProgressChunk):
+                    try:
+                        await progress_sink({
+                            "peer_pubkey": peer.remote_pubkey,
+                            "peer_display_name": peer.remote_display_name,
+                            "label": item.label,
+                            "detail": item.detail,
+                            "sequence": item.sequence,
+                        })
+                    except Exception as sink_err:  # pragma: no cover — sink is best-effort
+                        logger.warning(
+                            f"Federation progress_sink raised (continuing): {sink_err}"
+                        )
+                if not isinstance(item, ProgressChunk):
+                    final_item = item
+                yield item
+        finally:
+            # F4d — audit write in `finally` so cancellation, caller-side
+            # `aclose()`, or a consumer raising mid-iteration still produces
+            # one audit row per federated query. `final_item` stays None if
+            # we never reached a terminal yield → _classify_final maps that
+            # to `final_status="unknown"` with an explanatory error_message,
+            # which is the honest record of "I asked but we didn't finish".
+            # Write failures are swallowed in write_federation_audit.
+            from services.federation_audit import write_federation_audit
+            await write_federation_audit(
+                user_id=user_id,
+                peer_user_id=peer_id_snapshot,
+                peer_pubkey_snapshot=peer_pubkey_snapshot,
+                peer_display_name_snapshot=peer_display_snapshot,
+                query_text=query_text,
+                initiated_at=initiated_at,
+                final_item=final_item,
+            )
 
     async def _execute_tool_streaming_impl(
         self,

--- a/src/backend/services/mcp_client.py
+++ b/src/backend/services/mcp_client.py
@@ -1479,7 +1479,16 @@ class MCPManager:
             }
             return
 
+        # F4d — snapshot peer identity at query time so later display-name
+        # changes or peer deletion don't rewrite history.
+        from datetime import UTC, datetime as _dt
+        initiated_at = _dt.now(UTC).replace(tzinfo=None)
+        peer_pubkey_snapshot = peer.remote_pubkey
+        peer_display_snapshot = peer.remote_display_name
+        peer_id_snapshot = peer.id
+
         asker = FederationQueryAsker()
+        final_item: dict | None = None
         async for item in asker.query_peer(peer, query_text):
             # F4c — relay ProgressChunks to the chat WS sink if one was
             # threaded in. Enrich with stable peer identity (remote_pubkey)
@@ -1499,7 +1508,24 @@ class MCPManager:
                     logger.warning(
                         f"Federation progress_sink raised (continuing): {sink_err}"
                     )
+            if not isinstance(item, ProgressChunk):
+                final_item = item
             yield item
+
+        # F4d — one audit row per asker.query_peer lifecycle. Write AFTER
+        # the last yield so partial consumers (agent loop aborted mid-
+        # iteration) still get a row. Write failures are swallowed in
+        # write_federation_audit — the user already has their answer.
+        from services.federation_audit import write_federation_audit
+        await write_federation_audit(
+            user_id=user_id,
+            peer_user_id=peer_id_snapshot,
+            peer_pubkey_snapshot=peer_pubkey_snapshot,
+            peer_display_name_snapshot=peer_display_snapshot,
+            query_text=query_text,
+            initiated_at=initiated_at,
+            final_item=final_item,
+        )
 
     async def _execute_tool_streaming_impl(
         self,

--- a/src/frontend/src/App.jsx
+++ b/src/frontend/src/App.jsx
@@ -34,6 +34,7 @@ const BrainPage = lazy(() => import('./pages/BrainPage'));
 const BrainReviewPage = lazy(() => import('./pages/BrainReviewPage'));
 const CirclesSettingsPage = lazy(() => import('./pages/CirclesSettingsPage'));
 const CirclesPeersPage = lazy(() => import('./pages/CirclesPeersPage'));
+const FederationAuditPage = lazy(() => import('./pages/FederationAuditPage'));
 
 function AppRoutes() {
   const { isFeatureEnabled } = useAuth();
@@ -95,6 +96,11 @@ function AppRoutes() {
             <Route path="/brain/review" element={
               <ProtectedRoute>
                 <BrainReviewPage />
+              </ProtectedRoute>
+            } />
+            <Route path="/brain/audit" element={
+              <ProtectedRoute>
+                <FederationAuditPage />
               </ProtectedRoute>
             } />
             <Route path="/settings/circles" element={

--- a/src/frontend/src/components/Layout.jsx
+++ b/src/frontend/src/components/Layout.jsx
@@ -27,7 +27,8 @@ import {
   MapPin,
   Wrench,
   FileSearch,
-  Share2
+  Share2,
+  History
 } from 'lucide-react';
 import DeviceStatus from './DeviceStatus';
 import ThemeToggle from './ThemeToggle';
@@ -41,6 +42,7 @@ const mainNavigationConfig = [
   { nameKey: 'nav.knowledge', href: '/knowledge', icon: BookOpen, permission: ['kb.own', 'kb.shared', 'kb.all'], feature: 'knowledge' },
   { nameKey: 'nav.brain', href: '/brain', icon: Brain },
   { nameKey: 'nav.brainReview', href: '/brain/review', icon: Inbox },
+  { nameKey: 'nav.federationAudit', href: '/brain/audit', icon: History },
   { nameKey: 'nav.memory', href: '/memory', icon: Brain },
   { nameKey: 'nav.knowledgeGraph', href: '/knowledge-graph', icon: Share2, feature: 'knowledge_graph' },
   { nameKey: 'nav.tasks', href: '/tasks', icon: CheckSquare, feature: 'tasks' },

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -1101,6 +1101,7 @@
     "peerHoursAgo": "vor {{n}} Std.",
     "peerDaysAgo": "vor {{n}} Tagen",
     "revokePeer": "Kopplung aufheben",
+    "peerShowAudit": "Anfragen an diesen Peer anzeigen",
     "revokePeerTitle": "Kopplung aufheben?",
     "revokePeerConfirm": "Kopplung zu {{name}} wirklich beenden? Diese Renfield-Instanz kann danach nicht mehr auf deine geteilten Informationen zugreifen.",
     "peerRevoked": "Kopplung zu {{name}} beendet.",
@@ -1142,5 +1143,27 @@
     "pairAcceptFailed": "Einladung konnte nicht angenommen werden.",
     "pairQrCodeOfferAria": "QR-Code mit signierter Kopplungs-Einladung",
     "pairQrCodeResponseAria": "QR-Code mit signierter Kopplungs-Antwort"
+  },
+  "federationAudit": {
+    "title": "Föderations-Verlauf",
+    "subtitle": "Alle Anfragen, die du an gekoppelte Renfield-Instanzen gestellt hast.",
+    "loadFailed": "Verlauf konnte nicht geladen werden.",
+    "retentionNote": "Einträge werden 90 Tage aufbewahrt und danach automatisch entfernt.",
+    "filteredByPeer": "Gefiltert auf {{name}}.",
+    "clearFilter": "Filter entfernen",
+    "managePeersLink": "Peers verwalten →",
+    "emptyHeadline": "Noch keine föderierten Anfragen",
+    "emptyHint": "Sobald du eine Frage an ein gekoppeltes Renfield stellst, erscheint sie hier.",
+    "queryLabel": "Deine Frage",
+    "answerLabel": "Antwort",
+    "errorLabel": "Fehler",
+    "durationSubSecond": "< 1 Sek.",
+    "durationSeconds": "{{n}} Sek.",
+    "durationMinutes": "{{n}} Min.",
+    "status": {
+      "success": "Erfolgreich beantwortet",
+      "failed": "Fehlgeschlagen",
+      "unknown": "Status unbekannt (abgebrochen)"
+    }
   }
 }

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -46,6 +46,7 @@
     "memory": "Erinnerungen",
     "brain": "Zweites Gehirn",
     "brainReview": "Überprüfung",
+    "federationAudit": "Föderations-Verlauf",
     "circles": "Kreise",
     "intents": "Intents",
     "maintenance": "Wartung",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -46,6 +46,7 @@
     "memory": "Memories",
     "brain": "Second Brain",
     "brainReview": "Review",
+    "federationAudit": "Federation log",
     "circles": "Circles",
     "intents": "Intents",
     "maintenance": "Maintenance",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -1101,6 +1101,7 @@
     "peerHoursAgo": "{{n}}h ago",
     "peerDaysAgo": "{{n}}d ago",
     "revokePeer": "Revoke pairing",
+    "peerShowAudit": "Show queries to this peer",
     "revokePeerTitle": "Revoke pairing?",
     "revokePeerConfirm": "Really end pairing with {{name}}? This Renfield will no longer be able to query your shared atoms.",
     "peerRevoked": "Pairing with {{name}} revoked.",
@@ -1142,5 +1143,27 @@
     "pairAcceptFailed": "Couldn't accept the invitation.",
     "pairQrCodeOfferAria": "QR code containing signed pairing invitation",
     "pairQrCodeResponseAria": "QR code containing signed pairing response"
+  },
+  "federationAudit": {
+    "title": "Federation history",
+    "subtitle": "Every query you've sent to a paired Renfield.",
+    "loadFailed": "Couldn't load audit history.",
+    "retentionNote": "Entries are kept for 90 days and then automatically removed.",
+    "filteredByPeer": "Filtered to {{name}}.",
+    "clearFilter": "Clear filter",
+    "managePeersLink": "Manage peers →",
+    "emptyHeadline": "No federated queries yet",
+    "emptyHint": "Once you ask a paired Renfield a question, it shows up here.",
+    "queryLabel": "Your question",
+    "answerLabel": "Answer",
+    "errorLabel": "Error",
+    "durationSubSecond": "< 1 sec",
+    "durationSeconds": "{{n}} sec",
+    "durationMinutes": "{{n}} min",
+    "status": {
+      "success": "Answered successfully",
+      "failed": "Failed",
+      "unknown": "Unknown status (cancelled)"
+    }
   }
 }

--- a/src/frontend/src/pages/CirclesPeersPage.jsx
+++ b/src/frontend/src/pages/CirclesPeersPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
-import { Users, Trash2, Clock, Fingerprint } from 'lucide-react';
+import { Users, Trash2, Clock, Fingerprint, History } from 'lucide-react';
 import apiClient from '../utils/axios';
 import PageHeader from '../components/PageHeader';
 import Alert from '../components/Alert';
@@ -155,6 +155,14 @@ export default function CirclesPeersPage() {
                 </div>
               </div>
               <div className="sm:ml-4 sm:flex-shrink-0 flex items-center gap-2 mt-3 sm:mt-0">
+                <Link
+                  to={`/brain/audit?peer=${encodeURIComponent(peer.remote_pubkey)}`}
+                  className="btn-icon btn-icon-ghost"
+                  title={t('circles.peerShowAudit')}
+                  aria-label={t('circles.peerShowAudit')}
+                >
+                  <History className="w-4 h-4" />
+                </Link>
                 <button
                   type="button"
                   onClick={() => handleRevoke(peer)}

--- a/src/frontend/src/pages/FederationAuditPage.jsx
+++ b/src/frontend/src/pages/FederationAuditPage.jsx
@@ -245,7 +245,7 @@ export default function FederationAuditPage() {
                     <div className="text-xs text-gray-500 dark:text-gray-400 inline-flex items-center gap-2 flex-wrap">
                       <span className="inline-flex items-center gap-1">
                         <Fingerprint className="w-3 h-3" aria-hidden="true" />
-                        <code className="tabular-nums">{entry.peer_pubkey.slice(0, 24)}…</code>
+                        <code className="tabular-nums">{entry.peer_pubkey.slice(0, 12)}…</code>
                       </span>
                       <span>
                         {t(`federationAudit.status.${entry.final_status}`, { defaultValue: entry.final_status })}

--- a/src/frontend/src/pages/FederationAuditPage.jsx
+++ b/src/frontend/src/pages/FederationAuditPage.jsx
@@ -1,0 +1,263 @@
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link, useSearchParams } from 'react-router';
+import {
+  History,
+  Fingerprint,
+  CheckCircle2,
+  XCircle,
+  HelpCircle,
+  Clock,
+  ChevronDown,
+  ChevronRight,
+  ShieldCheck,
+  ShieldAlert,
+} from 'lucide-react';
+import apiClient from '../utils/axios';
+import PageHeader from '../components/PageHeader';
+import Alert from '../components/Alert';
+
+/**
+ * /brain/audit
+ *
+ * Asker-side federation audit feed: every federated query this user
+ * has made, newest first. One row per query lifecycle (initiate →
+ * terminal). Rows are read-only. Clicking expands to show the full
+ * query and the answer excerpt / error text.
+ *
+ * Filter `?peer=<pubkey>` is honored so the peers page can deep-link
+ * to "show me everything I asked this peer". Drop the filter with a
+ * "show all" button next to the header.
+ *
+ * Retention is 90 days server-side (lifecycle cleanup); no client-side
+ * pagination yet — the first 50 rows cover normal usage. If a
+ * household user hits that limit we'll add a "Load more" button.
+ */
+const PAGE_SIZE = 50;
+
+function StatusIcon({ status, verified }) {
+  if (status === 'success') {
+    return verified
+      ? <CheckCircle2 className="w-4 h-4 text-green-500 dark:text-green-400" aria-hidden="true" />
+      : <ShieldAlert className="w-4 h-4 text-amber-500 dark:text-amber-400" aria-hidden="true" />;
+  }
+  if (status === 'failed') {
+    return <XCircle className="w-4 h-4 text-red-500 dark:text-red-400" aria-hidden="true" />;
+  }
+  return <HelpCircle className="w-4 h-4 text-gray-400 dark:text-gray-500" aria-hidden="true" />;
+}
+
+function formatDateTime(iso, lang) {
+  if (!iso) return '';
+  try {
+    const d = new Date(iso);
+    return d.toLocaleString(lang === 'de' ? 'de-DE' : 'en-US', {
+      dateStyle: 'short',
+      timeStyle: 'short',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function formatRelativeDuration(startIso, endIso, t) {
+  if (!startIso || !endIso) return null;
+  try {
+    const start = new Date(startIso).getTime();
+    const end = new Date(endIso).getTime();
+    const deltaMs = end - start;
+    if (deltaMs < 0) return null;
+    if (deltaMs < 1000) return t('federationAudit.durationSubSecond');
+    if (deltaMs < 60000) return t('federationAudit.durationSeconds', { n: Math.round(deltaMs / 1000) });
+    return t('federationAudit.durationMinutes', { n: Math.round(deltaMs / 60000) });
+  } catch {
+    return null;
+  }
+}
+
+export default function FederationAuditPage() {
+  const { t, i18n } = useTranslation();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const peerFilter = searchParams.get('peer');
+
+  const [entries, setEntries] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [expanded, setExpanded] = useState(() => new Set());
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      const params = new URLSearchParams({ limit: String(PAGE_SIZE) });
+      if (peerFilter) params.set('peer_pubkey', peerFilter);
+      const response = await apiClient.get(`/api/federation/audit?${params}`);
+      setEntries(response.data.entries || []);
+      setError(null);
+    } catch {
+      setError(t('federationAudit.loadFailed'));
+    } finally {
+      setLoading(false);
+    }
+  }, [peerFilter, t]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const toggleExpand = (id) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  };
+
+  const clearPeerFilter = () => {
+    const next = new URLSearchParams(searchParams);
+    next.delete('peer');
+    setSearchParams(next);
+  };
+
+  const filteredPeerName = useMemo(() => {
+    if (!peerFilter || entries.length === 0) return null;
+    const match = entries.find((e) => e.peer_pubkey === peerFilter);
+    return match?.peer_display_name || peerFilter.slice(0, 12) + '…';
+  }, [peerFilter, entries]);
+
+  return (
+    <div className="max-w-5xl mx-auto p-6 space-y-6">
+      <PageHeader
+        icon={History}
+        title={t('federationAudit.title')}
+        subtitle={t('federationAudit.subtitle')}
+      />
+
+      {error && <Alert variant="error" onClose={() => setError(null)}>{error}</Alert>}
+
+      <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-gray-500 dark:text-gray-400">
+        <div>
+          {peerFilter ? (
+            <span>
+              {t('federationAudit.filteredByPeer', { name: filteredPeerName })}{' '}
+              <button
+                type="button"
+                onClick={clearPeerFilter}
+                className="text-primary-600 hover:underline"
+              >
+                {t('federationAudit.clearFilter')}
+              </button>
+            </span>
+          ) : (
+            <span>{t('federationAudit.retentionNote')}</span>
+          )}
+        </div>
+        <Link to="/settings/circles/peers" className="text-primary-600 hover:underline">
+          {t('federationAudit.managePeersLink')}
+        </Link>
+      </div>
+
+      {loading ? (
+        <div className="text-center py-12 text-gray-500 dark:text-gray-400">
+          {t('common.loading')}
+        </div>
+      ) : entries.length === 0 ? (
+        <div className="card text-center py-12">
+          <History className="w-12 h-12 mx-auto mb-3 text-gray-300 dark:text-gray-600" aria-hidden="true" />
+          <p className="text-gray-500 dark:text-gray-400 mb-2">
+            {t('federationAudit.emptyHeadline')}
+          </p>
+          <p className="text-sm text-gray-400 dark:text-gray-500">
+            {t('federationAudit.emptyHint')}
+          </p>
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {entries.map((entry) => {
+            const isOpen = expanded.has(entry.id);
+            const duration = formatRelativeDuration(entry.initiated_at, entry.finalized_at, t);
+            return (
+              <li key={entry.id} className="card p-0 overflow-hidden">
+                <button
+                  type="button"
+                  onClick={() => toggleExpand(entry.id)}
+                  className="w-full flex items-start gap-3 text-left p-3 hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                  aria-expanded={isOpen}
+                >
+                  {isOpen
+                    ? <ChevronDown className="w-4 h-4 mt-1 flex-shrink-0 text-gray-400" aria-hidden="true" />
+                    : <ChevronRight className="w-4 h-4 mt-1 flex-shrink-0 text-gray-400" aria-hidden="true" />
+                  }
+                  <div className="flex-1 min-w-0 space-y-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <StatusIcon status={entry.final_status} verified={entry.verified_signature} />
+                      <span className="font-medium text-gray-900 dark:text-white truncate">
+                        {entry.peer_display_name}
+                      </span>
+                      <span className="text-xs text-gray-500 dark:text-gray-400 inline-flex items-center gap-1">
+                        <Clock className="w-3 h-3" aria-hidden="true" />
+                        {formatDateTime(entry.initiated_at, i18n.language)}
+                      </span>
+                      {duration && (
+                        <span className="text-xs text-gray-400 dark:text-gray-500">
+                          · {duration}
+                        </span>
+                      )}
+                    </div>
+                    <div className="text-sm text-gray-600 dark:text-gray-300 truncate">
+                      {entry.query_text}
+                    </div>
+                  </div>
+                </button>
+                {isOpen && (
+                  <div className="border-t border-gray-200 dark:border-gray-700 p-3 space-y-3 bg-gray-50 dark:bg-gray-800/30">
+                    <div>
+                      <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
+                        {t('federationAudit.queryLabel')}
+                      </div>
+                      <p className="text-sm text-gray-900 dark:text-white whitespace-pre-wrap">
+                        {entry.query_text}
+                      </p>
+                    </div>
+                    {entry.answer_excerpt && (
+                      <div>
+                        <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1 inline-flex items-center gap-1">
+                          {entry.verified_signature && (
+                            <ShieldCheck className="w-3 h-3 text-green-500 dark:text-green-400" aria-hidden="true" />
+                          )}
+                          {t('federationAudit.answerLabel')}
+                        </div>
+                        <p className="text-sm text-gray-900 dark:text-white whitespace-pre-wrap">
+                          {entry.answer_excerpt}
+                        </p>
+                      </div>
+                    )}
+                    {entry.error_message && (
+                      <div>
+                        <div className="text-xs font-medium text-red-500 dark:text-red-400 mb-1">
+                          {t('federationAudit.errorLabel')}
+                        </div>
+                        <p className="text-sm text-red-600 dark:text-red-400 whitespace-pre-wrap">
+                          {entry.error_message}
+                        </p>
+                      </div>
+                    )}
+                    <div className="text-xs text-gray-500 dark:text-gray-400 inline-flex items-center gap-2 flex-wrap">
+                      <span className="inline-flex items-center gap-1">
+                        <Fingerprint className="w-3 h-3" aria-hidden="true" />
+                        <code className="tabular-nums">{entry.peer_pubkey.slice(0, 24)}…</code>
+                      </span>
+                      <span>
+                        {t(`federationAudit.status.${entry.final_status}`, { defaultValue: entry.final_status })}
+                      </span>
+                    </div>
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/tests/backend/test_federation_agent_integration.py
+++ b/tests/backend/test_federation_agent_integration.py
@@ -76,7 +76,9 @@ class TestFederationRouting:
         manager._tool_index["mcp.peer_7.query_brain"] = tool
 
         # Stub the PeerUser lookup + FederationQueryAsker at import time.
-        fake_peer = SimpleNamespace(id=7, remote_display_name="Mom", revoked_at=None)
+        fake_peer = SimpleNamespace(
+            id=7, remote_pubkey="a" * 64, remote_display_name="Mom", revoked_at=None,
+        )
         session_mock = AsyncMock()
         result_mock = MagicMock()
         result_mock.scalar_one_or_none = lambda: fake_peer
@@ -207,7 +209,9 @@ class TestFederationRouting:
             namespaced_name="mcp.peer_5.query_brain", description="", input_schema={},
         )
 
-        fake_peer = SimpleNamespace(id=5, remote_display_name="Dad", revoked_at=None)
+        fake_peer = SimpleNamespace(
+            id=5, remote_pubkey="b" * 64, remote_display_name="Dad", revoked_at=None,
+        )
         session_mock = AsyncMock()
         r = MagicMock()
         r.scalar_one_or_none = lambda: fake_peer

--- a/tests/backend/test_federation_audit.py
+++ b/tests/backend/test_federation_audit.py
@@ -1,0 +1,451 @@
+"""
+Tests for F4d — federation query audit (asker-side).
+
+Coverage:
+- write_federation_audit writes one row per query lifecycle with
+  correct final_status + verified_signature mapping
+- user_id=None skips the write (auth-disabled deploys)
+- classify_final handles success, failed, and aborted (None) cases
+- truncation caps respected on query/answer/error text
+- list_audit_for_user scopes strictly to the caller's user_id
+- prune_old_audit_rows deletes only rows older than retention_days
+- Integration: MCPManager._execute_federation_streaming writes the
+  audit row after the asker's terminal yield
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from services.federation_audit import (
+    FEDERATION_AUDIT_RETENTION_DAYS,
+    MAX_ANSWER_EXCERPT_LEN,
+    MAX_ERROR_MESSAGE_LEN,
+    MAX_QUERY_TEXT_LEN,
+    _classify_final,
+    _truncate,
+    list_audit_for_user,
+    prune_old_audit_rows,
+    write_federation_audit,
+)
+
+
+# =============================================================================
+# Pure helpers
+# =============================================================================
+
+
+class TestClassifyFinal:
+    @pytest.mark.unit
+    def test_success_sets_verified_and_excerpt(self):
+        status, verified, excerpt, err = _classify_final({
+            "success": True,
+            "message": "the wedding was on July 3rd",
+            "data": {"responder_pubkey": "a" * 64},
+        })
+        assert status == "success"
+        assert verified is True
+        assert excerpt == "the wedding was on July 3rd"
+        assert err is None
+
+    @pytest.mark.unit
+    def test_failure_carries_error_text(self):
+        status, verified, excerpt, err = _classify_final({
+            "success": False,
+            "message": "Responder signature verification failed",
+            "data": None,
+        })
+        assert status == "failed"
+        assert verified is False
+        assert excerpt is None
+        assert err == "Responder signature verification failed"
+
+    @pytest.mark.unit
+    def test_none_classifies_as_unknown(self):
+        """Aborted / cancelled queries (no terminal yield) get an honest
+        `unknown` row rather than a misleading success/failure."""
+        status, verified, excerpt, err = _classify_final(None)
+        assert status == "unknown"
+        assert verified is False
+        assert excerpt is None
+        assert err is not None and "cancel" in err.lower() or "abort" in err.lower()
+
+
+class TestTruncate:
+    @pytest.mark.unit
+    def test_short_string_unchanged(self):
+        assert _truncate("hi", 10) == "hi"
+
+    @pytest.mark.unit
+    def test_none_stays_none(self):
+        assert _truncate(None, 10) is None
+
+    @pytest.mark.unit
+    def test_long_string_ellipsis(self):
+        out = _truncate("x" * 100, 10)
+        assert len(out) == 10
+        assert out.endswith("…")
+
+    @pytest.mark.unit
+    def test_exact_boundary_no_truncation(self):
+        out = _truncate("x" * 10, 10)
+        assert out == "x" * 10
+
+
+# =============================================================================
+# write_federation_audit
+# =============================================================================
+
+
+class TestWriteFederationAudit:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_user_id_none_skips_write(self, monkeypatch):
+        """Auth-disabled deploys (user_id=None) must not write. The
+        FederationQueryLog.user_id column is NOT NULL — an attempted
+        insert would fail, and we can't attribute anonymous rows anyway."""
+        called = False
+
+        class _FakeSession:
+            async def __aenter__(self):
+                nonlocal called
+                called = True
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+        monkeypatch.setattr(
+            "services.federation_audit.AsyncSessionLocal",
+            lambda: _FakeSession(),
+        )
+
+        await write_federation_audit(
+            user_id=None,
+            peer_user_id=1,
+            peer_pubkey_snapshot="a" * 64,
+            peer_display_name_snapshot="Mom",
+            query_text="q",
+            initiated_at=datetime.now(UTC).replace(tzinfo=None),
+            final_item={"success": True, "message": "ok", "data": None},
+        )
+
+        assert called is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_success_writes_row_with_verified_true(self, monkeypatch):
+        captured = {}
+
+        class _FakeSession:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            def add(self, row):
+                captured["row"] = row
+
+            async def commit(self):
+                captured["committed"] = True
+
+        monkeypatch.setattr(
+            "services.federation_audit.AsyncSessionLocal",
+            lambda: _FakeSession(),
+        )
+
+        started = datetime(2026, 4, 22, 12, 0, 0)
+        await write_federation_audit(
+            user_id=42,
+            peer_user_id=7,
+            peer_pubkey_snapshot="a" * 64,
+            peer_display_name_snapshot="Mom",
+            query_text="Was hat Mom zur Hochzeit gesagt?",
+            initiated_at=started,
+            final_item={"success": True, "message": "She said yes", "data": {}},
+        )
+
+        row = captured["row"]
+        assert captured["committed"] is True
+        assert row.user_id == 42
+        assert row.peer_user_id == 7
+        assert row.peer_pubkey_snapshot == "a" * 64
+        assert row.peer_display_name_snapshot == "Mom"
+        assert row.query_text == "Was hat Mom zur Hochzeit gesagt?"
+        assert row.final_status == "success"
+        assert row.verified_signature is True
+        assert row.answer_excerpt == "She said yes"
+        assert row.error_message is None
+        assert row.initiated_at == started
+        assert row.finalized_at is not None
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_failure_writes_row_with_error_message(self, monkeypatch):
+        captured = {}
+
+        class _FakeSession:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            def add(self, row):
+                captured["row"] = row
+
+            async def commit(self):
+                captured["committed"] = True
+
+        monkeypatch.setattr(
+            "services.federation_audit.AsyncSessionLocal",
+            lambda: _FakeSession(),
+        )
+
+        await write_federation_audit(
+            user_id=1,
+            peer_user_id=1,
+            peer_pubkey_snapshot="b" * 64,
+            peer_display_name_snapshot="Dad",
+            query_text="q",
+            initiated_at=datetime.now(UTC).replace(tzinfo=None),
+            final_item={
+                "success": False,
+                "message": "Responder signature verification failed",
+                "data": None,
+            },
+        )
+
+        row = captured["row"]
+        assert row.final_status == "failed"
+        assert row.verified_signature is False
+        assert row.answer_excerpt is None
+        assert row.error_message == "Responder signature verification failed"
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_truncation_respected(self, monkeypatch):
+        captured = {}
+
+        class _FakeSession:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            def add(self, row):
+                captured["row"] = row
+
+            async def commit(self):
+                pass
+
+        monkeypatch.setattr(
+            "services.federation_audit.AsyncSessionLocal",
+            lambda: _FakeSession(),
+        )
+
+        long_query = "q" * (MAX_QUERY_TEXT_LEN + 500)
+        long_answer = "a" * (MAX_ANSWER_EXCERPT_LEN + 500)
+
+        await write_federation_audit(
+            user_id=1,
+            peer_user_id=1,
+            peer_pubkey_snapshot="c" * 64,
+            peer_display_name_snapshot="X",
+            query_text=long_query,
+            initiated_at=datetime.now(UTC).replace(tzinfo=None),
+            final_item={"success": True, "message": long_answer, "data": None},
+        )
+
+        row = captured["row"]
+        assert len(row.query_text) == MAX_QUERY_TEXT_LEN
+        assert row.query_text.endswith("…")
+        assert len(row.answer_excerpt) == MAX_ANSWER_EXCERPT_LEN
+        assert row.answer_excerpt.endswith("…")
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_db_failure_is_swallowed(self, monkeypatch):
+        """A DB blip during audit write must not surface to the caller —
+        the user has their answer already. The whole point of this
+        helper is "best-effort"."""
+
+        class _BrokenSession:
+            async def __aenter__(self):
+                raise RuntimeError("db unreachable")
+
+            async def __aexit__(self, *a):
+                return False
+
+        monkeypatch.setattr(
+            "services.federation_audit.AsyncSessionLocal",
+            lambda: _BrokenSession(),
+        )
+
+        # Should NOT raise.
+        await write_federation_audit(
+            user_id=1,
+            peer_user_id=1,
+            peer_pubkey_snapshot="a" * 64,
+            peer_display_name_snapshot="Mom",
+            query_text="q",
+            initiated_at=datetime.now(UTC).replace(tzinfo=None),
+            final_item={"success": True, "message": "ok", "data": None},
+        )
+
+
+# =============================================================================
+# MCPManager integration — the audit row IS written from the streaming path
+# =============================================================================
+
+
+class TestAuditIntegration:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_federation_streaming_writes_audit(self, tmp_path, monkeypatch):
+        """Regression guard: the full federation call path through
+        MCPManager must invoke write_federation_audit with the right
+        snapshot fields AND classify the final item correctly."""
+        from services.federation_identity import (
+            init_federation_identity,
+            reset_federation_identity_for_tests,
+        )
+        from services.mcp_client import (
+            MCPManager,
+            MCPServerConfig,
+            MCPServerState,
+            MCPToolInfo,
+            MCPTransportType,
+        )
+        from services.mcp_streaming import ProgressChunk
+
+        reset_federation_identity_for_tests()
+        init_federation_identity(tmp_path / "key")
+
+        manager = MCPManager()
+        config = MCPServerConfig(
+            name="peer_42", transport=MCPTransportType.FEDERATION,
+            streaming=True, peer_user_id=42,
+        )
+        state = MCPServerState(config=config)
+        state.connected = True
+        manager._servers["peer_42"] = state
+        manager._tool_index["mcp.peer_42.query_brain"] = MCPToolInfo(
+            server_name="peer_42", original_name="query_brain",
+            namespaced_name="mcp.peer_42.query_brain", description="", input_schema={},
+        )
+
+        fake_peer = SimpleNamespace(
+            id=42,
+            remote_pubkey="z" * 64,
+            remote_display_name="Grandma",
+            revoked_at=None,
+        )
+        session_mock = AsyncMock()
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none = lambda: fake_peer
+        session_mock.execute = AsyncMock(return_value=result_mock)
+        session_mock.__aenter__ = AsyncMock(return_value=session_mock)
+        session_mock.__aexit__ = AsyncMock(return_value=False)
+        monkeypatch.setattr(
+            "services.database.AsyncSessionLocal", lambda: session_mock,
+        )
+
+        async def fake_query_peer(self, peer, text):
+            yield ProgressChunk(label="retrieving", sequence=1)
+            yield {"success": True, "message": "the answer", "data": None}
+
+        monkeypatch.setattr(
+            "services.federation_query_asker.FederationQueryAsker.query_peer",
+            fake_query_peer,
+        )
+
+        # Spy on the audit write.
+        audit_calls = []
+
+        async def spy(**kwargs):
+            audit_calls.append(kwargs)
+
+        monkeypatch.setattr(
+            "services.federation_audit.write_federation_audit", spy,
+        )
+
+        final = await manager.execute_tool(
+            "mcp.peer_42.query_brain",
+            {"query": "wann war deine Hochzeit?"},
+            user_id=99,
+        )
+
+        assert final["success"] is True
+        assert len(audit_calls) == 1
+        call = audit_calls[0]
+        assert call["user_id"] == 99
+        assert call["peer_user_id"] == 42
+        assert call["peer_pubkey_snapshot"] == "z" * 64
+        assert call["peer_display_name_snapshot"] == "Grandma"
+        assert call["query_text"] == "wann war deine Hochzeit?"
+        assert call["initiated_at"] is not None
+        assert call["final_item"] == {"success": True, "message": "the answer", "data": None}
+
+        reset_federation_identity_for_tests()
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_revoked_peer_does_not_write_audit(self, monkeypatch):
+        """Revoked/unknown peer returns error FinalResult without
+        invoking the asker. No audit row is written — there was no
+        federated query to audit, and we don't want revoke attempts
+        spamming the log."""
+        from services.mcp_client import (
+            MCPManager,
+            MCPServerConfig,
+            MCPServerState,
+            MCPToolInfo,
+            MCPTransportType,
+        )
+
+        manager = MCPManager()
+        config = MCPServerConfig(
+            name="peer_99", transport=MCPTransportType.FEDERATION,
+            streaming=True, peer_user_id=99,
+        )
+        state = MCPServerState(config=config)
+        state.connected = True
+        manager._servers["peer_99"] = state
+        manager._tool_index["mcp.peer_99.query_brain"] = MCPToolInfo(
+            server_name="peer_99", original_name="query_brain",
+            namespaced_name="mcp.peer_99.query_brain", description="", input_schema={},
+        )
+
+        session_mock = AsyncMock()
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none = lambda: None
+        session_mock.execute = AsyncMock(return_value=result_mock)
+        session_mock.__aenter__ = AsyncMock(return_value=session_mock)
+        session_mock.__aexit__ = AsyncMock(return_value=False)
+        monkeypatch.setattr(
+            "services.database.AsyncSessionLocal", lambda: session_mock,
+        )
+
+        audit_calls = []
+
+        async def spy(**kwargs):
+            audit_calls.append(kwargs)
+
+        monkeypatch.setattr(
+            "services.federation_audit.write_federation_audit", spy,
+        )
+
+        final = await manager.execute_tool(
+            "mcp.peer_99.query_brain",
+            {"query": "q"},
+            user_id=1,
+        )
+
+        assert final["success"] is False
+        assert len(audit_calls) == 0

--- a/tests/backend/test_federation_audit.py
+++ b/tests/backend/test_federation_audit.py
@@ -449,3 +449,174 @@ class TestAuditIntegration:
 
         assert final["success"] is False
         assert len(audit_calls) == 0
+
+
+# =============================================================================
+# list / prune smoke tests
+# =============================================================================
+
+
+class TestListAndPrune:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_list_empty_returns_empty_list(self, monkeypatch):
+        """No rows for the user → empty list, not a crash."""
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+
+        session_mock = AsyncMock()
+        session_mock.execute = AsyncMock(return_value=mock_result)
+        session_mock.__aenter__ = AsyncMock(return_value=session_mock)
+        session_mock.__aexit__ = AsyncMock(return_value=False)
+        monkeypatch.setattr(
+            "services.federation_audit.AsyncSessionLocal",
+            lambda: session_mock,
+        )
+
+        from services.federation_audit import list_audit_for_user
+        rows = await list_audit_for_user(user_id=42)
+        assert rows == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_list_with_peer_filter_attaches_where_clause(self, monkeypatch):
+        """`peer_pubkey` kwarg narrows the query. We can't assert SQL
+        text from a Mock, but we can verify `execute` was called — and
+        that calling with/without the filter hits the same path."""
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+
+        session_mock = AsyncMock()
+        session_mock.execute = AsyncMock(return_value=mock_result)
+        session_mock.__aenter__ = AsyncMock(return_value=session_mock)
+        session_mock.__aexit__ = AsyncMock(return_value=False)
+        monkeypatch.setattr(
+            "services.federation_audit.AsyncSessionLocal",
+            lambda: session_mock,
+        )
+
+        from services.federation_audit import list_audit_for_user
+        await list_audit_for_user(user_id=1, peer_pubkey="a" * 64)
+
+        # The filter compiles into the statement passed to execute.
+        assert session_mock.execute.await_count == 1
+        stmt = session_mock.execute.call_args.args[0]
+        compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+        assert "peer_pubkey_snapshot" in compiled
+        assert "a" * 64 in compiled
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_prune_zero_expired_returns_zero(self, monkeypatch):
+        """No rows past retention → prune returns 0, no error log."""
+        mock_result = MagicMock()
+        mock_result.rowcount = 0
+
+        session_mock = AsyncMock()
+        session_mock.execute = AsyncMock(return_value=mock_result)
+        session_mock.commit = AsyncMock()
+        session_mock.__aenter__ = AsyncMock(return_value=session_mock)
+        session_mock.__aexit__ = AsyncMock(return_value=False)
+        monkeypatch.setattr(
+            "services.federation_audit.AsyncSessionLocal",
+            lambda: session_mock,
+        )
+
+        from services.federation_audit import prune_old_audit_rows
+        deleted = await prune_old_audit_rows(retention_days=90)
+        assert deleted == 0
+
+
+# =============================================================================
+# Cancellation / try-finally semantics (review S1 regression guard)
+# =============================================================================
+
+
+class TestCancellationAuditRow:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_asker_raising_mid_stream_still_writes_audit(
+        self, tmp_path, monkeypatch,
+    ):
+        """Regression guard for review S1: the try/finally in
+        _execute_federation_streaming must ensure one audit row is
+        written even when the asker raises mid-iteration (network
+        blip, internal bug, etc.). final_item stays None so
+        _classify_final maps to `unknown`."""
+        from services.federation_identity import (
+            init_federation_identity,
+            reset_federation_identity_for_tests,
+        )
+        from services.mcp_client import (
+            MCPManager,
+            MCPServerConfig,
+            MCPServerState,
+            MCPToolInfo,
+            MCPTransportType,
+        )
+        from services.mcp_streaming import ProgressChunk
+
+        reset_federation_identity_for_tests()
+        init_federation_identity(tmp_path / "key")
+
+        manager = MCPManager()
+        config = MCPServerConfig(
+            name="peer_77", transport=MCPTransportType.FEDERATION,
+            streaming=True, peer_user_id=77,
+        )
+        state = MCPServerState(config=config)
+        state.connected = True
+        manager._servers["peer_77"] = state
+        manager._tool_index["mcp.peer_77.query_brain"] = MCPToolInfo(
+            server_name="peer_77", original_name="query_brain",
+            namespaced_name="mcp.peer_77.query_brain", description="", input_schema={},
+        )
+
+        fake_peer = SimpleNamespace(
+            id=77, remote_pubkey="e" * 64, remote_display_name="Uncle",
+            revoked_at=None,
+        )
+        session_mock = AsyncMock()
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none = lambda: fake_peer
+        session_mock.execute = AsyncMock(return_value=result_mock)
+        session_mock.__aenter__ = AsyncMock(return_value=session_mock)
+        session_mock.__aexit__ = AsyncMock(return_value=False)
+        monkeypatch.setattr(
+            "services.database.AsyncSessionLocal", lambda: session_mock,
+        )
+
+        async def fake_query_peer(self, peer, text):
+            yield ProgressChunk(label="retrieving", sequence=1)
+            # Simulated mid-query crash — no terminal dict reached.
+            raise RuntimeError("simulated mid-query abort")
+
+        monkeypatch.setattr(
+            "services.federation_query_asker.FederationQueryAsker.query_peer",
+            fake_query_peer,
+        )
+
+        audit_calls: list[dict] = []
+
+        async def spy(**kwargs):
+            audit_calls.append(kwargs)
+
+        monkeypatch.setattr(
+            "services.federation_audit.write_federation_audit", spy,
+        )
+
+        # The RuntimeError bubbles up to us; the finally must still run
+        # and record the audit row.
+        with pytest.raises(RuntimeError, match="simulated mid-query abort"):
+            async for _ in manager.execute_tool_streaming(
+                "mcp.peer_77.query_brain", {"query": "q"}, user_id=1,
+            ):
+                pass
+
+        assert len(audit_calls) == 1
+        assert audit_calls[0]["user_id"] == 1
+        assert audit_calls[0]["peer_pubkey_snapshot"] == "e" * 64
+        # Terminal yield never reached → final_item None → classified unknown.
+        assert audit_calls[0]["final_item"] is None
+
+        reset_federation_identity_for_tests()

--- a/tests/frontend/react/pages/FederationAuditPage.test.jsx
+++ b/tests/frontend/react/pages/FederationAuditPage.test.jsx
@@ -1,0 +1,198 @@
+/**
+ * F4d — federation audit page.
+ *
+ * Covers: empty state, happy-path render with multiple entries, row
+ * expansion, peer filter via query param, and the success/failed/unknown
+ * status icons + localized copy.
+ */
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import FederationAuditPage from '../../../../src/frontend/src/pages/FederationAuditPage';
+import { renderWithRouter } from '../test-utils.jsx';
+import apiClient from '../../../../src/frontend/src/utils/axios';
+
+vi.mock('../../../../src/frontend/src/utils/axios', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+beforeAll(() => {
+  // In case any child component tries scrollIntoView
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+const MOM_PUBKEY = 'm'.repeat(64);
+const DAD_PUBKEY = 'd'.repeat(64);
+
+describe('FederationAuditPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiClient.get.mockReset();
+  });
+
+  it('renders empty state when no entries', async () => {
+    apiClient.get.mockResolvedValueOnce({
+      data: { entries: [], limit: 50, offset: 0, peer_pubkey: null },
+    });
+
+    renderWithRouter(<FederationAuditPage />, { route: '/brain/audit' });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Noch keine föderierten Anfragen/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders rows with peer, query, and initiation time', async () => {
+    apiClient.get.mockResolvedValueOnce({
+      data: {
+        entries: [
+          {
+            id: 1,
+            peer_user_id: 7,
+            peer_pubkey: MOM_PUBKEY,
+            peer_display_name: 'Mom',
+            query_text: 'Wann ist Omas Geburtstag?',
+            initiated_at: '2026-04-22T10:15:00',
+            finalized_at: '2026-04-22T10:15:03',
+            final_status: 'success',
+            verified_signature: true,
+            answer_excerpt: 'Am 14. Juni.',
+            error_message: null,
+          },
+          {
+            id: 2,
+            peer_user_id: 8,
+            peer_pubkey: DAD_PUBKEY,
+            peer_display_name: 'Dad',
+            query_text: 'Wie spät ist es bei dir?',
+            initiated_at: '2026-04-22T09:00:00',
+            finalized_at: null,
+            final_status: 'failed',
+            verified_signature: false,
+            answer_excerpt: null,
+            error_message: 'Peer connection refused',
+          },
+        ],
+        limit: 50, offset: 0, peer_pubkey: null,
+      },
+    });
+
+    renderWithRouter(<FederationAuditPage />, { route: '/brain/audit' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Mom')).toBeInTheDocument();
+      expect(screen.getByText('Dad')).toBeInTheDocument();
+    });
+    // Query previews shown on the row
+    expect(screen.getByText('Wann ist Omas Geburtstag?')).toBeInTheDocument();
+    expect(screen.getByText('Wie spät ist es bei dir?')).toBeInTheDocument();
+  });
+
+  it('expanding a row shows the full answer and fingerprint', async () => {
+    apiClient.get.mockResolvedValueOnce({
+      data: {
+        entries: [{
+          id: 1,
+          peer_user_id: 7,
+          peer_pubkey: MOM_PUBKEY,
+          peer_display_name: 'Mom',
+          query_text: 'Wann ist Omas Geburtstag?',
+          initiated_at: '2026-04-22T10:15:00',
+          finalized_at: '2026-04-22T10:15:03',
+          final_status: 'success',
+          verified_signature: true,
+          answer_excerpt: 'Am 14. Juni. Sie wird 87.',
+          error_message: null,
+        }],
+        limit: 50, offset: 0, peer_pubkey: null,
+      },
+    });
+
+    renderWithRouter(<FederationAuditPage />, { route: '/brain/audit' });
+
+    // Click the row's toggle button (button wraps the whole row)
+    const row = await screen.findByRole('button', { expanded: false, name: /Mom/i });
+    fireEvent.click(row);
+
+    await waitFor(() => {
+      expect(screen.getByText('Am 14. Juni. Sie wird 87.')).toBeInTheDocument();
+      // Truncated fingerprint appears on expansion
+      expect(screen.getByText(new RegExp(MOM_PUBKEY.slice(0, 24)))).toBeInTheDocument();
+    });
+  });
+
+  it('renders the error message on a failed entry when expanded', async () => {
+    apiClient.get.mockResolvedValueOnce({
+      data: {
+        entries: [{
+          id: 99,
+          peer_user_id: null,
+          peer_pubkey: DAD_PUBKEY,
+          peer_display_name: 'Dad',
+          query_text: 'Was gibt es zum Abendessen?',
+          initiated_at: '2026-04-22T18:00:00',
+          finalized_at: '2026-04-22T18:00:05',
+          final_status: 'failed',
+          verified_signature: false,
+          answer_excerpt: null,
+          error_message: 'Responder signature verification failed',
+        }],
+        limit: 50, offset: 0, peer_pubkey: null,
+      },
+    });
+
+    renderWithRouter(<FederationAuditPage />, { route: '/brain/audit' });
+
+    const row = await screen.findByRole('button', { name: /Dad/i });
+    fireEvent.click(row);
+
+    await waitFor(() => {
+      expect(screen.getByText('Responder signature verification failed')).toBeInTheDocument();
+    });
+  });
+
+  it('filters by peer when ?peer= query param is present', async () => {
+    apiClient.get.mockResolvedValueOnce({
+      data: {
+        entries: [{
+          id: 1,
+          peer_user_id: 7,
+          peer_pubkey: MOM_PUBKEY,
+          peer_display_name: 'Mom',
+          query_text: 'Wann war die Hochzeit?',
+          initiated_at: '2026-04-22T10:00:00',
+          finalized_at: '2026-04-22T10:00:02',
+          final_status: 'success',
+          verified_signature: true,
+          answer_excerpt: 'Am 3. Juli.',
+          error_message: null,
+        }],
+        limit: 50, offset: 0, peer_pubkey: MOM_PUBKEY,
+      },
+    });
+
+    renderWithRouter(
+      <FederationAuditPage />,
+      { route: `/brain/audit?peer=${MOM_PUBKEY}` },
+    );
+
+    await waitFor(() => {
+      expect(apiClient.get).toHaveBeenCalledWith(
+        expect.stringContaining(`peer_pubkey=${MOM_PUBKEY}`),
+      );
+      // Filter banner visible
+      expect(screen.getByText(/Gefiltert auf Mom/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows error alert on API failure', async () => {
+    apiClient.get.mockRejectedValueOnce(new Error('500'));
+
+    renderWithRouter(<FederationAuditPage />, { route: '/brain/audit' });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Verlauf konnte nicht geladen werden/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/frontend/react/pages/FederationAuditPage.test.jsx
+++ b/tests/frontend/react/pages/FederationAuditPage.test.jsx
@@ -117,8 +117,8 @@ describe('FederationAuditPage', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Am 14. Juni. Sie wird 87.')).toBeInTheDocument();
-      // Truncated fingerprint appears on expansion
-      expect(screen.getByText(new RegExp(MOM_PUBKEY.slice(0, 24)))).toBeInTheDocument();
+      // Truncated fingerprint appears on expansion — 12 chars to match the peers page
+      expect(screen.getByText(new RegExp(MOM_PUBKEY.slice(0, 12)))).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary

Lane F4d of v2 federation. Closes the last asker-side UX gap: users can now look back at every federated query they've made — which peer, when, what came back, and whether the signature verified. Before this, that data lived only in ephemeral log lines.

## What shipped

### Backend
- **New table `federation_query_log`** (migration `pc20260422_federation_audit`). One row per `FederationQueryAsker.query_peer` lifecycle. Peer identity stored as snapshot columns so later renames or peer deletions don't rewrite history. FK on `peer_users` is `ON DELETE SET NULL` for the same reason.
- **Write hook** in `MCPManager._execute_federation_streaming` after the asker's terminal yield. Captures `initiated_at` at entry, determines `final_status` from the FinalResult dict (`success`/`failed`/`unknown`), sets `verified_signature=True` only on success — the asker's `_finalize` returns success=True only after pair-anchor + Ed25519 verify pass.
- **Truncation at write** (1000 / 2000 / 500 chars for query / answer / error) to bound row size without hiding asker-visible content.
- **Best-effort write**: DB failures are logged and swallowed. The user has already received their answer — a DB blip must not surface as a tool failure.
- **`GET /api/federation/audit?limit=&offset=&peer_pubkey=`** — newest first, strictly scoped to the caller's `user_id`. **No admin escape hatch**: federation query trail is as sensitive as conversation history. 500-row hard cap on limit.
- **90-day retention** via new hourly cleanup task in `api.lifecycle._schedule_federation_audit_cleanup`, matching the existing chat-upload cleanup pattern.
- `user_id=None` (auth-disabled deploys) skips the write — can't attribute anonymous rows, column is NOT NULL by design.

### Frontend
- **New page at `/brain/audit`** (`FederationAuditPage`). Lists entries newest-first, one card per query, expandable to show the full question + answer + fingerprint. Status icon pivot (success/failed/unknown) with a distinct "signature verified" mark on successes.
- **`?peer=<pubkey>`** query param filters to a single peer — the peers page now has a "show queries to this peer" icon button that deep-links here with the filter applied.
- Retention note visible in the empty/default state so users know rows don't stick around forever.
- 27 new i18n keys under `federationAudit.*` + 1 `circles.peerShowAudit` (DE + EN).

## Privacy & scoping

- Rows are **asker-side only**. Responder-side audit (who asked me) is a separate future feature with its own privacy boundary per `docs/FEDERATION_MULTI_PEER.md` — do not conflate.
- Query text + answer excerpt ARE stored because a user-facing "what did I ask" feed needs them. Scoped per user, only visible via JWT auth.
- Snapshots (`peer_pubkey_snapshot` + `peer_display_name_snapshot`) preserve the query trail even if the peer is unpaired afterwards — but the asker's `user_id` is the sole access control and there is no cross-user visibility.

## What's in / out

**In:**
- Full backend plumbing (model, migration, service, route, retention task, write hook).
- Frontend page + peers-page link.
- 14 backend + 6 frontend tests.

**Out:**
- **Responder-side audit** (who asked me). Separate feature.
- **Cross-household "show provenance"** for answers (would require B to voluntarily report "used C too").
- **Export / download** of audit log. Easy follow-up once the UI settles.
- **Pagination beyond the first 50 rows.** If a household hits this limit, we'll add "Load more"; retention means it caps at 90 days anyway.

## Test plan

- [x] Backend: 14/14 new tests pass (`test_federation_audit.py`) — `classify_final` on success/failed/None, truncation caps, user_id=None skip, DB-failure swallowed, MCPManager integration write, revoked-peer doesn't audit.
- [x] Backend: 15/15 existing federation integration tests still pass after the SimpleNamespace stubs gained `remote_pubkey`.
- [x] Frontend: 6/6 new RTL tests pass — empty state, happy-path render, expansion with answer, expansion with error, `?peer=` filter, API-failure alert.
- [x] Frontend: all sibling federation tests (20) still green.
- [x] Syntax + lint: 0 errors, only pre-existing codebase warnings.
- [ ] Manual: ask a federated query → check a row lands in `/brain/audit` with the right status + excerpt.
- [ ] Manual: run retention once with a past-dated row → verify the cleanup log message + row deleted.
- [ ] Manual: deep-link from peers page `/brain/audit?peer=<pubkey>` → verify filter banner + filtered rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)