### PR TITLE
feat(review): human-readable labels in /brain/review queue

### DIFF
--- a/src/backend/api/routes/circles.py
+++ b/src/backend/api/routes/circles.py
@@ -35,6 +35,10 @@ from models.database import (
     Atom as AtomModel,
     Circle,
     CircleMembership,
+    ConversationMemory,
+    DocumentChunk,
+    KGEntity,
+    KGRelation,
     User,
 )
 from services.auth_service import get_user_or_default
@@ -86,12 +90,26 @@ class UpdateMemberRequest(BaseModel):
 
 
 class AtomReviewResponse(BaseModel):
-    """Atom in the Brain Review Queue — owner-only view."""
+    """Atom in the Brain Review Queue — owner-only view.
+
+    `title` + `preview` are human-readable fields the UI renders
+    instead of the raw atom_id UUID. An owner gating an atom's tier
+    needs to see WHAT is being gated, not a hex id.
+
+    Resolution per atom_type:
+      - kg_node        → entity.name                + entity.description
+      - kg_edge        → "subj predicate obj"       + (empty preview)
+      - kb_chunk       → documents.filename         + chunk.content[:200]
+      - conversation_memory → "Conversation 2026-04-19" + content[:200]
+      - unknown        → atom_type label            + (empty preview)
+    """
     atom_id: str
     atom_type: str
     policy: dict[str, Any]
     tier: int
     created_at: datetime
+    title: str
+    preview: str | None = None
 
 
 # =============================================================================
@@ -344,6 +362,10 @@ async def atoms_for_review(
         .limit(limit)
     )).scalars().all()
 
