### PR TITLE
feat(federation): F5b — per-peer + per-asker rate limits

### DIFF
--- a/src/backend/services/federation_query_responder.py
+++ b/src/backend/services/federation_query_responder.py
@@ -268,6 +268,19 @@ class FederationQueryResponder:
         if not _record_nonce(req.nonce, now=now):
             raise FederationQueryError("Nonce already seen (replay detected)")
 
+        # F5b — inbound rate limit keyed by asker_pubkey. Checked AFTER
+        # signature + timestamp + nonce so an unauthenticated flood
+        # can't probe the limiter state by pubkey. A valid signature
+        # is required to land in the rate-limit bucket at all, so the
+        # bucket's state is private to each authenticated peer.
+        from services.federation_rate_limits import acquire_responder_token
+        if not await acquire_responder_token(req.asker_pubkey):
+            logger.warning(
+                f"Federation responder rate limit hit for asker "
+                f"{req.asker_pubkey[:12]}…"
+            )
+            raise FederationQueryError("Rate limit exceeded for this asker")
+
         # F5a — depth + cycle hardening. Checked AFTER signature
         # verification because the fields are part of the canonical
         # payload (an adversary can't strip them). Errors collapse to a

--- a/src/backend/services/federation_rate_limits.py
+++ b/src/backend/services/federation_rate_limits.py
@@ -1,0 +1,88 @@
+"""
+Federation rate-limit registries (F5b).
+
+Two independent in-memory registries, each mapping a key to a
+TokenBucketRateLimiter:
+
+- ASKER_OUTBOUND: keyed by `peer.remote_pubkey`. Limits how fast THIS
+  Renfield can initiate federation queries against any single remote
+  peer. Checked in `MCPManager._execute_federation_streaming` before
+  invoking the asker.
+
+- RESPONDER_INBOUND: keyed by the incoming `asker_pubkey`. Limits how
+  fast any single paired asker can hammer us. Checked in
+  `FederationQueryResponder.handle_initiate` after signature
+  verification (a valid sig is required first — no oracle on "which
+  pubkey is rate-limited").
+
+Scope:
+  Single-process, in-memory. Sufficient for the one-backend-container
+  deployment Renfield ships today. F5c (Redis-backed pending requests)
+  will extend this too — rate-limit state shared across workers is the
+  same story as pending-request state.
+
+Cleanup:
+  Limiters accumulate one entry per distinct key. For a household with
+  2–5 paired peers total, that's 10 entries combined over a deployment's
+  lifetime — no cleanup needed. If we ever face a public/open-enrollment
+  deploy the registry grows unbounded; LRU-evict keyed by last-acquire
+  time would be the fix. Out of scope for F5b.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from services.mcp_client import TokenBucketRateLimiter
+from utils.config import settings
+
+
+# Keyed by `peer.remote_pubkey` (hex string). One limiter per remote peer.
+_asker_outbound: dict[str, TokenBucketRateLimiter] = {}
+# Keyed by `asker_pubkey` (hex string from the incoming envelope).
+_responder_inbound: dict[str, TokenBucketRateLimiter] = {}
+
+# Guards registry mutation on first-acquire (two concurrent initiates
+# for a new peer could race and create two limiters, losing one).
+_asker_lock = asyncio.Lock()
+_responder_lock = asyncio.Lock()
+
+
+async def acquire_asker_token(peer_pubkey: str) -> bool:
+    """Try to acquire one outbound token for `peer_pubkey`.
+
+    Returns True if the asker may proceed, False if rate-limited.
+    The limiter is created on first call and cached; subsequent
+    calls reuse the same bucket.
+    """
+    bucket = _asker_outbound.get(peer_pubkey)
+    if bucket is None:
+        async with _asker_lock:
+            # Double-check inside the lock (another coroutine may have
+            # created it while we awaited).
+            bucket = _asker_outbound.get(peer_pubkey)
+            if bucket is None:
+                bucket = TokenBucketRateLimiter(
+                    rate_per_minute=settings.federation_asker_rate_per_minute,
+                )
+                _asker_outbound[peer_pubkey] = bucket
+    return await bucket.acquire()
+
+
+async def acquire_responder_token(asker_pubkey: str) -> bool:
+    """Try to acquire one inbound token for `asker_pubkey`."""
+    bucket = _responder_inbound.get(asker_pubkey)
+    if bucket is None:
+        async with _responder_lock:
+            bucket = _responder_inbound.get(asker_pubkey)
+            if bucket is None:
+                bucket = TokenBucketRateLimiter(
+                    rate_per_minute=settings.federation_responder_rate_per_minute,
+                )
+                _responder_inbound[asker_pubkey] = bucket
+    return await bucket.acquire()
+
+
+def reset_for_tests() -> None:
+    """Test-only reset — every test starts with a clean view."""
+    _asker_outbound.clear()
+    _responder_inbound.clear()

--- a/src/backend/services/federation_rate_limits.py
+++ b/src/backend/services/federation_rate_limits.py
@@ -27,6 +27,12 @@ Cleanup:
   lifetime — no cleanup needed. If we ever face a public/open-enrollment
   deploy the registry grows unbounded; LRU-evict keyed by last-acquire
   time would be the fix. Out of scope for F5b.
+
+Runtime config:
+  `settings.federation_*_rate_per_minute` is read ONCE per key on
+  first-acquire. Changing the env var at runtime does NOT rebuild
+  existing buckets — the new rate only applies to keys that haven't
+  been seen yet. A backend restart picks up the new value cleanly.
 """
 from __future__ import annotations
 

