### PR TITLE
fix(agent): prevent stale tool errors from blocking retries

### DIFF
--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -1213,9 +1213,21 @@ WICHTIG: Nutze die ECHTEN Daten aus dem Ergebnis! Gib NUR die Antwort, KEIN JSON
                         f"{guard_result.violations}"
                     )
 
+            # Build assistant metadata once and reuse for both in-memory history
+            # and DB persistence. ``action_success`` lets the agent prompt builder
+            # mark prior failed tool turns so they are not misread as current state.
+            assistant_metadata = {
+                "intent": intent.get("intent") if intent else None,
+                "action_success": action_result.get("success") if action_result else None,
+            }
+            if action_summary:
+                assistant_metadata["action_summary"] = action_summary
+
             session_state.add_to_history("user", content)
             if full_response:
-                session_state.add_to_history("assistant", history_content)
+                session_state.add_to_history(
+                    "assistant", history_content, metadata=assistant_metadata
+                )
 
             # Persist messages to DB if session_id is provided
             if msg_session_id and full_response:
@@ -1234,12 +1246,6 @@ WICHTIG: Nutze die ECHTEN Daten aus dem Ergebnis! Gib NUR die Antwort, KEIN JSON
                         )
                         # Save assistant response (clean content for UI display)
                         # action_summary stored in metadata for LLM context reconstruction
-                        assistant_metadata = {
-                            "intent": intent.get("intent") if intent else None,
-                            "action_success": action_result.get("success") if action_result else None,
-                        }
-                        if action_summary:
-                            assistant_metadata["action_summary"] = action_summary
                         await ollama.save_message(
                             msg_session_id, "assistant", full_response, db_session,
                             metadata=assistant_metadata,
@@ -1300,8 +1306,15 @@ WICHTIG: Nutze die ECHTEN Daten aus dem Ergebnis! Gib NUR die Antwort, KEIN JSON
                 })
                 logger.info(f"📝 Proactive feedback requested for intent: {intent.get('intent')}")
 
