### PR TITLE
fix(audit): close KRITISCH findings K1-K7 (N+1, Secrets, env config)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,139 +1,464 @@
-# === Secrets ===
-# Für Produktion: ./bin/generate-secrets.sh ausführen (Docker Compose Secrets)
-# Für Entwicklung: Werte hier direkt setzen
+# =============================================================================
+# Renfield — Environment Configuration
+# =============================================================================
+#
+# This file is a complete reference of every env var Renfield reads. Values
+# shown are the defaults the code falls back to when the variable is unset.
+#
+# Secrets management:
+#   Development:  set plaintext values in `.env` at the repo root.
+#   Production:   run `./bin/generate-secrets.sh` to create files in secrets/
+#                 and use `docker-compose.prod.yml` — sensitive values are
+#                 read via `secrets_dir=/run/secrets`, NOT from .env.
+#
+# Two Settings classes live side-by-side:
+#   - utils.config.Settings      (platform — most of this file)
+#   - ha_glue.utils.config.HaGlueSettings  (Home Assistant / smart home —
+#     marked "[HA-GLUE]" below). Both read the same env space; names below
+#     are authoritative and match Python field names (uppercased).
+#
+# All fields documented here must exist in one of those classes. If you add
+# a new Setting, add it to this file too.
+#
+# =============================================================================
 
-# Datenbank
-# POSTGRES_PASSWORD=changeme  (Produktion: secrets/postgres_password)
+# -----------------------------------------------------------------------------
+# Edition / Feature Flags
+# -----------------------------------------------------------------------------
+# RENFIELD_EDITION: "community" (home assistant + RAG, default) or "pro"
+#                   (business, no smart home / cameras / satellites / voice)
+# Each FEATURE_* override is tri-state: unset → use edition preset, true/false
+# → force on/off regardless of edition.
+# RENFIELD_EDITION=community
+# FEATURE_SMART_HOME=
+# FEATURE_CAMERAS=
+# FEATURE_SATELLITES=
+# FEATURE_VOICE=
+# FEATURE_TASKS=
+# FEATURE_KNOWLEDGE=
+# FEATURE_KNOWLEDGE_GRAPH=
 
-# Home Assistant
-HOME_ASSISTANT_URL=http://homeassistant.local:8123
-# HOME_ASSISTANT_TOKEN=your_token  (Produktion: secrets/home_assistant_token)
+# -----------------------------------------------------------------------------
+# Database (PostgreSQL + pgvector)
+# -----------------------------------------------------------------------------
+# If DATABASE_URL is set, it takes precedence over the POSTGRES_* fields.
+# Otherwise the URL is assembled at startup from:
+#   postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+# DATABASE_URL=
+# POSTGRES_USER=renfield
+# POSTGRES_PASSWORD=changeme          # Production: secrets/postgres_password
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+POSTGRES_DB=renfield
+# DB_POOL_SIZE=10                     # SQLAlchemy pool_size (1-100)
+# DB_MAX_OVERFLOW=20                  # Max overflow connections (0-200)
+# DB_POOL_RECYCLE=3600                # Recycle after N seconds (60-86400)
 
-# n8n (Workflow Automation via MCP)
-# N8N_MCP_ENABLED=false
-# N8N_BASE_URL=http://n8n.local:5678      # Used in Pydantic Settings
-# N8N_API_URL=http://n8n.local:5678       # Used by n8n-mcp stdio subprocess
-# N8N_API_KEY=your_n8n_api_key            # n8n → Settings → API → Create API Key
+# -----------------------------------------------------------------------------
+# Redis (queues, caching, federation pending state)
+# -----------------------------------------------------------------------------
+REDIS_URL=redis://redis:6379
 
-# Calendar (Unified Calendar MCP Server — EWS, Google, CalDAV)
-# CALENDAR_ENABLED=false
-# CALENDAR_CONFIG=/config/calendar_accounts.yaml
-# Exchange (EWS): CALENDAR_WORK_USERNAME, CALENDAR_WORK_PASSWORD
-# Google Calendar: credentials.json + initial OAuth (see docs/kalender-integration-plan.md)
-# Nextcloud CalDAV: CALENDAR_VEREIN_USERNAME, CALENDAR_VEREIN_PASSWORD
-
-# Email MCP (IMAP/SMTP via renfield-mcp-mail)
-# EMAIL_MCP_ENABLED=false
-# MAIL_ACCOUNTS_CONFIG=/config/mail_accounts.yaml
-# One env var per mail account declared in mail_accounts.yaml; the name is
-# set via `password_env:` in that file. Example:
-# MAIL_PRIMARY_PASSWORD=                  # (Production: secrets/mail_primary_password)
-
-# Evolution API (WhatsApp — self-hosted, Profile: whatsapp)
-# EVOLUTION_API_KEY=                      # Starker zufaelliger Key fuer Evolution API Auth
-# EVOLUTION_API_URL=http://evolution-api:8080  # Docker-interne URL (n8n → Evolution)
-
-# Frigate (Kamera-System)
-FRIGATE_URL=http://frigate.local:5000
-
-# Ollama LLM
-# URL zur Ollama-Instanz (Standard: http://ollama:11434 für Docker-Container)
-# Für externe GPU-Instanz z.B.: http://cuda.local:11434
+# -----------------------------------------------------------------------------
+# Ollama (local LLM inference)
+# -----------------------------------------------------------------------------
+# Single Ollama host for all models by default. Set OLLAMA_FALLBACK_URL when
+# primary points at an external GPU (e.g. cuda.local) that may go offline —
+# fallback is typically the Docker host's own Ollama.
 OLLAMA_URL=http://ollama:11434
-
-# Optional: Fallback-Ollama wenn OLLAMA_URL nicht erreichbar (z.B. GPU-Host offline)
-# Empfohlen wenn OLLAMA_URL auf ein externes Gerät zeigt (cuda.local etc.)
-# Im Container: http://host.docker.internal:11434 = Ollama auf dem Docker-Host
 # OLLAMA_FALLBACK_URL=http://host.docker.internal:11434
+# OLLAMA_EMBED_URL=                   # Dedicated embedding host (default: OLLAMA_URL)
+# OLLAMA_VISION_URL=                  # Dedicated vision host (default: OLLAMA_URL)
+# OLLAMA_CONNECT_TIMEOUT=10.0         # TCP connect timeout (fast-fail when host down)
+# OLLAMA_READ_TIMEOUT=300.0           # Read timeout for long LLM responses
+# OLLAMA_NUM_CTX=32768                # Context window for all Ollama calls
 
-# Optional: Separate Ollama-Instanz für Embedding-Erzeugung
-# Nützlich wenn die GPU-Instanz unter Last steht (z.B. während Dokument-Ingestion)
-# OLLAMA_EMBED_URL=http://host.docker.internal:11434
+# Multi-model config (see docs/LLM_MODEL_GUIDE.md). Defaults are dev values;
+# production should pin to qwen3:14b / qwen3-embedding:4b.
+OLLAMA_CHAT_MODEL=qwen3:14b
+OLLAMA_RAG_MODEL=qwen3:14b
+OLLAMA_EMBED_MODEL=qwen3-embedding:4b
+OLLAMA_INTENT_MODEL=qwen3:8b
+# OLLAMA_MODEL=llama3.2:3b            # Legacy fallback
+# OLLAMA_VISION_MODEL=                # Empty = vision disabled. Example: minicpm-v
+# PAPERLESS_EXTRACTION_MODEL=         # Falls back to vision → chat
 
-# Timeout-Konfiguration (Standard: connect=10s, read=300s)
-# OLLAMA_CONNECT_TIMEOUT=10.0
-# OLLAMA_READ_TIMEOUT=300.0
-
-# Multi-Modell Konfiguration (see docs/LLM_MODEL_GUIDE.md for recommendations)
-OLLAMA_CHAT_MODEL=qwen3:14b        # Für normale Konversation (empfohlen: qwen3:14b)
-OLLAMA_RAG_MODEL=qwen3:14b         # Für RAG-Antworten (empfohlen: qwen3:14b)
-OLLAMA_EMBED_MODEL=qwen3-embedding:4b # Für Embeddings (768 Dimensionen, empfohlen: qwen3-embedding:4b)
-OLLAMA_INTENT_MODEL=qwen3:8b       # Für Intent-Erkennung (empfohlen: qwen3:8b)
-
-# Legacy (wird als OLLAMA_CHAT_MODEL verwendet falls gesetzt)
-OLLAMA_MODEL=qwen3:8b
-
-# Sprache
+# -----------------------------------------------------------------------------
+# Language / Voice (Whisper STT + Piper TTS)
+# -----------------------------------------------------------------------------
 DEFAULT_LANGUAGE=de
