### PR TITLE
feat(circles): atoms per document, not per chunk (closes #440)

### DIFF
--- a/docs/design/atoms-granularity.md
+++ b/docs/design/atoms-granularity.md
@@ -1,0 +1,383 @@
+# Atoms-Granularität — Chunk-Level vs Document-Level
+
+**Status:** Entwurf, pending Entscheidung
+**Kontext:** Lane B/C (v2.0.0) setzte `atoms` als polymorphen Access-Control-Layer über vier Quell-Tabellen. Für `document_chunks` wurde **pro Chunk** ein Atom angelegt — diese Entscheidung steht zur Debatte.
+
+---
+
+## Die Frage
+
+Soll der Access-Control-Layer für Dokumente auf **Chunk-Ebene** (eine Access-Richtlinie pro Text-Passage) oder auf **Dokument-Ebene** (eine Access-Richtlinie für das gesamte Dokument) greifen?
+
+---
+
+## Status quo
+
+```
+documents                           ← kein atom_id
+    ▲
+    │ FK
+    │
+document_chunks                     ← atom_id NOT NULL, circle_tier
+    ▲
+    │ FK (atom_id)
+    │
+atoms (type='kb_chunk')             ← eine Row pro Chunk
+```
+
+Ein Dokument mit 50 Chunks erzeugt:
+- 1 `documents` Row
+- 50 `document_chunks` Rows
+- 50 `atoms` Rows
+
+Access-Check pro Retrieval: `document_chunks.circle_tier` + optional `atom_explicit_grants` joint.
+
+`kb_shares_service` übersetzt ein „KB-Share" in **N Per-Chunk-Grants**.
+
+---
+
+## Problem
+
+### 1. Kontext-Verlust bei abweichenden Tiers
+
+Der Hauptkritikpunkt: **Tiers auf Chunk-Ebene zerreißen den Informations-Träger „Dokument".**
+
+Konkretes Beispiel: Rechnung mit 10 Chunks. Chunks 1–5 werden vom Eigentümer auf Tier 2 (household) gesetzt, Chunks 6–10 bleiben auf Tier 0 (self). Ein Household-Member sieht nur die ersten 5 Chunks.
+
+Was der Household-Member sieht: Adresse, Rechnungs-Header, halbe Tabelle.
+Was ihm fehlt: Summe, IBAN, wichtigste Zahlen.
+
+Die vermittelte „Information" ist nicht nur unvollständig — sie ist **strukturell falsch**. Der Leser glaubt, die Rechnung gesehen zu haben, hat aber aus Fragmenten einen verzerrten Eindruck rekonstruiert. Das ist schlechter als „keine Sicht".
+
+Analog: ein Geheimnis-Absatz in einem sonst öffentlichen Dokument — eine Leserin auf tier=4 sieht alles außer dem einen Absatz und denkt, die Geschichte sei vollständig.
+
+### 2. Write-Amplifikation
+
+Aktuell pro Dokument-Ingest: 1× Document-Row + N× Chunk-Rows + N× Atom-Rows + N× Atom-Source-ID-Updates.
+
+Für ein 200-Seiten-PDF mit ~600 Chunks: 1801 DB-Writes. Pro Atom 2 Round-Trips (INSERT mit Placeholder + UPDATE mit echter source_id). Das ist spürbar.
+
+### 3. Storage-Overhead
+
+~64 Bytes pro atoms-Row × 600 Chunks × 10k Dokumente = ~380 MB atoms-Tabelle nur für Chunk-Atoms. Nicht tragisch, aber dominant gegenüber den anderen Atom-Typen.
+
+### 4. Feature-Fläche, die niemand braucht
+
+Per-Chunk-Sharing ist Notion-mäßig hübsch („teile diesen einen Absatz"), aber:
+- Keine UI exponiert es
+- Typischer User-Intent ist „teile dieses Dokument" oder „teile diese KB"
+- Die Feature-Fläche wird vom Code getragen, nicht von Nutzern
+
+**Verifiziert gegen Prod-DB (2026-04-22):**
+
+```sql
+SELECT
+  (SELECT COUNT(*) FROM atom_explicit_grants
+   WHERE atom_id IN (SELECT atom_id FROM atoms WHERE atom_type='kb_chunk')) AS chunk_grants,
+  (SELECT COUNT(DISTINCT granted_to_user_id) FROM atom_explicit_grants
+   WHERE atom_id IN (SELECT atom_id FROM atoms WHERE atom_type='kb_chunk')) AS distinct_grantees;
+
+-- Ergebnis:
+--  chunk_grants | distinct_grantees
+-- --------------+-------------------
+--             0 |                 0
+```
+
+Keine Produktions-Abhängigkeit auf dem per-chunk Feature. Die Migration kann die Fläche ohne Aggregationslogik droppen. Der Gesamt-Bestand ist aktuell 123 kb_chunk-Atoms in 123 document_chunks-Rows (1:1, keine Inkonsistenz).
+
+---
+
+## Wo per-Element-Atoms weiterhin Sinn macht
+
+Chunks sind das **einzige** Quell-Schema, bei dem die Atom-pro-Row-Entscheidung fragwürdig ist:
+
+| Quelle | Natürliche Granularität | Bleibt 1-Atom-pro-Row? |
+|---|---|---|
+| `kg_entities` | eine Entity = eine Person/Ort/Organisation, semantisch atomar | **ja** |
+| `kg_relations` | ein Triple (subject, predicate, object), semantisch atomar | **ja** |
+| `conversation_memories` | ein extrahierter Fakt, semantisch atomar | **ja** |
+| `document_chunks` | Parse-Schnitt, **kein** semantisch atomares Ding | **nein** |
+
+Die Redesign-Entscheidung betrifft **nur** den RAG-Pfad.
+
+---
+
+## Vorschlag: Atoms auf Dokument-Ebene
+
+### Neues Modell
+
+```
+documents (type='kb_document')      ← atom_id NOT NULL, circle_tier
+    ▲
+    │ FK
+    │
+document_chunks                     ← kein atom_id mehr; circle_tier
+                                      denormalisiert aus documents
+    ▲
+    │ FK (atom_id) — entfällt
+    │
+atoms (type='kb_document')          ← eine Row pro Dokument
+```
+
+### Retrieval-Pfad
+
+Aktuell (Lane B SQL, vereinfacht):
+```sql
+SELECT ... FROM document_chunks c
+WHERE c.atom_id IN (SELECT atom_id FROM <circle-filter>)
+  OR c.circle_tier = 4 OR ...
+```
+
+Nach Umbau:
+```sql
+SELECT ... FROM document_chunks c
+JOIN documents d ON d.id = c.document_id
+WHERE d.atom_id IN (SELECT atom_id FROM <circle-filter>)
+  OR d.circle_tier = 4 OR ...
+```
+
+Der zusätzliche Join ist billig: `documents.id` ist PK, indexiert. `d.atom_id` ist indexiert (wird es — siehe Migration).
+
+**Alternative ohne Join**: `document_chunks.circle_tier` weiterhin denormalisieren, als Spiegel von `documents.circle_tier`. Update-Trigger auf documents propagiert auf alle Child-Chunks. Dann bleibt der Retrieval-Filter auf `document_chunks.circle_tier` wie heute — nur Ownership/atom_id-Check zieht auf documents um.
+
+Letzteres ist meine Empfehlung: minimaler Eingriff in Retrieval, Tier-Wechsel wird ein Write-Trigger-Kaskadeneffekt (ähnlich wie `AtomService.update_tier` schon für KG-Relations macht).
+
+### `kb_shares_service` wird einfacher
+
+Aktuell: ein KB-Share wird in 1× N Chunks = N Per-Chunk-Grants explodiert.
+Neu: ein KB-Share wird in 1× M Documents = M Per-Document-Grants explodiert.
+
+Für typische KBs ist M erheblich kleiner als N. „Share this KB" wird von ~10k AtomExplicitGrant-Rows auf ~100 reduziert.
+
+### Per-Chunk-Feature wird aufgegeben
+
+Die Fähigkeit „einzelne Chunks innerhalb eines Dokuments unterschiedlich teilen" entfällt. Explicit-Grants kann es nur pro Dokument geben.
+
+Das ist der **gewollte** Preis — der Informations-Kohärenz-Schutz, den du gerade beschrieben hast.
+
+---
+
+## Migration
+
+### Phase 1 — Schema
+
+Neue Alembic-Revision nach `pc20260420_circles_v1`:
+
+```python
+# Add atom_id to documents
+op.add_column("documents", sa.Column("atom_id", sa.String(36), nullable=True))
+op.add_column("documents", sa.Column("circle_tier", sa.Integer, nullable=False, server_default="0"))
+op.create_foreign_key(
+    "fk_documents_atom", "documents", "atoms",
+    ["atom_id"], ["atom_id"], ondelete="CASCADE",
+)
+
+# Drop atom_id from document_chunks (FK + NOT NULL + index)
+op.drop_constraint("fk_kb_chunks_atom", "document_chunks")  # name TBD
+op.drop_index("ix_document_chunks_atom_id", "document_chunks")
+op.drop_column("document_chunks", "atom_id")
+# circle_tier BLEIBT auf document_chunks — denormalisiert von documents
+```
+
+### Phase 2 — Backfill
+
+**Pre-Migration-Gate (FAIL LOUD):** Bevor wir die `kb_chunk`-Atoms droppen, sicherstellen dass keine Dokument-Row heterogene Chunk-Tiers hat. Wenn heute nicht in Prod, kann es durch Edits/Imports später auftreten — die Migration muss es als Assertion haben:
+
+```sql
+-- Fail if any document has chunks across different tiers — would silently
+-- collapse to the most-permissive tier in the backfill below otherwise.
+DO $$
+DECLARE
+    violating_count INTEGER;
+BEGIN
+    SELECT COUNT(*) INTO violating_count
+    FROM (
+        SELECT document_id
+        FROM document_chunks
+        GROUP BY document_id
+        HAVING COUNT(DISTINCT circle_tier) > 1
+    ) x;
+    IF violating_count > 0 THEN
+        RAISE EXCEPTION 'Migration blocked: % documents have chunks across heterogeneous tiers. Resolve before upgrade (consolidate tiers manually, or extend migration with MIN-based collapse logic).', violating_count;
+    END IF;
+END $$;
+```
+
+**Back-fill — konservative Collapse-Semantik:**
+
+```sql
+-- Eine Atom-Row pro Dokument. Tier wird aus MIN(chunks.circle_tier) abgeleitet,
+-- NICHT aus kb.default_circle_tier. Begründung: selbst wenn der Pre-Migration-Gate
+-- hetero-tier Chunks akzeptiert hat (falls jemand die Assertion manuell skipped),
+-- kollabieren wir conservativ auf den RESTRICTIVSTEN Tier. Jeder Chunk darf nach
+-- Migration mindestens so restrictiv gelesen werden wie vorher, nie permissiver.
+-- Wenn alle Chunks eines Doks denselben Tier haben (heute 100% der Fall), ist
+-- MIN == MAX == der eine Tier.
+INSERT INTO atoms (atom_id, atom_type, source_table, source_id, owner_user_id, policy, created_at, updated_at)
+SELECT
+    gen_random_uuid()::text,
+    'kb_document',
+    'documents',
+    d.id::text,
+    COALESCE(kb.owner_id, <admin_fallback>),
+    json_build_object(
+        'tier',
+        COALESCE(
+            (SELECT MIN(c.circle_tier) FROM document_chunks c WHERE c.document_id = d.id),
+            kb.default_circle_tier,
+            0
+        )
+    ),
+    d.created_at,
+    NOW()
+FROM documents d
+JOIN knowledge_bases kb ON kb.id = d.knowledge_base_id;
+
+UPDATE documents d
+SET atom_id = a.atom_id
+FROM atoms a
+WHERE a.atom_type = 'kb_document'
+  AND a.source_table = 'documents'
+  AND a.source_id = d.id::text;
+
+UPDATE documents
+SET circle_tier = (SELECT CAST(policy->>'tier' AS INTEGER) FROM atoms WHERE atom_id = documents.atom_id);
+
+ALTER TABLE documents ALTER COLUMN atom_id SET NOT NULL;
+
+-- Alte kb_chunk Atoms droppen (ON DELETE CASCADE sorgt für saubere Entfernung)
+DELETE FROM atoms WHERE atom_type = 'kb_chunk';
+```
+
+### Phase 2b — Tier-Cascade-Sicherheit
+
+`document_chunks.circle_tier` **muss** in derselben Transaktion wie `documents.circle_tier` fortgeschrieben werden, sonst entsteht ein **Retrieval-Leak-Window**: Dokument-Tier wurde auf `self` demoted, Chunks tragen noch `household`, der pgvector-Filter sieht die Chunks weiterhin als für Household-Peers lesbar — bis die Cascade nachzieht.
+
+**Pflicht-Implementierung in `AtomService.update_tier` für `kb_document`-Atoms:**
+
+```python
+# Siehe existing update_tier pattern für kg_node/kg_edge
+async def update_tier(self, atom_id, new_policy):
+    # ... existing atom + source row update ...
+
+    if atom.atom_type == "kb_document":
+        new_tier = int(new_policy.get("tier", 0))
+        # Atomar in derselben Session/Transaktion:
+        await self.db.execute(
+            text(
+                "UPDATE document_chunks SET circle_tier = :tier "
+                "WHERE document_id = :doc_id"
+            ),
+            {"tier": new_tier, "doc_id": int(atom.source_id)},
+        )
+```
+
+**Pflicht-Test:** Integration-Test der 50× einen mehrfach-Chunk-Dokument-Tier flippt unter 10 parallelen Sessions, danach assertiert:
+
+```sql
+SELECT COUNT(*) FROM document_chunks c
+JOIN documents d ON d.id = c.document_id
+WHERE c.circle_tier != d.circle_tier;
+-- MUSS 0 sein
+```
+
+**Langfristige Absicherung:** CI-Lint oder Ruff-Regel, die jede Retrieval-SQL daraufhin prüft, dass `document_chunks.circle_tier` nur gelesen wird, wenn `documents` mit gejoint ist. Alternative: eine DB-Trigger auf UPDATE von `documents.circle_tier`, die automatisch die Chunks mitaktualisiert (fail-safe, auch wenn App-Code den AtomService-Pfad umgeht).
+
+Ohne diese Maßnahme ist die Drift-Wahrscheinlichkeit ein Security-Bug, kein Cache-Problem.
+
+### Phase 3 — Code
+
+- `AtomService._table_for_atom_type`: `'kb_document' → 'documents'`, `'kb_chunk'` entfernen
+- `RAGService.process_existing_document`: Atom wird pro Dokument (vor dem Dokument-INSERT) erzeugt, Chunks werden unverändert mit `circle_tier` aus KB-Default geschrieben
+- `rag_retrieval`: Filter joint über `documents.atom_id` statt `document_chunks.atom_id`
+- `kb_shares_service`: KB-Share → Per-Document-Grants statt Per-Chunk-Grants
+- `polymorphic_atom_store`: Cross-Source-RRF integriert `kb_document`-Atoms in die Fusion (statt `kb_chunk`)
+
+### Phase 4 — Abgekündigte Feature entfernen
+
+Per-Chunk-Explicit-Grants. Wenn niemand sie nutzt, verlustfrei. Falls produktiv genutzt: Migration müsste sie verdichten (MAX über Chunks pro Dokument → Per-Document-Grant).
+
+---
+
+## Effort-Einschätzung
+
+| Phase | Human Team | CC+gstack |
+|---|---|---|
+| Alembic-Migration (+ Back-fill + Tests) | 1 Tag | 30 min |
+| `AtomService` + `RAGService` Umbau | 1 Tag | 30 min |
+| `kb_shares_service` + Retrieval-Pfade | 1 Tag | 30 min |
+| `polymorphic_atom_store` + Frontend-Auswirkungen | 2 Tage | 1 h |
+| Tests + Manual-E2E + Dogfood | 1 Tag | 45 min |
+| **Summe** | **~1 Woche** | **~3,5 Stunden** |
+
+---
+
+## Verifikation — Premissen gegen Prod-DB geprüft (2026-04-22)
+
+### P1 — Per-Chunk-Grants sind unbenutzt
+
+**Gate:**
+```sql
+SELECT COUNT(*) AS chunk_grants,
+       COUNT(DISTINCT granted_to_user_id) AS distinct_grantees
+FROM atom_explicit_grants
+WHERE atom_id IN (SELECT atom_id FROM atoms WHERE atom_type='kb_chunk');
+```
+
+**Ergebnis:** `chunk_grants=0, distinct_grantees=0` gegen Prod. Migration kann die Feature-Fläche risikofrei droppen. Keine Aggregations-Logik nötig.
+
+### P2 — JOIN-Cost gegenüber aktueller Query
+
+**Baseline (heute, ohne JOIN):** 4.15 ms, 957 shared buffer hits.
+**Neu (mit JOIN auf documents):** 4.26 ms, 958 shared buffer hits.
+**Overhead:** 0.11 ms (2.7 %), 1 zusätzlicher Buffer-Hit.
+
+Postgres wählt Hash Join; die documents-Seite ist 1-Digit-Count in Prod (6 Docs) und hasht in 9 KB. Selbst bei 10k Docs → ~160 KB Hash. Planner-Entscheidung ist stabil, keine Seq-Scan-Degradation zu erwarten.
+
+**Separate Erkenntnis:** pgvector-Retrieval läuft in Prod aktuell OHNE vector index (weder HNSW noch IVFFlat). Seq-Scan bei 123 Chunks ist trivial, aber das skaliert nicht. **Nicht-Blocker für diesen Redesign**, aber eigenes Issue wert.
+
+### P3 — Federation-Wire-Protokoll überlebt atom_type-Rename
+
+`FederationProvenance` (in `federation_query_schemas.py:145`) trägt `atom_id + atom_type` als Display-Metadaten. Responder serialisiert direkt aus dem internen `atom.atom_type`-Feld. Signed-Payload (`complete_canonical_payload`) deckt den String ab — kein Byte-Drift. Asker-Seite hat KEINE Hard-Codings auf spezifische `atom_type`-Werte (geprüft: `federation_query_asker.py`, `atom_store.py`).
+
+**Frontend-Impact:** `BrainReviewPage.jsx:11` (Farbmapping) und `i18n/locales/de.json:1084` + `en.json:1084` (Labels) verdrahten `kb_chunk`. Cosmetic-Rename in 3 Dateien nach Migration; i18n-Label war schon bisher „Dokument" (die Übersetzung log für den Chunk-Fall — wird zur Wahrheit).
+
+### Neu-identifizierte Risks (Claude-Subagent-Review, 2026-04-22)
+
+**Risk A — Tier-Cascade-Atomicity:** addressiert in Phase 2b oben.
+
+**Risk B — Back-fill-Collapse-Correctness:** addressiert durch MIN-basierte Aggregation + Pre-Migration-Gate oben. Prod ist heute konsistent (0 Docs mit heterogenen Chunk-Tiers verifiziert), aber die SQL ist defensive-correct-by-default.
+
+## Offene Fragen
+
+1. **Embedding-Level Retrieval** — geklärt: pgvector-Similarity bleibt per Chunk, Tier-Filter joint auf Documents. Performance ist messbar-vernachlässigbar (P2-Ergebnis).
+
+2. **Legacy-Uploads ohne KB** — geklärt: `documents.knowledge_base_id` ist NOT NULL, gibt es also nicht.
+
+3. **Vector-Index in Produktion** — **separates Issue**: aktuell kein HNSW/IVFFlat auf `document_chunks.embedding`. Seq-Scan ok bei 123 Chunks, nicht bei 10M. Sollte vor der nächsten Größenordnung passieren, aber unabhängig von der Atoms-Granularität.
+
+4. **`chat_uploads` → RAG-Indexierung** — Frontend-Paperclip-Upload → `/api/chat_upload/{id}/index` → RAGService.ingest_document. Funktioniert weiterhin; Atom wird einmal für das entstehende Document angelegt.
+
+---
+
+## Vorschlag zum Vorgehen
+
+**Kurzfristig (heute):**
+- #443 ist geschlossen ✓
+- #441 + #442 bleiben auf main, werden deployed → KG + Chat-Upload-Ownership greifen in Prod
+- **Akzeptierter Bruch:** RAG-Ingest + Memory-Save bleiben im `atom_id NOT NULL`-Fehler hängen, silent warnung. Für Memory (Hintergrund-Task): akzeptabel, aber nicht für RAG-Ingest. Falls RAG-Ingest in Produktion kritisch ist, brauchen wir einen **Zwischenfix**: den ConversationMemory-Teil von #443 **ohne** den document_chunks-Teil mergen. Das unblockt Memory ohne den RAG-Design-Punkt zu berühren.
+
+**Mittelfristig (nächste Session oder zwei):**
+- Separater PR für atom-per-document Migration, Phasen 1-4 wie oben
+- Ziel-Version: v2.1.0 (bump weil Schema-Change)
+
+**Langfristig:**
+- Rückblickend im v3-KG-Migration-Scope (siehe TODOS.md) nochmal evaluieren — ggf. ist `kb_document`-Atoms die richtige Basis dafür.
+
+---
+
+## Entscheidungen, die du treffen kannst
+
+1. **„Zwischenfix Memory jetzt, RAG-Atom-Redesign danach"** → ich spinne ConversationMemory aus #443 raus, neuer kleiner PR, deployed mit #441 + #442
+2. **„Erst Design finalisieren, dann alles zusammen"** → RAG/Memory bleibt gebrochen bis Redesign live ist. KG + Ownership gehen raus.
+3. **„Redesign zurückstellen, Status quo mergen"** → #443 wiederbeleben, per-chunk atoms akzeptieren, den Konzeptionsbruch dokumentieren und irgendwann in v3 anpacken.

--- a/src/backend/alembic/versions/pc20260423_atoms_per_document.py
+++ b/src/backend/alembic/versions/pc20260423_atoms_per_document.py
@@ -93,13 +93,18 @@ def upgrade() -> None:
         "documents",
         ["atom_id"],
     )
+    # ondelete=SET NULL (not CASCADE): atoms are metadata descriptors for
+    # documents, not their parents. Deleting an atom (admin cleanup, /api/atoms
+    # DELETE) must NOT nuke the Document + every chunk. The reverse direction
+    # — deleting a Document — is handled by the app's delete_document which
+    # explicitly cleans up the atom beforehand.
     op.create_foreign_key(
         "fk_documents_atom",
         "documents",
         "atoms",
         ["atom_id"],
         ["atom_id"],
-        ondelete="CASCADE",
+        ondelete="SET NULL",
     )
 
     # ---------------------------------------------------------------------
@@ -128,6 +133,12 @@ def upgrade() -> None:
 
             # One atoms row per existing document. Tier = MIN(chunks.tier).
             # Documents with no chunks fall back to kb.default_circle_tier.
+            #
+            # ON CONFLICT ON CONSTRAINT uq_atoms_source DO NOTHING makes the
+            # back-fill idempotent: re-running after a partial-rollback that
+            # left some kb_document atoms behind won't create duplicates. The
+            # unique constraint exists on atoms(atom_type, source_table,
+            # source_id) from pc20260420_circles_v1_schema.
             bind.exec_driver_sql(
                 "WITH new_atoms AS ("
                 "  INSERT INTO atoms (atom_id, atom_type, source_table, source_id, "
@@ -148,12 +159,27 @@ def upgrade() -> None:
                 "    NOW() "
                 "  FROM documents d "
                 "  JOIN knowledge_bases kb ON kb.id = d.knowledge_base_id "
+                "  ON CONFLICT ON CONSTRAINT uq_atoms_source DO NOTHING "
                 "  RETURNING atom_id, source_id"
                 ") "
                 "UPDATE documents d "
                 "SET atom_id = new_atoms.atom_id "
                 "FROM new_atoms "
                 "WHERE d.id::text = new_atoms.source_id"
+            )
+
+            # Defensive second UPDATE: catches any document whose atom already
+            # existed (ON CONFLICT skipped) — rare but possible on a re-run
+            # after a partial ROLLBACK that left atoms behind. Pairs docs →
+            # existing atoms via the unique constraint's lookup key.
+            bind.exec_driver_sql(
+                "UPDATE documents d "
+                "SET atom_id = a.atom_id "
+                "FROM atoms a "
+                "WHERE a.atom_type = 'kb_document' "
+                "  AND a.source_table = 'documents' "
+                "  AND a.source_id = d.id::text "
+                "  AND d.atom_id IS NULL"
             )
 
             # Denormalize the tier onto documents.circle_tier
@@ -164,8 +190,11 @@ def upgrade() -> None:
                 "WHERE d.atom_id = a.atom_id"
             )
 
