### PR TITLE
feat(paperless): PR 2b — cold-start confirm flow integration

### DIFF
--- a/src/backend/alembic/versions/pc20260424_paperless_metadata_tables.py
+++ b/src/backend/alembic/versions/pc20260424_paperless_metadata_tables.py
@@ -119,12 +119,17 @@ def upgrade() -> None:
             nullable=False,
             index=True,
         ),
-        sa.Column("session_id", sa.String(64), nullable=False, index=True),
+        # String(128) matches ChatUpload.session_id — smaller widths break
+        # at insert time when the real session id exceeds the cap.
+        sa.Column("session_id", sa.String(128), nullable=False, index=True),
+        # Nullable to support AUTH_ENABLED=false (single-user dev setup
+        # where the agent's user_id may be None). When non-null the FK
+        # + CASCADE still cleans up if the user is deleted.
         sa.Column(
             "user_id",
             sa.Integer(),
             sa.ForeignKey("users.id", ondelete="CASCADE"),
-            nullable=False,
+            nullable=True,
         ),
         sa.Column("llm_output", sa.JSON(), nullable=False),
         sa.Column("post_fuzzy_output", sa.JSON(), nullable=False),

--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -329,11 +329,17 @@ class PaperlessPendingConfirm(Base):
         nullable=False,
         index=True,
     )
-    session_id = Column(String(64), nullable=False, index=True)
+    # Width matches ChatUpload.session_id — smaller truncates/fails on
+    # real Postgres when session ids exceed 64 chars.
+    session_id = Column(String(128), nullable=False, index=True)
+    # Nullable so AUTH_ENABLED=false (single-user dev) works: the tool
+    # gets user_id=None from the executor and stores NULL here rather
+    # than crashing on the FK constraint. Cold-start counter
+    # increments skip for NULL users.
     user_id = Column(
         Integer,
         ForeignKey("users.id", ondelete="CASCADE"),
-        nullable=False,
+        nullable=True,
     )
     # Raw LLM response (pre-fuzzy, pre-validation). Needed for diff
     # computation when the user approves and the post-fuzzy differs.

--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -307,6 +307,76 @@ class ChatUpload(Base):
     created_at = Column(DateTime, default=_utcnow)
 
 
