### PR TITLE
feat(federation): F5e — TOFU auto-pinning during pairing

### DIFF
--- a/src/backend/services/federation_cert_pin.py
+++ b/src/backend/services/federation_cert_pin.py
@@ -48,6 +48,80 @@ def _normalize_fingerprint(s: str) -> str:
     return s.replace(":", "").replace(" ", "")
 
 
+async def probe_peer_cert_fingerprint(
+    endpoint_url: str,
+    *,
+    timeout: float = 5.0,
+) -> str | None:
+    """
+    Open a one-shot TLS connection to `endpoint_url` and return the
+    peer's leaf certificate SHA-256 as lowercase hex (no separators).
+
+    Returns None for:
+      - non-HTTPS endpoints (nothing to pin)
+      - TCP/TLS failures (host down, refused, timeout)
+      - peers that don't present a certificate or aren't speaking TLS
+
+    Used for two purposes:
+      - F5d verification — caller compares against a stored pin.
+      - F5e TOFU auto-pinning — caller stores the return value in
+        `PeerUser.transport_config.tls_fingerprint` at pairing time,
+        making every subsequent query verify against it.
+    """
+    parsed = urlparse(endpoint_url)
+    if parsed.scheme != "https":
+        return None
+    host = parsed.hostname
+    port = parsed.port or 443
+    if not host:
+        logger.warning(f"Federation cert-pin: malformed endpoint {endpoint_url}")
+        return None
+
+    # CERT_NONE because we're either doing our own fingerprint
+    # validation (F5d) or TOFU-capturing whatever cert is presented
+    # (F5e). CA validity isn't the question we're answering.
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+
+    try:
+        _reader, writer = await asyncio.wait_for(
+            asyncio.open_connection(host, port, ssl=ctx),
+            timeout=timeout,
+        )
+    except (OSError, asyncio.TimeoutError) as e:
+        logger.warning(
+            f"Federation cert-pin: could not connect to {host}:{port} for "
+            f"pre-flight: {e}"
+        )
+        return None
+
+    try:
+        ssl_obj = writer.get_extra_info("ssl_object")
+        if ssl_obj is None:
+            logger.warning(
+                f"Federation cert-pin: no SSL context on connection to "
+                f"{host}:{port} (server speaks plain TCP?)"
+            )
+            return None
+        cert_der = ssl_obj.getpeercert(binary_form=True)
+        if not cert_der:
+            logger.warning(
+                f"Federation cert-pin: peer {host}:{port} did not "
+                f"present a certificate"
+            )
+            return None
+        return hashlib.sha256(cert_der).hexdigest().lower()
+    finally:
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except Exception:  # noqa: BLE001
+            # Tearing down the probe socket cleanly is best-effort;
+            # any error here doesn't affect the verification result.
+            pass
+
+
 async def verify_peer_cert_fingerprint(
     endpoint_url: str,
     expected_fingerprint_hex: str,
@@ -74,54 +148,10 @@ async def verify_peer_cert_fingerprint(
         # Nothing to pin on plain HTTP; let the request proceed and
         # let the Ed25519 response signature do the integrity work.
         return True, None
-    host = parsed.hostname
-    port = parsed.port or 443
-    if not host:
-        logger.warning(f"Federation cert-pin: malformed endpoint {endpoint_url}")
+
+    actual = await probe_peer_cert_fingerprint(endpoint_url, timeout=timeout)
+    if actual is None:
+        # probe_peer_cert_fingerprint already logged the specific failure.
         return False, None
-
-    # CERT_NONE because we're doing our own fingerprint validation;
-    # CA validity isn't the question we're answering.
-    ctx = ssl.create_default_context()
-    ctx.check_hostname = False
-    ctx.verify_mode = ssl.CERT_NONE
-
-    try:
-        reader, writer = await asyncio.wait_for(
-            asyncio.open_connection(host, port, ssl=ctx),
-            timeout=timeout,
-        )
-    except (OSError, asyncio.TimeoutError) as e:
-        logger.warning(
-            f"Federation cert-pin: could not connect to {host}:{port} for "
-            f"pre-flight: {e}"
-        )
-        return False, None
-
-    try:
-        ssl_obj = writer.get_extra_info("ssl_object")
-        if ssl_obj is None:
-            logger.warning(
-                f"Federation cert-pin: no SSL context on connection to "
-                f"{host}:{port} (server speaks plain TCP?)"
-            )
-            return False, None
-        cert_der = ssl_obj.getpeercert(binary_form=True)
-        if not cert_der:
-            logger.warning(
-                f"Federation cert-pin: peer {host}:{port} did not "
-                f"present a certificate"
-            )
-            return False, None
-        actual = hashlib.sha256(cert_der).hexdigest()
-        expected_norm = _normalize_fingerprint(expected_fingerprint_hex)
-        actual_norm = _normalize_fingerprint(actual)
-        return actual_norm == expected_norm, actual_norm
-    finally:
-        writer.close()
-        try:
-            await writer.wait_closed()
-        except Exception:  # noqa: BLE001
-            # Tearing down the probe socket cleanly is best-effort;
-            # any error here doesn't affect the verification result.
-            pass
+    expected_norm = _normalize_fingerprint(expected_fingerprint_hex)
+    return actual == expected_norm, actual

--- a/src/backend/services/pairing_service.py
+++ b/src/backend/services/pairing_service.py
@@ -154,6 +154,66 @@ def _clear_nonce_cache_for_tests() -> None:
 
 
 # =============================================================================
+# F5e — TOFU auto-pin helper
+# =============================================================================
+
+
+async def _with_tofu_fingerprint(endpoints: list[dict]) -> dict:
+    """
+    Build a `transport_config` dict from the peer's advertised endpoints,
+    optionally enriched with a TLS cert SHA-256 captured at pair time.
+
+    TOFU semantics: the first time we see this peer (which is pair time),
+    we trust whatever cert their endpoint presents and record its SHA-256
+    as a pin. All subsequent federation requests verify against this
+    pin via F5d. If the peer rotates their cert, the next query fails
+    with a clear "fingerprint mismatch" and the operator re-pairs to
+    refresh the pin.
+
+    Best-effort: probe failures (non-HTTPS, connection timeout, plain
+    TCP servers) just skip the pin — transport_config omits
+    `tls_fingerprint` and F5d falls back to default CA validation
+    (which won't work for self-signed deploys, but the operator at
+    least sees "couldn't probe" in the pairing logs).
+    """
+    config: dict = {"endpoints": endpoints}
+    first_url = _first_https_url(endpoints)
+    if not first_url:
+        return config
+
+    from services.federation_cert_pin import probe_peer_cert_fingerprint
+    fingerprint = await probe_peer_cert_fingerprint(first_url)
+    if fingerprint:
+        config["tls_fingerprint"] = fingerprint
+        logger.info(
+            f"Pairing TOFU: pinned peer cert {fingerprint[:16]}… for {first_url}"
+        )
+    else:
+        logger.warning(
+            f"Pairing TOFU: could not probe cert for {first_url} — "
+            f"pinning skipped. Federation queries may fail until the "
+            f"operator sets `tls_fingerprint` manually or re-pairs."
+        )
+    return config
+
+
+def _first_https_url(endpoints: list[dict]) -> str | None:
+    """Extract the first https:// URL from a list of endpoint dicts.
+    Endpoint shapes tolerated: `{"url": ...}`, `{"endpoint_url": ...}`,
+    or bare strings in the list."""
+    for ep in endpoints or []:
+        if isinstance(ep, str):
+            url = ep
+        elif isinstance(ep, dict):
+            url = ep.get("url") or ep.get("endpoint_url")
+        else:
+            continue
+        if url and str(url).startswith("https://"):
+            return str(url)
+    return None
+
+
+# =============================================================================
 # Service
 # =============================================================================
 
@@ -225,12 +285,18 @@ class PairingService:
             raise PairingError("Tier must be between 0 and 4")
 
         # Persist the initiator as our peer + as a member of our circle at the chosen tier.
+        # F5e — TOFU-capture the initiator's TLS fingerprint at pair time
+        # so subsequent queries to them are pinned automatically. Best-
+        # effort: non-HTTPS endpoints, unreachable hosts, and certs that
+        # can't be retrieved all return None and we skip pinning
+        # (logged by the probe helper).
+        transport_config = await _with_tofu_fingerprint(offer.offered_endpoints)
         await self._upsert_peer_user(
             owner_user_id=current_user.id,
             remote_pubkey=offer.initiator_pubkey,
             remote_display_name=offer.display_name,
             remote_user_id=offer.initiator_user_id,
-            transport_config={"endpoints": offer.offered_endpoints},
+            transport_config=transport_config,
         )
         # Ensure the responder has a circles row (needed for membership FK).
         await _get_or_create_circle(self.db, current_user.id)
@@ -287,12 +353,14 @@ class PairingService:
         if not (0 <= their_tier_for_me <= 4):
             raise PairingError("Tier must be between 0 and 4")
 
+        # F5e — TOFU-capture the responder's TLS fingerprint.
+        transport_config = await _with_tofu_fingerprint(response.accepted_endpoints)
         peer = await self._upsert_peer_user(
             owner_user_id=current_user.id,
             remote_pubkey=response.responder_pubkey,
             remote_display_name=response.responder_display_name,
             remote_user_id=response.responder_user_id,
-            transport_config={"endpoints": response.accepted_endpoints},
+            transport_config=transport_config,
         )
         await _get_or_create_circle(self.db, current_user.id)
         await self._upsert_circle_membership(

--- a/src/backend/services/pairing_service.py
+++ b/src/backend/services/pairing_service.py
@@ -45,6 +45,8 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from services.federation_cert_pin import probe_peer_cert_fingerprint
+
 from models.database import (
     Circle,
     CircleMembership,
@@ -158,7 +160,15 @@ def _clear_nonce_cache_for_tests() -> None:
 # =============================================================================
 
 
-async def _with_tofu_fingerprint(endpoints: list[dict]) -> dict:
+# Pair-time probe timeout is tighter than the runtime F5d default:
+# LAN + Tailscale LAN peers handshake in <500ms; 2s is enough margin
+# without making the user wait on a stalled probe. A failed probe
+# still succeeds the pairing (no pin) — worst case is federation
+# queries later fall back to default CA validation.
+_TOFU_PROBE_TIMEOUT_SECONDS = 2.0
+
+
+async def _with_tofu_fingerprint(endpoints: list[Any] | None) -> dict:
     """
     Build a `transport_config` dict from the peer's advertised endpoints,
     optionally enriched with a TLS cert SHA-256 captured at pair time.
@@ -175,14 +185,28 @@ async def _with_tofu_fingerprint(endpoints: list[dict]) -> dict:
     `tls_fingerprint` and F5d falls back to default CA validation
     (which won't work for self-signed deploys, but the operator at
     least sees "couldn't probe" in the pairing logs).
+
+    An empty endpoints list is logged separately — pairing succeeds
+    but no federation query to this peer will succeed until an endpoint
+    is added. The distinction matters so operators can tell "probe
+    failed" apart from "the other side never advertised an endpoint".
     """
-    config: dict = {"endpoints": endpoints}
+    config: dict = {"endpoints": endpoints or []}
+    if not endpoints:
+        logger.warning(
+            "Pairing: peer advertised no endpoints — federation queries "
+            "to them will fail until an endpoint is added to their "
+            "PeerUser.transport_config"
+        )
+        return config
+
     first_url = _first_https_url(endpoints)
     if not first_url:
         return config
 
-    from services.federation_cert_pin import probe_peer_cert_fingerprint
-    fingerprint = await probe_peer_cert_fingerprint(first_url)
+    fingerprint = await probe_peer_cert_fingerprint(
+        first_url, timeout=_TOFU_PROBE_TIMEOUT_SECONDS,
+    )
     if fingerprint:
         config["tls_fingerprint"] = fingerprint
         logger.info(
@@ -197,10 +221,11 @@ async def _with_tofu_fingerprint(endpoints: list[dict]) -> dict:
     return config
 
 
-def _first_https_url(endpoints: list[dict]) -> str | None:
-    """Extract the first https:// URL from a list of endpoint dicts.
-    Endpoint shapes tolerated: `{"url": ...}`, `{"endpoint_url": ...}`,
-    or bare strings in the list."""
+def _first_https_url(endpoints: list[Any] | None) -> str | None:
+    """Extract the first https:// URL from a list of endpoint entries.
+    Entries tolerated: bare strings, `{"url": ...}`, `{"endpoint_url": ...}`.
+    Anything else (None, non-str/dict, protocol-less hostnames, ws://)
+    is skipped. Scheme match is case-insensitive."""
     for ep in endpoints or []:
         if isinstance(ep, str):
             url = ep
@@ -208,7 +233,7 @@ def _first_https_url(endpoints: list[dict]) -> str | None:
             url = ep.get("url") or ep.get("endpoint_url")
         else:
             continue
-        if url and str(url).startswith("https://"):
+        if url and str(url).lower().startswith("https://"):
             return str(url)
     return None
 

--- a/tests/backend/test_federation_tofu.py
+++ b/tests/backend/test_federation_tofu.py
@@ -18,7 +18,6 @@ Coverage:
 from __future__ import annotations
 
 import hashlib
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -69,6 +68,21 @@ class TestFirstHttpsUrl:
         """Non-string/dict entries are ignored (forward-compat)."""
         eps = [42, None, {"url": "https://mom.local:8443"}]
         assert _first_https_url(eps) == "https://mom.local:8443"
+
+    @pytest.mark.unit
+    def test_uppercase_scheme_accepted(self):
+        """Scheme match is case-insensitive — `HTTPS://` is valid."""
+        assert _first_https_url(["HTTPS://mom.local:8443"]) == "HTTPS://mom.local:8443"
+
+    @pytest.mark.unit
+    def test_picks_first_of_multiple_https(self):
+        """When several HTTPS endpoints are advertised, we pin the
+        first one. Future enhancement: rank by reachability."""
+        eps = [
+            {"url": "https://a.local:8443"},
+            {"url": "https://b.local:8443"},
+        ]
+        assert _first_https_url(eps) == "https://a.local:8443"
 
 
 # =============================================================================
@@ -124,11 +138,33 @@ class TestProbeFingerprint:
 class TestWithTofuFingerprint:
     @pytest.mark.asyncio
     @pytest.mark.unit
-    async def test_empty_endpoints_returns_bare_config(self):
-        """No endpoints → no pin, no probe attempt."""
+    async def test_empty_endpoints_returns_bare_config_and_warns(self, monkeypatch):
+        """No endpoints → no pin, no probe attempt. Warning logged so
+        operators can distinguish 'probe failed' from 'peer never
+        advertised an endpoint' — both block federation queries but
+        the fix is different. Loguru doesn't feed pytest's caplog, so
+        we intercept the logger directly."""
+        warnings_seen: list[str] = []
+
+        def fake_warning(msg, *a, **kw):
+            warnings_seen.append(str(msg))
+
+        import services.pairing_service as ps_mod
+        monkeypatch.setattr(ps_mod.logger, "warning", fake_warning)
+
         config = await _with_tofu_fingerprint([])
         assert config == {"endpoints": []}
         assert "tls_fingerprint" not in config
+        combined = " ".join(w.lower() for w in warnings_seen)
+        assert "endpoint" in combined
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_none_endpoints_returns_bare_config(self):
+        """None (missing field) is treated as empty — same outcome,
+        same warning, no crash."""
+        config = await _with_tofu_fingerprint(None)
+        assert config == {"endpoints": []}
 
     @pytest.mark.asyncio
     @pytest.mark.unit
@@ -148,7 +184,7 @@ class TestWithTofuFingerprint:
         async def fake_probe(url, *, timeout=5.0):
             return "a" * 64
         monkeypatch.setattr(
-            "services.federation_cert_pin.probe_peer_cert_fingerprint",
+            "services.pairing_service.probe_peer_cert_fingerprint",
             fake_probe,
         )
 
@@ -166,7 +202,7 @@ class TestWithTofuFingerprint:
         async def fake_probe(url, *, timeout=5.0):
             return None
         monkeypatch.setattr(
-            "services.federation_cert_pin.probe_peer_cert_fingerprint",
+            "services.pairing_service.probe_peer_cert_fingerprint",
             fake_probe,
         )
 
@@ -212,7 +248,7 @@ class TestPairingServiceTofuIntegration:
         async def fake_probe(url, *, timeout=5.0):
             return "b" * 64
         monkeypatch.setattr(
-            "services.federation_cert_pin.probe_peer_cert_fingerprint",
+            "services.pairing_service.probe_peer_cert_fingerprint",
             fake_probe,
         )
 
@@ -297,7 +333,7 @@ class TestPairingServiceTofuIntegration:
         async def fake_probe(url, *, timeout=5.0):
             return "c" * 64
         monkeypatch.setattr(
-            "services.federation_cert_pin.probe_peer_cert_fingerprint",
+            "services.pairing_service.probe_peer_cert_fingerprint",
             fake_probe,
         )
 
@@ -379,7 +415,7 @@ class TestPairingServiceTofuIntegration:
             probe_called = True
             return "deadbeef"
         monkeypatch.setattr(
-            "services.federation_cert_pin.probe_peer_cert_fingerprint",
+            "services.pairing_service.probe_peer_cert_fingerprint",
             fake_probe,
         )
 

--- a/tests/backend/test_federation_tofu.py
+++ b/tests/backend/test_federation_tofu.py
@@ -1,0 +1,428 @@
+"""
+Tests for F5e — TOFU auto-pinning during federation pairing.
+
+Coverage:
+- `probe_peer_cert_fingerprint` returns hex SHA on success, None on
+  every failure mode (non-https, connection error, no SSL, no cert).
+- `_with_tofu_fingerprint` helper extracts first HTTPS endpoint, probes,
+  latches the SHA into transport_config. Skips gracefully when:
+    - endpoints list is empty
+    - no HTTPS endpoint (http-only or no URL fields)
+    - probe returns None (host unreachable, plain TCP, etc.)
+- `_first_https_url` tolerates the three endpoint shapes in the wild
+  (bare string, `{"url": ...}`, `{"endpoint_url": ...}`).
+- Integration: PairingService.accept_offer + complete_handshake
+  populate `tls_fingerprint` via the probe when a HTTPS endpoint is
+  advertised; leave it out when the probe fails.
+"""
+from __future__ import annotations
+
+import hashlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from services.federation_cert_pin import probe_peer_cert_fingerprint
+from services.pairing_service import _first_https_url, _with_tofu_fingerprint
+
+
+# =============================================================================
+# _first_https_url — endpoint-shape tolerance
+# =============================================================================
+
+
+class TestFirstHttpsUrl:
+    @pytest.mark.unit
+    def test_empty_list_returns_none(self):
+        assert _first_https_url([]) is None
+        assert _first_https_url(None) is None
+
+    @pytest.mark.unit
+    def test_bare_string_endpoint(self):
+        assert _first_https_url(["https://mom.local:8443"]) == "https://mom.local:8443"
+
+    @pytest.mark.unit
+    def test_dict_url_key(self):
+        assert _first_https_url([{"url": "https://mom.local:8443"}]) == "https://mom.local:8443"
+
+    @pytest.mark.unit
+    def test_dict_endpoint_url_key(self):
+        assert _first_https_url([{"endpoint_url": "https://mom.local:8443"}]) == "https://mom.local:8443"
+
+    @pytest.mark.unit
+    def test_skips_http_picks_first_https(self):
+        """Mixed list — http:// URLs don't qualify for pinning, fall through."""
+        eps = [
+            {"url": "http://mom.local:8080"},
+            {"url": "https://mom.local:8443"},
+        ]
+        assert _first_https_url(eps) == "https://mom.local:8443"
+
+    @pytest.mark.unit
+    def test_no_https_returns_none(self):
+        """All http:// — nothing to pin."""
+        assert _first_https_url([{"url": "http://mom.local:8080"}]) is None
+
+    @pytest.mark.unit
+    def test_skips_malformed_entries(self):
+        """Non-string/dict entries are ignored (forward-compat)."""
+        eps = [42, None, {"url": "https://mom.local:8443"}]
+        assert _first_https_url(eps) == "https://mom.local:8443"
+
+
+# =============================================================================
+# probe_peer_cert_fingerprint
+# =============================================================================
+
+
+class TestProbeFingerprint:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_http_endpoint_returns_none(self):
+        assert await probe_peer_cert_fingerprint("http://mom.local:8080") is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_malformed_url_returns_none(self):
+        assert await probe_peer_cert_fingerprint("https://") is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_connection_failure_returns_none(self, monkeypatch):
+        async def boom(*a, **kw):
+            raise OSError("refused")
+        monkeypatch.setattr("asyncio.open_connection", boom)
+        assert await probe_peer_cert_fingerprint("https://unreachable:9999") is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_success_returns_lowercase_hex(self, monkeypatch):
+        cert_der = b"some-peer-cert"
+        expected = hashlib.sha256(cert_der).hexdigest()
+
+        ssl_obj = MagicMock()
+        ssl_obj.getpeercert.return_value = cert_der
+        writer = MagicMock()
+        writer.get_extra_info.return_value = ssl_obj
+        writer.close = MagicMock()
+        writer.wait_closed = AsyncMock()
+
+        async def fake_open(*a, **kw):
+            return MagicMock(), writer
+        monkeypatch.setattr("asyncio.open_connection", fake_open)
+
+        result = await probe_peer_cert_fingerprint("https://mom.local:8443")
+        assert result == expected.lower()
+
+
+# =============================================================================
+# _with_tofu_fingerprint — the pairing-service helper
+# =============================================================================
+
+
+class TestWithTofuFingerprint:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_empty_endpoints_returns_bare_config(self):
+        """No endpoints → no pin, no probe attempt."""
+        config = await _with_tofu_fingerprint([])
+        assert config == {"endpoints": []}
+        assert "tls_fingerprint" not in config
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_http_only_endpoints_skip_pin(self):
+        """Plain HTTP deploys can't be pinned — config omits
+        tls_fingerprint and the probe is never called."""
+        eps = [{"url": "http://mom.local:8080"}]
+        config = await _with_tofu_fingerprint(eps)
+        assert config == {"endpoints": eps}
+        assert "tls_fingerprint" not in config
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_https_with_successful_probe_latches_fingerprint(self, monkeypatch):
+        """Happy path — cert probe returns a SHA, helper writes it
+        through to transport_config."""
+        async def fake_probe(url, *, timeout=5.0):
+            return "a" * 64
+        monkeypatch.setattr(
+            "services.federation_cert_pin.probe_peer_cert_fingerprint",
+            fake_probe,
+        )
+
+        eps = [{"url": "https://mom.local:8443"}]
+        config = await _with_tofu_fingerprint(eps)
+        assert config["endpoints"] == eps
+        assert config["tls_fingerprint"] == "a" * 64
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_https_probe_failure_skips_pin(self, monkeypatch):
+        """Probe failure (None) → skip pinning but keep endpoints.
+        Logs a warning — operator sees the gap and can fix it
+        manually or re-pair."""
+        async def fake_probe(url, *, timeout=5.0):
+            return None
+        monkeypatch.setattr(
+            "services.federation_cert_pin.probe_peer_cert_fingerprint",
+            fake_probe,
+        )
+
+        eps = [{"url": "https://mom.local:8443"}]
+        config = await _with_tofu_fingerprint(eps)
+        assert config == {"endpoints": eps}
+        assert "tls_fingerprint" not in config
+
+
+# =============================================================================
+# PairingService integration — TOFU writes through on both sides
+# =============================================================================
+
+
+class TestPairingServiceTofuIntegration:
+    """Both accept_offer (responder side) and complete_handshake
+    (initiator side) must auto-pin at pair time. We verify by spying
+    on `_upsert_peer_user` and checking the transport_config it
+    receives."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_accept_offer_pins_initiator(self, tmp_path, monkeypatch):
+        import secrets
+        import time
+
+        from services.federation_identity import (
+            FederationIdentity,
+            init_federation_identity,
+            reset_federation_identity_for_tests,
+        )
+        from services.pairing_service import (
+            PairingOffer,
+            PairingService,
+            _canonical_bytes,
+        )
+
+        reset_federation_identity_for_tests()
+        init_federation_identity(tmp_path / "key")
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+        initiator = FederationIdentity(ed25519.Ed25519PrivateKey.generate())
+
+        async def fake_probe(url, *, timeout=5.0):
+            return "b" * 64
+        monkeypatch.setattr(
+            "services.federation_cert_pin.probe_peer_cert_fingerprint",
+            fake_probe,
+        )
+
+        captured_transport = {}
+
+        async def spy_upsert(self, **kwargs):
+            captured_transport["config"] = kwargs["transport_config"]
+            return MagicMock(id=1)
+
+        monkeypatch.setattr(
+            PairingService, "_upsert_peer_user", spy_upsert,
+        )
+        # Stub the circle + membership writes — not what this test cares about.
+        monkeypatch.setattr(
+            "services.pairing_service._get_or_create_circle",
+            AsyncMock(),
+        )
+        monkeypatch.setattr(
+            PairingService, "_upsert_circle_membership", AsyncMock(),
+        )
+
+        # Build a valid signed offer.
+        now = int(time.time())
+        unsigned = {
+            "version": 1,
+            "initiator_pubkey": initiator.public_key_hex(),
+            "initiator_user_id": 42,
+            "display_name": "A",
+            "nonce": secrets.token_hex(16),
+            "issued_at": now,
+            "expires_at": now + 600,
+            "offered_endpoints": [{"url": "https://a.local:8443"}],
+        }
+        sig = initiator.sign(_canonical_bytes(unsigned)).hex()
+        offer = PairingOffer(**unsigned, signature=sig)
+
+        # Cache the nonce so _verify_offer accepts it.
+        from services.pairing_service import _cache_nonce
+        _cache_nonce(offer.nonce, offer.expires_at, offer.initiator_user_id)
+
+        svc = PairingService(db=MagicMock())
+        current_user = MagicMock(id=99, username="B")
+        await svc.accept_offer(
+            current_user=current_user,
+            offer=offer,
+            my_tier_for_you=2,
+            accepted_endpoints=[],
+        )
+
+        assert "tls_fingerprint" in captured_transport["config"]
+        assert captured_transport["config"]["tls_fingerprint"] == "b" * 64
+        assert captured_transport["config"]["endpoints"] == [
+            {"url": "https://a.local:8443"}
+        ]
+
+        reset_federation_identity_for_tests()
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_complete_handshake_pins_responder(self, tmp_path, monkeypatch):
+        import time
+
+        from services.federation_identity import (
+            FederationIdentity,
+            init_federation_identity,
+            reset_federation_identity_for_tests,
+        )
+        from services.pairing_service import (
+            PairingResponse,
+            PairingService,
+            _canonical_bytes,
+            _cache_nonce,
+        )
+
+        reset_federation_identity_for_tests()
+        init_federation_identity(tmp_path / "key")
+
+        # Responder identity signs the response.
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+        responder = FederationIdentity(ed25519.Ed25519PrivateKey.generate())
+
+        async def fake_probe(url, *, timeout=5.0):
+            return "c" * 64
+        monkeypatch.setattr(
+            "services.federation_cert_pin.probe_peer_cert_fingerprint",
+            fake_probe,
+        )
+
+        captured_transport = {}
+
+        async def spy_upsert(self, **kwargs):
+            captured_transport["config"] = kwargs["transport_config"]
+            return MagicMock(id=2)
+
+        monkeypatch.setattr(
+            PairingService, "_upsert_peer_user", spy_upsert,
+        )
+        monkeypatch.setattr(
+            "services.pairing_service._get_or_create_circle", AsyncMock(),
+        )
+        monkeypatch.setattr(
+            PairingService, "_upsert_circle_membership", AsyncMock(),
+        )
+
+        nonce = "deadbeefdeadbeef" * 2
+        _cache_nonce(nonce, int(time.time()) + 600, initiator_user_id=7)
+        unsigned = {
+            "version": 1,
+            "nonce": nonce,
+            "responder_pubkey": responder.public_key_hex(),
+            "responder_user_id": 33,
+            "responder_display_name": "Mom",
+            "accepted_endpoints": [{"endpoint_url": "https://mom.local:8443"}],
+            "my_tier_for_you": 2,
+            "accepted_at": int(time.time()),
+        }
+        sig = responder.sign(_canonical_bytes(unsigned)).hex()
+        response = PairingResponse(**unsigned, signature=sig)
+
+        svc = PairingService(db=MagicMock())
+        await svc.complete_handshake(
+            current_user=MagicMock(id=7),
+            response=response,
+            their_tier_for_me=2,
+        )
+
+        assert captured_transport["config"]["tls_fingerprint"] == "c" * 64
+        assert captured_transport["config"]["endpoints"] == [
+            {"endpoint_url": "https://mom.local:8443"}
+        ]
+
+        reset_federation_identity_for_tests()
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_complete_handshake_without_https_endpoint_skips_pin(
+        self, tmp_path, monkeypatch,
+    ):
+        """When the responder advertises only http:// endpoints, pairing
+        still succeeds but the transport_config omits tls_fingerprint."""
+        import time
+
+        from services.federation_identity import (
+            FederationIdentity,
+            init_federation_identity,
+            reset_federation_identity_for_tests,
+        )
+        from services.pairing_service import (
+            PairingResponse,
+            PairingService,
+            _canonical_bytes,
+            _cache_nonce,
+        )
+
+        reset_federation_identity_for_tests()
+        init_federation_identity(tmp_path / "key")
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+        responder = FederationIdentity(ed25519.Ed25519PrivateKey.generate())
+
+        probe_called = False
+
+        async def fake_probe(url, *, timeout=5.0):
+            nonlocal probe_called
+            probe_called = True
+            return "deadbeef"
+        monkeypatch.setattr(
+            "services.federation_cert_pin.probe_peer_cert_fingerprint",
+            fake_probe,
+        )
+
+        captured = {}
+
+        async def spy_upsert(self, **kwargs):
+            captured["config"] = kwargs["transport_config"]
+            return MagicMock(id=9)
+
+        monkeypatch.setattr(PairingService, "_upsert_peer_user", spy_upsert)
+        monkeypatch.setattr(
+            "services.pairing_service._get_or_create_circle", AsyncMock(),
+        )
+        monkeypatch.setattr(
+            PairingService, "_upsert_circle_membership", AsyncMock(),
+        )
+
+        nonce = "cafebabecafebabe" * 2
+        _cache_nonce(nonce, int(time.time()) + 600, initiator_user_id=1)
+        unsigned = {
+            "version": 1,
+            "nonce": nonce,
+            "responder_pubkey": responder.public_key_hex(),
+            "responder_user_id": 2,
+            "responder_display_name": "Dad",
+            "accepted_endpoints": [{"url": "http://dad.local:8080"}],
+            "my_tier_for_you": 2,
+            "accepted_at": int(time.time()),
+        }
+        sig = responder.sign(_canonical_bytes(unsigned)).hex()
+        response = PairingResponse(**unsigned, signature=sig)
+
+        svc = PairingService(db=MagicMock())
+        await svc.complete_handshake(
+            current_user=MagicMock(id=1),
+            response=response,
+            their_tier_for_me=2,
+        )
+
+        assert probe_called is False, (
+            "Probe must NOT run when no HTTPS endpoint is advertised — "
+            "saves a 5s wait on every http-only pairing"
+        )
+        assert "tls_fingerprint" not in captured["config"]
+
+        reset_federation_identity_for_tests()


### PR DESCRIPTION
## Summary

Small capstone on the F5 hardening series. During the F4b pairing handshake, both sides now automatically probe the other's HTTPS endpoint, capture the leaf cert SHA-256, and store it in `PeerUser.transport_config.tls_fingerprint`. Every subsequent federation query is pinned (verified via F5d) without any operator copying hashes around.

**Before F5e:** F5d shipped but was unusable for self-signed home deploys — operators had to manually run `openssl x509 -fingerprint -sha256` and paste the result into `transport_config` via the DB. In practice nobody was going to do this.

**After F5e:** a paired peer is pinned automatically. Operators get defense-in-depth transport-layer MITM protection for free.

## Threat model

Unchanged from F5d — TOFU pinning is defense-in-depth on top of the Ed25519 pair-anchor signature.

- Pair-anchor signature remains the cryptographic ground truth. An adversary can't forge valid responder signatures without the responder's private key.
- TOFU captures whatever cert the endpoint presents at pair time. A MITM at pair time could latch THEIR cert instead — but the pair-anchor response signature would still reject that peer's later query responses because the MITM doesn't hold the real responder's Ed25519 key. So the worst outcome is "MITM triggers fingerprint-mismatch on future queries, user re-pairs," not "silent compromise."

## Implementation

- `federation_cert_pin.probe_peer_cert_fingerprint(endpoint_url)` factored out as a standalone helper (returns hex SHA or None). `verify_peer_cert_fingerprint` now delegates to it — same code path, same failure modes.
- `pairing_service._with_tofu_fingerprint(endpoints)` builds `transport_config` with optional pin. Called from both `accept_offer` (responder side — pins the initiator) and `complete_handshake` (initiator side — pins the responder).
- Best-effort: probe failures (non-HTTPS, connection timeout, plain TCP servers) just skip the pin with a warning. Pairing still succeeds.
- `_first_https_url` endpoint-shape tolerance covers the three forms in the wild.

## What's in / out

**In:**
- Probe helper refactored for reuse.
- Auto-pin at both pairing hooks.
- 18 new tests covering helper + integration paths.

**Out (deferred):**
- Cert-rotation UX — today rotation surfaces as "fingerprint mismatch → user must re-pair." A `/settings/circles/peers/{id}/repin` endpoint that probes + updates the pin in-place would be nicer. Deferred.
- Audit log entry on auto-pin (so operators can see in `/brain/audit` or a peer-detail page which pin was latched when).

## Test plan

- [x] Backend: 18/18 new tests pass
- [x] Backend: 88/88 across the 5 federation test files touched (1 pre-existing unrelated failure in test_federation_pairing.py)
- [x] Syntax + parse clean
- [ ] Manual: pair two Renfields over HTTPS with self-signed certs, verify `transport_config.tls_fingerprint` populated on both PeerUser rows, verify subsequent federated query succeeds
- [ ] Manual: rotate the responder's cert, verify the next query yields "fingerprint mismatch" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)