### PR TITLE
feat(agent): per-role native function calling toggle (default off)

### DIFF
--- a/src/backend/services/agent_router.py
+++ b/src/backend/services/agent_router.py
@@ -67,6 +67,15 @@ class AgentRole:
     sub_intent_definitions: dict[str, dict[str, str]] | None = None  # From config
     utterances: list[str] | None = None  # Example utterances for semantic fast-path
     keyword_boost: list[str] | None = None  # Keywords that boost this role in semantic router
+    # Opt-in Native Function Calling (OpenAI-style `tools=[]`) for this role.
+    # Default False → ReAct (tool descriptions embedded in the prompt, model
+    # emits JSON action) — the production path. When True AND the agent
+    # client reports supports_native_tools, AgentService passes a tools
+    # schema on every chat call and consumes `message.tool_calls` directly.
+    # Benchmarks show current-generation models regress accuracy in NFC
+    # mode (qwen3.5:27b 8/9 → 6/9, qwen3.6:35b 9/9 → 6/9); keep this flag
+    # at False unless a specific role + model pairing benchmarks clean.
+    native_function_calling: bool = False
 
 
 # Pre-built fallback roles
@@ -142,6 +151,7 @@ def _parse_roles(config: dict) -> dict[str, AgentRole]:
             sub_intent_definitions=sub_intent_definitions,
             utterances=utterances,
             keyword_boost=keyword_boost,
+            native_function_calling=bool(role_data.get("native_function_calling", False)),
         )
         roles[name] = role
 

--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from loguru import logger
 
-from services.agent_tools import AgentToolRegistry
+from services.agent_tools import AgentToolRegistry, unsanitize_tool_name
 from services.prompt_manager import prompt_manager
 from utils.circuit_breaker import agent_circuit_breaker
 from utils.config import settings
@@ -592,6 +592,96 @@ class AgentService:
         self._prompt_key = (role.prompt_key if role else None) or "agent_prompt"
         self._preselected_tools: dict | None = None
 
+    def _should_use_native_fc(self, agent_client) -> bool:
+        """Whether this step should use native function calling.
+
+        Requires both the role to opt in (``native_function_calling: true``
+        in ``config/agent_roles.yaml``) AND the agent client to advertise
+        ``supports_native_tools = True``. Default is False so the ReAct
+        path stays unchanged for every role that hasn't explicitly opted in.
+
+        Benchmarks (docs/qwen3.6-benchmark-full-2026-04-21.md and
+        docs/native-fc-benchmark-2026-04-16.md) show Native FC regresses
+        tool-selection accuracy on both qwen3.5:27b and qwen3.6:35b. Keep
+        the flag off unless a specific role + model pairing benchmarks
+        clean in your own data.
+        """
+        role_enabled = bool(getattr(self.role, "native_function_calling", False))
+        client_capable = bool(getattr(agent_client, "supports_native_tools", False))
+        return role_enabled and client_capable
+
+    @staticmethod
+    def _native_fc_parsed(raw_response) -> tuple[dict | None, str]:
+        """Extract an agent-loop `parsed` dict from a native-FC response.
+
+        Returns ``(parsed, response_text)`` where ``response_text`` is the
+        assistant content used for token tracking + logging, and ``parsed``
+        is one of:
+
+        - ``{"action": "<tool>", "parameters": {...}, "reason": "native_fc"}``
+          when the model emitted tool_calls (first call used; additional
+          calls are logged and ignored for parity with the ReAct loop).
+        - ``{"action": "final_answer", "answer": "<text>", "reason": "native_fc"}``
+          when the model emitted assistant content and no tool_calls.
+        - ``None`` when neither tool_calls nor content is present — caller
+          handles via the existing retry-nudge branch.
+
+        Handles both attribute-style (``raw_response.message.tool_calls``)
+        and dict-style (``raw_response["message"]["tool_calls"]``) responses
+        because different LLM client adapters (OpenAI vs Ollama vs Anthropic)
+        return slightly different shapes.
+        """
+        # Normalise the response envelope.
+        msg = getattr(raw_response, "message", None)
+        if msg is None and isinstance(raw_response, dict):
+            msg = raw_response.get("message") or {}
+        if msg is None:
+            return None, ""
+
+        def _field(obj, key, default=None):
+            if hasattr(obj, key):
+                return getattr(obj, key, default)
+            if isinstance(obj, dict):
+                return obj.get(key, default)
+            return default
+
+        content = _field(msg, "content", "") or ""
+        tool_calls = _field(msg, "tool_calls", None)
+
+        if tool_calls:
+            # Take the first call; the existing agent loop processes one tool per step.
+            tc = tool_calls[0]
+            fn = _field(tc, "function", {}) or {}
+            name = _field(fn, "name", "") or ""
+            args = _field(fn, "arguments", {})
+            if isinstance(args, str):
+                try:
+                    args = json.loads(args) if args else {}
+                except json.JSONDecodeError:
+                    args = {}
+            if not isinstance(args, dict):
+                args = {}
+            if len(tool_calls) > 1:
+                logger.debug(
+                    f"Native FC: {len(tool_calls)} tool_calls in one response, "
+                    f"using the first ({name}); ignoring the rest"
+                )
+            parsed = {
+                "action": unsanitize_tool_name(name),
+                "parameters": args,
+                "reason": "native_fc",
+            }
+            return parsed, content
+
+        if content:
+            return {
+                "action": "final_answer",
+                "answer": content,
+                "reason": "native_fc",
+            }, content
+
+        return None, ""
+
     async def _preselect_tools(
         self,
         message: str,
@@ -1073,6 +1163,19 @@ class AgentService:
         }
         json_system_message = prompt_manager.get("agent", "json_system_message", lang=lang)
 
