### PR TITLE
fix(alembic): auto-widen alembic_version.version_num to VARCHAR(64)

### DIFF
--- a/src/backend/alembic/env.py
+++ b/src/backend/alembic/env.py
@@ -169,6 +169,44 @@ def run_migrations_offline() -> None:
 
 
 def do_run_migrations(connection: Connection) -> None:
+    # Pre-migration bootstrap: ensure `alembic_version.version_num` is wide
+    # enough for our revision ID convention. Renfield uses human-readable
+    # IDs like `pc20260424_paperless_metadata_tables` which run up to ~40
+    # chars — Alembic's default column width is VARCHAR(32), so the first
+    # UPDATE would fail with `StringDataRightTruncationError` on a fresh
+    # DB and on any existing DB that still has the old 32-char column.
+    #
+    # Two idempotent operations handle both cases:
+    #   1. CREATE TABLE IF NOT EXISTS with VARCHAR(64) — covers fresh
+    #      installs. If the table already exists, this is a no-op and the
+    #      pre-existing column width is preserved.
+    #   2. Conditional ALTER to widen — covers existing installs that
+    #      were provisioned before this bootstrap existed (e.g. the prod
+    #      DB before PR 2a). Checks information_schema to stay idempotent.
+    #
+    # Both run in the same connection that Alembic will then configure;
+    # they're committed implicitly by the wrapping greenlet_spawn /
+    # asyncpg auto-commit semantics before `context.run_migrations()`
+    # opens its own transactions per migration.
+    connection.exec_driver_sql(
+        "CREATE TABLE IF NOT EXISTS alembic_version ("
+        "  version_num VARCHAR(64) NOT NULL,"
+        "  CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num)"
+        ")"
+    )
+    connection.exec_driver_sql(
+        "DO $$ BEGIN "
+        "  IF (SELECT character_maximum_length "
+        "      FROM information_schema.columns "
+        "      WHERE table_name='alembic_version' "
+        "        AND column_name='version_num') < 64 "
+        "  THEN "
+        "    ALTER TABLE alembic_version "
+        "    ALTER COLUMN version_num TYPE VARCHAR(64); "
+        "  END IF; "
+        "END $$;"
+    )
+
     context.configure(connection=connection, target_metadata=target_metadata)
 
     with context.begin_transaction():


### PR DESCRIPTION
## Summary

Renfield uses human-readable revision IDs (e.g. \`pc20260424_paperless_metadata_tables\`, 36 chars) that overflow Alembic's default \`VARCHAR(32)\` \`alembic_version.version_num\` column.

This bit prod during the PR 4 deploy — the migration job crashloop'd with \`StringDataRightTruncationError: value too long for type character varying(32)\`. Manual recovery was an \`ALTER TABLE alembic_version ALTER COLUMN version_num TYPE VARCHAR(64)\` against the running DB.

This PR moves the fix into \`env.py\` so fresh-DB installs (and any other environments transitioning) handle it without out-of-band SQL.

### How
Two idempotent statements before \`context.run_migrations()\`:
- \`CREATE TABLE IF NOT EXISTS alembic_version (..., VARCHAR(64))\` — fresh DBs get the wider column before Alembic would have created it at the default width.
- Conditional \`ALTER ... TYPE VARCHAR(64)\` via \`DO\` block that checks \`information_schema\` — covers existing DBs provisioned before this lands. No-op after the first run.

### Why not a migration
An Alembic migration can't widen the table it writes its own bookkeeping to — the crash happens on the \`UPDATE alembic_version\` that the migration machinery emits after the migration's \`upgrade()\` returns. Needs to run as setup.

## Test plan
- [x] Prod was fixed by this exact ALTER during the PR 4 deploy — the pattern is proven.
- [ ] Fresh-DB install: new Postgres, \`alembic upgrade head\` from base — should traverse all PR 2a+ migrations without truncation error.
- [ ] Existing-DB re-run: already-widened DB, \`alembic upgrade head\` — should be a no-op on the bootstrap SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)