### PR TITLE
fix(migration): DROP INDEX IF EXISTS for ix_document_chunks_atom_id

### DIFF
--- a/src/backend/alembic/versions/pc20260423_atoms_per_document.py
+++ b/src/backend/alembic/versions/pc20260423_atoms_per_document.py
@@ -219,19 +219,30 @@ def upgrade() -> None:
         bind.exec_driver_sql(
             "DELETE FROM atoms WHERE atom_type = 'kb_chunk'"
         )
-
-    # Drop the atom_id column on all dialects — ORM doesn't declare it
-    # anymore, so leaving it would cause create_all() on fresh SQLite DBs
-    # to produce different schemas than the migrated Postgres prod DB.
-    with op.batch_alter_table("document_chunks") as batch:
-        try:
-            batch.drop_index("ix_document_chunks_atom_id")
-        except Exception:
-            pass  # index may not exist on older dev DBs
-        try:
-            batch.drop_column("atom_id")
-        except Exception:
-            pass  # column may not exist on fresh SQLite create_all DBs
+        # IF EXISTS needed because the b-tree index was only created on dev
+        # DBs built via Base.metadata.create_all (the ORM had index=True).
+        # Prod was built via pc20260420_circles_v1_schema which only added
+        # the FK — Postgres does not auto-create an index for simple FKs,
+        # so there's nothing to drop. Using raw DDL because `batch_alter_table`
+        # defers execution until __exit__, where try/except around the
+        # op-building call cannot catch the deferred DDL error.
+        bind.exec_driver_sql("DROP INDEX IF EXISTS ix_document_chunks_atom_id")
+        bind.exec_driver_sql(
+            "ALTER TABLE document_chunks DROP COLUMN IF EXISTS atom_id"
+        )
+    else:
+        # SQLite (tests) — ALTER TABLE DROP COLUMN requires table rebuild via
+        # batch mode; try/except works here because batch materializes the
+        # CREATE TABLE … INSERT … DROP TABLE synchronously.
+        with op.batch_alter_table("document_chunks") as batch:
+            try:
+                batch.drop_index("ix_document_chunks_atom_id")
+            except Exception:
+                pass
+            try:
+                batch.drop_column("atom_id")
+            except Exception:
+                pass
 
 
 def downgrade() -> None:


### PR DESCRIPTION
## Summary
Hotfix for PR #444 deploy. The pc20260423 migration failed against prod with \`UndefinedObjectError: index \"ix_document_chunks_atom_id\" does not exist\`.

## Root cause
Prod builds via \`pc20260420_circles_v1_schema\` only created \`fk_document_chunks_atom\`; Postgres does not auto-create a b-tree index for a simple FK, so \`ix_document_chunks_atom_id\` never existed there. The index only appears on dev DBs built via \`Base.metadata.create_all\` (the ORM had \`index=True\` on the column that pc20260423 drops).

The previous try/except lived inside \`op.batch_alter_table\`, but batch mode defers DDL execution until \`__exit__\`. Except catches errors from constructing the op, not from running the accumulated SQL.

## Fix
Replaced with raw DDL using \`IF EXISTS\` on the Postgres path. Idempotent regardless of whether the index was ever created.

## Test plan
- [x] Alembic upgrade against prod DB succeeds (verified once merged + deployed)
- [x] Downgrade path unchanged