+        # Native function calling — opt-in per role AND requires the agent client
+        # to advertise `supports_native_tools`. Default path stays on ReAct.
+        use_native_fc = self._should_use_native_fc(agent_client)
+        native_fc_tools: list[dict] | None = None
+        if use_native_fc:
+            native_fc_tools = self.tool_registry.build_tools_schema(
+                self._preselected_tools
+            )
+            logger.info(
+                f"🔧 Native function calling ON for role '{getattr(self.role, 'name', '?')}' "
+                f"({len(native_fc_tools)} tools in schema)"
+            )
+
         for step_num in range(1, self.max_steps + 1):
             # Check total timeout
             elapsed = time.monotonic() - start_time
@@ -1107,6 +1210,9 @@ class AgentService:
             # Call LLM with per-step timeout
             try:
                 classification_kwargs = get_classification_chat_kwargs(agent_model)
+                chat_kwargs: dict = dict(classification_kwargs)
+                if use_native_fc and native_fc_tools:
+                    chat_kwargs["tools"] = native_fc_tools
                 raw_response = await asyncio.wait_for(
                     agent_client.chat(
                         model=agent_model,
@@ -1115,11 +1221,18 @@ class AgentService:
                             {"role": "user", "content": prompt},
                         ],
                         options=llm_options,
-                        **classification_kwargs,
+                        **chat_kwargs,
                     ),
                     timeout=self.step_timeout,
                 )
-                response_text = extract_response_content(raw_response) or ""
+                if use_native_fc:
+                    # Response carries tool_calls or content; parse to the
+                    # same {action, parameters, reason} shape the rest of
+                    # the loop consumes.
+                    _fc_parsed, response_text = self._native_fc_parsed(raw_response)
+                else:
+                    _fc_parsed = None
+                    response_text = extract_response_content(raw_response) or ""
                 await agent_circuit_breaker.record_success()
 
                 # Track token usage
@@ -1147,8 +1260,13 @@ class AgentService:
                 yield self._build_fallback_answer(context, step_num, str(e), lang=lang)
                 return
 
-            # Parse JSON response
-            parsed = _parse_agent_json(response_text)
+            # Parse the response. Native FC path returns `parsed` directly
+            # from structured tool_calls; ReAct path extracts JSON from the
+            # text content.
+            if use_native_fc:
+                parsed = _fc_parsed
+            else:
+                parsed = _parse_agent_json(response_text)
 
             # Treat JSON without "action" field as malformed (LLM output just parameters)
             if parsed and "action" not in parsed:
@@ -1162,6 +1280,9 @@ class AgentService:
                 retry_nudge = prompt_manager.get("agent", "retry_nudge", lang=lang)
                 nudge = prompt + retry_nudge
                 try:
+                    retry_kwargs: dict = dict(classification_kwargs)
+                    if use_native_fc and native_fc_tools:
+                        retry_kwargs["tools"] = native_fc_tools
                     retry_response = await asyncio.wait_for(
                         agent_client.chat(
                             model=agent_model,
@@ -1170,14 +1291,17 @@ class AgentService:
                                 {"role": "user", "content": nudge},
                             ],
                             options=llm_options_retry,
-                            **classification_kwargs,
+                            **retry_kwargs,
                         ),
                         timeout=self.step_timeout,
                     )
-                    response_text = extract_response_content(retry_response) or ""
+                    if use_native_fc:
+                        parsed, response_text = self._native_fc_parsed(retry_response)
+                    else:
+                        response_text = extract_response_content(retry_response) or ""
+                        parsed = _parse_agent_json(response_text)
                     context.track_tokens(nudge, response_text)
                     logger.info(f"🔄 Agent step {step_num} retry ({len(response_text)} chars): {response_text[:200]}")
-                    parsed = _parse_agent_json(response_text)
                 except Exception as e:
                     logger.warning(f"🔄 Agent step {step_num} retry failed: {e}")
 

--- a/src/backend/services/agent_tools.py
+++ b/src/backend/services/agent_tools.py
@@ -11,6 +11,7 @@ which tools it can call.
 Tool filtering is handled by AgentRouter which classifies messages into
 roles (smart_home, research, documents, etc.) with pre-defined MCP server lists.
 """
+import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Optional
 
@@ -20,12 +21,49 @@ if TYPE_CHECKING:
     from services.mcp_client import MCPManager
 
 
+# --- Tool name sanitization ------------------------------------------------
+# OpenAI / Ollama / most native-FC backends require tool names to match
+# ^[a-zA-Z0-9_-]+$. MCP namespaces use dots (e.g. "mcp.release.list_releases"),
+# which would be rejected. We round-trip by swapping dots for double
+# underscores during the request and reversing on the response.
+_SANITIZED_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+def sanitize_tool_name(name: str) -> str:
+    """Convert a dotted tool name to a native-FC-compatible identifier.
+
+    `mcp.release.list_releases` → `mcp__release__list_releases`.
+    Already-valid names pass through unchanged.
+    """
+    if _SANITIZED_NAME_RE.match(name):
+        return name
+    return name.replace(".", "__")
+
+
+def unsanitize_tool_name(name: str) -> str:
+    """Reverse of :func:`sanitize_tool_name`.
+
+    Collapses `__` back to `.`. Safe to call on names that were never
+    sanitized (idempotent for names without `__`).
+    """
+    return name.replace("__", ".")
+
+
 @dataclass
 class ToolDefinition:
-    """Definition of a tool available to the Agent."""
+    """Definition of a tool available to the Agent.
+
+    `parameters` is the flattened {param_name: description_str} form used by
+    the ReAct prompt builder. `input_schema` is the full JSON Schema from the
+    underlying tool source (MCP's input_schema, internal tool declarations,
+    plugin-registered tools). It is preserved so native function-calling
+    (OpenAI-style `tools=[]`) can emit proper JSON-Schema to the LLM without
+    a lossy round-trip through the flattened form.
+    """
     name: str
     description: str
     parameters: dict[str, str] = field(default_factory=dict)  # param_name -> description
+    input_schema: dict | None = None  # full JSON Schema, for native function calling
 
 
 class AgentToolRegistry:
@@ -138,6 +176,7 @@ class AgentToolRegistry:
                 name=mcp_tool.namespaced_name,
                 description=mcp_tool.description,
                 parameters=params,
+                input_schema=mcp_tool.input_schema,
             )
             self._tools[tool.name] = tool
             logger.debug(f"MCP agent tool registered: {tool.name}")
@@ -196,3 +235,54 @@ class AgentToolRegistry:
                 lines.append(f"- {tool.name}: {tool.description}")
 
         return "\n".join(lines)
+
+    def build_tools_schema(
+        self,
+        tools: dict[str, "ToolDefinition"] | None = None,
+    ) -> list[dict]:
+        """Build an OpenAI-format tools array for native function calling.
+
+        Produces the shape expected by OpenAI `/v1/chat/completions`, Ollama
+        `/api/chat`, llama.cpp `/v1/chat/completions`, vLLM, and Anthropic
+        (which is normalised to the same shape by AnthropicClient). Tool
+        names are sanitized via :func:`sanitize_tool_name` so they match
+        `^[a-zA-Z0-9_-]+$`. The caller is responsible for un-sanitizing
+        names on the response side before dispatching to the executor.
+
+        Falls back to a synthesised JSON Schema from the flattened
+        `parameters` dict when `input_schema` is absent (older tools
+        registered before the schema was preserved).
+
+        Args:
+            tools: Optional subset of registered tools to expose. None means
+                all registered tools.
+
+        Returns:
+            List of `{"type": "function", "function": {name, description, parameters}}`
+            dicts. Empty list if no tools are registered or selected.
+        """
+        tool_set = tools if tools is not None else self._tools
+        result: list[dict] = []
+        for tool in tool_set.values():
+            if tool.input_schema is not None:
+                schema = tool.input_schema
+            else:
+                # Synthesize a minimal schema from the flattened parameters.
+                # All params typed as string because we lost the original
+                # type info; the LLM still gets enough to call sanely.
+                schema = {
+                    "type": "object",
+                    "properties": {
+                        param: {"type": "string", "description": desc}
+                        for param, desc in tool.parameters.items()
+                    },
+                }
+            result.append({
+                "type": "function",
+                "function": {
+                    "name": sanitize_tool_name(tool.name),
+                    "description": tool.description,
+                    "parameters": schema,
+                },
+            })
+        return result

--- a/tests/backend/test_agent_router.py
+++ b/tests/backend/test_agent_router.py
@@ -292,6 +292,53 @@ class TestParseRoles:
         assert roles["general"].model is None
         assert roles["general"].ollama_url is None
 
+    @pytest.mark.unit
+    def test_native_function_calling_default_false(self):
+        """A role that does not set the flag gets native_function_calling=False."""
+        roles = _parse_roles(SAMPLE_CONFIG)
+        for role in roles.values():
+            assert role.native_function_calling is False
+
+    @pytest.mark.unit
+    def test_native_function_calling_opt_in(self):
+        """Setting native_function_calling: true in YAML is parsed."""
+        config = {
+            "roles": {
+                "experimental": {
+                    "description": {"de": "x", "en": "x"},
+                    "mcp_servers": [],
+                    "prompt_key": "agent_prompt",
+                    "native_function_calling": True,
+                },
+                "normal": {
+                    "description": {"de": "y", "en": "y"},
+                    "mcp_servers": [],
+                    "prompt_key": "agent_prompt",
+                },
+            }
+        }
+        roles = _parse_roles(config)
+        assert roles["experimental"].native_function_calling is True
+        assert roles["normal"].native_function_calling is False
+
+    @pytest.mark.unit
+    def test_native_function_calling_accepts_truthy_values(self):
+        """Truthy strings / 1 coerce to True, falsy to False (YAML may parse loosely)."""
+        config = {
+            "roles": {
+                "a": {"description": {"de": "a", "en": "a"}, "mcp_servers": [],
+                      "prompt_key": "agent_prompt", "native_function_calling": 1},
+                "b": {"description": {"de": "b", "en": "b"}, "mcp_servers": [],
+                      "prompt_key": "agent_prompt", "native_function_calling": 0},
+                "c": {"description": {"de": "c", "en": "c"}, "mcp_servers": [],
+                      "prompt_key": "agent_prompt", "native_function_calling": None},
+            }
+        }
+        roles = _parse_roles(config)
+        assert roles["a"].native_function_calling is True
+        assert roles["b"].native_function_calling is False
+        assert roles["c"].native_function_calling is False
+
 
 # ============================================================================
 # Test _filter_available_roles

--- a/tests/backend/test_agent_service.py
+++ b/tests/backend/test_agent_service.py
@@ -1944,3 +1944,170 @@ class TestTokenContextVars:
         # Real budget for a greeting is well under threshold
         assert budget["truncated"] is False
         assert budget["passes"] == []
+
+
+# ============================================================================
+# Native Function Calling — parse helpers and capability detection
+# ============================================================================
+
+
+class TestNativeFCParsed:
+    """Unit tests for AgentService._native_fc_parsed — the tool_calls → parsed
+    dict converter. Exercised with three shapes: tool_calls present, content
+    only, neither present.
+    """
+
+    @pytest.mark.unit
+    def test_tool_calls_attribute_style(self):
+        """OpenAI-style dict-or-obj response with tool_calls produces an action dict."""
+        from types import SimpleNamespace
+        raw = SimpleNamespace(
+            message=SimpleNamespace(
+                content="",
+                tool_calls=[
+                    SimpleNamespace(function=SimpleNamespace(
+                        name="mcp__release__list_releases",
+                        arguments='{"query": "REL-100"}',
+                    ))
+                ],
+            )
+        )
+        parsed, text = AgentService._native_fc_parsed(raw)
+        assert parsed == {
+            "action": "mcp.release.list_releases",
+            "parameters": {"query": "REL-100"},
+            "reason": "native_fc",
+        }
+        assert text == ""
+
+    @pytest.mark.unit
+    def test_tool_calls_dict_style(self):
+        """Ollama-style dict response (arguments already parsed)."""
+        raw = {
+            "message": {
+                "content": "",
+                "tool_calls": [
+                    {"function": {
+                        "name": "mcp__jira__search_issues",
+                        "arguments": {"jql": "project=REVA"},
+                    }}
+                ],
+            }
+        }
+        parsed, text = AgentService._native_fc_parsed(raw)
+        assert parsed["action"] == "mcp.jira.search_issues"
+        assert parsed["parameters"] == {"jql": "project=REVA"}
+        assert parsed["reason"] == "native_fc"
+        assert text == ""
+
+    @pytest.mark.unit
+    def test_content_only_yields_final_answer(self):
+        """When the model emits only assistant text, it's the final answer."""
+        from types import SimpleNamespace
+        raw = SimpleNamespace(
+            message=SimpleNamespace(content="Hier sind die Ergebnisse.", tool_calls=None)
+        )
+        parsed, text = AgentService._native_fc_parsed(raw)
+        assert parsed == {
+            "action": "final_answer",
+            "answer": "Hier sind die Ergebnisse.",
+            "reason": "native_fc",
+        }
+        assert text == "Hier sind die Ergebnisse."
+
+    @pytest.mark.unit
+    def test_empty_response_returns_none(self):
+        """No tool_calls, no content → caller falls through to retry nudge."""
+        from types import SimpleNamespace
+        raw = SimpleNamespace(message=SimpleNamespace(content="", tool_calls=None))
+        parsed, text = AgentService._native_fc_parsed(raw)
+        assert parsed is None
+        assert text == ""
+
+    @pytest.mark.unit
+    def test_multiple_tool_calls_takes_first(self):
+        """Parity with the ReAct loop which processes one tool per step."""
+        from types import SimpleNamespace
+        raw = SimpleNamespace(
+            message=SimpleNamespace(
+                content="",
+                tool_calls=[
+                    SimpleNamespace(function=SimpleNamespace(
+                        name="first_tool", arguments="{}",
+                    )),
+                    SimpleNamespace(function=SimpleNamespace(
+                        name="second_tool", arguments="{}",
+                    )),
+                ],
+            )
+        )
+        parsed, _ = AgentService._native_fc_parsed(raw)
+        assert parsed["action"] == "first_tool"
+
+    @pytest.mark.unit
+    def test_malformed_arguments_string_yields_empty_dict(self):
+        """If the backend returns invalid JSON for arguments, treat as {}."""
+        from types import SimpleNamespace
+        raw = SimpleNamespace(
+            message=SimpleNamespace(
+                content="",
+                tool_calls=[
+                    SimpleNamespace(function=SimpleNamespace(
+                        name="list_global_roles", arguments="not json at all",
+                    ))
+                ],
+            )
+        )
+        parsed, _ = AgentService._native_fc_parsed(raw)
+        assert parsed["parameters"] == {}
+
+
+class TestShouldUseNativeFC:
+    """Opt-in gate: role flag AND client capability must both be true."""
+
+    def _make_registry(self):
+        from services.agent_tools import AgentToolRegistry
+        return AgentToolRegistry(mcp_manager=_make_mock_mcp_manager())
+
+    @pytest.mark.unit
+    def test_default_off_when_no_role_flag(self):
+        """A role without native_function_calling=True keeps ReAct regardless of client."""
+        from services.agent_router import AgentRole
+        role = AgentRole(name="r", description={"de": "r", "en": "r"})
+        agent = AgentService(self._make_registry(), role=role)
+        client_with = MagicMock(supports_native_tools=True)
+        client_without = MagicMock(spec=[])
+        assert agent._should_use_native_fc(client_with) is False
+        assert agent._should_use_native_fc(client_without) is False
+
+    @pytest.mark.unit
+    def test_default_off_when_no_role_at_all(self):
+        """An AgentService with role=None never activates NFC."""
+        agent = AgentService(self._make_registry(), role=None)
+        client_with = MagicMock(supports_native_tools=True)
+        assert agent._should_use_native_fc(client_with) is False
+
+    @pytest.mark.unit
+    def test_on_when_role_opts_in_and_client_capable(self):
+        from services.agent_router import AgentRole
+        role = AgentRole(
+            name="r", description={"de": "r", "en": "r"},
+            native_function_calling=True,
+        )
+        agent = AgentService(self._make_registry(), role=role)
+        client = MagicMock(supports_native_tools=True)
+        assert agent._should_use_native_fc(client) is True
+
+    @pytest.mark.unit
+    def test_off_when_role_opts_in_but_client_incapable(self):
+        """Graceful fallback: if client doesn't expose supports_native_tools, stay on ReAct."""
+        from services.agent_router import AgentRole
+        role = AgentRole(
+            name="r", description={"de": "r", "en": "r"},
+            native_function_calling=True,
+        )
+        agent = AgentService(self._make_registry(), role=role)
+        client_no_attr = MagicMock(spec=[])
+        client_false = MagicMock(supports_native_tools=False)
+        assert agent._should_use_native_fc(client_no_attr) is False
+        assert agent._should_use_native_fc(client_false) is False

