### PR TITLE
fix(e2e): point health-check test at /health/ready

### DIFF
--- a/tests/e2e/test_ui_post_deploy.py
+++ b/tests/e2e/test_ui_post_deploy.py
@@ -159,7 +159,11 @@ def test_all():
         # ============================================================
         print("\n🏥 6. Health Check (sanitized errors)")
         try:
-            page.goto(f"{BASE_URL}/api/health/ready", wait_until="networkidle", timeout=10000)
+            # Health routes are mounted at the root (`/health` + `/health/ready`),
+            # not under `/api/*`. The readiness probe returns a JSON body with
+            # `"status": "healthy|unhealthy|degraded"` that the assertions below
+            # match on.
+            page.goto(f"{BASE_URL}/health/ready", wait_until="networkidle", timeout=10000)
             body = page.locator("body").inner_text()
             page.screenshot(path=f"{SCREENSHOTS}/06_health.png")
 


### PR DESCRIPTION
## Summary

Tiny test-only fix. The post-deploy UI test fetched \`/api/health/ready\` — but the readiness route is mounted at the root (\`@app.get(\"/health/ready\")\` in \`main.py\`), not under \`/api/*\`. Prod returns 404 at the wrong path, so the test asserted \`healthy|unhealthy|degraded\` against \`{\"detail\":\"Not Found\"}\` and failed.

Surfaced during the PR 4 post-deploy E2E run (14/15 pass → failing the health probe). Everything else in the suite was already green against prod.

## Test plan
- [x] Re-ran the full \`tests/e2e/test_ui_post_deploy.py\` against https://renfield.local after the fix: **15/15 pass**.
- [x] \`curl -sk https://renfield.local/health/ready\` returns the full readiness JSON; \`/api/health/ready\` is 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)