### PR TITLE
fix(kg): typo — scopeFilter → tierFilter in useEffect deps

### DIFF
--- a/src/frontend/src/pages/KnowledgeGraphPage.jsx
+++ b/src/frontend/src/pages/KnowledgeGraphPage.jsx
@@ -172,7 +172,7 @@ export default function KnowledgeGraphPage() {
     if (activeTab === 'entities') loadEntities();
     else if (activeTab === 'relations') loadRelations();
     else if (activeTab === 'stats') loadStats();
-  }, [activeTab, entitiesPage, relationsPage, typeFilter, searchQuery, scopeFilter, entityFilter]);
+  }, [activeTab, entitiesPage, relationsPage, typeFilter, searchQuery, tierFilter, entityFilter]);
 
   // Edit entity
   const openEditModal = (entity) => {


### PR DESCRIPTION
Page-mount crash on /knowledge-graph. `scopeFilter` in useEffect deps was a leftover from a rename; the actual state is `tierFilter`. One-char fix. Found via browser smoke test of live prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)