### PR TITLE
docs(deploy-skill): reflect k8s topology — .159 build box, Harbor, private cluster

### DIFF
--- a/.claude/skills/deploy-production/SKILL.md
+++ b/.claude/skills/deploy-production/SKILL.md
@@ -11,6 +11,7 @@ disable-model-invocation: true
 - **Pi Zero 2 W SD cards are EXTREMELY fragile** — SIGKILL during restart can brick the device. Always ask before restarting satellite services. See `references/satellite-deploy.md`.
 - **Never force-push to main** and never bypass branch protection; main merges go through a PR (see `git-workflow` skill).
 - **CI is intentionally non-functional for this project** — run tests on the .159 build box, not in CI.
+- **ConfigMap-provided files are NOT in the image.** `mcp_servers.yaml`, `agent_roles.yaml`, `kg_scopes.yaml`, `mail_accounts.yaml` live only in the `renfield-mcp-config` ConfigMap. If the build-box working copy ever grows these as untracked files or directories at `src/backend/config/*`, the resulting image breaks the pod's subPath mount with `not a directory`. Keep `src/backend/.dockerignore` carving these paths out, and clean them on .159 if you see root-owned leftovers from kubelet bind-mount artefacts.
 
 ## Topology at a glance
 
@@ -26,28 +27,27 @@ Single-VM `renfield.local` deployment on `/opt/renfield` is legacy / build-box o
 
 Images live in Harbor and are pulled by the cluster via `imagePullPolicy: Always` on the `:latest` tag (or pinned tags like `:v1.3.1`).
 
+Both Dockerfiles expect **their own directory as the build context** — not the repo root. The Dockerfile's `COPY requirements.txt constraints.txt ./` and `COPY wakeword-models /app/wakeword-models` resolve against context root, and those files live at `src/backend/*`, not at the repo root.
+
 ```bash
 # From the build box (.159). You need to be logged in:
 docker login registry.treehouse.x-idra.de
 
 # Backend (CPU image, ~3.5 GB — torch pinned to +cpu wheels via constraints.txt)
+cd /opt/renfield/src/backend
 docker build -t registry.treehouse.x-idra.de/renfield/backend:latest \
-  -f src/backend/Dockerfile .
+             -t registry.treehouse.x-idra.de/renfield/backend:pr<N>-<sha> \
+             -f Dockerfile .
 docker push registry.treehouse.x-idra.de/renfield/backend:latest
+docker push registry.treehouse.x-idra.de/renfield/backend:pr<N>-<sha>
 
 # Frontend (Nginx serving React build, ~144 MB)
-docker build -t registry.treehouse.x-idra.de/renfield/frontend:latest \
-  -f src/frontend/Dockerfile src/frontend/
+cd /opt/renfield/src/frontend
+docker build -t registry.treehouse.x-idra.de/renfield/frontend:latest -f Dockerfile .
 docker push registry.treehouse.x-idra.de/renfield/frontend:latest
 ```
 
-Tag pinning (recommended over `:latest` for traceability):
-
-```bash
-docker tag registry.treehouse.x-idra.de/renfield/backend:latest \
-          registry.treehouse.x-idra.de/renfield/backend:v1.3.2
-docker push registry.treehouse.x-idra.de/renfield/backend:v1.3.2
-```
+Always build + push a pinned tag (`pr<N>-<sha>`) alongside `:latest` — gives you an immutable rollback target (`kubectl set image deploy/backend backend=.../backend:pr<N>-<sha>`).
 
 **Why the image stays ~3.5 GB:** `src/backend/constraints.txt` pins `torch`/`torchaudio`/`torchvision` to the `+cpu` wheels so transitive deps (docling, easyocr, transformers) can't drag in the 2.7 GB CUDA runtime + 641 MB triton. Don't lift that constraint unless you've thought through the Harbor push timeout.
 

