### PR TITLE
feat(nav): add admin routing dashboard nav link

### DIFF
--- a/src/frontend/src/components/Layout.jsx
+++ b/src/frontend/src/components/Layout.jsx
@@ -28,7 +28,8 @@ import {
   Wrench,
   FileSearch,
   Share2,
-  History
+  History,
+  GitBranch
 } from 'lucide-react';
 import DeviceStatus from './DeviceStatus';
 import ThemeToggle from './ThemeToggle';
@@ -56,6 +57,7 @@ const adminNavigationConfig = [
   { nameKey: 'nav.smarthome', href: '/homeassistant', icon: Lightbulb, permission: ['ha.read', 'ha.control', 'ha.full'], feature: 'smart_home' },
   { nameKey: 'nav.integrations', href: '/admin/integrations', icon: Blocks, permission: ['admin', 'plugins.use', 'plugins.manage'] },
   { nameKey: 'nav.intents', href: '/admin/intents', icon: Zap, permission: ['admin'] },
+  { nameKey: 'nav.routingDashboard', href: '/admin/routing', icon: GitBranch, permission: ['admin'] },
   { nameKey: 'nav.users', href: '/admin/users', icon: UserCog, permission: ['admin'] },
   { nameKey: 'nav.roles', href: '/admin/roles', icon: Shield, permission: ['admin'] },
   { nameKey: 'nav.satellites', href: '/admin/satellites', icon: Satellite, permission: ['admin'], feature: 'satellites' },

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -49,6 +49,7 @@
     "federationAudit": "Föderations-Verlauf",
     "circles": "Kreise",
     "intents": "Intents",
+    "routingDashboard": "Routing Dashboard",
     "maintenance": "Wartung",
     "paperlessAudit": "Paperless Audit",
     "settings": "Einstellungen",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -49,6 +49,7 @@
     "federationAudit": "Federation log",
     "circles": "Circles",
     "intents": "Intents",
+    "routingDashboard": "Routing Dashboard",
     "maintenance": "Maintenance",
     "paperlessAudit": "Paperless Audit",
     "settings": "Settings",


### PR DESCRIPTION
## Summary

Re-resolved version of #372 (which had drifted with Layout.jsx and the i18n nav section). Original PR closes concurrently.

Adds a \`GitBranch\` nav item under the Admin section for \`/admin/routing\` so the page (already wired in App.jsx) becomes reachable from the UI. Gated by \`permission: ['admin']\`.

## Changes
- \`Layout.jsx\`: import \`GitBranch\`, add nav entry between \`intents\` and \`maintenance\`
- \`i18n/locales/{de,en}.json\`: add \`nav.routingDashboard\`

Closes #372.