+SUPPORTED_LANGUAGES=de,en
 WHISPER_MODEL=base
+# WHISPER_INITIAL_PROMPT=
+# WHISPER_PREPROCESS_ENABLED=true
+# WHISPER_PREPROCESS_NOISE_REDUCE=true
+# WHISPER_PREPROCESS_NORMALIZE=true
+# WHISPER_PREPROCESS_TARGET_DB=-20.0
 PIPER_VOICE=de_DE-thorsten-high
+PIPER_VOICES=de:de_DE-thorsten-high,en:en_US-amy-medium
 
-# Optional: OpenAI API für Fallback (falls offline nicht ausreicht)
-# OPENAI_API_KEY=sk-...
+# Speaker Recognition (pyannote-based voice identification)
+# SPEAKER_RECOGNITION_ENABLED=true
+# SPEAKER_RECOGNITION_THRESHOLD=0.25
+# SPEAKER_RECOGNITION_DEVICE=cpu      # or "cuda"
+# SPEAKER_AUTO_ENROLL=true
+# SPEAKER_CONTINUOUS_LEARNING=true
 
-# RAG (Retrieval-Augmented Generation)
-RAG_ENABLED=true
-RAG_CHUNK_SIZE=512              # Token-Limit pro Chunk
-RAG_CHUNK_OVERLAP=50            # Überlappung zwischen Chunks
-RAG_TOP_K=5                     # Anzahl der relevantesten Chunks pro Anfrage
-RAG_SIMILARITY_THRESHOLD=0.7    # Minimum Similarity (0-1)
+# -----------------------------------------------------------------------------
+# Output routing / advertised address
+# -----------------------------------------------------------------------------
+# ADVERTISE_HOST is the hostname/IP external services (like Home Assistant)
+# should use to reach the backend. Leave empty to fall back to
+# BACKEND_INTERNAL_URL for Docker-internal callers.
+# ADVERTISE_HOST=
+# ADVERTISE_PORT=8000
+# BACKEND_INTERNAL_URL=http://backend:8000
 
-# Document Upload
-UPLOAD_DIR=/app/data/uploads
-MAX_FILE_SIZE_MB=50
-ALLOWED_EXTENSIONS=pdf,docx,doc,txt,md,html,pptx,xlsx
+# -----------------------------------------------------------------------------
+# Wake word (opt-in)
+# -----------------------------------------------------------------------------
+# WAKE_WORD_ENABLED=false
+# WAKE_WORD_DEFAULT=hey_renfield
+# WAKE_WORD_THRESHOLD=0.5
+# WAKE_WORD_COOLDOWN_MS=2000
 
-# Agent Loop (ReAct — Multi-Step Tool Chaining)
-AGENT_ENABLED=false
-# AGENT_MAX_STEPS=5
+# -----------------------------------------------------------------------------
+# Agent Loop (ReAct — multi-step tool chaining)
+# -----------------------------------------------------------------------------
+# AGENT_ENABLED=false
+# AGENT_MAX_STEPS=12
 # AGENT_STEP_TIMEOUT=30.0
 # AGENT_TOTAL_TIMEOUT=120.0
-# AGENT_MODEL=                       # Optional: eigenes Modell für Agent
+# AGENT_MODEL=                        # Optional separate model
+# AGENT_OLLAMA_URL=                   # Optional separate host
+# AGENT_CONV_CONTEXT_MESSAGES=12
+# CONVERSATION_SUMMARY_THRESHOLD=10
+# AGENT_ROLES_PATH=config/agent_roles.yaml
+# AGENT_ROUTER_TIMEOUT=30.0
+# AGENT_ROUTER_MODEL=
+# AGENT_ROUTER_URL=
+# AGENT_ORCHESTRATOR_ENABLED=false
+# AGENT_HISTORY_LIMIT=20
+# AGENT_RESPONSE_TRUNCATION=2000
+# AGENT_BUDGET_THRESHOLD=0.85
+# AGENT_PARALLEL_TOOLS=true
+# AGENT_ORCHESTRATOR_PARALLEL=true
+# AGENT_DEFAULT_TEMPERATURE=0.1
+# AGENT_DEFAULT_NUM_PREDICT=2048
 
-# MCP Client (Model Context Protocol — externe Tool-Server)
-MCP_ENABLED=false
+# -----------------------------------------------------------------------------
+# MCP Client (Model Context Protocol — external tool servers)
+# -----------------------------------------------------------------------------
+# MCP_ENABLED=false
 # MCP_CONFIG_PATH=config/mcp_servers.yaml
 # MCP_REFRESH_INTERVAL=60
 # MCP_CONNECT_TIMEOUT=10.0
 # MCP_CALL_TIMEOUT=30.0
+# MCP_MAX_RESPONSE_SIZE=10240         # Bytes; large responses are truncated
 
-# MCP Server-spezifische Variablen (Beispiele)
-# HA_MCP_ENABLED=false
-# HA_MCP_URL=http://homeassistant.local:8123/api/mcp
+# MCP server toggles (mirror mcp_servers.yaml)
+# WEATHER_ENABLED=false
+# NEWS_ENABLED=false
+# SEARCH_ENABLED=false
+# CALENDAR_ENABLED=false
 
-# Conversation Memory (Langzeitgedaechtnis)
-# MEMORY_ENABLED=false                       # Langzeitgedaechtnis aktivieren (opt-in)
-# MEMORY_EXTRACTION_ENABLED=false            # Fakten automatisch aus Dialogen extrahieren
+# -----------------------------------------------------------------------------
+# Embeddings
+# -----------------------------------------------------------------------------
+# EMBEDDING_DIMENSION=768             # Must match OLLAMA_EMBED_MODEL output
 
-# Proaktive Benachrichtigungen (Webhooks von HA-Automationen)
-# PROACTIVE_ENABLED=false              # Master-Switch (opt-in)
-# PROACTIVE_SUPPRESSION_WINDOW=60      # Dedup-Fenster in Sekunden
-# PROACTIVE_TTS_DEFAULT=true           # TTS standardmäßig an
-# PROACTIVE_NOTIFICATION_TTL=86400     # Ablauf in Sekunden (24h)
+# -----------------------------------------------------------------------------
+# RAG (Retrieval-Augmented Generation)
+# -----------------------------------------------------------------------------
+# RAG_ENABLED=true
+# RAG_CHUNK_SIZE=512
+# RAG_CHUNK_OVERLAP=50
+# RAG_TOP_K=20
+# RAG_SIMILARITY_THRESHOLD=0.4
+# RAG_EMBEDDING_TIMEOUT=30.0
 
-# Phase 2: Notification Intelligence (alle opt-in)
-# PROACTIVE_SEMANTIC_DEDUP_ENABLED=false       # Semantische Deduplizierung via pgvector
-# PROACTIVE_SEMANTIC_DEDUP_THRESHOLD=0.85      # Cosine Similarity Schwelle
-# PROACTIVE_URGENCY_AUTO_ENABLED=false         # LLM-basierte Urgency-Klassifizierung
-# PROACTIVE_ENRICHMENT_ENABLED=false           # LLM Content Enrichment
-# PROACTIVE_ENRICHMENT_MODEL=                  # Optionales separates Modell
-# PROACTIVE_FEEDBACK_LEARNING_ENABLED=false    # Feedback-basierte Unterdrückung
-# PROACTIVE_FEEDBACK_SIMILARITY_THRESHOLD=0.80 # Schwelle für semantisches Matching
+# Hybrid search (BM25 + dense)
+# RAG_HYBRID_ENABLED=true
+# RAG_HYBRID_BM25_WEIGHT=0.5
+# RAG_HYBRID_DENSE_WEIGHT=0.5
+# RAG_HYBRID_RRF_K=60
+# RAG_HYBRID_FTS_CONFIG=german        # simple | german | english
 
