### PR TITLE
fix(atoms): PATCH /api/atoms/{id}/tier 500 — cast id to text in cascade

### DIFF
--- a/src/backend/services/atom_service.py
+++ b/src/backend/services/atom_service.py
@@ -253,11 +253,15 @@ class AtomService:
         atom_orm.policy = dict(new_policy)
         atom_orm.updated_at = datetime.now(UTC).replace(tzinfo=None)
 
-        # Cascade to source row.
+        # Cascade to source row. `atom.source_id` is always stored as
+        # TEXT (polymorphic across source tables), but most source tables
+        # have an INTEGER `id` column — asyncpg refuses to encode a Python
+        # str as int4, producing a 500. Compare via `id::text` so this
+        # works for any source-table id type (int, bigint, uuid, text).
         await self.db.execute(
             text(
                 f"UPDATE {atom_orm.source_table} SET circle_tier = :tier "
-                f"WHERE id = :source_id"
+                f"WHERE id::text = :source_id"
             ),
             {"tier": new_tier, "source_id": atom_orm.source_id},
         )

--- a/tests/backend/test_atom_service.py
+++ b/tests/backend/test_atom_service.py
@@ -117,6 +117,40 @@ class TestUpdateTier:
 
     @pytest.mark.asyncio
     @pytest.mark.unit
+    async def test_source_cascade_uses_text_cast_for_int_id_tables(self):
+        """Regression for prod 500 on PATCH /api/atoms/{id}/tier.
+
+        ``atom.source_id`` is TEXT (polymorphic across source tables),
+        but most source tables (documents, kg_entities, memories...)
+        have an INTEGER ``id`` column. asyncpg refuses to encode a
+        Python str as int4 and the whole PATCH 500s. The fix: compare
+        via ``id::text = :source_id`` so the SQL works regardless of
+        the source table's id type.
+        """
+        session = _mock_session()
+        atom_orm = MagicMock()
+        atom_orm.atom_type = "kb_document"
+        atom_orm.source_table = "documents"
+        atom_orm.source_id = "99"
+        session.execute = AsyncMock(side_effect=[
+            MagicMock(scalar_one_or_none=MagicMock(return_value=atom_orm)),
+            MagicMock(),
+            MagicMock(),
+        ])
+        svc = AtomService(session, resolver=MagicMock(invalidate_for_atom=MagicMock()))
+        await svc.update_tier("atom-x", {"tier": 3})
+
+        cascade_sql = str(session.execute.await_args_list[1].args[0])
+        assert "id::text = :source_id" in cascade_sql, (
+            f"Generic source cascade must cast id to text. SQL was: {cascade_sql}"
+        )
+        # Bind param is passed through as-is (a str) — no callers need
+        # to preconvert to int.
+        binds = session.execute.await_args_list[1].args[1]
+        assert binds == {"tier": 3, "source_id": "99"}
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
     async def test_kb_document_cascades_to_document_chunks(self):
         """Post pc20260423: kb_document tier changes MUST propagate to every
         chunk's denormalized circle_tier in the same transaction — otherwise


### PR DESCRIPTION
## Summary

User hit a 500 when trying to change a document atom's tier from /brain. Root cause in \`services/atom_service.py::update_tier\`:

\`\`\`sql
UPDATE {source_table} SET circle_tier = :tier WHERE id = :source_id
\`\`\`

\`atom.source_id\` is always TEXT (polymorphic across source tables — \`documents\`, \`kg_entities\`, \`conversation_memories\`, etc.), but most source tables have an \`INTEGER id\` column. asyncpg refuses to encode a Python \`str\` as \`int4\` and the PATCH dies with \`TypeError: 'str' object cannot be interpreted as an integer\`.

The \`kb_document\`-specific cascade block two steps below already does \`int(atom_orm.source_id)\` correctly; the generic source-table cascade didn't get the same treatment.

## Fix

Compare via \`id::text = :source_id\` in the generic cascade so the SQL works for any source-table id type (int, bigint, uuid, text). Same pattern \`kb_shares_service.py\` uses throughout.

## Test

New regression \`test_source_cascade_uses_text_cast_for_int_id_tables\` asserts:
- Cascade SQL contains \`id::text = :source_id\`
- \`source_id\` bind is passed through as a str (no caller preconversion)

All 10 atom-service tests pass on .159.

## Verified on prod

Backend log before fix (found via \`kubectl logs\` after user report):
\`\`\`
PATCH /api/atoms/a86b65bc-6cf1-4c21-815d-45d6f7d27728/tier HTTP/1.1" 500 Internal Server Error
TypeError: 'str' object cannot be interpreted as an integer
  at asyncpg/pgproto/codecs/int.pyx:54 in int4_encode
  from /app/services/atom_service.py:257 in update_tier
\`\`\`

## Test plan

- [ ] Rebuild + rollout
- [ ] Retry the PATCH the user hit — should return 200 with the new tier applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)