-            # Background: Extract memories from this exchange
-            if settings.memory_enabled and settings.memory_extraction_enabled and full_response:
+            # Background: Extract memories from this exchange.
+            # Skip when the turn recorded a failed tool action — extracting
+            # memories from error-response text would otherwise re-inject the
+            # error string into long-term memory as if it were a stable fact.
+            _action_success = assistant_metadata.get("action_success")
+            if (settings.memory_enabled
+                    and settings.memory_extraction_enabled
+                    and full_response
+                    and _action_success is not False):
                 task = asyncio.create_task(
                     _extract_memories_background(
                         user_message=content,

--- a/src/backend/api/websocket/shared.py
+++ b/src/backend/api/websocket/shared.py
@@ -60,9 +60,18 @@ class ConversationSessionState:
             return False
         return (time() - self.last_rag_timestamp) < self.CONTEXT_TIMEOUT_SECONDS
 
-    def add_to_history(self, role: str, content: str):
-        """Add a message to the conversation history."""
-        self.conversation_history.append({"role": role, "content": content})
+    def add_to_history(self, role: str, content: str, metadata: dict | None = None):
+        """Add a message to the conversation history.
+
+        When ``metadata`` is provided it is stored alongside role/content so
+        downstream consumers (e.g. the agent prompt builder) can distinguish
+        successful from failed tool-backed turns. Kept optional for callers
+        that don't track action outcomes.
+        """
+        entry: dict = {"role": role, "content": content}
+        if metadata is not None:
+            entry["metadata"] = metadata
+        self.conversation_history.append(entry)
         # Keep only last N messages in memory
         if len(self.conversation_history) > self.MAX_HISTORY_MESSAGES:
             self.conversation_history = self.conversation_history[-self.MAX_HISTORY_MESSAGES:]

--- a/src/backend/prompts/agent.yaml
+++ b/src/backend/prompts/agent.yaml
@@ -485,6 +485,8 @@ de:
     KONVERSATIONS-KONTEXT:
     {history_lines}
 
+    HINWEIS: Zeilen, die mit [VORHERIGE_FEHLGESCHLAGENE_AKTION] beginnen, beschreiben historische Tool-Fehler und sind KEIN Beleg fuer den aktuellen Zustand. Wenn der Nutzer eine so markierte Aktion erneut anfordert, fuehre das Tool NEU aus; antworte NICHT direkt mit final_answer unter Verweis auf den alten Fehler.
+
   # Step directives
   step_directive_first: "Beginne mit dem ERSTEN Schritt:"
   step_directive_next: "Was ist der nächste Schritt?"
@@ -1032,6 +1034,8 @@ en:
   conv_context_template: |
     CONVERSATION CONTEXT:
     {history_lines}
+
+    NOTE: Lines starting with [VORHERIGE_FEHLGESCHLAGENE_AKTION] describe historical tool failures and are NOT evidence of the current state. When the user re-requests an action marked this way, RE-RUN the tool; do NOT reply with final_answer citing the old error.
 
   # Step directives
   step_directive_first: "Start with the FIRST step:"

--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -857,6 +857,15 @@ class AgentService:
             for msg in recent:
                 role = "User" if msg.get("role") == "user" else "Assistant"
                 content = _compress_history_message(msg.get("content", ""))
+                # Mark assistant turns where the tool action failed. Without
+                # this marker the LLM has no way to tell a transient past
+                # failure (config bug, network blip) from the current state
+                # and tends to short-circuit to final_answer on retry. The
+                # marker is explicit so the conv_context_template hint can
+                # instruct the LLM to disregard it as current evidence.
+                if (msg.get("role") == "assistant"
+                        and (msg.get("metadata") or {}).get("action_success") is False):
+                    content = f"[VORHERIGE_FEHLGESCHLAGENE_AKTION] {content}"
                 history_lines.append(f"  {role}: {content}")
             conv_context = prompt_manager.get(
                 "agent", "conv_context_template", lang=lang,

--- a/tests/backend/test_agent_service.py
+++ b/tests/backend/test_agent_service.py
@@ -874,6 +874,80 @@ class TestAgentServiceRun:
         assert "KONVERSATIONS-KONTEXT" in prompt_content
         assert "Was ist das Wetter?" in prompt_content
 
+    async def _capture_prompt(self, history):
+        """Run one agent turn with the given history and return the rendered prompt."""
+        registry = self._make_registry()
+        ollama = self._make_ollama_mock([
+            '{"action": "final_answer", "answer": "OK", "reason": "Done"}'
+        ])
+        executor = self._make_executor_mock()
+
+        chat_calls = []
+        original_chat = ollama.client.chat
+
+        async def capturing_chat(**kwargs):
+            chat_calls.append(kwargs)
+            return await original_chat(**kwargs)
+
+        ollama.client.chat = capturing_chat
+        _shared_agent_client.chat = capturing_chat
+
+        agent = AgentService(registry, max_steps=5)
+        await collect_steps(
+            agent,
+            message="Bitte das Dokument erneut hochladen",
+            ollama=ollama,
+            executor=executor,
+            conversation_history=history,
+        )
+        assert chat_calls, "Expected at least one LLM call"
+        return chat_calls[0]["messages"][1]["content"]
+
+    @pytest.mark.unit
+    async def test_failed_action_history_marker_present(self):
+        """Prior assistant turn with action_success=False is marked in conv_context.
+
+        Regression guard for the ``stale 403`` bug: without the marker the LLM
+        treats the persisted error as the current state and short-circuits to
+        final_answer on the next turn instead of retrying the tool.
+        """
+        history = [
+            {"role": "user", "content": "Lade das Dokument hoch"},
+            {
+                "role": "assistant",
+                "content": "Fehler beim Hochladen: 403 Forbidden.",
+                "metadata": {"intent": "documents", "action_success": False},
+            },
+        ]
+        prompt_content = await self._capture_prompt(history)
+        assert "[VORHERIGE_FEHLGESCHLAGENE_AKTION]" in prompt_content
+        # The historical failure text is still visible (marker does not drop context)
+        assert "403" in prompt_content
+
+    @pytest.mark.unit
+    async def test_successful_action_history_unmarked(self):
+        """Successful prior turns must NOT carry the failed-action marker."""
+        history = [
+            {"role": "user", "content": "Suche nach Rechnungen"},
+            {
+                "role": "assistant",
+                "content": "5 Rechnungen gefunden.",
+                "metadata": {"intent": "documents", "action_success": True},
+            },
+        ]
+        prompt_content = await self._capture_prompt(history)
+        assert "[VORHERIGE_FEHLGESCHLAGENE_AKTION]" not in prompt_content
+
+    @pytest.mark.unit
+    async def test_history_without_metadata_unmarked(self):
+        """Entries that predate the metadata contract (no metadata key) stay unmarked."""
+        history = [
+            {"role": "user", "content": "Wie ist das Wetter?"},
+            {"role": "assistant", "content": "15°C in Berlin."},
+        ]
+        prompt_content = await self._capture_prompt(history)
+        assert "[VORHERIGE_FEHLGESCHLAGENE_AKTION]" not in prompt_content
+
 
 # ============================================================================
 # Test AgentService — Timeout and Safety


### PR DESCRIPTION
## Problem

After a transient tool failure (e.g. the Paperless 403 from the misconfigured `PAPERLESS_API_URL` that #429 fixed), the agent stopped retrying. Log signature: `🤖 Agent [documents] abgeschlossen: 0 Steps` and no outgoing POST to the tool — the old error string was simply re-rendered to the user.

## Root cause

The error response was persisted verbatim as an `assistant` turn in in-memory session state and the DB. On the next turn it entered `KONVERSATIONS-KONTEXT` in the agent prompt without any marker. Combined with the existing rule *"if a tool fails, reply with `final_answer` immediately"*, the LLM read the stale error as the current state and short-circuited at step 1.

## Fix (one PR, three coordinated changes)

1. **`ConversationSessionState.add_to_history`** (`shared.py`) accepts optional `metadata`. In-memory history now carries the same `action_success` flag DB persistence already stored.

2. **`agent_service._build_agent_prompt`** prepends `[VORHERIGE_FEHLGESCHLAGENE_AKTION]` to any assistant turn with `metadata.action_success is False`. `None` (general conversation) and `True` are untouched; legacy entries without metadata keep prior behaviour.

3. **`conv_context_template` (de + en)** gains a hint explaining the marker and instructing the LLM to re-run the tool instead of citing the old error. Co-locating the rule with the marker means every agent role (documents, media, smart_home, …) inherits it automatically via the shared template.

### Secondary

Memory extraction in `chat_handler.py` now skips when `action_success is False`, closing a second injection path where error text could otherwise have leaked into long-term `ConversationMemoryService` storage.

## Verification

- `py_compile` passes on all four edited Python files.
- YAML sanity-checked via `yaml.safe_load` inside the prod backend pod — both `de` and `en` `conv_context_template` parse and contain the hint.
- Marker logic dry-run on all four `action_success` states (False / True / missing / None): only False produces the marker.

Local `pytest` unavailable (no venv, Docker daemon not running in this session) — three new unit tests added in `test_agent_service.py`, relying on CI for execution.

## Test plan

- [x] `py_compile` on all edited files
- [x] YAML parse + key integrity
- [x] Marker logic dry-run (4 cases)
- [ ] CI unit tests (3 new: marker present / absent-on-success / absent-on-legacy-no-metadata)
- [ ] Manual E2E: provoke a transient tool error in prod, then re-request — agent must re-invoke the tool instead of echoing the old error

🤖 Generated with [Claude Code](https://claude.com/claude-code)