-# MCP Notification Polling (opt-in) — polls MCP servers for proactive notifications
-# NOTIFICATION_POLLER_ENABLED=false             # Master switch for MCP notification polling
-# NOTIFICATION_POLLER_STARTUP_DELAY=30          # Delay before first poll (seconds)
+# Context window / parent-child chunking
+# RAG_CONTEXT_WINDOW=1
+# RAG_CONTEXT_WINDOW_MAX=3
+# RAG_CONTEXTUAL_RETRIEVAL=true
+# RAG_CONTEXTUAL_MODEL=
+# RAG_PARENT_CHILD_ENABLED=true
+# RAG_CHILD_CHUNK_SIZE=256
+# RAG_PARENT_CHUNK_SIZE=1024
 
-# Reminders (opt-in)
-# PROACTIVE_REMINDERS_ENABLED=false            # Timer-Erinnerungen
-# PROACTIVE_REMINDER_CHECK_INTERVAL=15         # Prüfintervall in Sekunden
+# Reranking
+# RAG_RERANK_ENABLED=true
+# RAG_RERANK_MODEL=mxbai-rerank-base-v1
+# RAG_RERANK_TOP_K=5
 
-# Scheduling (Cron-basiert): Wird extern via n8n-Workflows oder HA-Automationen gelöst.
-# Diese senden per Webhook an POST /api/notifications/webhook.
-# Siehe: docs/PROACTIVE_SCHEDULING_TEMPLATES.md
+# OCR
+# RAG_FORCE_OCR=false
+# RAG_OCR_AUTO_DETECT=true
+# RAG_OCR_SPACE_THRESHOLD=0.03
 
-# Monitoring
-# METRICS_ENABLED=false                # Prometheus /metrics Endpoint (opt-in)
+# -----------------------------------------------------------------------------
+# Conversation Memory (long-term semantic memory, opt-in)
+# -----------------------------------------------------------------------------
+# MEMORY_ENABLED=false
+# MEMORY_RETRIEVAL_LIMIT=3
+# MEMORY_RETRIEVAL_THRESHOLD=0.7
+# MEMORY_MAX_PER_USER=500
+# MEMORY_CONTEXT_DECAY_DAYS=30
+# MEMORY_DEDUP_THRESHOLD=0.9
+# MEMORY_EXTRACTION_ENABLED=false
+# MEMORY_EXTRACTION_MODEL=
+# MEMORY_CLEANUP_INTERVAL=3600
+# MEMORY_ESSENTIAL_THRESHOLD=0.9
+# MEMORY_CONTRADICTION_RESOLUTION=false
+# MEMORY_CONTRADICTION_THRESHOLD=0.6
+# MEMORY_CONTRADICTION_TOP_K=5
+# MEMORY_EPISODIC_ENABLED=false
+# MEMORY_EPISODIC_MAX_PER_USER=100
+# MEMORY_EPISODIC_DECAY_DAYS=90
+# MEMORY_EPISODIC_SUMMARIZE_THRESHOLD=50
+# MEMORY_RELEVANCE_FILTER_ENABLED=true
+# MEMORY_RETRIEVAL_BUDGET_CHARS=2000
 
-# Logging
+# -----------------------------------------------------------------------------
+# Knowledge Graph (entity-relation triples, opt-in)
+# -----------------------------------------------------------------------------
+# KNOWLEDGE_GRAPH_ENABLED=false
+# KG_EXTRACTION_MODEL=
+# KG_SIMILARITY_THRESHOLD=0.85
+# KG_RETRIEVAL_THRESHOLD=0.70
+# KG_MAX_ENTITIES_PER_USER=5000
+# KG_MAX_CONTEXT_TRIPLES=15
+
+# -----------------------------------------------------------------------------
+# Document Upload
+# -----------------------------------------------------------------------------
+UPLOAD_DIR=/app/data/uploads
+MAX_FILE_SIZE_MB=50
+ALLOWED_EXTENSIONS=pdf,docx,doc,txt,md,html,pptx,xlsx,png,jpg,jpeg
+# CHAT_UPLOAD_MAX_CONTEXT_CHARS=50000
+# CHAT_UPLOAD_AUTO_INDEX=true
+# CHAT_UPLOAD_DEFAULT_KB_NAME=Chat Uploads
+# CHAT_UPLOAD_RETENTION_DAYS=30
+# CHAT_UPLOAD_CLEANUP_ENABLED=false
+# CHAT_UPLOAD_EMAIL_ACCOUNT=primary
+
+# -----------------------------------------------------------------------------
+# Federation (v2 — peer-to-peer Renfield mesh, opt-in)
+# -----------------------------------------------------------------------------
+# FEDERATION_MAX_DEPTH=3
+# FEDERATION_ASKER_RATE_PER_MINUTE=60
+# FEDERATION_RESPONDER_RATE_PER_MINUTE=30
+# FEDERATION_PENDING_USE_REDIS=false  # Set true for multi-worker deploys
+
+# -----------------------------------------------------------------------------
+# Monitoring / Logging
+# -----------------------------------------------------------------------------
+# METRICS_ENABLED=false               # Prometheus /metrics endpoint
 LOG_LEVEL=INFO
