### PR TITLE
feat(paperless): PR 2a — LLM metadata extractor core

### DIFF
--- a/src/backend/alembic/versions/pc20260424_paperless_metadata_tables.py
+++ b/src/backend/alembic/versions/pc20260424_paperless_metadata_tables.py
@@ -1,0 +1,164 @@
+"""Paperless metadata extraction — cold-start counter + pending confirms + examples
+
+Revision ID: pc20260424_paperless_metadata_tables
+Revises: pc20260423_atoms_per_document
+Create Date: 2026-04-24
+
+Design rationale: docs/design/paperless-llm-metadata.md
+
+PR 2a of the LLM-driven Paperless metadata feature. Creates three small
+pieces of state the extractor + confirm flow depend on. PR 2b wires the
+state machine that reads/writes them.
+
+Tables created:
+  paperless_extraction_examples — corrections captured at confirm time
+    (primary signal) + Paperless-UI-edit sweeps (secondary, PR 4).
+    Read in PR 3 by the prompt-augmentation path to prepend in-context
+    examples from real user corrections.
+
+  paperless_pending_confirms — transient state holding a completed
+    extraction between the first tool call (``forward_attachment_to_paperless``
+    returns ``action_required=paperless_confirm``) and the second
+    (``paperless_commit_upload`` receives the user's "ja"/"nein"/edit).
+    Wiped after commit or via PR 4's abandoned-confirm sweeper (24 h).
+
+Column added:
+  users.paperless_confirms_used — cold-start counter (N = 10 by default).
+    Increments only on successful upload; not on user-said-nein or on
+    Paperless-upload-failed paths. Once >= N, the confirm step is skipped
+    and extraction runs silently.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers
+revision = "pc20260424_paperless_metadata_tables"
+down_revision = "pc20260423_atoms_per_document"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ---------------------------------------------------------------------
+    # 1. users.paperless_confirms_used — cold-start counter
+    # ---------------------------------------------------------------------
+    op.add_column(
+        "users",
+        sa.Column(
+            "paperless_confirms_used",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+    # ---------------------------------------------------------------------
+    # 2. paperless_extraction_examples — correction-feedback source
+    # ---------------------------------------------------------------------
+    #
+    # llm_output     what the LLM emitted (post-fuzzy, post-validation)
+    # user_approved  what the user actually committed (after any edits)
+    # source         'confirm_diff' | 'paperless_ui_sweep' | 'seed'
+    # superseded     set by PR 4's no-re-edit filter when a ui_sweep row
+    #                turns out to be taxonomy drift, not an extraction
+    #                correction — the prompt-augmentation reader ignores
+    #                superseded rows.
+    #
+    op.create_table(
+        "paperless_extraction_examples",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("doc_text", sa.Text(), nullable=False),
+        sa.Column("llm_output", sa.JSON(), nullable=False),
+        sa.Column("user_approved", sa.JSON(), nullable=False),
+        sa.Column("source", sa.String(32), nullable=False),
+        sa.Column(
+            "superseded",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_paperless_extraction_examples_source",
+        "paperless_extraction_examples",
+        ["source", "superseded", "created_at"],
+    )
+
+    # ---------------------------------------------------------------------
+    # 3. paperless_pending_confirms — transient state between two tool calls
+    # ---------------------------------------------------------------------
+    #
+    # confirm_token  uuid4 in str form — agent receives this back from the
+    #                first call and passes it to paperless_commit_upload.
+    # attachment_id  ChatUpload pk; FK with ON DELETE CASCADE so that
+    #                deleting a stale upload drops the pending-confirm row.
+    # session_id     scope check for cross-session commit-token attempts
+    #                (same guard as #442).
+    # llm_output     raw LLM response (for diff computation in PR 2b)
+    # post_fuzzy_output  post-fuzzy, post-validation result the user
+    #                confirms against.
+    # proposals      new_entry_proposals[] to surface in the confirm
+    #                message.
+    # edit_rounds    prevents infinite confirm ↔ edit loops. Capped at 3
+    #                in PR 2b.
+    #
+    op.create_table(
+        "paperless_pending_confirms",
+        sa.Column("confirm_token", sa.String(36), primary_key=True),
+        sa.Column(
+            "attachment_id",
+            sa.Integer(),
+            sa.ForeignKey("chat_uploads.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("session_id", sa.String(64), nullable=False, index=True),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("llm_output", sa.JSON(), nullable=False),
+        sa.Column("post_fuzzy_output", sa.JSON(), nullable=False),
+        sa.Column("proposals", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column(
+            "edit_rounds",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    # Composite index for session-scoped lookups + oldest-first sweep.
+    op.create_index(
+        "ix_paperless_pending_confirms_session_created",
+        "paperless_pending_confirms",
+        ["session_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_paperless_pending_confirms_session_created",
+        table_name="paperless_pending_confirms",
+    )
+    op.drop_table("paperless_pending_confirms")
+    op.drop_index(
+        "ix_paperless_extraction_examples_source",
+        table_name="paperless_extraction_examples",
+    )
+    op.drop_table("paperless_extraction_examples")
+    op.drop_column("users", "paperless_confirms_used")

--- a/src/backend/prompts/paperless_metadata.yaml
+++ b/src/backend/prompts/paperless_metadata.yaml
@@ -28,7 +28,7 @@ de:
     - created_date: das Ausstellungsdatum laut Dokument (Rechnungsdatum,
       Ausstellungsdatum, Vertragsdatum — NICHT Zahlungsziel, NICHT das
       heutige Datum). Format YYYY-MM-DD.
-    - tags: maximal 3, thematisch relevant.
+    - tags: maximal 5, thematisch relevant.
     - confidence: 0.0 bis 1.0 pro Feld, deine Selbsteinschaetzung.
     - new_entry_proposals: optional. Nur wenn du sehr sicher bist, dass
       der Wert nicht in der Taxonomie steht und einen neuen Eintrag
@@ -138,7 +138,7 @@ en:
     - created_date: the document's issue date (invoice date, issue
       date, contract date — NOT the payment deadline, NOT today's
       date). Format YYYY-MM-DD.
-    - tags: at most 3, thematically relevant.
+    - tags: at most 5, thematically relevant.
     - confidence: 0.0 to 1.0 per field, your own estimate.
     - new_entry_proposals: optional. Only when you are highly confident
       the value is not in the taxonomy and a new entry is warranted.

--- a/src/backend/prompts/paperless_metadata.yaml
+++ b/src/backend/prompts/paperless_metadata.yaml
@@ -1,0 +1,231 @@
+# Paperless LLM Metadata Extraction Prompts
+#
+# Used by PaperlessMetadataExtractor.extract() to produce a structured
+# metadata dict (correspondent, document_type, tags, storage_path,
+# created_date) from a document's OCR'd text, constrained to the user's
+# current Paperless taxonomy.
+#
+# Prompt structure: system + user. The user prompt receives the pruned
+# taxonomy (top 20 correspondents + top 20 tags by recency, full
+# doc_types + storage_paths) plus three worked examples plus the
+# document text. LLM returns a JSON object matching the PaperlessMetadata
+# pydantic model.
+#
+# Design reference: docs/design/paperless-llm-metadata.md §Prompt template.
+
+de:
+  system: |
+    Du hilfst beim Ablegen von Dokumenten in Paperless-NGX. Lies den
+    extrahierten Dokumenttext und waehle die passendsten Felder aus der
+    vorhandenen Paperless-Taxonomie.
+
+    Regeln:
+    - Verwende nur Werte aus der unten aufgefuehrten Taxonomie. Wenn
+      nichts passt, gib null zurueck — erfinde nichts.
+    - title: beschreibend und dateisystemtauglich. Format: "<Dokumenttyp>
+      <Zeitraum/Bezug> - <Korrespondent>". Beispiel:
+      "Nebenkostenabrechnung 2025 - Stadtwerke Korschenbroich".
+    - created_date: das Ausstellungsdatum laut Dokument (Rechnungsdatum,
+      Ausstellungsdatum, Vertragsdatum — NICHT Zahlungsziel, NICHT das
+      heutige Datum). Format YYYY-MM-DD.
+    - tags: maximal 3, thematisch relevant.
+    - confidence: 0.0 bis 1.0 pro Feld, deine Selbsteinschaetzung.
+    - new_entry_proposals: optional. Nur wenn du sehr sicher bist, dass
+      der Wert nicht in der Taxonomie steht und einen neuen Eintrag
+      rechtfertigt. Ein Vorschlag pro Feld — drei neue Tags werden als
+      drei Eintraege emittiert.
+
+    Antworte ausschliesslich mit einem JSON-Objekt, kein Fliesstext,
+    keine Markdown-Code-Fences.
+
+  user: |
+    Paperless-Taxonomie (nach Relevanz gekuerzt):
+    correspondents: {correspondents}
+    document_types: {document_types}
+    tags: {tags}
+    storage_paths: {storage_paths}
+
+    Beispiele:
+
+    ---
+    Dokument:
+    "Stadtwerke Korschenbroich GmbH ... Nebenkostenabrechnung fuer den
+    Zeitraum 01.01.2025 - 31.12.2025 ... Gesamtbetrag: 1.842,00 EUR ...
+    Rechnungsdatum: 14.02.2026"
+
+    Antwort:
+    {{
+      "title": "Nebenkostenabrechnung 2025 - Stadtwerke Korschenbroich",
+      "correspondent": "Stadtwerke Korschenbroich",
+      "document_type": "Nebenkostenabrechnung",
+      "tags": ["wohnung", "nebenkosten-2025"],
+      "storage_path": "/wohnung/betriebskosten",
+      "created_date": "2026-02-14",
+      "confidence": {{
+        "title": 0.95, "correspondent": 0.98, "document_type": 0.95,
+        "storage_path": 0.85, "created_date": 0.98
+      }},
+      "new_entry_proposals": []
+    }}
+
+    ---
+    Dokument:
+    "Finanzamt Neuss ... Einkommensteuerbescheid fuer 2024 ...
+    Bescheiddatum: 12.09.2025 ... Steuernummer: 123/456/78900"
+
+    Antwort:
+    {{
+      "title": "Einkommensteuerbescheid 2024 - Finanzamt Neuss",
+      "correspondent": "Finanzamt Neuss",
+      "document_type": "Steuerbescheid",
+      "tags": ["steuer-2024", "wichtig"],
+      "storage_path": "/steuer/2024",
+      "created_date": "2025-09-12",
+      "confidence": {{
+        "title": 0.92, "correspondent": 0.98, "document_type": 0.94,
+        "storage_path": 0.88, "created_date": 0.99
+      }},
+      "new_entry_proposals": []
+    }}
+
+    ---
+    Dokument:
+    "Schreiner Meier ... Rechnung Nr. 2026-0042 ... Einbau Fensterbank
+    Esszimmer ... 380,00 EUR ... Rechnungsdatum: 18.03.2026"
+
+    (Taxonomie enthaelt "Schreiner Meier" NICHT.)
+
+    Antwort:
+    {{
+      "title": "Rechnung 2026-0042 - Schreiner Meier",
+      "correspondent": null,
+      "document_type": "Rechnung",
+      "tags": ["wohnung", "handwerker"],
+      "storage_path": "/wohnung/handwerker",
+      "created_date": "2026-03-18",
+      "confidence": {{
+        "title": 0.9, "document_type": 0.97, "storage_path": 0.7,
+        "created_date": 0.99
+      }},
+      "new_entry_proposals": [
+        {{
+          "field": "correspondent",
+          "value": "Schreiner Meier",
+          "reasoning": "Rechnungskopf nennt den Korrespondenten eindeutig; nicht in Taxonomie."
+        }}
+      ]
+    }}
+
+    ---
+    Jetzt das eigentliche Dokument:
+
+    {document_text}
+
+    Antwort:
+
+en:
+  system: |
+    You help archive documents in Paperless-NGX. Read the extracted
+    document text and pick the best-matching fields from the existing
+    Paperless taxonomy.
+
+    Rules:
+    - Use only values from the taxonomy listed below. If nothing fits,
+      return null — do not invent entries.
+    - title: descriptive, filesystem-safe. Format: "<document_type>
+      <period/reference> - <correspondent>". Example:
+      "Utility Bill 2025 - Municipal Utilities".
+    - created_date: the document's issue date (invoice date, issue
+      date, contract date — NOT the payment deadline, NOT today's
+      date). Format YYYY-MM-DD.
+    - tags: at most 3, thematically relevant.
+    - confidence: 0.0 to 1.0 per field, your own estimate.
+    - new_entry_proposals: optional. Only when you are highly confident
+      the value is not in the taxonomy and a new entry is warranted.
+      One proposal per field — three new tags become three entries.
+
+    Respond with a JSON object only — no prose, no markdown fences.
+
+  user: |
+    Paperless taxonomy (pruned by relevance):
+    correspondents: {correspondents}
+    document_types: {document_types}
+    tags: {tags}
+    storage_paths: {storage_paths}
+
+    Examples:
+
+    ---
+    Document:
+    "Acme Utilities Inc ... Utility bill for the period 01/01/2025 -
+    12/31/2025 ... Total: EUR 1,842.00 ... Invoice date: 2026-02-14"
+
+    Answer:
+    {{
+      "title": "Utility Bill 2025 - Acme Utilities",
+      "correspondent": "Acme Utilities",
+      "document_type": "Utility Bill",
+      "tags": ["home", "utilities-2025"],
+      "storage_path": "/home/utilities",
+      "created_date": "2026-02-14",
+      "confidence": {{
+        "title": 0.95, "correspondent": 0.98, "document_type": 0.95,
+        "storage_path": 0.85, "created_date": 0.98
+      }},
+      "new_entry_proposals": []
+    }}
+
+    ---
+    Document:
+    "IRS ... Income Tax Notice for 2024 ... Notice date: 2025-09-12 ...
+    Tax ID: 123-45-6789"
+
+    Answer:
+    {{
+      "title": "Income Tax Notice 2024 - IRS",
+      "correspondent": "IRS",
+      "document_type": "Tax Notice",
+      "tags": ["tax-2024", "important"],
+      "storage_path": "/tax/2024",
+      "created_date": "2025-09-12",
+      "confidence": {{
+        "title": 0.92, "correspondent": 0.98, "document_type": 0.94,
+        "storage_path": 0.88, "created_date": 0.99
+      }},
+      "new_entry_proposals": []
+    }}
+
+    ---
+    Document:
+    "Meier Carpentry ... Invoice 2026-0042 ... Install windowsill in
+    dining room ... USD 380.00 ... Invoice date: 2026-03-18"
+
+    (Taxonomy does NOT contain "Meier Carpentry".)
+
+    Answer:
+    {{
+      "title": "Invoice 2026-0042 - Meier Carpentry",
+      "correspondent": null,
+      "document_type": "Invoice",
+      "tags": ["home", "contractor"],
+      "storage_path": "/home/contractor",
+      "created_date": "2026-03-18",
+      "confidence": {{
+        "title": 0.9, "document_type": 0.97, "storage_path": 0.7,
+        "created_date": 0.99
+      }},
+      "new_entry_proposals": [
+        {{
+          "field": "correspondent",
+          "value": "Meier Carpentry",
+          "reasoning": "Invoice header names the correspondent unambiguously; not in taxonomy."
+        }}
+      ]
+    }}
+
+    ---
+    Now the actual document:
+
+    {document_text}
+
+    Answer:

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -67,6 +67,7 @@ python-jose[cryptography]>=3.3.0
 passlib[bcrypt]>=1.7.4
 bcrypt==4.0.1  # Pin to avoid compatibility issues with passlib
 python-dateutil>=2.8.2
+rapidfuzz>=3.9.0              # Fuzzy string matching (Paperless taxonomy resolution)
 
 # MCP Client (Model Context Protocol)
 mcp>=1.26.0

--- a/src/backend/services/paperless_metadata_extractor.py
+++ b/src/backend/services/paperless_metadata_extractor.py
@@ -1,0 +1,778 @@
+"""
+PaperlessMetadataExtractor — LLM-driven metadata extraction for Paperless-NGX uploads.
+
+Reads a chat-attached document via Docling, fetches the user's current
+Paperless taxonomy from the MCP server, asks the LLM to pick the best
+metadata fields from that taxonomy (with worked examples baked into the
+prompt), validates via pydantic + fuzzy-match + taxonomy-membership, and
+returns a structured result the caller can feed into
+``mcp.paperless.upload_document``.
+
+Design reference:
+    docs/design/paperless-llm-metadata.md
+
+This is PR 2a of the feature: the atomic extraction unit, independently
+testable, no dependency on the confirm flow. PR 2b wires this into the
+``forward_attachment_to_paperless`` tool + cold-start-only confirm state
+machine.
+
+ASCII flow — single extraction call:
+
+    extract(attachment_id, session_id, user_lang)
+        │
+        ▼
+    load ChatUpload (session-scoped per #442)
+        │
+        ▼
+    OCR / text-layer extraction via DocumentProcessor.extract_text_only
+    (Docling HybridChunker + EasyOCR fallback; vision-model path is a
+    PR 2b refinement once the agent-client wiring supports it)
+        │
+        ▼
+    fetch_taxonomy(mcp_manager)
+        │   calls mcp.paperless.list_* tools, prunes top-20 correspondents
+        │   and top-20 tags by recency from the `/api/documents/?ordering=-modified`
+        │   window provided by PR 1's MCP server.
+        │
+        ▼
+    render prompt (paperless_metadata.yaml) with taxonomy + doc_text
+        │
+        ▼
+    LLM call (settings.paperless_extraction_model || vision || chat)
+        │
+        ▼
+    validate(response)
+        │   1. pydantic parse
+        │   2. rapidfuzz near-match against taxonomy (rewrites silently
+        │      on one-candidate-within-threshold, flags ambiguous)
+        │   3. strict membership check (drops misses that weren't
+        │      flagged as new_entry_proposals)
+        │   4. clamp created_date (1900-01-01 ... today+1y)
+        │   5. cap tags at 5
+        │
+        ▼
+    ExtractionResult(metadata, proposals, confidence, source_text)
+"""
+from __future__ import annotations
+
+import json
+import unicodedata
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any, Literal
+
+from loguru import logger
+from pydantic import BaseModel, Field, ValidationError
+from rapidfuzz.distance import Levenshtein
+
+from services.prompt_manager import prompt_manager
+from utils.config import settings
+from utils.llm_client import (
+    extract_response_content,
+    get_classification_chat_kwargs,
+    get_default_client,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Top-N cuts for taxonomy pruning. Full doc_types + storage_paths are
+# always included; correspondents + tags are truncated by recency.
+_TOP_CORRESPONDENTS = 20
+_TOP_TAGS = 20
+
+# Fuzzy-match threshold. Levenshtein distance <= this many edits counts
+# as a near-match. 2 = "Stadtwerke Korschenbroich GmbH" can normalise to
+# "Stadtwerke Korschenbroich" (strip trailing "GmbH" costs ~5 edits —
+# actually above threshold, will land as a proposal; that's fine).
+# Shorter strings at distance 2 can match too-loosely, so we also cap
+# at <= 20% of the longer string's length.
+_FUZZY_MAX_DISTANCE = 2
+_FUZZY_MAX_RATIO = 0.2
+
+# Taxonomy cache TTL (in memory, per-process). 10 min balances freshness
+# with API-call cost. Invalidated on successful create_* via the MCP
+# server's own cache flush + Redis TTL here.
+_TAXONOMY_CACHE_TTL_S = 600
+
+# OCR text char cap fed to the LLM. Enough for the first few pages of a
+# typical document; longer is rarely informative and costs context budget.
+_MAX_DOC_CHARS = 12_000
+
+# created_date sanity clamps — documents dated outside this window are
+# OCR errors (1847 parsed from a page number, 2189 parsed from invoice
+# line). Today + 1 year to accommodate post-dated contracts / receipts
+# scanned slightly in advance.
+_DATE_MIN = date(1900, 1, 1)
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+class NewEntryProposal(BaseModel):
+    """Singleton proposal for a not-in-taxonomy value. Three new tags
+    become three separate proposals, not one entry with a list."""
+    field: Literal["correspondent", "document_type", "tag", "storage_path"]
+    value: str
+    reasoning: str
+
+
+class PaperlessMetadata(BaseModel):
+    """Output of the extractor.
+
+    Every taxonomy field is either ``None`` (LLM couldn't decide or
+    nothing matched) or a string guaranteed to be present in the user's
+    live Paperless taxonomy (because the validator checks exactly that).
+    ``new_entry_proposals`` carries LLM's confidence-gated suggestions
+    for values it thinks deserve a new taxonomy entry.
+    """
+    title: str | None = None
+    correspondent: str | None = None
+    document_type: str | None = None
+    tags: list[str] = Field(default_factory=list)
+    storage_path: str | None = None
+    created_date: date | None = None
+    confidence: dict[str, float] = Field(default_factory=dict)
+    new_entry_proposals: list[NewEntryProposal] = Field(default_factory=list)
+
+
+class ExtractionResult(BaseModel):
+    """What the caller (PR 2b's forward tool) sees.
+
+    On full success: ``metadata`` holds validated + fuzzy-normalised
+    values, ``doc_text`` carries the OCR text used (so the caller can
+    persist it into ``paperless_extraction_examples`` once the user
+    confirms), ``error`` is ``None``.
+
+    On any failure path: ``metadata`` is an empty ``PaperlessMetadata``
+    and ``error`` carries a short string the caller can surface.
+    Partial success (some fields dropped, some kept) still returns
+    ``error=None`` — the caller uses whatever's filled.
+    """
+    metadata: PaperlessMetadata
+    doc_text: str = ""
+    error: str | None = None
+
+
+class PaperlessTaxonomy(BaseModel):
+    """Snapshot of the user's Paperless taxonomy at extraction time."""
+    correspondents: list[str] = Field(default_factory=list)
+    document_types: list[str] = Field(default_factory=list)
+    tags: list[str] = Field(default_factory=list)
+    storage_paths: list[str] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — text normalisation, fuzzy matching, taxonomy pruning
+# ---------------------------------------------------------------------------
+
+
+def _normalise(value: str) -> str:
+    """Casefold + whitespace-strip + Unicode NFKC.
+
+    Applied to both LLM output and taxonomy entries before the fuzzy
+    comparison. Catches trivial variations ("Stadtwerke  Köln" vs
+    "stadtwerke köln") that would otherwise blow past the edit-distance
+    budget on Umlauts or spacing.
+    """
+    if not value:
+        return ""
+    return unicodedata.normalize("NFKC", value).strip().casefold()
+
+
+def _fuzzy_match(llm_value: str, taxonomy: list[str]) -> str | None:
+    """Return the canonical taxonomy entry near-matching ``llm_value``.
+
+    - Exact match after normalisation → return canonical spelling.
+    - Exactly one entry within edit-distance and ratio thresholds →
+      return canonical spelling.
+    - Zero candidates → return None (caller should treat as proposal).
+    - Two-or-more candidates within threshold → return None (ambiguous;
+      caller flags as proposal and surfaces the alternatives).
+
+    Rationale for the two thresholds: a raw Levenshtein of 2 would match
+    "Bob" to "Bo" (33% distance) which isn't a near-miss, it's a
+    different word. Gating on ratio <= 0.2 prevents tiny-string false
+    positives while leaving longer strings room to absorb small typos.
+    """
+    if not llm_value or not taxonomy:
+        return None
+
+    normalised_llm = _normalise(llm_value)
+    if not normalised_llm:
+        return None
+
+    # Exact pass first — cheap, catches the common case where the LLM
+    # emits a taxonomy entry verbatim.
+    for entry in taxonomy:
+        if _normalise(entry) == normalised_llm:
+            return entry
+
+    # Fuzzy pass with both absolute and ratio constraints.
+    candidates: list[str] = []
+    for entry in taxonomy:
+        normalised_entry = _normalise(entry)
+        if not normalised_entry:
+            continue
+        distance = Levenshtein.distance(normalised_llm, normalised_entry)
+        if distance > _FUZZY_MAX_DISTANCE:
+            continue
+        max_len = max(len(normalised_llm), len(normalised_entry))
+        if max_len == 0:
+            continue
+        ratio = distance / max_len
+        if ratio > _FUZZY_MAX_RATIO:
+            continue
+        candidates.append(entry)
+
+    if len(candidates) == 1:
+        return candidates[0]
+    # Zero candidates OR ambiguous multi-match → caller handles as
+    # proposal (ambiguity surfaces in the confirm UI).
+    return None
+
+
+def prune_taxonomy(
+    *,
+    correspondents: list[str],
+    document_types: list[str],
+    tags: list[str],
+    storage_paths: list[str],
+    recent_correspondent_ids: list[str] | None = None,
+    recent_tag_ids: list[str] | None = None,
+    top_correspondents: int = _TOP_CORRESPONDENTS,
+    top_tags: int = _TOP_TAGS,
+) -> PaperlessTaxonomy:
+    """Prune long taxonomy lists so the prompt stays within the local
+    model's reliable-attention window.
+
+    - correspondents: keep ``top_correspondents`` by recency-of-use.
+      ``recent_correspondent_ids`` is an ordered list from the MCP
+      server's most-recently-modified-documents query (PR 1 exposes
+      this via the ordering of items returned from its helpers); the
+      first N unique ones win.
+    - tags: same pattern.
+    - document_types, storage_paths: included in full. Typical
+      household Paperless has < 30 of each and they're small strings,
+      so pruning doesn't save meaningful tokens.
+
+    When ``recent_*_ids`` is ``None`` (cold start, no usage signal
+    yet), the first ``top_*`` entries of the raw list are kept in their
+    natural order — safe default for fresh installs.
+    """
+    def _pick_by_recency(all_entries: list[str], recent_ids: list[str] | None, cap: int) -> list[str]:
+        if not recent_ids:
+            return all_entries[:cap]
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for entry in recent_ids:
+            if entry in seen or entry not in all_entries:
+                continue
+            seen.add(entry)
+            ordered.append(entry)
+            if len(ordered) >= cap:
+                break
+        # Pad with any remaining entries that didn't show up in recency
+        # — keeps the prompt focused on actually-seen entries while not
+        # dropping rare-but-present ones entirely if the cap has room.
+        if len(ordered) < cap:
+            for entry in all_entries:
+                if entry in seen:
+                    continue
+                ordered.append(entry)
+                seen.add(entry)
+                if len(ordered) >= cap:
+                    break
+        return ordered
+
+    return PaperlessTaxonomy(
+        correspondents=_pick_by_recency(correspondents, recent_correspondent_ids, top_correspondents),
+        document_types=document_types,
+        tags=_pick_by_recency(tags, recent_tag_ids, top_tags),
+        storage_paths=storage_paths,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def _date_max() -> date:
+    """Computed fresh per call so tests that freeze the clock via
+    ``pytest-freezegun`` or similar see the right ceiling."""
+    return date.today() + timedelta(days=365)
+
+
+def validate_extraction(
+    raw_output: dict,
+    taxonomy: PaperlessTaxonomy,
+) -> PaperlessMetadata:
+    """Full validation pipeline. Caller passes the parsed LLM JSON dict.
+
+    1. Pydantic shape check — malformed → ValidationError raises up.
+    2. Fuzzy match against each taxonomy dimension. One-candidate wins
+       silently (rewrites llm value to canonical); zero or ambiguous
+       drops the field to ``None`` — unless the LLM simultaneously
+       emitted a ``new_entry_proposal`` for that field, in which case
+       the proposal survives for user review.
+    3. Strict taxonomy membership — after fuzzy, assert the value is in
+       the list. Defence-in-depth; should never drop here.
+    4. ``created_date`` clamped to [1900-01-01, today+1y].
+    5. ``tags`` truncated at 5.
+    """
+    # Step 1 — parse. Any shape error raises; caller catches.
+    try:
+        metadata = PaperlessMetadata(**raw_output)
+    except ValidationError as exc:
+        # Add the raw dict to the exception note so debugging shows what
+        # the LLM actually emitted. pydantic's own error is verbose
+        # enough that appending is more useful than replacing.
+        raise ValueError(f"Malformed LLM output: {exc}") from exc
+
+    # Group the LLM's proposals by field for quick lookup during fuzzy
+    # fallback — if the LLM flagged "correspondent" as proposal, we
+    # don't need to silently drop the field value too.
+    proposed_fields = {p.field for p in metadata.new_entry_proposals}
+
+    # Step 2 + 3 — fuzzy + strict membership.
+    metadata.correspondent = _validate_singleton_field(
+        metadata.correspondent,
+        taxonomy.correspondents,
+        field_name="correspondent",
+        has_proposal=("correspondent" in proposed_fields),
+    )
+    metadata.document_type = _validate_singleton_field(
+        metadata.document_type,
+        taxonomy.document_types,
+        field_name="document_type",
+        has_proposal=("document_type" in proposed_fields),
+    )
+    metadata.storage_path = _validate_singleton_field(
+        metadata.storage_path,
+        taxonomy.storage_paths,
+        field_name="storage_path",
+        has_proposal=("storage_path" in proposed_fields),
+    )
+
+    # Tags are list-valued; each element goes through fuzzy-then-strict
+    # independently, misses are dropped silently (proposals work at
+    # field-not-element granularity — a tag proposal covers one missing
+    # tag, not the whole list).
+    validated_tags: list[str] = []
+    for tag in metadata.tags:
+        canonical = _fuzzy_match(tag, taxonomy.tags)
+        if canonical is not None:
+            validated_tags.append(canonical)
+        else:
+            logger.debug("Dropping tag not in taxonomy: %r", tag)
+    metadata.tags = validated_tags[:5]  # Step 5 — cap
+
+    # Step 4 — date clamps.
+    if metadata.created_date is not None:
+        if metadata.created_date < _DATE_MIN or metadata.created_date > _date_max():
+            logger.warning(
+                "Dropping created_date out of range: %s",
+                metadata.created_date,
+            )
+            metadata.created_date = None
+
+    return metadata
+
+
+def _validate_singleton_field(
+    value: str | None,
+    taxonomy: list[str],
+    *,
+    field_name: str,
+    has_proposal: bool,
+) -> str | None:
+    """Apply fuzzy+strict validation to one taxonomy-constrained field.
+
+    If the LLM also emitted a new_entry_proposal for this field, we keep
+    ``None`` as the field value (the proposal carries the intent).
+    Otherwise we log the dropped value for later debugging.
+    """
+    if value is None:
+        return None
+
+    canonical = _fuzzy_match(value, taxonomy)
+    if canonical is not None:
+        return canonical
+
+    # Not in taxonomy. If there's a matching proposal, that's intended —
+    # silently return None (the caller surfaces the proposal in the
+    # confirm UI). If not, the LLM hallucinated; log for debugging.
+    if not has_proposal:
+        logger.debug(
+            "Dropping %s not in taxonomy (no proposal): %r",
+            field_name,
+            value,
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Prompt rendering
+# ---------------------------------------------------------------------------
+
+
+def render_prompt(
+    *,
+    doc_text: str,
+    taxonomy: PaperlessTaxonomy,
+    lang: str = "de",
+) -> tuple[str, str]:
+    """Build (system, user) messages for the LLM call.
+
+    Taxonomy lists render as comma-separated inline strings; the prompt
+    template doesn't try to pretty-print them because LLMs tolerate
+    either shape and CSV keeps the token count down.
+    """
+    system = prompt_manager.get(
+        "paperless_metadata", "system",
+        default="Extract Paperless metadata.", lang=lang,
+    )
+    user = prompt_manager.get(
+        "paperless_metadata", "user",
+        default="{document_text}",
+        lang=lang,
+        correspondents=", ".join(taxonomy.correspondents) or "(none)",
+        document_types=", ".join(taxonomy.document_types) or "(none)",
+        tags=", ".join(taxonomy.tags) or "(none)",
+        storage_paths=", ".join(taxonomy.storage_paths) or "(none)",
+        document_text=doc_text[:_MAX_DOC_CHARS],
+    )
+    return system, user
+
+
+# ---------------------------------------------------------------------------
+# Extractor
+# ---------------------------------------------------------------------------
+
+
+class PaperlessMetadataExtractor:
+    """Orchestrates the full extraction pipeline for one attachment.
+
+    Construct once per request with the MCP manager (for taxonomy
+    fetches) and an LLM client (for the extraction call). Call
+    ``extract(attachment_id, session_id, lang)`` to run the pipeline
+    and get back an ``ExtractionResult``.
+
+    Stateless across calls — no per-extractor cache; the taxonomy cache
+    lives on the module level and can be shared across extractor
+    instances within the same process.
+    """
+
+    def __init__(
+        self,
+        *,
+        mcp_manager: Any = None,
+        llm_client: Any = None,
+        document_processor: Any = None,
+    ):
+        self.mcp_manager = mcp_manager
+        self._llm_client = llm_client
+        self._document_processor = document_processor
+        # Per-process taxonomy cache. Entry shape:
+        # {"fetched_at": float_epoch, "taxonomy": PaperlessTaxonomy,
+        #  "correspondents_full": list[str], ...}
+        self._taxonomy_cache: dict[str, Any] = {}
+
+    # -- Extraction entry point --
+
+    async def extract(
+        self,
+        *,
+        attachment_id: int,
+        session_id: str | None,
+        lang: str = "de",
+    ) -> ExtractionResult:
+        """Run the full pipeline on a ChatUpload and return structured
+        metadata. Never raises on expected failure paths — sets
+        ``error`` on the result instead.
+        """
+        # 1. Load the ChatUpload, honour the session-scoping guard from #442.
+        upload = await self._load_upload(attachment_id, session_id)
+        if upload is None:
+            return ExtractionResult(
+                metadata=PaperlessMetadata(),
+                error=f"Attachment {attachment_id} not found",
+            )
+
+        # 2. Extract text (Docling; vision-model path is PR 2b refinement).
+        doc_text = await self._extract_text(upload.file_path)
+        if not doc_text:
+            return ExtractionResult(
+                metadata=PaperlessMetadata(),
+                error="Konnte Dokument nicht lesen (OCR lieferte keinen Text).",
+            )
+
+        # 3. Fetch + prune taxonomy.
+        taxonomy = await self._fetch_taxonomy()
+        if taxonomy is None:
+            # Paperless unreachable or MCP down. Treat as recoverable —
+            # caller falls back to bare upload.
+            return ExtractionResult(
+                metadata=PaperlessMetadata(),
+                doc_text=doc_text,
+                error="Paperless-Taxonomie nicht erreichbar; Metadaten-Extraktion uebersprungen.",
+            )
+
+        # 4. Render prompt + call LLM.
+        system, user = render_prompt(
+            doc_text=doc_text, taxonomy=taxonomy, lang=lang,
+        )
+        try:
+            raw = await self._call_llm(system, user)
+        except Exception as exc:
+            logger.warning("LLM call for metadata extraction failed: %s", exc)
+            return ExtractionResult(
+                metadata=PaperlessMetadata(),
+                doc_text=doc_text,
+                error=f"LLM-Extraktion fehlgeschlagen: {exc}",
+            )
+
+        parsed = _parse_llm_json(raw)
+        if parsed is None:
+            return ExtractionResult(
+                metadata=PaperlessMetadata(),
+                doc_text=doc_text,
+                error="LLM lieferte keine gueltige JSON-Antwort.",
+            )
+
+        # 5. Validate + fuzzy-match + clamp.
+        try:
+            metadata = validate_extraction(parsed, taxonomy)
+        except ValueError as exc:
+            logger.warning("Metadata validation failed: %s", exc)
+            return ExtractionResult(
+                metadata=PaperlessMetadata(),
+                doc_text=doc_text,
+                error=f"Metadaten-Validierung fehlgeschlagen: {exc}",
+            )
+
+        return ExtractionResult(metadata=metadata, doc_text=doc_text, error=None)
+
+    # -- Helpers (overridable for testing) --
+
+    async def _load_upload(self, attachment_id: int, session_id: str | None):
+        """Lookup with session-scoping (see #442)."""
+        from sqlalchemy import select
+
+        from models.database import ChatUpload
+        from services.database import AsyncSessionLocal
+
+        async with AsyncSessionLocal() as db:
+            query = select(ChatUpload).where(ChatUpload.id == attachment_id)
+            if session_id is not None:
+                query = query.where(ChatUpload.session_id == session_id)
+            result = await db.execute(query)
+            upload = result.scalar_one_or_none()
+
+        if upload is None:
+            return None
+        if not upload.file_path or not Path(upload.file_path).is_file():
+            logger.warning("ChatUpload %s file missing on disk: %r", attachment_id, upload.file_path)
+            return None
+        return upload
+
+    async def _extract_text(self, file_path: str) -> str:
+        """Docling-based OCR / text-layer extraction.
+
+        Vision-model path is deferred to PR 2b: it requires coordinating
+        with the agent client to send image bytes + text, which the
+        existing llm_client surface doesn't yet support cleanly. Docling
+        alone covers typed documents (the 80% case) and falls back to
+        EasyOCR for scans via the existing ``rag_ocr_auto_detect``
+        settings on ``DocumentProcessor``.
+        """
+        if self._document_processor is None:
+            from services.document_processor import DocumentProcessor
+            self._document_processor = DocumentProcessor()
+        text = await self._document_processor.extract_text_only(
+            file_path, max_chars=_MAX_DOC_CHARS,
+        )
+        return text or ""
+
+    async def _fetch_taxonomy(self) -> PaperlessTaxonomy | None:
+        """Query the MCP server's list_* tools for the current taxonomy.
+
+        Results are cached in-process for ``_TAXONOMY_CACHE_TTL_S``.
+        Cache invalidation on successful ``create_*`` is a PR 2b concern
+        (the commit tool clears the cache when it fires a create).
+        """
+        if self.mcp_manager is None:
+            logger.warning("No MCP manager wired; cannot fetch Paperless taxonomy")
+            return None
+
+        import time as _time
+        now = _time.time()
+        cached = self._taxonomy_cache.get("entry")
+        if cached and (now - cached["fetched_at"]) < _TAXONOMY_CACHE_TTL_S:
+            return cached["taxonomy"]
+
+        # The MCP server exposes list_storage_paths + list_custom_fields
+        # today; for correspondents / document_types / tags we query
+        # Paperless directly via search_documents or via dedicated
+        # helpers the MCP server could add. For PR 2a we leverage the
+        # taxonomy cache that PR 1 warms up via _ensure_caches — the
+        # list_* tools return the already-resolved lists.
+        try:
+            correspondents = await self._list_via_mcp("list_correspondents")
+            document_types = await self._list_via_mcp("list_document_types")
+            tags = await self._list_via_mcp("list_tags")
+            storage_paths = await self._list_via_mcp(
+                "list_storage_paths", field="paths", value_key="path",
+            )
+        except Exception as exc:
+            logger.warning("Taxonomy fetch failed: %s", exc)
+            return None
+
+        taxonomy = prune_taxonomy(
+            correspondents=correspondents,
+            document_types=document_types,
+            tags=tags,
+            storage_paths=storage_paths,
+        )
+        self._taxonomy_cache["entry"] = {"fetched_at": now, "taxonomy": taxonomy}
+        return taxonomy
+
+    async def _list_via_mcp(
+        self,
+        tool_name: str,
+        *,
+        field: str = "items",
+        value_key: str = "name",
+    ) -> list[str]:
+        """Thin wrapper: call ``mcp.paperless.{tool_name}`` and return
+        the list of names.
+
+        The MCP server today has ``list_storage_paths`` (returns
+        ``{"paths": [{"id": ..., "path": ...}]}``) and
+        ``list_custom_fields``. For the three dimensions the audit V2 PR
+        doesn't yet have dedicated list tools for (correspondents,
+        document_types, tags), we fall back to scraping the MCP server's
+        in-memory cache via a well-known diagnostic tool name — this
+        gap is explicitly flagged in the design doc and filled in
+        PR 2b's MCP-server additions if needed. For now, unknown tools
+        return an empty list; the extractor gracefully falls through
+        with fewer dimensions rather than crashing.
+        """
+        full_name = f"mcp.paperless.{tool_name}"
+        try:
+            result = await self.mcp_manager.execute_tool(full_name, {})
+        except Exception as exc:
+            logger.debug("MCP tool %s unavailable: %s", full_name, exc)
+            return []
+
+        if not result or not result.get("success"):
+            return []
+
+        inner_msg = result.get("message")
+        payload: Any = None
+        if isinstance(inner_msg, str):
+            try:
+                payload = json.loads(inner_msg)
+            except json.JSONDecodeError:
+                return []
+        elif isinstance(inner_msg, dict):
+            payload = inner_msg
+
+        if not isinstance(payload, dict):
+            return []
+
+        items = payload.get(field) or []
+        if not isinstance(items, list):
+            return []
+
+        names: list[str] = []
+        for item in items:
+            if isinstance(item, dict):
+                name = item.get(value_key)
+                if isinstance(name, str):
+                    names.append(name)
+            elif isinstance(item, str):
+                names.append(item)
+        return names
+
+    async def _call_llm(self, system: str, user: str) -> str:
+        """Single LLM call with the classification kwargs (low
+        temperature, deterministic). Returns raw response text.
+        """
+        model = (
+            settings.paperless_extraction_model
+            or settings.ollama_vision_model
+            or settings.ollama_chat_model
+        )
+        if not model:
+            raise RuntimeError("No extraction model configured")
+
+        client = self._llm_client or get_default_client()
+        classification_kwargs = get_classification_chat_kwargs(model)
+
+        response = await client.chat(
+            model=model,
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            options={"temperature": 0.1, "num_predict": 800},
+            **classification_kwargs,
+        )
+        return extract_response_content(response) or ""
+
+
+# ---------------------------------------------------------------------------
+# JSON parsing — robust to markdown fences and small noise
+# ---------------------------------------------------------------------------
+
+
+def _parse_llm_json(raw: str) -> dict | None:
+    """Parse an LLM response to a dict.
+
+    Tolerates markdown code fences (```json ... ```) and leading/
+    trailing prose around the JSON object. Returns ``None`` if nothing
+    parseable is found — caller treats that as extraction failure and
+    falls back to bare upload.
+    """
+    if not raw:
+        return None
+    text = raw.strip()
+
+    # Strip code fences if present.
+    if text.startswith("```"):
+        # Remove opening fence line (```, ```json, etc.)
+        newline_idx = text.find("\n")
+        if newline_idx >= 0:
+            text = text[newline_idx + 1:]
+        # Remove closing fence
+        if text.endswith("```"):
+            text = text[:-3]
+        text = text.strip()
+
+    # Find the balanced JSON object. Use the first '{' through the
+    # matching '}' — naive but sufficient for single-object responses,
+    # and the prompt explicitly asks for one.
+    first = text.find("{")
+    last = text.rfind("}")
+    if first < 0 or last <= first:
+        return None
+    json_fragment = text[first:last + 1]
+
+    try:
+        parsed = json.loads(json_fragment)
+    except json.JSONDecodeError as exc:
+        logger.debug("Could not parse LLM JSON: %s | raw=%r", exc, raw[:200])
+        return None
+
+    if not isinstance(parsed, dict):
+        return None
+
+    # created_date often comes as a string from the LLM. Pydantic
+    # handles str-to-date coercion, so pass through unchanged.
+    return parsed

--- a/src/backend/services/paperless_metadata_extractor.py
+++ b/src/backend/services/paperless_metadata_extractor.py
@@ -47,7 +47,7 @@ ASCII flow — single extraction call:
         │      on one-candidate-within-threshold, flags ambiguous)
         │   3. strict membership check (drops misses that weren't
         │      flagged as new_entry_proposals)
-        │   4. clamp created_date (1900-01-01 ... today+1y)
+        │   4. clamp created_date (today-10y ... today+1y)
         │   5. cap tags at 5
         │
         ▼
@@ -56,6 +56,8 @@ ASCII flow — single extraction call:
 from __future__ import annotations
 
 import json
+import re
+import time
 import unicodedata
 from datetime import date, timedelta
 from pathlib import Path
@@ -65,6 +67,7 @@ from loguru import logger
 from pydantic import BaseModel, Field, ValidationError
 from rapidfuzz.distance import Levenshtein
 
+from models.database import ChatUpload
 from services.prompt_manager import prompt_manager
 from utils.config import settings
 from utils.llm_client import (
@@ -83,29 +86,75 @@ from utils.llm_client import (
 _TOP_CORRESPONDENTS = 20
 _TOP_TAGS = 20
 
-# Fuzzy-match threshold. Levenshtein distance <= this many edits counts
-# as a near-match. 2 = "Stadtwerke Korschenbroich GmbH" can normalise to
-# "Stadtwerke Korschenbroich" (strip trailing "GmbH" costs ~5 edits —
-# actually above threshold, will land as a proposal; that's fine).
-# Shorter strings at distance 2 can match too-loosely, so we also cap
-# at <= 20% of the longer string's length.
+# Fuzzy-match thresholds. Levenshtein distance <= this many edits counts
+# as a near-match. Short strings at distance 2 can match too-loosely,
+# so we also cap at <= 20% of the longer string's length.
+#
+# Levenshtein alone doesn't catch corporate-suffix variations like
+# "Stadtwerke Korschenbroich GmbH" → "Stadtwerke Korschenbroich" (5
+# deletions, over threshold). _CORPORATE_SUFFIXES strips those
+# suffixes before comparison so the design doc's motivating case
+# actually works.
 _FUZZY_MAX_DISTANCE = 2
 _FUZZY_MAX_RATIO = 0.2
 
+# Case-insensitive; matched at the tail after normalisation. Each entry
+# is a standalone token that may appear at the end of a correspondent
+# string, optionally followed by punctuation. The list covers the
+# German + US/UK forms a household Paperless is likely to see; add more
+# as needed.
+_CORPORATE_SUFFIX_PATTERN = re.compile(
+    r"\s*(?:"
+    r"gmbh|ag|kg|kgaa|se|ohg|ug|mbh|e\.v\.|ev|"           # German
+    r"inc\.?|llc\.?|llp\.?|ltd\.?|plc\.?|corp\.?|co\.?|&\s*co\.?|"  # US / UK
+    r"s\.?\s*a\.?|s\.?\s*l\.?|s\.?\s*r\.?\s*l\.?|"         # Romance
+    r"b\.?\s*v\.?|n\.?\s*v\.?"                              # Dutch
+    r")\s*[.,]?\s*$",
+    re.IGNORECASE,
+)
+
+# Per-field confidence gate for new_entry_proposals. Below this the LLM
+# is too uncertain to justify surfacing a create-proposal to the user —
+# drop the proposal silently. Matches the design doc's § Validation
+# step 3 wording.
+_PROPOSAL_CONFIDENCE_MIN = 0.6
+
 # Taxonomy cache TTL (in memory, per-process). 10 min balances freshness
 # with API-call cost. Invalidated on successful create_* via the MCP
-# server's own cache flush + Redis TTL here.
+# server's own cache flush; cross-pod consistency is a v2 concern.
 _TAXONOMY_CACHE_TTL_S = 600
 
 # OCR text char cap fed to the LLM. Enough for the first few pages of a
 # typical document; longer is rarely informative and costs context budget.
 _MAX_DOC_CHARS = 12_000
 
-# created_date sanity clamps — documents dated outside this window are
-# OCR errors (1847 parsed from a page number, 2189 parsed from invoice
-# line). Today + 1 year to accommodate post-dated contracts / receipts
-# scanned slightly in advance.
-_DATE_MIN = date(1900, 1, 1)
+# created_date sanity clamps. Design § Validation step 4 says "10 years
+# past, 1 year future." Computed fresh per call so tests that freeze
+# the clock see the right window.
+_DATE_PAST_YEARS = 10
+_DATE_FUTURE_DAYS = 365
+
+
+# ---------------------------------------------------------------------------
+# Module-level taxonomy cache
+# ---------------------------------------------------------------------------
+#
+# Lives at module scope (not on the extractor instance) so that
+# per-request PaperlessMetadataExtractor instances share the warm
+# cache. Typical request creates a fresh extractor → previously the
+# cache reset every time; now the 10-min TTL actually works.
+#
+# Shape: {"fetched_at": float_epoch, "taxonomy": PaperlessTaxonomy}
+# Empty dict == no cache yet.
+_TAXONOMY_CACHE: dict[str, Any] = {}
+
+
+def _invalidate_taxonomy_cache() -> None:
+    """Flush the cache. Called when a create_* succeeds (the commit
+    tool in PR 2b) so freshly-added entries show up in the next
+    extraction without waiting for the TTL.
+    """
+    _TAXONOMY_CACHE.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -184,19 +233,41 @@ def _normalise(value: str) -> str:
     return unicodedata.normalize("NFKC", value).strip().casefold()
 
 
+def _strip_corporate_suffix(value: str) -> str:
+    """Drop one trailing corporate suffix (GmbH, Inc, LLC, …) from a
+    normalised string.
+
+    The LLM often emits "Stadtwerke Korschenbroich GmbH" when the
+    taxonomy has "Stadtwerke Korschenbroich" — a Levenshtein distance
+    of 5 that would blow past the fuzzy threshold. Stripping the
+    suffix before comparison brings distance to 0, trivial hit.
+
+    Only strips one suffix (non-greedy tail) and only when it's the
+    last token. "Foo GmbH Bar" stays unchanged (legitimately
+    different entity).
+    """
+    if not value:
+        return value
+    return _CORPORATE_SUFFIX_PATTERN.sub("", value).strip()
+
+
 def _fuzzy_match(llm_value: str, taxonomy: list[str]) -> str | None:
     """Return the canonical taxonomy entry near-matching ``llm_value``.
 
-    - Exact match after normalisation → return canonical spelling.
-    - Exactly one entry within edit-distance and ratio thresholds →
-      return canonical spelling.
-    - Zero candidates → return None (caller should treat as proposal).
-    - Two-or-more candidates within threshold → return None (ambiguous;
-      caller flags as proposal and surfaces the alternatives).
+    Three passes, each resolving to the canonical spelling or falling
+    through to the next:
 
-    Rationale for the two thresholds: a raw Levenshtein of 2 would match
-    "Bob" to "Bo" (33% distance) which isn't a near-miss, it's a
-    different word. Gating on ratio <= 0.2 prevents tiny-string false
+    1. Exact match after normalisation.
+    2. Exact match after corporate-suffix stripping on both sides
+       (catches "Stadtwerke Korschenbroich GmbH" → "Stadtwerke
+       Korschenbroich", the design doc's canonical case).
+    3. Levenshtein distance ≤ 2 AND edit-ratio ≤ 0.2 against every
+       normalised taxonomy entry. Exactly one candidate within
+       threshold → canonical. Zero or multiple (ambiguous) → None.
+
+    Rationale for the two thresholds on pass 3: a raw Levenshtein of 2
+    would match "Bob" to "Bo" (33% distance) which isn't a near-miss,
+    it's a different word. The ratio cap prevents tiny-string false
     positives while leaving longer strings room to absorb small typos.
     """
     if not llm_value or not taxonomy:
@@ -206,11 +277,30 @@ def _fuzzy_match(llm_value: str, taxonomy: list[str]) -> str | None:
     if not normalised_llm:
         return None
 
-    # Exact pass first — cheap, catches the common case where the LLM
-    # emits a taxonomy entry verbatim.
+    # Pass 1 — exact after casefold + NFKC. Catches the common case
+    # where the LLM emits a taxonomy entry verbatim.
     for entry in taxonomy:
         if _normalise(entry) == normalised_llm:
             return entry
+
+    # Pass 2 — exact match after corporate-suffix stripping. The
+    # stripping is symmetric: drop suffixes from both sides so
+    # "Stadtwerke GmbH" in the taxonomy still matches "Stadtwerke"
+    # from the LLM and vice versa.
+    stripped_llm = _strip_corporate_suffix(normalised_llm)
+    if stripped_llm and stripped_llm != normalised_llm:
+        for entry in taxonomy:
+            stripped_entry = _strip_corporate_suffix(_normalise(entry))
+            if stripped_entry == stripped_llm:
+                return entry
+    # Also try: LLM emits "Stadtwerke", taxonomy has "Stadtwerke GmbH".
+    # Suffix strip on the taxonomy side catches this.
+    for entry in taxonomy:
+        normalised_entry = _normalise(entry)
+        stripped_entry = _strip_corporate_suffix(normalised_entry)
+        if stripped_entry and stripped_entry != normalised_entry:
+            if stripped_entry == normalised_llm:
+                return entry
 
     # Fuzzy pass with both absolute and ratio constraints.
     candidates: list[str] = []
@@ -302,10 +392,16 @@ def prune_taxonomy(
 # ---------------------------------------------------------------------------
 
 
+def _date_min() -> date:
+    """Computed fresh per call so tests that freeze the clock see the
+    right floor. Design § Validation step 4: ten years past."""
+    return date.today() - timedelta(days=_DATE_PAST_YEARS * 365)
+
+
 def _date_max() -> date:
-    """Computed fresh per call so tests that freeze the clock via
-    ``pytest-freezegun`` or similar see the right ceiling."""
-    return date.today() + timedelta(days=365)
+    """Computed fresh per call so tests that freeze the clock see the
+    right ceiling. Design § Validation step 4: one year future."""
+    return date.today() + timedelta(days=_DATE_FUTURE_DAYS)
 
 
 def validate_extraction(
@@ -322,7 +418,7 @@ def validate_extraction(
        the proposal survives for user review.
     3. Strict taxonomy membership — after fuzzy, assert the value is in
        the list. Defence-in-depth; should never drop here.
-    4. ``created_date`` clamped to [1900-01-01, today+1y].
+    4. ``created_date`` clamped to [today-10y, today+1y].
     5. ``tags`` truncated at 5.
     """
     # Step 1 — parse. Any shape error raises; caller catches.
@@ -334,9 +430,43 @@ def validate_extraction(
         # enough that appending is more useful than replacing.
         raise ValueError(f"Malformed LLM output: {exc}") from exc
 
-    # Group the LLM's proposals by field for quick lookup during fuzzy
-    # fallback — if the LLM flagged "correspondent" as proposal, we
-    # don't need to silently drop the field value too.
+    # Confidence-gate the proposals first. Design § Validation step 3:
+    # proposals below _PROPOSAL_CONFIDENCE_MIN (0.6) are dropped
+    # silently — the LLM is too uncertain to justify surfacing a
+    # create-proposal to the user. Check confidence per-field: a low
+    # confidence on the FIELD (e.g. confidence.correspondent = 0.2)
+    # drops any proposals for that field.
+    high_confidence_proposals: list[NewEntryProposal] = []
+    for proposal in metadata.new_entry_proposals:
+        # The LLM emits confidence keyed by field name (singular for
+        # fields, plural "tags" for the list). Proposal.field is always
+        # singular ("correspondent", "document_type", "tag",
+        # "storage_path") per the Literal typing.
+        confidence_key = proposal.field
+        # For tag proposals, the LLM's confidence is usually keyed
+        # "tags" in its response. Accept either.
+        confidence = metadata.confidence.get(confidence_key)
+        if confidence is None and proposal.field == "tag":
+            confidence = metadata.confidence.get("tags")
+        if confidence is None:
+            # LLM didn't emit confidence for this field. Be permissive
+            # — drop-silent would lose useful signal when the model
+            # forgets the confidence block. Let the proposal survive.
+            high_confidence_proposals.append(proposal)
+            continue
+        if confidence >= _PROPOSAL_CONFIDENCE_MIN:
+            high_confidence_proposals.append(proposal)
+        else:
+            logger.debug(
+                "Dropping low-confidence proposal (%.2f < %.2f): %s=%r",
+                confidence, _PROPOSAL_CONFIDENCE_MIN,
+                proposal.field, proposal.value,
+            )
+    metadata.new_entry_proposals = high_confidence_proposals
+
+    # Group the surviving proposals by field for quick lookup during
+    # fuzzy fallback — if the LLM flagged "correspondent" as proposal,
+    # we don't need to silently drop the field value too.
     proposed_fields = {p.field for p in metadata.new_entry_proposals}
 
     # Step 2 + 3 — fuzzy + strict membership.
@@ -372,9 +502,10 @@ def validate_extraction(
             logger.debug("Dropping tag not in taxonomy: %r", tag)
     metadata.tags = validated_tags[:5]  # Step 5 — cap
 
-    # Step 4 — date clamps.
+    # Step 4 — date clamps. Both bounds are computed fresh per call so
+    # tests with a frozen clock see the window they expect.
     if metadata.created_date is not None:
-        if metadata.created_date < _DATE_MIN or metadata.created_date > _date_max():
+        if metadata.created_date < _date_min() or metadata.created_date > _date_max():
             logger.warning(
                 "Dropping created_date out of range: %s",
                 metadata.created_date,
@@ -478,10 +609,9 @@ class PaperlessMetadataExtractor:
         self.mcp_manager = mcp_manager
         self._llm_client = llm_client
         self._document_processor = document_processor
-        # Per-process taxonomy cache. Entry shape:
-        # {"fetched_at": float_epoch, "taxonomy": PaperlessTaxonomy,
-        #  "correspondents_full": list[str], ...}
-        self._taxonomy_cache: dict[str, Any] = {}
+        # Taxonomy cache is at module level (_TAXONOMY_CACHE) so repeated
+        # per-request extractor instances share the warm cache — the
+        # 10-minute TTL only makes sense across instances.
 
     # -- Extraction entry point --
 
@@ -561,10 +691,15 @@ class PaperlessMetadataExtractor:
     # -- Helpers (overridable for testing) --
 
     async def _load_upload(self, attachment_id: int, session_id: str | None):
-        """Lookup with session-scoping (see #442)."""
+        """Lookup with session-scoping (see #442).
+
+        ``AsyncSessionLocal`` stays a local import because importing
+        ``services.database`` at module level triggers engine creation,
+        which forces every caller (including unit tests) to have a
+        Postgres-ready env. Session-scoped fetch avoids that cost.
+        """
         from sqlalchemy import select
 
-        from models.database import ChatUpload
         from services.database import AsyncSessionLocal
 
         async with AsyncSessionLocal() as db:
@@ -610,18 +745,15 @@ class PaperlessMetadataExtractor:
             logger.warning("No MCP manager wired; cannot fetch Paperless taxonomy")
             return None
 
-        import time as _time
-        now = _time.time()
-        cached = self._taxonomy_cache.get("entry")
+        now = time.time()
+        cached = _TAXONOMY_CACHE.get("entry")
         if cached and (now - cached["fetched_at"]) < _TAXONOMY_CACHE_TTL_S:
             return cached["taxonomy"]
 
-        # The MCP server exposes list_storage_paths + list_custom_fields
-        # today; for correspondents / document_types / tags we query
-        # Paperless directly via search_documents or via dedicated
-        # helpers the MCP server could add. For PR 2a we leverage the
-        # taxonomy cache that PR 1 warms up via _ensure_caches — the
-        # list_* tools return the already-resolved lists.
+        # The MCP server exposes list_correspondents, list_document_types,
+        # list_tags, list_storage_paths (v1.3.0+). Taxonomy cache on the
+        # MCP server side is shared across tools — one round-trip per
+        # dimension on a cold cache, zero on warm.
         try:
             correspondents = await self._list_via_mcp("list_correspondents")
             document_types = await self._list_via_mcp("list_document_types")
@@ -639,7 +771,7 @@ class PaperlessMetadataExtractor:
             tags=tags,
             storage_paths=storage_paths,
         )
-        self._taxonomy_cache["entry"] = {"fetched_at": now, "taxonomy": taxonomy}
+        _TAXONOMY_CACHE["entry"] = {"fetched_at": now, "taxonomy": taxonomy}
         return taxonomy
 
     async def _list_via_mcp(
@@ -652,25 +784,38 @@ class PaperlessMetadataExtractor:
         """Thin wrapper: call ``mcp.paperless.{tool_name}`` and return
         the list of names.
 
-        The MCP server today has ``list_storage_paths`` (returns
-        ``{"paths": [{"id": ..., "path": ...}]}``) and
-        ``list_custom_fields``. For the three dimensions the audit V2 PR
-        doesn't yet have dedicated list tools for (correspondents,
-        document_types, tags), we fall back to scraping the MCP server's
-        in-memory cache via a well-known diagnostic tool name — this
-        gap is explicitly flagged in the design doc and filled in
-        PR 2b's MCP-server additions if needed. For now, unknown tools
-        return an empty list; the extractor gracefully falls through
-        with fewer dimensions rather than crashing.
+        Requires ``renfield-mcp-paperless`` v1.3.0 or later, which
+        exposes ``list_correspondents`` / ``list_document_types`` /
+        ``list_tags`` / ``list_storage_paths`` as read-only wrappers
+        around the MCP server's already-populated taxonomy caches.
+
+        On any failure path (tool not found, transport error, JSON
+        parse failure, unexpected payload shape), returns an empty
+        list AND logs at WARNING so the "empty taxonomy in prod"
+        failure mode is visible in logs rather than silently degraded.
+        The extractor falls through with fewer dimensions rather than
+        crashing the whole pipeline.
         """
         full_name = f"mcp.paperless.{tool_name}"
         try:
             result = await self.mcp_manager.execute_tool(full_name, {})
         except Exception as exc:
-            logger.debug("MCP tool %s unavailable: %s", full_name, exc)
+            logger.warning("MCP tool %s unreachable: %s", full_name, exc)
             return []
 
         if not result or not result.get("success"):
+            # Distinguish "unknown tool" (MCP server too old) from
+            # "tool ran but errored" so the ops signal is clear.
+            err = (result or {}).get("message") or "no message"
+            err_str = err if isinstance(err, str) else str(err)
+            if "unknown" in err_str.lower() or "not found" in err_str.lower():
+                logger.warning(
+                    "MCP tool %s not available — is the MCP server at "
+                    "v1.3.0 or later? (got: %s)",
+                    full_name, err_str[:120],
+                )
+            else:
+                logger.warning("MCP tool %s failed: %s", full_name, err_str[:120])
             return []
 
         inner_msg = result.get("message")
@@ -679,15 +824,27 @@ class PaperlessMetadataExtractor:
             try:
                 payload = json.loads(inner_msg)
             except json.JSONDecodeError:
+                logger.warning(
+                    "MCP tool %s returned non-JSON message: %r",
+                    full_name, inner_msg[:120],
+                )
                 return []
         elif isinstance(inner_msg, dict):
             payload = inner_msg
 
         if not isinstance(payload, dict):
+            logger.warning(
+                "MCP tool %s returned unexpected payload shape: %s",
+                full_name, type(payload).__name__,
+            )
             return []
 
         items = payload.get(field) or []
         if not isinstance(items, list):
+            logger.warning(
+                "MCP tool %s field %r is not a list: %s",
+                full_name, field, type(items).__name__,
+            )
             return []
 
         names: list[str] = []

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -59,6 +59,11 @@ class Settings(BaseSettings):
     ollama_fallback_url: str = ""                 # Fallback Ollama URL if primary is unreachable (e.g. http://host.docker.internal:11434)
     ollama_vision_model: str = ""                  # Vision-capable model (e.g. "minicpm-v"). Empty = vision disabled.
     ollama_vision_url: str | None = None         # Separate Ollama URL for vision model (default: ollama_url)
+    # Paperless metadata extraction — per docs/design/paperless-llm-metadata.md
+    # § 2. Vision-first on scanned docs, Docling text-layer shortcut for
+    # plain-text PDFs/docx/md. Empty → falls back to ollama_vision_model,
+    # then ollama_chat_model. The extractor uses whichever is set.
+    paperless_extraction_model: str = ""
     ollama_embed_url: str | None = None          # Separate Ollama URL for embeddings (default: ollama_url)
 
     # Home Assistant / Frigate settings moved to ha_glue/utils/config.py

--- a/tests/backend/test_paperless_metadata_extractor.py
+++ b/tests/backend/test_paperless_metadata_extractor.py
@@ -88,11 +88,47 @@ class TestFuzzyMatch:
         assert _fuzzy_match("Stadtwerke Korschenbroic", taxonomy) == "Stadtwerke Korschenbroich"
 
     @pytest.mark.unit
-    def test_distance_over_threshold_drops(self):
+    def test_corporate_suffix_stripped_before_comparison(self):
+        """The design doc's motivating case: LLM emits the full legal
+        name (with GmbH/AG/Inc suffix) while the taxonomy stores the
+        short form. Levenshtein distance would be too high; the
+        suffix-strip pass catches it."""
         taxonomy = ["Stadtwerke Korschenbroich"]
-        # "Stadtwerke Korschenbroich GmbH" adds " GmbH" = 5 chars. Over
-        # the max-distance threshold → no match.
-        assert _fuzzy_match("Stadtwerke Korschenbroich GmbH", taxonomy) is None
+        # GmbH — German form
+        assert _fuzzy_match("Stadtwerke Korschenbroich GmbH", taxonomy) == "Stadtwerke Korschenbroich"
+
+    @pytest.mark.unit
+    def test_corporate_suffix_symmetric(self):
+        """Works either direction: LLM drops the suffix that's in the
+        taxonomy, OR LLM adds a suffix the taxonomy doesn't have."""
+        assert _fuzzy_match("Stadtwerke", ["Stadtwerke GmbH"]) == "Stadtwerke GmbH"
+        assert _fuzzy_match("Stadtwerke GmbH", ["Stadtwerke"]) == "Stadtwerke"
+
+    @pytest.mark.unit
+    def test_corporate_suffix_many_forms(self):
+        taxonomy = ["Acme"]
+        for suffix in ["GmbH", "AG", "Inc.", "LLC", "Ltd", "Corp", "S.A.", "B.V.", "e.V."]:
+            assert _fuzzy_match(f"Acme {suffix}", taxonomy) == "Acme", (
+                f"Suffix {suffix!r} should strip to 'Acme'"
+            )
+
+    @pytest.mark.unit
+    def test_corporate_suffix_only_at_tail(self):
+        """Don't strip mid-string occurrences — 'Foo GmbH Bar' stays
+        as a legitimately different entity."""
+        taxonomy = ["Acme"]
+        # "Acme GmbH Deutschland" — GmbH not at tail, full string
+        # different from "Acme", no match.
+        assert _fuzzy_match("Acme GmbH Deutschland", taxonomy) is None
+
+    @pytest.mark.unit
+    def test_truly_different_strings_still_drop(self):
+        """Suffix stripping must not create false positives. Two
+        different entities should still fail to match."""
+        taxonomy = ["Stadtwerke Korschenbroich"]
+        # "Stadtwerke Köln GmbH" strips to "Stadtwerke Köln" which is
+        # still distance > threshold from "Stadtwerke Korschenbroich".
+        assert _fuzzy_match("Stadtwerke Köln GmbH", taxonomy) is None
 
     @pytest.mark.unit
     def test_short_string_ratio_guard(self):
@@ -318,17 +354,35 @@ class TestValidateExtraction:
         assert len(result.tags) == 5
 
     @pytest.mark.unit
-    def test_created_date_before_1900_dropped(self):
-        """Documents dated 1847 are OCR errors."""
+    def test_created_date_more_than_10_years_past_dropped(self):
+        """Design § Validation step 4: 10 years past is the floor.
+        Documents dated older than that are OCR errors (1985 parsed
+        from prose, 1847 from a page number)."""
+        old = (date.today() - timedelta(days=365 * 15)).isoformat()
         raw = {
             "title": "T",
             "correspondent": None,
             "document_type": "Rechnung",
             "tags": [],
-            "created_date": "1847-03-14",
+            "created_date": old,
         }
         result = validate_extraction(raw, _taxonomy())
         assert result.created_date is None
+
+    @pytest.mark.unit
+    def test_created_date_within_10_years_past_accepted(self):
+        """A doc dated 8 years ago is still plausibly a real receipt
+        the user is archiving late."""
+        recent = (date.today() - timedelta(days=365 * 8)).isoformat()
+        raw = {
+            "title": "T",
+            "correspondent": None,
+            "document_type": "Rechnung",
+            "tags": [],
+            "created_date": recent,
+        }
+        result = validate_extraction(raw, _taxonomy())
+        assert result.created_date is not None
 
     @pytest.mark.unit
     def test_created_date_too_far_future_dropped(self):
@@ -657,6 +711,240 @@ class TestExtractorIntegration:
 
         assert result.error is not None
         assert "model" in result.error.lower() or "fehlgeschlagen" in result.error.lower()
+
+
+# ===========================================================================
+# Confidence-gated proposals
+# ===========================================================================
+
+
+class TestConfidenceGating:
+    @pytest.mark.unit
+    def test_high_confidence_proposal_survives(self):
+        """Confidence ≥ 0.6 on the field name → proposal passes."""
+        raw = {
+            "title": "T",
+            "correspondent": "Schreiner Meier",
+            "document_type": "Rechnung",
+            "tags": [],
+            "confidence": {"correspondent": 0.85},
+            "new_entry_proposals": [
+                {"field": "correspondent", "value": "Schreiner Meier",
+                 "reasoning": "Rechnungskopf."},
+            ],
+        }
+        result = validate_extraction(raw, _taxonomy())
+        assert len(result.new_entry_proposals) == 1
+        assert result.new_entry_proposals[0].value == "Schreiner Meier"
+
+    @pytest.mark.unit
+    def test_low_confidence_proposal_dropped(self):
+        """Confidence < 0.6 on the proposal field → dropped."""
+        raw = {
+            "title": "T",
+            "correspondent": "Unsichtbar Ltd",
+            "document_type": "Rechnung",
+            "tags": [],
+            "confidence": {"correspondent": 0.3},
+            "new_entry_proposals": [
+                {"field": "correspondent", "value": "Unsichtbar Ltd",
+                 "reasoning": "Unsicher, ob so gelesen."},
+            ],
+        }
+        result = validate_extraction(raw, _taxonomy())
+        assert result.new_entry_proposals == []
+
+    @pytest.mark.unit
+    def test_missing_confidence_permissive(self):
+        """No confidence entry for the proposal field → be permissive
+        (don't drop). Keeps the signal when the LLM forgets the
+        confidence block entirely."""
+        raw = {
+            "title": "T",
+            "correspondent": "Schreiner Meier",
+            "document_type": "Rechnung",
+            "tags": [],
+            # No confidence entry at all.
+            "new_entry_proposals": [
+                {"field": "correspondent", "value": "Schreiner Meier",
+                 "reasoning": "..."},
+            ],
+        }
+        result = validate_extraction(raw, _taxonomy())
+        assert len(result.new_entry_proposals) == 1
+
+    @pytest.mark.unit
+    def test_tag_proposal_uses_plural_confidence_key(self):
+        """The LLM often keys confidence as 'tags' (plural list) even
+        though proposals are singular 'tag'. Accept either."""
+        raw = {
+            "title": "T",
+            "tags": [],
+            "confidence": {"tags": 0.9},
+            "new_entry_proposals": [
+                {"field": "tag", "value": "new-tag",
+                 "reasoning": "..."},
+            ],
+        }
+        result = validate_extraction(raw, _taxonomy())
+        assert len(result.new_entry_proposals) == 1
+
+
+# ===========================================================================
+# Malformed individual fields — partial-shape failures
+# ===========================================================================
+
+
+class TestPartialShapeFailures:
+    @pytest.mark.unit
+    def test_malformed_date_string_raises(self):
+        """Invalid date string — pydantic rejects. More common than
+        tag-type mismatch in real LLM output."""
+        raw = {
+            "title": "T",
+            "tags": [],
+            "created_date": "not-a-date",
+        }
+        with pytest.raises(ValueError):
+            validate_extraction(raw, _taxonomy())
+
+    @pytest.mark.unit
+    def test_malformed_proposal_shape_raises(self):
+        """Proposal with a wrong field name (not in Literal)."""
+        raw = {
+            "title": "T",
+            "tags": [],
+            "new_entry_proposals": [
+                {"field": "not-a-real-field", "value": "x", "reasoning": "y"},
+            ],
+        }
+        with pytest.raises(ValueError):
+            validate_extraction(raw, _taxonomy())
+
+
+# ===========================================================================
+# Module-level taxonomy cache
+# ===========================================================================
+
+
+class TestTaxonomyCacheIsModuleScoped:
+    """Regression guard: the cache lives at module scope so different
+    extractor instances share it. Previously each instance had its
+    own empty dict and the TTL was effectively dead."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_cache_shared_across_instances(self):
+        from services import paperless_metadata_extractor as pme
+
+        # Reset cache state for this test.
+        pme._TAXONOMY_CACHE.clear()
+
+        mcp_calls: list[str] = []
+
+        async def _mcp_execute(tool_name: str, params: dict):
+            mcp_calls.append(tool_name)
+            if "correspondents" in tool_name:
+                return {"success": True, "message": '{"items": [{"name": "A"}]}'}
+            if "document_types" in tool_name:
+                return {"success": True, "message": '{"items": [{"name": "T"}]}'}
+            if "tags" in tool_name:
+                return {"success": True, "message": '{"items": [{"name": "t"}]}'}
+            if "storage_paths" in tool_name:
+                return {"success": True, "message": '{"paths": [{"path": "/x"}]}'}
+            return {"success": False}
+
+        mcp = MagicMock()
+        mcp.execute_tool = AsyncMock(side_effect=_mcp_execute)
+
+        # First extractor instance — cold cache, 4 MCP calls.
+        ext1 = pme.PaperlessMetadataExtractor(mcp_manager=mcp)
+        tax1 = await ext1._fetch_taxonomy()
+        first_call_count = len(mcp_calls)
+        assert first_call_count == 4
+        assert tax1 is not None
+
+        # Second instance — warm cache, zero MCP calls.
+        ext2 = pme.PaperlessMetadataExtractor(mcp_manager=mcp)
+        tax2 = await ext2._fetch_taxonomy()
+        assert len(mcp_calls) == first_call_count  # no new calls
+        assert tax2 is not None
+        # Same data (identity not guaranteed, but equal).
+        assert tax2.correspondents == tax1.correspondents
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_invalidate_forces_refetch(self):
+        from services import paperless_metadata_extractor as pme
+
+        pme._TAXONOMY_CACHE.clear()
+
+        call_count = {"n": 0}
+
+        async def _mcp_execute(tool_name: str, params: dict):
+            call_count["n"] += 1
+            if "correspondents" in tool_name:
+                return {"success": True, "message": '{"items": []}'}
+            if "document_types" in tool_name:
+                return {"success": True, "message": '{"items": []}'}
+            if "tags" in tool_name:
+                return {"success": True, "message": '{"items": []}'}
+            if "storage_paths" in tool_name:
+                return {"success": True, "message": '{"paths": []}'}
+            return {"success": False}
+
+        mcp = MagicMock()
+        mcp.execute_tool = AsyncMock(side_effect=_mcp_execute)
+
+        ext = pme.PaperlessMetadataExtractor(mcp_manager=mcp)
+        await ext._fetch_taxonomy()
+        first = call_count["n"]
+
+        # Invalidate → next fetch re-queries MCP.
+        pme._invalidate_taxonomy_cache()
+        await ext._fetch_taxonomy()
+        assert call_count["n"] == first * 2
+
+
+# ===========================================================================
+# _list_via_mcp — log surface for unknown-tool path
+# ===========================================================================
+
+
+class TestListViaMcpLogging:
+    """The 'MCP server too old' case must log at WARNING so ops can
+    see the empty-taxonomy degradation instead of silently shipping
+    broken extractions."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_unknown_tool_logs_warning_with_version_hint(self, caplog):
+        mcp = MagicMock()
+        mcp.execute_tool = AsyncMock(return_value={
+            "success": False,
+            "message": "Unknown MCP tool: mcp.paperless.list_correspondents",
+        })
+        ext = PaperlessMetadataExtractor(mcp_manager=mcp)
+
+        import logging
+        with caplog.at_level(logging.WARNING, logger="loguru"):
+            result = await ext._list_via_mcp("list_correspondents")
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_non_json_message_handled(self):
+        """If the MCP response message is unparseable, return [] and
+        don't crash."""
+        mcp = MagicMock()
+        mcp.execute_tool = AsyncMock(return_value={
+            "success": True,
+            "message": "<!DOCTYPE html><html>502 Bad Gateway",
+        })
+        ext = PaperlessMetadataExtractor(mcp_manager=mcp)
+        result = await ext._list_via_mcp("list_correspondents")
+        assert result == []
 
 
 # ===========================================================================

--- a/tests/backend/test_paperless_metadata_extractor.py
+++ b/tests/backend/test_paperless_metadata_extractor.py
@@ -1,0 +1,688 @@
+"""
+Unit tests for PaperlessMetadataExtractor — pure-unit coverage of the
+non-IO pieces (fuzzy match, pruning, validation, prompt render, JSON
+parsing) plus one end-to-end extract() call with every dependency mocked.
+
+Full integration with a real Paperless + Docling + LLM is deferred to
+the eval suite (see docs/design/paperless-llm-metadata.md § Eval corpus).
+
+All tests @pytest.mark.unit — no network, no DB engine.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.paperless_metadata_extractor import (
+    ExtractionResult,
+    NewEntryProposal,
+    PaperlessMetadata,
+    PaperlessMetadataExtractor,
+    PaperlessTaxonomy,
+    _fuzzy_match,
+    _normalise,
+    _parse_llm_json,
+    prune_taxonomy,
+    render_prompt,
+    validate_extraction,
+)
+
+
+# ===========================================================================
+# _normalise
+# ===========================================================================
+
+
+class TestNormalise:
+    @pytest.mark.unit
+    def test_casefolds(self):
+        assert _normalise("Stadtwerke") == "stadtwerke"
+
+    @pytest.mark.unit
+    def test_strips_surrounding_whitespace(self):
+        assert _normalise("  Finanzamt  ") == "finanzamt"
+
+    @pytest.mark.unit
+    def test_nfkc_normalises_compatibility_chars(self):
+        # Fullwidth exclamation → ASCII (both folded). Mainly guards
+        # against ligatures and fullwidth CJK Paperless admins might
+        # have entered copy-paste.
+        assert _normalise("ＡＢＣ") == "abc"
+
+    @pytest.mark.unit
+    def test_umlauts_preserved(self):
+        # NFKC doesn't fold Umlauts to ae/oe/ue. Fuzzy matching on the
+        # canonical Umlaut form is what we want.
+        assert _normalise("Müller") == "müller"
+
+    @pytest.mark.unit
+    def test_empty_returns_empty(self):
+        assert _normalise("") == ""
+        assert _normalise(None) == ""  # None-tolerant
+
+
+# ===========================================================================
+# _fuzzy_match
+# ===========================================================================
+
+
+class TestFuzzyMatch:
+    @pytest.mark.unit
+    def test_exact_hit_returns_canonical(self):
+        taxonomy = ["Stadtwerke Korschenbroich", "Finanzamt Neuss"]
+        assert _fuzzy_match("Stadtwerke Korschenbroich", taxonomy) == "Stadtwerke Korschenbroich"
+
+    @pytest.mark.unit
+    def test_case_insensitive_hit(self):
+        taxonomy = ["Stadtwerke Korschenbroich"]
+        assert _fuzzy_match("stadtwerke korschenbroich", taxonomy) == "Stadtwerke Korschenbroich"
+
+    @pytest.mark.unit
+    def test_near_match_rewrites_to_canonical(self):
+        taxonomy = ["Stadtwerke Korschenbroich"]
+        # "Korschenbroic" vs "Korschenbroich" = distance 1, ratio ~0.04
+        # Both thresholds satisfied → canonical wins.
+        assert _fuzzy_match("Stadtwerke Korschenbroic", taxonomy) == "Stadtwerke Korschenbroich"
+
+    @pytest.mark.unit
+    def test_distance_over_threshold_drops(self):
+        taxonomy = ["Stadtwerke Korschenbroich"]
+        # "Stadtwerke Korschenbroich GmbH" adds " GmbH" = 5 chars. Over
+        # the max-distance threshold → no match.
+        assert _fuzzy_match("Stadtwerke Korschenbroich GmbH", taxonomy) is None
+
+    @pytest.mark.unit
+    def test_short_string_ratio_guard(self):
+        """For 3-letter names, edit distance 2 would be 67% — the ratio
+        cap kicks in before the distance cap."""
+        taxonomy = ["Bob"]
+        # "Alice" vs "Bob" — distance 4, over both caps. No match.
+        assert _fuzzy_match("Alice", taxonomy) is None
+        # "Bo" vs "Bob" — distance 1, ratio 0.33 > 0.2 → no match.
+        assert _fuzzy_match("Bo", taxonomy) is None
+
+    @pytest.mark.unit
+    def test_ambiguous_multi_match_drops_to_none(self):
+        """Two near-matches within threshold → ambiguous, caller
+        surfaces proposal instead of arbitrarily picking one."""
+        taxonomy = ["Telekom DE", "Telekom DK"]
+        # "Telekom DX" is distance 1 from both. Ambiguous.
+        assert _fuzzy_match("Telekom DX", taxonomy) is None
+
+    @pytest.mark.unit
+    def test_empty_inputs_return_none(self):
+        assert _fuzzy_match("", ["A", "B"]) is None
+        assert _fuzzy_match("A", []) is None
+        assert _fuzzy_match(None, ["A"]) is None
+
+    @pytest.mark.unit
+    def test_umlaut_near_match(self):
+        taxonomy = ["Müller"]
+        # "Muller" (ASCII) vs "Müller" (Umlaut) — distance 1, ratio OK.
+        assert _fuzzy_match("Muller", taxonomy) == "Müller"
+
+
+# ===========================================================================
+# prune_taxonomy
+# ===========================================================================
+
+
+class TestPruneTaxonomy:
+    @pytest.mark.unit
+    def test_no_recency_returns_first_n(self):
+        """Cold start — no recency signal. Keep the first N entries."""
+        correspondents = [f"C{i}" for i in range(30)]
+        result = prune_taxonomy(
+            correspondents=correspondents,
+            document_types=["Rechnung"],
+            tags=[],
+            storage_paths=[],
+            top_correspondents=5,
+        )
+        assert result.correspondents == ["C0", "C1", "C2", "C3", "C4"]
+
+    @pytest.mark.unit
+    def test_recency_reorders_within_cap(self):
+        """Most-recent entries should appear first, padded from the
+        remaining list until the cap is filled."""
+        correspondents = ["A", "B", "C", "D", "E"]
+        # Recency says "D was used recently, then A, then B."
+        result = prune_taxonomy(
+            correspondents=correspondents,
+            document_types=[],
+            tags=[],
+            storage_paths=[],
+            recent_correspondent_ids=["D", "A", "B"],
+            top_correspondents=4,
+        )
+        # First 3 from recency, then 4th from remaining (C, dropping E).
+        assert result.correspondents == ["D", "A", "B", "C"]
+
+    @pytest.mark.unit
+    def test_document_types_never_pruned(self):
+        """document_types + storage_paths are included in full because
+        they're typically < 30 and small strings."""
+        document_types = [f"Type{i}" for i in range(100)]
+        result = prune_taxonomy(
+            correspondents=[], document_types=document_types,
+            tags=[], storage_paths=[],
+        )
+        assert result.document_types == document_types
+
+    @pytest.mark.unit
+    def test_storage_paths_never_pruned(self):
+        paths = [f"/path/{i}" for i in range(50)]
+        result = prune_taxonomy(
+            correspondents=[], document_types=[],
+            tags=[], storage_paths=paths,
+        )
+        assert result.storage_paths == paths
+
+    @pytest.mark.unit
+    def test_tags_pruned_by_recency(self):
+        """Same recency logic applies to tags."""
+        tags = [f"t{i}" for i in range(30)]
+        result = prune_taxonomy(
+            correspondents=[], document_types=[], tags=tags, storage_paths=[],
+            recent_tag_ids=["t25", "t24", "t23"],
+            top_tags=5,
+        )
+        assert result.tags[:3] == ["t25", "t24", "t23"]
+        assert len(result.tags) == 5
+
+    @pytest.mark.unit
+    def test_recency_entries_not_in_list_are_skipped(self):
+        """If the recency signal names entries that aren't in the
+        current taxonomy (deleted after the recency snapshot), skip
+        them rather than crash."""
+        result = prune_taxonomy(
+            correspondents=["A", "B", "C"],
+            document_types=[], tags=[], storage_paths=[],
+            recent_correspondent_ids=["DELETED", "A", "GONE"],
+            top_correspondents=5,
+        )
+        # Only A survives from recency; rest padded in order.
+        assert result.correspondents == ["A", "B", "C"]
+
+
+# ===========================================================================
+# validate_extraction
+# ===========================================================================
+
+
+def _taxonomy() -> PaperlessTaxonomy:
+    return PaperlessTaxonomy(
+        correspondents=["Stadtwerke Korschenbroich", "Finanzamt Neuss"],
+        document_types=["Rechnung", "Steuerbescheid", "Nebenkostenabrechnung"],
+        tags=["wohnung", "steuer-2025", "nebenkosten-2025"],
+        storage_paths=["/wohnung/betriebskosten", "/steuer/2025"],
+    )
+
+
+class TestValidateExtraction:
+    @pytest.mark.unit
+    def test_happy_path_all_hits(self):
+        raw = {
+            "title": "Nebenkostenabrechnung 2025 - Stadtwerke Korschenbroich",
+            "correspondent": "Stadtwerke Korschenbroich",
+            "document_type": "Nebenkostenabrechnung",
+            "tags": ["wohnung", "nebenkosten-2025"],
+            "storage_path": "/wohnung/betriebskosten",
+            "created_date": "2026-02-14",
+            "confidence": {"title": 0.95, "correspondent": 0.98},
+        }
+        result = validate_extraction(raw, _taxonomy())
+        assert result.correspondent == "Stadtwerke Korschenbroich"
+        assert result.document_type == "Nebenkostenabrechnung"
+        assert result.tags == ["wohnung", "nebenkosten-2025"]
+        assert result.storage_path == "/wohnung/betriebskosten"
+        assert result.created_date == date(2026, 2, 14)
+        assert result.new_entry_proposals == []
+
+    @pytest.mark.unit
+    def test_fuzzy_rewrite_silent_on_near_match(self):
+        """LLM emits 'Stadtwerke Korschenbroic' (missing 'h'). Fuzzy
+        rewrites to canonical — no drop, no proposal."""
+        raw = {
+            "title": "Test",
+            "correspondent": "Stadtwerke Korschenbroic",
+            "document_type": "Rechnung",
+            "tags": [],
+        }
+        result = validate_extraction(raw, _taxonomy())
+        assert result.correspondent == "Stadtwerke Korschenbroich"
+
+    @pytest.mark.unit
+    def test_non_taxonomy_value_dropped_when_no_proposal(self):
+        """LLM hallucinates a correspondent not in taxonomy, no
+        proposal flagged — field drops to None, nothing surfaces."""
+        raw = {
+            "title": "Test",
+            "correspondent": "Gibt Es Nicht GmbH",
+            "document_type": "Rechnung",
+            "tags": [],
+        }
+        result = validate_extraction(raw, _taxonomy())
+        assert result.correspondent is None
+        assert result.new_entry_proposals == []
+
+    @pytest.mark.unit
+    def test_non_taxonomy_value_survives_as_proposal(self):
+        """LLM emits a value not in taxonomy AND flags it as a proposal.
+        Field stays None (proposal carries the intent), proposal
+        survives for user review."""
+        raw = {
+            "title": "Test",
+            "correspondent": "Schreiner Meier",
+            "document_type": "Rechnung",
+            "tags": [],
+            "new_entry_proposals": [
+                {"field": "correspondent", "value": "Schreiner Meier",
+                 "reasoning": "Rechnungskopf, nicht in Taxonomie."},
+            ],
+        }
+        result = validate_extraction(raw, _taxonomy())
+        assert result.correspondent is None
+        assert len(result.new_entry_proposals) == 1
+        assert result.new_entry_proposals[0].value == "Schreiner Meier"
+
+    @pytest.mark.unit
+    def test_tags_non_taxonomy_entries_dropped(self):
+        """Tags are list-valued — misses drop silently, hits are kept."""
+        raw = {
+            "title": "Test",
+            "correspondent": None,
+            "document_type": "Rechnung",
+            "tags": ["wohnung", "made-up-tag", "steuer-2025"],
+        }
+        result = validate_extraction(raw, _taxonomy())
+        assert "wohnung" in result.tags
+        assert "steuer-2025" in result.tags
+        assert "made-up-tag" not in result.tags
+
+    @pytest.mark.unit
+    def test_tags_capped_at_5(self):
+        raw = {
+            "title": "T",
+            "correspondent": None,
+            "document_type": "Rechnung",
+            "tags": ["wohnung"] * 10,  # silly, but tests cap
+        }
+        taxonomy = _taxonomy()
+        taxonomy.tags.extend(["t1", "t2", "t3", "t4", "t5", "t6", "t7"])
+        raw["tags"] = ["wohnung", "t1", "t2", "t3", "t4", "t5", "t6"]
+        result = validate_extraction(raw, taxonomy)
+        assert len(result.tags) == 5
+
+    @pytest.mark.unit
+    def test_created_date_before_1900_dropped(self):
+        """Documents dated 1847 are OCR errors."""
+        raw = {
+            "title": "T",
+            "correspondent": None,
+            "document_type": "Rechnung",
+            "tags": [],
+            "created_date": "1847-03-14",
+        }
+        result = validate_extraction(raw, _taxonomy())
+        assert result.created_date is None
+
+    @pytest.mark.unit
+    def test_created_date_too_far_future_dropped(self):
+        """Year 2189 is also an OCR error."""
+        raw = {
+            "title": "T",
+            "correspondent": None,
+            "document_type": "Rechnung",
+            "tags": [],
+            "created_date": "2189-01-01",
+        }
+        result = validate_extraction(raw, _taxonomy())
+        assert result.created_date is None
+
+    @pytest.mark.unit
+    def test_created_date_up_to_one_year_future_accepted(self):
+        """Slightly post-dated contracts / receipts are legitimate."""
+        future = (date.today() + timedelta(days=30)).isoformat()
+        raw = {
+            "title": "T",
+            "correspondent": None,
+            "document_type": "Rechnung",
+            "tags": [],
+            "created_date": future,
+        }
+        result = validate_extraction(raw, _taxonomy())
+        assert result.created_date is not None
+
+    @pytest.mark.unit
+    def test_malformed_schema_raises_value_error(self):
+        """A totally wrong shape (e.g. tags as string not list) raises
+        ValueError. Caller catches and falls back to bare upload."""
+        raw = {
+            "title": "T",
+            "tags": "not-a-list",  # type mismatch
+        }
+        with pytest.raises(ValueError):
+            validate_extraction(raw, _taxonomy())
+
+    @pytest.mark.unit
+    def test_empty_dict_produces_empty_metadata(self):
+        """Edge case — LLM emitted literally {} (or close to it). No
+        fields set, no crash."""
+        result = validate_extraction({}, _taxonomy())
+        assert result.correspondent is None
+        assert result.document_type is None
+        assert result.tags == []
+        assert result.storage_path is None
+        assert result.created_date is None
+
+
+# ===========================================================================
+# _parse_llm_json
+# ===========================================================================
+
+
+class TestParseLLMJson:
+    @pytest.mark.unit
+    def test_bare_json(self):
+        assert _parse_llm_json('{"a": 1}') == {"a": 1}
+
+    @pytest.mark.unit
+    def test_fenced_json(self):
+        raw = '```json\n{"a": 1}\n```'
+        assert _parse_llm_json(raw) == {"a": 1}
+
+    @pytest.mark.unit
+    def test_fenced_no_language(self):
+        raw = "```\n{\"a\": 1}\n```"
+        assert _parse_llm_json(raw) == {"a": 1}
+
+    @pytest.mark.unit
+    def test_prose_around_json(self):
+        """LLM sometimes adds 'Sure, here is the JSON:' preamble."""
+        raw = 'Sure, here it is: {"a": 1, "b": "x"}. Hope this helps!'
+        assert _parse_llm_json(raw) == {"a": 1, "b": "x"}
+
+    @pytest.mark.unit
+    def test_empty_string(self):
+        assert _parse_llm_json("") is None
+
+    @pytest.mark.unit
+    def test_no_braces(self):
+        assert _parse_llm_json("no JSON here") is None
+
+    @pytest.mark.unit
+    def test_invalid_json(self):
+        assert _parse_llm_json("{not valid json}") is None
+
+    @pytest.mark.unit
+    def test_non_dict_array(self):
+        """LLM emitted an array where we expect an object — refuse."""
+        assert _parse_llm_json("[1, 2, 3]") is None
+
+
+# ===========================================================================
+# render_prompt
+# ===========================================================================
+
+
+class TestRenderPrompt:
+    @pytest.mark.unit
+    def test_injects_taxonomy_and_doc_text(self):
+        taxonomy = PaperlessTaxonomy(
+            correspondents=["Stadtwerke", "Finanzamt"],
+            document_types=["Rechnung"],
+            tags=["wohnung"],
+            storage_paths=["/x"],
+        )
+        system, user = render_prompt(
+            doc_text="Hello world", taxonomy=taxonomy, lang="de",
+        )
+        assert "JSON" in system or "json" in system.lower()
+        assert "Stadtwerke" in user
+        assert "Rechnung" in user
+        assert "/x" in user
+        assert "Hello world" in user
+
+    @pytest.mark.unit
+    def test_empty_taxonomy_renders_gracefully(self):
+        """Cold-start, no taxonomy yet — prompt should still render,
+        just noting (none) for each dimension."""
+        taxonomy = PaperlessTaxonomy()
+        _, user = render_prompt(doc_text="doc", taxonomy=taxonomy)
+        assert "(none)" in user
+
+    @pytest.mark.unit
+    def test_doc_text_truncated_past_cap(self):
+        """Very long documents get truncated to the LLM-context cap."""
+        long_doc = "A" * 20_000
+        taxonomy = PaperlessTaxonomy()
+        _, user = render_prompt(doc_text=long_doc, taxonomy=taxonomy)
+        # User prompt must not contain the full 20k A's.
+        assert "A" * 20_000 not in user
+
+
+# ===========================================================================
+# End-to-end extract() — every dependency mocked
+# ===========================================================================
+
+
+class TestExtractorIntegration:
+    def _mock_upload(self, tmp_path):
+        """Create a ChatUpload-shaped mock with a real file on disk."""
+        file = tmp_path / "test.pdf"
+        file.write_text("dummy")
+        upload = MagicMock()
+        upload.id = 1
+        upload.file_path = str(file)
+        upload.filename = "test.pdf"
+        return upload
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_happy_path_end_to_end(self, tmp_path):
+        upload = self._mock_upload(tmp_path)
+
+        llm_response = SimpleNamespace(
+            message=SimpleNamespace(
+                content='{"title": "T", "correspondent": "Stadtwerke Korschenbroich", '
+                        '"document_type": "Rechnung", "tags": ["wohnung"], '
+                        '"storage_path": "/wohnung/betriebskosten", '
+                        '"created_date": "2026-02-14", "new_entry_proposals": []}',
+            ),
+        )
+        llm_client = MagicMock()
+        llm_client.chat = AsyncMock(return_value=llm_response)
+
+        doc_proc = MagicMock()
+        doc_proc.extract_text_only = AsyncMock(return_value="Stadtwerke Korschenbroich ...")
+
+        mcp = MagicMock()
+
+        async def _mcp_execute(tool_name: str, params: dict):
+            if "correspondents" in tool_name:
+                return {"success": True, "message": '{"items": [{"name": "Stadtwerke Korschenbroich"}, {"name": "Finanzamt Neuss"}]}'}
+            if "document_types" in tool_name:
+                return {"success": True, "message": '{"items": [{"name": "Rechnung"}]}'}
+            if "tags" in tool_name:
+                return {"success": True, "message": '{"items": [{"name": "wohnung"}]}'}
+            if "storage_paths" in tool_name:
+                return {"success": True, "message": '{"paths": [{"path": "/wohnung/betriebskosten"}]}'}
+            return {"success": False}
+
+        mcp.execute_tool = AsyncMock(side_effect=_mcp_execute)
+
+        extractor = PaperlessMetadataExtractor(
+            mcp_manager=mcp, llm_client=llm_client, document_processor=doc_proc,
+        )
+        # Bypass the DB lookup by pre-resolving the upload.
+        extractor._load_upload = AsyncMock(return_value=upload)
+
+        # settings.paperless_extraction_model needs to be set so the
+        # model-picker doesn't raise.
+        with patch("services.paperless_metadata_extractor.settings") as s:
+            s.paperless_extraction_model = "qwen3:8b"
+            s.ollama_vision_model = ""
+            s.ollama_chat_model = ""
+            result = await extractor.extract(
+                attachment_id=1, session_id="test-session", lang="de",
+            )
+
+        assert result.error is None
+        assert result.metadata.correspondent == "Stadtwerke Korschenbroich"
+        assert result.metadata.document_type == "Rechnung"
+        assert result.metadata.storage_path == "/wohnung/betriebskosten"
+        assert result.doc_text.startswith("Stadtwerke")
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_missing_attachment_returns_error(self):
+        extractor = PaperlessMetadataExtractor()
+        extractor._load_upload = AsyncMock(return_value=None)
+
+        result = await extractor.extract(
+            attachment_id=99, session_id="s", lang="de",
+        )
+        assert result.error is not None
+        assert "99" in result.error
+        assert result.metadata == PaperlessMetadata()
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_ocr_empty_result_returns_error(self, tmp_path):
+        upload = self._mock_upload(tmp_path)
+        doc_proc = MagicMock()
+        doc_proc.extract_text_only = AsyncMock(return_value="")
+
+        extractor = PaperlessMetadataExtractor(document_processor=doc_proc)
+        extractor._load_upload = AsyncMock(return_value=upload)
+
+        result = await extractor.extract(
+            attachment_id=1, session_id="s", lang="de",
+        )
+        assert "OCR" in result.error or "Dokument nicht lesen" in result.error
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_taxonomy_fetch_fails_returns_error(self, tmp_path):
+        upload = self._mock_upload(tmp_path)
+        doc_proc = MagicMock()
+        doc_proc.extract_text_only = AsyncMock(return_value="document text")
+
+        # MCP manager that raises on every call
+        mcp = MagicMock()
+        mcp.execute_tool = AsyncMock(side_effect=RuntimeError("paperless down"))
+
+        extractor = PaperlessMetadataExtractor(
+            mcp_manager=mcp, document_processor=doc_proc,
+        )
+        extractor._load_upload = AsyncMock(return_value=upload)
+
+        result = await extractor.extract(
+            attachment_id=1, session_id="s", lang="de",
+        )
+        # _list_via_mcp catches and returns [] for each dimension, so
+        # pruning produces an empty taxonomy — which is fine, not an
+        # error. The LLM call will fail or return empty, and THAT's
+        # the error surface. This test confirms we at least don't
+        # crash the whole pipeline on taxonomy fetch failure.
+        #
+        # If the LLM is not configured either, we get the "no model"
+        # error — let's check we reached the LLM-call step by not
+        # erroring earlier.
+        assert result.error is not None
+        assert result.doc_text == "document text"  # OCR did run
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_llm_malformed_response_falls_back_cleanly(self, tmp_path):
+        upload = self._mock_upload(tmp_path)
+
+        llm_response = SimpleNamespace(
+            message=SimpleNamespace(content="not json at all, just prose"),
+        )
+        llm_client = MagicMock()
+        llm_client.chat = AsyncMock(return_value=llm_response)
+
+        doc_proc = MagicMock()
+        doc_proc.extract_text_only = AsyncMock(return_value="doc text")
+
+        mcp = MagicMock()
+        mcp.execute_tool = AsyncMock(return_value={"success": True, "message": '{"items": []}'})
+
+        extractor = PaperlessMetadataExtractor(
+            mcp_manager=mcp, llm_client=llm_client, document_processor=doc_proc,
+        )
+        extractor._load_upload = AsyncMock(return_value=upload)
+
+        with patch("services.paperless_metadata_extractor.settings") as s:
+            s.paperless_extraction_model = "qwen3:8b"
+            s.ollama_vision_model = ""
+            s.ollama_chat_model = ""
+            result = await extractor.extract(
+                attachment_id=1, session_id="s", lang="de",
+            )
+
+        # Malformed JSON → error surfaced, metadata empty, but OCR
+        # text preserved so the caller can still upload bare.
+        assert result.error is not None
+        assert result.doc_text == "doc text"
+        assert result.metadata == PaperlessMetadata()
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_no_model_configured_returns_error(self, tmp_path):
+        upload = self._mock_upload(tmp_path)
+        doc_proc = MagicMock()
+        doc_proc.extract_text_only = AsyncMock(return_value="doc text")
+
+        mcp = MagicMock()
+        mcp.execute_tool = AsyncMock(return_value={"success": True, "message": '{"items": []}'})
+
+        extractor = PaperlessMetadataExtractor(
+            mcp_manager=mcp, document_processor=doc_proc,
+        )
+        extractor._load_upload = AsyncMock(return_value=upload)
+
+        with patch("services.paperless_metadata_extractor.settings") as s:
+            s.paperless_extraction_model = ""
+            s.ollama_vision_model = ""
+            s.ollama_chat_model = ""
+            result = await extractor.extract(
+                attachment_id=1, session_id="s", lang="de",
+            )
+
+        assert result.error is not None
+        assert "model" in result.error.lower() or "fehlgeschlagen" in result.error.lower()
+
+
+# ===========================================================================
+# Pydantic models — basic contract checks
+# ===========================================================================
+
+
+class TestDataModels:
+    @pytest.mark.unit
+    def test_new_entry_proposal_rejects_invalid_field(self):
+        from pydantic import ValidationError
+        with pytest.raises(ValidationError):
+            NewEntryProposal(
+                field="not-a-valid-field",
+                value="X",
+                reasoning="...",
+            )
+
+    @pytest.mark.unit
+    def test_new_entry_proposal_accepts_all_four_dimensions(self):
+        for field in ("correspondent", "document_type", "tag", "storage_path"):
+            p = NewEntryProposal(field=field, value="X", reasoning="...")
+            assert p.field == field
+
+    @pytest.mark.unit
+    def test_extraction_result_defaults(self):
+        r = ExtractionResult(metadata=PaperlessMetadata())
+        assert r.doc_text == ""
+        assert r.error is None


### PR DESCRIPTION
## Summary

Ships the atomic extraction unit from [\`docs/design/paperless-llm-metadata.md\`](docs/design/paperless-llm-metadata.md). Independently testable; the confirm-flow integration (PR 2b) will wire this into \`forward_attachment_to_paperless\`.

Depends on [renfield-mcp-paperless PR #5](https://github.com/ebongard/renfield-mcp-paperless/pull/5) (already merged → v1.2.0) for \`mcp.paperless.list_*\` / \`create_*\` tools.

## What it does

One \`extract(attachment_id, session_id, lang)\` call:

1. Loads \`ChatUpload\` with session-scoping (#442 pattern)
2. OCR via Docling \`extract_text_only\` (text-layer + EasyOCR fallback, 12k char cap)
3. Fetches Paperless taxonomy via MCP server list tools
4. Prunes to top-20 correspondents + top-20 tags by recency; keeps full doc_types + storage_paths
5. Renders localized prompt (DE/EN, three worked examples each, including one new-correspondent case)
6. LLM call using \`settings.paperless_extraction_model\` → vision → chat fallback chain
7. Five-step validation: pydantic → rapidfuzz near-match → strict membership → date clamp → tag cap
8. Returns \`ExtractionResult(metadata, doc_text, error)\` — never raises on expected failure paths

## Highlights

- **Fuzzy match** via \`rapidfuzz.distance.Levenshtein\`, distance ≤ 2 AND edit-ratio ≤ 0.2 against normalised taxonomy. Catches \"Stadtwerke Korschenbroic\" → \"Stadtwerke Korschenbroich\" silently; ambiguous multi-match drops to proposal instead of arbitrarily picking.
- **Taxonomy pruning** keeps the prompt inside the local model's reliable-attention window (<8k tokens on 7-14B models).
- **New-entry proposals**: LLM can flag \"this value isn't in your taxonomy but I'm confident it should be\" per field. Proposals survive validation even when the field itself drops to null; caller surfaces for user approval in PR 2b's confirm step.
- **Failure-soft**: every expected error (missing attachment, empty OCR, taxonomy fetch failure, malformed LLM response, no model configured) returns a populated \`error\` field rather than raising. Callers fall back to bare upload.

## Files

| File | LOC | Purpose |
|---|---|---|
| \`src/backend/services/paperless_metadata_extractor.py\` | 778 | Core service |
| \`src/backend/prompts/paperless_metadata.yaml\` | 231 | DE+EN prompts with 3 worked examples each |
| \`src/backend/alembic/versions/pc20260424_paperless_metadata_tables.py\` | 164 | Migration: users.paperless_confirms_used + 2 tables |
| \`tests/backend/test_paperless_metadata_extractor.py\` | 688 | ~45 unit tests across 9 classes |
| \`src/backend/requirements.txt\` | +1 | \`rapidfuzz>=3.9.0\` |
| \`src/backend/utils/config.py\` | +5 | \`settings.paperless_extraction_model\` |

## Scope

**In this PR:**
- Extractor service + all pure-unit logic (fuzzy match, pruning, validation, JSON parsing, prompt render)
- Migration + new tables (pending_confirms, extraction_examples) with downgrade
- Pydantic models (\`PaperlessMetadata\`, \`NewEntryProposal\`, \`ExtractionResult\`, \`PaperlessTaxonomy\`)
- \`rapidfuzz\` dep + config setting

**Deferred to PR 2b:**
- Inline extraction in \`forward_attachment_to_paperless\`
- \`skip_metadata\` heuristic
- Cold-start-only confirm state machine
- \`paperless_commit_upload\` tool
- Cold-start counter increment on successful upload

**Later:** PR 3 (prompt augmentation), PR 4 (sweeper), PR 5 (card).

## Test plan
- [x] Pure-unit logic smoke-tested end-to-end against a clean env: all functions produce expected results
- [x] Prompt YAML loads cleanly (PromptManager logs \`paperless_metadata:c82cdce14bd9\`)
- [x] \`{{\`→\`{\` format_map escaping verified in the rendered prompt
- [ ] Full test suite: \`make test-backend\` (needs Docker — conftest pulls Settings, sensitive to local .env shape)
- [ ] Manual: apply migration against a dev Postgres + verify new columns / tables