### PR TITLE
fix(satellite): attach action_success metadata to in-memory history (#431)

### DIFF
--- a/src/backend/ha_glue/api/websocket/satellite_handler.py
+++ b/src/backend/ha_glue/api/websocket/satellite_handler.py
@@ -571,9 +571,24 @@ Gib eine kurze, natürliche Antwort. KEIN JSON, nur Text."""
 
                     logger.info(f"💬 Response: '{response_text[:100]}...'")
 
+                    # Build assistant metadata once for both in-memory history and DB
+                    # persistence. ``action_success`` lets the agent prompt builder mark
+                    # prior failed tool turns so they are not misread as current state
+                    # (see #430). The ollama client's pydantic Message model silently
+                    # drops unknown keys, so keeping metadata on the in-memory dict does
+                    # not leak into the LLM call.
+                    assistant_metadata = {
+                        "intent": intent.get("intent") if intent else None,
+                        "action_success": action_result.get("success") if action_result else None,
+                    }
+
                     # Update in-memory conversation history (keep max 5 exchanges = 10 messages)
                     satellite_conversation_history.append({"role": "user", "content": text})
-                    satellite_conversation_history.append({"role": "assistant", "content": response_text})
+                    satellite_conversation_history.append({
+                        "role": "assistant",
+                        "content": response_text,
+                        "metadata": assistant_metadata,
+                    })
                     if len(satellite_conversation_history) > 10:
                         satellite_conversation_history[:] = satellite_conversation_history[-10:]
 
@@ -591,10 +606,7 @@ Gib eine kurze, natürliche Antwort. KEIN JSON, nur Text."""
                                 )
                                 await ollama.save_message(
                                     satellite_db_session_id, "assistant", response_text, db_session,
-                                    metadata={
-                                        "intent": intent.get("intent") if intent else None,
-                                        "action_success": action_result.get("success") if action_result else None
-                                    }
+                                    metadata=assistant_metadata,
                                 )
                                 logger.debug(f"💾 Satellite messages saved to DB: {satellite_db_session_id}")
                         except Exception as e:

--- a/src/backend/ha_glue/api/websocket/satellite_handler.py
+++ b/src/backend/ha_glue/api/websocket/satellite_handler.py
@@ -86,6 +86,26 @@ async def _route_satellite_tts_output(
         await satellite_manager.send_tts_audio(session_id, tts_audio, is_final=True)
 
 
+def _build_assistant_metadata(
+    intent: dict | None,
+    action_result: dict | None,
+) -> dict:
+    """Shape for both in-memory satellite history and DB save.
+
+    ``action_success`` lets ``agent_service._build_agent_prompt`` mark prior
+    failed tool turns with ``[VORHERIGE_FEHLGESCHLAGENE_AKTION]`` so a stale
+    error string cannot masquerade as current state on the next turn.
+    See #430 (web-chat path) and #431 (this satellite path).
+
+    Returns a fresh dict each call — callers may mutate/annotate the result
+    without affecting other sites.
+    """
+    return {
+        "intent": intent.get("intent") if intent else None,
+        "action_success": action_result.get("success") if action_result else None,
+    }
+
+
 @router.websocket("/ws/satellite")
 async def satellite_websocket(
     websocket: WebSocket,
@@ -571,16 +591,10 @@ Gib eine kurze, natürliche Antwort. KEIN JSON, nur Text."""
 
                     logger.info(f"💬 Response: '{response_text[:100]}...'")
 
-                    # Build assistant metadata once for both in-memory history and DB
-                    # persistence. ``action_success`` lets the agent prompt builder mark
-                    # prior failed tool turns so they are not misread as current state
-                    # (see #430). The ollama client's pydantic Message model silently
-                    # drops unknown keys, so keeping metadata on the in-memory dict does
-                    # not leak into the LLM call.
-                    assistant_metadata = {
-                        "intent": intent.get("intent") if intent else None,
-                        "action_success": action_result.get("success") if action_result else None,
-                    }
+                    # The ollama client's pydantic Message model silently drops unknown
+                    # keys, so keeping ``metadata`` on the in-memory dict is safe — it
+                    # never reaches the LLM, only the agent prompt builder and the DB.
+                    assistant_metadata = _build_assistant_metadata(intent, action_result)
 
                     # Update in-memory conversation history (keep max 5 exchanges = 10 messages)
                     satellite_conversation_history.append({"role": "user", "content": text})

--- a/tests/backend/test_satellite_history_metadata.py
+++ b/tests/backend/test_satellite_history_metadata.py
@@ -1,0 +1,112 @@
+"""
+Regression guard for satellite_handler.py in-memory conversation history shape.
+
+Context: #431 — satellite_conversation_history used to append assistant turns as
+``{"role", "content"}`` without metadata, so the #430 marker for failed actions
+never fired on satellite-sourced history. After the fix, each assistant append
+carries ``metadata`` with ``intent`` + ``action_success``.
+
+These tests cover two invariants of that contract:
+
+1. The assistant entry shape includes ``metadata.action_success`` as a bool (or
+   None) so ``agent_service._build_agent_prompt`` can detect failed turns.
+2. The 10-message in-memory trim (``history[:] = history[-10:]``) preserves the
+   ``metadata`` key — i.e. nothing in the trim logic silently strips it.
+
+End-to-end marker rendering is already covered by
+``tests/backend/test_agent_service.py::test_failed_action_history_marker_present``;
+these tests nail down the producer-side shape that feeds it.
+"""
+import pytest
+
+
+def _append_like_satellite_handler(
+    history: list[dict],
+    user_text: str,
+    response_text: str,
+    intent: dict | None,
+    action_result: dict | None,
+) -> None:
+    """Mirror the exact append pattern from satellite_handler.py.
+
+    Keep this in sync with the handler — if the real code evolves (e.g. stores
+    additional metadata keys), update this helper and the tests will cover the
+    new contract.
+    """
+    assistant_metadata = {
+        "intent": intent.get("intent") if intent else None,
+        "action_success": action_result.get("success") if action_result else None,
+    }
+    history.append({"role": "user", "content": user_text})
+    history.append({
+        "role": "assistant",
+        "content": response_text,
+        "metadata": assistant_metadata,
+    })
+    if len(history) > 10:
+        history[:] = history[-10:]
+
+
+@pytest.mark.unit
+def test_assistant_entry_carries_action_success_metadata():
+    """Assistant turns from satellite handler expose action_success for the agent prompt builder."""
+    history: list[dict] = []
+    _append_like_satellite_handler(
+        history,
+        user_text="Lade das Dokument hoch",
+        response_text="Entschuldigung, das konnte ich nicht ausführen: 403 Forbidden.",
+        intent={"intent": "documents.upload"},
+        action_result={"success": False, "message": "403 Forbidden"},
+    )
+
+    assistant = history[-1]
+    assert assistant["role"] == "assistant"
+    assert assistant["metadata"]["action_success"] is False
+    assert assistant["metadata"]["intent"] == "documents.upload"
+
+
+@pytest.mark.unit
+def test_assistant_metadata_missing_action_is_none():
+    """General-conversation turns (no tool run) yield metadata=None, not missing key."""
+    history: list[dict] = []
+    _append_like_satellite_handler(
+        history,
+        user_text="Wie geht es dir?",
+        response_text="Mir geht es gut, danke!",
+        intent={"intent": "general.conversation"},
+        action_result=None,
+    )
+
+    assistant = history[-1]
+    # None (no action taken) must be distinguishable from False (action failed)
+    # — the agent prompt builder only marks ``is False``, so None stays unmarked.
+    assert assistant["metadata"]["action_success"] is None
+    assert assistant["metadata"]["intent"] == "general.conversation"
+
+
+@pytest.mark.unit
+def test_metadata_survives_10_message_trim():
+    """The 10-message trim must not drop metadata from retained entries."""
+    history: list[dict] = []
+    # Simulate 8 exchanges (16 messages) — more than the 10-message budget.
+    for i in range(8):
+        success = i != 3  # turn 4 failed
+        _append_like_satellite_handler(
+            history,
+            user_text=f"Turn {i} user",
+            response_text=f"Turn {i} response",
+            intent={"intent": "documents.upload"},
+            action_result={"success": success},
+        )
+
+    assert len(history) == 10, "trim should cap at exactly 10 messages"
+    # The failed turn (turn 4, response = index 7 after trim) should still be here.
+    assistants = [m for m in history if m["role"] == "assistant"]
+    assert len(assistants) == 5, "5 assistant entries retained after trim"
+    # All retained assistant entries must still carry metadata
+    for msg in assistants:
+        assert "metadata" in msg
+        assert "action_success" in msg["metadata"]
+    # At least one failed entry should survive and be distinguishable
+    failed_turns = [m for m in assistants if m["metadata"]["action_success"] is False]
+    assert len(failed_turns) >= 1, "failed turn metadata must survive the trim"

--- a/tests/backend/test_satellite_history_metadata.py
+++ b/tests/backend/test_satellite_history_metadata.py
@@ -1,17 +1,21 @@
 """
-Regression guard for satellite_handler.py in-memory conversation history shape.
+Regression guard for the metadata contract between satellite_handler.py and the
+agent prompt builder.
 
 Context: #431 — satellite_conversation_history used to append assistant turns as
 ``{"role", "content"}`` without metadata, so the #430 marker for failed actions
 never fired on satellite-sourced history. After the fix, each assistant append
-carries ``metadata`` with ``intent`` + ``action_success``.
+carries ``metadata`` with ``intent`` + ``action_success``, produced by the
+module-level ``_build_assistant_metadata`` helper in ``satellite_handler``.
 
-These tests cover two invariants of that contract:
+These tests exercise the real helper (not a mirror) so any drift in the shape
+will fail the suite:
 
-1. The assistant entry shape includes ``metadata.action_success`` as a bool (or
-   None) so ``agent_service._build_agent_prompt`` can detect failed turns.
-2. The 10-message in-memory trim (``history[:] = history[-10:]``) preserves the
-   ``metadata`` key — i.e. nothing in the trim logic silently strips it.
+1. ``_build_assistant_metadata`` returns ``action_success`` as bool (or None)
+   so ``agent_service._build_agent_prompt`` can detect failed turns.
+2. ``None`` (no tool run) is distinguishable from ``False`` (tool failed).
+3. The 10-message in-memory trim preserves the metadata key on retained
+   entries — nothing in the trim logic silently drops it.
 
 End-to-end marker rendering is already covered by
 ``tests/backend/test_agent_service.py::test_failed_action_history_marker_present``;
@@ -19,24 +23,23 @@ these tests nail down the producer-side shape that feeds it.
 """
 import pytest
 
+from ha_glue.api.websocket.satellite_handler import _build_assistant_metadata
 
-def _append_like_satellite_handler(
+
+def _append_turn(
     history: list[dict],
     user_text: str,
     response_text: str,
     intent: dict | None,
     action_result: dict | None,
 ) -> None:
-    """Mirror the exact append pattern from satellite_handler.py.
+    """Simulate one satellite round-trip by calling the real helper and trimming.
 
-    Keep this in sync with the handler — if the real code evolves (e.g. stores
-    additional metadata keys), update this helper and the tests will cover the
-    new contract.
+    Only the trim semantics are inlined — the metadata shape comes from the
+    production ``_build_assistant_metadata``, so drift in the shape will be
+    caught by the shape-focused tests below.
     """
-    assistant_metadata = {
-        "intent": intent.get("intent") if intent else None,
-        "action_success": action_result.get("success") if action_result else None,
-    }
+    assistant_metadata = _build_assistant_metadata(intent, action_result)
     history.append({"role": "user", "content": user_text})
     history.append({
         "role": "assistant",
@@ -48,50 +51,57 @@ def _append_like_satellite_handler(
 
 
 @pytest.mark.unit
-def test_assistant_entry_carries_action_success_metadata():
-    """Assistant turns from satellite handler expose action_success for the agent prompt builder."""
-    history: list[dict] = []
-    _append_like_satellite_handler(
-        history,
-        user_text="Lade das Dokument hoch",
-        response_text="Entschuldigung, das konnte ich nicht ausführen: 403 Forbidden.",
+def test_failed_action_yields_action_success_false():
+    """Failed tool runs must produce ``action_success=False`` for the marker to fire."""
+    md = _build_assistant_metadata(
         intent={"intent": "documents.upload"},
         action_result={"success": False, "message": "403 Forbidden"},
     )
-
-    assistant = history[-1]
-    assert assistant["role"] == "assistant"
-    assert assistant["metadata"]["action_success"] is False
-    assert assistant["metadata"]["intent"] == "documents.upload"
+    assert md["action_success"] is False
+    assert md["intent"] == "documents.upload"
 
 
 @pytest.mark.unit
-def test_assistant_metadata_missing_action_is_none():
-    """General-conversation turns (no tool run) yield metadata=None, not missing key."""
-    history: list[dict] = []
-    _append_like_satellite_handler(
-        history,
-        user_text="Wie geht es dir?",
-        response_text="Mir geht es gut, danke!",
+def test_missing_action_yields_action_success_none():
+    """General-conversation turns (no tool run) produce ``None``, not ``False``.
+
+    This distinction matters because the agent prompt builder only marks
+    ``is False`` — ``None`` must stay unmarked.
+    """
+    md = _build_assistant_metadata(
         intent={"intent": "general.conversation"},
         action_result=None,
     )
+    assert md["action_success"] is None
+    assert md["intent"] == "general.conversation"
 
-    assistant = history[-1]
-    # None (no action taken) must be distinguishable from False (action failed)
-    # — the agent prompt builder only marks ``is False``, so None stays unmarked.
-    assert assistant["metadata"]["action_success"] is None
-    assert assistant["metadata"]["intent"] == "general.conversation"
+
+@pytest.mark.unit
+def test_missing_intent_yields_intent_none():
+    """Defensive: handler-level fallback sets intent at L541, but the helper must
+    tolerate ``None`` as input rather than raising AttributeError."""
+    md = _build_assistant_metadata(intent=None, action_result={"success": True})
+    assert md["intent"] is None
+    assert md["action_success"] is True
+
+
+@pytest.mark.unit
+def test_successful_action_yields_action_success_true():
+    md = _build_assistant_metadata(
+        intent={"intent": "documents.search"},
+        action_result={"success": True},
+    )
+    assert md["action_success"] is True
 
 
 @pytest.mark.unit
 def test_metadata_survives_10_message_trim():
     """The 10-message trim must not drop metadata from retained entries."""
     history: list[dict] = []
-    # Simulate 8 exchanges (16 messages) — more than the 10-message budget.
+    # Simulate 8 exchanges (16 messages) — exceeds the 10-message budget.
     for i in range(8):
-        success = i != 3  # turn 4 failed
-        _append_like_satellite_handler(
+        success = i != 3  # one failed turn
+        _append_turn(
             history,
             user_text=f"Turn {i} user",
             response_text=f"Turn {i} response",
@@ -99,14 +109,11 @@ def test_metadata_survives_10_message_trim():
             action_result={"success": success},
         )
 
-    assert len(history) == 10, "trim should cap at exactly 10 messages"
-    # The failed turn (turn 4, response = index 7 after trim) should still be here.
+    assert len(history) == 10
     assistants = [m for m in history if m["role"] == "assistant"]
-    assert len(assistants) == 5, "5 assistant entries retained after trim"
-    # All retained assistant entries must still carry metadata
+    assert len(assistants) == 5
     for msg in assistants:
         assert "metadata" in msg
         assert "action_success" in msg["metadata"]
-    # At least one failed entry should survive and be distinguishable
     failed_turns = [m for m in assistants if m["metadata"]["action_success"] is False]
     assert len(failed_turns) >= 1, "failed turn metadata must survive the trim"


### PR DESCRIPTION
## Problem

Sibling to #430. The web-chat path threads `action_success` through `ConversationSessionState.add_to_history` so the agent prompt builder can mark prior failed tool turns. The satellite path builds its own `satellite_conversation_history` list and was still appending plain `{"role", "content"}` dicts without metadata.

The `[VORHERIGE_FEHLGESCHLAGENE_AKTION]` marker therefore never fired on satellite-sourced history. The satellite flow doesn't currently go through `AgentService._build_agent_prompt` (uses `ActionExecutor` + plain `chat_stream`), so the exact "0 Steps" hallucination from #430 was not reproducible here — but an error string stored verbatim in history could still bias the next plain-chat turn.

## Fix

Build `assistant_metadata` once (intent + action_success), attach it to the in-memory assistant entry, and reuse the same dict for the DB save at the same site. No duplicated computation.

## Safety

Ollama's pydantic `Message` model silently drops unknown keys — verified in the running backend pod:

```python
>>> from ollama import Message
>>> Message(role='user', content='hi', metadata={'x': 1})
role='user' content='hi' thinking=None images=None tool_name=None tool_calls=None
```

Carrying `metadata` on satellite history entries will not leak into LLM calls regardless of which consumer (`chat_stream`, `chat_stream_with_image`, `extract_ranked_intents`) the history is passed to.

## Test

`tests/backend/test_satellite_history_metadata.py` pins the producer-side contract:

1. Assistant entry carries `metadata.action_success` as bool (or None) — distinguishable from missing key
2. General-conversation turns yield `action_success=None` (not `False`), so the marker stays suppressed
3. Metadata survives the 10-message in-memory trim (`history[:] = history[-10:]`)

End-to-end marker rendering is already covered in `test_agent_service.py::test_failed_action_history_marker_present` (#430), so the consumer side needs no duplicate coverage.

Dry-run in prod pod passed all 3 assertions:
```
len=10 assistants=5 failed_retained=1
general: action_success=None
failed: action_success=False
all 3 invariants OK
```

## Test plan

- [x] Logic dry-run against 8-round simulated satellite session
- [x] Ollama client unknown-key tolerance verified in prod pod
- [x] `py_compile` clean on `satellite_handler.py` + new test file
- [ ] CI unit tests (3 new in `test_satellite_history_metadata.py`)
- [ ] Manual: trigger a satellite action failure via voice, then re-request same action — agent should not re-cite old error

Closes #431
Related: #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)