-            # Make atom_id NOT NULL now that every existing row has one
-            op.alter_column("documents", "atom_id", nullable=False)
+            # Leave documents.atom_id nullable to match the ORM and the
+            # empty-users bootstrap path (create_all on fresh SQLite + first-
+            # run Postgres before any user exists). Application invariant:
+            # RAGService.create_document_record always populates atom_id when
+            # at least one user is in the DB — see services/rag_service.py.
 
     else:  # sqlite (tests)
         # On SQLite tests we don't run back-fill; Base.metadata.create_all

--- a/src/backend/alembic/versions/pc20260423_atoms_per_document.py
+++ b/src/backend/alembic/versions/pc20260423_atoms_per_document.py
@@ -1,0 +1,284 @@
+"""Atoms per document — collapse per-chunk atoms to per-document atoms
+
+Revision ID: pc20260423_atoms_per_document
+Revises: pc20260422_federation_audit
+Create Date: 2026-04-23
+
+Design rationale: docs/design/atoms-granularity.md
+
+The circles v1 migration (pc20260420_circles_v1_schema) placed atoms at the
+chunk level — one atom per document_chunks row, with ``atom_id NOT NULL + FK``.
+That granularity allows per-chunk tier overrides, but splits the semantic
+information-carrier (a document) across different access levels — a reader
+in tier N sees SOME chunks of a document, gets a distorted picture.
+
+This migration moves the access-control unit up to the document:
+
+  BEFORE                              AFTER
+  documents          (no atom)        documents          atom_id + circle_tier
+  document_chunks    atom_id NOT NULL document_chunks    circle_tier only
+  atoms (kb_chunk)   1-per-chunk      atoms (kb_document) 1-per-document
+
+Chunks keep ``circle_tier`` as a denormalized mirror of the parent document's
+tier so the hot retrieval path (pgvector + tier-filter) doesn't need the join.
+AtomService.update_tier on a kb_document atom cascades into document_chunks
+in the same transaction.
+
+Verified against prod-DB (2026-04-22):
+  - 0 atom_explicit_grants for kb_chunk atoms (feature not in use)
+  - 0 documents with heterogeneous chunk tiers (collapse is lossless)
+  - 123 kb_chunk atoms / 123 document_chunks rows (1:1, no drift)
+
+Pre-migration gate below re-verifies the heterogeneity invariant at
+migration time — a defensive assertion in case the dataset evolved between
+design and deployment.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers
+revision = "pc20260423_atoms_per_document"
+down_revision = "pc20260422_federation_audit"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+
+    # ---------------------------------------------------------------------
+    # Pre-migration gate — fail loud if any document has chunks across
+    # different circle_tiers. MIN-based collapse below would otherwise
+    # silently promote some chunks (tier-up leak) when merging to a single
+    # document atom.
+    # ---------------------------------------------------------------------
+    if dialect == "postgresql":
+        result = bind.exec_driver_sql(
+            "SELECT document_id, COUNT(DISTINCT circle_tier) AS tiers "
+            "FROM document_chunks "
+            "GROUP BY document_id "
+            "HAVING COUNT(DISTINCT circle_tier) > 1"
+        ).fetchall()
+        if result:
+            details = ", ".join(f"doc {r[0]}: {r[1]} tiers" for r in result[:5])
+            raise RuntimeError(
+                f"Migration blocked: {len(result)} documents have chunks across "
+                f"heterogeneous circle_tiers ({details}). "
+                "Either consolidate tiers in the app first (set each document's "
+                "chunks to the most-restrictive tier across the set) or extend "
+                "this migration with an aggregation policy. See "
+                "docs/design/atoms-granularity.md § Pre-Migration-Gate."
+            )
+
+    # ---------------------------------------------------------------------
+    # 1. Add Document.atom_id + Document.circle_tier columns
+    # ---------------------------------------------------------------------
+    op.add_column(
+        "documents",
+        sa.Column("atom_id", sa.String(36), nullable=True),
+    )
+    op.add_column(
+        "documents",
+        sa.Column(
+            "circle_tier",
+            sa.Integer,
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    op.create_index(
+        "ix_documents_atom_id",
+        "documents",
+        ["atom_id"],
+    )
+    op.create_foreign_key(
+        "fk_documents_atom",
+        "documents",
+        "atoms",
+        ["atom_id"],
+        ["atom_id"],
+        ondelete="CASCADE",
+    )
+
+    # ---------------------------------------------------------------------
+    # 2. Back-fill atoms (one per document, MIN-based tier collapse)
+    # ---------------------------------------------------------------------
+    if dialect == "postgresql":
+        bind.exec_driver_sql("CREATE EXTENSION IF NOT EXISTS pgcrypto")
+
+        # Determine fallback owner (first user id) for documents whose parent
+        # KB has NULL owner_id. Matches pc20260420_circles_v1 pattern.
+        fallback_user_id = bind.exec_driver_sql(
+            "SELECT id FROM users ORDER BY id ASC LIMIT 1"
+        ).scalar()
+
+        if fallback_user_id is None:
+            # No users yet (fresh DB pre-bootstrap). Skip back-fill; the
+            # bootstrap path goes through RAGService which will register
+            # atoms itself. Schema changes above are still applied.
+            import logging
+            logging.getLogger("alembic").warning(
+                "pc20260423_atoms_per_document: no users in DB — skipping "
+                "back-fill. documents.atom_id stays NULL on pre-existing rows."
+            )
+        else:
+            fb = int(fallback_user_id)
+
+            # One atoms row per existing document. Tier = MIN(chunks.tier).
+            # Documents with no chunks fall back to kb.default_circle_tier.
+            bind.exec_driver_sql(
+                "WITH new_atoms AS ("
+                "  INSERT INTO atoms (atom_id, atom_type, source_table, source_id, "
+                "                     owner_user_id, policy, created_at, updated_at) "
+                "  SELECT "
+                "    gen_random_uuid()::text, "
+                "    'kb_document', "
+                "    'documents', "
+                "    d.id::text, "
+                f"    COALESCE(kb.owner_id, {fb}), "
+                "    json_build_object('tier', COALESCE( "
+                "      (SELECT MIN(c.circle_tier) FROM document_chunks c "
+                "       WHERE c.document_id = d.id), "
+                "      kb.default_circle_tier, "
+                "      0 "
+                "    )), "
+                "    d.created_at, "
+                "    NOW() "
+                "  FROM documents d "
+                "  JOIN knowledge_bases kb ON kb.id = d.knowledge_base_id "
+                "  RETURNING atom_id, source_id"
+                ") "
+                "UPDATE documents d "
+                "SET atom_id = new_atoms.atom_id "
+                "FROM new_atoms "
+                "WHERE d.id::text = new_atoms.source_id"
+            )
+
+            # Denormalize the tier onto documents.circle_tier
+            bind.exec_driver_sql(
+                "UPDATE documents d "
+                "SET circle_tier = CAST(a.policy->>'tier' AS INTEGER) "
+                "FROM atoms a "
+                "WHERE d.atom_id = a.atom_id"
+            )
+
+            # Make atom_id NOT NULL now that every existing row has one
+            op.alter_column("documents", "atom_id", nullable=False)
+
+    else:  # sqlite (tests)
+        # On SQLite tests we don't run back-fill; Base.metadata.create_all
+        # builds the schema at the post-migration state, and individual tests
+        # populate their own atoms as needed. Leave atom_id nullable on
+        # SQLite to avoid tests that never inserted an atoms row failing.
+        pass
+
+    # ---------------------------------------------------------------------
+    # 3. Drop document_chunks.atom_id (FK, index, column)
+    # ---------------------------------------------------------------------
+    if dialect == "postgresql":
+        # FK name from pc20260420_circles_v1_schema — hard-coded because
+        # autogen would need a reflection call in the migration body.
+        op.drop_constraint(
+            "fk_document_chunks_atom",
+            "document_chunks",
+            type_="foreignkey",
+        )
+        # Old kb_chunk atoms will cascade-delete on FK drop anyway, but we
+        # delete them explicitly for audit clarity.
+        bind.exec_driver_sql(
+            "DELETE FROM atoms WHERE atom_type = 'kb_chunk'"
+        )
+
+    # Drop the atom_id column on all dialects — ORM doesn't declare it
+    # anymore, so leaving it would cause create_all() on fresh SQLite DBs
+    # to produce different schemas than the migrated Postgres prod DB.
+    with op.batch_alter_table("document_chunks") as batch:
+        try:
+            batch.drop_index("ix_document_chunks_atom_id")
+        except Exception:
+            pass  # index may not exist on older dev DBs
+        try:
+            batch.drop_column("atom_id")
+        except Exception:
+            pass  # column may not exist on fresh SQLite create_all DBs
+
+
+def downgrade() -> None:
+    """Rollback: re-add per-chunk atoms from per-document atoms.
+
+    NOTE: this is a LOSSY downgrade. Any app-level tier changes applied via
+    AtomService.update_tier(kb_document) are propagated to all chunks in
+    the current state; we reconstruct per-chunk atoms using the document's
+    current tier. Any historical per-chunk tier diversity that existed
+    before the upgrade back-fill is not recoverable — this is the same
+    trade-off the upgrade's MIN-based collapse accepted.
+    """
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+
+    # 1. Re-add document_chunks.atom_id (nullable first)
+    op.add_column(
+        "document_chunks",
+        sa.Column("atom_id", sa.String(36), nullable=True),
+    )
+    op.create_index(
+        "ix_document_chunks_atom_id",
+        "document_chunks",
+        ["atom_id"],
+    )
+
+    if dialect == "postgresql":
+        # 2. For each document with an atom, create per-chunk atoms copying
+        #    the document's owner + tier. New UUIDs per chunk.
+        bind.exec_driver_sql("CREATE EXTENSION IF NOT EXISTS pgcrypto")
+        bind.exec_driver_sql(
+            "WITH new_atoms AS ("
+            "  INSERT INTO atoms (atom_id, atom_type, source_table, source_id, "
+            "                     owner_user_id, policy, created_at, updated_at) "
+            "  SELECT "
+            "    gen_random_uuid()::text, "
+            "    'kb_chunk', "
+            "    'document_chunks', "
+            "    c.id::text, "
+            "    d_atoms.owner_user_id, "
+            "    d_atoms.policy, "
+            "    c.created_at, "
+            "    NOW() "
+            "  FROM document_chunks c "
+            "  JOIN documents d ON d.id = c.document_id "
+            "  JOIN atoms d_atoms ON d_atoms.atom_id = d.atom_id "
+            "  WHERE d.atom_id IS NOT NULL "
+            "  RETURNING atom_id, source_id"
+            ") "
+            "UPDATE document_chunks c "
+            "SET atom_id = new_atoms.atom_id "
+            "FROM new_atoms "
+            "WHERE c.id::text = new_atoms.source_id"
+        )
+
+        # 3. Delete kb_document atoms
+        bind.exec_driver_sql(
+            "DELETE FROM atoms WHERE atom_type = 'kb_document'"
+        )
+
+        # 4. Re-create FK on document_chunks
+        op.create_foreign_key(
+            "fk_document_chunks_atom",
+            "document_chunks",
+            "atoms",
+            ["atom_id"],
+            ["atom_id"],
+            ondelete="CASCADE",
+        )
+
+    # 5. Drop Document columns
+    op.drop_constraint(
+        "fk_documents_atom",
+        "documents",
+        type_="foreignkey",
+    )
+    op.drop_index("ix_documents_atom_id", table_name="documents")
+    op.drop_column("documents", "atom_id")
+    op.drop_column("documents", "circle_tier")

--- a/src/backend/api/routes/atoms.py
+++ b/src/backend/api/routes/atoms.py
@@ -1,5 +1,5 @@
 """
