### PR TITLE
docs: add Second Brain + Circles docs, catch up FEATURES.md and CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,144 @@
+# Changelog
+
+Alle markanten Änderungen an Renfield, seit Release `v1.2.0`. Format lehnt sich an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/) an; Versionierung folgt [SemVer](https://semver.org/lang/de/).
+
+---
+
+## [v2.0.0] — 2026-04-21
+
+Erste Major-Version seit `v1.0.0`. Der Sprung reflektiert drei generationelle Architektur-Schritte — **Circles / Second Brain**, **Federation v2**, **Async Worker-Split** — sowie die Umstellung auf **k8s** als Produktions-Topologie.
+
+### ⚠ Aufwärtskompatibilität
+
+- **Circles-Migration**: Bestehende Daten in `document_chunks`, `kg_entities`, `kg_relations`, `conversation_memories` erhalten über die Alembic-Migrationen aus Lane B automatisch `atom_id`- und `circle_tier`-Spalten. Default-Tier ist `2` (household) für Dokumente, `1` (trusted) für Chat-Memories. Single-User-Installationen (`AUTH_ENABLED=false`) sehen keine Verhaltensänderung — der Tier-Filter ist kurzgeschlossen.
+- **Chat-Upload ist nun asynchron**: `POST /api/chat_upload` liefert sofort mit `status=pending` und einer `upload_id`; Frontend pollt `GET /api/chat_upload/{id}` auf `status=completed`. Synchrone Upload-Clients müssen auf Polling umgestellt werden.
+- **Agent-visible Paperless-Tools**: `mcp.paperless.upload_document` wurde aus der Agent-Tool-Liste entfernt. Für den Upload angehängter Dokumente über den Chat existiert das neue `internal.forward_attachment_to_paperless` (keine Code-Änderung notwendig in nutzerseitigem Prompt — der Agent wählt das Tool automatisch).
+- **Konversations-Memory respektiert Circles**: `ConversationMemoryService.retrieve()` filtert nun nach Tier-Reichweite. Aufrufer **müssen** `user_id=asker_id` übergeben; `None` im auth-enabled Modus reduziert auf Tier 4 allein.
+
+### Hinzugefügt
+
+#### Circles & Second Brain (neu)
+
+- **Circles v1** — fünfstufige Zugriffsleiter (self, trusted, household, extended, public) pro Eigentümer, 4-Zweig-Zugriffsregel (OWNER ∨ PUBLIC ∨ EXPLICIT GRANT ∨ TIER-REACH). Lanes A/B/C in [#401](https://github.com/ebongard/renfield/pull/401), [#402](https://github.com/ebongard/renfield/pull/402), [#403](https://github.com/ebongard/renfield/pull/403).
+- **Atoms-Registry** — polymorphe Identitätsschicht über `document_chunks`, `kg_entities`, `kg_relations`, `conversation_memories`. Denormalisierte `circle_tier`- und `atom_id`-Spalten auf den Quell-Tabellen für SQL-Filter-Performance.
+- **Cross-Source-Suche** via Reciprocal Rank Fusion — `/api/atoms`, `/brain`-Page.
+- **Review-Queue** — `/brain/review` zeigt neu klassifizierbare Atome mit menschenlesbaren Labels ([#427](https://github.com/ebongard/renfield/pull/427)).
+- **KB-Share-Explosion** — `kb_shares_service` expandiert KB-Level-Shares in Per-Chunk-Grants.
+- **Explicit Grants** — Notion/Drive-Ausnahmen über `atom_explicit_grants`.
+- **Frontend-Seiten** — `/brain`, `/brain/review`, `/settings/circles`, `/settings/circles/peers`.
+- Dokumentation: [`docs/CIRCLES.md`](docs/CIRCLES.md), [`docs/SECOND_BRAIN.md`](docs/SECOND_BRAIN.md).
+
+#### Federation v2 — Multi-Peer
+
+- **F1 MCP-Streaming-Surface** — Wire-Protokoll für streamende MCP-Server ([#406](https://github.com/ebongard/renfield/pull/406), [#407](https://github.com/ebongard/renfield/pull/407)).
+- **F2 Pairing** — Ed25519-Identität + `peer_users` ([#408](https://github.com/ebongard/renfield/pull/408)).
+- **F3 query_brain** — Responder-Backend ([#410](https://github.com/ebongard/renfield/pull/410)), Asker `RemoteBrainMCPClient` ([#411](https://github.com/ebongard/renfield/pull/411)), Agent-Loop-Integration mit Ollama-Synthese ([#412](https://github.com/ebongard/renfield/pull/412)).
+- **F4 UX** — Peers-Seite + Revoke ([#413](https://github.com/ebongard/renfield/pull/413)), Pairing-QR-Modals ([#414](https://github.com/ebongard/renfield/pull/414)), Live-Progress-Relay *„frage Moms Brain…"* ([#415](https://github.com/ebongard/renfield/pull/415)), Audit-Feed unter `/brain/audit` ([#416](https://github.com/ebongard/renfield/pull/416)).
+- **F5 Robustheit** — Depth + Cycle Detection ([#417](https://github.com/ebongard/renfield/pull/417)), Per-Peer + Per-Asker Rate-Limits ([#418](https://github.com/ebongard/renfield/pull/418)), Redis-backed Pending-Request-Store ([#419](https://github.com/ebongard/renfield/pull/419)), TLS-Fingerprint-Pinning ([#420](https://github.com/ebongard/renfield/pull/420)), TOFU Auto-Pinning beim Pairing ([#421](https://github.com/ebongard/renfield/pull/421)).
+- Dokumentation: [`docs/FEDERATION_MULTI_PEER.md`](docs/FEDERATION_MULTI_PEER.md).
+
+#### Asynchrone Document-Ingestion — Worker Split
+
+- **PR A** — Infrastruktur für Async-Ingestion mit Status-Polling ([#388](https://github.com/ebongard/renfield/pull/388)).
+- **PR B** — RAGService in `extractor` / `ingestor` aufgeteilt.
+- **PR C1/C2** — Upload-Cutover, Polling-Frontend, A11y, HTTP-Semantik ([#391](https://github.com/ebongard/renfield/pull/391), [#393](https://github.com/ebongard/renfield/pull/393)).
+- Eigener `document-worker`-Deployment (siehe [`docs/DOCUMENT_WORKER_SPLIT.md`](docs/DOCUMENT_WORKER_SPLIT.md)).
+
+#### Kubernetes-Produktion
+
+- **Private GPU-Cluster** als Ziel-Deploy ([#386](https://github.com/ebongard/renfield/pull/386)) — Manifeste in `k8s/`, Blackwell-GPU-Nodes (RTX 5070 Ti / 5060 Ti), Traefik-Ingress, Harbor-artiges Private Registry.
+- Dokumentation: [`docs/KUBERNETES_DEPLOYMENT.md`](docs/KUBERNETES_DEPLOYMENT.md).
+
+#### Agent & Routing
+
+- **Orchestrator + Adaptive Cards** — parallele Sub-Agent-Koordination ([#374](https://github.com/ebongard/renfield/pull/374), [#384](https://github.com/ebongard/renfield/pull/384)).
+- **Sub-Intent Dispatch** — feingranulare Routing-Entscheidungen via Hook ([#307](https://github.com/ebongard/renfield/pull/307), [#384](https://github.com/ebongard/renfield/pull/384)).
+- **Context-aware Routing** — Entity-Pre-Routing + Keyword-Boosting ([#368](https://github.com/ebongard/renfield/pull/368)).
+- **Parallel Tool Execution** — Multi-Tool-Calls in einem Agent-Step ([#328](https://github.com/ebongard/renfield/pull/328)).
+- **Routing-Trace-Dashboard** — Admin-UI + `post_routing`-Hook ([#370](https://github.com/ebongard/renfield/pull/370)).
+- **Token-Budget-Enforcement** + Tool-Preselection + Output-Guard ([#312](https://github.com/ebongard/renfield/pull/312)).
+- **Routine-Agent** — Good-Night / Good-Morning-Sequenzen ([#271](https://github.com/ebongard/renfield/pull/271)).
+- **Stale-Tool-Error-Marker** — `[VORHERIGE_FEHLGESCHLAGENE_AKTION]` verhindert, dass historische Fehler Re-Execution blockieren ([#430](https://github.com/ebongard/renfield/pull/430)).
+- **Internal-Tool `forward_attachment_to_paperless`** — der Agent leitet angehängte Dateien an Paperless weiter, ohne jemals base64 zu sehen ([#433](https://github.com/ebongard/renfield/pull/433)).
+
+#### Auth & Multi-Tenancy
+
+- **Pluggable Authentication** via Hook-System ([#334](https://github.com/ebongard/renfield/pull/334)), `ProtectedRoute` für Chat ([#335](https://github.com/ebongard/renfield/pull/335)).
+- **Voice Authentication** per Sprechererkennung (optional).
+- **White-Label-Branding** via `VITE_APP_NAME` + `VITE_APP_LOGO_URL` ([#378](https://github.com/ebongard/renfield/pull/378), [#379](https://github.com/ebongard/renfield/pull/379)).
+
+#### RAG-Qualität
+
+- **Contextual Retrieval** + Reranking + Parent-Child-Chunking + Eval-Pipeline ([#324](https://github.com/ebongard/renfield/pull/324)).
+- **Knowledge-Graph-Scopes** — konfigurierbare Entitätstypen ([#318](https://github.com/ebongard/renfield/pull/318)).
+
+#### Memory
+
+- **Episodic Lifecycle** — Confidence Decay, Trigger-Pattern, konfigurierbares Extraktions-Modell ([#331](https://github.com/ebongard/renfield/pull/331)).
+- **Always-Inject Essential Memories** — wichtige Fakten landen unabhängig von Similarity-Score im Kontext ([#251](https://github.com/ebongard/renfield/pull/251)).
+- **Per-User Personality Style** ([#276](https://github.com/ebongard/renfield/pull/276)).
+
+#### Satellites
+
+- **Visual Queries** — Satelliten-Kamera + Vision-LLM für Fragen zum Bild vor Ort.
+- **XVF3800** USB-Array + Enviro pHAT ([#310](https://github.com/ebongard/renfield/pull/310)).
+- **Whisplay HAT**-Support.
+- **Konfigurierbare IDLE-LED-Farbe** pro Satellit.
+- **Neue Satelliten**: Esszimmer ([#292](https://github.com/ebongard/renfield/pull/292)), Arbeitszimmer, BensZimmer.
+- **Action-Success-Metadata** in Konversationshistorie — verhindert Fehler-Nachgeplapper in Follow-ups ([#431](https://github.com/ebongard/renfield/pull/431), [#432](https://github.com/ebongard/renfield/pull/432)).
+
+#### Media
+
+- **Media Follow Me** — Wiedergabe folgt dem Nutzer zwischen Räumen ([#240](https://github.com/ebongard/renfield/pull/240)).
+- **TuneIn-Radio-Integration** ([#237](https://github.com/ebongard/renfield/pull/237)).
+- **Genre-Suchhints** in Agent-Prompts ([#235](https://github.com/ebongard/renfield/pull/235)).
+- **Room-Owner-Dropdown** in Admin-UI ([#240](https://github.com/ebongard/renfield/pull/240)).
+
+#### Hook-System
+
+- **`pre_agent_context`** + **`pre_save_message`**-Hooks, erweiterte History-Window ([#302](https://github.com/ebongard/renfield/pull/302)).
+- **`execute_tool`**-Hook für Plugin-Tool-Dispatch.
+- **`token_budget_info`** + **`token_usage_info`** ContextVars für Plugins ([#409](https://github.com/ebongard/renfield/pull/409)).
+
+#### Mobile & PWA
+
+- **iOS-Capacitor-Wrapper** mit PWA-Icons für iPhone-App ([#329](https://github.com/ebongard/renfield/pull/329)).
+
+#### Admin
+
+- **Conversation Summary** — LLM-basierte Zusammenfassung + `context_vars` ([#304](https://github.com/ebongard/renfield/pull/304)).
+- **Admin-Maintenance-Page** — Knowledge-Graph-Qualität, Duplikat-Erkennung, Bulk-Cleanup.
+
+#### Plugin-Infrastruktur
+
+- **Alembic Plugin-Metadata-Discovery** ([#363](https://github.com/ebongard/renfield/pull/363)).
+- **ha_glue-aware env.py** für Autogenerate ([#357](https://github.com/ebongard/renfield/pull/357)).
+
+### Behoben
+
+- **Paperless-Upload-Chain** — URL-Suffix (`/api/api/`, [#429](https://github.com/ebongard/renfield/pull/429)), MIME-Type (`application/octet-stream` → echte Typen, `renfield-mcp-paperless#3`), Base64-Validation (`renfield-mcp-paperless#4`), Agent-Halluzination-Vermeidung ([#433](https://github.com/ebongard/renfield/pull/433)).
+- **Lifecycle AsyncSessionLocal-Shadow** — Import-Reihenfolge in `_init_mcp` ([#428](https://github.com/ebongard/renfield/pull/428)).
+- **KG useEffect-Dependency-Typo** — `scopeFilter` → `tierFilter` ([#426](https://github.com/ebongard/renfield/pull/426)).
+- **Circles Render-Fix** — `ConfirmDialogComponent` als Element, nicht Komponente ([#425](https://github.com/ebongard/renfield/pull/425)).
+- **Auth-Disabled Guards** auf verbleibende Circle/Atom-Routen ([#424](https://github.com/ebongard/renfield/pull/424)).
+- Weitere ~45 Fixes; Details im Git-Log.
+
+### Sicherheit
+
+- **Input-Guard**, **MCP-Kompaktierung**, **Memory-Defense** — Reva-Backport Prio 1 ([#311](https://github.com/ebongard/renfield/pull/311)).
+- **TLS-Cert-Pinning** für Federation-Peers.
+- **Session-Scoped Attachment-Lookup** — verhindert Cross-Session-Zugriff auf fremde Chat-Uploads ([#433](https://github.com/ebongard/renfield/pull/433) follow-up).
+
+### Dokumentation
+
+- Neu: [`docs/CIRCLES.md`](docs/CIRCLES.md), [`docs/SECOND_BRAIN.md`](docs/SECOND_BRAIN.md), [`docs/FEDERATION_MULTI_PEER.md`](docs/FEDERATION_MULTI_PEER.md), [`docs/KUBERNETES_DEPLOYMENT.md`](docs/KUBERNETES_DEPLOYMENT.md), [`docs/DOCUMENT_WORKER_SPLIT.md`](docs/DOCUMENT_WORKER_SPLIT.md).
+
+---
+
+## [v1.2.0] und früher
+
+Keine CHANGELOG-Einträge vor `v2.0.0`. Vollständige Commit-Historie: [`git log v1.0.0..v1.2.0`](https://github.com/ebongard/renfield/compare/v1.0.0...v1.2.0).
+
+---
+
+[v2.0.0]: https://github.com/ebongard/renfield/compare/v1.2.0...v2.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,24 @@ docker exec -it renfield-backend alembic downgrade -1
 
 For architecture questions, use the `architecture-guide` agent.
 
+### Platform-owned internal agent tools
+
+The agent loop sees a mix of MCP tools (`mcp.<server>.<tool>`) and `internal.*` tools. Internal tools are platform-level wrappers that bundle multi-step workflows or chain MCP calls with real server-side state. Two live on the platform core (rest live in `ha_glue`):
+
+| Tool | Purpose | Source |
+|---|---|---|
+| `internal.knowledge_search` | Semantic RAG search over the user's knowledge base | `services/knowledge_tool.py` |
+| `internal.forward_attachment_to_paperless` | Forward a chat-attached file to Paperless using real server-stored bytes — prevents the LLM from handling base64 payloads it can't actually see | `services/chat_upload_tool.py` |
+
+Dispatch for both is a special case in `services/action_executor.py` that injects dependencies the generic `intent.startswith("internal.")` hook path cannot provide (`mcp_manager`, `session_id`).
+
+### Agent stale-error marker
+
+Failed tool turns are persisted with `action_success: False` in message metadata. The `conv_context` builder in `services/agent_service.py` prepends `[VORHERIGE_FEHLGESCHLAGENE_AKTION]` to those assistant messages when re-injecting history into the next agent turn. The `conv_context_template` in `prompts/agent.yaml` carries a hint telling the LLM to treat marker lines as historical, not as current state — so a repeated user request retries the tool instead of echoing the old error.
+
 ### Circles v1 (access tiers)
+
+Detailed user-facing and architectural documentation: [`docs/CIRCLES.md`](docs/CIRCLES.md). Narrative of the broader knowledge system (the four subsystems circles protect): [`docs/SECOND_BRAIN.md`](docs/SECOND_BRAIN.md). Code-level summary below.
 
 Five-rung ladder on every source row that participates in retrieval:
 

--- a/docs/CIRCLES.md
+++ b/docs/CIRCLES.md
@@ -1,0 +1,151 @@
+# Circles — Zugriffsebenen im persönlichen Wissensnetz
+
+Renfields **Circles** sind das Autorisierungsmodell über den persönlichen Wissensdaten. Kein RBAC, kein Sharepoint-Folder: eine personenzentrische Ringstruktur, die abbildet, wie Menschen ihr Wissen im echten Leben staffeln — etwas gehört *nur mir*, etwas meinen *vertrauten Nahen*, etwas dem *Haushalt*, etwas *benannten Außenstehenden*, und ein kleiner Teil *öffentlich*.
+
+Alle Retrieval-Wege in Renfield (RAG, Knowledge Graph, Memory) ziehen Circles als Filter heran. Wer Zugriff hat, entscheidet der Circle-Graph — nicht das Dateisystem, nicht ACLs.
+
+---
+
+## Die fünf Stufen
+
+| Tier | Name | Bedeutung |
+|---|---|---|
+| 0 | **self** | nur der Eigentümer |
+| 1 | **trusted** | 1–3 engste Vertraute (Partner, enge Freunde) |
+| 2 | **household** | Familie / Mitbewohner |
+| 3 | **extended** | benannte Außenstehende (Kollegen, weitere Verwandtschaft) |
+| 4 | **public** | jeder |
+
+Die Leiter ist **monoton**: Tier *n* schließt alle niedrigeren Stufen ein. Wer im `household` ist, sieht *self* und *trusted* explizit **nicht**, aber alles was auf Tier 2 markiert ist. Eine Information erhält **eine** Tier-Zuweisung und ist damit vollständig beschrieben.
+
+**Wichtig**: die Leiter ist *pro Eigentümer* definiert. Jeder Nutzer hat eine eigene Circle-Dimension, eigene Mitgliederlisten, eigene Entscheidungen — Alice' „trusted" und Bobs „trusted" sind verschiedene Mengen.
+
+---
+
+## Zugriffsregel (4-Zweig-Filter)
+
+Ein Nutzer A sieht ein Atom mit Eigentümer O und Tier T wenn **eine** der folgenden Bedingungen erfüllt ist:
+
+1. **OWNER** — A == O (der Eigentümer sieht immer alles Eigene)
+2. **PUBLIC** — T == 4 (öffentliche Atome hat jeder)
+3. **EXPLICIT GRANT** — in `atom_explicit_grants` existiert ein Eintrag `(atom_id, granted_to_user_id=A)` (der Notion/Drive/Dropbox-Ausnahme-Fall: *„teile dieses eine Dokument mit dieser einen Person, ohne ihre Tier-Einstufung anzufassen"*)
+4. **TIER-REACH** — über `circle_memberships` ist A in einem Circle von O, dessen Tier ≤ T ist (Leiter-Reichweite)
+
+Die Vier-Zweig-Logik wird einmal zentral formuliert in `services/circle_sql.py` und in jedes Retrieval-Modul als SQL-`WHERE`-Klausel injiziert — kein Retrieval-Code schreibt die Policy selbst.
+
+**Edge-Case — Single-User-Mode**: bei `AUTH_ENABLED=false` wird die gesamte Filterlogik übersprungen (OR-Short-Circuit). Ein einzelner Nutzer sieht alles, unabhängig von Tiers.
+
+---
+
+## Atoms — der polymorphe Identitätsträger
+
+Jede „Informationseinheit" die einen Circle tragen soll, bekommt einen Eintrag in der `atoms`-Tabelle. Ein Atom ist:
+
+```
+atom_id           — UUID, primary key
+atom_type         — "document_chunk" | "kg_entity" | "kg_relation" | "conversation_memory" | ...
+source_table      — Name der Quell-Tabelle ("document_chunks", "kg_entities", ...)
+source_id         — ID in der Quell-Tabelle (Text, da heterogen)
+owner_user_id     — der Eigentümer
+policy            — JSON: {"circle_tier": 2, ...}
+```
+
+Die Quell-Tabellen tragen **denormalisiert** eine `circle_tier`- und `atom_id`-Spalte — nicht als Wahrheitsquelle, sondern als Performance-Abkürzung: das Retrieval kann in einem einzigen `JOIN` filtern, ohne jedes Mal über `atoms.policy` aufzulösen.
+
+**Invariante**: Schreibzugriffe auf source_tables gehen **ausschließlich** über `AtomService.upsert_atom`. Direkter `INSERT` in `document_chunks`/`kg_entities`/etc. ist durch Code-Review + einen CI-Lint verboten. Das garantiert, dass `atoms` und die denormalisierten Spalten nicht auseinanderlaufen.
+
+### Tier-Cascade
+
+Wenn der Eigentümer eine Tier-Änderung an einem Atom vornimmt (`PATCH /api/atoms/{id}`), kaskadiert die Änderung auf alle incidenten Relationen (bei `kg_entity`-Atoms) und aktualisiert die denormalisierten `circle_tier`-Spalten in einem Transaktions-Schritt. Konsistenz zwischen `atoms.policy` und Quell-Tabelle ist ein ACID-Commit.
+
+---
+
+## Datenmodell
+
+| Tabelle | Zweck |
+|---|---|
+| `atoms` | polymorphe Registry, ein Eintrag pro Circle-tragende Information |
+| `atom_explicit_grants` | Ausnahme-Grants: `(atom_id, granted_to_user_id, permission_level)` |
+| `circles` | Pro-User Tier-Konfiguration (optionale Anpassung der 5 Standard-Stufen) |
+| `circle_memberships` | Wer ist in welchem Tier-Ring welches Eigentümers |
+| `kb_shares` | Knowledge-Base-Level Share → explodiert in Per-Chunk-Grants (siehe `kb_shares_service.py`) |
+
+**Denormalisierte Spalten**: `document_chunks.circle_tier`, `document_chunks.atom_id`, dasselbe Paar auf `kg_entities`, `kg_relations`, `conversation_memories`.
+
+---
+
+## Retrieval-Pfade
+
+Jedes Subsystem, das Inhalte dem LLM präsentiert, wendet den Circle-Filter an:
+
+| Modul | Eingang | Filterstelle |
+|---|---|---|
+| `services/rag_retrieval.py` | `rag.search(query, user_id=asker)` | SQL-WHERE über `circle_sql.build_filter()` |
+| `services/kg_retrieval.py` | KG-Entity-Lookup aus Agent-Prompt | dieselbe `build_filter()`-Funktion |
+| `services/memory_retrieval.py` | `ConversationMemoryService.retrieve(user_id=asker)` | dito |
+| `services/polymorphic_atom_store.py` | `/api/atoms` Cross-Source-Suche | Reciprocal Rank Fusion über alle vier Atom-Typen mit Filter pro Source |
+
+**Verhaltensänderung vor/nach Circles**: `ConversationMemoryService.retrieve()` respektiert nun Circle-Reichweite — Tier-2-Haushaltsmitglieder sehen die Memories der anderen auf Tier 2. Vorher war der Filter strikt `user_id == asker_id`. Aufrufer **müssen** `user_id=asker_id` übergeben; `None` reduziert im auth-enabled Modus auf `public` (Tier 4) allein.
+
+---
+
+## Cache & Policy Resolution
+
+`services/circle_resolver.py` hält einen `PolicyEvaluator` mit In-Memory-Cache der Circle-Memberships pro Eigentümer. Der Cache wird bei Membership-Änderungen (`POST /api/circles/me/members`) invalidiert. Resolver-Aufrufe außerhalb der SQL-Filter-Pfade (z.B. einzelner `can_access_atom`-Check vor einer Schreiboperation) gehen durch diesen Cache.
+
+---
+
+## Services
+
+| Service | Zuständigkeit |
+|---|---|
+| `services/atom_service.py` | `upsert_atom`, Tier-Cascade, Atom-Löschung |
+| `services/circle_resolver.py` | `PolicyEvaluator` + Cache, Access-Checks außerhalb von SQL |
+| `services/circle_sql.py` | `build_filter(user_id)` — die zentrale WHERE-Klausel-Factory |
+| `services/polymorphic_atom_store.py` | Cross-Source-Retrieval mit RRF für `/api/atoms` |
+| `services/kb_shares_service.py` | KB-Level-Share → generiert pro Chunk einen `AtomExplicitGrant` |
+
+---
+
+## HTTP-Routen
+
+| Route | Zweck |
+|---|---|
+| `GET /api/atoms` | Unified Cross-Source-Search (`/brain` Frontend) |
+| `PATCH /api/atoms/{id}` | Tier ändern; cascade auf incidente Relationen |
+| `GET /api/circles/me` | Eigene Circle-Konfiguration laden |
+| `GET /api/circles/me/members` | Mitgliederlisten pro Tier |
+| `POST /api/circles/me/members` | Mitglied in einem Tier hinzufügen/entfernen |
+| `GET /api/circles/me/review` | Review-Queue (Atome, die der Eigentümer neu klassifizieren sollte) |
+| `GET /api/knowledge-graph/circle-tiers` | Lokalisierte Leiter-Labels (de/en) |
+| `PATCH /api/knowledge-graph/entities/{id}/circle-tier` | Tier pro KG-Entity; Cascade |
+
+---
+
+## Frontend-Seiten
+
+| Route | Funktion |
+|---|---|
+| `/brain` | Cross-Source-Suche über eigene Wissensebene |
+| `/brain/review` | Review-Queue: vom System vorgeschlagene Tier-Zuweisungen bestätigen |
+| `/settings/circles` | Circle-Mitglieder pro Stufe verwalten |
+| `/settings/circles/peers` | Federations-Peers (für externe Anfragen über die Circle-Grenze) |
+
+Shared Komponenten: `TierBadge` + `TierPicker` nutzen die `.tier-badge-{0..4}`-Utilities aus `src/frontend/src/index.css` — farbliche Zuordnung *self* (warm) → *public* (kühl), siehe `DESIGN.md`.
+
+---
+
+## Anti-Patterns
+
+- **Direkter INSERT in Source-Tabellen** — umgeht AtomService, produziert inkonsistente denormalisierte Spalten. Review blockiert.
+- **Retrieval mit `user_id=None` im auth-enabled Modus** — reduziert die Ergebnisse still auf Tier 4 alleine. Jede `rag.search()`-Call-Site muss den Asker übergeben.
+- **Tier auf Source-Tabelle statt über AtomService ändern** — die `atoms.policy`-Quelle bleibt dann falsch.
+- **Circles mit RPBAC verwechseln** — RPBAC (`docs/ACCESS_CONTROL.md`) ist eine Schicht darunter (*kann der Nutzer überhaupt mit Renfield sprechen?*); Circles ist darüber (*wessen Wissen bekommt er zu sehen?*).
+
+---
+
+## Siehe auch
+
+- [SECOND_BRAIN.md](SECOND_BRAIN.md) — Überblick über die vier Wissenssysteme, die Circles als Filter verwenden
+- [ACCESS_CONTROL.md](ACCESS_CONTROL.md) — RPBAC (Authentifizierung + Rollen, orthogonal zu Circles)
+- `CLAUDE.md` — Developer-zentrische Zusammenfassung mit Code-Referenzen

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -28,6 +28,13 @@ Renfield ist ein vollständig offline-fähiger, selbst-gehosteter **digitaler As
 - **Volltext-Suche**: Durchsuche frühere Konversationen
 - **Satellite-Sessions**: Tägliche Sessions für Voice-Commands
 
+### Dateianhänge & Weiterleitung an Paperless
+- **Paperclip-Upload**: Nutzer hängen Dateien im Chat-Eingabefeld an; `POST /api/chat_upload` speichert sie, OCR läuft asynchron
+- **OCR-Text im Kontext**: Der Agent sieht den extrahierten Text per `document_context`-Prompt-Block inklusive `[attachment_id=N]`-Marker pro Datei
+- **Natürliche Weiterleitung nach Paperless**: „Lade diese Rechnung nach Paperless hoch" → Agent ruft `internal.forward_attachment_to_paperless(attachment_id=N)` auf; die Datei wird **direkt von Server-Storage** gelesen und als echte Bytes zum Paperless-MCP geleitet — der Agent handhabt nie Base64-Inhalte und kann daher nichts halluzinieren
+- **Session-Scope**: Die Attachment-Lookup ist auf die Chat-Session des Nutzers beschränkt — kein Cross-Session-Zugriff auf fremde Uploads
+- **HTTP-Fallback**: `POST /api/chat_upload/{id}/paperless` als direkter Endpoint für Frontend-Buttons (ohne LLM im Loop)
+
 ## Sprach-Interface
 
 ### Speech-to-Text (STT)
@@ -56,6 +63,23 @@ Siehe [SPEAKER_RECOGNITION.md](SPEAKER_RECOGNITION.md) für Details.
 - **Audio-Ausgabe**: Antwort wird per TTS über DLNA-Renderer oder Satellite-Speaker abgespielt
 
 Siehe [SATELLITE_CAMERA.md](SATELLITE_CAMERA.md) für Details.
+
+## Second Brain — Persönliches Wissensnetz
+
+Renfield pflegt für jeden Nutzer ein persönliches Wissenssystem aus vier Informationsarten — Dokument-Chunks (RAG), Conversation Memories, Knowledge-Graph-Entities und -Relations — die über eine gemeinsame Atom-Registry ansprechbar sind. Cross-Source-Suche unter `/brain` fusioniert die vier Quellen via Reciprocal Rank Fusion.
+
+Siehe [SECOND_BRAIN.md](SECOND_BRAIN.md) für den narrativen Überblick und das Ingestion-Flow.
+
+## Zugriffsebenen (Circles)
+
+Eigentum und Sichtbarkeit wird über die **Circles** modelliert — eine fünfstufige Leiter (`self`, `trusted`, `household`, `extended`, `public`), die die reale Weitergabe-Intuition abbildet: etwas gehört mir, etwas meinen Vertrauten, etwas dem Haushalt, etwas benannten Externen, ein kleiner Teil öffentlich.
+
+- Jedes Atom trägt **eine** Tier-Zuweisung
+- Pro-Eigentümer-Dimension: Alice' `trusted` ist nicht Bobs `trusted`
+- Vier-Zweig-Zugriffsregel: OWNER ∨ PUBLIC ∨ EXPLICIT GRANT ∨ TIER-REACH
+- `AUTH_ENABLED=false` short-circuited den Filter (Single-User-Mode)
+
+Siehe [CIRCLES.md](CIRCLES.md) für Datenmodell, Services, Routen und Frontend-Seiten.
 
 ## Konversations-Gedächtnis (Langzeit)
 
@@ -169,6 +193,10 @@ Einfache Medien-Befehle (`stop`, `pause`, `play`, `skip`, `weiter`, `leiser`, `l
 
 Der Agent bricht automatisch ab, wenn wiederholte Suchen (z.B. Jellyfin-Suche) keine neuen Ergebnisse liefern. Verhindert Endlos-Schleifen bei nicht-vorhandenen Medien.
 
+### Stale-Tool-Error-Schutz
+
+Frühere fehlgeschlagene Aktionen werden im `KONVERSATIONS-KONTEXT` mit dem Marker `[VORHERIGE_FEHLGESCHLAGENE_AKTION]` gekennzeichnet. Der Agent-Prompt weist explizit darauf hin, dass solche historischen Fehler **nicht** den aktuellen Zustand belegen — fordert der Nutzer dieselbe Aktion erneut an, wird das Tool neu ausgeführt statt mit einer alten Fehlermeldung zu antworten. Der Marker wird aus dem `action_success`-Metadatum am Message-Turn abgeleitet.
+
 ### Konfiguration
 
 ```env
@@ -223,7 +251,7 @@ Alle externen Integrationen laufen als MCP-Server. Tools werden automatisch als 
 | **jellyfin** | stdio (Python) | Media Server | 13 (Musik, Filme, Serien) |
 | **dlna** | streamable_http | DLNA Renderer (Gapless Queue Playback) | 7 (Play, Stop, Queue, Transport) |
 | **n8n** | stdio (npx) | Workflow Automation | 12 (Workflow CRUD, Templates) |
-| **paperless** | stdio (Python) | Dokumenten-Management | 1+ |
+| **paperless** | stdio (Python) | Dokumenten-Management | 4 agentsichtbar (search, get, update, download); `upload_document` ist bewusst nicht im Agent-Prompt — siehe `internal.forward_attachment_to_paperless` |
 | **email** | stdio (Python) | Multi-Account IMAP/SMTP | 4 (List, Search, Read, Send) |
 | **homeassistant** | streamable_http | Smart Home | 5+ (Steuerung, Status) |
 

--- a/docs/SECOND_BRAIN.md
+++ b/docs/SECOND_BRAIN.md
@@ -1,0 +1,136 @@
+# Second Brain — Persönliches Wissenssystem in Renfield
+
+Renfield pflegt für jeden Nutzer ein persönliches Wissensnetz: ein „zweites Gehirn", aufgebaut aus vier Informationsarten, die unterschiedlich gewonnen und gespeichert werden, aber über eine gemeinsame Identitäts- und Zugriffsschicht als ein einziges Gedächtnis ansprechbar sind. Nichts davon wird in eine Cloud ausgelagert — Ingestion, Embedding, Indizierung, Retrieval laufen vollständig lokal.
+
+Dieses Dokument beschreibt das Zusammenspiel. Für die einzelnen Subsysteme existieren dedizierte Abschnitte in [`FEATURES.md`](FEATURES.md); für die Zugriffslogik siehe [`CIRCLES.md`](CIRCLES.md).
+
+---
+
+## Die vier Informationsarten
+
+| Typ | Quelle | Extraktion | Persistenz |
+|---|---|---|---|
+| **Dokument-Chunks** (RAG) | Datei-Uploads (PDF, DOCX, TXT, Markdown, Bilder mit OCR) | Parsing + Chunking + Embedding | `document_chunks` (pgvector) |
+| **Conversation Memories** (Langzeit) | Chat- und Sprach-Turns | LLM-Extraktion nach Relevanz-Gate | `conversation_memories` (pgvector) |
+| **KG-Entities** | Dokumente **und** Konversationen | LLM-Extraktion (strukturiertes JSON) | `kg_entities` (pgvector + Graph-Kanten) |
+| **KG-Relations** | Entity-Kontexte | LLM im KG-Extraction-Step | `kg_relations` (gerichtet) |
+
+Jede dieser Zeilen trägt zwei denormalisierte Spalten: `atom_id` (Verweis auf die polymorphe Registry) und `circle_tier`. Das lässt ein Retrieval in einem einzigen SQL-Statement sowohl joinen als auch zugriffskontrollieren.
+
+---
+
+## Gemeinsame Identität — der Atoms-Layer
+
+Die vier Informationsarten leben in verschiedenen Tabellen mit verschiedenen Schemata. Die `atoms`-Registry hebt sie auf eine gemeinsame Ebene:
+
+```
+                                 ┌──────────────────────┐
+                                 │   atoms (registry)   │
+                                 ├──────────────────────┤
+                                 │  atom_id  (UUID)     │
+                                 │  atom_type           │
+                                 │  source_table        │
+                                 │  source_id           │
+                                 │  owner_user_id       │
+                                 │  policy (JSON)       │
+                                 └──────────────────────┘
+                                            ▲
+             ┌──────────────────┬───────────┼───────────────┬───────────────────┐
+             │                  │           │               │                   │
+ ┌───────────┴─────────┐ ┌──────┴──────┐ ┌──┴──────────┐ ┌──┴──────────────┐
+ │   document_chunks   │ │ kg_entities │ │ kg_relations │ │ conversation_   │
+ │   (atom_id FK,      │ │ (atom_id,   │ │ (atom_id,    │ │ memories        │
+ │    circle_tier)     │ │  tier)      │ │  tier)       │ │ (atom_id, tier) │
+ └─────────────────────┘ └─────────────┘ └──────────────┘ └─────────────────┘
+```
+
+Jeder Schreibzugriff auf eine der Quell-Tabellen läuft über `services/atom_service.py::upsert_atom`. Direkte `INSERT`s sind durch Code-Review + einen CI-Lint verboten. Die Invariante: `atoms.policy` ist die Wahrheit, die denormalisierten Spalten sind der Performance-Schatten.
+
+---
+
+## Retrieval — Cross-Source mit Rang-Fusion
+
+Wenn ein Nutzer fragt *„Was weiß ich über Am Stirkenbend 20?"*, will er keine Treffer-Liste pro Subsystem — er will **eine** Antwort, in der alle vier Informationsarten vertreten sein können.
+
+`services/polymorphic_atom_store.py` löst das per **Reciprocal Rank Fusion (RRF)**:
+
+1. Parallele Vektorsuche gegen alle vier Quell-Tabellen mit der Query-Embedding.
+2. Jede Quell-Tabelle liefert ihr Top-*k* unter Berücksichtigung des Circle-Filters (`services/circle_sql.build_filter`).
+3. RRF berechnet einen kombinierten Rang-Score pro Atom anhand der Position in den jeweiligen Ergebnislisten.
+4. Die fusionierte Top-*n*-Liste wandert zurück zum Aufrufer, angereichert mit Source-Metadaten (Dokumenttitel, Entity-Label, Memory-Kategorie).
+
+Der API-Endpunkt `/api/atoms` und die `/brain`-Frontend-Seite exponieren genau diesen Weg.
+
+Die spezialisierten Retrieval-Pfade bleiben daneben erhalten:
+
+- **RAG** (`services/rag_retrieval.py`) — wenn der Agent explizit nach Dokumenten sucht
+- **KG** (`services/kg_retrieval.py`) — wenn Entity-Resolution nötig ist
+- **Memory** (`services/memory_retrieval.py` / `ConversationMemoryService.retrieve`) — im Chat-Handler als Prompt-Kontext
+
+Alle drei nutzen dieselbe `circle_sql.build_filter`-Klausel, sodass Circle-Reichweite in jedem Pfad identisch angewendet wird.
+
+---
+
+## Ingestion — wie Wissen entsteht
+
+```
+┌─────────────┐    ┌────────────────┐    ┌──────────────────┐
+│  Datei      │───▶│ chat_upload    │───▶│ extraction       │
+│  (Paperclip)│    │ (+ ChatUpload) │    │ (Docling/PDF/    │
+└─────────────┘    └────────────────┘    │  OCR)            │
+                                          └────────┬─────────┘
+                                                   ▼
+                                          ┌──────────────────┐
+                                          │ RAGService       │
+                                          │ .ingest_document │─┐
+                                          └──────────────────┘ │
+                                                               ▼
+                                          ┌──────────────────────────┐
+                                          │ atoms + document_chunks  │
+                                          │ (mit circle_tier)        │
+                                          └──────────────────────────┘
+                                                   │
+                                                   ▼
+                                          ┌──────────────────────────┐
+                                          │ Hook: post_document_     │
+                                          │ ingest                   │
+                                          │  └─▶ KG-Extraction       │
+                                          │  └─▶ Paperless-Audit     │
+                                          │  └─▶ Custom Plugins      │
+                                          └──────────────────────────┘
+```
+
+**Chat-Memory** läuft analog, aber als Hintergrund-Task nach jeder Chat-Response (`_extract_memories_background` in `chat_handler.py`). Eine mehrstufige Gate-Kette (Stage 1–4) entscheidet, ob eine Konversation memorable Fakten enthielt; wenn ja, extrahiert ein LLM-Call die Fakten und legt sie als `conversation_memories` an — wieder mit Atom-Registrierung und Tier-Zuweisung.
+
+**KG-Extraktion** läuft sowohl bei Dokument-Ingest (als Hook) als auch bei Chat-Memory-Ingest. Derselbe LLM-Prompt, unterschiedliche Quell-Kontexte. Entity-Deduplizierung per Cosine-Similarity (Embedding-basiert) verhindert das Anlegen von `Eduard van den Bongard` und `Eduard` als zwei Entitäten.
+
+---
+
+## Tier-Defaults und Tier-Review
+
+Neue Atome erhalten einen **Default-Tier** — aktuell `2` (household) bei Dokument-Uploads, `1` (trusted) bei KG-Entities aus Chat-Memories. Die Defaults sind bewusst eher einschränkend: was nicht ausdrücklich geteilt wurde, bleibt nah am Eigentümer.
+
+`/brain/review` listet Atome, die der Eigentümer neu klassifizieren sollte — neue Uploads, Entities mit Tier-Konflikten zwischen Relationen, Memories die ein Gate knapp passiert haben. Der Eigentümer kann dort batch-weise Tiers setzen; die Tier-Cascade propagiert auf incidente Relationen.
+
+---
+
+## Federation — Zweite Gehirne, die sich begegnen
+
+Zwei paarweise verbundene Renfield-Instanzen können Queries über die Circle-Grenze schicken: Nutzer A auf Maschine M1 fragt, Nutzer B auf M2 antwortet aus seinem Second Brain — aber nur mit Atomen, für die B's Circles den Leseranger A enthalten. Details siehe [`FEDERATION_MULTI_PEER.md`](FEDERATION_MULTI_PEER.md). Der Circle-Filter läuft dabei **auf der Responder-Seite** — A bekommt nie zu sehen, was er nicht sehen darf, nicht weil M1 filtert, sondern weil M2 gar nichts anderes zurückgibt.
+
+---
+
+## Daten-Besitz
+
+Atome gehören immer **genau einem** `owner_user_id`. Es gibt keine geteilten Atome ohne expliziten Grant — das Modell kennt keinen „shared folder" mit Eigentum-am-Ordner. Das hält die Verantwortlichkeit scharf: wer ein Atom löscht, löscht *sein* Atom; was Mitglieder niedrigerer Tiers davon sehen, war nie *ihres*.
+
+Konsequenz: bei User-Löschung werden alle Atome des Nutzers kaskadierend gelöscht. `AtomExplicitGrant`-Einträge zu anderen Nutzern ebenso. Dort wo KG-Relations auf gelöschte Entitäten zeigen, werden sie mit-abgeräumt.
+
+---
+
+## Siehe auch
+
+- [CIRCLES.md](CIRCLES.md) — Zugriffsebenen-Modell, Datentabellen und Retrieval-Filter im Detail
+- [FEATURES.md](FEATURES.md) — Einzel-Feature-Beschreibungen (RAG, Memory, KG)
+- [ACCESS_CONTROL.md](ACCESS_CONTROL.md) — RPBAC-Schicht darunter (Authentifizierung + Rollen)
+- [FEDERATION_MULTI_PEER.md](FEDERATION_MULTI_PEER.md) — Cross-Instance-Queries über die Circle-Grenze


### PR DESCRIPTION
## Problem

Two central concepts — **Circles** (the access-tier model on top of atoms) and **Second Brain** (the four knowledge subsystems that circles protect) — were implemented and live in production but only described in CLAUDE.md's code-reference form. Users and new contributors had no entry point; the 4-branch access rule, the atoms polymorphic registry, and the cross-source RRF retrieval were effectively tribal knowledge.

## What this PR adds

### Dedicated docs

- **``docs/CIRCLES.md``** — covers the 5-rung ladder, the 4-branch access rule (OWNER ∨ PUBLIC ∨ EXPLICIT GRANT ∨ TIER-REACH), the atoms registry as the canonical policy source with denormalized ``circle_tier`` columns as the performance shadow, tier cascade semantics, the kb_shares → atom_explicit_grants explosion, all services + routes + frontend pages, and a short anti-pattern list (direct INSERTs, ``user_id=None`` silent reduction to Tier 4, tier-change outside AtomService).
- **``docs/SECOND_BRAIN.md``** — narrative overview: the four information types (document chunks / conversation memories / KG entities / KG relations), the atoms layer that unifies them, cross-source Reciprocal Rank Fusion at ``/api/atoms``, ingestion flow from upload through RAG + post_document_ingest hook to KG extraction, tier defaults + the ``/brain/review`` queue, and the federation angle.

### FEATURES.md updates

- New top-level sections **Second Brain** and **Zugriffsebenen (Circles)** as user-facing entry points linking to the deep docs.
- Chat-attachment → Paperless feature block documenting the paperclip-upload flow and the new ``internal.forward_attachment_to_paperless`` tool (shipped in #433).
- Stale-tool-error marker section — the ``[VORHERIGE_FEHLGESCHLAGENE_AKTION]`` convention from #430.
- Paperless MCP table row corrected to reflect the agent-visible tool count after ``upload_document`` was filtered out of ``prompt_tools``.

### CLAUDE.md updates

- New *Platform-owned internal agent tools* section — table covering ``internal.knowledge_search`` and the new ``internal.forward_attachment_to_paperless``, with notes on the special-case dispatch in ``action_executor.py``.
- New *Agent stale-error marker* section — short dev-reference for the marker + ``conv_context_template`` mechanism.
- Circles section opens with pointers to the new ``docs/CIRCLES.md`` and ``docs/SECOND_BRAIN.md`` — keeps the terse code-reference for developers while external readers get the narrative.

## Non-goals

- No code changes. Purely documentation.
- Not a style rewrite of existing docs — only adds the missing coverage and corrects the Paperless MCP table row.

## Test plan

- [x] Markdown renders (no broken tables, all internal links resolve within the repo)
- [x] No mention of implementation details that don't exist (``atoms`` / ``circle_memberships`` / ``atom_explicit_grants`` tables verified in ``models/database.py``, services verified by grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)