--- a/tests/backend/test_agent_tools.py
+++ b/tests/backend/test_agent_tools.py
@@ -382,3 +382,148 @@ class TestSelectRelevantTools:
         assert any(n.startswith("mcp.paperless") for n in names)
         assert any(n.startswith("mcp.email") for n in names)
         assert any(n.startswith("mcp.homeassistant") for n in names)
+
+
+# ============================================================================
+# Native Function Calling plumbing — sanitize/unsanitize + build_tools_schema
+# ============================================================================
+
+
+class TestSanitizeToolName:
+    """Round-trip between dotted MCP names and native-FC-compatible names."""
+
+    @pytest.mark.unit
+    def test_mcp_namespaced_name_is_sanitized(self):
+        from services.agent_tools import sanitize_tool_name
+        assert sanitize_tool_name("mcp.release.list_releases") == "mcp__release__list_releases"
+
+    @pytest.mark.unit
+    def test_already_valid_name_passes_through(self):
+        """A bare name that already matches ^[a-zA-Z0-9_-]+$ is unchanged."""
+        from services.agent_tools import sanitize_tool_name
+        assert sanitize_tool_name("list_global_roles") == "list_global_roles"
+        assert sanitize_tool_name("find-stuff") == "find-stuff"
+
+    @pytest.mark.unit
+    def test_unsanitize_reverses_sanitize(self):
+        from services.agent_tools import sanitize_tool_name, unsanitize_tool_name
+        orig = "mcp.jira.search_issues"
+        assert unsanitize_tool_name(sanitize_tool_name(orig)) == orig
+
+    @pytest.mark.unit
+    def test_unsanitize_is_idempotent_for_bare_names(self):
+        """Calling unsanitize on names without '__' is a no-op."""
+        from services.agent_tools import unsanitize_tool_name
+        assert unsanitize_tool_name("list_global_roles") == "list_global_roles"
+
+
+class TestBuildToolsSchema:
+    """OpenAI-format tools schema for native function calling."""
+
+    def _make_mcp_tool(self, name: str, description: str, input_schema: dict) -> MagicMock:
+        tool = MagicMock()
+        tool.namespaced_name = name
+        tool.server_name = name.split(".")[1] if name.startswith("mcp.") else name
+        tool.description = description
+        tool.input_schema = input_schema
+        return tool
+
+    def _make_registry_with_tools(self, tools):
+        mcp_manager = MagicMock()
+        mcp_manager.get_all_tools.return_value = tools
+        return AgentToolRegistry(mcp_manager=mcp_manager)
+
+    @pytest.mark.unit
+    def test_returns_openai_tools_format(self):
+        """Schema entries have {type: function, function: {name, description, parameters}}."""
+        tool = self._make_mcp_tool(
+            "mcp.release.list_releases",
+            "List releases",
+            {"type": "object", "properties": {"active": {"type": "boolean"}}},
+        )
+        registry = self._make_registry_with_tools([tool])
+        schema = registry.build_tools_schema()
+
+        assert len(schema) == 1
+        entry = schema[0]
+        assert entry["type"] == "function"
+        assert entry["function"]["name"] == "mcp__release__list_releases"
+        assert entry["function"]["description"] == "List releases"
+        assert entry["function"]["parameters"]["properties"]["active"]["type"] == "boolean"
+
+    @pytest.mark.unit
+    def test_empty_registry_returns_empty_list(self):
+        registry = self._make_registry_with_tools([])
+        assert registry.build_tools_schema() == []
+
+    @pytest.mark.unit
+    def test_preselection_filters_output(self):
+        """Passing a subset of tools scopes the schema to just those."""
+        t1 = self._make_mcp_tool("mcp.a.foo", "foo", {"type": "object", "properties": {}})
+        t2 = self._make_mcp_tool("mcp.a.bar", "bar", {"type": "object", "properties": {}})
+        registry = self._make_registry_with_tools([t1, t2])
+        preselected = {"mcp.a.foo": registry.get_tool("mcp.a.foo")}
+        schema = registry.build_tools_schema(preselected)
+        assert len(schema) == 1
+        assert schema[0]["function"]["name"] == "mcp__a__foo"
+
+    @pytest.mark.unit
+    def test_full_input_schema_is_preserved(self):
+        """Nested schemas with required fields and typed properties pass through intact."""
+        input_schema = {
+            "type": "object",
+            "properties": {
+                "release_id": {"type": "string", "description": "Full release ID"},
+                "limit": {"type": "integer", "minimum": 1},
+            },
+            "required": ["release_id"],
+        }
+        tool = self._make_mcp_tool("mcp.release.get_release", "Get release", input_schema)
+        registry = self._make_registry_with_tools([tool])
+        schema = registry.build_tools_schema()
+        assert schema[0]["function"]["parameters"] == input_schema
+
+    @pytest.mark.unit
+    def test_tool_without_input_schema_gets_synthesised_schema(self):
+        """ToolDefinition with only flattened parameters gets a minimal fallback."""
+        registry = AgentToolRegistry()
+        registry._tools["plugin.custom"] = ToolDefinition(
+            name="plugin.custom",
+            description="Plugin-registered tool",
+            parameters={"x": "description of x", "y": "description of y"},
+            input_schema=None,
+        )
+        schema = registry.build_tools_schema()
+        assert schema[0]["function"]["name"] == "plugin__custom"
+        params = schema[0]["function"]["parameters"]
+        assert params["type"] == "object"
+        assert params["properties"]["x"]["type"] == "string"
+        assert params["properties"]["x"]["description"] == "description of x"
+        assert params["properties"]["y"]["type"] == "string"
+
+
+class TestToolDefinitionInputSchema:
+    """input_schema preservation through registration."""
+
+    @pytest.mark.unit
+    def test_mcp_registration_preserves_input_schema(self):
+        """When an MCP tool is registered, the full JSON Schema is retained on
+        the ToolDefinition so build_tools_schema can emit it verbatim."""
+        input_schema = {
+            "type": "object",
+            "properties": {"entity_id": {"type": "string"}},
+            "required": ["entity_id"],
+        }
+        mcp_tool = MagicMock()
+        mcp_tool.namespaced_name = "mcp.homeassistant.turn_on"
+        mcp_tool.server_name = "homeassistant"
+        mcp_tool.description = "Turn on a device"
+        mcp_tool.input_schema = input_schema
+
+        mcp_manager = MagicMock()
+        mcp_manager.get_all_tools.return_value = [mcp_tool]
+        registry = AgentToolRegistry(mcp_manager=mcp_manager)
+
+        tool = registry.get_tool("mcp.homeassistant.turn_on")
+        assert tool is not None
+        assert tool.input_schema == input_schema