--- a/.claude/skills/deploy-production/SKILL.md
+++ b/.claude/skills/deploy-production/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deploy-production
-description: Production deployment guide for Renfield. Covers Docker deployment, secrets management, satellite provisioning, and production safety rules. Triggers on "deploy", "Deployment", "production", "Produktion", "satellite deploy", "rsync", "renfield.local".
+description: Production deployment guide for Renfield. Build box .159, Harbor registry, private k8s cluster. Triggers on "deploy", "Deployment", "production", "Produktion", "satellite deploy", "kubectl apply", "rsync", "registry.treehouse".
 disable-model-invocation: true
 ---
 
@@ -8,43 +8,121 @@ disable-model-invocation: true
 
 ## CRITICAL SAFETY
 
-- **Pi Zero 2 W SD cards are EXTREMELY fragile** — SIGKILL during restart can brick the device
-- **NEVER** run `docker-compose.prod.yml` on production — keine GPU auf PRD!
-- **NEVER** change production config to make tests work — tests must work with existing production
-- **Frontend:** `docker-compose.yml` has `target: development` — on PRD must build with production target manually
+- **Pi Zero 2 W SD cards are EXTREMELY fragile** — SIGKILL during restart can brick the device. Always ask before restarting satellite services. See `references/satellite-deploy.md`.
+- **Never force-push to main** and never bypass branch protection; main merges go through a PR (see `git-workflow` skill).
+- **CI is intentionally non-functional for this project** — run tests on the .159 build box, not in CI.
 
-## Production Server
+## Topology at a glance
 
-- Host: `renfield.local` at `/opt/renfield`
-- No GPU — always use `docker compose up` (CPU-only), NOT `docker-compose.prod.yml`
+| Role | Where | Notes |
+|---|---|---|
+| Build box | `192.168.1.159` (`renfield.local` mDNS often flaky — use the IP) | Docker Compose up for dev/test only. Used for `docker build` + `docker push`. Runs the full backend/test stack so pytest is executed here. **Not production.** |
+| Container registry | `https://registry.treehouse.x-idra.de` | Harbor. Namespace paths used: `renfield/backend`, `renfield/frontend`. `harbor-pull-secret` already exists in the `renfield` k8s namespace. |
+| Production | Private k8s cluster (kubectl context **`renfield-private`**) | GPU-accelerated LLM, Traefik ingress, Longhorn storage, MetalLB LB at `192.168.1.230`. Canonical doc: `docs/KUBERNETES_DEPLOYMENT.md`. |
 
-## Deploy Workflow
+Single-VM `renfield.local` deployment on `/opt/renfield` is legacy / build-box only. Anything calling itself a "prod rsync" is referring to the build box, not production.
 
-```bash
-# 1. Sync code (exclude secrets)
-rsync -av --exclude='.env' --exclude='secrets/' --exclude='.git' --exclude='node_modules' ./ renfield.local:/opt/renfield/
+## Build + push workflow
 
-# 2. Rebuild backend (on production server)
-ssh renfield.local 'cd /opt/renfield && docker compose up -d --build'
-
-# 3. Frontend (MUST use production target!)
-ssh renfield.local 'cd /opt/renfield && \
-  docker build --target production -t renfield-frontend src/frontend/ && \
-  docker rm -f renfield-frontend && \
-  docker run -d --name renfield-frontend --network renfield_renfield-network --network-alias frontend --restart unless-stopped renfield-frontend && \
-  docker restart renfield-nginx'
-```
-
-**WARNING:** Do NOT use `docker compose up -d --build` for frontend on PRD — it builds the development target and breaks Nginx!
-
-## Database Migrations
+Images live in Harbor and are pulled by the cluster via `imagePullPolicy: Always` on the `:latest` tag (or pinned tags like `:v1.3.1`).
 
 ```bash
-ssh renfield.local 'docker exec -it renfield-backend alembic upgrade head'
+# From the build box (.159). You need to be logged in:
+docker login registry.treehouse.x-idra.de
+
+# Backend (CPU image, ~3.5 GB — torch pinned to +cpu wheels via constraints.txt)
+docker build -t registry.treehouse.x-idra.de/renfield/backend:latest \
+  -f src/backend/Dockerfile .
+docker push registry.treehouse.x-idra.de/renfield/backend:latest
+
+# Frontend (Nginx serving React build, ~144 MB)
+docker build -t registry.treehouse.x-idra.de/renfield/frontend:latest \
+  -f src/frontend/Dockerfile src/frontend/
+docker push registry.treehouse.x-idra.de/renfield/frontend:latest
 ```
 