+    # Enrich with human-readable title + preview per source table. One
+    # bulk query per atom_type keeps the N+1 risk in check even when
+    # the review queue is filled with a mix of kg + chunk atoms.
+    labels = await _resolve_review_labels(db, rows)
     return [
         AtomReviewResponse(
             atom_id=r.atom_id,
@@ -351,9 +373,132 @@ async def atoms_for_review(
             policy=r.policy or {"tier": 0},
             tier=int((r.policy or {"tier": 0}).get("tier", 0)),
             created_at=r.created_at,
+            title=labels[r.atom_id][0],
+            preview=labels[r.atom_id][1],
         )
         for r in rows
     ]
+
+
+async def _resolve_review_labels(
+    db: AsyncSession, atoms: list[AtomModel],
+) -> dict[str, tuple[str, str | None]]:
+    """Bulk-resolve (title, preview) for a list of atoms by atom_type.
+
+    Returns a dict keyed by atom_id. Falls back to
+    ("unknown {atom_type}", None) for atoms whose source row is
+    missing (e.g., source table was deleted after the atom was
+    written — cleanup job not wired yet).
+
+    Kept private to this module because the mapping is review-UI-
+    specific: `kg_edge` renders the predicate, not the row id; that's
+    not how the knowledge-graph page labels relations.
+    """
+    PREVIEW_MAX = 200
+
+    # Group atoms by source_table so we can do one SELECT per table.
+    by_table: dict[str, list[AtomModel]] = {}
+    for a in atoms:
+        by_table.setdefault(a.source_table, []).append(a)
+
+    out: dict[str, tuple[str, str | None]] = {}
+
+    def _truncate(s: str | None) -> str | None:
+        if not s:
+            return None
+        s = s.strip()
+        return s if len(s) <= PREVIEW_MAX else s[: PREVIEW_MAX - 1] + "…"
+
+    # --- kg_entities ---
+    kg_node_atoms = by_table.get("kg_entities", [])
+    if kg_node_atoms:
+        source_ids = [int(a.source_id) for a in kg_node_atoms if a.source_id.isdigit()]
+        ents = {}
+        if source_ids:
+            rows = (await db.execute(
+                select(KGEntity).where(KGEntity.id.in_(source_ids))
+            )).scalars().all()
+            ents = {e.id: e for e in rows}
+        for a in kg_node_atoms:
+            e = ents.get(int(a.source_id)) if a.source_id.isdigit() else None
+            if e is not None:
+                out[a.atom_id] = (e.name, _truncate(e.description))
+            else:
+                out[a.atom_id] = (f"Unknown entity ({a.source_id})", None)
+
+    # --- kg_relations ---
+    kg_edge_atoms = by_table.get("kg_relations", [])
+    if kg_edge_atoms:
+        source_ids = [int(a.source_id) for a in kg_edge_atoms if a.source_id.isdigit()]
+        rels = {}
+        if source_ids:
+            # Eager-load subject + object so we can read their names.
+            from sqlalchemy.orm import selectinload
+            rows = (await db.execute(
+                select(KGRelation)
+                .where(KGRelation.id.in_(source_ids))
+                .options(
+                    selectinload(KGRelation.subject),
+                    selectinload(KGRelation.object),
+                )
+            )).scalars().all()
+            rels = {r.id: r for r in rows}
+        for a in kg_edge_atoms:
+            r = rels.get(int(a.source_id)) if a.source_id.isdigit() else None
+            if r is not None and r.subject is not None and r.object is not None:
+                title = f"{r.subject.name} {r.predicate} {r.object.name}"
+                out[a.atom_id] = (title, None)
+            else:
+                out[a.atom_id] = (f"Unknown relation ({a.source_id})", None)
+
+    # --- document_chunks ---
+    chunk_atoms = by_table.get("document_chunks", [])
+    if chunk_atoms:
+        source_ids = [int(a.source_id) for a in chunk_atoms if a.source_id.isdigit()]
+        chunks = {}
+        if source_ids:
+            from sqlalchemy.orm import selectinload
+            rows = (await db.execute(
+                select(DocumentChunk)
+                .where(DocumentChunk.id.in_(source_ids))
+                .options(selectinload(DocumentChunk.document))
+            )).scalars().all()
+            chunks = {c.id: c for c in rows}
+        for a in chunk_atoms:
+            c = chunks.get(int(a.source_id)) if a.source_id.isdigit() else None
+            if c is not None:
+                doc = getattr(c, "document", None)
+                title = (doc.title if doc and getattr(doc, "title", None) else None) \
+                    or (doc.filename if doc else None) \
+                    or "Document chunk"
+                out[a.atom_id] = (title, _truncate(c.content))
+            else:
+                out[a.atom_id] = (f"Unknown chunk ({a.source_id})", None)
+
+    # --- conversation_memories ---
+    memory_atoms = by_table.get("conversation_memories", [])
+    if memory_atoms:
+        source_ids = [int(a.source_id) for a in memory_atoms if a.source_id.isdigit()]
+        mems = {}
+        if source_ids:
+            rows = (await db.execute(
+                select(ConversationMemory).where(ConversationMemory.id.in_(source_ids))
+            )).scalars().all()
+            mems = {m.id: m for m in rows}
+        for a in memory_atoms:
+            m = mems.get(int(a.source_id)) if a.source_id.isdigit() else None
+            if m is not None:
+                stamp = m.created_at.strftime("%Y-%m-%d %H:%M") if m.created_at else "?"
+                out[a.atom_id] = (f"Memory · {stamp}", _truncate(m.content))
+            else:
+                out[a.atom_id] = (f"Unknown memory ({a.source_id})", None)
+
+    # Backstop — any atom_type we don't have a resolver for gets a
+    # generic label so the row still renders useful info.
+    for a in atoms:
+        out.setdefault(a.atom_id, (f"Unknown {a.atom_type}", None))
+
+    return out
 
 
 # =============================================================================

--- a/src/frontend/src/pages/BrainReviewPage.jsx
+++ b/src/frontend/src/pages/BrainReviewPage.jsx
@@ -155,8 +155,25 @@ export default function BrainReviewPage() {
                       {t('circles.capturedAt')}: {formatDate(atom.created_at)}
                     </span>
                   </div>
-                  <code className="block text-xs text-gray-500 dark:text-gray-400 break-all">
-                    {atom.atom_id}
+                  {/* Human-readable label resolved by the backend from
+                      the atom's source row. UUID is kept visible but
+                      demoted to a fingerprint so debugging is still
+                      possible. */}
+                  {atom.title && (
+                    <p className="font-medium text-gray-900 dark:text-white truncate">
+                      {atom.title}
+                    </p>
+                  )}
+                  {atom.preview && (
+                    <p className="text-sm text-gray-600 dark:text-gray-300 line-clamp-2">
+                      {atom.preview}
+                    </p>
+                  )}
+                  <code
+                    className="block text-[10px] text-gray-400 dark:text-gray-500 truncate"
+                    title={atom.atom_id}
+                  >
+                    {atom.atom_id.slice(0, 8)}…
                   </code>
                 </div>
                 <div className="sm:ml-4 sm:flex-shrink-0">

--- a/tests/backend/test_atoms_for_review_labels.py
+++ b/tests/backend/test_atoms_for_review_labels.py
@@ -1,0 +1,167 @@
+"""
+Tests for `/api/circles/me/atoms-for-review` label resolution.
+
+Regression guard: the endpoint used to return only `atom_id`, which
+the Brain Review UI displayed as a raw UUID — a human cannot pick a
+tier for an unlabeled hex string. The response now includes a
+`title` + optional `preview` resolved from each atom's source row.
+
+Covers:
+- kg_node → entity.name + description
+- kg_edge → "subject predicate object"
+- kb_chunk → document.filename + chunk.content
+- conversation_memory → "Memory · YYYY-MM-DD HH:MM" + content
+- orphan source_id → "Unknown … (id)" fallback (no crash)
+- mixed atom types → each gets its type-specific label, no bleed
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from api.routes.circles import _resolve_review_labels
+
+
+def _atom(atom_id: str, atom_type: str, source_table: str, source_id: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        atom_id=atom_id,
+        atom_type=atom_type,
+        source_table=source_table,
+        source_id=source_id,
+    )
+
+
+def _scalars_returning(objs: list) -> MagicMock:
+    """Mock a `db.execute` result whose .scalars().all() yields `objs`."""
+    result = MagicMock()
+    scalars = MagicMock()
+    scalars.all = MagicMock(return_value=objs)
+    result.scalars = MagicMock(return_value=scalars)
+    return result
+
+
+class TestResolveReviewLabels:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_kg_node_resolves_to_entity_name_and_description(self):
+        atom = _atom("a1", "kg_node", "kg_entities", "42")
+        entity = SimpleNamespace(id=42, name="Katharinenstraße", description="Straße in Korschenbroich")
+
+        db = MagicMock()
+        db.execute = AsyncMock(return_value=_scalars_returning([entity]))
+
+        out = await _resolve_review_labels(db, [atom])
+        assert out == {"a1": ("Katharinenstraße", "Straße in Korschenbroich")}
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_kg_edge_resolves_to_subject_predicate_object(self):
+        atom = _atom("e1", "kg_edge", "kg_relations", "7")
+        subj = SimpleNamespace(name="Heizung")
+        obj = SimpleNamespace(name="Erdgas")
+        relation = SimpleNamespace(id=7, predicate="verwendet", subject=subj, object=obj)
+
+        db = MagicMock()
+        db.execute = AsyncMock(return_value=_scalars_returning([relation]))
+
+        out = await _resolve_review_labels(db, [atom])
+        assert out == {"e1": ("Heizung verwendet Erdgas", None)}
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_kb_chunk_prefers_document_title_then_filename(self):
+        atom_with_title = _atom("c1", "kb_chunk", "document_chunks", "10")
+        atom_without_title = _atom("c2", "kb_chunk", "document_chunks", "11")
+
+        doc_titled = SimpleNamespace(title="Nebenkostenabrechnung 2025", filename="NK_2025.pdf")
+        doc_untitled = SimpleNamespace(title=None, filename="mysterium.pdf")
+        chunks = [
+            SimpleNamespace(id=10, content="Die Nebenkosten für 2025 belaufen sich auf...", document=doc_titled),
+            SimpleNamespace(id=11, content="Kapitel 4: Betriebskosten", document=doc_untitled),
+        ]
+
+        db = MagicMock()
+        db.execute = AsyncMock(return_value=_scalars_returning(chunks))
+
+        out = await _resolve_review_labels(db, [atom_with_title, atom_without_title])
+        # Titled → title wins
+        assert out["c1"][0] == "Nebenkostenabrechnung 2025"
+        assert out["c1"][1].startswith("Die Nebenkosten")
+        # Untitled → falls back to filename
+        assert out["c2"][0] == "mysterium.pdf"
+        assert out["c2"][1] == "Kapitel 4: Betriebskosten"
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_conversation_memory_uses_timestamp_prefix(self):
+        atom = _atom("m1", "conversation_memory", "conversation_memories", "99")
+        mem = SimpleNamespace(
+            id=99,
+            content="Max erwähnt, dass er morgen um 8 Uhr abgeholt werden möchte.",
+            created_at=datetime(2026, 4, 19, 14, 30),
+        )
+
+        db = MagicMock()
+        db.execute = AsyncMock(return_value=_scalars_returning([mem]))
+
+        out = await _resolve_review_labels(db, [atom])
+        title, preview = out["m1"]
+        assert title.startswith("Memory · 2026-04-19")
+        assert "Max erwähnt" in preview
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_orphan_source_id_falls_back_to_unknown(self):
+        """Source row was deleted after the atom was written. Endpoint
+        must still return a row — "Unknown entity (42)" — so the UI
+        renders something instead of crashing."""
+        atom = _atom("a1", "kg_node", "kg_entities", "42")
+
+        db = MagicMock()
+        db.execute = AsyncMock(return_value=_scalars_returning([]))  # no rows
+
+        out = await _resolve_review_labels(db, [atom])
+        assert out["a1"] == ("Unknown entity (42)", None)
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_non_numeric_source_id_does_not_crash(self):
+        """Defensive: a malformed atom whose source_id isn't an int
+        should be labeled 'unknown' without triggering ValueError."""
+        atom = _atom("a1", "kg_node", "kg_entities", "not-a-number")
+
+        db = MagicMock()
+        db.execute = AsyncMock(return_value=_scalars_returning([]))
+
+        out = await _resolve_review_labels(db, [atom])
+        assert out["a1"][0].startswith("Unknown entity")
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_long_preview_is_truncated_with_ellipsis(self):
+        atom = _atom("a1", "kg_node", "kg_entities", "1")
+        long_desc = "x" * 500
+        entity = SimpleNamespace(id=1, name="Test", description=long_desc)
+
+        db = MagicMock()
+        db.execute = AsyncMock(return_value=_scalars_returning([entity]))
+
+        out = await _resolve_review_labels(db, [atom])
+        _, preview = out["a1"]
+        assert preview.endswith("…")
+        assert len(preview) == 200
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_unknown_atom_type_gets_generic_fallback(self):
+        """A future atom_type the resolver doesn't know about gets a
+        generic 'Unknown xyz' label — forward-compat without UI crash."""
+        atom = _atom("a1", "satellite_telemetry", "some_future_table", "1")
+        db = MagicMock()
+        db.execute = AsyncMock()  # won't be called — no matching bucket
+
+        out = await _resolve_review_labels(db, [atom])
+        assert out["a1"] == ("Unknown satellite_telemetry", None)


### PR DESCRIPTION
Raw UUIDs in the review queue are not actionable for a human — user can't pick a tier for `2410803c-be78-4110-989a-eefe9f473462`.

Endpoint now joins each atom to its source row for a human title + preview. Batched per source_table (N+4 queries max). Orphan/unknown atoms get 'Unknown entity (id)' fallback so the queue still renders.

Found via first-deploy review of the circles UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)