### PR DESCRIPTION
## Summary

Re-introduces Native Function Calling code paths — this time as an **opt-in per-role flag**, `native_function_calling: bool = False`. The production ReAct path is byte-for-byte unchanged unless a role explicitly sets the flag.

## Why opt-in, not default on

Two recent benchmarks (2026-04-16 and 2026-04-21) both concluded Native FC **regresses tool-selection accuracy**:

| Model | ReAct | Native FC |
|---|---|---|
| qwen3.5:27b | 8/9 first-tool | 6/9 |
| qwen3.6:35b | 9/9 first-tool | 6/9 |

Native FC *is* ~20% faster per call but it skips required search steps, invents short IDs, and introduces 1 duplicate call on the `dup_bait_empty` test — a regression that holds across both models.

This PR is the plumbing the 2026-04-21 full side-by-side asked for, so future model releases can be A/B tested per role without hand-editing the agent loop. It does **not** change any role's behavior today.

## Changes

**`services/agent_tools.py`**
- `ToolDefinition.input_schema: dict | None` — preserves the full JSON Schema from the MCP tool source (previously flattened to `{param_name: description_str}` and lost). Default `None` keeps plugin-registered tools working.
- `_register_mcp_tools` populates `input_schema` from `mcp_tool.input_schema`.
- Module-level `sanitize_tool_name` / `unsanitize_tool_name`: `.` ↔ `__` round-trip required by OpenAI/Ollama/llama.cpp (`^[a-zA-Z0-9_-]+$`). Idempotent on already-valid names.
- `AgentToolRegistry.build_tools_schema()` — produces the OpenAI-format `[{type, function: {name, description, parameters}}]` array from the registry. Takes an optional subset dict for pre-selection. Synthesises a minimal schema when a tool lacks `input_schema`.