--- a/src/backend/services/mcp_client.py
+++ b/src/backend/services/mcp_client.py
@@ -1479,6 +1479,27 @@ class MCPManager:
             }
             return
 
+        # F5b — outbound rate limit keyed by peer.remote_pubkey. Before
+        # we spend any time on the asker, check that we haven't already
+        # fired too many queries at this peer in the last minute. Hit
+        # surfaces as a FinalResult failure (no retry) — the agent loop
+        # will see it as a normal tool error and move on.
+        from services.federation_rate_limits import acquire_asker_token
+        if not await acquire_asker_token(peer.remote_pubkey):
+            logger.warning(
+                f"Federation asker rate limit hit for peer "
+                f"{peer.remote_display_name} ({peer.remote_pubkey[:12]}…)"
+            )
+            yield {
+                "success": False,
+                "message": (
+                    f"Rate limit reached for peer "
+                    f"{peer.remote_display_name}. Try again in a moment."
+                ),
+                "data": None,
+            }
+            return
+
         # F4d — snapshot peer identity at query time so later display-name
         # changes or peer deletion don't rewrite history.
         from datetime import UTC, datetime as _dt

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -233,6 +233,17 @@ class Settings(BaseSettings):
     # also the latency + trust surface.
     federation_max_depth: int = Field(default=3, ge=1, le=10)
 
+    # Federation (F5b — rate limits).
+    # Asker-side: max initiate calls per minute per paired peer. Throttles
+    # how fast THIS Renfield can hammer a single remote peer. At 60/min
+    # (default) a reasonable upper bound is 1 query/sec sustained.
+    federation_asker_rate_per_minute: int = Field(default=60, ge=1, le=600)
+    # Responder-side: max initiate calls per minute from any one asker
+    # pubkey. Defense against a compromised-or-rogue paired peer flooding
+    # us. 30/min (default) is 0.5 QPS sustained — generous for household
+    # use, tight enough that abuse is obvious.
+    federation_responder_rate_per_minute: int = Field(default=30, ge=1, le=600)
+
     # Monitoring
     metrics_enabled: bool = False  # Enable Prometheus /metrics endpoint
 

--- a/tests/backend/test_federation_rate_limits.py
+++ b/tests/backend/test_federation_rate_limits.py
@@ -109,6 +109,23 @@ class TestRegistries:
         # B is untouched.
         assert await acquire_asker_token("b" * 64) is True
 
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_concurrent_first_acquire_creates_one_bucket(self):
+        """Belt-and-suspenders: many concurrent first-acquires for the
+        same key must end up sharing ONE bucket (the double-checked
+        lock pattern). If two coroutines both lost the lock race and
+        each created their own bucket, one would be discarded and the
+        rate limit would silently double for that key."""
+        import asyncio
+        results = await asyncio.gather(
+            *[acquire_asker_token("z" * 64) for _ in range(20)]
+        )
+        # All should succeed (default 60/min budget, 20 < 60).
+        assert all(results)
+        # Critically: exactly one bucket created.
+        assert len(_asker_outbound) == 1
+
 
 # =============================================================================
 # Integration — asker-side block surfaces as FinalResult failure

