### PR TITLE
fix(chat-upload): reuse existing doc on duplicate (file_hash, kb_id)

### DIFF
--- a/src/backend/api/routes/chat_upload.py
+++ b/src/backend/api/routes/chat_upload.py
@@ -532,35 +532,76 @@ async def _auto_index_to_kb(
         # Step 1 — Document row + enqueue, within a short-lived session.
         async with AsyncSessionLocal() as db:
             kb = await _get_or_create_default_kb(db)
-
-            from services.rag_service import RAGService
-            rag = RAGService(db)
-            doc = await rag.create_document_record(
-                file_path=file_path,
-                knowledge_base_id=kb.id,
-                filename=filename,
-                file_hash=file_hash,
-            )
-            doc_id = doc.id
             kb_id = kb.id
 
-            # Link the chat upload to the pending doc up-front so the
-            # UI can show "processing" without waiting for the worker.
-            upload_row = (await db.execute(
-                select(ChatUpload).where(ChatUpload.id == upload_id)
+            # Re-upload of the same file into the same KB: the unique
+            # constraint `uq_documents_file_hash_kb` fires on a second
+            # INSERT and the auto-index path raises IntegrityError,
+            # surfacing to the user as "Auto-index failed". Pre-check
+            # for an existing doc with this hash and reuse it instead
+            # — link the chat upload to the existing doc and let the
+            # poll loop pick up its current state (likely already
+            # `completed`, in which case the user gets an immediate
+            # "document_ready" notification).
+            from models.database import Document as _Doc
+            existing = (await db.execute(
+                select(_Doc)
+                .where(_Doc.file_hash == file_hash)
+                .where(_Doc.knowledge_base_id == kb_id)
             )).scalar_one_or_none()
-            if upload_row:
-                upload_row.document_id = doc_id
-                upload_row.knowledge_base_id = kb_id
-                await db.commit()
 
-        queue = DocumentTaskQueue(redis_client=get_redis())
-        await queue.enqueue({
-            "document_id": doc_id,
-            "force_ocr": False,
-            "user_id": None,
-        })
-        logger.info(f"Chat upload {upload_id} enqueued as doc {doc_id} → KB {kb_id}")
+            if existing is not None:
+                doc_id = existing.id
+                upload_row = (await db.execute(
+                    select(ChatUpload).where(ChatUpload.id == upload_id)
+                )).scalar_one_or_none()
+                if upload_row:
+                    upload_row.document_id = doc_id
+                    upload_row.knowledge_base_id = kb_id
+                    await db.commit()
+                logger.info(
+                    f"Chat upload {upload_id} matches existing doc {doc_id} "
+                    f"in KB {kb_id} (hash={file_hash[:12]}…) — reusing"
+                )
+                # Skip enqueue; fall through to the poll loop which
+                # will detect status=completed on the next iteration
+                # and notify the session.
+                doc = existing
+            else:
+                from services.rag_service import RAGService
+                rag = RAGService(db)
+                doc = await rag.create_document_record(
+                    file_path=file_path,
+                    knowledge_base_id=kb_id,
+                    filename=filename,
+                    file_hash=file_hash,
+                )
+                doc_id = doc.id
+
+                # Link the chat upload to the pending doc up-front so
+                # the UI can show "processing" without waiting for the
+                # worker.
+                upload_row = (await db.execute(
+                    select(ChatUpload).where(ChatUpload.id == upload_id)
+                )).scalar_one_or_none()
+                if upload_row:
+                    upload_row.document_id = doc_id
+                    upload_row.knowledge_base_id = kb_id
+                    await db.commit()
+
+        # Only enqueue when we created a NEW document row. Re-uploads
+        # that hit the existing-doc branch above already have a worker
+        # task in some terminal state (or in flight) — the poll loop
+        # picks up `completed`/`failed` directly. Re-enqueuing a
+        # completed doc would burn worker cycles for no gain.
+        if existing is None:
+            queue = DocumentTaskQueue(redis_client=get_redis())
+            await queue.enqueue({
+                "document_id": doc_id,
+                "force_ocr": False,
+                "user_id": None,
+            })
+            logger.info(f"Chat upload {upload_id} enqueued as doc {doc_id} → KB {kb_id}")
 
         # Step 2 — poll for terminal state. Check first, sleep after,
         # so a worker that finishes in <2s notifies the UI immediately

--- a/tests/backend/test_chat_upload_worker_path.py
+++ b/tests/backend/test_chat_upload_worker_path.py
@@ -203,3 +203,75 @@ async def test_auto_index_worker_failure_surfaces_error(
 
     err = next(n for n in notifications if n["type"] == "document_error")
     assert "Docling threw on page 42" in err["error"]
+
+
+@pytest.mark.unit
+@pytest.mark.database
+async def test_auto_index_reuses_existing_doc_on_duplicate_hash(
+    db_session, kb, chat_upload_row,
+):
+    """Re-uploading the same file into the same KB used to crash the
+    auto-index path with `IntegrityError: duplicate key value violates
+    unique constraint "uq_documents_file_hash_kb"` because
+    create_document_record blindly INSERTed.
+
+    The fix: pre-check for an existing (file_hash, kb_id) row and
+    reuse it — link the chat upload to the existing doc, skip the
+    enqueue, and let the poll loop deliver document_ready immediately
+    if the existing doc is already completed.
+    """
+    notifications: list[dict] = []
+
+    async def _fake_notify(session_id, payload):
+        notifications.append({"session": session_id, **payload})
+
+    hash_val = hashlib.sha256(b"already-uploaded-once").hexdigest()
+    existing_doc = Document(
+        filename="duplicate.pdf",
+        file_path="/tmp/duplicate.pdf",
+        file_hash=hash_val,
+        knowledge_base_id=kb.id,
+        status="completed",
+        chunk_count=42,
+    )
+    db_session.add(existing_doc)
+    await db_session.commit()
+    await db_session.refresh(existing_doc)
+
+    create_record = AsyncMock()  # MUST NOT be called
+    enqueue_mock = AsyncMock()    # MUST NOT be called
+
+    with patch(
+        "api.routes.chat_upload._get_or_create_default_kb",
+        new=AsyncMock(return_value=kb),
+    ), patch(
+        "api.routes.chat_upload._worker_is_alive",
+        new=AsyncMock(return_value=True),
+    ), patch(
+        "services.rag_service.RAGService.create_document_record",
+        new=create_record,
+    ), patch(
+        "services.task_queue.DocumentTaskQueue.enqueue",
+        new=enqueue_mock,
+    ), patch(
+        "api.websocket.shared.notify_session",
+        new=_fake_notify,
+    ):
+        await _auto_index_to_kb(
+            upload_id=chat_upload_row.id,
+            file_path="/tmp/duplicate.pdf",
+            filename="duplicate.pdf",
+            file_hash=hash_val,
+            session_id="sess-dup",
+        )
+
+    # No INSERT, no enqueue: we reused the existing doc cleanly.
+    create_record.assert_not_called()
+    enqueue_mock.assert_not_called()
+
+    # The session got a document_ready for the existing doc.
+    types = [n["type"] for n in notifications]
+    assert "document_ready" in types
+    ready = next(n for n in notifications if n["type"] == "document_ready")
+    assert ready["document_id"] == existing_doc.id
+    assert ready["chunk_count"] == 42


### PR DESCRIPTION
## Summary

User hit \`Auto-index failed for upload N: ... duplicate key value violates unique constraint "uq_documents_file_hash_kb"\` when re-uploading a previously-indexed file via chat.

## Root cause

\`_auto_index_to_kb\` in \`api/routes/chat_upload.py\` calls \`rag.create_document_record\` which always INSERTs. The \`(file_hash, knowledge_base_id)\` unique constraint (#396) fires on the second upload of the same file. The main upload route already handles this case (returns 409); the chat path didn't.

## Fix

Pre-check for an existing \`(file_hash, kb_id)\` row before insert. On a hit:
- Link the chat upload to the existing doc
- Skip the worker enqueue (the existing doc has been processed already, or has a task in flight)
- Fall through to the poll loop which delivers \`document_ready\` immediately if the existing doc is \`status=completed\`

## Test

\`test_auto_index_reuses_existing_doc_on_duplicate_hash\` seeds a completed Document and asserts \`create_document_record\` and \`enqueue\` are both NOT called, and the session gets a \`document_ready\` for the existing doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)