-## See Also
+Tag pinning (recommended over `:latest` for traceability):
 
-- `references/secrets.md` — Docker secrets management
-- `references/docker-variants.md` — Docker Compose configurations
-- `references/satellite-deploy.md` — Satellite safety & provisioning
+```bash
+docker tag registry.treehouse.x-idra.de/renfield/backend:latest \
+          registry.treehouse.x-idra.de/renfield/backend:v1.3.2
+docker push registry.treehouse.x-idra.de/renfield/backend:v1.3.2
+```
+
+**Why the image stays ~3.5 GB:** `src/backend/constraints.txt` pins `torch`/`torchaudio`/`torchvision` to the `+cpu` wheels so transitive deps (docling, easyocr, transformers) can't drag in the 2.7 GB CUDA runtime + 641 MB triton. Don't lift that constraint unless you've thought through the Harbor push timeout.
+
+## Cluster rollout
+
+```bash
+kubectl config use-context renfield-private
+
+# Rolling restart to pull a new :latest
+kubectl -n renfield rollout restart deploy/backend
+kubectl -n renfield rollout restart deploy/document-worker
+kubectl -n renfield rollout restart deploy/frontend
+
+# Or pin an explicit tag
+kubectl -n renfield set image deploy/backend \
+  backend=registry.treehouse.x-idra.de/renfield/backend:v1.3.2
+
+# Watch the rollout
+kubectl -n renfield get pods -w
+```
+
+### Migrations
+
+```bash
+kubectl -n renfield apply -f k8s/alembic-upgrade-job.yaml
+kubectl -n renfield logs -f job/alembic-upgrade
+kubectl -n renfield delete job alembic-upgrade
+```
+
+The job uses the same backend image; if you just pushed a new image, run migrations before the deployment restart so the new code doesn't hit an old schema.
+
+### ConfigMap changes
+
+When `config/mcp_servers.yaml` / `config/agent_roles.yaml` / `config/kg_scopes.yaml` / `config/mail_accounts.*.yaml` change in the repo, rewrite the `renfield-mcp-config` ConfigMap **before** the rolling restart — otherwise pods get stuck in `ContainerCreating` on a missing subPath:
+
+```bash
+kubectl -n renfield create configmap renfield-mcp-config \
+  --from-file=config/mcp_servers.yaml \
+  --from-file=config/agent_roles.yaml \
+  --from-file=config/kg_scopes.yaml \
+  --from-file=mail_accounts.yaml=config/mail_accounts.default.yaml \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n renfield rollout restart deploy/backend
+```
+
+### Smoke test
+
+```bash
+curl -sk https://renfield.local/health   # {"status":"ok"}
+curl -sI http://renfield.local/          # 308 → https
+```
+
+## Build-box testing (not production)
+
+The .159 build box runs the full Docker Compose stack for integration testing. It's where pytest lives because CI doesn't run.
+
+```bash
+# Rsync the working copy to the build box (exclude secrets + scratch)
+rsync -avz --exclude='.env' --exclude='secrets/' --exclude='.git' \
+  --exclude='node_modules' --exclude='__pycache__' --exclude='tasks/' \
+  /Users/evdb/projects.ai/renfield/ 192.168.1.159:/opt/renfield/
+
+# Run the suite inside the backend container
+#   Source mount:  /opt/renfield/src/backend → /app
+#   Tests mount:   /opt/renfield/tests       → /tests
+ssh 192.168.1.159 "docker exec renfield-backend python -m pytest /tests/backend/... -q"
+```
+
+For a narrow-scope rsync of a few files, per-file `rsync` calls matching the repo layout are usually faster than a full tree sync. See `memory/reference_test_runner_159.md` for the full test-runner workflow including the "filter by subsystem + compare against pre-change tip via `git stash`" pattern used to distinguish regressions from the ~161 pre-existing failures.
+
+**Do NOT** treat the build-box Compose stack as production. It runs without GPU, has no Harbor pull credentials plumbed in, and is routinely reset during testing.
+
+## See also
+
+- `docs/KUBERNETES_DEPLOYMENT.md` — canonical manifest + cluster-inventory reference
+- `references/secrets.md` — Docker secrets + Harbor pull secret
+- `references/docker-variants.md` — Compose variants (dev vs. build-box vs. retired prod compose)
+- `references/satellite-deploy.md` — Satellite safety & provisioning (Ansible playbook, SD-card brick risk, 4-mic HAT gotchas)

