### PR TITLE
fix(lifecycle): remove shadowing AsyncSessionLocal import

### DIFF
--- a/src/backend/api/lifecycle.py
+++ b/src/backend/api/lifecycle.py
@@ -330,7 +330,6 @@ async def _init_mcp(app: "FastAPI"):
         # Non-fatal on failure: an empty peer list or schema-migration-
         # not-yet-applied DB should not block backend startup.
         try:
-            from services.database import AsyncSessionLocal
             from services.peer_mcp_registry import sync_peers
             async with AsyncSessionLocal() as peer_session:
                 await sync_peers(manager, peer_session)


### PR DESCRIPTION
## Summary
- Inner `from services.database import AsyncSessionLocal` in `_init_mcp` shadowed the module-level import and turned the name function-local, so the earlier reference at line 296 tripped `UnboundLocalError` on every backend startup.
- Cascade in production: MCP init crashed → `app.state.mcp_manager = None` → `_init_paperless_audit` bailed out with "Paperless MCP not configured" → `/api/admin/paperless-audit/status` returned 503 even though Paperless itself was healthy.

## Test plan
- [x] Syntax check via `ast.parse`
- [ ] Backend pod restarts cleanly on k8s without the UnboundLocalError in logs
- [ ] `/api/admin/paperless-audit/status` returns 200 (not 503)
- [ ] `/admin/paperless-audit` page renders without error boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)