### PR TITLE
fix(kg): register new entities + relations in the atoms table

### DIFF
--- a/src/backend/services/knowledge_graph_service.py
+++ b/src/backend/services/knowledge_graph_service.py
@@ -109,6 +109,87 @@ class KnowledgeGraphService:
     def __init__(self, db: AsyncSession):
         self.db = db
         self._ollama_client = None
+        # Cached fallback owner id — resolved lazily via _resolve_owner_user_id
+        # when a writer doesn't carry an authenticated user (auth disabled, or
+        # background jobs extracted from anonymous context). Matches the
+        # migration's back-fill pattern: "first user by id" (see
+        # pc20260420_circles_v1_schema.py:344).
+        self._fallback_owner_id: int | None = None
+
+    async def _resolve_owner_user_id(self, user_id: int | None) -> int | None:
+        """Resolve a non-null owner for atom rows, or None if unavailable.
+
+        Falls back to the first user's id when ``user_id`` is None — matches
+        the migration's back-fill pattern (pc20260420_circles_v1_schema.py:344).
+        Returns None only in dev setups (empty users table) where atom
+        registration is skipped and the source row is written with
+        ``atom_id=None``. Production always has the admin user from
+        bootstrap, so this is never None in real deploys.
+        """
+        if user_id is not None:
+            return user_id
+        if self._fallback_owner_id is not None:
+            return self._fallback_owner_id
+        from models.database import User
+        result = await self.db.execute(
+            select(User.id).order_by(User.id.asc()).limit(1)
+        )
+        fallback = result.scalar()
+        if fallback is None:
+            return None
+        self._fallback_owner_id = int(fallback)
+        return self._fallback_owner_id
+
+    async def _create_atom_for_new_source(
+        self,
+        atom_type: str,
+        owner_user_id: int,
+        tier: int,
+    ) -> str:
+        """Pre-create an ``atoms`` row before inserting the source row.
+
+        The source-table ``atom_id`` columns carry a NOT NULL constraint and
+        a non-deferrable FK back to ``atoms.atom_id`` (per the
+        pc20260420_circles_v1 migration). That means the atoms row must
+        already exist when the source-row INSERT fires. The source row's
+        primary key is auto-incremented and only known after flush, so we
+        seed ``atoms.source_id`` with a unique placeholder; the caller
+        invokes :meth:`_finalize_atom_source_id` after flushing the source
+        row to overwrite the placeholder with the real PK.
+        """
+        from datetime import UTC, datetime
+        import uuid as _uuid
+        from models.database import Atom as AtomORM
+        atom_id = str(_uuid.uuid4())
+        source_table = {
+            "kg_node": "kg_entities",
+            "kg_edge": "kg_relations",
+        }[atom_type]
+        placeholder = f"__pending__{atom_id}"
+        now = datetime.now(UTC).replace(tzinfo=None)
+        atom_row = AtomORM(
+            atom_id=atom_id,
+            atom_type=atom_type,
+            source_table=source_table,
+            source_id=placeholder,
+            owner_user_id=int(owner_user_id),
+            policy={"tier": int(tier)},
+            created_at=now,
+            updated_at=now,
+        )
+        self.db.add(atom_row)
+        await self.db.flush()
+        return atom_id
+
+    async def _finalize_atom_source_id(self, atom_id: str, source_id: int) -> None:
+        """Replace the placeholder ``source_id`` on an atoms row with the
+        freshly-flushed source-row's primary key."""
+        from models.database import Atom as AtomORM
+        atom = (await self.db.execute(
+            select(AtomORM).where(AtomORM.atom_id == atom_id)
+        )).scalar_one()
+        atom.source_id = str(source_id)
+        await self.db.flush()
 
     async def _get_ollama_client(self):
         if self._ollama_client is None:
@@ -366,16 +447,41 @@ class KnowledgeGraphService:
         # promote later via /api/atoms/{id}/tier. The scope column is gone
         # but the model declaration retains it for back-compat (Lane C
         # cleanup will remove the ORM stub).