+
+# -----------------------------------------------------------------------------
+# Security — Core
+# -----------------------------------------------------------------------------
+# SECRET_KEY=changeme-in-production   # Production: secrets/secret_key
+# TRUSTED_PROXIES=                    # Comma-separated CIDRs, e.g.
+                                      # "172.18.0.0/16,127.0.0.1"
+
+# -----------------------------------------------------------------------------
+# Authentication / Authorization
+# -----------------------------------------------------------------------------
+# AUTH_ENABLED=false                  # Enable auth (default off for dev)
+# ACCESS_TOKEN_EXPIRE_MINUTES=1440    # 24h
+# REFRESH_TOKEN_EXPIRE_DAYS=30
+# PASSWORD_MIN_LENGTH=8
+# ALLOW_REGISTRATION=true
+# REQUIRE_EMAIL_VERIFICATION=false
+# VOICE_AUTH_ENABLED=false
+# VOICE_AUTH_MIN_CONFIDENCE=0.7
+# DEFAULT_ADMIN_USERNAME=admin
+# DEFAULT_ADMIN_PASSWORD=changeme     # Production: secrets/default_admin_password
+
+# -----------------------------------------------------------------------------
+# CORS / WebSocket / Rate limiting
+# -----------------------------------------------------------------------------
+# CORS_ORIGINS=*
+# WS_AUTH_ENABLED=false               # Set true in production
+# WS_TOKEN_EXPIRE_MINUTES=60
+# WS_RATE_LIMIT_ENABLED=true
+# WS_RATE_LIMIT_PER_SECOND=50
+# WS_RATE_LIMIT_PER_MINUTE=1000
+# WS_MAX_CONNECTIONS_PER_IP=10
+# WS_MAX_MESSAGE_SIZE=1000000         # 1 MB
+# WS_MAX_AUDIO_BUFFER_SIZE=10000000   # 10 MB
+# WS_PROTOCOL_VERSION=1.0
+
+# REST API rate limiting (slowapi expressions)
+# API_RATE_LIMIT_ENABLED=true
+# API_RATE_LIMIT_DEFAULT=100/minute
+# API_RATE_LIMIT_AUTH=10/minute
+# API_RATE_LIMIT_VOICE=30/minute
+# API_RATE_LIMIT_CHAT=60/minute
+# API_RATE_LIMIT_ADMIN=200/minute
+
+# Device / satellite session timeouts
+# DEVICE_SESSION_TIMEOUT=30.0
+# DEVICE_HEARTBEAT_TIMEOUT=60.0
+
+# -----------------------------------------------------------------------------
+# Circuit Breaker (LLM + agent recovery)
+# -----------------------------------------------------------------------------
+# CB_FAILURE_THRESHOLD=3
+# CB_LLM_RECOVERY_TIMEOUT=30.0
+# CB_AGENT_RECOVERY_TIMEOUT=60.0
+
+# -----------------------------------------------------------------------------
+# Proactive Notifications (webhooks, reminders, opt-in)
+# -----------------------------------------------------------------------------
+# PROACTIVE_ENABLED=false
+# PROACTIVE_SUPPRESSION_WINDOW=60
+# PROACTIVE_TTS_DEFAULT=true
+# PROACTIVE_NOTIFICATION_TTL=86400
+
+# Phase 2: intelligence
+# PROACTIVE_SEMANTIC_DEDUP_ENABLED=false
+# PROACTIVE_SEMANTIC_DEDUP_THRESHOLD=0.85
+# PROACTIVE_URGENCY_AUTO_ENABLED=false
+# PROACTIVE_ENRICHMENT_ENABLED=false
+# PROACTIVE_ENRICHMENT_MODEL=
+# PROACTIVE_FEEDBACK_LEARNING_ENABLED=false
+# PROACTIVE_FEEDBACK_SIMILARITY_THRESHOLD=0.80
+
+# Phase 3: reminders
+# PROACTIVE_REMINDERS_ENABLED=false
+# PROACTIVE_REMINDER_CHECK_INTERVAL=15
+
+# MCP notification polling (fires proactive events from MCP servers)
+# NOTIFICATION_POLLER_ENABLED=false
+# NOTIFICATION_POLLER_STARTUP_DELAY=30
+
+# Intent feedback cache
+# INTENT_FEEDBACK_CACHE_TTL=300
+
+# n8n
+# N8N_TIMEOUT=30.0
+# N8N_BASE_URL=http://n8n.local:5678   # Pydantic field
+# N8N_API_URL=http://n8n.local:5678    # n8n-mcp stdio subprocess
+# N8N_API_KEY=                         # Production: secrets/n8n_api_key
+# N8N_MCP_ENABLED=false
+
+# -----------------------------------------------------------------------------
+# SearXNG
+# -----------------------------------------------------------------------------
+# SEARXNG_API_URL=
+# SEARXNG_INSTANCES=
+
+# -----------------------------------------------------------------------------
+# Email MCP
+# -----------------------------------------------------------------------------
+# EMAIL_MCP_ENABLED=false
+# MAIL_ACCOUNTS_CONFIG=/config/mail_accounts.yaml
+# MAIL_PRIMARY_PASSWORD=               # Production: secrets/mail_primary_password
+
+# -----------------------------------------------------------------------------
+# Evolution API (WhatsApp — self-hosted, consumed by n8n workflows)
+# -----------------------------------------------------------------------------
+# EVOLUTION_API_KEY=
+# EVOLUTION_API_URL=http://evolution-api:8080
+
+# -----------------------------------------------------------------------------
+# Plugin system
+# -----------------------------------------------------------------------------
+# PLUGIN_MODULE=                      # e.g. "renfield_twin.hooks:register"
+
+# =============================================================================
+# [HA-GLUE] Home Assistant / smart-home configuration
+# =============================================================================
+# Everything below is defined in ha_glue.utils.config.HaGlueSettings. Platform
+# deploys without ha_glue/ installed ignore these fields.
+# -----------------------------------------------------------------------------
+
+# Home Assistant
+HOME_ASSISTANT_URL=http://homeassistant.local:8123
+# HOME_ASSISTANT_TOKEN=                # Production: secrets/home_assistant_token
+
+# Frigate (cameras / NVR)
+FRIGATE_URL=http://frigate.local:5000
+# FRIGATE_TIMEOUT=10.0
+
+# HA integration cache / timeout
+# HA_TIMEOUT=10.0
+# HA_CACHE_TTL=300
+# HA_MCP_ENABLED=false
+
+# Paperless-NGX
+# PAPERLESS_ENABLED=false
+# PAPERLESS_API_URL=
+# PAPERLESS_API_TOKEN=                 # Production: secrets/paperless_api_token
+
+# Paperless Audit (opt-in housekeeping)
+# PAPERLESS_AUDIT_ENABLED=false
+# PAPERLESS_AUDIT_MODEL=
+# PAPERLESS_AUDIT_SCHEDULE=02:00
+# PAPERLESS_AUDIT_FIX_MODE=review     # review | auto_threshold | auto_all
+# PAPERLESS_AUDIT_CONFIDENCE_THRESHOLD=0.9
+# PAPERLESS_AUDIT_OCR_THRESHOLD=2
+# PAPERLESS_AUDIT_BATCH_DELAY=2.0
+
+# Presence Detection (BLE room-level)
+# PRESENCE_ENABLED=false
+# PRESENCE_STALE_TIMEOUT=120
+# PRESENCE_HYSTERESIS_SCANS=2
+# PRESENCE_RSSI_THRESHOLD=-80
+# PRESENCE_HOUSEHOLD_ROLES=Admin,Familie
+# PRESENCE_WEBHOOK_URL=
+# PRESENCE_WEBHOOK_SECRET=             # Production: secrets/presence_webhook_secret
+# PRESENCE_ANALYTICS_RETENTION_DAYS=90
+
+# Media Follow Me (playback follows user between rooms)
+# MEDIA_FOLLOW_ENABLED=false           # Requires PRESENCE_ENABLED=true
+# MEDIA_FOLLOW_SUSPEND_TIMEOUT=600.0
+# MEDIA_FOLLOW_RESUME_DELAY=2.0
+
+# Radio (TuneIn)
+# RADIO_ENABLED=false
+# TUNEIN_PARTNER_ID=
+
+# Jellyfin
+# JELLYFIN_ENABLED=false
+# JELLYFIN_URL=
+# JELLYFIN_BASE_URL=                   # Production: secrets/jellyfin_base_url
+# JELLYFIN_API_KEY=                    # Production: secrets/jellyfin_api_key
+# JELLYFIN_TOKEN=                      # Production: secrets/jellyfin_token
+# JELLYFIN_USER_ID=                    # Production: secrets/jellyfin_user_id
+
+# Satellite OTA Updates
+# SATELLITE_LATEST_VERSION=1.0.0
+# SATELLITE_PACKAGE_CACHE_TTL=300
+
+# Rooms
+# ROOMS_AUTO_CREATE_FROM_SATELLITE=true
+
+# =============================================================================
+# Frontend build-time variables (Vite, consumed by src/frontend/Dockerfile)
+# =============================================================================
+# These are NOT read by the Python backend. docker-compose.prod*.yml passes
+# them as `args:` into the frontend build, where Vite bakes them into the
+# production bundle. Leaving them empty causes the frontend to use same-origin
+# URLs (which is what you want behind the nginx reverse proxy). Set them
+# explicitly only when the frontend is served from a different origin than
+# the API (rare; typical production deploys proxy everything through nginx
+# at the same host).
+#
+# Example — production behind nginx at https://renfield.example.com:
+#   EXTERNAL_URL=https://renfield.example.com
+#   EXTERNAL_WS_URL=wss://renfield.example.com
+#
+# The Dockerfile appends "/ws" to EXTERNAL_WS_URL, so pass the scheme+host only.
+# EXTERNAL_URL=
+# EXTERNAL_WS_URL=

--- a/bin/generate-secrets.sh
+++ b/bin/generate-secrets.sh
@@ -91,6 +91,16 @@ prompt_secret "home_assistant_token" "Home Assistant Long-Lived Access Token:"
 prompt_secret "openweather_api_key" "OpenWeatherMap API Key (https://openweathermap.org/api):"
 prompt_secret "newsapi_key" "NewsAPI Key (https://newsapi.org/):"
 prompt_secret "jellyfin_api_key" "Jellyfin API Key:"
+prompt_secret "jellyfin_token" "Jellyfin Access Token (optional, leer = ueberspringen):"
+prompt_secret "jellyfin_base_url" "Jellyfin Base URL (z.B. http://jellyfin.local:8096):"
+prompt_secret "jellyfin_user_id" "Jellyfin User ID (GUID):"
+prompt_secret "n8n_api_key" "n8n API Key (Settings → API → Create API Key):"
+prompt_secret "paperless_api_token" "Paperless-NGX API Token:"
+prompt_secret "mail_primary_password" "Mail primary account IMAP/SMTP password:"
+
+echo ""
+echo "3. Auto-generierte Shared Secrets (Webhooks, etc.):"
+generate_token "presence_webhook_secret" 32
 
 echo ""
 echo "=== Fertig ==="