**`services/agent_router.py`**
- `AgentRole.native_function_calling: bool = False` + parse from YAML via `role_data.get("native_function_calling", False)`.

**`services/agent_service.py`**
- `AgentService._should_use_native_fc(client)` — gates on role flag AND `getattr(client, "supports_native_tools", False)`. Missing attribute is treated as `False` (graceful fallback).
- `AgentService._native_fc_parsed(raw_response)` — static helper. Returns `({action, parameters, reason}, response_text)`:
  - tool_calls present → `{action: <unsanitized name>, parameters, reason: "native_fc"}`; takes the first call when multiple (one-tool-per-step parity with ReAct).
  - content only → `{action: "final_answer", answer: content, reason: "native_fc"}`.
  - neither → `(None, "")`, caller falls through to the existing retry-nudge branch.
- Main loop in `_run_impl`: when `use_native_fc` is True, passes `tools=` to `agent_client.chat(...)` and consumes `message.tool_calls`. Same for the retry path. When False, byte-for-byte unchanged.

**No Reva-side change required.** Users opt in by adding `native_function_calling: true` under a role in `config/agent_roles.yaml`.

## Tests (29 new)

`tests/backend/test_agent_tools.py`:
- `TestSanitizeToolName` (4 tests) — round-trip, idempotency for bare names
- `TestBuildToolsSchema` (5 tests) — OpenAI shape, preselection filtering, full schema pass-through, synthesised fallback for plugin tools without `input_schema`
- `TestToolDefinitionInputSchema` (1 test) — `_register_mcp_tools` populates the new field