--- a/src/backend/.dockerignore
+++ b/src/backend/.dockerignore
@@ -1,0 +1,30 @@
+# Dockerignore for the backend image. The build context is src/backend/ (not
+# the repo root — see .claude/skills/deploy-production/SKILL.md).
+#
+# The three YAML files below are provided by the `renfield-mcp-config`
+# ConfigMap at runtime via subPath mounts. They must NOT ship in the image:
+# kubelet subPath-mounting a file over a file works; over a directory or
+# missing path it fails with "not a directory". If a stray file or
+# directory with these names ends up in the build context (e.g. from
+# kubelet artifacts on the build box, or a local copy someone left
+# behind), the build would silently bake it in and every pod restart
+# after the next deploy would crashloop on the mount.
+config/mcp_servers.yaml
+config/agent_roles.yaml
+config/kg_scopes.yaml
+config/mail_accounts.yaml
+config/mail_accounts.default.yaml
+
+# Python bytecode caches, test artefacts, editor scratch.
+__pycache__
+*.pyc
+*.pyo
+.pytest_cache
+.mypy_cache
+.ruff_cache
+.coverage
+htmlcov
+
+# Virtualenvs shouldn't leak into the image.
+.venv
+venv


### PR DESCRIPTION
## Summary

The \`deploy-production\` skill still described the legacy single-VM deploy to \`renfield.local:/opt/renfield\`. Actual topology is now three distinct nodes:

- **Build box** at \`192.168.1.159\` (mDNS \`renfield.local\` is flaky — IP is the reliable form). Docker Compose stack for integration testing; pytest runs here because CI is intentionally non-functional.
- **Harbor registry** at \`https://registry.treehouse.x-idra.de\` with \`renfield/backend\` + \`renfield/frontend\` paths. \`harbor-pull-secret\` already exists in the \`renfield\` namespace.
- **Production** on the private k8s cluster (kubectl context \`renfield-private\`). Canonical reference: \`docs/KUBERNETES_DEPLOYMENT.md\`.

Replaces the build+push+rsync workflow with \`docker build\` → \`docker push\` to Harbor → \`kubectl rollout restart\` (or \`set image\` for a pinned tag). Build-box testing workflow kept as a secondary section so the rsync-and-pytest flow is still documented — just no longer conflated with prod.

## Test plan
- [x] Claims verified against \`docs/KUBERNETES_DEPLOYMENT.md\` (cluster inventory, manifest structure, Harbor naming)
- [x] Images already live in Harbor and are pulled with \`imagePullPolicy: Always\` — verified in \`k8s/backend.yaml\`, \`k8s/frontend.yaml\`, \`k8s/document-worker.yaml\`
- [ ] Human review: anything missing about Reva / twin deploy paths? (Those are private-repo downstream, may warrant a cross-link.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)