### PR TITLE
feat(federation): F5a — depth + cycle detection

### DIFF
--- a/src/backend/services/federation_query_asker.py
+++ b/src/backend/services/federation_query_asker.py
@@ -211,13 +211,24 @@ class FederationQueryAsker:
         endpoint: str,
         query_text: str,
     ) -> QueryBrainInitiateResponse | None:
-        """Sign + POST the initiate request. Returns None on HTTP error."""
+        """Sign + POST the initiate request. Returns None on HTTP error.
+
+        F5a — first-hop queries carry `depth=settings.federation_max_depth`
+        and `path=[my_pubkey]`. Any future transitive cascade from a
+        responder must decrement depth and append its own pubkey before
+        re-signing; the asker side (here) never cascades, so we always
+        start fresh.
+        """
+        from utils.config import settings as _settings
+        my_pubkey = self.identity.public_key_hex()
         unsigned = {
-            "version": 1,
-            "asker_pubkey": self.identity.public_key_hex(),
+            "version": 2,
+            "asker_pubkey": my_pubkey,
             "query": query_text,
             "nonce": secrets.token_hex(16),
             "timestamp": int(time.time()),
+            "depth": _settings.federation_max_depth,
+            "path": [my_pubkey],
         }
         signature = self.identity.sign(_canonical_bytes(unsigned)).hex()
         req = QueryBrainInitiateRequest(**unsigned, signature=signature)

--- a/src/backend/services/federation_query_asker.py
+++ b/src/backend/services/federation_query_asker.py
@@ -75,6 +75,7 @@ from services.mcp_streaming import (
     ProgressChunk,
 )
 from services.pairing_service import _canonical_bytes
+from utils.config import settings
 
 
 # Timeouts (seconds) — responder-side TTL is 60s (F3a), so we cap here.
@@ -214,12 +215,16 @@ class FederationQueryAsker:
         """Sign + POST the initiate request. Returns None on HTTP error.
 
         F5a — first-hop queries carry `depth=settings.federation_max_depth`
-        and `path=[my_pubkey]`. Any future transitive cascade from a
-        responder must decrement depth and append its own pubkey before
-        re-signing; the asker side (here) never cascades, so we always
-        start fresh.
+        and `path=[my_pubkey]`. Both travel through the signed canonical
+        payload so an on-path attacker can't strip them.
+
+        Cascade note: today Renfield never cascades transitively. If/when
+        we wire it, the cascader signs a FRESH envelope as the new
+        asker_pubkey (pair-anchor binding at the next hop requires it);
+        the original originator survives in `path[0]` as provenance +
+        cycle-defense, never as a trust claim. F5a does not commit to
+        any specific cascade design.
         """
-        from utils.config import settings as _settings
         my_pubkey = self.identity.public_key_hex()
         unsigned = {
             "version": 2,
@@ -227,7 +232,7 @@ class FederationQueryAsker:
             "query": query_text,
             "nonce": secrets.token_hex(16),
             "timestamp": int(time.time()),
-            "depth": _settings.federation_max_depth,
+            "depth": settings.federation_max_depth,
             "path": [my_pubkey],
         }
         signature = self.identity.sign(_canonical_bytes(unsigned)).hex()

--- a/src/backend/services/federation_query_responder.py
+++ b/src/backend/services/federation_query_responder.py
@@ -268,11 +268,18 @@ class FederationQueryResponder:
         if not _record_nonce(req.nonce, now=now):
             raise FederationQueryError("Nonce already seen (replay detected)")
 
-        # F5a — depth + cycle detection. Checked AFTER signature
+        # F5a — depth + cycle hardening. Checked AFTER signature
         # verification because the fields are part of the canonical