--- a/tests/backend/test_federation_rate_limits.py
+++ b/tests/backend/test_federation_rate_limits.py
@@ -1,0 +1,284 @@
+"""
+Tests for F5b — federation rate limits.
+
+Two registries, tested independently + in integration:
+
+- `acquire_asker_token(peer_pubkey)` — asker-side outbound bucket
+- `acquire_responder_token(asker_pubkey)` — responder-side inbound bucket
+
+Integration tests drive through the full `MCPManager._execute_federation_streaming`
+and `FederationQueryResponder.handle_initiate` paths to confirm the
+limiters actually gate the wire-level flows.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+from services.federation_identity import (
+    FederationIdentity,
+    init_federation_identity,
+    reset_federation_identity_for_tests,
+)
+from services.federation_rate_limits import (
+    _asker_outbound,
+    _responder_inbound,
+    acquire_asker_token,
+    acquire_responder_token,
+    reset_for_tests,
+)
+
+
+# =============================================================================
+# Unit — registries in isolation
+# =============================================================================
+
+
+class TestRegistries:
+    def setup_method(self) -> None:
+        reset_for_tests()
+
+    def teardown_method(self) -> None:
+        reset_for_tests()
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_asker_registry_creates_one_limiter_per_peer(self, monkeypatch):
+        """First acquire seeds a bucket; subsequent reuses it."""
+        assert len(_asker_outbound) == 0
+        ok = await acquire_asker_token("a" * 64)
+        assert ok is True
+        assert len(_asker_outbound) == 1
+        # Second peer gets its own bucket.
+        ok = await acquire_asker_token("b" * 64)
+        assert ok is True
+        assert len(_asker_outbound) == 2
+        # Same peer reuses.
+        ok = await acquire_asker_token("a" * 64)
+        assert ok is True
+        assert len(_asker_outbound) == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_asker_registry_exhausts_then_refills(self, monkeypatch):
+        """Spending all tokens returns False; time passing refills."""
+        # Pin rate low so we can drain quickly.
+        from services.federation_rate_limits import _asker_outbound as store
+        from services.mcp_client import TokenBucketRateLimiter
+
+        bucket = TokenBucketRateLimiter(rate_per_minute=3)  # 3 tokens initial
+        store["x" * 64] = bucket
+
+        assert await acquire_asker_token("x" * 64) is True
+        assert await acquire_asker_token("x" * 64) is True
+        assert await acquire_asker_token("x" * 64) is True
+        # Exhausted.
+        assert await acquire_asker_token("x" * 64) is False
+
+        # Simulate time passing for refill. Manually advance the
+        # bucket's internal clock — otherwise we'd need to sleep.
+        bucket.last_update -= 30  # 30 seconds ago → 1.5 tokens refilled
+        assert await acquire_asker_token("x" * 64) is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_responder_registry_is_independent_of_asker_registry(self):
+        """Two separate namespaces — an asker-side hit on key K doesn't
+        exhaust the responder-side bucket for the same K."""
+        assert await acquire_asker_token("k" * 64) is True
+        # Responder-side still has its full budget for the same key.
+        assert await acquire_responder_token("k" * 64) is True
+        assert len(_asker_outbound) == 1
+        assert len(_responder_inbound) == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_rate_limit_isolates_peers(self):
+        """Exhausting peer A's bucket leaves peer B's untouched."""
+        from services.federation_rate_limits import _asker_outbound as store
+        from services.mcp_client import TokenBucketRateLimiter
+
+        store["a" * 64] = TokenBucketRateLimiter(rate_per_minute=1)
+        # Drain A
+        assert await acquire_asker_token("a" * 64) is True
+        assert await acquire_asker_token("a" * 64) is False
+        # B is untouched.
+        assert await acquire_asker_token("b" * 64) is True
+
+
+# =============================================================================
+# Integration — asker-side block surfaces as FinalResult failure
+# =============================================================================
+
+
+class TestAskerSideIntegration:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_execute_federation_streaming_rate_limited(
+        self, tmp_path, monkeypatch,
+    ):
+        """When the asker-side token bucket is empty, the MCPManager
+        federation branch must NOT call the asker — yields a single
+        FinalResult failure with a user-friendly message."""
+        from services.federation_rate_limits import _asker_outbound
+        from services.mcp_client import (
+            MCPManager,
+            MCPServerConfig,
+            MCPServerState,
+            MCPToolInfo,
+            MCPTransportType,
+            TokenBucketRateLimiter,
+        )
+
+        reset_for_tests()
+        reset_federation_identity_for_tests()
+        init_federation_identity(tmp_path / "key")
+
+        manager = MCPManager()
+        config = MCPServerConfig(
+            name="peer_1", transport=MCPTransportType.FEDERATION,
+            streaming=True, peer_user_id=1,
+        )
+        state = MCPServerState(config=config)
+        state.connected = True
+        manager._servers["peer_1"] = state
+        manager._tool_index["mcp.peer_1.query_brain"] = MCPToolInfo(
+            server_name="peer_1", original_name="query_brain",
+            namespaced_name="mcp.peer_1.query_brain", description="", input_schema={},
+        )
+
+        fake_peer = SimpleNamespace(
+            id=1, remote_pubkey="z" * 64, remote_display_name="Mom",
+            revoked_at=None,
+        )
+        session_mock = AsyncMock()
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none = lambda: fake_peer
+        session_mock.execute = AsyncMock(return_value=result_mock)
+        session_mock.__aenter__ = AsyncMock(return_value=session_mock)
+        session_mock.__aexit__ = AsyncMock(return_value=False)
+        monkeypatch.setattr(
+            "services.database.AsyncSessionLocal", lambda: session_mock,
+        )
+
+        # Pre-exhaust the bucket for this peer.
+        _asker_outbound["z" * 64] = TokenBucketRateLimiter(rate_per_minute=1)
+        assert await acquire_asker_token("z" * 64) is True  # consume the 1 token
+        assert await acquire_asker_token("z" * 64) is False
+
+        # Asker must NOT be invoked — assert via spy.
+        asker_called = False
+
+        async def should_not_be_called(self, peer, text):
+            nonlocal asker_called
+            asker_called = True
+            yield {"success": True, "message": "", "data": None}
+
+        monkeypatch.setattr(
+            "services.federation_query_asker.FederationQueryAsker.query_peer",
+            should_not_be_called,
+        )
+
+        final = await manager.execute_tool(
+            "mcp.peer_1.query_brain", {"query": "q"}, user_id=1,
+        )
+        assert asker_called is False
+        assert final["success"] is False
+        assert "rate limit" in final["message"].lower()
+
+        reset_federation_identity_for_tests()
+        reset_for_tests()
+
+
+# =============================================================================
+# Integration — responder-side block surfaces as FederationQueryError
+# =============================================================================
+
+
+class TestResponderSideIntegration:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_handle_initiate_rate_limited(self, tmp_path):
+        """When the responder-side bucket is empty for this asker,
+        handle_initiate raises FederationQueryError after sig+nonce
+        checks pass."""
+        import secrets
+
+        from services.federation_query_responder import (
+            FederationQueryError,
+            FederationQueryResponder,
+            _clear_state_for_tests,
+        )
+        from services.federation_query_schemas import QueryBrainInitiateRequest
+        from services.federation_rate_limits import (
+            _responder_inbound,
+        )
+        from services.mcp_client import TokenBucketRateLimiter
+        from services.pairing_service import _canonical_bytes
+
+        reset_for_tests()
+        reset_federation_identity_for_tests()
+        init_federation_identity(tmp_path / "responder_key")
+        _clear_state_for_tests()
+
+        asker = FederationIdentity(ed25519.Ed25519PrivateKey.generate())
+        asker_pubkey = asker.public_key_hex()
+
+        # db mock that returns a valid peer for this asker
+        db = MagicMock()
+        peer = MagicMock()
+        peer.id = 7
+        peer.circle_owner_id = 1
+        peer.remote_pubkey = asker_pubkey
+        peer.remote_user_id = 42
+        peer.revoked_at = None
+        membership = MagicMock(value=2)
+
+        async def execute_side(stmt):
+            r = MagicMock()
+            if "peer_users" in str(stmt):
+                r.scalar_one_or_none = lambda: peer
+            elif "circle_memberships" in str(stmt):
+                r.scalar_one_or_none = lambda: membership
+            else:
+                r.scalar_one_or_none = lambda: None
+            return r
+
+        db.execute = AsyncMock(side_effect=execute_side)
+        db.commit = AsyncMock()
+
+        responder = FederationQueryResponder(db=db)
+        responder._run_query = AsyncMock()
+
+        def build_req(nonce: str) -> QueryBrainInitiateRequest:
+            unsigned = {
+                "version": 2,
+                "asker_pubkey": asker_pubkey,
+                "query": "q",
+                "nonce": nonce,
+                "timestamp": int(time.time()),
+                "depth": 3,
+                "path": [asker_pubkey],
+            }
+            sig = asker.sign(_canonical_bytes(unsigned)).hex()
+            return QueryBrainInitiateRequest(**unsigned, signature=sig)
+
+        # Pre-exhaust the responder bucket for this asker_pubkey.
+        _responder_inbound[asker_pubkey] = TokenBucketRateLimiter(
+            rate_per_minute=1,
+        )
+        # First call consumes the token and SUCCEEDS.
+        resp = await responder.handle_initiate(build_req(secrets.token_hex(16)))
+        assert resp.request_id
+
+        # Second call exhausts → rejected with rate-limit error.
+        with pytest.raises(FederationQueryError, match="[Rr]ate limit"):
+            await responder.handle_initiate(build_req(secrets.token_hex(16)))
+
+        reset_federation_identity_for_tests()
+        _clear_state_for_tests()
+        reset_for_tests()


### PR DESCRIPTION
## Summary

F5b — second F5 hardening lane. Two independent token-bucket registries gate federation traffic so neither asker nor responder can be hammered by abuse:

- **Asker-side outbound** — keyed by `peer.remote_pubkey`, throttles how fast THIS Renfield can initiate queries against any one remote peer. Default 60/min (1 QPS).
- **Responder-side inbound** — keyed by incoming `asker_pubkey`, throttles how fast any single paired asker can hammer us. Default 30/min (0.5 QPS).

Reuses the existing `TokenBucketRateLimiter` from `mcp_client.py`; new module `services/federation_rate_limits.py` is just the keyed-registry shim with first-acquire double-checked locking.

## What's in / out

**In:**
- 2 new settings (`federation_asker_rate_per_minute`, `federation_responder_rate_per_minute`).
- Asker-side check in `MCPManager._execute_federation_streaming` before invoking the asker.
- Responder-side check in `FederationQueryResponder.handle_initiate` after sig + timestamp + nonce.
- 6 new backend tests (registry semantics + 2 integration tests).

**Out (deferred):**
- **F5c** — Redis-backed pending requests (limiters are also single-process; both will move together).
- **F5d** — TLS fingerprint pinning.
- LRU eviction of the limiter dicts (unbounded growth — fine for households with 2–5 peers, would matter for an open-enrollment deploy).

## Tradeoffs

- **Bucket location: after sig+nonce.** A valid signature is required to land in the per-pubkey bucket at all. This means an unauthenticated flood costs us Ed25519 verify per request (~200μs) before being rejected by sig — but doesn't pollute the limiter. Pre-sig rate-limiting would need a second key (e.g., source IP), out of scope here.
- **Hit surfaces as a tool failure on the asker side, HTTP 400 on the responder.** Asker hit shows the user a "rate limit reached for peer X" message; responder hit returns a uniform 400 to the requester.

## Test plan

- [x] Backend: 6/6 new tests pass (`test_federation_rate_limits.py`)
- [x] Backend: 76/76 across the full federation suite
- [x] Syntax + parse clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)