### PR TITLE
fix(config): register forward_attachment_to_paperless in the production-used agent_roles.yaml

### DIFF
--- a/config/agent_roles.yaml
+++ b/config/agent_roles.yaml
@@ -36,7 +36,7 @@ roles:
       de: "Dokumente und E-Mail: Suche in Wissensdatenbank und Paperless, Download, Versand"
       en: "Documents and email: search knowledge base and Paperless, download, send"
     mcp_servers: [paperless, email]
-    internal_tools: [internal.knowledge_search]
+    internal_tools: [internal.knowledge_search, internal.forward_attachment_to_paperless]
     max_steps: 8
     prompt_key: agent_prompt_documents
 


### PR DESCRIPTION
## Problem

#433 added ``internal.forward_attachment_to_paperless`` to the documents role in ``src/backend/config/agent_roles.yaml``. That file is a stale duplicate — the **actually mounted** copy, served via the ``renfield-mcp-config`` ConfigMap into ``/app/config/agent_roles.yaml``, is the top-level ``config/agent_roles.yaml``.

Verified during post-deploy smoke test:

\`\`\`
$ kubectl exec backend-... -- yq '.roles.documents.internal_tools' /app/config/agent_roles.yaml
[internal.knowledge_search]   # <-- missing the new tool
\`\`\`

Result: the architectural fix merged to main, the new image carried the tool implementation, but the agent's documents role never saw the tool in its loadout at runtime. The Paperless-upload flow would still have fallen back to the old hallucination path.

## Fix

One-line addition to the top-level ``config/agent_roles.yaml``.

A separate follow-up should consolidate or delete the ``src/backend/config/*.yaml`` duplicates to prevent this drift (the two copies have been diverging for a while — the top-level has ``play_album_on_dlna``, ``play_radio``, routine role, etc.).

## Deploy

After merge:

\`\`\`bash
kubectl -n renfield delete configmap renfield-mcp-config
kubectl -n renfield create configmap renfield-mcp-config \\
  --from-file=mcp_servers.yaml=config/mcp_servers.yaml \\
  --from-file=agent_roles.yaml=config/agent_roles.yaml \\
  --from-file=kg_scopes.yaml=config/kg_scopes.yaml \\
  --from-file=mail_accounts.yaml=config/mail_accounts.default.yaml
kubectl -n renfield rollout restart deploy/backend deploy/document-worker
\`\`\`

No new image needed — ConfigMap-only change.

Related: #433, `renfield-mcp-paperless#3`, `renfield-mcp-paperless#4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)