### PR TITLE
fix(k8s): drop duplicate /api suffix from PAPERLESS_API_URL

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -27,7 +27,7 @@ data:
   # Hostpoint shared-hosting IP (Wildcard A-record leftover) and presents
   # a *.web.hostpoint.ch cert — unusable. Paperless is reachable directly
   # on the cluster subnet.
-  PAPERLESS_API_URL: "http://192.168.1.162:8000/api"
+  PAPERLESS_API_URL: "http://192.168.1.162:8000"
 
   # Models (auto-pulled by Ollama on first use if missing from NFS)
   OLLAMA_MODEL: "qwen3:14b"


### PR DESCRIPTION
## Summary

- `renfield_mcp_paperless` appends `/api/<endpoint>/` paths itself, so the configured base URL must not already end in `/api`.
- The k8s configmap had `http://192.168.1.162:8000/api`, producing requests to `/api/api/documents/post_document/` → **403 Forbidden** on `upload_document` (and similar tools).
- Drops the suffix. Now consistent with `.env` (line 92) and `docs/ENVIRONMENT_VARIABLES.md`, which both use the suffix-free form.

## Test plan

- [x] Applied configmap to `renfield-private` cluster, rolled out `backend` and `document-worker`
- [x] Verified `PAPERLESS_API_URL=http://192.168.1.162:8000` in new pod env
- [x] MCP server `paperless` reconnected (4/8 tools, tier-filtered)
- [x] Paperless caches fully loaded (903 correspondents, 383 doc types, 1461 tags) — would have failed on 403
- [ ] End-to-end: trigger `upload_document` via chat/agent and confirm document appears in Paperless

🤖 Generated with [Claude Code](https://claude.com/claude-code)