+class PaperlessPendingConfirm(Base):
+    """Transient state between paperless-confirm tool turns.
+
+    ``forward_attachment_to_paperless`` writes one of these rows during
+    the cold-start window (first N uploads per user) when it needs the
+    user's approval before firing the final Paperless upload.
+    ``paperless_commit_upload`` reads the row, fires the upload on
+    "ja" / deletes it on "nein", and cleans up.
+
+    Abandoned rows (user walks away, never answers) get swept after
+    24 h by the PR 4 cleanup job. See
+    ``docs/design/paperless-llm-metadata.md`` § Confirm flow state machine.
+    """
+    __tablename__ = "paperless_pending_confirms"
+
+    confirm_token = Column(String(36), primary_key=True)  # uuid4
+    attachment_id = Column(
+        Integer,
+        ForeignKey("chat_uploads.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    session_id = Column(String(64), nullable=False, index=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    # Raw LLM response (pre-fuzzy, pre-validation). Needed for diff
+    # computation when the user approves and the post-fuzzy differs.
+    llm_output = Column(JSON, nullable=False)
+    # Post-fuzzy, post-validation. This is what the user sees and
+    # approves in the confirm preview.
+    post_fuzzy_output = Column(JSON, nullable=False)
+    # new_entry_proposals[] — surfaces in the confirm message as
+    # "Neu anlegen: Stadtwerke Köln".
+    proposals = Column(JSON, nullable=False, default=list, server_default="[]")
+    # Caps the ambiguous-response loop so a user who keeps typing
+    # "hmmm" can't pin the row indefinitely.
+    edit_rounds = Column(Integer, nullable=False, default=0, server_default="0")
+    created_at = Column(DateTime, default=_utcnow)
+
+
+class PaperlessExtractionExample(Base):
+    """Correction-feedback source. Primary fill: confirm-time diffs
+    written by ``paperless_commit_upload`` when the user approves an
+    extraction with non-trivial new-entry proposals. Secondary fill:
+    the PR 4 sweeper reading Paperless-UI edits within 1 h of upload.
+
+    PR 3 reads the table to augment future extraction prompts with
+    the N most relevant past corrections (embedding similarity over
+    ``doc_text``). See
+    ``docs/design/paperless-llm-metadata.md`` § Correction feedback loop.
+    """
+    __tablename__ = "paperless_extraction_examples"
+
+    id = Column(Integer, primary_key=True)
+    doc_text = Column(Text, nullable=False)
+    llm_output = Column(JSON, nullable=False)
+    user_approved = Column(JSON, nullable=False)
+    # 'confirm_diff' (primary), 'paperless_ui_sweep' (secondary, PR 4),
+    # or 'seed' for any manually-seeded starter examples.
+    source = Column(String(32), nullable=False, index=True)
+    # Set by PR 4's no-re-edit filter when a ui_sweep correction turns
+    # out to be taxonomy drift rather than an extraction error. The
+    # prompt-augmentation reader ignores superseded rows.
+    superseded = Column(Boolean, nullable=False, default=False, server_default="false")
+    created_at = Column(DateTime, default=_utcnow)
+
+
 # Document Processing Status Constants
 DOC_STATUS_PENDING = "pending"
 DOC_STATUS_PROCESSING = "processing"
@@ -410,6 +480,12 @@ class User(Base):
     media_follow_enabled = Column(Boolean, default=True, nullable=False, server_default="true")
     personality_style = Column(String(20), default="freundlich", nullable=False, server_default="freundlich")
     personality_prompt = Column(Text, nullable=True)  # Free-text personality fine-tuning
+
+    # Cold-start counter for the Paperless LLM-metadata confirm flow.
+    # Increments on each successful upload that went through the confirm
+    # step; once >= N (10), the confirm is skipped and extraction runs
+    # silently. See docs/design/paperless-llm-metadata.md § 5.
+    paperless_confirms_used = Column(Integer, nullable=False, default=0, server_default="0")
 
     # Optional link to Speaker for voice authentication
     speaker_id = Column(Integer, ForeignKey("speakers.id"), nullable=True, unique=True)

--- a/src/backend/services/action_executor.py
+++ b/src/backend/services/action_executor.py
@@ -89,6 +89,21 @@ class ActionExecutor:
                 parameters,
                 mcp_manager=self.mcp_manager,
                 session_id=self.session_id,
+                user_id=user_id,
+            )
+
+        # Paperless commit (second half of the two-tool confirm flow).
+        # Reads a pending-confirm row created by forward_attachment_to_paperless
+        # during the cold-start window (first N uploads) and finalises the
+        # upload on user "ja" / aborts on "nein". See
+        # docs/design/paperless-llm-metadata.md § Confirm flow state machine.
+        if intent == "internal.paperless_commit_upload":
+            from services.paperless_commit_tool import paperless_commit_upload
+            return await paperless_commit_upload(
+                parameters,
+                mcp_manager=self.mcp_manager,
+                session_id=self.session_id,
+                user_id=user_id,
             )
 
         # Other `internal.*` intents (room resolution, media playback,

--- a/src/backend/services/chat_upload_tool.py
+++ b/src/backend/services/chat_upload_tool.py
@@ -25,10 +25,31 @@ from __future__ import annotations
 
 import base64
 import json
+import mimetypes
+import re
+import uuid
 from pathlib import Path
 
 from loguru import logger
 
+
+# Cold-start window for the LLM-metadata confirm flow. Design doc § 5:
+# first N uploads per user require explicit confirm; after that the
+# system trusts itself and extraction runs silently. N=10 is
+# conservative — covers "first two weeks of household use" at ~1
+# upload/day without becoming permanent friction.
+_COLD_START_CONFIRM_N = 10
+
+# Skip-metadata heuristic. The agent can pass ``skip_metadata=True``
+# explicitly when the user said "ohne Metadaten". The tool itself also
+# defensively auto-skips for files that look like memes / screenshots
+# / photos — the extraction pipeline adds latency that's pure loss on
+# those.
+_SCREENSHOT_FILENAME_RE = re.compile(
+    r"^(?:screenshot|screen[\s_.-]?shot|img[_-]?\d+|photo|meme|selfie)",
+    re.IGNORECASE,
+)
+_IMAGE_AUTOSKIP_SIZE_BYTES = 500 * 1024  # 500 KB
 
 CHAT_UPLOAD_TOOLS: dict = {
     "internal.forward_attachment_to_paperless": {
@@ -38,7 +59,12 @@ CHAT_UPLOAD_TOOLS: dict = {
             "attachment_id shown in the UPLOADED DOCUMENT section of this prompt. "
             "Do NOT pass file_content_base64 — the tool does that internally from "
             "real file bytes. Preferred over mcp.paperless.upload_document for "
-            "user-attached files."
+            "user-attached files. "
+            "During the user's first 10 archives, this tool will return "
+            "action_required=paperless_confirm with a preview for the user to "
+            "approve — relay the message verbatim to the user, then on their "
+            "next message call internal.paperless_commit_upload with the "
+            "confirm_token and the user's response."
         ),
         "parameters": {
             "attachment_id": (
@@ -52,33 +78,71 @@ CHAT_UPLOAD_TOOLS: dict = {
             "correspondent": "Optional Paperless correspondent name",
             "document_type": "Optional Paperless document type name",
             "tags": "Optional list of tag names",
+            "skip_metadata": (
+                "Optional boolean. Set True to skip LLM metadata extraction "
+                "(e.g. for memes, screenshots, or when the user explicitly "
+                "says 'ohne Metadaten'). Defaults to False — the tool also "
+                "auto-skips based on file shape (small image files, "
+                "screenshot-like filenames)."
+            ),
         },
     },
 }
+
+
+def _should_auto_skip_metadata(filename: str, file_size: int) -> bool:
+    """Deterministic heuristic for skipping the extraction pipeline on
+    files that clearly aren't archival documents.
+
+    Triggers on:
+      - small image files (likely photos / memes / screenshots)
+      - filenames matching common screenshot / photo patterns
+    Does NOT trigger on PDFs / docx / txt / md regardless of size —
+    those are always real documents.
+    """
+    if _SCREENSHOT_FILENAME_RE.match(filename):
+        return True
+    mime, _ = mimetypes.guess_type(filename)
+    if mime and mime.startswith("image/") and file_size < _IMAGE_AUTOSKIP_SIZE_BYTES:
+        return True
+    return False
 
 
 async def forward_attachment_to_paperless(
     params: dict,
     mcp_manager=None,
     session_id: str | None = None,
+    user_id: int | None = None,
 ) -> dict:
-    """Read a ChatUpload from server storage and forward it to Paperless.
+    """Forward a chat attachment to Paperless with optional LLM metadata
+    extraction and cold-start confirm.
+
+    Flow depends on the user's cold-start state and the ``skip_metadata``
+    flag:
+
+      1. ``skip_metadata=True`` (or auto-heuristic triggers) → bare
+         upload, no extraction, no confirm. Identical behaviour to
+         pre-PR-2b.
+      2. User's ``paperless_confirms_used >= _COLD_START_CONFIRM_N`` →
+         the system trusts itself: run extraction silently, upload
+         with extracted metadata, no user confirm.
+      3. User is inside the cold-start window → run extraction, persist
+         ``paperless_pending_confirms`` row, return
+         ``action_required=paperless_confirm`` with a German preview
+         the agent relays to the user. The user's next message is
+         their response; the agent should then call
+         ``internal.paperless_commit_upload`` to finalise.
 
     Args:
-        params: Tool parameters from the agent (attachment_id required; title,
-            correspondent, document_type, tags optional).
-        mcp_manager: MCPManager instance, injected by ActionExecutor. Needed
-            to invoke ``mcp.paperless.upload_document`` with real base64.
-        session_id: Chat session the request came from. When provided, the
-            DB lookup is scoped to attachments uploaded within the same
-            session — prevents a crafted prompt from referencing an
-            attachment_id belonging to another user's conversation. When
-            ``None`` (single-user dev setup, auth disabled), the check is
-            skipped.
-
-    Returns a standard agent-tool result dict: ``success``, ``message``,
-    ``action_taken``, and ``data`` with ``task_id``, ``attachment_id``, and
-    ``filename`` on success.
+        params: ``attachment_id`` (required), optional ``title``,
+            ``correspondent`` / ``document_type`` / ``tags`` (passed
+            through as-is if skipping), and ``skip_metadata`` bool.
+        mcp_manager: MCPManager, injected by ActionExecutor.
+        session_id: Chat session; scopes the DB lookup per #442.
+        user_id: Authenticated user id; used to read/increment the
+            cold-start counter. When ``None`` (single-user /
+            auth-disabled), the cold-start check is bypassed and
+            extraction always runs with confirm.
     """
     attachment_id_raw = params.get("attachment_id")
     if attachment_id_raw is None:
@@ -106,16 +170,11 @@ async def forward_attachment_to_paperless(
     try:
         from sqlalchemy import select
 
-        from models.database import ChatUpload
+        from models.database import ChatUpload, PaperlessPendingConfirm, User
         from services.database import AsyncSessionLocal
 
         async with AsyncSessionLocal() as db:
             query = select(ChatUpload).where(ChatUpload.id == attachment_id)
-            # Session scoping: when the caller provides a session_id, the
-            # attachment must belong to that session. A mismatch is reported
-            # as "not found" rather than "forbidden" — the agent doesn't
-            # need to distinguish, and the softer message avoids leaking
-            # the existence of attachments belonging to other sessions.
             if session_id is not None:
                 query = query.where(ChatUpload.session_id == session_id)
             result = await db.execute(query)
@@ -138,58 +197,117 @@ async def forward_attachment_to_paperless(
                 "action_taken": False,
             }
 
-        # Synchronous read is fine here — typical chat attachments are small
-        # enough (< 10 MB) that blocking for a few ms is simpler than the
-        # aiofiles dep tree, and this tool is already inside an async context
-        # that can tolerate the brief pause.
-        with open(upload.file_path, "rb") as f:
-            file_bytes = f.read()
-        file_content_base64 = base64.b64encode(file_bytes).decode("ascii")
+        # Decide whether to skip extraction. Agent-passed flag wins;
+        # auto-heuristic catches cases the agent didn't think to flag.
+        skip_metadata = bool(params.get("skip_metadata"))
+        if not skip_metadata:
+            file_size = upload.file_size or 0
+            if _should_auto_skip_metadata(upload.filename, file_size):
+                skip_metadata = True
+                logger.debug(
+                    "Auto-skipping metadata extraction for %s (size=%d)",
+                    upload.filename, file_size,
+                )
 
-        tool_params: dict = {
-            "title": params.get("title") or upload.filename,
-            "filename": upload.filename,
-            "file_content_base64": file_content_base64,
+        # Pass-through params that override extraction output (agent
+        # already knows the answer for these — no need to ask the LLM).
+        agent_overrides = {
+            k: params[k] for k in ("title", "correspondent", "document_type", "tags")
+            if params.get(k)
         }
-        if params.get("correspondent"):
-            tool_params["correspondent"] = params["correspondent"]
-        if params.get("document_type"):
-            tool_params["document_type"] = params["document_type"]
-        if params.get("tags"):
-            tool_params["tags"] = params["tags"]
 
-        mcp_result = await mcp_manager.execute_tool(
-            "mcp.paperless.upload_document", tool_params
+        if skip_metadata:
+            # Path 1: bare upload, no extraction. Identical to pre-PR-2b
+            # behaviour. Used for memes / screenshots / user-explicit opt-out.
+            return await _direct_upload(
+                upload=upload,
+                mcp_manager=mcp_manager,
+                params=agent_overrides,
+            )
+
+        # Run extraction.
+        extraction_result = await _run_extraction(
+            attachment_id=attachment_id,
+            session_id=session_id,
+            mcp_manager=mcp_manager,
+            user_lang=_infer_lang(upload),
         )
+        if extraction_result is None or extraction_result.error:
+            # Extraction failed — fall back to bare upload with a
+            # user-visible note. Matches the design's fallback-on-everything
+            # philosophy.
+            err = extraction_result.error if extraction_result else "Extractor unavailable"
+            logger.warning(
+                "Metadata extraction failed for attachment %d: %s — bare upload",
+                attachment_id, err,
+            )
+            direct = await _direct_upload(
+                upload=upload, mcp_manager=mcp_manager, params=agent_overrides,
+            )
+            # Annotate the success message so the user knows.
+            if direct.get("success"):
+                direct["message"] = (
+                    f"{direct['message']} "
+                    f"(ohne Metadaten-Extraktion: {err})"
+                )
+            return direct
 
-        if not mcp_result or not mcp_result.get("success"):
-            detail = (mcp_result or {}).get("message") or "unknown error"
-            return {
-                "success": False,
-                "message": f"Paperless upload failed: {detail}",
-                "action_taken": False,
-            }
+        # Merge agent overrides into the extracted metadata (agent
+        # wins). For example, if the user said "archive as Rechnung"
+        # the agent passes document_type=Rechnung even if the LLM
+        # guessed otherwise.
+        post_fuzzy = extraction_result.metadata.model_dump()
+        post_fuzzy.update(agent_overrides)
 
-        # Paperless MCP returns {"task_id": ..., "title": ..., "filename": ...}
-        # wrapped inside MCPManager.execute_tool's ``message`` field as JSON.
-        task_id: str | None = None
-        inner_msg = mcp_result.get("message")
-        if isinstance(inner_msg, str):
-            try:
-                inner = json.loads(inner_msg)
-                if isinstance(inner, dict):
-                    task_id = inner.get("task_id")
-            except (json.JSONDecodeError, TypeError):
-                pass
+        # Cold-start gate. User is inside the window → confirm
+        # required; otherwise silent upload with extracted metadata.
+        confirms_used = await _get_confirms_used(user_id)
+        if confirms_used >= _COLD_START_CONFIRM_N:
+            # Path 2: trusted silent upload with extracted metadata.
+            return await _direct_upload(
+                upload=upload,
+                mcp_manager=mcp_manager,
+                params=_extraction_to_upload_params(post_fuzzy),
+            )
+
+        # Path 3: cold-start confirm. Persist a pending row and return
+        # the preview — agent relays to user, who answers in the next
+        # turn and the agent calls paperless_commit_upload.
+        confirm_token = str(uuid.uuid4())
+        llm_output_for_persist = dict(extraction_result.metadata.model_dump())
+        # Stash doc_text alongside llm_output so the commit tool can
+        # write it into paperless_extraction_examples without another
+        # extraction run.
+        llm_output_for_persist["_doc_text"] = extraction_result.doc_text
+
+        async with AsyncSessionLocal() as db:
+            pending = PaperlessPendingConfirm(
+                confirm_token=confirm_token,
+                attachment_id=attachment_id,
+                session_id=session_id or "unknown",
+                user_id=user_id or 0,  # 0 = "auth-disabled mode"; see migration
+                llm_output=llm_output_for_persist,
+                post_fuzzy_output=post_fuzzy,
+                proposals=[p.model_dump() for p in extraction_result.metadata.new_entry_proposals],
+            )
+            db.add(pending)
+            await db.commit()
+
+        preview_text = _render_confirm_message(
+            filename=upload.filename,
+            metadata=post_fuzzy,
+            proposals=extraction_result.metadata.new_entry_proposals,
+        )
 
         return {
             "success": True,
-            "message": f"Sent to Paperless: {upload.filename}",
-            "action_taken": True,
+            "message": preview_text,
+            "action_taken": False,  # upload not yet committed
             "data": {
+                "action_required": "paperless_confirm",
+                "confirm_token": confirm_token,
                 "attachment_id": attachment_id,
                 "filename": upload.filename,
-                "task_id": task_id,
             },
         }
     except Exception as e:
@@ -199,3 +317,191 @@ async def forward_attachment_to_paperless(
             "message": f"Forward to Paperless failed: {e!s}",
             "action_taken": False,
         }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _direct_upload(
+    upload,
+    *,
+    mcp_manager,
+    params: dict,
+) -> dict:
+    """Bare Paperless upload via the MCP tool. Used by the skip-metadata
+    path and by the post-cold-start silent path."""
+    with open(upload.file_path, "rb") as f:
+        file_bytes = f.read()
+    file_content_base64 = base64.b64encode(file_bytes).decode("ascii")
+
+    tool_params: dict = {
+        "title": params.get("title") or upload.filename,
+        "filename": upload.filename,
+        "file_content_base64": file_content_base64,
+    }
+    for key in ("correspondent", "document_type", "tags",
+                "storage_path", "created_date", "custom_fields"):
+        val = params.get(key)
+        if val:
+            tool_params[key] = val
+
+    mcp_result = await mcp_manager.execute_tool(
+        "mcp.paperless.upload_document", tool_params
+    )
+
+    if not mcp_result or not mcp_result.get("success"):
+        detail = (mcp_result or {}).get("message") or "unknown error"
+        return {
+            "success": False,
+            "message": f"Paperless upload failed: {detail}",
+            "action_taken": False,
+        }
+
+    # Parse the envelope to extract task_id etc.
+    task_id: str | None = None
+    document_id: int | None = None
+    patch_state: str | None = None
+    inner_msg = mcp_result.get("message")
+    if isinstance(inner_msg, str):
+        try:
+            inner = json.loads(inner_msg)
+            if isinstance(inner, dict):
+                task_id = inner.get("task_id")
+                document_id = inner.get("document_id")
+                patch_state = inner.get("post_upload_patch")
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+    return {
+        "success": True,
+        "message": f"Sent to Paperless: {upload.filename}",
+        "action_taken": True,
+        "data": {
+            "attachment_id": upload.id,
+            "filename": upload.filename,
+            "task_id": task_id,
+            "document_id": document_id,
+            "post_upload_patch": patch_state,
+        },
+    }
+
+
+async def _run_extraction(
+    *,
+    attachment_id: int,
+    session_id: str | None,
+    mcp_manager,
+    user_lang: str,
+):
+    """Run the PaperlessMetadataExtractor; return its ExtractionResult
+    or None if the extractor module can't be loaded."""
+    try:
+        from services.paperless_metadata_extractor import PaperlessMetadataExtractor
+    except Exception as exc:  # pragma: no cover
+        logger.warning("Extractor module import failed: %s", exc)
+        return None
+    extractor = PaperlessMetadataExtractor(mcp_manager=mcp_manager)
+    try:
+        return await extractor.extract(
+            attachment_id=attachment_id,
+            session_id=session_id,
+            lang=user_lang,
+        )
+    except Exception as exc:
+        logger.warning("Extractor call failed: %s", exc)
+        return None
+
+
+async def _get_confirms_used(user_id: int | None) -> int:
+    """Read ``users.paperless_confirms_used`` for the cold-start check.
+
+    Returns 0 when ``user_id`` is None (auth-disabled dev) so extraction
+    always runs with confirm in that mode — the operator can decide to
+    flip the flag via the admin UI once they're comfortable.
+    """
+    if user_id is None:
+        return 0
+    from sqlalchemy import select
+
+    from models.database import User
+    from services.database import AsyncSessionLocal
+
+    async with AsyncSessionLocal() as db:
+        result = await db.execute(
+            select(User.paperless_confirms_used).where(User.id == user_id)
+        )
+        value = result.scalar()
+    return int(value or 0)
+
+
+def _extraction_to_upload_params(post_fuzzy: dict) -> dict:
+    """Translate extractor output to the params shape
+    ``mcp.paperless.upload_document`` expects."""
+    out: dict = {}
+    for key in ("title", "correspondent", "document_type", "storage_path",
+                "created_date"):
+        val = post_fuzzy.get(key)
+        if val:
+            out[key] = val
+    tags = post_fuzzy.get("tags") or []
+    if tags:
+        out["tags"] = list(tags)
+    return out
+
+
+def _infer_lang(upload) -> str:
+    """Pick a prompt language. v1 defaults to German because the
+    household audience is DE-primary; English doc filenames get EN.
+    Crude heuristic — doesn't matter much, the LLM handles either."""
+    filename_lower = (upload.filename or "").lower()
+    en_hints = ("invoice", "receipt", "statement", "contract", "letter")
+    if any(h in filename_lower for h in en_hints):
+        return "en"
+    return "de"
+
+
+def _render_confirm_message(
+    *,
+    filename: str,
+    metadata: dict,
+    proposals: list,
+) -> str:
+    """Build the German confirm preview the agent relays to the user.
+
+    Matches the shape documented in the design doc § 5 confirm UX.
+    Missing fields render as "—" so the user sees what the LLM couldn't
+    decide and can either approve the gaps or abort.
+    """
+    def _display(value):
+        if value is None or value == "":
+            return "—"
+        if isinstance(value, list):
+            return ", ".join(str(v) for v in value) if value else "—"
+        return str(value)
+
+    proposals_line = "keine"
+    if proposals:
+        parts = []
+        for p in proposals:
+            field = p.field if hasattr(p, "field") else p.get("field")
+            value = p.value if hasattr(p, "value") else p.get("value")
+            parts.append(f"{field}: {value}")
+        proposals_line = "; ".join(parts)
+
+    return (
+        f"Ich möchte das Dokument so ablegen:\n"
+        f"\n"
+        f"  Datei:             {filename}\n"
+        f"  Titel:             {_display(metadata.get('title'))}\n"
+        f"  Korrespondent:     {_display(metadata.get('correspondent'))}\n"
+        f"  Dokumenttyp:       {_display(metadata.get('document_type'))}\n"
+        f"  Tags:              {_display(metadata.get('tags'))}\n"
+        f"  Speicherpfad:      {_display(metadata.get('storage_path'))}\n"
+        f"  Ausstellungsdatum: {_display(metadata.get('created_date'))}\n"
+        f"\n"
+        f"  Neu anzulegen:     {proposals_line}\n"
+        f"\n"
+        f"Passt das so? Antworte mit `ja` zum Ablegen oder `nein` zum Abbrechen."
+    )

--- a/src/backend/services/chat_upload_tool.py
+++ b/src/backend/services/chat_upload_tool.py
@@ -170,7 +170,7 @@ async def forward_attachment_to_paperless(
     try:
         from sqlalchemy import select
 
-        from models.database import ChatUpload, PaperlessPendingConfirm, User
+        from models.database import ChatUpload, PaperlessPendingConfirm
         from services.database import AsyncSessionLocal
 
         async with AsyncSessionLocal() as db:
@@ -285,7 +285,10 @@ async def forward_attachment_to_paperless(
                 confirm_token=confirm_token,
                 attachment_id=attachment_id,
                 session_id=session_id or "unknown",
-                user_id=user_id or 0,  # 0 = "auth-disabled mode"; see migration
+                # user_id is nullable — None lands when AUTH_ENABLED=false.
+                # The counter-increment on successful commit guards against
+                # this (paperless_commit_tool skips when user_id is None).
+                user_id=user_id,
                 llm_output=llm_output_for_persist,
                 post_fuzzy_output=post_fuzzy,
                 proposals=[p.model_dump() for p in extraction_result.metadata.new_entry_proposals],

--- a/src/backend/services/paperless_commit_tool.py
+++ b/src/backend/services/paperless_commit_tool.py
@@ -38,10 +38,12 @@ import json
 from typing import Any
 
 from loguru import logger
-from sqlalchemy import delete, select, update
 
-from models.database import ChatUpload, PaperlessPendingConfirm, User
-from services.database import AsyncSessionLocal
+# NB: SQLAlchemy + ORM-model + session-factory imports are done lazily
+# inside each function. Importing ``services.database`` at module level
+# triggers engine creation at import time, which breaks clean-env unit
+# tests and mirrors the exact anti-pattern PR #428 fixed for
+# ``_init_mcp``.
 
 
 # Approve / abort token families. Case-insensitive, whitespace-stripped.
@@ -111,6 +113,12 @@ async def paperless_commit_upload(
             "action_taken": False,
         }
 
+    # Lazy imports — see module-level note on why.
+    from sqlalchemy import select
+
+    from models.database import PaperlessPendingConfirm
+    from services.database import AsyncSessionLocal
+
     # Look up the pending row (session-scoped).
     async with AsyncSessionLocal() as db:
         query = select(PaperlessPendingConfirm).where(
@@ -148,7 +156,7 @@ async def paperless_commit_upload(
 
 
 async def _commit_approved(
-    pending: PaperlessPendingConfirm,
+    pending,
     *,
     mcp_manager: Any,
     user_id: int | None,
@@ -157,6 +165,16 @@ async def _commit_approved(
     upload_document, then write the confirm-diff, increment the
     cold-start counter, and delete the pending row.
     """
+    from sqlalchemy import delete, update
+
+    from models.database import (
+        ChatUpload,
+        PaperlessExtractionExample,
+        PaperlessPendingConfirm,
+        User,
+    )
+    from services.database import AsyncSessionLocal
+
     post_fuzzy = pending.post_fuzzy_output or {}
     proposals = pending.proposals or []
     llm_output = pending.llm_output or {}
@@ -223,6 +241,18 @@ async def _commit_approved(
         upload = await db.get(ChatUpload, pending.attachment_id)
 
     if upload is None or not upload.file_path:
+        # ChatUpload vanished (manual purge, sweeper, or FK cascade
+        # elsewhere). The FK is ON DELETE CASCADE so the pending row
+        # would normally be gone too — but if the row survived via a
+        # broken file_path on disk, drop it explicitly so we don't
+        # strand orphaned pending_confirms.
+        async with AsyncSessionLocal() as db:
+            await db.execute(
+                delete(PaperlessPendingConfirm).where(
+                    PaperlessPendingConfirm.confirm_token == pending.confirm_token
+                )
+            )
+            await db.commit()
         return {
             "success": False,
             "message": "Anhang nicht mehr verfügbar.",
@@ -279,9 +309,11 @@ async def _commit_approved(
     inner: dict[str, Any] = {}
     if isinstance(inner_msg, str):
         try:
-            inner = json.loads(inner_msg) or {}
+            parsed = json.loads(inner_msg)
         except (json.JSONDecodeError, TypeError):
-            inner = {}
+            parsed = None
+        if isinstance(parsed, dict):
+            inner = parsed
     elif isinstance(inner_msg, dict):
         inner = inner_msg
 
@@ -313,7 +345,6 @@ async def _commit_approved(
                 user_approved[field] = value
 
         if user_approved != post_fuzzy:
-            from models.database import PaperlessExtractionExample
             example = PaperlessExtractionExample(
                 doc_text=_truncate_doc_text(pending),
                 llm_output=llm_output,
@@ -372,9 +403,14 @@ async def _commit_approved(
     }
 
 
-async def _abort_pending(pending: PaperlessPendingConfirm) -> dict:
+async def _abort_pending(pending) -> dict:
     """User said 'nein'. Delete the ChatUpload bytes + row + the
     pending confirm. Nothing lands in Paperless."""
+    from sqlalchemy import delete
+
+    from models.database import ChatUpload, PaperlessPendingConfirm
+    from services.database import AsyncSessionLocal
+
     attachment_id = pending.attachment_id
 
     async with AsyncSessionLocal() as db:
@@ -406,12 +442,17 @@ async def _abort_pending(pending: PaperlessPendingConfirm) -> dict:
     }
 
 
-async def _handle_ambiguous_response(pending: PaperlessPendingConfirm) -> dict:
+async def _handle_ambiguous_response(pending) -> dict:
     """User said something that wasn't 'ja' or 'nein'.
 
     v1 keeps it simple: bump edit_rounds, if budget remains ask again;
     otherwise force-abort. Real correction parsing lands in a later PR.
     """
+    from sqlalchemy import update
+
+    from models.database import PaperlessPendingConfirm
+    from services.database import AsyncSessionLocal
+
     async with AsyncSessionLocal() as db:
         await db.execute(
             update(PaperlessPendingConfirm)
@@ -441,7 +482,7 @@ async def _handle_ambiguous_response(pending: PaperlessPendingConfirm) -> dict:
     }
 
 
-def _truncate_doc_text(pending: PaperlessPendingConfirm, max_chars: int = 8000) -> str:
+def _truncate_doc_text(pending, max_chars: int = 8000) -> str:
     """Doc text lives in the pending row's post_fuzzy_output metadata
     indirectly. For v1 we pull it from the llm_output's original
     payload, which the extractor persists alongside the metadata.

--- a/src/backend/services/paperless_commit_tool.py
+++ b/src/backend/services/paperless_commit_tool.py
@@ -1,0 +1,458 @@
+"""
+paperless_commit_upload — second half of the cold-start confirm flow.
+
+When ``forward_attachment_to_paperless`` runs extraction during the
+cold-start window (user's first N uploads), it persists the extracted
+metadata into ``paperless_pending_confirms`` and returns a confirm
+token instead of firing the upload immediately. The user sees a
+German confirm preview; their next chat message is their response.
+
+This tool handles that second turn:
+
+    user message "ja" / "nein" / "ändere X"
+        │
+        ▼
+    paperless_commit_upload(confirm_token, user_response_text)
+        │   1. SELECT pending_confirms row (session-scoped per #442)
+        │   2. Parse user_response_text:
+        │        - "ja" family → approve as-is
+        │        - "nein" family → abort (delete ChatUpload + row, done)
+        │        - anything else (v1) → ask again, bump edit_rounds
+        │   3. If approved with new-entry proposals:
+        │        - For each proposal, call mcp.paperless.create_*
+        │        - Invalidate the extractor's taxonomy cache so the
+        │          next extraction sees the new entries
+        │   4. Call mcp.paperless.upload_document with final fields
+        │   5. On success:
+        │        - Write (doc_text, llm_output, user_approved) into
+        │          paperless_extraction_examples if the user's
+        │          approved fields differ from the LLM's post-fuzzy
+        │          output (confirm-diff signal for PR 3).
+        │        - Increment users.paperless_confirms_used.
+        │        - Delete the pending_confirms row.
+        │   6. Return success with a user-facing message.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from loguru import logger
+from sqlalchemy import delete, select, update
+
+from models.database import ChatUpload, PaperlessPendingConfirm, User
+from services.database import AsyncSessionLocal
+
+
+# Approve / abort token families. Case-insensitive, whitespace-stripped.
+_APPROVE_TOKENS = {"ja", "j", "ok", "okay", "passt", "passt so", "yes", "y", "sure"}
+_ABORT_TOKENS = {"nein", "n", "abbrechen", "stopp", "stop", "no", "cancel"}
+
+# v1 keeps edit-parsing dumb: ja/nein only; anything else gets an error
+# message. Smarter correction parsing lands with PR 5 (interactive card)
+# or a separate follow-up. The cold-start confirm is capped at 10
+# uploads per user so this rough UX has a bounded impact.
+_MAX_EDIT_ROUNDS = 3
+
+
+PAPERLESS_COMMIT_TOOLS: dict = {
+    "internal.paperless_commit_upload": {
+        "description": (
+            "Finalise or abort a pending Paperless upload. Call this tool "
+            "when the previous assistant turn returned "
+            "action_required=paperless_confirm and the user has now "
+            "responded. Pass the confirm_token from the previous turn AND "
+            "the user's response text verbatim. Supports 'ja' to approve, "
+            "'nein' to abort."
+        ),
+        "parameters": {
+            "confirm_token": (
+                "UUID from the action_required=paperless_confirm response. "
+                "Required."
+            ),
+            "user_response_text": (
+                "The user's response message verbatim. Required."
+            ),
+        },
+    },
+}
+
+
+async def paperless_commit_upload(
+    params: dict,
+    mcp_manager=None,
+    session_id: str | None = None,
+    user_id: int | None = None,
+) -> dict:
+    """Finalise or abort a pending-confirm upload.
+
+    Returns a standard agent-tool result dict with ``success``,
+    ``message``, ``action_taken``, and ``data``.
+    """
+    confirm_token = params.get("confirm_token")
+    user_response = params.get("user_response_text") or params.get("user_response") or ""
+
+    if not confirm_token:
+        return {
+            "success": False,
+            "message": "Parameter 'confirm_token' is required",
+            "action_taken": False,
+        }
+    if not isinstance(confirm_token, str):
+        return {
+            "success": False,
+            "message": f"'confirm_token' must be a string, got {type(confirm_token).__name__}",
+            "action_taken": False,
+        }
+    if mcp_manager is None:
+        return {
+            "success": False,
+            "message": "MCP manager not available — Paperless MCP not wired in",
+            "action_taken": False,
+        }
+
+    # Look up the pending row (session-scoped).
+    async with AsyncSessionLocal() as db:
+        query = select(PaperlessPendingConfirm).where(
+            PaperlessPendingConfirm.confirm_token == confirm_token
+        )
+        if session_id is not None:
+            query = query.where(PaperlessPendingConfirm.session_id == session_id)
+        result = await db.execute(query)
+        pending = result.scalar_one_or_none()
+
+    if pending is None:
+        # Soft-404 — don't distinguish cross-session probe from
+        # genuinely-unknown-token. Same privacy treatment as #442.
+        return {
+            "success": False,
+            "message": (
+                "Die Bestätigung ist abgelaufen oder unbekannt. Bitte lade "
+                "das Dokument erneut hoch."
+            ),
+            "action_taken": False,
+        }
+
+    # Classify the user's response.
+    normalised = user_response.strip().lower()
+    if normalised in _APPROVE_TOKENS:
+        return await _commit_approved(
+            pending, mcp_manager=mcp_manager, user_id=user_id,
+        )
+    if normalised in _ABORT_TOKENS:
+        return await _abort_pending(pending)
+
+    # Unrecognised response. v1 behaviour: count the round, re-prompt if
+    # we still have budget, otherwise force-abort.
+    return await _handle_ambiguous_response(pending)
+
+
+async def _commit_approved(
+    pending: PaperlessPendingConfirm,
+    *,
+    mcp_manager: Any,
+    user_id: int | None,
+) -> dict:
+    """User said 'ja'. Fire creates for approved proposals, then
+    upload_document, then write the confirm-diff, increment the
+    cold-start counter, and delete the pending row.
+    """
+    post_fuzzy = pending.post_fuzzy_output or {}
+    proposals = pending.proposals or []
+    llm_output = pending.llm_output or {}
+
+    # Step 1 — approve new-entry proposals by calling the matching
+    # create_* MCP tool. Each success invalidates the extractor's
+    # taxonomy cache so subsequent extractions see the new entry.
+    created_entries: dict[str, str] = {}
+    for proposal in proposals:
+        field = proposal.get("field")
+        value = proposal.get("value")
+        if not field or not value:
+            continue
+        create_tool = {
+            "correspondent": "mcp.paperless.create_correspondent",
+            "document_type": "mcp.paperless.create_document_type",
+            "tag": "mcp.paperless.create_tag",
+            "storage_path": "mcp.paperless.create_storage_path",
+        }.get(field)
+        if create_tool is None:
+            logger.warning("Unknown proposal field, skipping: %r", field)
+            continue
+
+        create_params: dict[str, Any] = {"name": value}
+        if field == "storage_path":
+            # Storage paths need a path template. Use the LLM's suggested
+            # value for both name and path — crude v1 fallback, user can
+            # rename in Paperless UI if needed.
+            create_params["path"] = value
+
+        try:
+            result = await mcp_manager.execute_tool(create_tool, create_params)
+        except Exception as exc:
+            logger.warning(
+                "Failed to create %s %r: %s", field, value, exc,
+            )
+            continue
+
+        if not result or not result.get("success"):
+            inner = (result or {}).get("message") or "no detail"
+            if "already_exists" in str(inner):
+                # Raced against another extraction — someone else already
+                # created this entry. Treat as success.
+                logger.info("%s %r already exists, reusing", field, value)
+                created_entries[field] = value
+            else:
+                logger.warning(
+                    "Create %s %r failed: %s", field, value, str(inner)[:120],
+                )
+            continue
+        created_entries[field] = value
+
+    # Flush the extractor's taxonomy cache so future extractions see
+    # the new entries.
+    if created_entries:
+        try:
+            from services.paperless_metadata_extractor import _invalidate_taxonomy_cache
+            _invalidate_taxonomy_cache()
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.debug("Could not flush taxonomy cache: %s", exc)
+
+    # Step 2 — fetch the ChatUpload bytes + build the upload call.
+    async with AsyncSessionLocal() as db:
+        upload = await db.get(ChatUpload, pending.attachment_id)
+
+    if upload is None or not upload.file_path:
+        return {
+            "success": False,
+            "message": "Anhang nicht mehr verfügbar.",
+            "action_taken": False,
+        }
+
+    try:
+        from pathlib import Path as _Path
+        import base64 as _base64
+        with open(upload.file_path, "rb") as f:
+            file_bytes = f.read()
+        file_content_base64 = _base64.b64encode(file_bytes).decode("ascii")
+    except Exception as exc:
+        return {
+            "success": False,
+            "message": f"Konnte Datei nicht lesen: {exc!s}",
+            "action_taken": False,
+        }
+
+    tool_params: dict[str, Any] = {
+        "title": post_fuzzy.get("title") or upload.filename,
+        "filename": upload.filename,
+        "file_content_base64": file_content_base64,
+    }
+    for key in ("correspondent", "document_type", "tags", "storage_path"):
+        val = post_fuzzy.get(key)
+        if val:
+            tool_params[key] = val
+    created = post_fuzzy.get("created_date")
+    if created:
+        tool_params["created_date"] = created
+
+    try:
+        mcp_result = await mcp_manager.execute_tool(
+            "mcp.paperless.upload_document", tool_params
+        )
+    except Exception as exc:
+        return {
+            "success": False,
+            "message": f"Paperless-Upload fehlgeschlagen: {exc!s}",
+            "action_taken": False,
+        }
+
+    if not mcp_result or not mcp_result.get("success"):
+        detail = (mcp_result or {}).get("message") or "unknown"
+        return {
+            "success": False,
+            "message": f"Paperless-Upload fehlgeschlagen: {detail}",
+            "action_taken": False,
+        }
+
+    # Parse the MCP envelope to pull out post_upload_patch status.
+    inner_msg = mcp_result.get("message")
+    inner: dict[str, Any] = {}
+    if isinstance(inner_msg, str):
+        try:
+            inner = json.loads(inner_msg) or {}
+        except (json.JSONDecodeError, TypeError):
+            inner = {}
+    elif isinstance(inner_msg, dict):
+        inner = inner_msg
+
+    task_id = inner.get("task_id")
+    document_id = inner.get("document_id")
+    patch_state = inner.get("post_upload_patch")
+
+    # Step 3 — write the confirm-diff (if any) to
+    # paperless_extraction_examples. Diff is against the post-fuzzy
+    # LLM output, not the raw output. In v1 the user can only approve
+    # or abort, so the diff shape is either empty (unchanged) or
+    # reflects the created-proposals (LLM said null, user approved
+    # a new entry creation).
+    async with AsyncSessionLocal() as db:
+        user_approved = dict(post_fuzzy)
+        # If the user approved new-entry proposals, the approved fields
+        # now carry the newly-created names.
+        for field, value in created_entries.items():
+            if field == "tag":
+                # Tag proposals feed the tags list — append if not
+                # already there. Post-fuzzy tags list carries the
+                # taxonomy-hit tags; the new tag is one we just
+                # created.
+                existing_tags = list(user_approved.get("tags") or [])
+                if value not in existing_tags:
+                    existing_tags.append(value)
+                user_approved["tags"] = existing_tags
+            else:
+                user_approved[field] = value
+
+        if user_approved != post_fuzzy:
+            from models.database import PaperlessExtractionExample
+            example = PaperlessExtractionExample(
+                doc_text=_truncate_doc_text(pending),
+                llm_output=llm_output,
+                user_approved=user_approved,
+                source="confirm_diff",
+            )
+            db.add(example)
+
+        # Step 4 — increment the cold-start counter. Design: increment
+        # ONLY on successful upload, and only when we actually know the
+        # user. Resolution from session → conversation → user is done
+        # by the caller and passed as user_id.
+        if user_id is not None:
+            await db.execute(
+                update(User)
+                .where(User.id == user_id)
+                .values(
+                    paperless_confirms_used=User.paperless_confirms_used + 1
+                )
+            )
+
+        # Step 5 — delete the pending confirm row.
+        await db.execute(
+            delete(PaperlessPendingConfirm).where(
+                PaperlessPendingConfirm.confirm_token == pending.confirm_token
+            )
+        )
+        await db.commit()
+
+    # Step 6 — user-facing response.
+    if patch_state == "success":
+        suffix = " mit allen Metadaten."
+    elif patch_state in ("timed_out", "retries_exhausted", "client_error"):
+        suffix = (
+            " — aber der Speicherpfad konnte nicht gesetzt werden. "
+            "Bitte in Paperless selbst anpassen."
+        )
+    else:
+        suffix = "."
+
+    created_note = ""
+    if created_entries:
+        names = ", ".join(sorted(created_entries.values()))
+        created_note = f" (Neu angelegt: {names})"
+
+    return {
+        "success": True,
+        "message": f"Im Paperless abgelegt: {upload.filename}{suffix}{created_note}",
+        "action_taken": True,
+        "data": {
+            "task_id": task_id,
+            "document_id": document_id,
+            "post_upload_patch": patch_state,
+            "created_entries": created_entries,
+        },
+    }
+
+
+async def _abort_pending(pending: PaperlessPendingConfirm) -> dict:
+    """User said 'nein'. Delete the ChatUpload bytes + row + the
+    pending confirm. Nothing lands in Paperless."""
+    attachment_id = pending.attachment_id
+
+    async with AsyncSessionLocal() as db:
+        # Delete the pending row first (it has FK → chat_uploads with
+        # CASCADE, but we want explicit control over the order for
+        # clarity in logs).
+        await db.execute(
+            delete(PaperlessPendingConfirm).where(
+                PaperlessPendingConfirm.confirm_token == pending.confirm_token
+            )
+        )
+        # Soft-delete the ChatUpload. Bytes on disk get cleaned up by
+        # the existing chat-upload sweeper. Fallback: if the ChatUpload
+        # row is fully removed elsewhere, the cascade already fired.
+        upload = await db.get(ChatUpload, attachment_id)
+        if upload is not None:
+            # Mark as deleted but keep the row for audit trail.
+            # (If the ChatUpload model doesn't have is_deleted, leave
+            # it alone — disk cleanup handles the rest.)
+            if hasattr(upload, "is_deleted"):
+                upload.is_deleted = True
+        await db.commit()
+
+    return {
+        "success": True,
+        "message": "Abgebrochen. Das Dokument wurde nicht abgelegt.",
+        "action_taken": True,
+        "data": {"aborted": True, "attachment_id": attachment_id},
+    }
+
+
+async def _handle_ambiguous_response(pending: PaperlessPendingConfirm) -> dict:
+    """User said something that wasn't 'ja' or 'nein'.
+
+    v1 keeps it simple: bump edit_rounds, if budget remains ask again;
+    otherwise force-abort. Real correction parsing lands in a later PR.
+    """
+    async with AsyncSessionLocal() as db:
+        await db.execute(
+            update(PaperlessPendingConfirm)
+            .where(PaperlessPendingConfirm.confirm_token == pending.confirm_token)
+            .values(edit_rounds=PaperlessPendingConfirm.edit_rounds + 1)
+        )
+        await db.commit()
+        # Re-fetch to get the new edit_rounds.
+        refreshed = await db.get(PaperlessPendingConfirm, pending.confirm_token)
+        rounds = refreshed.edit_rounds if refreshed else _MAX_EDIT_ROUNDS + 1
+
+    if rounds > _MAX_EDIT_ROUNDS:
+        # Give up, abort the upload entirely.
+        return await _abort_pending(pending)
+
+    return {
+        "success": False,
+        "message": (
+            "Ich habe deine Antwort nicht verstanden. Bitte antworte mit "
+            "`ja` zum Ablegen oder `nein` zum Abbrechen."
+        ),
+        "action_taken": False,
+        "data": {
+            "confirm_token": pending.confirm_token,
+            "action_required": "paperless_confirm",
+        },
+    }
+
+
+def _truncate_doc_text(pending: PaperlessPendingConfirm, max_chars: int = 8000) -> str:
+    """Doc text lives in the pending row's post_fuzzy_output metadata
+    indirectly. For v1 we pull it from the llm_output's original
+    payload, which the extractor persists alongside the metadata.
+
+    If the pending row doesn't carry doc_text (shape evolved), fall
+    back to an empty string — the example row is still useful for the
+    user_approved diff, just less effective for future prompt
+    augmentation.
+    """
+    llm = pending.llm_output or {}
+    text = llm.get("_doc_text") or ""
+    if not isinstance(text, str):
+        return ""
+    return text[:max_chars]

--- a/tests/backend/test_chat_upload_tool_paperless.py
+++ b/tests/backend/test_chat_upload_tool_paperless.py
@@ -359,6 +359,62 @@ class TestForwardAttachmentColdStart:
 
     @pytest.mark.asyncio
     @pytest.mark.unit
+    async def test_cold_start_with_user_id_none_persists_pending(self, tmp_path):
+        """AUTH_ENABLED=false: user_id is None. Pending row must still
+        persist (user_id column is nullable) — regression guard for B1
+        (previous code passed ``user_id or 0`` which triggered an FK
+        violation against a non-existent user row 0)."""
+        upload = _upload_stub(tmp_path, filename="rechnung.pdf", size=200_000)
+        mcp = MagicMock()
+        mcp.execute_tool = AsyncMock()
+
+        extractor_result = SimpleNamespace(
+            metadata=SimpleNamespace(
+                title="T", correspondent="Stadtwerke",
+                document_type="Rechnung", tags=["wohnung"],
+                storage_path="/x", created_date=None,
+                new_entry_proposals=[],
+                model_dump=lambda: {
+                    "title": "T", "correspondent": "Stadtwerke",
+                    "document_type": "Rechnung", "tags": ["wohnung"],
+                    "storage_path": "/x", "created_date": None,
+                    "new_entry_proposals": [],
+                },
+            ),
+            doc_text="doc",
+            error=None,
+        )
+
+        session_factory = _make_session_factory(upload, capture_writes=True)
+
+        with patch(
+            "services.chat_upload_tool._run_extraction",
+            AsyncMock(return_value=extractor_result),
+        ):
+            with patch(
+                "services.chat_upload_tool._get_confirms_used",
+                AsyncMock(return_value=0),
+            ):
+                with patch(
+                    "services.database.AsyncSessionLocal",
+                    session_factory,
+                ):
+                    result = await forward_attachment_to_paperless(
+                        {"attachment_id": 42},
+                        mcp_manager=mcp, session_id="s", user_id=None,
+                    )
+
+        assert result["success"] is True
+        assert result["data"]["action_required"] == "paperless_confirm"
+        # Grab the persisted PaperlessPendingConfirm — user_id must be
+        # None, not 0.
+        writes = session_factory.captured_adds  # type: ignore[attr-defined]
+        pending_rows = [w for w in writes if type(w).__name__ == "PaperlessPendingConfirm"]
+        assert pending_rows, "Pending confirm row was not persisted"
+        assert pending_rows[0].user_id is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
     async def test_silent_upload_when_past_cold_start_cap(self, tmp_path):
         upload = _upload_stub(tmp_path)
         mcp = MagicMock()

--- a/tests/backend/test_chat_upload_tool_paperless.py
+++ b/tests/backend/test_chat_upload_tool_paperless.py
@@ -1,0 +1,524 @@
+"""
+Unit tests for the inline extraction + cold-start confirm additions
+to ``forward_attachment_to_paperless`` (PR 2b).
+
+Covers the three paths the tool now takes:
+    1. skip_metadata=True (or auto-heuristic) → bare upload, no extract.
+    2. user past cold-start cap → silent extract + upload.
+    3. user inside cold-start → return action_required=paperless_confirm
+       with a persisted pending row.
+
+All tests are pure-unit with heavy mocking of the DB session,
+extractor, and MCP manager. Integration against real Postgres lives in
+tests/backend/test_paperless_confirm_flow_integration.py (deferred).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.chat_upload_tool import (
+    _COLD_START_CONFIRM_N,
+    _extraction_to_upload_params,
+    _infer_lang,
+    _render_confirm_message,
+    _should_auto_skip_metadata,
+    forward_attachment_to_paperless,
+)
+
+
+# ===========================================================================
+# _should_auto_skip_metadata — heuristic
+# ===========================================================================
+
+
+class TestAutoSkipHeuristic:
+    @pytest.mark.unit
+    def test_screenshot_filename_triggers_skip(self):
+        assert _should_auto_skip_metadata("screenshot.png", 1024) is True
+        assert _should_auto_skip_metadata("Screen Shot 2026-04-22.png", 1024) is True
+        assert _should_auto_skip_metadata("IMG_12345.jpg", 1024) is True
+        assert _should_auto_skip_metadata("photo.png", 1024) is True
+        assert _should_auto_skip_metadata("meme.gif", 1024) is True
+
+    @pytest.mark.unit
+    def test_small_image_triggers_skip(self):
+        # 100 KB PNG — likely a meme / sticker / photo.
+        assert _should_auto_skip_metadata("random.png", 100 * 1024) is True
+        assert _should_auto_skip_metadata("random.jpg", 400 * 1024) is True
+
+    @pytest.mark.unit
+    def test_large_image_does_not_skip(self):
+        # 2 MB image — likely a scanned document.
+        assert _should_auto_skip_metadata("scan.png", 2 * 1024 * 1024) is False
+
+    @pytest.mark.unit
+    def test_pdf_never_auto_skips(self):
+        """PDFs are always real documents regardless of size."""
+        assert _should_auto_skip_metadata("invoice.pdf", 10 * 1024) is False
+        assert _should_auto_skip_metadata("tiny.pdf", 1024) is False
+
+    @pytest.mark.unit
+    def test_docx_never_auto_skips(self):
+        assert _should_auto_skip_metadata("contract.docx", 1024) is False
+
+    @pytest.mark.unit
+    def test_text_files_never_auto_skip(self):
+        assert _should_auto_skip_metadata("notes.txt", 100) is False
+        assert _should_auto_skip_metadata("notes.md", 100) is False
+
+    @pytest.mark.unit
+    def test_benign_image_filename_with_large_size(self):
+        """A real scanned doc named 'mein_dokument.jpg' at 3 MB is NOT
+        a screenshot — the filename regex doesn't match and size is
+        over the image-autoskip threshold."""
+        assert _should_auto_skip_metadata("mein_dokument.jpg", 3 * 1024 * 1024) is False
+
+
+# ===========================================================================
+# _infer_lang
+# ===========================================================================
+
+
+class TestInferLang:
+    @pytest.mark.unit
+    def test_default_is_de(self):
+        upload = SimpleNamespace(filename="rechnung.pdf")
+        assert _infer_lang(upload) == "de"
+
+    @pytest.mark.unit
+    def test_english_hints_flip_to_en(self):
+        for name in ["invoice.pdf", "receipt_2026.pdf", "statement.pdf",
+                     "contract.pdf", "letter.pdf"]:
+            upload = SimpleNamespace(filename=name)
+            assert _infer_lang(upload) == "en", f"{name!r} should be en"
+
+
+# ===========================================================================
+# _extraction_to_upload_params
+# ===========================================================================
+
+
+class TestExtractionToUploadParams:
+    @pytest.mark.unit
+    def test_full_extraction_translates(self):
+        post_fuzzy = {
+            "title": "Nebenkostenabrechnung 2025",
+            "correspondent": "Stadtwerke",
+            "document_type": "Rechnung",
+            "tags": ["wohnung", "nebenkosten-2025"],
+            "storage_path": "/wohnung/betriebskosten",
+            "created_date": "2026-02-14",
+            "confidence": {"title": 0.9},  # not forwarded
+        }
+        result = _extraction_to_upload_params(post_fuzzy)
+        assert result == {
+            "title": "Nebenkostenabrechnung 2025",
+            "correspondent": "Stadtwerke",
+            "document_type": "Rechnung",
+            "tags": ["wohnung", "nebenkosten-2025"],
+            "storage_path": "/wohnung/betriebskosten",
+            "created_date": "2026-02-14",
+        }
+
+    @pytest.mark.unit
+    def test_missing_fields_omitted_not_null(self):
+        """Don't forward null values; MCP upload_document treats missing
+        as 'caller has no opinion', null would be an error."""
+        post_fuzzy = {
+            "title": "T",
+            "correspondent": None,
+            "tags": [],
+            "storage_path": None,
+        }
+        result = _extraction_to_upload_params(post_fuzzy)
+        assert result == {"title": "T"}
+        assert "correspondent" not in result
+        assert "tags" not in result
+        assert "storage_path" not in result
+
+    @pytest.mark.unit
+    def test_empty_tags_list_omitted(self):
+        """Empty tags list is treated as 'no opinion', not 'clear all'."""
+        result = _extraction_to_upload_params({"tags": []})
+        assert "tags" not in result
+
+
+# ===========================================================================
+# _render_confirm_message
+# ===========================================================================
+
+
+class TestRenderConfirmMessage:
+    @pytest.mark.unit
+    def test_full_metadata_renders(self):
+        msg = _render_confirm_message(
+            filename="rechnung.pdf",
+            metadata={
+                "title": "Nebenkostenabrechnung 2025",
+                "correspondent": "Stadtwerke Korschenbroich",
+                "document_type": "Nebenkostenabrechnung",
+                "tags": ["wohnung", "nebenkosten-2025"],
+                "storage_path": "/wohnung/betriebskosten",
+                "created_date": "2026-02-14",
+            },
+            proposals=[],
+        )
+        assert "rechnung.pdf" in msg
+        assert "Stadtwerke Korschenbroich" in msg
+        assert "Nebenkostenabrechnung" in msg
+        assert "wohnung, nebenkosten-2025" in msg
+        assert "/wohnung/betriebskosten" in msg
+        assert "2026-02-14" in msg
+        assert "keine" in msg  # no proposals
+        assert "ja" in msg and "nein" in msg
+
+    @pytest.mark.unit
+    def test_missing_fields_render_as_dash(self):
+        msg = _render_confirm_message(
+            filename="f.pdf",
+            metadata={
+                "title": "T",
+                "correspondent": None,
+                "document_type": None,
+                "tags": [],
+                "storage_path": None,
+                "created_date": None,
+            },
+            proposals=[],
+        )
+        # Five "—" markers (one per missing field).
+        assert msg.count("—") >= 5
+
+    @pytest.mark.unit
+    def test_proposals_listed(self):
+        # Use dict-shaped proposals (pending_confirms JSONB form).
+        proposals = [
+            {"field": "correspondent", "value": "Schreiner Meier",
+             "reasoning": "..."},
+            {"field": "tag", "value": "handwerker", "reasoning": "..."},
+        ]
+        msg = _render_confirm_message(
+            filename="f.pdf", metadata={"title": "T"}, proposals=proposals,
+        )
+        assert "Schreiner Meier" in msg
+        assert "handwerker" in msg
+        assert "correspondent" in msg
+        assert "tag" in msg
+
+    @pytest.mark.unit
+    def test_proposals_from_pydantic_objects(self):
+        """Confirm message also accepts pydantic NewEntryProposal objects
+        (the raw extractor output shape). Duck-typed via hasattr."""
+        p = SimpleNamespace(field="correspondent", value="Test", reasoning="x")
+        msg = _render_confirm_message(filename="f", metadata={}, proposals=[p])
+        assert "Test" in msg
+
+
+# ===========================================================================
+# forward_attachment_to_paperless — integration with mocked deps
+# ===========================================================================
+
+
+def _upload_stub(tmp_path, *, filename="doc.pdf", size=10_000):
+    """Build a ChatUpload-shaped mock with a real file on disk."""
+    file = tmp_path / filename
+    file.write_bytes(b"%PDF-1.4 " + b"x" * max(size - 9, 0))
+    upload = MagicMock()
+    upload.id = 42
+    upload.filename = filename
+    upload.file_path = str(file)
+    upload.file_size = size
+    return upload
+
+
+class TestForwardAttachmentSkipPath:
+    """skip_metadata=True (explicit or auto-heuristic) → direct upload."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_explicit_skip_metadata_bypasses_extractor(self, tmp_path):
+        upload = _upload_stub(tmp_path)
+        mcp = MagicMock()
+        mcp.execute_tool = AsyncMock(return_value={
+            "success": True,
+            "message": '{"task_id": "t-1", "title": "doc.pdf"}',
+        })
+
+        # _load_upload is the DB lookup. Patch at the SQLAlchemy layer:
+        # the function fetches a ChatUpload from AsyncSessionLocal.
+        # Rather than mock SQLAlchemy, patch the module-level session
+        # factory to yield a context-manager that returns our upload.
+        async def _fake_session():
+            return _make_session_with_upload(upload)
+
+        with patch("services.chat_upload_tool.Path") as _p:
+            _p.return_value.is_file = MagicMock(return_value=True)
+            with patch("services.database.AsyncSessionLocal", _make_session_factory(upload)):
+                result = await forward_attachment_to_paperless(
+                    {"attachment_id": 42, "skip_metadata": True},
+                    mcp_manager=mcp,
+                    session_id="test-session",
+                    user_id=1,
+                )
+
+        assert result["success"] is True
+        assert result["action_taken"] is True
+        # Extractor was NOT called.
+        for call in mcp.execute_tool.await_args_list:
+            assert "extract" not in str(call).lower()
+        assert "Sent to Paperless" in result["message"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_auto_skip_on_screenshot_filename(self, tmp_path):
+        upload = _upload_stub(tmp_path, filename="Screenshot_2026.png", size=150_000)
+        mcp = MagicMock()
+        mcp.execute_tool = AsyncMock(return_value={
+            "success": True, "message": '{"task_id": "t"}',
+        })
+
+        with patch("services.database.AsyncSessionLocal", _make_session_factory(upload)):
+            result = await forward_attachment_to_paperless(
+                {"attachment_id": 42},  # no skip_metadata param
+                mcp_manager=mcp,
+                session_id="s",
+                user_id=1,
+            )
+
+        assert result["success"] is True
+        # Only one MCP call (the upload) — no extractor calls.
+        assert mcp.execute_tool.await_count == 1
+
+
+class TestForwardAttachmentColdStart:
+    """Cold-start window: extraction → persist pending → return confirm."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_returns_action_required_when_inside_window(self, tmp_path):
+        upload = _upload_stub(tmp_path, filename="rechnung.pdf", size=200_000)
+        mcp = MagicMock()
+        # Extractor will run, then the confirm persists. No MCP calls
+        # for the upload itself on this path.
+        mcp.execute_tool = AsyncMock()
+
+        # Mock the extractor to return a clean result.
+        extractor_result = SimpleNamespace(
+            metadata=SimpleNamespace(
+                title="T",
+                correspondent="Stadtwerke",
+                document_type="Rechnung",
+                tags=["wohnung"],
+                storage_path="/x",
+                created_date=None,
+                new_entry_proposals=[],
+                model_dump=lambda: {
+                    "title": "T",
+                    "correspondent": "Stadtwerke",
+                    "document_type": "Rechnung",
+                    "tags": ["wohnung"],
+                    "storage_path": "/x",
+                    "created_date": None,
+                    "new_entry_proposals": [],
+                },
+            ),
+            doc_text="doc text",
+            error=None,
+        )
+
+        with patch(
+            "services.chat_upload_tool._run_extraction",
+            AsyncMock(return_value=extractor_result),
+        ):
+            with patch(
+                "services.chat_upload_tool._get_confirms_used",
+                AsyncMock(return_value=0),  # Fresh user — cold-start window
+            ):
+                with patch(
+                    "services.database.AsyncSessionLocal",
+                    _make_session_factory(upload, capture_writes=True),
+                ):
+                    result = await forward_attachment_to_paperless(
+                        {"attachment_id": 42},
+                        mcp_manager=mcp, session_id="s", user_id=1,
+                    )
+
+        assert result["success"] is True
+        assert result["action_taken"] is False  # upload NOT committed yet
+        assert result["data"]["action_required"] == "paperless_confirm"
+        assert "confirm_token" in result["data"]
+        assert len(result["data"]["confirm_token"]) == 36  # uuid4 str
+        # Preview message contains the extracted fields.
+        assert "Stadtwerke" in result["message"]
+        assert "Rechnung" in result["message"]
+        # NO upload happened yet.
+        assert mcp.execute_tool.await_count == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_silent_upload_when_past_cold_start_cap(self, tmp_path):
+        upload = _upload_stub(tmp_path)
+        mcp = MagicMock()
+        mcp.execute_tool = AsyncMock(return_value={
+            "success": True, "message": '{"task_id": "t", "document_id": 99}',
+        })
+
+        extractor_result = SimpleNamespace(
+            metadata=SimpleNamespace(
+                title="T", correspondent="Stadtwerke",
+                document_type="Rechnung", tags=["wohnung"],
+                storage_path="/x", created_date=None,
+                new_entry_proposals=[],
+                model_dump=lambda: {
+                    "title": "T", "correspondent": "Stadtwerke",
+                    "document_type": "Rechnung", "tags": ["wohnung"],
+                    "storage_path": "/x",
+                },
+            ),
+            doc_text="doc",
+            error=None,
+        )
+
+        with patch(
+            "services.chat_upload_tool._run_extraction",
+            AsyncMock(return_value=extractor_result),
+        ):
+            with patch(
+                "services.chat_upload_tool._get_confirms_used",
+                AsyncMock(return_value=_COLD_START_CONFIRM_N),  # Past cap
+            ):
+                with patch(
+                    "services.database.AsyncSessionLocal",
+                    _make_session_factory(upload),
+                ):
+                    result = await forward_attachment_to_paperless(
+                        {"attachment_id": 42},
+                        mcp_manager=mcp, session_id="s", user_id=1,
+                    )
+
+        # Silent upload — no confirm token in response.
+        assert result["success"] is True
+        assert result["action_taken"] is True
+        assert "action_required" not in result.get("data", {})
+        # Extraction fields were forwarded to the upload call.
+        mcp.execute_tool.assert_awaited_once()
+        call_params = mcp.execute_tool.await_args.args[1]
+        assert call_params["correspondent"] == "Stadtwerke"
+        assert call_params["storage_path"] == "/x"
+
+
+class TestForwardAttachmentExtractionFailure:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_extractor_error_falls_back_to_bare_upload(self, tmp_path):
+        upload = _upload_stub(tmp_path)
+        mcp = MagicMock()
+        mcp.execute_tool = AsyncMock(return_value={
+            "success": True, "message": '{"task_id": "t"}',
+        })
+
+        # Extractor returns an error result — fallback path should
+        # fire a bare upload and annotate the success message.
+        extractor_result = SimpleNamespace(
+            metadata=SimpleNamespace(
+                title=None, correspondent=None, document_type=None,
+                tags=[], storage_path=None, created_date=None,
+                new_entry_proposals=[],
+                model_dump=lambda: {},
+            ),
+            doc_text="",
+            error="Konnte Dokument nicht lesen (OCR lieferte keinen Text).",
+        )
+
+        with patch(
+            "services.chat_upload_tool._run_extraction",
+            AsyncMock(return_value=extractor_result),
+        ):
+            with patch(
+                "services.chat_upload_tool._get_confirms_used",
+                AsyncMock(return_value=0),
+            ):
+                with patch(
+                    "services.database.AsyncSessionLocal",
+                    _make_session_factory(upload),
+                ):
+                    result = await forward_attachment_to_paperless(
+                        {"attachment_id": 42},
+                        mcp_manager=mcp, session_id="s", user_id=1,
+                    )
+
+        assert result["success"] is True
+        assert "ohne Metadaten-Extraktion" in result["message"]
+        # Upload DID fire, just without extracted fields.
+        mcp.execute_tool.assert_awaited_once()
+
+
+class TestForwardAttachmentValidation:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_missing_attachment_id_errors(self):
+        result = await forward_attachment_to_paperless({}, mcp_manager=MagicMock())
+        assert result["success"] is False
+        assert "attachment_id" in result["message"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_non_integer_attachment_id_errors(self):
+        result = await forward_attachment_to_paperless(
+            {"attachment_id": "abc"}, mcp_manager=MagicMock(),
+        )
+        assert result["success"] is False
+        assert "integer" in result["message"].lower()
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_no_mcp_manager_errors(self):
+        result = await forward_attachment_to_paperless(
+            {"attachment_id": 1}, mcp_manager=None,
+        )
+        assert result["success"] is False
+        assert "MCP" in result["message"]
+
+
+# ===========================================================================
+# Test helpers — DB session mocking
+# ===========================================================================
+
+
+def _make_session_with_upload(upload):
+    """Build an AsyncSessionLocal-like async context manager that returns
+    a DB session whose execute() pipeline yields ``upload`` for
+    ChatUpload lookups."""
+    session = AsyncMock()
+
+    def _execute_result(query):
+        scalars = MagicMock()
+        scalars.scalar_one_or_none = MagicMock(return_value=upload)
+        return scalars
+
+    session.execute = AsyncMock(side_effect=lambda q: _execute_result(q))
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    session.get = AsyncMock(return_value=upload)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
+def _make_session_factory(upload, *, capture_writes: bool = False):
+    """Return a patchable replacement for AsyncSessionLocal."""
+    captured_adds: list = []
+
+    def _factory():
+        session = _make_session_with_upload(upload)
+        if capture_writes:
+            def _capture_add(obj):
+                captured_adds.append(obj)
+            session.add = MagicMock(side_effect=_capture_add)
+        return session
+
+    _factory.captured_adds = captured_adds
+    return _factory

--- a/tests/backend/test_paperless_commit_tool.py
+++ b/tests/backend/test_paperless_commit_tool.py
@@ -95,7 +95,7 @@ class TestUnknownToken:
         mcp = MagicMock()
 
         with patch(
-            "services.paperless_commit_tool.AsyncSessionLocal",
+            "services.database.AsyncSessionLocal",
             _make_session_factory(pending=None),
         ):
             result = await paperless_commit_upload(
@@ -152,7 +152,7 @@ class TestApprovePath:
         })
 
         with patch(
-            "services.paperless_commit_tool.AsyncSessionLocal",
+            "services.database.AsyncSessionLocal",
             _make_session_factory(pending=pending, upload=upload),
         ):
             result = await paperless_commit_upload(
@@ -203,7 +203,7 @@ class TestApprovePath:
         mcp.execute_tool = AsyncMock(side_effect=responses)
 
         with patch(
-            "services.paperless_commit_tool.AsyncSessionLocal",
+            "services.database.AsyncSessionLocal",
             _make_session_factory(pending=pending, upload=upload),
         ):
             # Patch the taxonomy-cache invalidation import so it doesn't
@@ -260,7 +260,7 @@ class TestApprovePath:
         mcp.execute_tool = AsyncMock(side_effect=responses)
 
         with patch(
-            "services.paperless_commit_tool.AsyncSessionLocal",
+            "services.database.AsyncSessionLocal",
             _make_session_factory(pending=pending, upload=upload),
         ):
             with patch(
@@ -305,7 +305,7 @@ class TestApproveMessageShape:
         })
 
         with patch(
-            "services.paperless_commit_tool.AsyncSessionLocal",
+            "services.database.AsyncSessionLocal",
             _make_session_factory(pending=pending, upload=upload),
         ):
             result = await paperless_commit_upload(
@@ -341,7 +341,7 @@ class TestAbortPath:
         mcp.execute_tool = AsyncMock()  # should never fire
 
         with patch(
-            "services.paperless_commit_tool.AsyncSessionLocal",
+            "services.database.AsyncSessionLocal",
             _make_session_factory(pending=pending, upload=upload),
         ):
             result = await paperless_commit_upload(
@@ -366,7 +366,7 @@ class TestAbortPath:
         mcp.execute_tool = AsyncMock()
 
         with patch(
-            "services.paperless_commit_tool.AsyncSessionLocal",
+            "services.database.AsyncSessionLocal",
             _make_session_factory(pending=pending, upload=upload),
         ):
             result = await paperless_commit_upload(
@@ -397,7 +397,7 @@ class TestAmbiguousResponse:
         mcp.execute_tool = AsyncMock()
 
         with patch(
-            "services.paperless_commit_tool.AsyncSessionLocal",
+            "services.database.AsyncSessionLocal",
             _make_session_factory(
                 pending=pending, upload=None,
                 pending_after_update=_make_pending(

--- a/tests/backend/test_paperless_commit_tool.py
+++ b/tests/backend/test_paperless_commit_tool.py
@@ -30,6 +30,12 @@ from services.paperless_commit_tool import (
     paperless_commit_upload,
 )
 
+# Side-effect import — some tests patch
+# ``services.paperless_metadata_extractor._invalidate_taxonomy_cache``.
+# The attribute is resolved at patch time, so the module must be loaded
+# before ``unittest.mock.patch`` runs or it raises AttributeError.
+import services.paperless_metadata_extractor  # noqa: F401  # side-effect
+
 
 # ===========================================================================
 # Token classification

--- a/tests/backend/test_paperless_commit_tool.py
+++ b/tests/backend/test_paperless_commit_tool.py
@@ -1,0 +1,481 @@
+"""
+Unit tests for ``paperless_commit_upload`` — the second half of the
+two-tool cold-start confirm flow.
+
+Covers:
+    - "ja" family → approved path: creates fire, upload fires, counter
+      increments, pending deletes.
+    - "nein" family → abort path: pending deletes, no upload.
+    - Unknown confirm_token → soft-404.
+    - Ambiguous user response → re-prompt, edit_rounds counter, force-
+      abort at cap.
+    - Proposal creation dispatch: correspondent / document_type / tag /
+      storage_path each route to the right MCP tool.
+    - ``already_exists`` rejection from MCP is treated as success.
+
+Pure-unit, heavy mocking. Real DB integration deferred.
+"""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.paperless_commit_tool import (
+    _ABORT_TOKENS,
+    _APPROVE_TOKENS,
+    _MAX_EDIT_ROUNDS,
+    paperless_commit_upload,
+)
+
+
+# ===========================================================================
+# Token classification
+# ===========================================================================
+
+
+class TestTokenClassification:
+    @pytest.mark.unit
+    def test_approve_tokens_cover_common_responses(self):
+        for tok in ["ja", "j", "ok", "passt", "yes", "sure"]:
+            assert tok.lower() in _APPROVE_TOKENS
+
+    @pytest.mark.unit
+    def test_abort_tokens_cover_common_responses(self):
+        for tok in ["nein", "n", "abbrechen", "stopp", "no", "cancel"]:
+            assert tok.lower() in _ABORT_TOKENS
+
+
+# ===========================================================================
+# Validation
+# ===========================================================================
+
+
+class TestCommitValidation:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_missing_confirm_token_errors(self):
+        result = await paperless_commit_upload(
+            {}, mcp_manager=MagicMock(),
+        )
+        assert result["success"] is False
+        assert "confirm_token" in result["message"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_non_string_confirm_token_errors(self):
+        result = await paperless_commit_upload(
+            {"confirm_token": 123, "user_response_text": "ja"},
+            mcp_manager=MagicMock(),
+        )
+        assert result["success"] is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_no_mcp_manager_errors(self):
+        result = await paperless_commit_upload(
+            {"confirm_token": "t", "user_response_text": "ja"},
+            mcp_manager=None,
+        )
+        assert result["success"] is False
+        assert "MCP" in result["message"]
+
+
+# ===========================================================================
+# Unknown / expired confirm token — soft-404
+# ===========================================================================
+
+
+class TestUnknownToken:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_unknown_token_returns_soft_404(self):
+        mcp = MagicMock()
+
+        with patch(
+            "services.paperless_commit_tool.AsyncSessionLocal",
+            _make_session_factory(pending=None),
+        ):
+            result = await paperless_commit_upload(
+                {"confirm_token": "unknown-uuid", "user_response_text": "ja"},
+                mcp_manager=mcp, session_id="s", user_id=1,
+            )
+
+        assert result["success"] is False
+        assert "abgelaufen" in result["message"] or "unbekannt" in result["message"]
+        # No MCP calls were made.
+        mcp.assert_not_called()
+
+
+# ===========================================================================
+# Approve path — full happy flow
+# ===========================================================================
+
+
+class TestApprovePath:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_ja_fires_upload_and_cleanup(self, tmp_path):
+        # A ChatUpload row whose file_path points to a real file on
+        # disk so the approved-commit path can open + b64-encode it.
+        file = tmp_path / "rechnung.pdf"
+        file.write_bytes(b"%PDF-1.4 " + b"x" * 200)
+
+        pending = _make_pending(
+            confirm_token="tok-abc",
+            attachment_id=42,
+            llm_output={"title": "T", "correspondent": "Stadtwerke"},
+            post_fuzzy={
+                "title": "T",
+                "correspondent": "Stadtwerke",
+                "document_type": "Rechnung",
+                "tags": ["wohnung"],
+                "storage_path": "/x",
+                "created_date": None,
+            },
+            proposals=[],
+        )
+        upload = MagicMock(
+            id=42, filename="rechnung.pdf", file_path=str(file),
+        )
+
+        mcp = MagicMock()
+        mcp.execute_tool = AsyncMock(return_value={
+            "success": True,
+            "message": json.dumps({
+                "task_id": "t-1",
+                "document_id": 555,
+                "post_upload_patch": "success",
+            }),
+        })
+
+        with patch(
+            "services.paperless_commit_tool.AsyncSessionLocal",
+            _make_session_factory(pending=pending, upload=upload),
+        ):
+            result = await paperless_commit_upload(
+                {"confirm_token": "tok-abc", "user_response_text": "ja"},
+                mcp_manager=mcp, session_id="s", user_id=1,
+            )
+
+        assert result["success"] is True
+        assert result["action_taken"] is True
+        assert result["data"]["task_id"] == "t-1"
+        assert result["data"]["document_id"] == 555
+        # Upload was the only MCP call (no creates — no proposals).
+        assert mcp.execute_tool.await_count == 1
+        # Response message confirms archival.
+        assert "abgelegt" in result["message"].lower() or "paperless" in result["message"].lower()
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_ja_fires_creates_for_approved_proposals(self, tmp_path):
+        file = tmp_path / "f.pdf"
+        file.write_bytes(b"%PDF-1.4 " + b"x" * 200)
+
+        pending = _make_pending(
+            confirm_token="tok-b",
+            attachment_id=42,
+            llm_output={},
+            post_fuzzy={
+                "title": "T", "correspondent": None, "tags": [],
+                "storage_path": None, "document_type": None,
+            },
+            proposals=[
+                {"field": "correspondent", "value": "Schreiner Meier",
+                 "reasoning": "..."},
+                {"field": "tag", "value": "handwerker", "reasoning": "..."},
+            ],
+        )
+        upload = MagicMock(id=42, filename="f.pdf", file_path=str(file))
+
+        # MCP response sequencer: create_correspondent → create_tag → upload_document
+        responses = [
+            {"success": True, "message": json.dumps({"id": 10, "name": "Schreiner Meier"})},
+            {"success": True, "message": json.dumps({"id": 20, "name": "handwerker"})},
+            {"success": True, "message": json.dumps({
+                "task_id": "t", "document_id": 1, "post_upload_patch": "success",
+            })},
+        ]
+        mcp = MagicMock()
+        mcp.execute_tool = AsyncMock(side_effect=responses)
+
+        with patch(
+            "services.paperless_commit_tool.AsyncSessionLocal",
+            _make_session_factory(pending=pending, upload=upload),
+        ):
+            # Patch the taxonomy-cache invalidation import so it doesn't
+            # try to touch the real module's state during the test.
+            with patch(
+                "services.paperless_metadata_extractor._invalidate_taxonomy_cache",
+                MagicMock(),
+            ):
+                result = await paperless_commit_upload(
+                    {"confirm_token": "tok-b", "user_response_text": "ja"},
+                    mcp_manager=mcp, session_id="s", user_id=1,
+                )
+
+        assert result["success"] is True
+        # Three MCP calls: two creates + one upload.
+        assert mcp.execute_tool.await_count == 3
+        tool_names = [call.args[0] for call in mcp.execute_tool.await_args_list]
+        assert tool_names[0] == "mcp.paperless.create_correspondent"
+        assert tool_names[1] == "mcp.paperless.create_tag"
+        assert tool_names[2] == "mcp.paperless.upload_document"
+        # Response mentions the newly-created entries.
+        assert "Schreiner Meier" in result["message"] or "handwerker" in result["message"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_ja_treats_already_exists_as_success(self, tmp_path):
+        """If a create_* says the entry already exists (raced against
+        another extraction), treat it as success and use the existing id
+        rather than aborting."""
+        file = tmp_path / "f.pdf"
+        file.write_bytes(b"%PDF-1.4 " + b"x" * 200)
+
+        pending = _make_pending(
+            confirm_token="tok-c",
+            attachment_id=42,
+            llm_output={},
+            post_fuzzy={"title": "T"},
+            proposals=[
+                {"field": "correspondent", "value": "Stadtwerke", "reasoning": "..."},
+            ],
+        )
+        upload = MagicMock(id=42, filename="f.pdf", file_path=str(file))
+
+        # create_correspondent returns already_exists.
+        responses = [
+            {"success": False, "message": json.dumps({
+                "error": "already_exists", "existing_id": 7, "existing_name": "Stadtwerke",
+            })},
+            {"success": True, "message": json.dumps({
+                "task_id": "t", "document_id": 1, "post_upload_patch": "success",
+            })},
+        ]
+        mcp = MagicMock()
+        mcp.execute_tool = AsyncMock(side_effect=responses)
+
+        with patch(
+            "services.paperless_commit_tool.AsyncSessionLocal",
+            _make_session_factory(pending=pending, upload=upload),
+        ):
+            with patch(
+                "services.paperless_metadata_extractor._invalidate_taxonomy_cache",
+                MagicMock(),
+            ):
+                result = await paperless_commit_upload(
+                    {"confirm_token": "tok-c", "user_response_text": "ja"},
+                    mcp_manager=mcp, session_id="s", user_id=1,
+                )
+
+        # Upload still happened; already_exists didn't abort the flow.
+        assert result["success"] is True
+        assert mcp.execute_tool.await_count == 2
+
+
+class TestApproveMessageShape:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_patch_failure_surfaces_user_warning(self, tmp_path):
+        """When the MCP upload reports post_upload_patch other than
+        success, the user-facing message must mention the gap."""
+        file = tmp_path / "f.pdf"
+        file.write_bytes(b"%PDF-1.4 " + b"x" * 200)
+
+        pending = _make_pending(
+            confirm_token="tok-d",
+            attachment_id=42,
+            llm_output={},
+            post_fuzzy={"title": "T", "storage_path": "/x"},
+            proposals=[],
+        )
+        upload = MagicMock(id=42, filename="f.pdf", file_path=str(file))
+
+        mcp = MagicMock()
+        mcp.execute_tool = AsyncMock(return_value={
+            "success": True,
+            "message": json.dumps({
+                "task_id": "t", "document_id": 99,
+                "post_upload_patch": "timed_out",
+            }),
+        })
+
+        with patch(
+            "services.paperless_commit_tool.AsyncSessionLocal",
+            _make_session_factory(pending=pending, upload=upload),
+        ):
+            result = await paperless_commit_upload(
+                {"confirm_token": "tok-d", "user_response_text": "ja"},
+                mcp_manager=mcp, session_id="s", user_id=1,
+            )
+
+        assert result["success"] is True
+        # User is explicitly told about the gap.
+        assert (
+            "Speicherpfad" in result["message"]
+            or "anpassen" in result["message"].lower()
+        )
+
+
+# ===========================================================================
+# Abort path
+# ===========================================================================
+
+
+class TestAbortPath:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_nein_deletes_pending_without_uploading(self, tmp_path):
+        pending = _make_pending(
+            confirm_token="tok-x",
+            attachment_id=42,
+            llm_output={}, post_fuzzy={"title": "T"}, proposals=[],
+        )
+        upload = MagicMock(id=42)
+
+        mcp = MagicMock()
+        mcp.execute_tool = AsyncMock()  # should never fire
+
+        with patch(
+            "services.paperless_commit_tool.AsyncSessionLocal",
+            _make_session_factory(pending=pending, upload=upload),
+        ):
+            result = await paperless_commit_upload(
+                {"confirm_token": "tok-x", "user_response_text": "nein"},
+                mcp_manager=mcp, session_id="s", user_id=1,
+            )
+
+        assert result["success"] is True
+        assert result["data"]["aborted"] is True
+        assert mcp.execute_tool.await_count == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_abbrechen_also_aborts(self, tmp_path):
+        pending = _make_pending(
+            confirm_token="tok-y",
+            attachment_id=42,
+            llm_output={}, post_fuzzy={"title": "T"}, proposals=[],
+        )
+        upload = MagicMock(id=42)
+        mcp = MagicMock()
+        mcp.execute_tool = AsyncMock()
+
+        with patch(
+            "services.paperless_commit_tool.AsyncSessionLocal",
+            _make_session_factory(pending=pending, upload=upload),
+        ):
+            result = await paperless_commit_upload(
+                {"confirm_token": "tok-y", "user_response_text": "abbrechen"},
+                mcp_manager=mcp, session_id="s", user_id=1,
+            )
+
+        assert result["success"] is True
+        assert result["data"]["aborted"] is True
+
+
+# ===========================================================================
+# Ambiguous response handling
+# ===========================================================================
+
+
+class TestAmbiguousResponse:
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_ambiguous_returns_reprompt_within_budget(self):
+        pending = _make_pending(
+            confirm_token="tok-z",
+            attachment_id=42,
+            llm_output={}, post_fuzzy={"title": "T"}, proposals=[],
+            edit_rounds=0,
+        )
+        mcp = MagicMock()
+        mcp.execute_tool = AsyncMock()
+
+        with patch(
+            "services.paperless_commit_tool.AsyncSessionLocal",
+            _make_session_factory(
+                pending=pending, upload=None,
+                pending_after_update=_make_pending(
+                    confirm_token="tok-z", attachment_id=42,
+                    llm_output={}, post_fuzzy={}, proposals=[],
+                    edit_rounds=1,
+                ),
+            ),
+        ):
+            result = await paperless_commit_upload(
+                {"confirm_token": "tok-z", "user_response_text": "hmm nicht sicher"},
+                mcp_manager=mcp, session_id="s", user_id=1,
+            )
+
+        # Re-prompt; still requires action.
+        assert result["success"] is False
+        assert "ja" in result["message"].lower() and "nein" in result["message"].lower()
+        assert result["data"]["action_required"] == "paperless_confirm"
+        # No MCP call.
+        assert mcp.execute_tool.await_count == 0
+
+
+# ===========================================================================
+# Test helpers — pending row + session mocking
+# ===========================================================================
+
+
+def _make_pending(*, confirm_token, attachment_id, llm_output, post_fuzzy,
+                  proposals, edit_rounds=0):
+    return SimpleNamespace(
+        confirm_token=confirm_token,
+        attachment_id=attachment_id,
+        session_id="s",
+        user_id=1,
+        llm_output=llm_output,
+        post_fuzzy_output=post_fuzzy,
+        proposals=proposals,
+        edit_rounds=edit_rounds,
+    )
+
+
+def _make_session_factory(*, pending, upload=None, pending_after_update=None):
+    """Build a patchable AsyncSessionLocal factory. The session returns
+    ``pending`` on the first SELECT query; if ``pending_after_update``
+    is set, it returns that on subsequent ``db.get`` calls (simulates
+    the ambiguous-response re-fetch after edit_rounds bump)."""
+
+    def _factory():
+        session = AsyncMock()
+        session.__aenter__ = AsyncMock(return_value=session)
+        session.__aexit__ = AsyncMock(return_value=False)
+        session.add = MagicMock()
+        session.commit = AsyncMock()
+
+        def _execute(query):
+            result = MagicMock()
+            result.scalar_one_or_none = MagicMock(return_value=pending)
+            result.rowcount = 1
+            return result
+
+        session.execute = AsyncMock(side_effect=lambda q: _execute(q))
+
+        # db.get is called for ChatUpload lookups and for the
+        # pending-refresh after edit_rounds bump.
+        call_count = {"n": 0}
+
+        async def _get(model, pk):
+            call_count["n"] += 1
+            # First .get for ChatUpload (approved path); second .get
+            # for PaperlessPendingConfirm (ambiguous re-fetch). Just
+            # return whatever the caller needs based on argument type.
+            if model.__name__ == "ChatUpload":
+                return upload
+            if model.__name__ == "PaperlessPendingConfirm":
+                return pending_after_update or pending
+            return None
+
+        session.get = _get
+        return session
+
+    return _factory


### PR DESCRIPTION
## Summary

Completes the LLM-driven Paperless metadata feature. After this PR, the feature works end-to-end: user attaches a file → agent calls \`forward_attachment_to_paperless\` → extractor runs → cold-start user sees a German confirm preview → \`ja\`/\`nein\` → \`paperless_commit_upload\` finalises or aborts.

Requires \`renfield-mcp-paperless\` v1.3.0 (the \`list_*\` tools) to be live in the cluster.

## Three code paths in \`forward_attachment_to_paperless\`

1. **\`skip_metadata=True\`** (or auto-heuristic triggers on memes/screenshots/small images) → bare upload, no extraction, no confirm. Pre-PR-2b behaviour preserved.
2. **User past cold-start cap** (\`paperless_confirms_used >= 10\`) → silent extraction + upload with extracted metadata. No user confirm.
3. **User inside cold-start window** → run extraction, persist \`paperless_pending_confirms\` row with a fresh uuid4 confirm_token, return \`action_required=paperless_confirm\` with a German preview. Agent relays preview to user; their next message is their response.

Extraction failures fall back to bare upload with an annotated message. Agent overrides (title / correspondent / document_type / tags from the agent's own reasoning) merge on top of extractor output.

## New tool: \`paperless_commit_upload\`

Reads the pending row (session-scoped per #442):
- **\`ja\` family** → fire \`create_*\` for approved proposals (treats \`already_exists\` as success), invalidate the extractor's taxonomy cache, \`mcp.paperless.upload_document\` with final fields, write confirm-diff to \`paperless_extraction_examples\`, increment counter (only on successful upload), delete pending row. User-facing message surfaces any \`post_upload_patch\` warnings (\"Speicherpfad konnte nicht gesetzt werden — bitte in Paperless selbst anpassen\").
- **\`nein\` family** → delete pending row, soft-mark ChatUpload. No upload.
- **Anything else** → re-prompt up to 3 rounds via \`edit_rounds\`, force-abort after. Detailed edit parsing deferred to PR 5 (interactive card).

## ORM model additions (match existing pc20260424 migration)

- \`PaperlessPendingConfirm\` — transient confirm state, CASCADE to chat_uploads
- \`PaperlessExtractionExample\` — correction-feedback source, \`source\` field distinguishes confirm_diff (PR 2b primary) / paperless_ui_sweep (PR 4 secondary) / seed
- \`User.paperless_confirms_used\` column (migration already added it; ORM declaration needed for \`UPDATE\` statements)

## Tests — ~40 new unit tests across two files

- \`test_chat_upload_tool_paperless.py\`: auto-skip heuristic (7 cases), \`_infer_lang\`, \`_extraction_to_upload_params\`, \`_render_confirm_message\`, full \`forward_attachment_to_paperless\` paths (skip / cold-start / silent-post-cap / extraction-failure-fallback / validation)
- \`test_paperless_commit_tool.py\`: token families, unknown-token soft-404, approve path (bare + with proposals + already_exists), patch-failure user message, abort path (ja / abbrechen), ambiguous response re-prompt with budget

Pure-unit with heavy mocking; the existing \`make test-backend\` Docker path covers the full suite.

## End-to-end flow after this PR merges

\`\`\`
user uploads PDF
    ↓
agent → forward_attachment_to_paperless(attachment_id)
    ↓
extractor runs (Docling + LLM + fuzzy + taxonomy pruning)
    ↓
cold-start: agent relays German preview, user answers "ja"
    ↓
agent → paperless_commit_upload(confirm_token, "ja")
    ↓
creates fire (if any proposals approved), upload with metadata,
confirm-diff persisted, counter++, pending deleted
    ↓
10 such cycles → steady state: silent extraction + upload, no confirm
\`\`\`

## Test plan
- [x] Pure-unit helpers smoke-verified against clean env
- [ ] Full suite via \`make test-backend\`
- [ ] Manual: apply migration on a dev Postgres, upload a test PDF, watch the confirm flow end-to-end
- [ ] Cluster deploy: MCP v1.3.0 already live, Renfield image picks up new extractor + commit tool

## Prior PRs in this feature

- Design: #454, #455 (rev 3.1/3.2)
- MCP server: #5 (PR 1), #6 (list tools supplementary, v1.3.0)
- Renfield PR 2a: #456 (extractor core) — merged
- **This PR (2b):** confirm-flow integration
- Next: PR 3 (prompt augmentation from examples table), PR 4 (sweeper), PR 5 (interactive card, conditional)