-Atoms API — read/edit access to atoms (kb_chunks, kg_nodes, kg_edges,
+Atoms API — read/edit access to atoms (kb_documents, kg_nodes, kg_edges,
 conversation_memories) through the unified circles framework.
 
 All endpoints require authentication. Access checks use CircleResolver:

--- a/src/backend/api/routes/circles.py
+++ b/src/backend/api/routes/circles.py
@@ -36,6 +36,7 @@ from models.database import (
     Circle,
     CircleMembership,
     ConversationMemory,
+    Document,
     DocumentChunk,
     KGEntity,
     KGRelation,
@@ -451,7 +452,45 @@ async def _resolve_review_labels(
             else:
                 out[a.atom_id] = (f"Unknown relation ({a.source_id})", None)
 
-    # --- document_chunks ---
+    # --- documents (kb_document atoms, post pc20260423) ---
+    doc_atoms = by_table.get("documents", [])
+    if doc_atoms:
+        source_ids = [int(a.source_id) for a in doc_atoms if a.source_id.isdigit()]
+        docs = {}
+        first_chunks: dict[int, DocumentChunk] = {}
+        if source_ids:
+            rows = (await db.execute(
+                select(Document).where(Document.id.in_(source_ids))
+            )).scalars().all()
+            docs = {d.id: d for d in rows}
+            # Pull a preview chunk per document (lowest chunk_index) for the
+            # review-UI snippet. Chunks no longer carry atoms, so we fetch
+            # through document_chunks directly.
+            chunk_rows = (await db.execute(
+                select(DocumentChunk)
+                .where(DocumentChunk.document_id.in_(source_ids))
+                .order_by(
+                    DocumentChunk.document_id.asc(),
+                    DocumentChunk.chunk_index.asc(),
+                )
+            )).scalars().all()
+            for c in chunk_rows:
+                first_chunks.setdefault(c.document_id, c)
+        for a in doc_atoms:
+            d = docs.get(int(a.source_id)) if a.source_id.isdigit() else None
+            if d is not None:
+                title = (d.title if getattr(d, "title", None) else None) \
+                    or d.filename \
+                    or "Document"
+                preview = first_chunks.get(d.id)
+                snippet = _truncate(preview.content) if preview else None
+                out[a.atom_id] = (title, snippet)
+            else:
+                out[a.atom_id] = (f"Unknown document ({a.source_id})", None)
+
+    # --- document_chunks (legacy pre-pc20260423 atoms; post-migration this
+    #     list is empty because the migration deleted kb_chunk atoms, but we
+    #     keep the branch for defensive reading of any straggler data) ---
     chunk_atoms = by_table.get("document_chunks", [])
     if chunk_atoms:
         source_ids = [int(a.source_id) for a in chunk_atoms if a.source_id.isdigit()]

--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -942,15 +942,12 @@ TIER_PUBLIC = 4
 
 # Atom type discriminators — one per source table the polymorphic registry
 # wraps. Keep in sync with PolymorphicAtomStore source dispatch.
+# 'kb_chunk' was retired in pc20260423_atoms_per_document; historical alembic
+# migrations hard-code that string literal where they still need it.
 ATOM_TYPE_KB_DOCUMENT = "kb_document"
 ATOM_TYPE_KG_NODE = "kg_node"
 ATOM_TYPE_KG_EDGE = "kg_edge"
 ATOM_TYPE_CONVERSATION_MEMORY = "conversation_memory"
-# Legacy constant retained for back-compat with existing imports (mostly tests
-# and old alembic migrations). Not used in new writer code paths — the atom_type
-# 'kb_chunk' is no longer written by RAGService after the atoms-per-document
-# migration (pc20260423_atoms_per_document).
-ATOM_TYPE_KB_CHUNK = "kb_chunk"
 
 # Atom explicit grant permission levels — mirrors the legacy KB_PERM_*
 # values for migration parity.

--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -199,6 +199,14 @@ class Document(Base):
     created_at = Column(DateTime, default=_utcnow)
     processed_at = Column(DateTime, nullable=True)
 
+    # Circles v2 (atoms-per-document): the access-control unit moved from
+    # per-chunk to per-document (see docs/design/atoms-granularity.md). The
+    # atoms row carries atom_type='kb_document' and owner/policy; chunks no
+    # longer carry atom_id themselves but keep a denormalized circle_tier
+    # mirrored from this column for fast SQL retrieval filters.
+    atom_id = Column(String(36), ForeignKey("atoms.atom_id", ondelete="CASCADE"), nullable=True, index=True)
+    circle_tier = Column(Integer, nullable=False, default=0)
+
     # Beziehungen
     knowledge_base = relationship("KnowledgeBase", back_populates="documents")
     chunks = relationship("DocumentChunk", back_populates="document", cascade="all, delete-orphan")
@@ -245,11 +253,15 @@ class DocumentChunk(Base):
     # Additional Metadata (JSON für Flexibilität)
     chunk_metadata = Column(JSON, nullable=True)  # Umbenannt von 'metadata' (SQLAlchemy reserved)
 
-    # Circles v1: FK to atoms registry + denormalized circle_tier for SQL filter perf.
-    # atom_id populated by AtomService.upsert_atom in a single transaction with the
-    # source-row write. circle_tier defaults to 0 (self) for fresh-DB rows; back-filled
-    # from parent KB's default_circle_tier during pc20260420_circles_v1 migration.
-    atom_id = Column(String(36), ForeignKey("atoms.atom_id", ondelete="CASCADE"), nullable=True, index=True)
+    # Circles v2 (atoms-per-document): chunks no longer carry atom_id. The
+    # access-control unit is the parent Document — retrieval joins chunks →
+    # documents and filters on documents.atom_id / documents.circle_tier.
+    # circle_tier is kept here as a denormalized mirror of
+    # Document.circle_tier so existing pgvector queries that filter on the
+    # chunk-level tier continue to work without the JOIN for hot paths.
+    # AtomService.update_tier on a kb_document atom cascades into this
+    # column via UPDATE document_chunks SET circle_tier=? WHERE document_id=?.
+    # (Dropped in pc20260423_atoms_per_document migration.)
     circle_tier = Column(Integer, nullable=False, default=0)
 
     # Timestamps
@@ -930,10 +942,15 @@ TIER_PUBLIC = 4
 
 # Atom type discriminators — one per source table the polymorphic registry
 # wraps. Keep in sync with PolymorphicAtomStore source dispatch.
-ATOM_TYPE_KB_CHUNK = "kb_chunk"
+ATOM_TYPE_KB_DOCUMENT = "kb_document"
 ATOM_TYPE_KG_NODE = "kg_node"
 ATOM_TYPE_KG_EDGE = "kg_edge"
 ATOM_TYPE_CONVERSATION_MEMORY = "conversation_memory"
+# Legacy constant retained for back-compat with existing imports (mostly tests
+# and old alembic migrations). Not used in new writer code paths — the atom_type
+# 'kb_chunk' is no longer written by RAGService after the atoms-per-document
+# migration (pc20260423_atoms_per_document).
+ATOM_TYPE_KB_CHUNK = "kb_chunk"
 
 # Atom explicit grant permission levels — mirrors the legacy KB_PERM_*
 # values for migration parity.

--- a/src/backend/services/atom_service.py
+++ b/src/backend/services/atom_service.py
@@ -49,10 +49,10 @@ from sqlalchemy import select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.database import (
-    Atom as AtomModel,
     ATOM_TYPE_KB_DOCUMENT,
     ATOM_TYPE_KG_EDGE,
     ATOM_TYPE_KG_NODE,
+    Atom as AtomModel,
 )
 from services.atom_types import Atom
 from services.circle_resolver import CircleResolver, atom_from_orm
@@ -369,14 +369,15 @@ class AtomService:
 def _table_for_atom_type(atom_type: str) -> str:
     """Map atom_type discriminator → source table name.
 
-    Post-atoms-per-document migration (pc20260423): the RAG access-control
-    unit is ``kb_document`` / ``documents``. The legacy ``kb_chunk`` mapping
-    is retained only so old atoms rows are still reachable for read/delete;
-    writers should not produce ``kb_chunk`` atoms anymore.
+    Post-atoms-per-document (pc20260423): ``kb_chunk`` is deliberately absent
+    — the migration deletes every ``kb_chunk`` atom, ``document_chunks.atom_id``
+    no longer exists, and ``upsert_atom``'s generic ``UPDATE … SET atom_id``
+    would fail on that column. Any writer that still produces ``kb_chunk``
+    atoms will raise ``ValueError`` here loudly rather than silently corrupting
+    state downstream.
     """
     table_map = {
         "kb_document": "documents",
-        "kb_chunk": "document_chunks",  # legacy; see note above
         "kg_node": "kg_entities",
         "kg_edge": "kg_relations",
         "conversation_memory": "conversation_memories",

--- a/src/backend/services/atom_service.py
+++ b/src/backend/services/atom_service.py
@@ -50,6 +50,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.database import (
     Atom as AtomModel,
+    ATOM_TYPE_KB_DOCUMENT,
     ATOM_TYPE_KG_EDGE,
     ATOM_TYPE_KG_NODE,
 )
@@ -60,7 +61,7 @@ from services.circle_resolver import CircleResolver, atom_from_orm
 # Source table → discriminator atom_type → row id column map.
 # Used by update_tier to dispatch the denormalized circle_tier write.
 _SOURCE_TABLE_TIER_UPDATE = {
-    "document_chunks": "id",
+    "documents": "id",          # kb_document atom → documents.circle_tier + cascade to chunks
     "kg_entities": "id",
     "kg_relations": "id",
     "conversation_memories": "id",
@@ -168,6 +169,72 @@ class AtomService:
         await self.db.commit()
         return atom_id
 
+    async def create_with_source(
+        self,
+        *,
+        atom_type: str,
+        owner_user_id: int,
+        tier: int,
+    ) -> str:
+        """Pre-create an atoms row before the source row exists.
+
+        Source-table writers for every type EXCEPT ``kb_document`` hit a
+        chicken-and-egg: their ``atom_id`` column is NOT NULL + non-deferrable
+        FK to ``atoms.atom_id`` (pc20260420_circles_v1_schema.py), but the
+        source row's PK is auto-incremented and only known after flush. This
+        method seeds the atoms row with a unique placeholder ``source_id``;
+        the caller invokes :meth:`finalize_source_id` after flushing the
+        source row to patch the real PK.
+
+        Returns the minted atom_id. Intended call pattern:
+
+            atom_id = await atom_svc.create_with_source(
+                atom_type="conversation_memory",
+                owner_user_id=42, tier=0,
+            )
+            memory = ConversationMemory(..., atom_id=atom_id, circle_tier=0)
+            self.db.add(memory); await self.db.flush()
+            await atom_svc.finalize_source_id(atom_id, memory.id)
+
+        For ``kb_document`` atoms, Documents are registered BEFORE chunks
+        and their own FK is nullable (see post-pc20260423 schema), so the
+        placeholder dance still applies because Document.atom_id is set
+        to the minted atom_id at creation time before the document row is
+        flushed. RAGService uses this helper the same way.
+        """
+        atom_id = str(uuid.uuid4())
+        source_table = _table_for_atom_type(atom_type)
+        placeholder = f"__pending__{atom_id}"
+        now = datetime.now(UTC).replace(tzinfo=None)
+        atom_row = AtomModel(
+            atom_id=atom_id,
+            atom_type=atom_type,
+            source_table=source_table,
+            source_id=placeholder,
+            owner_user_id=int(owner_user_id),
+            policy={"tier": int(tier)},
+            created_at=now,
+            updated_at=now,
+        )
+        self.db.add(atom_row)
+        await self.db.flush()
+        return atom_id
+
+    async def finalize_source_id(self, atom_id: str, source_id: int | str) -> None:
+        """Replace the placeholder ``source_id`` on an atoms row with the
+        real PK now that the source row has been flushed.
+
+        Paired with :meth:`create_with_source`. Callers MUST invoke this
+        after the source-row flush; skipping it leaves the atoms row
+        pointing at a ``__pending__<uuid>`` placeholder that retrieval
+        will never find a match for.
+        """
+        atom = (await self.db.execute(
+            select(AtomModel).where(AtomModel.atom_id == atom_id)
+        )).scalar_one()
+        atom.source_id = str(source_id)
+        await self.db.flush()
+
     async def update_tier(self, atom_id: str, new_policy: dict[str, Any]) -> None:
         """
         Update atom.policy + cascade to source row's denormalized circle_tier.
@@ -194,6 +261,19 @@ class AtomService:
             ),
             {"tier": new_tier, "source_id": atom_orm.source_id},
         )
+
+        # kb_document cascade: propagate the new tier to every chunk of
+        # this document in the SAME transaction — otherwise retrieval would
+        # read stale document_chunks.circle_tier and leak chunks at the old
+        # tier until someone noticed (Risk A from the design doc review).
+        if atom_orm.atom_type == ATOM_TYPE_KB_DOCUMENT:
+            await self.db.execute(
+                text(
+                    "UPDATE document_chunks SET circle_tier = :tier "
+                    "WHERE document_id = :doc_id"
+                ),
+                {"tier": new_tier, "doc_id": int(atom_orm.source_id)},
+            )
 
         # KG node cascade: incident relations recompute MIN(subject, object).
         if atom_orm.atom_type == ATOM_TYPE_KG_NODE:
@@ -287,9 +367,16 @@ class AtomService:
 
 
 def _table_for_atom_type(atom_type: str) -> str:
-    """Map atom_type discriminator → source table name."""
+    """Map atom_type discriminator → source table name.
+
+    Post-atoms-per-document migration (pc20260423): the RAG access-control
+    unit is ``kb_document`` / ``documents``. The legacy ``kb_chunk`` mapping
+    is retained only so old atoms rows are still reachable for read/delete;
+    writers should not produce ``kb_chunk`` atoms anymore.
+    """
     table_map = {
-        "kb_chunk": "document_chunks",
+        "kb_document": "documents",
+        "kb_chunk": "document_chunks",  # legacy; see note above
         "kg_node": "kg_entities",
         "kg_edge": "kg_relations",
         "conversation_memory": "conversation_memories",
@@ -302,12 +389,13 @@ def _table_for_atom_type(atom_type: str) -> str:
 def _source_id_for(atom: Atom) -> str:
     """Extract the source row's primary key as a string."""
     payload = atom.payload or {}
-    # Prefer explicit chunk_id / entity_id / relation_id / memory_id keys
-    for key in ("chunk_id", "entity_id", "relation_id", "memory_id"):
+    # Prefer explicit document_id / chunk_id / entity_id / relation_id /
+    # memory_id keys (ordered most-specific first).
+    for key in ("document_id", "chunk_id", "entity_id", "relation_id", "memory_id"):
         if key in payload:
             return str(payload[key])
     # Fall back to the atom's stored source_id placeholder if set elsewhere
     raise ValueError(
         f"Cannot determine source_id for atom {atom.atom_type}: "
-        f"payload missing chunk_id/entity_id/relation_id/memory_id"
+        f"payload missing document_id/chunk_id/entity_id/relation_id/memory_id"
     )

--- a/src/backend/services/atom_types.py
+++ b/src/backend/services/atom_types.py
@@ -124,7 +124,8 @@ class Atom:
     but if you need defensive immutability across boundaries, use from_mutable.
     """
     atom_id: str            # UUID4 as 36-char string
-    atom_type: str          # one of {'kb_chunk', 'kg_node', 'kg_edge', 'conversation_memory'}
+    atom_type: str          # one of {'kb_document', 'kg_node', 'kg_edge', 'conversation_memory'}
+                            # ('kb_chunk' is a retired legacy value, see pc20260423)
     owner_user_id: int
     policy: dict[str, Any]
     created_at: datetime

--- a/src/backend/services/circle_sql.py
+++ b/src/backend/services/circle_sql.py
@@ -184,15 +184,20 @@ def document_chunks_circles_filter(
     asker_id: int,
     *,
     chunk_alias: str = "dc",
+    doc_alias: str = "d",
     kb_alias: str = "kb",
 ) -> tuple[str, dict[str, Any]]:
     """
     Returns (clause, params) for circle-filtering document_chunks.
 
-    Tier comes from `dc.circle_tier` (denormalized per-chunk so chunk-level
-    re-tiering is honored). Ownership comes from `kb.owner_id` because chunks
-    don't carry a user_id directly. Callers MUST include the JOIN to
-    knowledge_bases under `kb_alias` (or override the alias).
+    Post-atoms-per-document (pc20260423): the access-control unit is the
+    parent Document. ``atom_explicit_grants`` hang on ``atoms`` rows with
+    ``source_table='documents'``, so the explicit-grant EXISTS check must
+    match against ``d.id`` (not ``dc.id``). Tier stays on ``dc.circle_tier``
+    (denormalized mirror of ``d.circle_tier``) for the hot-path similarity
+    filter. Ownership still comes from ``kb.owner_id`` (documents inherit
+    from KB owner). Callers MUST join knowledge_bases under ``kb_alias``
+    AND documents under ``doc_alias``.
 
     Example:
         clause, params = document_chunks_circles_filter(asker_id=42)
@@ -203,13 +208,13 @@ def document_chunks_circles_filter(
             WHERE ... AND ({clause})
         '''
     """
-    src = "document_chunks"
+    src = "documents"
     clause = circles_filter_clause(
         table_alias=chunk_alias,
         owner_col="owner_id",
         tier_col="circle_tier",
         source_table_value=src,
         owner_table_alias=kb_alias,
-        source_id_expr=f"{chunk_alias}.id",
+        source_id_expr=f"{doc_alias}.id",
     )
     return clause, circles_filter_params(asker_id, source_table_value=src)

--- a/src/backend/services/conversation_memory_service.py
+++ b/src/backend/services/conversation_memory_service.py
@@ -72,6 +72,36 @@ class ConversationMemoryService:
     def __init__(self, db: AsyncSession):
         self.db = db
         self._ollama_client = None
+        # Cached fallback admin id for atoms registration when save() is
+        # called without an authenticated user_id (single-user mode). See
+        # _resolve_owner_user_id.
+        self._fallback_owner_id: int | None = None
+
+    async def _resolve_owner_user_id(self, user_id: int | None) -> int | None:
+        """Resolve a non-null atoms owner, or None if no users exist.
+
+        Matches pc20260420_circles_v1_schema.py back-fill: explicit user_id,
+        else first user (admin), else None (empty-users-table dev setups
+        where atom registration is skipped).
+        """
+        if user_id is not None:
+            return user_id
+        if self._fallback_owner_id is not None:
+            return self._fallback_owner_id
+        from models.database import User
+        result = await self.db.execute(
+            select(User.id).order_by(User.id.asc()).limit(1)
+        )
+        fallback = result.scalar()
+        if fallback is None:
+            return None
+        self._fallback_owner_id = int(fallback)
+        return self._fallback_owner_id
+
+    def _atom_service(self):
+        """Lazy AtomService bound to the same DB session."""
+        from services.atom_service import AtomService
+        return AtomService(self.db)
 
     async def _get_ollama_client(self):
         """Lazy initialization of Ollama client for embeddings."""
@@ -144,10 +174,27 @@ class ConversationMemoryService:
                 # Deactivate the least important memory
                 await self._deactivate_least_important(user_id)
 
+        # Atom-first ordering: conversation_memories.atom_id is NOT NULL +
+        # non-deferrable FK, so the atoms row must exist before the source
+        # INSERT. See AtomService.create_with_source for the 3-phase
+        # contract. owner_id is None only in fresh-DB dev setups; atom
+        # registration is then skipped and memory.atom_id stays NULL
+        # (ORM column is nullable, test SQLite lets this through).
+        owner_id = await self._resolve_owner_user_id(user_id)
+        default_tier = 0  # self — owner promotes via /api/atoms
+        atom_id: str | None = None
+        atom_svc = self._atom_service()
+        if owner_id is not None:
+            atom_id = await atom_svc.create_with_source(
+                atom_type="conversation_memory",
+                owner_user_id=owner_id,
+                tier=default_tier,
+            )
+
         memory = ConversationMemory(
             content=content,
             category=category,
-            user_id=user_id,
+            user_id=owner_id,
             embedding=embedding,
             importance=importance,
             source_session_id=source_session_id,
@@ -158,9 +205,13 @@ class ConversationMemoryService:
             team_id=team_id,
             confidence=confidence,
             trigger_pattern=trigger_pattern,
+            atom_id=atom_id,
+            circle_tier=default_tier,
         )
         self.db.add(memory)
         await self.db.flush()
+        if atom_id is not None:
+            await atom_svc.finalize_source_id(atom_id, memory.id)
 
         await self._record_history(
             memory_id=memory.id,

--- a/src/backend/services/kb_shares_service.py
+++ b/src/backend/services/kb_shares_service.py
@@ -60,6 +60,9 @@ async def share_kb(
             f"(expected one of {sorted(_PERM_RANK)})"
         )
 
+    # Post-atoms-per-document (pc20260423): one grant per DOCUMENT, not per
+    # chunk. The KB-share explosion size drops from O(chunks) to O(documents);
+    # for a typical book-sized KB that's 2-3 orders of magnitude smaller.
     now = datetime.now(UTC).replace(tzinfo=None)
     await db.execute(
         text(
@@ -67,9 +70,8 @@ async def share_kb(
             "  (atom_id, granted_to_user_id, permission_level, granted_by, granted_at) "
             "SELECT a.atom_id, :target, :perm, :granter, :now "
             "FROM atoms a "
-            "JOIN document_chunks dc ON a.source_id = dc.id::text "
-            "JOIN documents d ON dc.document_id = d.id "
-            "WHERE a.source_table = 'document_chunks' "
+            "JOIN documents d ON a.source_id = d.id::text "
+            "WHERE a.source_table = 'documents' "
             "  AND d.knowledge_base_id = :kb_id "
             "ON CONFLICT (atom_id, granted_to_user_id) DO UPDATE "
             "  SET permission_level = EXCLUDED.permission_level, "
@@ -104,11 +106,10 @@ async def revoke_kb_share(
     result = await db.execute(
         text(
             "DELETE FROM atom_explicit_grants g "
-            "USING atoms a, document_chunks dc, documents d "
+            "USING atoms a, documents d "
             "WHERE g.atom_id = a.atom_id "
-            "  AND a.source_table = 'document_chunks' "
-            "  AND a.source_id = dc.id::text "
-            "  AND dc.document_id = d.id "
+            "  AND a.source_table = 'documents' "
+            "  AND a.source_id = d.id::text "
             "  AND d.knowledge_base_id = :kb_id "
             "  AND g.granted_to_user_id = :target"
         ),
@@ -136,15 +137,14 @@ async def list_kb_shares(db: AsyncSession, kb_id: int) -> list[dict[str, Any]]:
     """
     result = await db.execute(
         text(
-            "WITH latest_per_chunk AS ("
+            "WITH latest_per_doc AS ("
             "  SELECT DISTINCT ON (g.granted_to_user_id, g.atom_id) "
             "    g.granted_to_user_id, g.atom_id, g.permission_level, "
             "    g.granted_by, g.granted_at "
             "  FROM atom_explicit_grants g "
             "  JOIN atoms a ON g.atom_id = a.atom_id "
-            "  JOIN document_chunks dc ON a.source_id = dc.id::text "
-            "  JOIN documents d ON dc.document_id = d.id "
-            "  WHERE a.source_table = 'document_chunks' "
+            "  JOIN documents d ON a.source_id = d.id::text "
+            "  WHERE a.source_table = 'documents' "
             "    AND d.knowledge_base_id = :kb_id "
             "  ORDER BY g.granted_to_user_id, g.atom_id, g.granted_at DESC "
             "), "
@@ -153,19 +153,19 @@ async def list_kb_shares(db: AsyncSession, kb_id: int) -> list[dict[str, Any]]:
             "         MAX(CASE permission_level "
             "             WHEN 'admin' THEN 3 WHEN 'write' THEN 2 ELSE 1 END) AS rank, "
             "         MAX(granted_at) AS latest_at "
-            "  FROM latest_per_chunk "
+            "  FROM latest_per_doc "
             "  GROUP BY granted_to_user_id "
             ") "
             "SELECT DISTINCT ON (r.granted_to_user_id) "
             "       r.granted_to_user_id AS user_id, "
             "       r.rank, "
             "       r.latest_at AS granted_at, "
-            "       lpc.granted_by "
+            "       lpd.granted_by "
             "FROM ranked r "
-            "JOIN latest_per_chunk lpc "
-            "  ON lpc.granted_to_user_id = r.granted_to_user_id "
-            "  AND lpc.granted_at = r.latest_at "
-            "ORDER BY r.granted_to_user_id, lpc.granted_by NULLS LAST"
+            "JOIN latest_per_doc lpd "
+            "  ON lpd.granted_to_user_id = r.granted_to_user_id "
+            "  AND lpd.granted_at = r.latest_at "
+            "ORDER BY r.granted_to_user_id, lpd.granted_by NULLS LAST"
         ),
         {"kb_id": kb_id},
     )
@@ -193,9 +193,8 @@ async def get_user_kb_permission_level(
             "             WHEN 'admin' THEN 3 WHEN 'write' THEN 2 ELSE 1 END) AS rank "
             "FROM atom_explicit_grants g "
             "JOIN atoms a ON g.atom_id = a.atom_id "
-            "JOIN document_chunks dc ON a.source_id = dc.id::text "
-            "JOIN documents d ON dc.document_id = d.id "
-            "WHERE a.source_table = 'document_chunks' "
+            "JOIN documents d ON a.source_id = d.id::text "
+            "WHERE a.source_table = 'documents' "
             "  AND d.knowledge_base_id = :kb_id "
             "  AND g.granted_to_user_id = :user_id"
         ),
@@ -208,15 +207,14 @@ async def get_user_kb_permission_level(
 
 
 async def list_user_shared_kb_ids(db: AsyncSession, user_id: int) -> set[int]:
-    """KB IDs the user has any chunk-level grant on."""
+    """KB IDs the user has any document-level grant on."""
     result = await db.execute(
         text(
             "SELECT DISTINCT d.knowledge_base_id "
             "FROM atom_explicit_grants g "
             "JOIN atoms a ON g.atom_id = a.atom_id "
-            "JOIN document_chunks dc ON a.source_id = dc.id::text "
-            "JOIN documents d ON dc.document_id = d.id "
-            "WHERE a.source_table = 'document_chunks' "
+            "JOIN documents d ON a.source_id = d.id::text "
+            "WHERE a.source_table = 'documents' "
             "  AND g.granted_to_user_id = :user_id "
             "  AND d.knowledge_base_id IS NOT NULL"
         ),

--- a/src/backend/services/knowledge_graph_service.py
+++ b/src/backend/services/knowledge_graph_service.py
@@ -140,56 +140,12 @@ class KnowledgeGraphService:
         self._fallback_owner_id = int(fallback)
         return self._fallback_owner_id
 
-    async def _create_atom_for_new_source(
-        self,
-        atom_type: str,
-        owner_user_id: int,
-        tier: int,
-    ) -> str:
-        """Pre-create an ``atoms`` row before inserting the source row.
-
-        The source-table ``atom_id`` columns carry a NOT NULL constraint and
-        a non-deferrable FK back to ``atoms.atom_id`` (per the
-        pc20260420_circles_v1 migration). That means the atoms row must
-        already exist when the source-row INSERT fires. The source row's
-        primary key is auto-incremented and only known after flush, so we
-        seed ``atoms.source_id`` with a unique placeholder; the caller
-        invokes :meth:`_finalize_atom_source_id` after flushing the source
-        row to overwrite the placeholder with the real PK.
+    def _atom_service(self):
+        """Lazy AtomService bound to the same DB session. Shared helper for
+        create_with_source / finalize_source_id (see atom_service.py).
         """
-        from datetime import UTC, datetime
-        import uuid as _uuid
-        from models.database import Atom as AtomORM
-        atom_id = str(_uuid.uuid4())
-        source_table = {
-            "kg_node": "kg_entities",
-            "kg_edge": "kg_relations",
-        }[atom_type]
-        placeholder = f"__pending__{atom_id}"
-        now = datetime.now(UTC).replace(tzinfo=None)
-        atom_row = AtomORM(
-            atom_id=atom_id,
-            atom_type=atom_type,
-            source_table=source_table,
-            source_id=placeholder,
-            owner_user_id=int(owner_user_id),
-            policy={"tier": int(tier)},
-            created_at=now,
-            updated_at=now,
-        )
-        self.db.add(atom_row)
-        await self.db.flush()
-        return atom_id
-
-    async def _finalize_atom_source_id(self, atom_id: str, source_id: int) -> None:
-        """Replace the placeholder ``source_id`` on an atoms row with the
-        freshly-flushed source-row's primary key."""
-        from models.database import Atom as AtomORM
-        atom = (await self.db.execute(
-            select(AtomORM).where(AtomORM.atom_id == atom_id)
-        )).scalar_one()
-        atom.source_id = str(source_id)
-        await self.db.flush()
+        from services.atom_service import AtomService
+        return AtomService(self.db)
 
     async def _get_ollama_client(self):
         if self._ollama_client is None:
@@ -463,7 +419,7 @@ class KnowledgeGraphService:
         # that actually runs.
         atom_id: str | None = None
         if owner_id is not None:
-            atom_id = await self._create_atom_for_new_source(
+            atom_id = await self._atom_service().create_with_source(
                 atom_type="kg_node",
                 owner_user_id=owner_id,
                 tier=default_tier,
@@ -480,7 +436,7 @@ class KnowledgeGraphService:
         self.db.add(entity)
         await self.db.flush()
         if atom_id is not None:
-            await self._finalize_atom_source_id(atom_id, entity.id)
+            await self._atom_service().finalize_source_id(atom_id, entity.id)
         logger.debug(f"KG: New entity '{name}' ({entity_type}) id={entity.id} atom_id={atom_id}")
         return entity
 
@@ -592,7 +548,7 @@ class KnowledgeGraphService:
         owner_id = await self._resolve_owner_user_id(user_id)
         atom_id: str | None = None
         if owner_id is not None:
-            atom_id = await self._create_atom_for_new_source(
+            atom_id = await self._atom_service().create_with_source(
                 atom_type="kg_edge",
                 owner_user_id=owner_id,
                 tier=relation_tier,
@@ -610,7 +566,7 @@ class KnowledgeGraphService:
         self.db.add(relation)
         await self.db.flush()
         if atom_id is not None:
-            await self._finalize_atom_source_id(atom_id, relation.id)
+            await self._atom_service().finalize_source_id(atom_id, relation.id)
         logger.debug(
             f"KG: New relation {subject_id} --{predicate}--> {object_id} "
             f"atom_id={atom_id} tier={relation_tier}"

--- a/src/backend/services/polymorphic_atom_store.py
+++ b/src/backend/services/polymorphic_atom_store.py
@@ -132,49 +132,69 @@ def _now() -> datetime:
 
 
 def _wrap_rag_results(rag_results: Any) -> list[AtomMatch]:
-    """Convert RAGRetrieval.search output -> list[AtomMatch]."""
+    """Convert RAGRetrieval.search output -> list[AtomMatch].
+
+    Post-atoms-per-document (pc20260423): emits one AtomMatch per unique
+    DOCUMENT, not per chunk. Multiple chunks of the same document that
+    matched the query collapse to a single match carrying the best-scoring
+    chunk's snippet. This keeps the polymorphic Cross-Source RRF fusion
+    fair — documents compete on equal footing with KG entities and
+    memories, rather than a long document flooding the top-K with its own
+    chunks.
+    """
     if isinstance(rag_results, Exception) or not rag_results:
         return []
-    matches = []
+
+    # Group chunk results by document atom_id, keeping the highest similarity
+    # per document. RAGRetrieval.search returns chunks sorted by similarity
+    # desc; we preserve that order when collapsing.
     now = _now()
-    for rank, result in enumerate(rag_results, start=1):
+    seen_atoms: dict[str, AtomMatch] = {}
+    next_rank = 1
+    for result in rag_results:
         chunk = result.get("chunk", {})
         doc = result.get("document", {})
-        # Per PR #402 review SHOULD-FIX #11: warn-log when atom_id is missing
-        # (should never happen post-migration; if it does, the back-fill skipped
-        # this row or a writer bypassed AtomService).
-        if chunk.get("atom_id") is None:
+
+        doc_atom_id = doc.get("atom_id")
+        if doc_atom_id is None:
             logger.warning(
-                f"PolymorphicAtomStore: chunk id={chunk.get('id')} has no atom_id "
-                f"(post-migration this should not happen — back-fill missed this row "
-                f"or writer bypassed AtomService.upsert_atom)"
+                f"PolymorphicAtomStore: document id={doc.get('id')} has no atom_id "
+                f"(post-migration this should not happen — back-fill missed this "
+                f"row or writer bypassed AtomService.create_with_source)"
             )
-        atom_id = chunk.get("atom_id") or f"kb_chunk:{chunk.get('id', 0)}"
-        matches.append(
-            AtomMatch(
-                atom=Atom(
-                    atom_id=str(atom_id),
-                    atom_type="kb_chunk",
-                    owner_user_id=0,
-                    policy={"tier": chunk.get("circle_tier", 0)},
-                    created_at=now,
-                    updated_at=now,
-                    payload={
-                        "chunk_id": chunk.get("id"),
-                        "document_id": doc.get("id"),
-                        "content": chunk.get("content", ""),
-                        "page_number": chunk.get("page_number"),
-                        "section_title": chunk.get("section_title"),
-                        "document_filename": doc.get("filename", ""),
-                        "document_title": doc.get("title"),
-                    },
-                ),
-                score=float(result.get("similarity", 0.0)),
-                snippet=chunk.get("content", "")[:200],
-                rank=rank,
-            )
+            doc_atom_id = f"kb_document:{doc.get('id', 0)}"
+        atom_id = str(doc_atom_id)
+
+        if atom_id in seen_atoms:
+            continue  # already have a higher-scoring chunk for this document
+
+        similarity = float(result.get("similarity", 0.0))
+        seen_atoms[atom_id] = AtomMatch(
+            atom=Atom(
+                atom_id=atom_id,
+                atom_type="kb_document",
+                owner_user_id=0,
+                # Chunks carry the denormalized tier from their document;
+                # either side gives the same value, chunk-side is cheap.
+                policy={"tier": chunk.get("circle_tier", doc.get("circle_tier", 0))},
+                created_at=now,
+                updated_at=now,
+                payload={
+                    "document_id": doc.get("id"),
+                    "best_chunk_id": chunk.get("id"),
+                    "content": chunk.get("content", ""),
+                    "page_number": chunk.get("page_number"),
+                    "section_title": chunk.get("section_title"),
+                    "document_filename": doc.get("filename", ""),
+                    "document_title": doc.get("title"),
+                },
+            ),
+            score=similarity,
+            snippet=chunk.get("content", "")[:200],
+            rank=next_rank,
         )
-    return matches
+        next_rank += 1
+    return list(seen_atoms.values())
 
 
 def _wrap_kg_context(kg_context: Any) -> list[AtomMatch]:

--- a/src/backend/services/rag_retrieval.py
+++ b/src/backend/services/rag_retrieval.py
@@ -203,8 +203,11 @@ class RAGRetrieval:
                 dc.chunk_type,
                 dc.chunk_metadata,
                 dc.parent_chunk_id,
+                dc.circle_tier,
                 d.filename,
                 d.title as doc_title,
+                d.atom_id as doc_atom_id,
+                d.circle_tier as doc_circle_tier,
                 1 - (dc.embedding <=> CAST(:embedding AS vector)) as similarity
             FROM document_chunks dc
             JOIN documents d ON dc.document_id = d.id
@@ -238,11 +241,14 @@ class RAGRetrieval:
                     "section_title": row.section_title,
                     "chunk_type": row.chunk_type,
                     "parent_chunk_id": getattr(row, "parent_chunk_id", None),
+                    "circle_tier": getattr(row, "circle_tier", 0),
                 },
                 "document": {
                     "id": row.document_id,
                     "filename": row.filename,
                     "title": row.doc_title or row.filename,
+                    "atom_id": getattr(row, "doc_atom_id", None),
+                    "circle_tier": getattr(row, "doc_circle_tier", 0),
                 },
                 "similarity": round(similarity, 4),
             })
@@ -279,8 +285,11 @@ class RAGRetrieval:
                 dc.chunk_type,
                 dc.chunk_metadata,
                 dc.parent_chunk_id,
+                dc.circle_tier,
                 d.filename,
                 d.title as doc_title,
+                d.atom_id as doc_atom_id,
+                d.circle_tier as doc_circle_tier,
                 ts_rank_cd(dc.search_vector, websearch_to_tsquery(:fts_config, :or_query)) as rank
             FROM document_chunks dc
             JOIN documents d ON dc.document_id = d.id
@@ -314,11 +323,14 @@ class RAGRetrieval:
                     "section_title": row.section_title,
                     "chunk_type": row.chunk_type,
                     "parent_chunk_id": getattr(row, "parent_chunk_id", None),
+                    "circle_tier": getattr(row, "circle_tier", 0),
                 },
                 "document": {
                     "id": row.document_id,
                     "filename": row.filename,
                     "title": row.doc_title or row.filename,
+                    "atom_id": getattr(row, "doc_atom_id", None),
+                    "circle_tier": getattr(row, "doc_circle_tier", 0),
                 },
                 "similarity": round(float(row.rank), 6),
             }

--- a/src/backend/services/rag_service.py
+++ b/src/backend/services/rag_service.py
@@ -58,6 +58,36 @@ class RAGService:
         self.db = db
         self.processor = DocumentProcessor()
         self._ollama_client = None
+        # Cached admin fallback id for atoms registration when the parent KB
+        # has no explicit owner (legacy rows / pre-auth KBs). Resolved lazily.
+        self._fallback_owner_id: int | None = None
+
+    async def _resolve_owner_user_id(self, user_id: int | None) -> int | None:
+        """Resolve a non-null atoms owner, or None when no users exist.
+
+        Matches pc20260420_circles_v1_schema.py back-fill logic: prefer the
+        explicit owner, else fall back to the first user (admin). Returns
+        None only in empty-users fresh-DB dev setups so callers can skip
+        atom registration (e.g. pre-bootstrap unit tests).
+        """
+        if user_id is not None:
+            return user_id
+        if self._fallback_owner_id is not None:
+            return self._fallback_owner_id
+        from models.database import User
+        result = await self.db.execute(
+            select(User.id).order_by(User.id.asc()).limit(1)
+        )
+        fallback = result.scalar()
+        if fallback is None:
+            return None
+        self._fallback_owner_id = int(fallback)
+        return self._fallback_owner_id
+
+    def _atom_service(self):
+        """Lazy AtomService bound to the same DB session."""
+        from services.atom_service import AtomService
+        return AtomService(self.db)
 
     async def _get_ollama_client(self):
         """Lazy initialization des Ollama Clients"""
@@ -186,19 +216,60 @@ class RAGService:
         ``process_existing_document`` (#388). The ``ingest_document``
         wrapper still exists for callers that need synchronous ingestion
         (currently chat upload, reindex) — those run Docling in-process.
+
+        Circles v2 (atoms-per-document): the atoms registry row is created
+        here, at the same time as the Document, so every document that
+        exists in the DB is access-controlled from the first commit. Chunks
+        created later inherit ``circle_tier`` from the document.
         """
         actual_filename = filename or os.path.basename(file_path)
+
+        # Resolve KB owner + default tier for the atoms registration.
+        kb_owner_id: int | None = None
+        kb_default_tier = 0
+        if knowledge_base_id is not None:
+            kb_info = (await self.db.execute(
+                select(KnowledgeBase.owner_id, KnowledgeBase.default_circle_tier)
+                .where(KnowledgeBase.id == knowledge_base_id)
+            )).first()
+            if kb_info is not None:
+                kb_owner_id = kb_info.owner_id
+                kb_default_tier = int(kb_info.default_circle_tier or 0)
+
+        atom_owner = await self._resolve_owner_user_id(kb_owner_id)
+
+        # Pre-create the atoms row so the Document.atom_id FK has a valid
+        # target when the document INSERT fires. Skipped only in empty-users
+        # dev setups (pre-bootstrap), which leaves doc.atom_id NULL on
+        # SQLite test DBs — prod always has the bootstrap admin.
+        atom_id: str | None = None
+        atom_svc = self._atom_service()
+        if atom_owner is not None:
+            atom_id = await atom_svc.create_with_source(
+                atom_type="kb_document",
+                owner_user_id=atom_owner,
+                tier=kb_default_tier,
+            )
+
         doc = Document(
             file_path=file_path,
             filename=actual_filename,
             knowledge_base_id=knowledge_base_id,
             file_hash=file_hash,
             status=DOC_STATUS_PENDING,
+            atom_id=atom_id,
+            circle_tier=kb_default_tier,
         )
         self.db.add(doc)
         await self.db.commit()
         await self.db.refresh(doc)
-        logger.info(f"Dokument erstellt: ID={doc.id}, Datei={actual_filename}, status=pending")
+        if atom_id is not None:
+            await atom_svc.finalize_source_id(atom_id, doc.id)
+            await self.db.commit()
+        logger.info(
+            f"Dokument erstellt: ID={doc.id}, Datei={actual_filename}, "
+            f"status=pending, atom_id={atom_id}, tier={kb_default_tier}"
+        )
         return doc
 
     async def process_existing_document(
@@ -264,6 +335,15 @@ class RAGService:
                 chunk_objects = await self._ingest_parent_child(doc.id, chunks, sem)
             else:
                 chunk_objects = await self._ingest_flat(doc.id, chunks, sem)
+
+            # Post-atoms-per-document (#pc20260423): chunks no longer carry
+            # their own atom_id. They inherit circle_tier from the parent
+            # Document — set here so retrieval's hot-path SQL filter (which
+            # reads document_chunks.circle_tier without a JOIN) stays valid
+            # even between document-level tier changes and the subsequent
+            # AtomService.update_tier cascade.
+            for chunk in chunk_objects:
+                chunk.circle_tier = int(doc.circle_tier or 0)
 
             chunk_count = len(chunk_objects)
             if chunk_objects:

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -1081,7 +1081,7 @@
     "removeMember": "Mitglied entfernen",
     "removeMemberConfirm": "{{name}} aus allen Kreisen entfernen?",
     "atomType": {
-      "kb_chunk": "Dokument",
+      "kb_document": "Dokument",
       "kg_node": "Entität",
       "kg_edge": "Beziehung",
       "conversation_memory": "Erinnerung"

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -1081,7 +1081,7 @@
     "removeMember": "Remove member",
     "removeMemberConfirm": "Remove {{name}} from all circles?",
     "atomType": {
-      "kb_chunk": "Document",
+      "kb_document": "Document",
       "kg_node": "Entity",
       "kg_edge": "Relation",
       "conversation_memory": "Memory"

--- a/src/frontend/src/pages/BrainPage.jsx
+++ b/src/frontend/src/pages/BrainPage.jsx
@@ -8,7 +8,7 @@ import Badge from '../components/Badge';
 import TierBadge from '../components/TierBadge';
 
 const ATOM_TYPE_COLORS = {
-  kb_chunk: 'blue',
+  kb_document: 'blue',
   kg_node: 'amber',
   kg_edge: 'purple',
   conversation_memory: 'teal',

--- a/src/frontend/src/pages/BrainReviewPage.jsx
+++ b/src/frontend/src/pages/BrainReviewPage.jsx
@@ -8,7 +8,7 @@ import Badge from '../components/Badge';
 import TierPicker from '../components/TierPicker';
 
 const ATOM_TYPE_COLORS = {
-  kb_chunk: 'blue',
+  kb_document: 'blue',
   kg_node: 'amber',
   kg_edge: 'purple',
   conversation_memory: 'teal',

--- a/tests/backend/test_atom_service.py
+++ b/tests/backend/test_atom_service.py
@@ -39,7 +39,7 @@ def _existing_source_row(scalar=1):
     return res
 
 
-def _new_atom(atom_type="kb_chunk", payload=None) -> Atom:
+def _new_atom(atom_type="kb_document", payload=None) -> Atom:
     return Atom(
         atom_id="",  # triggers UUID mint
         atom_type=atom_type,
@@ -117,10 +117,10 @@ class TestUpdateTier:
 
     @pytest.mark.asyncio
     @pytest.mark.unit
-    async def test_kb_chunk_writes_source_tier_only(self):
+    async def test_kb_document_writes_source_tier_only(self):
         session = _mock_session()
         atom_orm = MagicMock()
-        atom_orm.atom_type = "kb_chunk"
+        atom_orm.atom_type = "kb_document"
         atom_orm.source_table = "document_chunks"
         atom_orm.source_id = "99"
         session.execute = AsyncMock(side_effect=[
@@ -130,7 +130,7 @@ class TestUpdateTier:
         svc = AtomService(session, resolver=MagicMock(invalidate_for_atom=MagicMock()))
         await svc.update_tier("atom-x", {"tier": 3})
 
-        # 2 executes: SELECT atom, UPDATE source. No cascade for kb_chunk.
+        # 2 executes: SELECT atom, UPDATE source. No cascade for kb_document.
         assert session.execute.await_count == 2
         session.commit.assert_awaited_once()
 

--- a/tests/backend/test_atom_service.py
+++ b/tests/backend/test_atom_service.py
@@ -117,21 +117,32 @@ class TestUpdateTier:
 
     @pytest.mark.asyncio
     @pytest.mark.unit
-    async def test_kb_document_writes_source_tier_only(self):
+    async def test_kb_document_cascades_to_document_chunks(self):
+        """Post pc20260423: kb_document tier changes MUST propagate to every
+        chunk's denormalized circle_tier in the same transaction — otherwise
+        the hot-path SQL filter keeps reading stale chunk tiers and leaks
+        chunks at the old tier (Risk A from docs/design/atoms-granularity.md).
+        """
         session = _mock_session()
         atom_orm = MagicMock()
         atom_orm.atom_type = "kb_document"
-        atom_orm.source_table = "document_chunks"
+        atom_orm.source_table = "documents"
         atom_orm.source_id = "99"
         session.execute = AsyncMock(side_effect=[
             MagicMock(scalar_one_or_none=MagicMock(return_value=atom_orm)),
-            MagicMock(),  # UPDATE source.circle_tier
+            MagicMock(),  # UPDATE documents.circle_tier
+            MagicMock(),  # UPDATE document_chunks.circle_tier — cascade
         ])
         svc = AtomService(session, resolver=MagicMock(invalidate_for_atom=MagicMock()))
         await svc.update_tier("atom-x", {"tier": 3})
 
-        # 2 executes: SELECT atom, UPDATE source. No cascade for kb_document.
-        assert session.execute.await_count == 2
+        # 3 executes: SELECT atom + UPDATE documents + UPDATE document_chunks.
+        assert session.execute.await_count == 3
+        cascade_sql = str(session.execute.await_args_list[2].args[0])
+        assert "UPDATE document_chunks" in cascade_sql
+        assert "document_id = :doc_id" in cascade_sql
+        binds = session.execute.await_args_list[2].args[1]
+        assert binds == {"tier": 3, "doc_id": 99}
         session.commit.assert_awaited_once()
 
     @pytest.mark.asyncio

--- a/tests/backend/test_atoms_for_review_labels.py
+++ b/tests/backend/test_atoms_for_review_labels.py
@@ -9,7 +9,7 @@ tier for an unlabeled hex string. The response now includes a
 Covers:
 - kg_node → entity.name + description
 - kg_edge → "subject predicate object"
-- kb_chunk → document.filename + chunk.content
+- kb_document → document.filename + chunk.content
 - conversation_memory → "Memory · YYYY-MM-DD HH:MM" + content
 - orphan source_id → "Unknown … (id)" fallback (no crash)
 - mixed atom types → each gets its type-specific label, no bleed
@@ -72,9 +72,9 @@ class TestResolveReviewLabels:
 
     @pytest.mark.asyncio
     @pytest.mark.unit
-    async def test_kb_chunk_prefers_document_title_then_filename(self):
-        atom_with_title = _atom("c1", "kb_chunk", "document_chunks", "10")
-        atom_without_title = _atom("c2", "kb_chunk", "document_chunks", "11")
+    async def test_kb_document_prefers_document_title_then_filename(self):
+        atom_with_title = _atom("c1", "kb_document", "document_chunks", "10")
+        atom_without_title = _atom("c2", "kb_document", "document_chunks", "11")
 
         doc_titled = SimpleNamespace(title="Nebenkostenabrechnung 2025", filename="NK_2025.pdf")
         doc_untitled = SimpleNamespace(title=None, filename="mysterium.pdf")

--- a/tests/backend/test_circle_sql.py
+++ b/tests/backend/test_circle_sql.py
@@ -128,25 +128,32 @@ class TestConversationMemoriesWrapper:
 
 class TestDocumentChunksWrapper:
     def test_owner_from_kb_tier_from_chunk(self):
+        """Post pc20260423 (atoms-per-document): the access-control unit is
+        the parent Document, so the grant subquery anchors on ``documents``
+        with source_id = d.id. Tier still comes from the chunk row (fast
+        denormalized path — avoids the chunk→document JOIN in the hot
+        similarity filter). Ownership still comes from kb.owner_id.
+        """
         clause, params = document_chunks_circles_filter(asker_id=42)
         # Owner branch references kb.owner_id, not dc.user_id
         assert "kb.owner_id = :asker_id" in clause
-        # Tier check is on chunk row
+        # Tier check is on chunk row (denormalized)
         assert "dc.circle_tier = :asker_id_pub" in clause
         # Membership reaches kb.owner_id
         assert "m.circle_owner_id = kb.owner_id" in clause
-        # Grant subquery anchored on document_chunks (bound, not interpolated)
+        # Grant subquery anchored on documents (document-level atoms)
         assert "a.source_table = :asker_id_src" in clause
-        assert "a.source_id = (dc.id)::text" in clause
+        assert "a.source_id = (d.id)::text" in clause
         assert params == {
-            "asker_id": 42, "asker_id_pub": TIER_PUBLIC, "asker_id_src": "document_chunks",
+            "asker_id": 42, "asker_id_pub": TIER_PUBLIC, "asker_id_src": "documents",
         }
 
     def test_custom_aliases(self):
         clause, _ = document_chunks_circles_filter(
-            asker_id=42, chunk_alias="chunks", kb_alias="bases",
+            asker_id=42, chunk_alias="chunks", doc_alias="doc", kb_alias="bases",
         )
         assert "bases.owner_id = :asker_id" in clause
         assert "chunks.circle_tier = :asker_id_pub" in clause
         assert "m.circle_owner_id = bases.owner_id" in clause
-        assert "a.source_id = (chunks.id)::text" in clause
+        # Grant anchor follows the doc_alias now, not the chunk_alias.
+        assert "a.source_id = (doc.id)::text" in clause

--- a/tests/backend/test_circles_v1_services.py
+++ b/tests/backend/test_circles_v1_services.py
@@ -51,7 +51,7 @@ def _atom(atom_id="x", policy=None, owner=42) -> Atom:
         policy = {"tier": 2}
     return Atom(
         atom_id=atom_id,
-        atom_type="kb_chunk",
+        atom_type="kb_document",
         owner_user_id=owner,
         policy=policy,
         created_at=datetime.now(UTC).replace(tzinfo=None),
@@ -112,7 +112,7 @@ class TestAtomTier:
         now = datetime.now(UTC).replace(tzinfo=None)
         atom = Atom.from_mutable(
             atom_id="x",
-            atom_type="kb_chunk",
+            atom_type="kb_document",
             owner_user_id=42,
             policy=source_policy,
             created_at=now,
@@ -128,7 +128,7 @@ class TestAtomTier:
         now = datetime.now(UTC).replace(tzinfo=None)
         atom = Atom.from_mutable(
             atom_id="x",
-            atom_type="kb_chunk",
+            atom_type="kb_document",
             owner_user_id=42,
             policy={"tier": 0},
             created_at=now,
@@ -153,7 +153,7 @@ class TestProvenanceRedaction:
         # across queries by atom_id. Verify the redacted ID is a valid UUID
         # and is NOT the original.
         import uuid as _uuid
-        p = Provenance(atom_id="abc-123-real", atom_type="kb_chunk", display_label="from doc", score=0.85)
+        p = Provenance(atom_id="abc-123-real", atom_type="kb_document", display_label="from doc", score=0.85)
         redacted = p.redacted_for_remote()
         assert redacted.atom_id != p.atom_id
         # Should parse as a valid UUID4
@@ -404,7 +404,7 @@ class TestSourceWrapping:
         }]
         result = _wrap_rag_results(rag_results)
         assert len(result) == 1
-        assert result[0].atom.atom_type == "kb_chunk"
+        assert result[0].atom.atom_type == "kb_document"
         assert result[0].atom.atom_id == "atom-7"
         assert result[0].atom.policy == {"tier": 2}
         assert result[0].score == 0.91
@@ -420,7 +420,7 @@ class TestSourceWrapping:
             "similarity": 0.5,
         }]
         result = _wrap_rag_results(rag_results)
-        assert result[0].atom.atom_id == "kb_chunk:42"
+        assert result[0].atom.atom_id == "kb_document:42"
 
     @pytest.mark.unit
     def test_kg_wrapper_handles_exception_input(self):

--- a/tests/backend/test_circles_v1_services.py
+++ b/tests/backend/test_circles_v1_services.py
@@ -389,23 +389,31 @@ class TestSourceWrapping:
         assert _wrap_rag_results(None) == []
 
     @pytest.mark.unit
-    def test_rag_wrapper_extracts_chunk_fields(self):
+    def test_rag_wrapper_extracts_document_fields(self):
+        """Post pc20260423: the atom id + owner live on the document, not
+        on the chunk. Chunks contribute content/snippet + denormalized tier.
+        """
         rag_results = [{
             "chunk": {
                 "id": 7,
                 "content": "The cat sat on the mat.",
                 "page_number": 3,
                 "section_title": "Pets",
-                "atom_id": "atom-7",
                 "circle_tier": 2,
             },
-            "document": {"id": 1, "filename": "cats.pdf", "title": "Cat Lore"},
+            "document": {
+                "id": 1,
+                "filename": "cats.pdf",
+                "title": "Cat Lore",
+                "atom_id": "doc-atom-1",
+                "circle_tier": 2,
+            },
             "similarity": 0.91,
         }]
         result = _wrap_rag_results(rag_results)
         assert len(result) == 1
         assert result[0].atom.atom_type == "kb_document"
-        assert result[0].atom.atom_id == "atom-7"
+        assert result[0].atom.atom_id == "doc-atom-1"
         assert result[0].atom.policy == {"tier": 2}
         assert result[0].score == 0.91
         assert "cat sat" in result[0].snippet
@@ -413,14 +421,53 @@ class TestSourceWrapping:
 
     @pytest.mark.unit
     def test_rag_wrapper_falls_back_to_synthetic_atom_id_when_missing(self):
-        # Pre-migration data won't have atom_id populated yet; use synthetic id.
+        # Defensive fallback when document.atom_id is absent (shouldn't happen
+        # post-migration, but we log a warning and synthesize rather than crash).
         rag_results = [{
             "chunk": {"id": 42, "content": "x"},
             "document": {"id": 1, "filename": "y", "title": "z"},
             "similarity": 0.5,
         }]
         result = _wrap_rag_results(rag_results)
-        assert result[0].atom.atom_id == "kb_document:42"
+        assert result[0].atom.atom_id == "kb_document:1"
+        assert result[0].atom.atom_type == "kb_document"
+
+    @pytest.mark.unit
+    def test_rag_wrapper_collapses_chunks_to_one_atom_per_document(self):
+        """Post pc20260423: multiple chunk hits from the same document
+        collapse to ONE AtomMatch carrying the best-scoring chunk's snippet.
+        Without this, a single long document floods cross-source RRF with
+        its own chunks and starves KG / memory results.
+        """
+        rag_results = [
+            {
+                "chunk": {"id": 1, "content": "first para", "circle_tier": 0},
+                "document": {"id": 42, "filename": "a.pdf", "title": "A",
+                             "atom_id": "doc-42", "circle_tier": 0},
+                "similarity": 0.95,
+            },
+            {
+                "chunk": {"id": 2, "content": "second para", "circle_tier": 0},
+                "document": {"id": 42, "filename": "a.pdf", "title": "A",
+                             "atom_id": "doc-42", "circle_tier": 0},
+                "similarity": 0.80,
+            },
+            {
+                "chunk": {"id": 3, "content": "B chunk", "circle_tier": 0},
+                "document": {"id": 99, "filename": "b.pdf", "title": "B",
+                             "atom_id": "doc-99", "circle_tier": 0},
+                "similarity": 0.70,
+            },
+        ]
+        result = _wrap_rag_results(rag_results)
+        assert len(result) == 2
+        # Best-scoring chunk wins for doc-42 — snippet from chunk id=1.
+        doc42 = next(r for r in result if r.atom.atom_id == "doc-42")
+        assert doc42.score == 0.95
+        assert "first para" in doc42.snippet
+        assert doc42.atom.payload["best_chunk_id"] == 1
+        # Ranks reassigned sequentially after collapse.
+        assert sorted(r.rank for r in result) == [1, 2]
 
     @pytest.mark.unit
     def test_kg_wrapper_handles_exception_input(self):

--- a/tests/backend/test_kb_shares_service.py
+++ b/tests/backend/test_kb_shares_service.py
@@ -44,12 +44,15 @@ async def test_share_kb_emits_upsert_with_join_chain():
 
     db.execute.assert_called_once()
     sql_text = str(db.execute.call_args.args[0])
-    # The join chain hits atoms → document_chunks → documents
+    # Post pc20260423: grants anchor on documents (one grant per doc), not
+    # per chunk. The join chain is atoms → documents directly.
     assert "INSERT INTO atom_explicit_grants" in sql_text
     assert "FROM atoms a" in sql_text
-    assert "JOIN document_chunks dc" in sql_text
-    assert "JOIN documents d" in sql_text
-    assert "WHERE a.source_table = 'document_chunks'" in sql_text
+    assert "JOIN documents d ON a.source_id = d.id::text" in sql_text
+    assert "WHERE a.source_table = 'documents'" in sql_text
+    # Chunks must not appear anywhere — regression guard against reverting
+    # the atoms-per-document granularity change.
+    assert "document_chunks" not in sql_text
     # Idempotent upsert
     assert "ON CONFLICT" in sql_text
     # Bind params
@@ -128,8 +131,8 @@ async def test_list_kb_shares_uses_distinct_on_for_paired_granter():
     sql = str(db.execute.call_args.args[0])
     # DISTINCT ON ensures one row per user, paired correctly.
     assert "DISTINCT ON" in sql
-    # latest_per_chunk CTE picks most-recent grant per (user, chunk).
-    assert "latest_per_chunk" in sql
+    # Post pc20260423: CTE picks most-recent grant per (user, document).
+    assert "latest_per_doc" in sql
     # The legacy arbitrary MAX(granted_by) must not appear.
     assert "MAX(granted_by)" not in sql.replace(" ", "")
     assert "MAX(g.granted_by)" not in sql


### PR DESCRIPTION
## Summary
- Collapse atom ownership boundary from chunks → documents. Chunks are retrieval fragments, not ownership units.
- `documents` gets `atom_id` + `circle_tier`; `document_chunks` keeps `circle_tier` only (denormalized retrieval hint).
- KB-share writes drop from O(chunks) to O(documents) — 2-3 orders of magnitude smaller for book-sized KBs.
- RAG retrieval now aggregates chunks back to parent documents in `polymorphic_atom_store`, so cross-source RRF ranks documents.
- Brain Review UI shows document filename + first-chunk preview instead of opaque per-chunk label.

## Design doc
Full problem framing + verification of three premises (zero existing chunk grants, JOIN latency +0.11ms, federation wire safety) lives in [`docs/design/atoms-granularity.md`](docs/design/atoms-granularity.md).

## Migration `pc20260423_atoms_per_document`
- **Pre-migration gate:** aborts with a clear message if any document has heterogeneous chunk tiers. No silent data loss.
- **Back-fill:** inserts `documents.atom_id` using `MIN(chunk.circle_tier)` — conservative owner-visibility choice.
- **Cleanup:** drops `document_chunks.atom_id` FK + column, deletes orphan `kb_chunk` atoms.
- **Downgrade:** reverses by re-minting per-chunk atoms from parent tier.
- Dry-run against prod-Postgres confirmed: 6 docs get atoms, 123 stale chunk atoms deleted, no errors.

## Wire protocol
Federation v2 treats `atom_type` as opaque metadata, so `kb_chunk` → `kb_document` is non-breaking for peers on older revisions.

## Test plan
- [ ] `make test-backend` passes (renamed atom_service, review_labels, circles_v1_services tests)
- [ ] Alembic upgrade/downgrade clean on fresh DB
- [ ] Alembic upgrade succeeds against prod data (pre-verified via dry-run)
- [ ] Brain Review UI shows document titles + previews, not raw chunk ids
- [ ] KB share round-trip: share → list → revoke works on documents-joined SQL
- [ ] RAG search returns one result per document, not per chunk
- [ ] Conversation memory + KG writes use `AtomService.create_with_source`/`finalize_source_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)