### PR TITLE
fix(circles,atoms): auth-disabled guard on remaining routes

### DIFF
--- a/src/backend/api/routes/atoms.py
+++ b/src/backend/api/routes/atoms.py
@@ -29,7 +29,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from models.database import Atom as AtomModel, User
 from services.atom_service import AtomService
 from services.atom_types import Atom
-from services.auth_service import get_current_user
+from services.auth_service import get_user_or_default
 from services.circle_resolver import CircleResolver, atom_from_orm
 from services.database import get_db
 from services.polymorphic_atom_store import PolymorphicAtomStore
@@ -94,7 +94,7 @@ async def query_atoms(
     q: str = "",
     top_k: int = 20,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_user_or_default),
 ):
     """
     Query atoms accessible to the current user.
@@ -130,7 +130,7 @@ async def query_atoms(
 async def get_atom(
     atom_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_user_or_default),
 ):
     """
     Fetch a single atom by ID.
@@ -151,7 +151,7 @@ async def update_atom_tier(
     atom_id: str,
     body: UpdateTierRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_user_or_default),
 ):
     """
     Change an atom's circle policy. Owner-only.
@@ -189,7 +189,7 @@ async def update_atom_tier(
 async def delete_atom(
     atom_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_user_or_default),
 ):
     """
     Soft-delete an atom (marks source row inactive). Owner-only.

--- a/src/backend/api/routes/circles.py
+++ b/src/backend/api/routes/circles.py
@@ -37,7 +37,7 @@ from models.database import (
     CircleMembership,
     User,
 )
-from services.auth_service import get_current_user
+from services.auth_service import get_user_or_default
 from services.circle_resolver import CircleResolver
 from services.database import get_db
 
@@ -102,7 +102,7 @@ class AtomReviewResponse(BaseModel):
 @router.get("/me/settings", response_model=CircleSettingsResponse)
 async def get_settings(
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_user_or_default),
 ):
     """Return the authenticated user's circle settings."""
     circle = await _get_or_create_circle(db, current_user.id)
@@ -119,7 +119,7 @@ async def get_settings(
 async def update_settings(
     body: UpdateSettingsRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_user_or_default),
 ):
     """Partial update of dimension_config and/or default_capture_policy."""
     circle = await _get_or_create_circle(db, current_user.id)
@@ -147,7 +147,7 @@ async def update_settings(
 @router.get("/me/members", response_model=list[MembershipResponse])
 async def list_members(
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_user_or_default),
 ):
     """
     List every member across every dimension of my circles.
@@ -193,7 +193,7 @@ async def list_members(
 async def add_member(
     body: AddMemberRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_user_or_default),
 ):
     """Add a member to one of my dimensions (or update if already present)."""
     if body.member_user_id == current_user.id:
@@ -246,7 +246,7 @@ async def update_member(
     user_id: int,
     body: UpdateMemberRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_user_or_default),
 ):
     """Change one dimension's value for a member."""
     existing = (await db.execute(
@@ -285,7 +285,7 @@ async def remove_member(
     user_id: int,
     dimension: str | None = None,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_user_or_default),
 ):
     """
     Remove a member from a specific dimension (?dimension=tier),
@@ -320,7 +320,7 @@ async def atoms_for_review(
     days: int = 7,
     limit: int = 50,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_user_or_default),
 ):
     """
     Brain Review Queue — atoms captured in the last N days, owner-only.


### PR DESCRIPTION
Follow-up to #423 — circles.py + atoms.py have the same `current_user.id` crash on AUTH_ENABLED=false. Switches 11 routes to the `get_user_or_default` helper introduced in #423.

Smoke-tested via headless browser against prod: `/settings/circles` hit the React error boundary; backend logs showed `circles.py:160 list_members` with `AttributeError: 'NoneType' object has no attribute 'id'`. Same pattern for all circles/atoms routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)