+        #
+        # Atom registration order matters here: the kg_entities.atom_id
+        # column is NOT NULL with a non-deferrable FK to atoms.atom_id, so
+        # the atoms row must exist BEFORE the entity INSERT (see #438).
+        # We pre-create with a placeholder source_id, INSERT the entity
+        # carrying the just-minted atom_id, then patch the atoms row's
+        # source_id once entity.id is known.
+        owner_id = await self._resolve_owner_user_id(user_id)
+        default_tier = 0
+        # owner_id is None only in dev/test setups with an empty users table;
+        # in that path we skip atom registration and write the entity with
+        # atom_id=None (the source-row ORM column is nullable). Production
+        # always has the bootstrap admin, so the atom-backed path is the one
+        # that actually runs.
+        atom_id: str | None = None
+        if owner_id is not None:
+            atom_id = await self._create_atom_for_new_source(
+                atom_type="kg_node",
+                owner_user_id=owner_id,
+                tier=default_tier,
+            )
         entity = KGEntity(
-            user_id=user_id,
+            user_id=owner_id,
             name=name,
             entity_type=entity_type if entity_type in KG_ENTITY_TYPES else "thing",
             description=description,
             embedding=embedding,
+            atom_id=atom_id,
+            circle_tier=default_tier,
         )
         self.db.add(entity)
         await self.db.flush()