`tests/backend/test_agent_router.py`:
- `test_native_function_calling_default_false` — every existing sample role defaults to off
- `test_native_function_calling_opt_in` — YAML `native_function_calling: true` is parsed
- `test_native_function_calling_accepts_truthy_values` — `1`/`0`/`None` coerce sanely

`tests/backend/test_agent_service.py`:
- `TestNativeFCParsed` (6 tests) — attribute-style, dict-style, content-only, empty, multiple tool_calls, malformed arguments string
- `TestShouldUseNativeFC` (4 tests) — default off, role=None path, role+client both required, missing client attribute

## Test plan

- [x] All four files pass `python3 -c "import ast; ast.parse(...)"` syntax check
- [x] No change to existing tests; new tests are additive
- [x] Default-off means existing `test_agent_service.py::TestAgentServiceRun` suite keeps passing with zero modification
- [ ] CI full run

## Related history

- `docs/native-fc-benchmark-2026-04-16.md` (in Reva): original benchmark that recommended staying on ReAct
- `docs/qwen3.6-benchmark-full-2026-04-21.md` (in Reva): full side-by-side benchmark that triggered this PR
- Reva `docs/technical-debt.md` TD-07: records the 2026-03-22 removal of the old `native_fc_enabled` flag. This PR re-introduces the toggle in a cleaner per-role form.