### PR TITLE
fix(deps): pin renfield-mcp-paperless to v1.4.0 (Paperless upload 400 fix)

### DIFF
--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -75,7 +75,7 @@ jsonschema>=4.21.0            # JSON Schema validation for MCP tool inputs
 
 # MCP Servers (standalone packages)
 renfield-mcp-weather @ https://github.com/ebongard/renfield_mcp_weather/archive/refs/heads/main.tar.gz
-renfield-mcp-paperless @ https://github.com/ebongard/renfield-mcp-paperless/archive/refs/heads/main.tar.gz
+renfield-mcp-paperless @ https://github.com/ebongard/renfield-mcp-paperless/archive/refs/tags/v1.4.0.tar.gz
 renfield-mcp-mail @ https://github.com/ebongard/renfield-mcp-mail/archive/refs/heads/main.tar.gz
 aiosmtplib>=3.0                  # Required by renfield-mcp-mail (not auto-resolved from archive installs)
 renfield-mcp-jellyfin @ https://github.com/ebongard/renfield-mcp-jellyfin/archive/refs/heads/main.tar.gz


### PR DESCRIPTION
## Summary

Pins \`renfield-mcp-paperless\` to the tagged \`v1.4.0\` release instead of main-HEAD. This brings the upstream fix from [ebongard/renfield-mcp-paperless#7](https://github.com/ebongard/renfield-mcp-paperless/pull/7) into the Renfield backend image so production uploads stop 400-ing.

## The upstream bug

\`mcp.paperless.upload_document\` passed \`correspondent\` / \`document_type\` / \`tags\` as raw name strings. Paperless's \`post_document\` endpoint uses DRF \`PrimaryKeyRelatedField\` and rejected with:

\`\`\`
{"correspondent":["Incorrect type. Expected pk value, received str."]}
\`\`\`

…surfaced to the user as a plain \`Client error '400 Bad Request'\` because \`httpx.raise_for_status()\` dropped Paperless's error body.

## The fix

v1.4.0:
- Resolves names → IDs via the existing \`_ensure_caches\` + \`_resolve_name_to_id\` helpers (same pattern the post-upload PATCH path already used for \`storage_path\`).
- Unknown names fail fast with \`"Unknown X: '…'. Create it first via create_X, or omit the field."\`.
- Replaces \`resp.raise_for_status()\` with an explicit 4xx/5xx guard that propagates Paperless's response body.

## Why pin the tag

\`requirements.txt\` currently tracks \`refs/heads/main\`. Docker's pip-install layer caches on the URL text, so builds would reuse the pre-fix layer until someone manually broke the cache. Pinning to \`refs/tags/v1.4.0\` bumps the URL, forces a fresh pip resolve, and gives the image an immutable rollback target.

## Test plan

- [ ] Rebuild backend image on .159 — pip layer cache invalidates, v1.4.0 installed
- [ ] Push to Harbor, rollout deploy/backend + deploy/document-worker
- [ ] Upload a document via chat at https://renfield.local — should succeed now instead of returning the 400
- [ ] If the agent passes metadata with a name that Paperless doesn't have, the new error surfaces (\`Unknown correspondent: '…'. Create it first via create_correspondent\`) instead of the generic 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)