### PR TITLE
fix(agent): give attached files a real path to Paperless (no more hallucinated base64)

### DIFF
--- a/config/mcp_servers.yaml
+++ b/config/mcp_servers.yaml
@@ -251,11 +251,18 @@ servers:
     env:
       PAPERLESS_API_URL: "${PAPERLESS_API_URL:-}"
       PAPERLESS_API_TOKEN: "${PAPERLESS_API_TOKEN:-}"
+    # Note: ``upload_document`` is intentionally NOT exposed to the agent
+    # prompt. The agent has no access to raw file bytes, so when it saw this
+    # tool it hallucinated placeholder base64 ("base64_encoded_content_of...")
+    # and Paperless rejected the garbage with HTTP 400. User-attached files go
+    # through ``internal.forward_attachment_to_paperless`` (platform tool) which
+    # reads the real bytes from chat_uploads storage. This MCP tool remains
+    # discoverable for direct code paths (chat_upload.forward_to_paperless HTTP
+    # endpoint) — prompt_tools only filters the agent-visible list.
     prompt_tools:
       - search_documents
       - get_document
       - update_document
-      - upload_document
     examples:
       de:
         - "Suche nach Rechnungen in Paperless"

--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -316,6 +316,7 @@ async def _fetch_document_context(attachment_ids: list[int], lang: str) -> str:
             text = doc.extracted_text[:max_chars] if doc.extracted_text else ""
             return prompt_manager.get(
                 "chat", "document_context_section", lang=lang,
+                attachment_id=str(doc.id),
                 filename=doc.filename or "document",
                 file_size=_format_file_size(doc.file_size),
                 document_text=text,
@@ -328,6 +329,7 @@ async def _fetch_document_context(attachment_ids: list[int], lang: str) -> str:
             text = doc.extracted_text[:per_doc_chars] if doc.extracted_text else ""
             section = prompt_manager.get(
                 "chat", "document_separator", lang=lang,
+                attachment_id=str(doc.id),
                 filename=doc.filename or "document",
                 file_size=_format_file_size(doc.file_size),
                 document_text=text,

--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -937,7 +937,7 @@ async def websocket_endpoint(
                         agent_used = True
                         orchestrated = True
                         logger.info(f"🎼 Orchestrator: {len(sub_queries)} sub-queries → {[sq.get('role') for sq in sub_queries]}")
-                        executor = ActionExecutor(mcp_manager=mcp_manager)
+                        executor = ActionExecutor(mcp_manager=mcp_manager, session_id=msg_session_id)
                         agent_tool_results = []
                         async for step in orchestrator.run_orchestrated(
                             sub_queries=sub_queries,
@@ -1012,7 +1012,7 @@ async def websocket_endpoint(
                         internal_filter=role.internal_tools,
                     )
                     agent = AgentService(tool_registry, role=role)
-                    executor = ActionExecutor(mcp_manager=mcp_manager)
+                    executor = ActionExecutor(mcp_manager=mcp_manager, session_id=msg_session_id)
 
                     agent_tool_results = []
 
@@ -1116,7 +1116,7 @@ async def websocket_endpoint(
                         intent_used = intent_candidate
                         break
 
-                    executor = ActionExecutor(mcp_manager=mcp_mgr)
+                    executor = ActionExecutor(mcp_manager=mcp_mgr, session_id=msg_session_id)
                     candidate_result = await executor.execute(
                         intent_candidate, user_permissions=user_permissions,
                         user_id=user_id,

--- a/src/backend/config/agent_roles.yaml
+++ b/src/backend/config/agent_roles.yaml
@@ -36,7 +36,7 @@ roles:
       de: "Dokumente und E-Mail: Suche in Wissensdatenbank und Paperless, Download, Versand"
       en: "Documents and email: search knowledge base and Paperless, download, send"
     mcp_servers: [paperless, email]
-    internal_tools: [internal.knowledge_search]
+    internal_tools: [internal.knowledge_search, internal.forward_attachment_to_paperless]
     max_steps: 8
     prompt_key: agent_prompt_documents
 

--- a/src/backend/prompts/agent.yaml
+++ b/src/backend/prompts/agent.yaml
@@ -212,6 +212,7 @@ de:
     - Um Dokumente per E-Mail zu versenden: (1) search_documents, (2) download_document, (3) send_email
     - Heruntergeladene Dokumente werden AUTOMATISCH als Anhaenge eingefuegt
     - Uebergib bei send_email KEINE attachments
+    - Wenn der Nutzer ein im Chat angehaengtes Dokument an Paperless senden will ("lade hoch", "sende an Paperless"), nutze IMMER internal.forward_attachment_to_paperless mit der attachment_id aus dem HOCHGELADENES DOKUMENT-Block. NIEMALS mcp.paperless.upload_document aufrufen und NIEMALS file_content_base64 erfinden — der Agent hat keinen Zugriff auf die echten Datei-Bytes.
     - Beende NICHT mit final_answer wenn noch Schritte offen sind
     - Wenn ein Such-Tool 0 Ergebnisse liefert, wiederhole NICHT dieselbe Suche. Versuche: (1) Kuerzeren Suchbegriff, (2) alternative Schreibweise, (3) anderes Tool. Nach 2 gescheiterten Suchen zum gleichen Thema: Gib final_answer mit "nicht gefunden".
     - Die finale Antwort muss natuerlich und auf Deutsch sein
@@ -771,6 +772,7 @@ en:
     - To send documents by email: (1) search_documents, (2) download_document, (3) send_email
     - Downloaded documents are AUTOMATICALLY attached
     - Do NOT pass attachments to send_email
+    - When the user wants to send a document they attached in this chat to Paperless ("upload", "send to Paperless"), ALWAYS use internal.forward_attachment_to_paperless with the attachment_id from the UPLOADED DOCUMENT block. NEVER call mcp.paperless.upload_document and NEVER invent file_content_base64 — the agent has no access to real file bytes.
     - Do NOT give final_answer if steps are still open
     - If a search tool returns 0 results, do NOT repeat the same search. Try: (1) Shorter query, (2) alternative spelling, (3) different tool. After 2 failed searches for the same topic: Give final_answer with "not found".
     - The final answer must be natural and in English

--- a/src/backend/prompts/chat.yaml
+++ b/src/backend/prompts/chat.yaml
@@ -50,18 +50,18 @@ de:
     Widerspreche ihnen nicht, es sei denn der Benutzer korrigiert dich explizit.
 
   document_context_section: |
-    HOCHGELADENES DOKUMENT ({filename}, {file_size}):
+    HOCHGELADENES DOKUMENT [attachment_id={attachment_id}] ({filename}, {file_size}):
     {document_text}
 
-    WICHTIG: Der Benutzer hat dieses Dokument hochgeladen. Beantworte Fragen basierend auf dem Dokumentinhalt. Zitiere relevante Stellen wenn moeglich.
+    WICHTIG: Der Benutzer hat dieses Dokument hochgeladen. Beantworte Fragen basierend auf dem Dokumentinhalt. Zitiere relevante Stellen wenn moeglich. Will der Nutzer das Dokument weiterleiten (z.B. an Paperless), nutze die oben angegebene attachment_id.
 
   document_context_multi_section: |
     HOCHGELADENE DOKUMENTE ({count} Dateien):
     {documents}
 
-    WICHTIG: Der Benutzer hat diese Dokumente hochgeladen. Beantworte Fragen basierend auf den Dokumentinhalten. Zitiere relevante Stellen und nenne das jeweilige Dokument.
+    WICHTIG: Der Benutzer hat diese Dokumente hochgeladen. Beantworte Fragen basierend auf den Dokumentinhalten. Zitiere relevante Stellen und nenne das jeweilige Dokument. Will der Nutzer ein Dokument weiterleiten, nutze die pro Dokument angegebene attachment_id.
 
-  document_separator: "--- DOKUMENT: {filename} ({file_size}) ---\n{document_text}"
+  document_separator: "--- DOKUMENT [attachment_id={attachment_id}]: {filename} ({file_size}) ---\n{document_text}"
 
   personality_context: |
     KOMMUNIKATIONSSTIL:
@@ -125,18 +125,18 @@ en:
     Don't contradict them unless the user explicitly corrects you.
 
   document_context_section: |
-    UPLOADED DOCUMENT ({filename}, {file_size}):
+    UPLOADED DOCUMENT [attachment_id={attachment_id}] ({filename}, {file_size}):
     {document_text}
 
-    IMPORTANT: The user has uploaded this document. Answer questions based on the document content. Cite relevant passages when possible.
+    IMPORTANT: The user has uploaded this document. Answer questions based on the document content. Cite relevant passages when possible. If the user wants to forward the document (e.g. to Paperless), use the attachment_id shown above.
 
   document_context_multi_section: |
     UPLOADED DOCUMENTS ({count} files):
     {documents}
 
-    IMPORTANT: The user has uploaded these documents. Answer questions based on the document contents. Cite relevant passages and name the respective document.
+    IMPORTANT: The user has uploaded these documents. Answer questions based on the document contents. Cite relevant passages and name the respective document. If the user wants to forward a document, use the attachment_id shown for each.
 
-  document_separator: "--- DOCUMENT: {filename} ({file_size}) ---\n{document_text}"
+  document_separator: "--- DOCUMENT [attachment_id={attachment_id}]: {filename} ({file_size}) ---\n{document_text}"
 
   personality_context: |
     COMMUNICATION STYLE:

--- a/src/backend/services/action_executor.py
+++ b/src/backend/services/action_executor.py
@@ -69,6 +69,17 @@ class ActionExecutor:
             from services.knowledge_tool import knowledge_search
             return await knowledge_search(parameters)
 
+        # Platform-owned internal tool: forward a chat attachment to Paperless.
+        # The agent passes only the attachment_id; the tool reads real file
+        # bytes from storage and calls mcp.paperless.upload_document under the
+        # hood. This removes the base64-hallucination surface the LLM had when
+        # it saw mcp.paperless.upload_document directly.
+        if intent == "internal.forward_attachment_to_paperless":
+            from services.chat_upload_tool import forward_attachment_to_paperless
+            return await forward_attachment_to_paperless(
+                parameters, mcp_manager=self.mcp_manager
+            )
+
         # Other `internal.*` intents (room resolution, media playback,
         # presence, radio) live in ha_glue and are dispatched via the
         # `execute_tool` hook. Platform-only deploys without ha_glue fall

--- a/src/backend/services/action_executor.py
+++ b/src/backend/services/action_executor.py
@@ -11,9 +11,14 @@ from loguru import logger
 class ActionExecutor:
     """Führt Intents aus und gibt Ergebnisse zurück"""
 
-    def __init__(self, mcp_manager=None):
+    def __init__(self, mcp_manager=None, session_id: str | None = None):
         # MCP system (handles HA, n8n, camera, weather, search, news, etc.)
         self.mcp_manager = mcp_manager
+        # Chat session id (WebSocket session), used by ownership-sensitive
+        # internal tools like ``forward_attachment_to_paperless`` to scope
+        # DB lookups to the user's own conversation. Optional for backwards
+        # compatibility with callers that don't carry session context.
+        self.session_id = session_id
 
     async def execute(
         self,
@@ -74,10 +79,16 @@ class ActionExecutor:
         # bytes from storage and calls mcp.paperless.upload_document under the
         # hood. This removes the base64-hallucination surface the LLM had when
         # it saw mcp.paperless.upload_document directly.
+        #
+        # ``session_id`` is forwarded so the tool can scope the DB lookup to
+        # the current user's conversation — prevents a crafted prompt from
+        # addressing an attachment uploaded in someone else's session.
         if intent == "internal.forward_attachment_to_paperless":
             from services.chat_upload_tool import forward_attachment_to_paperless
             return await forward_attachment_to_paperless(
-                parameters, mcp_manager=self.mcp_manager
+                parameters,
+                mcp_manager=self.mcp_manager,
+                session_id=self.session_id,
             )
 
         # Other `internal.*` intents (room resolution, media playback,

--- a/src/backend/services/agent_tools.py
+++ b/src/backend/services/agent_tools.py
@@ -83,9 +83,12 @@ class AgentToolRegistry:
         Args:
             internal_filter: If set, only register these tool names. None = all.
         """
+        from services.chat_upload_tool import CHAT_UPLOAD_TOOLS
         from services.knowledge_tool import KNOWLEDGE_TOOL
 
-        for name, definition in KNOWLEDGE_TOOL.items():
+        platform_tools: dict = {**KNOWLEDGE_TOOL, **CHAT_UPLOAD_TOOLS}
+
+        for name, definition in platform_tools.items():
             if internal_filter is not None and name not in internal_filter:
                 continue
 

--- a/src/backend/services/chat_upload_tool.py
+++ b/src/backend/services/chat_upload_tool.py
@@ -1,0 +1,185 @@
+"""
+Chat-Upload Tool — Platform-owned agent tool.
+
+Gives the agent a way to forward a file the user has attached in the chat
+(via the paperclip icon → ``POST /api/chat_upload``) to Paperless-NGX, without
+ever handling raw base64 bytes in the LLM scratchpad.
+
+The agent sees the ``attachment_id`` in the ``document_context`` block of its
+prompt. It calls this tool with the ID. The tool reads the real file bytes
+from server storage, base64-encodes them, and invokes
+``mcp.paperless.upload_document`` under the hood.
+
+Why this wrapper exists
+-----------------------
+Before this module, the agent had direct access to ``mcp.paperless.upload_document``
+in its tool list. Because the file bytes are never in the LLM context, the
+agent hallucinated placeholder strings like
+``"base64_encoded_content_of_the_invoice"`` and forwarded them to Paperless.
+The resulting HTTP 400 trapped the agent in retry loops. See the deploy
+chain around the Paperless-MIME and base64-validation PRs for the defensive
+layers; this tool is the architectural fix that removes the hallucination
+surface entirely.
+"""
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+from loguru import logger
+
+
+CHAT_UPLOAD_TOOLS: dict = {
+    "internal.forward_attachment_to_paperless": {
+        "description": (
+            "Forward a file the user has attached to this chat to Paperless-NGX "
+            "for OCR and archiving. Reads the file from server storage using the "
+            "attachment_id shown in the UPLOADED DOCUMENT section of this prompt. "
+            "Do NOT pass file_content_base64 — the tool does that internally from "
+            "real file bytes. Preferred over mcp.paperless.upload_document for "
+            "user-attached files."
+        ),
+        "parameters": {
+            "attachment_id": (
+                "Integer ID of the attachment shown in the UPLOADED DOCUMENT "
+                "section. Required."
+            ),
+            "title": (
+                "Optional Paperless document title. Defaults to the attachment "
+                "filename."
+            ),
+            "correspondent": "Optional Paperless correspondent name",
+            "document_type": "Optional Paperless document type name",
+            "tags": "Optional list of tag names",
+        },
+    },
+}
+
+
+async def forward_attachment_to_paperless(params: dict, mcp_manager=None) -> dict:
+    """Read a ChatUpload from server storage and forward it to Paperless.
+
+    Args:
+        params: Tool parameters from the agent (attachment_id required; title,
+            correspondent, document_type, tags optional).
+        mcp_manager: MCPManager instance, injected by ActionExecutor. Needed
+            to invoke ``mcp.paperless.upload_document`` with real base64.
+
+    Returns a standard agent-tool result dict: ``success``, ``message``,
+    ``action_taken``, and ``data`` with ``task_id``, ``attachment_id``, and
+    ``filename`` on success.
+    """
+    attachment_id_raw = params.get("attachment_id")
+    if attachment_id_raw is None:
+        return {
+            "success": False,
+            "message": "Parameter 'attachment_id' is required",
+            "action_taken": False,
+        }
+    try:
+        attachment_id = int(attachment_id_raw)
+    except (TypeError, ValueError):
+        return {
+            "success": False,
+            "message": f"'attachment_id' must be an integer, got: {attachment_id_raw!r}",
+            "action_taken": False,
+        }
+
+    if mcp_manager is None:
+        return {
+            "success": False,
+            "message": "MCP manager not available — Paperless MCP not wired in",
+            "action_taken": False,
+        }
+
+    try:
+        from sqlalchemy import select
+
+        from models.database import ChatUpload
+        from services.database import AsyncSessionLocal
+
+        async with AsyncSessionLocal() as db:
+            result = await db.execute(
+                select(ChatUpload).where(ChatUpload.id == attachment_id)
+            )
+            upload = result.scalar_one_or_none()
+
+        if not upload:
+            return {
+                "success": False,
+                "message": f"Attachment {attachment_id} not found",
+                "action_taken": False,
+            }
+
+        if not upload.file_path or not Path(upload.file_path).is_file():
+            return {
+                "success": False,
+                "message": (
+                    f"Attachment {attachment_id} ({upload.filename}) is no "
+                    "longer available on disk"
+                ),
+                "action_taken": False,
+            }
+
+        # Synchronous read is fine here — typical chat attachments are small
+        # enough (< 10 MB) that blocking for a few ms is simpler than the
+        # aiofiles dep tree, and this tool is already inside an async context
+        # that can tolerate the brief pause.
+        with open(upload.file_path, "rb") as f:
+            file_bytes = f.read()
+        file_content_base64 = base64.b64encode(file_bytes).decode("ascii")
+
+        tool_params: dict = {
+            "title": params.get("title") or upload.filename,
+            "filename": upload.filename,
+            "file_content_base64": file_content_base64,
+        }
+        if params.get("correspondent"):
+            tool_params["correspondent"] = params["correspondent"]
+        if params.get("document_type"):
+            tool_params["document_type"] = params["document_type"]
+        if params.get("tags"):
+            tool_params["tags"] = params["tags"]
+
+        mcp_result = await mcp_manager.execute_tool(
+            "mcp.paperless.upload_document", tool_params
+        )
+
+        if not mcp_result or not mcp_result.get("success"):
+            detail = (mcp_result or {}).get("message") or "unknown error"
+            return {
+                "success": False,
+                "message": f"Paperless upload failed: {detail}",
+                "action_taken": False,
+            }
+
+        # Paperless MCP returns {"task_id": ..., "title": ..., "filename": ...}
+        # wrapped inside MCPManager.execute_tool's ``message`` field as JSON.
+        task_id: str | None = None
+        inner_msg = mcp_result.get("message")
+        if isinstance(inner_msg, str):
+            try:
+                inner = json.loads(inner_msg)
+                if isinstance(inner, dict):
+                    task_id = inner.get("task_id")
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        return {
+            "success": True,
+            "message": f"Sent to Paperless: {upload.filename}",
+            "action_taken": True,
+            "data": {
+                "attachment_id": attachment_id,
+                "filename": upload.filename,
+                "task_id": task_id,
+            },
+        }
+    except Exception as e:
+        logger.error(f"forward_attachment_to_paperless error: {e}")
+        return {
+            "success": False,
+            "message": f"Forward to Paperless failed: {e!s}",
+            "action_taken": False,
+        }

--- a/src/backend/services/chat_upload_tool.py
+++ b/src/backend/services/chat_upload_tool.py
@@ -57,7 +57,11 @@ CHAT_UPLOAD_TOOLS: dict = {
 }
 
 
-async def forward_attachment_to_paperless(params: dict, mcp_manager=None) -> dict:
+async def forward_attachment_to_paperless(
+    params: dict,
+    mcp_manager=None,
+    session_id: str | None = None,
+) -> dict:
     """Read a ChatUpload from server storage and forward it to Paperless.
 
     Args:
@@ -65,6 +69,12 @@ async def forward_attachment_to_paperless(params: dict, mcp_manager=None) -> dic
             correspondent, document_type, tags optional).
         mcp_manager: MCPManager instance, injected by ActionExecutor. Needed
             to invoke ``mcp.paperless.upload_document`` with real base64.
+        session_id: Chat session the request came from. When provided, the
+            DB lookup is scoped to attachments uploaded within the same
+            session — prevents a crafted prompt from referencing an
+            attachment_id belonging to another user's conversation. When
+            ``None`` (single-user dev setup, auth disabled), the check is
+            skipped.
 
     Returns a standard agent-tool result dict: ``success``, ``message``,
     ``action_taken``, and ``data`` with ``task_id``, ``attachment_id``, and
@@ -100,9 +110,15 @@ async def forward_attachment_to_paperless(params: dict, mcp_manager=None) -> dic
         from services.database import AsyncSessionLocal
 
         async with AsyncSessionLocal() as db:
-            result = await db.execute(
-                select(ChatUpload).where(ChatUpload.id == attachment_id)
-            )
+            query = select(ChatUpload).where(ChatUpload.id == attachment_id)
+            # Session scoping: when the caller provides a session_id, the
+            # attachment must belong to that session. A mismatch is reported
+            # as "not found" rather than "forbidden" — the agent doesn't
+            # need to distinguish, and the softer message avoids leaking
+            # the existence of attachments belonging to other sessions.
+            if session_id is not None:
+                query = query.where(ChatUpload.session_id == session_id)
+            result = await db.execute(query)
             upload = result.scalar_one_or_none()
 
         if not upload:

--- a/tests/backend/test_chat_upload_tool.py
+++ b/tests/backend/test_chat_upload_tool.py
@@ -41,21 +41,36 @@ def _teardown_stubs(added: list[str]) -> None:
         sys.modules.pop(mod_name, None)
 
 
-def _make_upload(file_path: str | None, filename: str = "Invoice-001.pdf"):
+def _make_upload(
+    file_path: str | None,
+    filename: str = "Invoice-001.pdf",
+    session_id: str | None = "session-abc",
+):
     """Build a stand-in for a ``ChatUpload`` ORM row."""
     upload = MagicMock()
     upload.id = 42
     upload.filename = filename
     upload.file_path = file_path
+    upload.session_id = session_id
     return upload
 
 
-def _mock_db_returning(upload):
-    """Mock AsyncSessionLocal + query result returning the given upload (or None)."""
+def _mock_db_returning(upload, captured_query_holder: list | None = None):
+    """Mock AsyncSessionLocal + query result returning the given upload (or None).
+
+    When ``captured_query_holder`` is a list, the executed ``select`` statement
+    is appended to it so tests can assert on the resulting WHERE clause.
+    """
     mock_db = AsyncMock()
     mock_result = MagicMock()
     mock_result.scalar_one_or_none = MagicMock(return_value=upload)
-    mock_db.execute = AsyncMock(return_value=mock_result)
+
+    async def _capture_execute(stmt):
+        if captured_query_holder is not None:
+            captured_query_holder.append(stmt)
+        return mock_result
+
+    mock_db.execute = _capture_execute
 
     @asynccontextmanager
     async def mock_session():
@@ -249,6 +264,81 @@ class TestForwardAttachmentToPaperless:
             assert "Invalid base64" in result["message"]
         finally:
             Path(tmp_path).unlink(missing_ok=True)
+
+    @pytest.mark.unit
+    async def test_session_scope_filters_query(self):
+        """When session_id is passed, the DB query must include a
+        ``session_id ==`` clause to scope the lookup to the user's own
+        conversation. Without scoping the agent could reference
+        attachments from other sessions just by guessing the integer id.
+        """
+        # Upload is "found" (non-None) but we only care that the query
+        # carried the scoping clause — the tool will go on to try a
+        # filesystem read and fail, which is fine for this assertion.
+        upload = _make_upload(file_path="/tmp/nonexistent-scope-test")
+        captured: list = []
+        stubs = _stub_db_module()
+        try:
+            with patch(
+                "services.database.AsyncSessionLocal",
+                _mock_db_returning(upload, captured_query_holder=captured),
+                create=True,
+            ), patch("models.database.ChatUpload", MagicMock(), create=True):
+                await forward_attachment_to_paperless(
+                    {"attachment_id": 42},
+                    mcp_manager=AsyncMock(),
+                    session_id="session-abc",
+                )
+        finally:
+            _teardown_stubs(stubs)
+        assert len(captured) == 1, "expected exactly one DB query"
+        # The literal-compiled SQL exposes both SELECT projection and WHERE
+        # clauses. ``session_id`` appears in the SELECT list of every query
+        # (it's a column), so we count occurrences: an unscoped query has
+        # 1 mention (projection), a scoped query has 2 (projection + WHERE).
+        from sqlalchemy.dialects import sqlite
+        compiled = str(captured[0].compile(
+            compile_kwargs={"literal_binds": True},
+            dialect=sqlite.dialect(),
+        ))
+        assert compiled.count("session_id") >= 2, (
+            f"query must include session_id in WHERE clause when scoped; got:\n{compiled}"
+        )
+
+    @pytest.mark.unit
+    async def test_session_scope_none_skips_filter(self):
+        """Backwards-compat: without session_id, no scoping filter is added.
+
+        Covers legacy call sites and single-user dev setups where auth is off.
+        """
+        upload = _make_upload(file_path="/tmp/nonexistent-no-scope")
+        captured: list = []
+        stubs = _stub_db_module()
+        try:
+            with patch(
+                "services.database.AsyncSessionLocal",
+                _mock_db_returning(upload, captured_query_holder=captured),
+                create=True,
+            ), patch("models.database.ChatUpload", MagicMock(), create=True):
+                await forward_attachment_to_paperless(
+                    {"attachment_id": 42},
+                    mcp_manager=AsyncMock(),
+                    # no session_id
+                )
+        finally:
+            _teardown_stubs(stubs)
+        assert len(captured) == 1
+        from sqlalchemy.dialects import sqlite
+        compiled = str(captured[0].compile(
+            compile_kwargs={"literal_binds": True},
+            dialect=sqlite.dialect(),
+        ))
+        # session_id appears in the SELECT projection of every query (it's
+        # a column). Scoping adds it to the WHERE clause, doubling the count.
+        # Without scoping we expect exactly 1 mention.
+        assert compiled.count("session_id") == 1, (
+            f"no session scoping should be added when session_id is None; got:\n{compiled}"
+        )
 
     @pytest.mark.unit
     async def test_malformed_mcp_message_still_succeeds_with_null_task_id(self):

--- a/tests/backend/test_chat_upload_tool.py
+++ b/tests/backend/test_chat_upload_tool.py
@@ -1,0 +1,286 @@
+"""
+Tests for ``services.chat_upload_tool.forward_attachment_to_paperless``.
+
+The tool is the architectural fix for the "agent hallucinates base64" bug:
+instead of the LLM inventing ``file_content_base64`` for
+``mcp.paperless.upload_document`` (it has no access to real file bytes),
+it passes an ``attachment_id`` and this tool reads the real bytes from
+server storage and forwards them to Paperless via the MCP under the hood.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+import tempfile
+from contextlib import asynccontextmanager
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.chat_upload_tool import forward_attachment_to_paperless
+
+
+def _stub_db_module() -> list[str]:
+    """Ensure ``services.database`` is importable (asyncpg isn't installed in
+    the minimal test env). Mirrors the pattern used in test_knowledge_tool.py.
+    """
+    added: list[str] = []
+    for mod_name in ("services.database", "models.database"):
+        if mod_name not in sys.modules:
+            sys.modules[mod_name] = ModuleType(mod_name)
+            added.append(mod_name)
+    return added
+
+
+def _teardown_stubs(added: list[str]) -> None:
+    for mod_name in added:
+        sys.modules.pop(mod_name, None)
+
+
+def _make_upload(file_path: str | None, filename: str = "Invoice-001.pdf"):
+    """Build a stand-in for a ``ChatUpload`` ORM row."""
+    upload = MagicMock()
+    upload.id = 42
+    upload.filename = filename
+    upload.file_path = file_path
+    return upload
+
+
+def _mock_db_returning(upload):
+    """Mock AsyncSessionLocal + query result returning the given upload (or None)."""
+    mock_db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none = MagicMock(return_value=upload)
+    mock_db.execute = AsyncMock(return_value=mock_result)
+
+    @asynccontextmanager
+    async def mock_session():
+        yield mock_db
+
+    return mock_session
+
+
+class TestForwardAttachmentToPaperless:
+
+    @pytest.mark.unit
+    async def test_missing_attachment_id(self):
+        """Required attachment_id triggers a clear error, no DB/MCP access."""
+        result = await forward_attachment_to_paperless({}, mcp_manager=MagicMock())
+        assert result["success"] is False
+        assert "attachment_id" in result["message"]
+
+    @pytest.mark.unit
+    async def test_non_integer_attachment_id(self):
+        """Non-integer attachment_id is rejected with a message including the bad value."""
+        result = await forward_attachment_to_paperless(
+            {"attachment_id": "not-a-number"}, mcp_manager=MagicMock()
+        )
+        assert result["success"] is False
+        assert "integer" in result["message"].lower()
+
+    @pytest.mark.unit
+    async def test_missing_mcp_manager(self):
+        """Without an MCP manager the tool cannot reach Paperless — fail fast."""
+        result = await forward_attachment_to_paperless(
+            {"attachment_id": 42}, mcp_manager=None
+        )
+        assert result["success"] is False
+        assert "mcp" in result["message"].lower()
+
+    @pytest.mark.unit
+    async def test_attachment_not_found(self):
+        """Unknown attachment_id returns a not-found error."""
+        stubs = _stub_db_module()
+        try:
+            with patch(
+                "services.database.AsyncSessionLocal",
+                _mock_db_returning(None),
+                create=True,
+            ), patch("models.database.ChatUpload", MagicMock(), create=True):
+                result = await forward_attachment_to_paperless(
+                    {"attachment_id": 999}, mcp_manager=AsyncMock()
+                )
+        finally:
+            _teardown_stubs(stubs)
+        assert result["success"] is False
+        assert "999" in result["message"]
+
+    @pytest.mark.unit
+    async def test_file_missing_on_disk(self):
+        """ChatUpload row without a valid file_path returns a clear error."""
+        upload = _make_upload(file_path="/tmp/does-not-exist-123.pdf")
+        stubs = _stub_db_module()
+        try:
+            with patch(
+                "services.database.AsyncSessionLocal",
+                _mock_db_returning(upload),
+                create=True,
+            ), patch("models.database.ChatUpload", MagicMock(), create=True):
+                result = await forward_attachment_to_paperless(
+                    {"attachment_id": 42}, mcp_manager=AsyncMock()
+                )
+        finally:
+            _teardown_stubs(stubs)
+        assert result["success"] is False
+        assert "disk" in result["message"].lower()
+
+    @pytest.mark.unit
+    async def test_happy_path_calls_mcp_with_real_bytes(self):
+        """Valid attachment → real file bytes base64-encoded → MCP call carries them."""
+        pdf_bytes = b"%PDF-1.4\n" + b"x" * 200  # >= 100 bytes (MCP size floor)
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            f.write(pdf_bytes)
+            tmp_path = f.name
+
+        try:
+            upload = _make_upload(file_path=tmp_path, filename="Invoice-001.pdf")
+
+            mock_mcp = AsyncMock()
+            mock_mcp.execute_tool = AsyncMock(return_value={
+                "success": True,
+                "message": json.dumps({
+                    "task_id": "abc-123",
+                    "title": "Invoice-001.pdf",
+                    "filename": "Invoice-001.pdf",
+                }),
+            })
+
+            stubs = _stub_db_module()
+            try:
+                with patch(
+                    "services.database.AsyncSessionLocal",
+                    _mock_db_returning(upload),
+                    create=True,
+                ), patch("models.database.ChatUpload", MagicMock(), create=True):
+                    result = await forward_attachment_to_paperless(
+                        {"attachment_id": 42, "correspondent": "ACME"},
+                        mcp_manager=mock_mcp,
+                    )
+            finally:
+                _teardown_stubs(stubs)
+
+            assert result["success"] is True
+            assert result["data"]["task_id"] == "abc-123"
+            assert result["data"]["filename"] == "Invoice-001.pdf"
+            assert result["data"]["attachment_id"] == 42
+
+            # MCP was called with the REAL base64, not a placeholder
+            mock_mcp.execute_tool.assert_called_once()
+            call_args = mock_mcp.execute_tool.call_args
+            assert call_args.args[0] == "mcp.paperless.upload_document"
+            sent_params = call_args.args[1]
+            decoded = base64.b64decode(sent_params["file_content_base64"])
+            assert decoded == pdf_bytes
+            assert sent_params["filename"] == "Invoice-001.pdf"
+            assert sent_params["correspondent"] == "ACME"
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
+
+    @pytest.mark.unit
+    async def test_title_override(self):
+        """When the agent passes a title, it overrides the filename default."""
+        pdf_bytes = b"%PDF-1.4\n" + b"y" * 200
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            f.write(pdf_bytes)
+            tmp_path = f.name
+
+        try:
+            upload = _make_upload(file_path=tmp_path, filename="raw.pdf")
+            mock_mcp = AsyncMock()
+            mock_mcp.execute_tool = AsyncMock(return_value={
+                "success": True,
+                "message": json.dumps({"task_id": "t-1"}),
+            })
+
+            stubs = _stub_db_module()
+            try:
+                with patch(
+                    "services.database.AsyncSessionLocal",
+                    _mock_db_returning(upload),
+                    create=True,
+                ), patch("models.database.ChatUpload", MagicMock(), create=True):
+                    await forward_attachment_to_paperless(
+                        {"attachment_id": 42, "title": "Invoice January"},
+                        mcp_manager=mock_mcp,
+                    )
+            finally:
+                _teardown_stubs(stubs)
+
+            sent_params = mock_mcp.execute_tool.call_args.args[1]
+            assert sent_params["title"] == "Invoice January"
+            assert sent_params["filename"] == "raw.pdf"
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
+
+    @pytest.mark.unit
+    async def test_mcp_failure_surfaces_detail(self):
+        """When the MCP call fails, the detail is propagated to the agent."""
+        pdf_bytes = b"%PDF-1.4\n" + b"z" * 200
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            f.write(pdf_bytes)
+            tmp_path = f.name
+
+        try:
+            upload = _make_upload(file_path=tmp_path)
+            mock_mcp = AsyncMock()
+            mock_mcp.execute_tool = AsyncMock(return_value={
+                "success": False,
+                "message": "Invalid base64 content.",
+            })
+
+            stubs = _stub_db_module()
+            try:
+                with patch(
+                    "services.database.AsyncSessionLocal",
+                    _mock_db_returning(upload),
+                    create=True,
+                ), patch("models.database.ChatUpload", MagicMock(), create=True):
+                    result = await forward_attachment_to_paperless(
+                        {"attachment_id": 42}, mcp_manager=mock_mcp
+                    )
+            finally:
+                _teardown_stubs(stubs)
+
+            assert result["success"] is False
+            assert "Invalid base64" in result["message"]
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
+
+    @pytest.mark.unit
+    async def test_malformed_mcp_message_still_succeeds_with_null_task_id(self):
+        """MCP returns success but the inner message isn't parseable JSON — we
+        should still report success (the upload went through) with task_id=None."""
+        pdf_bytes = b"%PDF-1.4\n" + b"q" * 200
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            f.write(pdf_bytes)
+            tmp_path = f.name
+
+        try:
+            upload = _make_upload(file_path=tmp_path)
+            mock_mcp = AsyncMock()
+            mock_mcp.execute_tool = AsyncMock(return_value={
+                "success": True,
+                "message": "not json at all",
+            })
+
+            stubs = _stub_db_module()
+            try:
+                with patch(
+                    "services.database.AsyncSessionLocal",
+                    _mock_db_returning(upload),
+                    create=True,
+                ), patch("models.database.ChatUpload", MagicMock(), create=True):
+                    result = await forward_attachment_to_paperless(
+                        {"attachment_id": 42}, mcp_manager=mock_mcp
+                    )
+            finally:
+                _teardown_stubs(stubs)
+
+            assert result["success"] is True
+            assert result["data"]["task_id"] is None
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)


### PR DESCRIPTION
## Problem

The agent entered infinite retry loops on ``lade Rechnung hoch``-style requests: it invoked ``mcp.paperless.upload_document`` with a literal placeholder string (``\"base64_encoded_content_of_the_invoice\"``) because the LLM never sees the bytes of an attached file — only the OCR text. Paperless rejected the garbage with opaque HTTP 400s. Related MIME and DNS-level fixes in #429, ``renfield-mcp-paperless#3``/``#4`` addressed the 403 and the silent-decode path, but the root cause — an agent tool that requires data the agent doesn't have — remained.

## Fix

A new platform internal tool **``internal.forward_attachment_to_paperless(attachment_id, …)``**. It reads the real ``ChatUpload`` row + file from storage, base64-encodes the bytes, and invokes ``mcp.paperless.upload_document`` under the hood. The agent never handles raw bytes — it only passes an integer ID.

### Plumbing

| File | Change |
|---|---|
| ``services/chat_upload_tool.py`` *(new)* | ``CHAT_UPLOAD_TOOLS`` dict + async handler, analogous to ``knowledge_tool.py`` |
| ``services/agent_tools.py`` | ``_register_internal_tools`` merges new tools alongside ``KNOWLEDGE_TOOL`` |
| ``services/action_executor.py`` | Explicit dispatch for the new intent (it needs ``self.mcp_manager``) |
| ``api/websocket/chat_handler.py`` | ``_fetch_document_context`` passes ``attachment_id`` into the templates |
| ``prompts/chat.yaml`` *(de + en)* | Templates expose ``[attachment_id=N]`` marker and forwarding hint |
| ``prompts/agent.yaml`` — ``agent_prompt_documents`` *(de + en)* | Rule: use ``internal.forward_attachment_to_paperless``, never raw ``mcp.paperless.upload_document`` with invented base64 |
| ``config/agent_roles.yaml`` | Documents role adds the new internal tool |
| ``config/mcp_servers.yaml`` | ``upload_document`` removed from ``paperless.prompt_tools`` (still discoverable by direct-code callers via ``all_discovered_tools``) |

### Direct-code path unchanged

The frontend's ``/api/chat_upload/{id}/paperless`` endpoint (``chat_upload.forward_to_paperless``) keeps working — it calls ``manager.execute_tool(\"mcp.paperless.upload_document\", …)`` by name, which lookups against ``all_discovered_tools``, not the ``prompt_tools``-filtered set.

## Test

``tests/backend/test_chat_upload_tool.py`` covers nine cases:

1. Missing ``attachment_id``
2. Non-integer ``attachment_id``
3. Missing ``mcp_manager``
4. Attachment not in DB
5. File missing from disk
6. Happy path — asserts MCP receives **real** base64 matching on-disk bytes
7. ``title`` overrides filename
8. MCP failure surfaces detail to the agent
9. Malformed MCP response yields ``success=True`` with ``task_id=None``

Template rendering was dry-run in the prod pod with both ``de`` and ``en``; all three templates (``document_context_section``, ``document_separator``, ``document_context_multi_section``) produce the ``[attachment_id=N]`` marker cleanly.

## Relation to other PRs

- ``renfield-mcp-paperless#3`` (merged, deployed) — fixed MIME type ``application/octet-stream`` → ``application/pdf``
- ``renfield-mcp-paperless#4`` (open) — strict base64 validation, defensive against future misuse
- **This PR** — architectural fix: agent no longer has the hallucination surface

## Test plan

- [x] ``py_compile`` on all 5 edited Python files + new test file
- [x] YAML parse + key integrity on all 4 edited YAML files
- [x] Template rendering dry-run (4 lang × template combinations)
- [ ] CI unit tests (9 new in ``test_chat_upload_tool.py``)
- [ ] Manual E2E: attach PDF in chat, say ``lade nach Paperless`` — agent must call ``internal.forward_attachment_to_paperless`` with the shown attachment_id, real bytes reach Paperless, task_id returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)