-        logger.debug(f"KG: New entity '{name}' ({entity_type}) id={entity.id}")
+        if atom_id is not None:
+            await self._finalize_atom_source_id(atom_id, entity.id)
+        logger.debug(f"KG: New entity '{name}' ({entity_type}) id={entity.id} atom_id={atom_id}")
         return entity
 
     async def _find_similar_entity(
@@ -472,17 +578,43 @@ class KnowledgeGraphService:
             await self.db.flush()
             return existing
 
+        # Inherit the relation's circle_tier from MIN(subject_tier, object_tier)
+        # — the relation can be no more visible than the more-restricted endpoint
+        # (CEO Finding E cascade rule, mirrors AtomService.update_tier:198-210).
+        endpoints = (await self.db.execute(
+            select(KGEntity.circle_tier).where(KGEntity.id.in_([subject_id, object_id]))
+        )).scalars().all()
+        relation_tier = min(endpoints) if endpoints else 0
+
+        # Same atom-first ordering as _get_or_create_entity: kg_relations.atom_id
+        # is NOT NULL with a non-deferrable FK, so the atoms row is pre-created
+        # with a placeholder source_id and patched after the relation flushes.
+        owner_id = await self._resolve_owner_user_id(user_id)
+        atom_id: str | None = None
+        if owner_id is not None:
+            atom_id = await self._create_atom_for_new_source(
+                atom_type="kg_edge",
+                owner_user_id=owner_id,
+                tier=relation_tier,
+            )
         relation = KGRelation(
-            user_id=user_id,
+            user_id=owner_id,
             subject_id=subject_id,
             predicate=predicate,
             object_id=object_id,
             confidence=confidence,
             source_session_id=source_session_id,
+            atom_id=atom_id,
+            circle_tier=relation_tier,
         )
         self.db.add(relation)
         await self.db.flush()
-        logger.debug(f"KG: New relation {subject_id} --{predicate}--> {object_id}")
+        if atom_id is not None:
+            await self._finalize_atom_source_id(atom_id, relation.id)
+        logger.debug(
+            f"KG: New relation {subject_id} --{predicate}--> {object_id} "
+            f"atom_id={atom_id} tier={relation_tier}"
+        )
         return relation
 
     # =========================================================================

--- a/tests/backend/test_knowledge_graph_service.py
+++ b/tests/backend/test_knowledge_graph_service.py
@@ -166,6 +166,99 @@ class TestResolveEntity:
 # Save Relation
 # ==========================================================================
 
+class TestAtomRegistration:
+    """New entities and relations must register with the atoms table so they
+    participate in circle-aware retrieval. Regression guard for #438 — the
+    kg_entities.atom_id / kg_relations.atom_id columns are NOT NULL + FK to
+    atoms.atom_id in production; without pre-creating the atoms row, every
+    KG extraction after a document ingest failed with an IntegrityError."""
+
+    @pytest.mark.unit
+    async def test_new_entity_gets_atom_id_when_user_exists(
+        self, kg_service, db_session, test_user
+    ):
+        """When a user is present, a new entity gets an atom_id and a matching
+        atoms row (source_id points at the entity PK, atom_type='kg_node')."""
+        from models.database import Atom as AtomORM
+        kg_service._find_similar_entity = AsyncMock(return_value=None)
+
+        result = await kg_service.resolve_entity(
+            "Acme", "organization", user_id=test_user.id,
+        )
+
+        assert result.atom_id is not None, "new entity must carry an atom_id"
+        atom = (await db_session.execute(
+            select(AtomORM).where(AtomORM.atom_id == result.atom_id)
+        )).scalar_one()
+        assert atom.atom_type == "kg_node"
+        assert atom.source_table == "kg_entities"
+        assert atom.source_id == str(result.id)  # placeholder was patched
+        assert atom.owner_user_id == test_user.id
+        assert atom.policy["tier"] == 0
+
+    @pytest.mark.unit
+    async def test_new_relation_gets_atom_id(
+        self, kg_service, db_session, test_user
+    ):
+        """save_relation creates the matching atoms row with atom_type='kg_edge'
+        and the source_id pointing at the relation's PK after flush."""
+        from models.database import Atom as AtomORM
+        # Route resolve_entity through the service so both entities get atoms.
+        kg_service._find_similar_entity = AsyncMock(return_value=None)
+        subj = await kg_service.resolve_entity("Alice", "person", user_id=test_user.id)
+        obj = await kg_service.resolve_entity("Bob", "person", user_id=test_user.id)
+
+        relation = await kg_service.save_relation(
+            subject_id=subj.id,
+            predicate="knows",
+            object_id=obj.id,
+            user_id=test_user.id,
+        )
+
+        assert relation.atom_id is not None
+        atom = (await db_session.execute(
+            select(AtomORM).where(AtomORM.atom_id == relation.atom_id)
+        )).scalar_one()
+        assert atom.atom_type == "kg_edge"
+        assert atom.source_table == "kg_relations"
+        assert atom.source_id == str(relation.id)
+        assert atom.owner_user_id == test_user.id
+
+    @pytest.mark.unit
+    async def test_relation_tier_inherits_from_min_endpoint(
+        self, kg_service, db_session, test_user
+    ):
+        """Relation circle_tier = MIN(subject.tier, object.tier) — the relation
+        can be no more visible than the stricter endpoint (CEO Finding E)."""
+        kg_service._find_similar_entity = AsyncMock(return_value=None)
+        subj = await kg_service.resolve_entity("S", "person", user_id=test_user.id)
+        obj = await kg_service.resolve_entity("O", "person", user_id=test_user.id)
+        # Promote subject to tier 3 so the MIN is 0 (object) — visibility limited.
+        subj.circle_tier = 3
+        await db_session.flush()
+
+        relation = await kg_service.save_relation(
+            subject_id=subj.id, predicate="k", object_id=obj.id, user_id=test_user.id,
+        )
+        assert relation.circle_tier == 0
+
+    @pytest.mark.unit
+    async def test_empty_users_table_skips_atom_registration(
+        self, kg_service, db_session
+    ):
+        """Dev / fresh-DB case with no users yet: the entity is still written
+        (atom_id stays None) instead of exploding. Production always has the
+        bootstrap admin, so this path only kicks in for seed scripts / tests."""
+        # Ensure users table is empty for this test (no test_user fixture).
+        kg_service._find_similar_entity = AsyncMock(return_value=None)
+
+        result = await kg_service.resolve_entity("Ghost", "concept", user_id=None)
+
+        assert result.atom_id is None, "no owner available → no atom row created"
+        # Entity still usable — it just doesn't participate in circles retrieval.
+        assert result.name == "Ghost"
+
+
 class TestSaveRelation:
     """Tests for KnowledgeGraphService.save_relation()."""
 


### PR DESCRIPTION
## Problem

Every document ingest and every chat-memory KG extraction failed in production with

\`\`\`
null value in column "atom_id" of relation "kg_entities" violates not-null constraint
\`\`\`

Observed during the v2.0.0 deploy test. The circles v1 migration (\`pc20260420_circles_v1_schema.py\`) tightened \`kg_entities.atom_id\` and \`kg_relations.atom_id\` to \`NOT NULL\` with a non-deferrable FK to \`atoms.atom_id\`, but the KG extraction writer in \`KnowledgeGraphService\` was still doing raw \`self.db.add(entity)\` without registering the atoms row. The exception was caught and logged as a warning, so the application kept running without any KG enrichment on new content.

## Why the straightforward "call AtomService.upsert_atom after insert" doesn't work

\`AtomService.upsert_atom\` verifies the source row already exists (\`atom_service.py:109-117\`) before creating the atoms row. But inserting the source row first fails the \`NOT NULL\` on \`atom_id\`. Classic chicken-and-egg.

## Fix

Three-phase atom-first ordering:

1. Mint UUID + INSERT atoms row with placeholder \`source_id = '__pending__' + uuid\` so the source-row FK has a valid target.
2. INSERT the kg_entity / kg_relation with \`atom_id\` and \`circle_tier\` pre-set.
3. After flush exposes the source-row PK, UPDATE atoms.source_id with the real id.

All three share the unit-of-work transaction; failure at any step rolls back cleanly.

### Helpers added

- \`_resolve_owner_user_id\` — caller's user id, or admin fallback (first user by id), or None if the users table is empty (fresh-DB dev). Mirrors the migration's back-fill pattern.
- \`_create_atom_for_new_source\` — phase 1.
- \`_finalize_atom_source_id\` — phase 3.

Relation tier derivation matches existing cascade rule from \`AtomService.update_tier\`: \`circle_tier = MIN(subject.tier, object.tier)\` so a relation can be no more visible than its stricter endpoint.

### Dev / test safety

When \`_resolve_owner_user_id\` returns None (empty users table — only pre-bootstrap), the atom registration is skipped and the source row is written with \`atom_id=None\`. The ORM column is nullable so this works under SQLite tests. Production always has the bootstrap admin, so the atom-backed path is the one that actually runs.

## Tests

Four new unit tests in \`test_knowledge_graph_service.py::TestAtomRegistration\`:

1. New entity with authenticated user → atoms row present, types correct, \`source_id\` patched to real PK
2. New relation → atoms row with \`atom_type='kg_edge'\`, source_id patched
3. Relation \`circle_tier\` inherits MIN(subject, object) tier
4. Empty-users-table fallback: entity still created, atom_id stays None (regression guard for the test-fixture path)

## Verification

Ran the 3-phase SQL sequence against the live Postgres schema in a \`BEGIN; ... ROLLBACK;\` transaction. All three steps succeed; the FK chain is valid; \`atoms.source_id\` is correctly patched from placeholder to entity PK.

Pytest is not installed in the current prod pod (and CI remains dormant per parking decision), so the new unit tests were \`py_compile\`-checked but not executed. They follow the existing \`TestResolveEntity\` / \`TestSaveRelation\` patterns in the same file and should run against the existing conftest SQLite fixture without further setup.

## Scope

This PR fixes the KG writer explicitly called out in #438. \`RAGService._ingest_flat / _ingest_parent_child\` and \`ConversationMemoryService.save\` carry the same shape of bug (same NOT NULL constraint, same writer bypass). Sibling tracked in #440.

Closes #438
Related: #440 (RAG + Memory writers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)