-        # payload (an adversary can't strip them). The error text here
-        # is uniformly "federation query failed" at the route layer;
-        # we log the specific reason for operators.
+        # payload (an adversary can't strip them). Errors collapse to a
+        # uniform "federation query failed" at the route layer
+        # (federation_query.py) — no oracle; we log the specific reason
+        # for operators.
+        #
+        # We accept any depth >= 0 without decrementing. depth=0 means
+        # "you're the last stop — no further cascade allowed" and we do
+        # the work normally. A future cascader (Renfield doesn't cascade
+        # today) would decrement before forwarding the new fresh-signed
+        # envelope.
         my_pubkey = self.identity.public_key_hex()
         if req.depth < 0:
             logger.warning(
@@ -287,9 +294,11 @@ class FederationQueryResponder:
                 f"path_len={len(req.path)})"
             )
             raise FederationQueryError("Federation cycle detected")
-        # Asker-side hygiene check: path MUST contain asker_pubkey.
-        # This prevents an adversary from stripping the originator
-        # identity out of the chain to hide provenance.
+        # Path-integrity check: the sender's own pubkey MUST be in the
+        # path. This prevents an adversary from stripping the originator
+        # from the chain to hide provenance. Path entries beyond
+        # asker_pubkey are informational (never trust claims); only the
+        # envelope's signature is authoritative.
         if req.asker_pubkey not in req.path:
             logger.warning(
                 f"Federation query rejected: asker_pubkey not in path "

--- a/src/backend/services/federation_query_responder.py
+++ b/src/backend/services/federation_query_responder.py
@@ -268,6 +268,35 @@ class FederationQueryResponder:
         if not _record_nonce(req.nonce, now=now):
             raise FederationQueryError("Nonce already seen (replay detected)")
 
+        # F5a — depth + cycle detection. Checked AFTER signature
+        # verification because the fields are part of the canonical
+        # payload (an adversary can't strip them). The error text here
+        # is uniformly "federation query failed" at the route layer;
+        # we log the specific reason for operators.
+        my_pubkey = self.identity.public_key_hex()
+        if req.depth < 0:
+            logger.warning(
+                f"Federation query rejected: negative depth "
+                f"({req.depth}, asker={req.asker_pubkey[:12]}…)"
+            )
+            raise FederationQueryError("Query depth exhausted")
+        if my_pubkey in req.path:
+            logger.warning(
+                f"Federation query rejected: cycle — own pubkey "
+                f"in path (asker={req.asker_pubkey[:12]}…, "
+                f"path_len={len(req.path)})"
+            )
+            raise FederationQueryError("Federation cycle detected")
+        # Asker-side hygiene check: path MUST contain asker_pubkey.
+        # This prevents an adversary from stripping the originator
+        # identity out of the chain to hide provenance.
+        if req.asker_pubkey not in req.path:
+            logger.warning(
+                f"Federation query rejected: asker_pubkey not in path "
+                f"(asker={req.asker_pubkey[:12]}…)"
+            )
+            raise FederationQueryError("Malformed path: asker_pubkey missing")
+
         peer = await self._lookup_peer(req.asker_pubkey)
 
         # Resolve the asker's local visible tier. The responder granted

--- a/src/backend/services/federation_query_schemas.py
+++ b/src/backend/services/federation_query_schemas.py
@@ -70,15 +70,35 @@ class QueryBrainInitiateRequest(BaseModel):
     Asker-signed request to kick off a federated query.
 
     Signature covers the canonical-JSON encoding of every non-signature
-    field (asker_pubkey, query, nonce, timestamp). Responder MUST
-    reject requests whose timestamp falls outside a ±60s window and
-    must remember the nonce to reject replays.
+    field (version, asker_pubkey, query, nonce, timestamp, depth, path).
+    Responder MUST reject requests whose timestamp falls outside a ±60s
+    window, must remember the nonce to reject replays, and (F5a) must
+    reject if `depth <= 0` or its own pubkey already appears in `path`
+    (cycle).
+
+    Version 2 of the envelope adds `depth` + `path` for F5a. Because the
+    federation network is pre-production the bump is hard — v1 peers
+    will be rejected at signature verification (the canonical payload
+    shape differs). No backwards-compat shim.
     """
-    version: int = 1
+    version: int = 2
     asker_pubkey: str = Field(..., min_length=64, max_length=64)  # hex
     query: str = Field(..., max_length=4000)
     nonce: str = Field(..., min_length=16)  # 128-bit, hex-encoded
     timestamp: int  # unix seconds; responder rejects > ±60s from its clock
+    # F5a — remaining hop budget. Asker sets to settings.federation_max_depth.
+    # Each responder that cascades transitively MUST send the downstream
+    # request with depth-1. When depth reaches 0, cascading is impossible
+    # but the current hop's work still happens (the 0 is "you're the last
+    # stop"). Responders short-circuit with a terminal failure only if
+    # they receive depth < 0 OR depth < 1 when they intend to cascade.
+    depth: int = Field(default=3, ge=0, le=10)
+    # F5a — asker pubkeys already in the call chain. First-hop queries
+    # carry just the originator's pubkey. Each transitive cascader
+    # appends its own pubkey before sending the downstream request.
+    # Responder rejects if its own pubkey is already in this list
+    # (cycle detection).
+    path: list[str] = Field(default_factory=list, max_length=10)
     signature: str = Field(..., min_length=128, max_length=128)  # hex
 
 
@@ -147,6 +167,11 @@ def initiate_canonical_payload(req: QueryBrainInitiateRequest) -> dict[str, Any]
     Return the dict over which `signature` is Ed25519-signed by the asker.
     Shared by signer and verifier to avoid byte drift (same pattern as
     pairing_service._canonical_bytes).
+
+    `depth` and `path` are included so an adversary can't strip the
+    cycle-detection fields after the asker signs — mutation would
+    invalidate the signature. `path` is sorted... actually no, path
+    order matters (it's the call chain). We sign the list as-is.
     """
     return {
         "version": req.version,
@@ -154,6 +179,8 @@ def initiate_canonical_payload(req: QueryBrainInitiateRequest) -> dict[str, Any]
         "query": req.query,
         "nonce": req.nonce,
         "timestamp": req.timestamp,
+        "depth": req.depth,
+        "path": list(req.path),  # copy so later mutations don't alias
     }
 
 

--- a/src/backend/services/federation_query_schemas.py
+++ b/src/backend/services/federation_query_schemas.py
@@ -73,8 +73,22 @@ class QueryBrainInitiateRequest(BaseModel):
     field (version, asker_pubkey, query, nonce, timestamp, depth, path).
     Responder MUST reject requests whose timestamp falls outside a ±60s
     window, must remember the nonce to reject replays, and (F5a) must
-    reject if `depth <= 0` or its own pubkey already appears in `path`
+    reject if `depth < 0` or its own pubkey already appears in `path`
     (cycle).
+
+    F5a design — `depth` and `path` are hardening fields only. They do
+    NOT grant cross-peer trust:
+      - The envelope's `asker_pubkey` IS the sender, signed with the
+        sender's key, bound to the receiver's pair-anchor. That's the
+        only trust anchor.
+      - `path` is a provenance / cycle-defense marker. Entries beyond
+        `asker_pubkey` (if cascade is ever wired) are informational —
+        a receiver never verifies them against its peer table.
+      - Cascade mechanics (if/when added): the cascader signs a fresh
+        envelope AS THE NEW asker (pair-anchor requires it). The
+        original originator's pubkey lives on in `path[0]` for audit
+        and cycle detection, but the new receiver trusts only its
+        directly paired peer.
 
     Version 2 of the envelope adds `depth` + `path` for F5a. Because the
     federation network is pre-production the bump is hard — v1 peers
@@ -86,18 +100,20 @@ class QueryBrainInitiateRequest(BaseModel):
     query: str = Field(..., max_length=4000)
     nonce: str = Field(..., min_length=16)  # 128-bit, hex-encoded
     timestamp: int  # unix seconds; responder rejects > ±60s from its clock
-    # F5a — remaining hop budget. Asker sets to settings.federation_max_depth.
-    # Each responder that cascades transitively MUST send the downstream
-    # request with depth-1. When depth reaches 0, cascading is impossible
-    # but the current hop's work still happens (the 0 is "you're the last
-    # stop"). Responders short-circuit with a terminal failure only if
-    # they receive depth < 0 OR depth < 1 when they intend to cascade.
+    # F5a — remaining hop budget (resource guard). Asker sets to
+    # settings.federation_max_depth. Responder rejects depth<0. A
+    # future cascader decrements before forwarding. depth=0 means
+    # "you're the last stop — no further cascade allowed but do your
+    # own work"; the responder accepts and processes normally.
     depth: int = Field(default=3, ge=0, le=10)
-    # F5a — asker pubkeys already in the call chain. First-hop queries
-    # carry just the originator's pubkey. Each transitive cascader
-    # appends its own pubkey before sending the downstream request.
-    # Responder rejects if its own pubkey is already in this list
-    # (cycle detection).
+    # F5a — cycle-defense + provenance marker. Carries asker pubkeys
+    # already in the call chain. First-hop queries carry
+    # `[originator_pubkey]`. A future cascader appends its own pubkey
+    # when minting the DOWNSTREAM (fresh-signed) envelope, so the
+    # receiver sees the chain. Receivers reject when their own pubkey
+    # is already in the list (cycle) — but DO NOT treat path entries
+    # as trust claims; only the envelope's `asker_pubkey` signature
+    # is authoritative. Max 10 at schema level bounds path growth.
     path: list[str] = Field(default_factory=list, max_length=10)
     signature: str = Field(..., min_length=128, max_length=128)  # hex
 
@@ -168,10 +184,9 @@ def initiate_canonical_payload(req: QueryBrainInitiateRequest) -> dict[str, Any]
     Shared by signer and verifier to avoid byte drift (same pattern as
     pairing_service._canonical_bytes).
 
-    `depth` and `path` are included so an adversary can't strip the
-    cycle-detection fields after the asker signs — mutation would
-    invalidate the signature. `path` is sorted... actually no, path
-    order matters (it's the call chain). We sign the list as-is.
+    `depth` and `path` are signed so an adversary can't strip them
+    after the fact to bypass cycle detection / hop budget. `path` is
+    encoded in order (it's a call chain, not a set).
     """
     return {
         "version": req.version,

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -225,6 +225,14 @@ class Settings(BaseSettings):
     chat_upload_cleanup_enabled: bool = False
     chat_upload_email_account: str = "primary"
 
+    # Federation (v2 — F5a depth + cycle detection)
+    # Max number of federation hops a query can traverse before
+    # responders reject with "too deep". 1 = direct asker→responder
+    # only (no transitive). Default 3 matches the household assumption
+    # of at most A→B→C→D chains; larger values widen the reach but
+    # also the latency + trust surface.
+    federation_max_depth: int = Field(default=3, ge=1, le=10)
+
     # Monitoring
     metrics_enabled: bool = False  # Enable Prometheus /metrics endpoint
 

--- a/tests/backend/test_federation_query_responder.py
+++ b/tests/backend/test_federation_query_responder.py
@@ -117,15 +117,26 @@ def _sign_initiate(
     query: str = "what is mom's recipe?",
     nonce: str | None = None,
     timestamp: int | None = None,
+    depth: int = 3,
+    path: list[str] | None = None,
 ) -> QueryBrainInitiateRequest:
+    """Build a signed v2 initiate envelope.
+
+    `path` defaults to `[asker.pubkey]` — the realistic first-hop shape
+    after F5a. Tests that want to exercise cycle detection pass an
+    explicit `path` carrying the responder's own pubkey.
+    """
     import secrets
 
+    my_pubkey = asker.public_key_hex()
     unsigned = {
-        "version": 1,
-        "asker_pubkey": asker.public_key_hex(),
+        "version": 2,
+        "asker_pubkey": my_pubkey,
         "query": query,
         "nonce": nonce or secrets.token_hex(16),
         "timestamp": timestamp if timestamp is not None else int(time.time()),
+        "depth": depth,
+        "path": path if path is not None else [my_pubkey],
     }
     sig = asker.sign(_canonical_bytes(unsigned)).hex()
     return QueryBrainInitiateRequest(**unsigned, signature=sig)
@@ -136,6 +147,8 @@ def _sign_retrieve(
     request_id: str,
     timestamp: int | None = None,
 ) -> QueryBrainRetrieveRequest:
+    # Retrieve envelope is unchanged by F5a (depth/path live only on
+    # /initiate) so version stays 1 for the poll request.
     unsigned = {
         "version": 1,
         "request_id": request_id,
@@ -235,6 +248,105 @@ class TestHandleInitiate:
         req = _sign_initiate(asker_identity)
         with pytest.raises(FederationQueryError, match="Unknown or revoked"):
             await responder.handle_initiate(req)
+
+
+# =============================================================================
+# F5a — depth + cycle detection
+# =============================================================================
+
+
+class TestDepthAndCycleDetection:
+    @pytest.mark.unit
+    def test_negative_depth_rejected_at_parse_time(self, asker_identity):
+        """Pydantic ge=0 on the `depth` field is the first line of
+        defense: a wire-level request with negative depth can't even
+        reach handle_initiate. The handler's own `depth < 0` branch is
+        defense-in-depth for any future non-HTTP entry point."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="greater_than_equal"):
+            _sign_initiate(asker_identity, depth=-1)
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_depth_zero_accepted_as_leaf(
+        self, mock_db_with_peer, asker_identity, responder_identity,
+    ):
+        """depth=0 means 'you're the last hop — do the work but don't
+        cascade'. Valid at initiate time; cascading from here would be
+        a responder-side bug, not an asker-side one."""
+        responder = FederationQueryResponder(db=mock_db_with_peer)
+        req = _sign_initiate(asker_identity, depth=0)
+
+        resp = await responder.handle_initiate(req)
+        assert resp.request_id
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_cycle_rejected_when_own_pubkey_in_path(
+        self, mock_db_with_peer, asker_identity, responder_identity,
+    ):
+        """Responder sees its own pubkey in path → refuses to process.
+        This is the defense against A→B→C→B chains."""
+        responder = FederationQueryResponder(db=mock_db_with_peer)
+        my_pubkey = responder_identity.public_key_hex()
+        asker_pubkey = asker_identity.public_key_hex()
+        # Path includes the responder already — mimics a transitive
+        # request that looped back.
+        req = _sign_initiate(
+            asker_identity,
+            path=[asker_pubkey, my_pubkey],
+        )
+
+        with pytest.raises(FederationQueryError, match="cycle"):
+            await responder.handle_initiate(req)
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_asker_pubkey_missing_from_path_rejected(
+        self, mock_db_with_peer, asker_identity, responder_identity,
+    ):
+        """Path must include asker_pubkey — stripping it is an attempt
+        to erase the originator from the call chain, which would let
+        an adversary anonymize queries."""
+        responder = FederationQueryResponder(db=mock_db_with_peer)
+        # Sign with a path that omits the asker's own pubkey.
+        req = _sign_initiate(asker_identity, path=["c" * 64])
+
+        with pytest.raises(FederationQueryError, match="path|asker_pubkey"):
+            await responder.handle_initiate(req)
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_happy_path_with_realistic_depth_and_path(
+        self, mock_db_with_peer, asker_identity,
+    ):
+        """Sanity: a standard first-hop request (depth=3, path=[asker])
+        is accepted. Regression guard against the schema bump breaking
+        the common case."""
+        responder = FederationQueryResponder(db=mock_db_with_peer)
+        req = _sign_initiate(asker_identity)  # defaults: depth=3, path=[asker]
+
+        resp = await responder.handle_initiate(req)
+        assert resp.request_id
+        assert resp.accepted_at
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_tampered_path_breaks_signature(
+        self, mock_db_with_peer, asker_identity,
+    ):
+        """An adversary stripping `path` on the wire (to hide the chain)
+        must fail signature verification — the canonical payload covers
+        path, so any mutation invalidates the sig."""
+        responder = FederationQueryResponder(db=mock_db_with_peer)
+        req = _sign_initiate(asker_identity)
+
+        tampered = QueryBrainInitiateRequest(
+            **{**req.model_dump(), "path": []},
+        )
+        with pytest.raises(FederationQueryError, match="Signature"):
+            await responder.handle_initiate(tampered)
 
 
 # =============================================================================

--- a/tests/backend/test_federation_query_responder.py
+++ b/tests/backend/test_federation_query_responder.py
@@ -319,12 +319,13 @@ class TestDepthAndCycleDetection:
     @pytest.mark.asyncio
     @pytest.mark.unit
     async def test_happy_path_with_realistic_depth_and_path(
-        self, mock_db_with_peer, asker_identity,
+        self, mock_db_with_peer, asker_identity, responder_identity,
     ):
         """Sanity: a standard first-hop request (depth=3, path=[asker])
         is accepted. Regression guard against the schema bump breaking
         the common case."""
         responder = FederationQueryResponder(db=mock_db_with_peer)
+        responder._run_query = AsyncMock()  # skip real synthesis
         req = _sign_initiate(asker_identity)  # defaults: depth=3, path=[asker]
 
         resp = await responder.handle_initiate(req)
@@ -334,7 +335,7 @@ class TestDepthAndCycleDetection:
     @pytest.mark.asyncio
     @pytest.mark.unit
     async def test_tampered_path_breaks_signature(
-        self, mock_db_with_peer, asker_identity,
+        self, mock_db_with_peer, asker_identity, responder_identity,
     ):
         """An adversary stripping `path` on the wire (to hide the chain)
         must fail signature verification — the canonical payload covers


### PR DESCRIPTION
## Summary

F5a is the correctness gate before the rest of F5 hardening (per-peer rate limits F5b, Redis-backed state F5c, cert pinning F5d). Adds `depth` + `path` fields to the signed `/initiate` envelope so future transitive federation can't loop forever or create cycles.

## What shipped

### Envelope changes (bumped to version 2)

- `depth: int` — hop budget. Asker sets to `settings.federation_max_depth` (default 3). Pydantic clamps 0-10.
- `path: list[str]` — asker pubkeys visited so far. First-hop carries `[originator]`. Transitive cascaders append their own pubkey. Max 10 entries at schema level.

### Responder checks (in `handle_initiate`, AFTER sig verify)

- `depth < 0` → `Query depth exhausted`
- own pubkey already in `path` → `Federation cycle detected`
- `asker_pubkey` not in `path` → `Malformed path` (anti-anonymization)

Both fields are in the canonical signing payload so they can't be stripped by a MITM.

### New setting

`federation_max_depth: int = 3` in `utils/config.py` (range 1-10).

## What's in / out

**In:**
- Schema + asker + responder plumbing
- 6 new backend tests (`TestDepthAndCycleDetection`)
- Test helper `_sign_initiate` updated to build v2 envelopes so all pre-existing federation tests still pass

**Out (deferred to later F5 lanes):**
- **F5b** — per-peer outbound + per-asker-user inbound rate limits
- **F5c** — Redis-backed `_pending_requests` for multi-process deploys
- **F5d** — TLS fingerprint pinning (use `PeerUser.transport_config.tls_fingerprint`)
- Actual transitive cascade support — today Renfield doesn't cascade; the `depth`/`path` fields are future-proofing. If/when we wire it, the cascader will need to decrement `depth` and append its own pubkey before re-signing.

## Pre-production note

Renfield is pre-production so the v1→v2 envelope bump is hard: no backwards-compat shim. Any paired peer still running v1 will fail signature verification against the new canonical payload. Per the user's standing "Lane B+ ships destructive migration in ONE PR" preference.

## Test plan

- [x] Backend: 18/18 responder tests pass (12 pre-existing + 6 new)
- [x] Backend: 70/70 across the full federation suite (responder + asker + agent integration + audit) 
- [x] Syntax + type parse: all files parse clean
- [ ] Manual: two paired Renfields, verify normal `query_brain` still works (sig verification over v2 payload)
- [ ] Manual: craft a path with the responder's own pubkey, POST directly → see 400 with cycle reason in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)