### PR TITLE
fix(paperless): serialize created_date to ISO in JSON columns

### DIFF
--- a/src/backend/services/chat_upload_tool.py
+++ b/src/backend/services/chat_upload_tool.py
@@ -254,10 +254,13 @@ async def forward_attachment_to_paperless(
             return direct
 
         # Merge agent overrides into the extracted metadata (agent
-        # wins). For example, if the user said "archive as Rechnung"
-        # the agent passes document_type=Rechnung even if the LLM
-        # guessed otherwise.
-        post_fuzzy = extraction_result.metadata.model_dump()
+        # wins). `mode="json"` serialises pydantic dates to ISO
+        # strings so the dict is safe to write into a JSON column
+        # downstream (paperless_pending_confirms.post_fuzzy_output).
+        # Without it, `created_date` comes back as a datetime.date
+        # which SQLAlchemy's default JSON encoder can't handle and
+        # the whole INSERT fails.
+        post_fuzzy = extraction_result.metadata.model_dump(mode="json")
         post_fuzzy.update(agent_overrides)
 
         # Cold-start gate. User is inside the window → confirm
@@ -278,7 +281,11 @@ async def forward_attachment_to_paperless(
         # the preview — agent relays to user, who answers in the next
         # turn and the agent calls paperless_commit_upload.
         confirm_token = str(uuid.uuid4())
-        llm_output_for_persist = dict(extraction_result.metadata.model_dump())
+        # Same `mode="json"` reason as post_fuzzy above — these dicts
+        # flow into the paperless_pending_confirms.llm_output /
+        # .proposals JSON columns; any datetime.date inside would kill
+        # the INSERT.
+        llm_output_for_persist = extraction_result.metadata.model_dump(mode="json")
         # Stash doc_text alongside llm_output so the commit tool can
         # write it into paperless_extraction_examples without another
         # extraction run.
@@ -295,7 +302,10 @@ async def forward_attachment_to_paperless(
                 user_id=user_id,
                 llm_output=llm_output_for_persist,
                 post_fuzzy_output=post_fuzzy,
-                proposals=[p.model_dump() for p in extraction_result.metadata.new_entry_proposals],
+                proposals=[
+                    p.model_dump(mode="json")
+                    for p in extraction_result.metadata.new_entry_proposals
+                ],
             )
             db.add(pending)
             await db.commit()

--- a/tests/backend/test_chat_upload_tool_paperless.py
+++ b/tests/backend/test_chat_upload_tool_paperless.py
@@ -315,7 +315,7 @@ class TestForwardAttachmentColdStart:
                 storage_path="/x",
                 created_date=None,
                 new_entry_proposals=[],
-                model_dump=lambda: {
+                model_dump=lambda **_kw: {
                     "title": "T",
                     "correspondent": "Stadtwerke",
                     "document_type": "Rechnung",
@@ -374,7 +374,7 @@ class TestForwardAttachmentColdStart:
                 document_type="Rechnung", tags=["wohnung"],
                 storage_path="/x", created_date=None,
                 new_entry_proposals=[],
-                model_dump=lambda: {
+                model_dump=lambda **_kw: {
                     "title": "T", "correspondent": "Stadtwerke",
                     "document_type": "Rechnung", "tags": ["wohnung"],
                     "storage_path": "/x", "created_date": None,
@@ -415,6 +415,89 @@ class TestForwardAttachmentColdStart:
 
     @pytest.mark.asyncio
     @pytest.mark.unit
+    async def test_created_date_serialised_as_iso_string_for_json_columns(
+        self, tmp_path,
+    ):
+        """Regression for prod 2026-04-24: ``forward_attachment_to_paperless``
+        persisted ``post_fuzzy_output`` / ``llm_output`` via
+        ``pydantic.model_dump()`` (default mode) — which leaves
+        ``created_date`` as a ``datetime.date`` object. SQLAlchemy's JSON
+        encoder can't handle it, the INSERT 500s with
+        ``TypeError: Object of type date is not JSON serializable``,
+        and the tool reports ``Forward to Paperless failed: …``.
+
+        Fix: ``model_dump(mode="json")`` forces ISO-string serialisation
+        of every date in the payload BEFORE it reaches the JSON column.
+        This test asserts the persisted dict is JSON-serialisable.
+        """
+        import json
+        from datetime import date
+        import services.chat_upload_tool as cut_mod
+
+        upload = _upload_stub(tmp_path, filename="rechnung.pdf", size=200_000)
+        mcp = MagicMock()
+        mcp.execute_tool = AsyncMock()
+
+        # Real pydantic model with a real date — so model_dump(mode="json")
+        # matters. SimpleNamespace mocks would hide the bug.
+        from services.paperless_metadata_extractor import (
+            ExtractionResult, PaperlessMetadata,
+        )
+        extractor_result = ExtractionResult(
+            metadata=PaperlessMetadata(
+                title="Rechnung 2026",
+                correspondent="Anthropic, PBC",
+                document_type="Rechnung",
+                tags=["Rechnung", "2026"],
+                created_date=date(2026, 4, 24),
+                new_entry_proposals=[],
+            ),
+            doc_text="doc",
+            error=None,
+        )
+
+        session_factory = _make_session_factory(upload, capture_writes=True)
+
+        with patch(
+            "services.chat_upload_tool._run_extraction",
+            AsyncMock(return_value=extractor_result),
+        ), patch(
+            "services.chat_upload_tool._get_confirms_used",
+            AsyncMock(return_value=0),
+        ), patch(
+            "services.database.AsyncSessionLocal",
+            session_factory,
+        ):
+            result = await forward_attachment_to_paperless(
+                {"attachment_id": 42},
+                mcp_manager=mcp, session_id="s", user_id=None,
+            )
+
+        assert result["success"] is True, (
+            f"forward_attachment_to_paperless failed: {result}"
+        )
+        writes = session_factory.captured_adds  # type: ignore[attr-defined]
+        pending_rows = [
+            w for w in writes if type(w).__name__ == "PaperlessPendingConfirm"
+        ]
+        assert pending_rows, "Pending confirm row was not persisted"
+        row = pending_rows[0]
+        # Every dict that flows into a JSON column must round-trip through
+        # json.dumps without a TypeError.
+        for field_name in ("llm_output", "post_fuzzy_output", "proposals"):
+            payload = getattr(row, field_name)
+            try:
+                json.dumps(payload)
+            except TypeError as exc:
+                pytest.fail(
+                    f"{field_name} contains a non-JSON-serialisable value "
+                    f"({exc}). Full payload: {payload!r}"
+                )
+        # Specifically: created_date is an ISO string, not a date object.
+        assert row.post_fuzzy_output.get("created_date") == "2026-04-24"
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
     async def test_silent_upload_when_past_cold_start_cap(self, tmp_path):
         upload = _upload_stub(tmp_path)
         mcp = MagicMock()
@@ -428,7 +511,7 @@ class TestForwardAttachmentColdStart:
                 document_type="Rechnung", tags=["wohnung"],
                 storage_path="/x", created_date=None,
                 new_entry_proposals=[],
-                model_dump=lambda: {
+                model_dump=lambda **_kw: {
                     "title": "T", "correspondent": "Stadtwerke",
                     "document_type": "Rechnung", "tags": ["wohnung"],
                     "storage_path": "/x",
@@ -483,7 +566,7 @@ class TestForwardAttachmentExtractionFailure:
                 title=None, correspondent=None, document_type=None,
                 tags=[], storage_path=None, created_date=None,
                 new_entry_proposals=[],
-                model_dump=lambda: {},
+                model_dump=lambda **_kw: {},
             ),
             doc_text="",
             error="Konnte Dokument nicht lesen (OCR lieferte keinen Text).",


### PR DESCRIPTION
## Summary

User hit another prod 500 from the chat→Paperless flow, now on the cold-start persist path instead of the MCP upload path fixed in #467:

\`\`\`
forward_attachment_to_paperless — Forward to Paperless failed:
(builtins.TypeError) Object of type date is not JSON serializable
[SQL: INSERT INTO paperless_pending_confirms (... post_fuzzy_output
... created_date: date(2026, 4, 24) ...)]
\`\`\`

## Root cause

\`PaperlessMetadata.created_date\` is a pydantic \`date\` field. \`.model_dump()\` defaults to \`mode="python"\` which keeps the \`datetime.date\` object. That dict then flows into a \`sa.JSON\` column on \`paperless_pending_confirms\`; SQLAlchemy's default encoder doesn't serialise \`date\` and asyncpg refuses the \`INSERT\`.

## Fix

Call \`.model_dump(mode="json")\` at all three sites in \`chat_upload_tool.py::forward_attachment_to_paperless\` that feed a pydantic dict into a JSON column: \`post_fuzzy_output\`, \`llm_output\`, and each \`NewEntryProposal\` in \`proposals\`. \`mode="json"\` converts dates to ISO strings, which also matches what the downstream MCP \`upload_document\` expects for its \`created_date\` param.

## Test

- New \`test_created_date_serialised_as_iso_string_for_json_columns\` uses a real pydantic \`PaperlessMetadata\` with \`date(2026, 4, 24)\` and asserts the persisted row's JSON fields round-trip through \`json.dumps\` without raising.
- Fixed two sibling tests (\`test_cold_start_with_user_id_none_persists_pending\`, \`test_silent_upload_when_past_cold_start_cap\`) whose \`SimpleNamespace\` mocks used zero-arg \`model_dump\` lambdas — updated to \`lambda **_kw: {...}\` so they don't blow up when the code now passes \`mode="json"\`.

26/26 tests pass on .159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)