--- a/docker-compose.prod-cpu.yml
+++ b/docker-compose.prod-cpu.yml
@@ -94,9 +94,11 @@ services:
       - jellyfin_api_key
       - jellyfin_token
       - jellyfin_base_url
+      - jellyfin_user_id
       - n8n_api_key
       - paperless_api_token
       - mail_primary_password
+      - presence_webhook_secret
     volumes:
       - ./src/backend:/app
       - ./src/satellite:/app/satellite
@@ -201,9 +203,13 @@ secrets:
     file: ./secrets/jellyfin_token
   jellyfin_base_url:
     file: ./secrets/jellyfin_base_url
+  jellyfin_user_id:
+    file: ./secrets/jellyfin_user_id
   n8n_api_key:
     file: ./secrets/n8n_api_key
   paperless_api_token:
     file: ./secrets/paperless_api_token
   mail_primary_password:
     file: ./secrets/mail_primary_password
+  presence_webhook_secret:
+    file: ./secrets/presence_webhook_secret

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -101,9 +101,11 @@ services:
       - jellyfin_api_key
       - jellyfin_token
       - jellyfin_base_url
+      - jellyfin_user_id
       - n8n_api_key
       - paperless_api_token
       - mail_primary_password
+      - presence_webhook_secret
     volumes:
       - ./src/backend:/app
       - ./src/satellite:/app/satellite  # For OTA update package building
@@ -160,9 +162,11 @@ services:
       - jellyfin_api_key
       - jellyfin_token
       - jellyfin_base_url
+      - jellyfin_user_id
       - n8n_api_key
       - paperless_api_token
       - mail_primary_password
+      - presence_webhook_secret
     volumes:
       - ./src/backend:/app
       - ./src/satellite:/app/satellite
@@ -278,9 +282,13 @@ secrets:
     file: ./secrets/jellyfin_token
   jellyfin_base_url:
     file: ./secrets/jellyfin_base_url
+  jellyfin_user_id:
+    file: ./secrets/jellyfin_user_id
   n8n_api_key:
     file: ./secrets/n8n_api_key
   paperless_api_token:
     file: ./secrets/paperless_api_token
   mail_primary_password:
     file: ./secrets/mail_primary_password
+  presence_webhook_secret:
+    file: ./secrets/presence_webhook_secret

--- a/src/backend/api/routes/knowledge.py
+++ b/src/backend/api/routes/knowledge.py
@@ -810,10 +810,43 @@ async def list_knowledge_bases(
         )
         owner_map = {row.id: row.username for row in owner_result.all()}
 
+    # Fixes audit K2: previously `get_user_kb_permission(kb, ...)` was called
+    # in the loop below, firing one atom_explicit_grants query per KB. The
+    # batch helper pulls every grant in a single GROUP BY, and the rest of
+    # the permission rules (owner / kb.all / public+kb.shared) resolve from
+    # data we already have in memory.
+    grants_by_kb: dict[int, str] = {}
+    user_has_kb_all = False
+    user_has_kb_shared = False
+    if settings.auth_enabled and user:
+        user_perms = user.get_permissions()
+        user_has_kb_all = has_permission(user_perms, Permission.KB_ALL)
+        user_has_kb_shared = has_permission(user_perms, Permission.KB_SHARED)
+        kb_ids_for_grants = [kb.id for kb in accessible_bases]
+        if kb_ids_for_grants and not user_has_kb_all:
+            from services.kb_shares_service import get_user_kb_permission_levels
+            grants_by_kb = await get_user_kb_permission_levels(
+                db, user.id, kb_ids_for_grants
+            )
+
+    def _resolve_permission(kb: KnowledgeBase) -> str | None:
+        if not settings.auth_enabled or not user:
+            return "admin"
+        if user_has_kb_all:
+            return "admin"
+        if kb.owner_id == user.id:
+            return "owner"
+        grant = grants_by_kb.get(kb.id)
+        if grant:
+            return grant
+        if getattr(kb, "is_public", False) and user_has_kb_shared:
+            return "read"
+        return None
+
     # Build response with user-specific info
     response = []
     for kb in accessible_bases:
-        perm = await get_user_kb_permission(kb, user, db) if user else "admin"
+        perm = _resolve_permission(kb)
         owner_username = owner_map.get(kb.owner_id) if kb.owner_id else None
 
         response.append(KnowledgeBaseResponse(

--- a/src/backend/ha_glue/services/presence_webhook.py
+++ b/src/backend/ha_glue/services/presence_webhook.py
@@ -18,7 +18,7 @@ async def _dispatch(event: str, **kwargs):
 
     headers = {"Content-Type": "application/json"}
     if ha_glue_settings.presence_webhook_secret:
-        headers["X-Webhook-Secret"] = ha_glue_settings.presence_webhook_secret
+        headers["X-Webhook-Secret"] = ha_glue_settings.presence_webhook_secret.get_secret_value()
 
     payload = {"event": event, **kwargs}
     try:

--- a/src/backend/ha_glue/utils/config.py
+++ b/src/backend/ha_glue/utils/config.py
@@ -92,7 +92,7 @@ class HaGlueSettings(BaseSettings):
     presence_rssi_threshold: int = -80                  # dBm, signals weaker than this are ignored
     presence_household_roles: str = "Admin,Familie"     # Roles considered household members for privacy TTS
     presence_webhook_url: str = ""                      # URL to POST presence events (empty = disabled)
-    presence_webhook_secret: str = ""                   # Shared secret for webhook auth (X-Webhook-Secret header)
+    presence_webhook_secret: SecretStr | None = None    # Shared secret for webhook auth (X-Webhook-Secret header)
     presence_analytics_retention_days: int = 90         # Days to keep presence events for analytics
 
     # === Media Follow Me (playback follows user between rooms) ===

--- a/src/backend/services/kb_shares_service.py
+++ b/src/backend/services/kb_shares_service.py
@@ -221,3 +221,42 @@ async def list_user_shared_kb_ids(db: AsyncSession, user_id: int) -> set[int]:
         {"user_id": user_id},
     )
     return {int(r[0]) for r in result.fetchall()}
+
+
+async def get_user_kb_permission_levels(
+    db: AsyncSession,
+    user_id: int,
+    kb_ids: list[int] | set[int] | None = None,
+) -> dict[int, str]:
+    """Batch-fixes audit K2: replaces the per-KB `get_user_kb_permission_level`
+    loop with a single GROUP-BY query. Returns {kb_id: "read"|"write"|"admin"}
+    for every KB the user has any grant on. KBs without a grant are absent.
+
+    If `kb_ids` is provided, the result is restricted to that subset (still
+    one query); `None` returns the full map for the user.
+    """
+    params: dict[str, Any] = {"user_id": user_id}
+    sql = (
+        "SELECT d.knowledge_base_id, "
+        "       MAX(CASE g.permission_level "
+        "             WHEN 'admin' THEN 3 WHEN 'write' THEN 2 ELSE 1 END) AS rank "
+        "FROM atom_explicit_grants g "
+        "JOIN atoms a ON g.atom_id = a.atom_id "
+        "JOIN documents d ON a.source_id = d.id::text "
+        "WHERE a.source_table = 'documents' "
+        "  AND g.granted_to_user_id = :user_id "
+        "  AND d.knowledge_base_id IS NOT NULL"
+    )
+    if kb_ids is not None:
+        if not kb_ids:
+            return {}
+        sql += " AND d.knowledge_base_id = ANY(:kb_ids)"
+        params["kb_ids"] = list(kb_ids)
+    sql += " GROUP BY d.knowledge_base_id"
+
+    result = await db.execute(text(sql), params)
+    rank_to_perm = {1: "read", 2: "write", 3: "admin"}
+    return {
+        int(row.knowledge_base_id): rank_to_perm[int(row.rank)]
+        for row in result.fetchall()
+    }

--- a/tasks/audit-findings-plan.md
+++ b/tasks/audit-findings-plan.md
@@ -17,43 +17,41 @@ Consolidated results from 4 systematic audits (DB Performance, Config Hardcodes,
 
 ## KRITISCH (7)
 
-### K1. N+1 Query: KB Permissions Listing
-- **Datei:** `api/routes/knowledge.py:760-790`
-- **Problem:** Loop queries User table per KBPermission (2 queries per iteration)
-- **Fix:** Use `selectinload(KBPermission.user)` or explicit JOIN
-- **Impact:** 10 permissions = 20 extra queries
+Status nach Branch `audit/k1-k7` (PR aus diesem Branch schliesst K1-K7 komplett).
 
-### K2. N+1 Query: KB Access Check
-- **Datei:** `api/routes/knowledge.py:487-503`
-- **Problem:** Queries KBPermission table per KB in loop
-- **Fix:** Batch-load all user permissions in one query upfront
-- **Impact:** 50 KBs = 50 extra queries
+### K1. N+1 Query: KB Permissions Listing — RESOLVED (pre-existing fix)
+- **Datei:** `api/routes/knowledge.py::list_kb_permissions` (heute ~Zeile 1124)
+- **Status:** Die Ursprungs-Beobachtung war zum Auditzeitpunkt bereits behoben. Die heutige Implementation lädt alle referenzierten User in **einer** Abfrage per `select(User).where(User.id.in_(all_user_ids))`; pro Share gibt es keine zweite User-Query.
+- **Verifikation:** `tests/backend/test_kb_shares_service.py::test_list_kb_shares_*` deckt die Aggregat-SQL ab.
 
-### K3. N+1 Query: Conversation List
-- **Datei:** `services/conversation_service.py:254-268`
-- **Problem:** 2 queries per conversation (count + first message)
-- **Fix:** Window functions or aggregation in single query
-- **Impact:** 50 conversations = 100 extra queries
+### K2. N+1 Query: KB Access Check — FIXED
+- **Datei:** `api/routes/knowledge.py::list_knowledge_bases` (~Zeile 761) + `services/kb_shares_service.py`
+- **Problem:** `get_user_kb_permission(kb, user, db)` wurde je KB in der Response-Schleife aufgerufen → pro KB eine `atom_explicit_grants`-Query.
+- **Fix:** Neuer Batch-Helper `get_user_kb_permission_levels(db, user_id, kb_ids)` lädt alle Grants mit einem `GROUP BY` in **einer** Query. Die uebrigen Permission-Regeln (Owner / KB_ALL / public+KB_SHARED) kommen aus In-Memory-Daten ohne zusaetzliche DB-Rundtrips.
+- **Regression-Guard:** `tests/backend/test_kb_shares_service.py::test_get_user_kb_permission_levels_*` plus `tests/backend/test_knowledge.py::TestKnowledgeBaseAPI::test_list_knowledge_bases_batches_permission_lookups`.
 
-### K4. .env.example covers only 17% of Settings
-- **Datei:** `.env.example` (22 of 126 variables documented)
-- **Problem:** New deployments lack guidance for 104 configuration options
-- **Fix:** Expand .env.example with all variables, grouped and commented
+### K3. N+1 Query: Conversation List — RESOLVED (pre-existing fix)
+- **Datei:** `services/conversation_service.py::list_all` (~Zeile 434)
+- **Status:** Ebenfalls bereits gefixt: `message_count` kommt aus einem Count-Subquery, der `preview` aus einem `ROW_NUMBER() OVER (...)`-Window. Eine einzige SQL-Anweisung pro Seite.
+- **Verifikation:** `tests/backend/test_conversation_service.py::TestListAll` deckt Pagination, Sortierung, User-Filter und Preview-Semantik ab.
 
-### K5. No SecretStr for sensitive fields
-- **Datei:** `utils/config.py`
-- **Problem:** Passwords, tokens, API keys typed as `str` — visible in logs/repr
-- **Fix:** Change to `SecretStr` for postgres_password, secret_key, all tokens
+### K4. .env.example covers only 17% of Settings — FIXED
+- **Datei:** `.env.example`
+- **Fix:** Komplett-Rewrite als gruppierte Referenz aller ~240 Felder (Platform + `HaGlueSettings`). Jede Section kommentiert die Default-Werte und Produktions-Hinweise (Docker Secrets, SecretStr, Profile-Toggles).
 
-### K6. Production Docker Secrets incomplete
-- **Datei:** `docker-compose.prod.yml`
-- **Problem:** Email passwords, JELLYFIN_USER_ID, SEARXNG credentials missing from secrets
-- **Fix:** Add all sensitive values to Docker Secrets
+### K5. No SecretStr for sensitive fields — FIXED
+- **Datei:** `utils/config.py`, `ha_glue/utils/config.py`
+- **Status:** Passwoerter, Tokens und API-Keys sind durchgehend `SecretStr`:
+  `postgres_password`, `secret_key`, `default_admin_password`, `mail_primary_password`, `n8n_api_key` (platform) sowie `home_assistant_token`, `paperless_api_token`, `jellyfin_api_key`, `jellyfin_token` (ha_glue). Restliche Luecke `presence_webhook_secret` wurde auf `SecretStr | None` umgestellt; Consumer (`ha_glue/services/presence_webhook.py`) ruft `.get_secret_value()`.
+- **Regression-Guard:** `tests/backend/test_presence_webhook.py` verwendet jetzt `SecretStr("my-secret-token")`.
 
-### K7. EXTERNAL_URL / EXTERNAL_WS_URL undefined
-- **Datei:** `docker-compose.prod.yml`
-- **Problem:** Frontend references `${EXTERNAL_URL}` but it's never defined anywhere
-- **Fix:** Document in .env.example, add to Settings class
+### K6. Production Docker Secrets incomplete — FIXED
+- **Dateien:** `docker-compose.prod.yml`, `docker-compose.prod-cpu.yml`, `bin/generate-secrets.sh`
+- **Fix:** `jellyfin_user_id` und `presence_webhook_secret` zu Secrets-Liste und `secrets:`-Block in beiden Compose-Dateien hinzugefuegt. `generate-secrets.sh` prompt't jetzt auch fuer `jellyfin_token`, `jellyfin_base_url`, `jellyfin_user_id`, `n8n_api_key`, `paperless_api_token`, `mail_primary_password` und auto-generiert `presence_webhook_secret`.
+
+### K7. EXTERNAL_URL / EXTERNAL_WS_URL undefined — FIXED
+- **Dateien:** `.env.example`, `docker-compose.prod*.yml`
+- **Fix:** Variablen sind dokumentiert in `.env.example` (Section "Frontend build-time variables") mit Beispiel-Werten + Erklaerung, dass es Vite-Build-Args sind, die in das PWA-Bundle einkompiliert werden. Kein Settings-Feld noetig (kein Backend-Consumer); leere Werte sind default-fallback fuer Same-Origin-Deploys hinter Nginx.
 
 ---
 
@@ -228,14 +226,17 @@ Consolidated results from 4 systematic audits (DB Performance, Config Hardcodes,
 ## Priorisierte Roadmap
 
 ### Phase 1: Performance & Security (DB + Config)
-- [ ] K1-K3: Fix N+1 queries (knowledge.py, conversation_service.py)
-- [ ] K5: SecretStr for sensitive Settings fields
-- [ ] K6-K7: Complete Docker Secrets + define EXTERNAL_URL
+- [x] K1: verified pre-existing fix (batched user lookup in list_kb_permissions)
+- [x] K2: batched permission lookup in list_knowledge_bases
+- [x] K3: verified pre-existing fix (single-query list_all with window function)
+- [x] K5: SecretStr for sensitive Settings fields (presence_webhook_secret closed the last gap)
+- [x] K6: complete Docker Secrets (jellyfin_user_id, presence_webhook_secret)
+- [x] K7: define EXTERNAL_URL / EXTERNAL_WS_URL in .env.example
 - [ ] W1: Configure DB connection pool
 - [ ] W12: Fix alembic.ini credentials
 
 ### Phase 2: Konfiguration aufraumen
-- [ ] K4: Expand .env.example to 100% coverage
+- [x] K4: Expand .env.example to 100% coverage
 - [ ] W5: Extract hardcoded timeouts to Settings
 - [ ] W6: Agent/Router LLM options from YAML, not Python hardcodes
 - [ ] W7-W8: Circuit breaker + cache TTLs configurable

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -22,10 +22,9 @@ Reva Enterprise Teams-bot depends on Renfield internals that were removed or cha
 - **Items:** Semantic Router in AgentRouter · XML delimiter tags in prompts · Episodic Memory · Memory source/scope/confidence fields · Procedural memory category · `_serialize_for_prompt()` · `utils/request_context.py` · `prompt_hashes` on PromptManager
 - **Also two MODERATE signature changes** (AgentService.__init__, token budget, `retrieve_for_prompt()` return format) documented in the same file §11-§13.
 
-### KRITISCH audit findings (K1-K7)
-Performance + security gaps flagged in systematic audit; each is production-exposed today.
-- **Primary source:** `tasks/audit-findings-plan.md` §KRITISCH, §Priorisierte Roadmap Phase 1
-- **Items:** K1-K3 three N+1 query bugs (knowledge.py, conversation_service.py) · K4 .env.example at 17% coverage · K5 missing `SecretStr` on sensitive Settings fields · K6 production Docker Secrets incomplete · K7 `EXTERNAL_URL`/`EXTERNAL_WS_URL` referenced but undefined
+### KRITISCH audit findings (K1-K7) — RESOLVED (branch `audit/k1-k7`, PR pending)
+Closed in one branch: K2 got a batched permission lookup; K1/K3 were already fixed before the audit was written; K4 is a full .env.example rewrite covering 100% of Settings + ha_glue; K5 converted the last plaintext secret (`presence_webhook_secret`) to SecretStr; K6 added the two missing Docker Secrets to both prod compose files + the generator script; K7 documented EXTERNAL_URL/EXTERNAL_WS_URL as Vite build args.
+- **Primary source:** `tasks/audit-findings-plan.md` §KRITISCH (now marked done)
 
 ---
 

--- a/tests/backend/test_kb_shares_service.py
+++ b/tests/backend/test_kb_shares_service.py
@@ -176,3 +176,63 @@ async def test_list_user_shared_kb_ids_returns_set_of_ints():
 
     assert isinstance(ids, set)
     assert ids == {7, 42, 101}
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_get_user_kb_permission_levels_batches_into_one_query():
+    """Audit K2 regression guard: a list of KBs resolves with exactly one
+    SQL execute call regardless of how many KBs are passed in."""
+    db = MagicMock()
+    fake_result = MagicMock()
+    fake_result.fetchall.return_value = [
+        MagicMock(knowledge_base_id=1, rank=3),
+        MagicMock(knowledge_base_id=2, rank=2),
+        MagicMock(knowledge_base_id=3, rank=1),
+    ]
+    db.execute = AsyncMock(return_value=fake_result)
+
+    levels = await kb_shares_service.get_user_kb_permission_levels(
+        db, user_id=42, kb_ids=[1, 2, 3, 4, 5]
+    )
+
+    db.execute.assert_awaited_once()
+    assert levels == {1: "admin", 2: "write", 3: "read"}
+    # GROUP BY must be present — single query, not per-KB
+    sql = str(db.execute.call_args.args[0])
+    assert "GROUP BY d.knowledge_base_id" in sql
+    assert "ANY(:kb_ids)" in sql
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_get_user_kb_permission_levels_empty_kb_ids_short_circuits():
+    db = MagicMock()
+    db.execute = AsyncMock()
+
+    levels = await kb_shares_service.get_user_kb_permission_levels(
+        db, user_id=42, kb_ids=[]
+    )
+
+    assert levels == {}
+    db.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_get_user_kb_permission_levels_none_returns_all_grants():
+    db = MagicMock()
+    fake_result = MagicMock()
+    fake_result.fetchall.return_value = [
+        MagicMock(knowledge_base_id=7, rank=2),
+    ]
+    db.execute = AsyncMock(return_value=fake_result)
+
+    levels = await kb_shares_service.get_user_kb_permission_levels(
+        db, user_id=42, kb_ids=None
+    )
+
+    assert levels == {7: "write"}
+    sql = str(db.execute.call_args.args[0])
+    # Without a kb_ids filter, the ANY() clause is absent
+    assert "ANY(:kb_ids)" not in sql

--- a/tests/backend/test_knowledge.py
+++ b/tests/backend/test_knowledge.py
@@ -387,6 +387,81 @@ class TestKnowledgeBaseAPI:
         data = response.json()
         assert isinstance(data, list)
 
+    @pytest.mark.unit
+    async def test_list_knowledge_bases_batches_permission_lookups(self, monkeypatch):
+        """Audit K2 regression guard: when list_knowledge_bases resolves
+        permissions for N KBs, `get_user_kb_permission_levels` is called at
+        most ONCE — not N times (the pre-fix behavior that fired one
+        atom_explicit_grants query per KB in the response loop)."""
+        from api.routes import knowledge as route_mod
+        from services import kb_shares_service
+        from unittest.mock import AsyncMock, MagicMock
+
+        call_counter = {"n": 0}
+
+        async def fake_levels(db, user_id, kb_ids=None):
+            call_counter["n"] += 1
+            ids = list(kb_ids) if kb_ids is not None else []
+            return {kb_id: "write" for kb_id in ids}
+
+        monkeypatch.setattr(
+            kb_shares_service, "get_user_kb_permission_levels", fake_levels
+        )
+
+        # 10 shared KBs, none owned by the asker — forces the route into the
+        # batched grants path (not the "owner" early return).
+        fake_kbs = [
+            MagicMock(
+                id=i, name=f"kb{i}", description="", is_active=True,
+                is_public=False, owner_id=99,
+                created_at=None, updated_at=None,
+            )
+            for i in range(1, 11)
+        ]
+        shared_ids = {kb.id for kb in fake_kbs}
+
+        async def fake_shared_ids(db, user_id):
+            return shared_ids
+
+        monkeypatch.setattr(
+            kb_shares_service, "list_user_shared_kb_ids", fake_shared_ids
+        )
+
+        monkeypatch.setattr(route_mod.settings, "auth_enabled", True)
+
+        fake_user = MagicMock()
+        fake_user.id = 42
+        fake_user.get_permissions = lambda: set()
+
+        fake_rag = MagicMock()
+        fake_rag.list_knowledge_bases = AsyncMock(return_value=fake_kbs)
+
+        fake_db = MagicMock()
+        empty_owners = MagicMock()
+        empty_owners.all = lambda: []
+        fake_db.execute = AsyncMock(return_value=empty_owners)
+
+        from models import permissions as perms_mod
+
+        def grant_all(user_perms, perm):
+            # Reject KB_ALL so the code reaches the batched grant lookup;
+            # reject KB_NONE so it doesn't early-return empty. Anything else
+            # (KB_SHARED, KB_OWN) — allow.
+            if perm in (perms_mod.Permission.KB_ALL, perms_mod.Permission.KB_NONE):
+                return False
+            return True
+
+        monkeypatch.setattr(route_mod, "has_permission", grant_all)
+
+        result = await route_mod.list_knowledge_bases(
+            rag=fake_rag, user=fake_user, db=fake_db
+        )
+
+        # All 10 KBs surfaced, one batch call — not ten per-KB calls.
+        assert len(result) == 10
+        assert call_counter["n"] == 1
+        assert all(kb.permission == "write" for kb in result)
+
     @pytest.mark.integration
     async def test_create_knowledge_base_endpoint(self, async_client: AsyncClient):
         """Testet POST /api/knowledge/bases"""

--- a/tests/backend/test_knowledge.py
+++ b/tests/backend/test_knowledge.py
@@ -387,6 +387,7 @@ class TestKnowledgeBaseAPI:
         data = response.json()
         assert isinstance(data, list)
 
+    @pytest.mark.asyncio
     @pytest.mark.unit
     async def test_list_knowledge_bases_batches_permission_lookups(self, monkeypatch):
         """Audit K2 regression guard: when list_knowledge_bases resolves
@@ -395,6 +396,7 @@ class TestKnowledgeBaseAPI:
         atom_explicit_grants query per KB in the response loop)."""
         from api.routes import knowledge as route_mod
         from services import kb_shares_service
+        from types import SimpleNamespace
         from unittest.mock import AsyncMock, MagicMock
 
         call_counter = {"n": 0}
@@ -409,9 +411,11 @@ class TestKnowledgeBaseAPI:
         )
 
         # 10 shared KBs, none owned by the asker — forces the route into the
-        # batched grants path (not the "owner" early return).
+        # batched grants path (not the "owner" early return). SimpleNamespace
+        # (not MagicMock) because Pydantic validates the response fields and
+        # MagicMock's reserved `name` attribute would leak through.
         fake_kbs = [
-            MagicMock(
+            SimpleNamespace(
                 id=i, name=f"kb{i}", description="", is_active=True,
                 is_public=False, owner_id=99,
                 created_at=None, updated_at=None,
@@ -429,9 +433,7 @@ class TestKnowledgeBaseAPI:
 
         monkeypatch.setattr(route_mod.settings, "auth_enabled", True)
 
-        fake_user = MagicMock()
-        fake_user.id = 42
-        fake_user.get_permissions = lambda: set()
+        fake_user = SimpleNamespace(id=42, get_permissions=lambda: set())
 
         fake_rag = MagicMock()
         fake_rag.list_knowledge_bases = AsyncMock(return_value=fake_kbs)

--- a/tests/backend/test_presence_webhook.py
+++ b/tests/backend/test_presence_webhook.py
@@ -5,6 +5,16 @@ Tests for presence webhook dispatcher.
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from pydantic import SecretStr
+
+
+def _mock_ha_glue_settings(**overrides):
+    base = {
+        "presence_webhook_url": "http://n8n.local/webhook/presence",
+        "presence_webhook_secret": None,
+    }
+    base.update(overrides)
+    return type("S", (), base)()
 
 
 @pytest.mark.unit
@@ -12,11 +22,6 @@ class TestPresenceWebhook:
     @pytest.mark.asyncio
     async def test_dispatch_posts_to_url(self):
         """Webhook POSTs event payload to configured URL."""
-        mock_settings = type("S", (), {
-            "presence_webhook_url": "http://n8n.local/webhook/presence",
-            "presence_webhook_secret": "",
-        })()
-
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.raise_for_status = lambda: None
@@ -24,8 +29,11 @@ class TestPresenceWebhook:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_response)
 
-        with patch("services.presence_webhook.settings", mock_settings):
-            import services.presence_webhook as mod
+        with patch(
+            "ha_glue.services.presence_webhook.ha_glue_settings",
+            _mock_ha_glue_settings(),
+        ):
+            import ha_glue.services.presence_webhook as mod
             mod._client = mock_client
 
             await mod._dispatch("presence_enter_room", user_id=1, room_id=10)
@@ -38,17 +46,11 @@ class TestPresenceWebhook:
         assert payload["user_id"] == 1
         assert payload["room_id"] == 10
 
-        # Cleanup
         mod._client = None
 
     @pytest.mark.asyncio
     async def test_dispatch_includes_secret_header(self):
-        """When secret configured, X-Webhook-Secret header is sent."""
-        mock_settings = type("S", (), {
-            "presence_webhook_url": "http://n8n.local/webhook/presence",
-            "presence_webhook_secret": "my-secret-token",
-        })()
-
+        """When SecretStr secret configured, X-Webhook-Secret header carries the plaintext."""
         mock_response = AsyncMock()
         mock_response.status_code = 200
         mock_response.raise_for_status = lambda: None
@@ -56,8 +58,11 @@ class TestPresenceWebhook:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_response)
 
-        with patch("services.presence_webhook.settings", mock_settings):
-            import services.presence_webhook as mod
+        with patch(
+            "ha_glue.services.presence_webhook.ha_glue_settings",
+            _mock_ha_glue_settings(presence_webhook_secret=SecretStr("my-secret-token")),
+        ):
+            import ha_glue.services.presence_webhook as mod
             mod._client = mock_client
 
             await mod._dispatch("presence_leave_room", user_id=1, room_id=10)
@@ -66,40 +71,32 @@ class TestPresenceWebhook:
         headers = call_args[1]["headers"]
         assert headers["X-Webhook-Secret"] == "my-secret-token"
 
-        # Cleanup
         mod._client = None
 
     @pytest.mark.asyncio
     async def test_dispatch_error_logged_not_raised(self):
         """Network error doesn't propagate (fire-and-forget)."""
-        mock_settings = type("S", (), {
-            "presence_webhook_url": "http://n8n.local/webhook/presence",
-            "presence_webhook_secret": "",
-        })()
-
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(side_effect=Exception("Connection refused"))
 
-        with patch("services.presence_webhook.settings", mock_settings):
-            import services.presence_webhook as mod
+        with patch(
+            "ha_glue.services.presence_webhook.ha_glue_settings",
+            _mock_ha_glue_settings(),
+        ):
+            import ha_glue.services.presence_webhook as mod
             mod._client = mock_client
 
-            # Should not raise
             await mod._dispatch("presence_enter_room", user_id=1, room_id=10)
 
-        # Cleanup
         mod._client = None
 
     def test_register_skipped_when_no_url(self):
         """No URL configured → no hooks registered."""
-        mock_settings = type("S", (), {
-            "presence_webhook_url": "",
-            "presence_webhook_secret": "",
-        })()
-
-        with patch("services.presence_webhook.settings", mock_settings), \
-             patch("services.presence_webhook.register_hook") as mock_register:
-            import services.presence_webhook as mod
+        with patch(
+            "ha_glue.services.presence_webhook.ha_glue_settings",
+            _mock_ha_glue_settings(presence_webhook_url=""),
+        ), patch("ha_glue.services.presence_webhook.register_hook") as mock_register:
+            import ha_glue.services.presence_webhook as mod
             mod.register_presence_webhooks()
 
         mock_register.assert_not_called()


### PR DESCRIPTION
## Summary

Closes all seven KRITISCH audit findings from `tasks/audit-findings-plan.md`. Three were already fixed before the audit was written; the other four are addressed here in one branch.

| # | Status | Change |
|---|--------|--------|
| K1 | pre-fixed | `list_kb_permissions` already batch-loads users via `User.id.in_(...)` — doc now cites the verification tests |
| K2 | **fixed** | `list_knowledge_bases` looped `get_user_kb_permission()` per KB → 1 `atom_explicit_grants` query per KB. New `get_user_kb_permission_levels(db, user_id, kb_ids)` batch helper pulls every grant in a single `GROUP BY`; remaining rules (owner / kb.all / public+kb.shared) resolve from in-memory data |
| K3 | pre-fixed | `ConversationService.list_all` already uses count-subquery + `ROW_NUMBER()` window — doc updated |
| K4 | **fixed** | `.env.example` rewritten as a complete reference (~240 env vars across `Settings` + `HaGlueSettings`), grouped and commented |
| K5 | **fixed** | Last plaintext sensitive field `presence_webhook_secret: str` → `SecretStr \| None`; dispatcher calls `.get_secret_value()` |
| K6 | **fixed** | `jellyfin_user_id` + `presence_webhook_secret` added to Docker Secrets in both `docker-compose.prod.yml` and `docker-compose.prod-cpu.yml`; `bin/generate-secrets.sh` prompts for the remaining sensitive values + auto-generates the webhook token |
| K7 | **fixed** | `EXTERNAL_URL` / `EXTERNAL_WS_URL` documented in `.env.example` (Vite build args, not backend Settings) with same-origin vs split-origin guidance |

## Regression guards

- `test_kb_shares_service.py` — 3 tests lock the batched SQL shape (`GROUP BY d.knowledge_base_id`, `ANY(:kb_ids)` gated on non-empty list, empty short-circuit, `None` returns full map)
- `test_knowledge.py::test_list_knowledge_bases_batches_permission_lookups` — route-level guard: 10 KBs → batch helper called exactly once
- `test_presence_webhook.py` — repaired stale import path + `SecretStr("my-secret-token")` assertion

## Test plan

- [ ] Run `make test-backend` on .159 build box (local CI is non-functional per project memory)
- [ ] Verify `docker compose -f docker-compose.prod.yml config` and `-cpu.yml config` still parse (pre-committed ✓)
- [ ] Spot-check the `.env.example` rewrite against `Settings` fields — no orphaned names

🤖 Generated with [Claude Code](https://claude.com/claude-code)