### PR TITLE
fix(circles): render ConfirmDialogComponent as element, not component

### DIFF
--- a/src/frontend/src/pages/CirclesPeersPage.jsx
+++ b/src/frontend/src/pages/CirclesPeersPage.jsx
@@ -179,7 +179,7 @@ export default function CirclesPeersPage() {
         </ul>
       )}
 
-      <ConfirmDialogComponent />
+      {ConfirmDialogComponent}
     </div>
   );
 }

--- a/src/frontend/src/pages/CirclesSettingsPage.jsx
+++ b/src/frontend/src/pages/CirclesSettingsPage.jsx
@@ -366,7 +366,7 @@ export default function CirclesSettingsPage() {
         </form>
       </Modal>
 
-      <ConfirmDialogComponent />
+      {ConfirmDialogComponent}
     </div>
   );
 }


### PR DESCRIPTION
Latent Circles v1 bug (#388) surfaced on first prod deploy of Circles UI. Both `<ConfirmDialogComponent />` sites in CirclesSettingsPage + CirclesPeersPage trigger React #130 because the hook returns an element, not a component. Three other pages already use the correct `{ConfirmDialogComponent}` form.

Found via headless-browser smoke test of the live deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)