### PR TITLE
fix(chat-upload): scope HTTP endpoints to the requesting user

### DIFF
--- a/src/backend/api/routes/chat_upload.py
+++ b/src/backend/api/routes/chat_upload.py
@@ -21,6 +21,7 @@ from models.database import (
     UPLOAD_STATUS_COMPLETED,
     UPLOAD_STATUS_FAILED,
     ChatUpload,
+    Conversation,
     KnowledgeBase,
 )
 from services.auth_service import get_optional_user
@@ -167,18 +168,42 @@ async def upload_chat_document(
 # ============================================================================
 
 
+async def _get_owned_upload(
+    db: AsyncSession,
+    upload_id: int,
+    user,
+) -> ChatUpload | None:
+    """Fetch a ChatUpload, scoped to the authenticated user's conversations.
+
+    Ownership model: ChatUpload rows carry ``session_id`` only; the link back
+    to a user runs through ``Conversation.user_id``. We join chat_uploads →
+    conversations and filter by the authenticated user's id.
+
+    When ``user`` is None (AUTH_ENABLED=false or anonymous dev setup), the
+    scoping filter is skipped — matches the single-user fallback convention
+    established in #433. In auth-enabled multi-user mode, a cross-user lookup
+    returns None (soft 404) rather than a 403, so the response doesn't leak
+    the existence of other users' uploads.
+    """
+    query = select(ChatUpload).where(ChatUpload.id == upload_id)
+    if user is not None:
+        query = query.join(
+            Conversation, Conversation.session_id == ChatUpload.session_id,
+        ).where(Conversation.user_id == user.id)
+    result = await db.execute(query)
+    return result.scalar_one_or_none()
+
+
 @router.post("/upload/{upload_id}/index", response_model=IndexResponse)
 async def index_chat_upload(
     upload_id: int,
     request: IndexRequest,
     db: AsyncSession = Depends(get_db),
+    user=Depends(get_optional_user),
 ):
     """Index a chat upload into a RAG knowledge base."""
-    # Fetch upload
-    result = await db.execute(
-        select(ChatUpload).where(ChatUpload.id == upload_id)
-    )
-    upload = result.scalar_one_or_none()
+    # Fetch upload (scoped to the authenticated user's conversations)
+    upload = await _get_owned_upload(db, upload_id, user)
     if not upload:
         raise HTTPException(status_code=404, detail="Upload not found")
 
@@ -232,13 +257,11 @@ async def forward_to_paperless(
     upload_id: int,
     request: Request,
     db: AsyncSession = Depends(get_db),
+    user=Depends(get_optional_user),
 ):
     """Forward a chat upload to Paperless-NGX via MCP."""
-    # Fetch upload
-    result = await db.execute(
-        select(ChatUpload).where(ChatUpload.id == upload_id)
-    )
-    upload = result.scalar_one_or_none()
+    # Fetch upload (scoped to the authenticated user's conversations)
+    upload = await _get_owned_upload(db, upload_id, user)
     if not upload:
         raise HTTPException(status_code=404, detail="Upload not found")
 
@@ -301,13 +324,11 @@ async def forward_via_email(
     email_request: EmailForwardRequest,
     request: Request,
     db: AsyncSession = Depends(get_db),
+    user=Depends(get_optional_user),
 ):
     """Forward a chat upload via Email MCP."""
-    # Fetch upload
-    result = await db.execute(
-        select(ChatUpload).where(ChatUpload.id == upload_id)
-    )
-    upload = result.scalar_one_or_none()
+    # Fetch upload (scoped to the authenticated user's conversations)
+    upload = await _get_owned_upload(db, upload_id, user)
     if not upload:
         raise HTTPException(status_code=404, detail="Upload not found")
 

--- a/tests/backend/test_chat_upload.py
+++ b/tests/backend/test_chat_upload.py
@@ -819,6 +819,170 @@ class TestChatUploadEmail:
 # Phase 4: Cleanup Endpoint Tests
 # ============================================================================
 
+class TestChatUploadOwnership:
+    """Ownership scoping on the /upload/{id}/paperless, /email, /index endpoints.
+
+    Regression guard for #434 — in multi-user (AUTH_ENABLED=true) setups,
+    an authenticated user A could previously forward user B's chat upload
+    to Paperless/email by guessing the integer id. All three endpoints now
+    scope the ChatUpload lookup via Conversation.user_id.
+    """
+
+    @pytest.mark.backend
+    async def test_paperless_rejects_cross_user_upload(
+        self, async_client: AsyncClient, db_session: AsyncSession, test_user
+    ):
+        """Authenticated user B cannot forward an upload owned by user A."""
+        from main import app
+        from models.database import Conversation, User
+        from services.auth_service import get_optional_user
+
+        # User A uploaded a file tied to conversation C_A
+        user_a_conv = Conversation(session_id="sess-A", user_id=test_user.id)
+        db_session.add(user_a_conv)
+        await db_session.commit()
+
+        import tempfile
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            f.write(b"%PDF-1.4 test")
+            tmp_path = f.name
+        try:
+            upload = ChatUpload(
+                session_id="sess-A",
+                filename="secret.pdf",
+                file_type="pdf",
+                file_size=200,
+                status="completed",
+                file_path=tmp_path,
+            )
+            db_session.add(upload)
+            await db_session.commit()
+            await db_session.refresh(upload)
+
+            # A different user (B) attempts to forward
+            user_b = User(
+                username="user_b", email="b@test",
+                password_hash="x", role_id=test_user.role_id,
+            )
+            db_session.add(user_b)
+            await db_session.commit()
+            await db_session.refresh(user_b)
+
+            app.dependency_overrides[get_optional_user] = lambda: user_b
+            try:
+                response = await async_client.post(
+                    f"/api/chat/upload/{upload.id}/paperless"
+                )
+            finally:
+                app.dependency_overrides.pop(get_optional_user, None)
+
+            # Soft 404 — don't leak existence to cross-user probes
+            assert response.status_code == 404
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
+
+    @pytest.mark.backend
+    async def test_paperless_accepts_owner(
+        self, async_client: AsyncClient, db_session: AsyncSession, test_user
+    ):
+        """The owning user CAN forward their own upload (happy path)."""
+        from main import app
+        from models.database import Conversation
+        from services.auth_service import get_optional_user
+
+        conv = Conversation(session_id="sess-owner", user_id=test_user.id)
+        db_session.add(conv)
+        await db_session.commit()
+
+        import tempfile
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            f.write(b"%PDF-1.4 mine")
+            tmp_path = f.name
+        try:
+            upload = ChatUpload(
+                session_id="sess-owner",
+                filename="mine.pdf",
+                file_type="pdf",
+                file_size=200,
+                status="completed",
+                file_path=tmp_path,
+            )
+            db_session.add(upload)
+            await db_session.commit()
+            await db_session.refresh(upload)
+
+            import json
+            mcp_result = {
+                "success": True,
+                "message": json.dumps({
+                    "success": True,
+                    "data": {"task_id": "t-1", "title": "mine.pdf", "filename": "mine.pdf"},
+                }),
+            }
+            mock_manager = AsyncMock()
+            mock_manager.execute_tool = AsyncMock(return_value=mcp_result)
+            app.state.mcp_manager = mock_manager
+            app.dependency_overrides[get_optional_user] = lambda: test_user
+            try:
+                response = await async_client.post(
+                    f"/api/chat/upload/{upload.id}/paperless"
+                )
+            finally:
+                app.state.mcp_manager = None
+                app.dependency_overrides.pop(get_optional_user, None)
+
+            assert response.status_code == 200
+            assert response.json()["paperless_task_id"] == "t-1"
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
+
+    @pytest.mark.backend
+    async def test_anonymous_bypass_when_auth_disabled(
+        self, async_client: AsyncClient, db_session: AsyncSession
+    ):
+        """Without an authenticated user (AUTH_ENABLED=false), the scoping
+        filter is skipped — matches single-user dev-mode convention."""
+        import tempfile
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            f.write(b"%PDF-1.4 solo")
+            tmp_path = f.name
+        try:
+            upload = ChatUpload(
+                session_id="sess-solo",
+                filename="solo.pdf",
+                file_type="pdf",
+                file_size=200,
+                status="completed",
+                file_path=tmp_path,
+            )
+            db_session.add(upload)
+            await db_session.commit()
+            await db_session.refresh(upload)
+
+            # No dep override → get_optional_user returns None by default in tests
+            import json
+            from main import app
+            mcp_result = {
+                "success": True,
+                "message": json.dumps({
+                    "success": True,
+                    "data": {"task_id": "t-solo"},
+                }),
+            }
+            mock_manager = AsyncMock()
+            mock_manager.execute_tool = AsyncMock(return_value=mcp_result)
+            app.state.mcp_manager = mock_manager
+            try:
+                response = await async_client.post(
+                    f"/api/chat/upload/{upload.id}/paperless"
+                )
+            finally:
+                app.state.mcp_manager = None
+            assert response.status_code == 200
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
+
+
 class TestChatUploadCleanup:
     """Tests for DELETE /api/chat/upload/cleanup and _cleanup_uploads"""
 


### PR DESCRIPTION
## Problem

Three HTTP endpoints allowed cross-user attachment access in AUTH_ENABLED=true setups:

- \`POST /api/chat/upload/{id}/paperless\` — forward to Paperless
- \`POST /api/chat/upload/{id}/email\` — forward via email
- \`POST /api/chat/upload/{id}/index\` — index into a RAG knowledge base

All three looked up \`ChatUpload\` by integer id only:

\`\`\`python
result = await db.execute(
    select(ChatUpload).where(ChatUpload.id == upload_id)
)
\`\`\`

An authenticated user A could POST to any of these routes with user B's upload id and trigger the action on user B's file.

## Fix

New \`_get_owned_upload\` helper joins \`chat_uploads\` → \`conversations\` and filters by \`Conversation.user_id\`. All three endpoints route through it. When the authenticated user is None (AUTH_ENABLED=false or anonymous dev setup), the scoping filter is skipped — matches the single-user fallback convention from #433.

Soft 404 on cross-user probe, not 403 — mirrors the agent-side convention so responses don't leak existence of other users' uploads.

## Ownership model

\`ChatUpload\` carries \`session_id\` but no \`user_id\` column. The link back to a user runs via:

\`\`\`
ChatUpload.session_id → Conversation.session_id → Conversation.user_id
\`\`\`

Using Conversation as the ownership proof avoids a schema migration and matches how the agent path (\`internal.forward_attachment_to_paperless\`) already thinks about it.

## Test plan

- [x] Syntax checks pass (\`py_compile\`)
- [x] Three new tests in \`TestChatUploadOwnership\`:
  - Cross-user POST to /paperless returns 404
  - Owner's POST to /paperless succeeds with expected task_id
  - Anonymous POST (no user) still works — auth-disabled back-compat
- [ ] CI: dormant, will not run (out of scope per current policy)
- [ ] Manual: force AUTH_ENABLED=true locally, upload as user A, try to forward as user B → 404

Closes #434
Related: #433 (agent-side attachment flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)