### PR TITLE
fix(paperless): finish cold-start confirm flow + JSON-safe MCP truncation

### DIFF
--- a/src/backend/services/chat_upload_tool.py
+++ b/src/backend/services/chat_upload_tool.py
@@ -87,6 +87,30 @@ CHAT_UPLOAD_TOOLS: dict = {
             ),
         },
     },
+    "internal.paperless_commit_upload": {
+        "description": (
+            "Second half of the cold-start confirm flow. Call this AFTER the "
+            "user replies to a paperless_confirm preview produced by "
+            "internal.forward_attachment_to_paperless. Reads the pending row "
+            "by confirm_token, parses the user's response (ja / nein / inline "
+            "edits like 'tags: foo, bar'), and finalises the upload to "
+            "Paperless. Until this tool is wired into the agent registry, the "
+            "cold-start confirm flow gets stuck after step 1 with "
+            "'Unbekanntes Tool: internal.paperless_commit_upload'."
+        ),
+        "parameters": {
+            "confirm_token": (
+                "UUID returned in the data.confirm_token field of the "
+                "preceding forward_attachment_to_paperless response. Required."
+            ),
+            "user_response_text": (
+                "The user's verbatim reply to the confirm preview. Accepts "
+                "'ja' / 'yes' to commit as-shown, 'nein' / 'no' to abort, or "
+                "an inline edit like 'tags: rechnung, 2026' / "
+                "'correspondent: Anthropic'. Required."
+            ),
+        },
+    },
 }
 
 

--- a/src/backend/services/mcp_client.py
+++ b/src/backend/services/mcp_client.py
@@ -541,16 +541,32 @@ def _truncate_response(text: str, max_size: int = MAX_RESPONSE_SIZE) -> str:
                     else:
                         hi = mid - 1
                 data[array_key] = slimmed[:best]
-                result = json.dumps(data, ensure_ascii=False)
+                # Embed the truncation note INSIDE the JSON envelope so
+                # downstream callers that do `json.loads(message)` (e.g.
+                # paperless_metadata_extractor._list_via_mcp) still
+                # succeed. A human-readable suffix appended after the
+                # closing brace was producing
+                # `MCP tool ... returned non-JSON message` warnings and
+                # a silent fall-through to "empty taxonomy" extraction
+                # — which masked the size issue for months.
                 if best < total:
-                    result += f"\n\n[... Showing {best} of {total} results]"
-                return result
+                    data["_truncation"] = {
+                        "showing": best,
+                        "total": total,
+                        "note": f"Showing {best} of {total} results",
+                    }
+                return json.dumps(data, ensure_ascii=False)
     except (json.JSONDecodeError, TypeError, KeyError):
         pass
 
-    # Fallback: byte-level truncation (reuse pre-encoded bytes)
+    # Fallback: byte-level truncation. For non-JSON MCP responses (rare),
+    # the human-readable suffix is fine — there's nothing structured to
+    # parse. The size in the message is computed live so it stays
+    # accurate when MAX_RESPONSE_SIZE changes.
     truncated = text_bytes[:max_size - 50].decode('utf-8', errors='ignore')
-    return truncated + "\n\n[... Response truncated (exceeded 10KB limit)]"
+    return truncated + (
+        f"\n\n[... Response truncated (exceeded {max_size // 1024}KB limit)]"
+    )
 
 
 # Regex pattern to detect and redact credentials in MCP responses.

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -138,7 +138,7 @@ class Settings(BaseSettings):
     mcp_refresh_interval: int = 60        # Background refresh interval (seconds)
     mcp_connect_timeout: float = 10.0     # Connection timeout per server (seconds)
     mcp_call_timeout: float = 30.0        # Tool call timeout (seconds)
-    mcp_max_response_size: int = Field(default=10240, ge=1024, le=524288)  # 10KB max response
+    mcp_max_response_size: int = Field(default=131072, ge=1024, le=524288)  # 128KB max response — accommodates list_correspondents on real corpora (~70KB at ~900 entries) without truncating mid-payload
 
     # Agent Advanced
     agent_history_limit: int = Field(default=20, ge=1, le=100)       # Max history steps in agent loop

--- a/tests/backend/test_chat_upload_tool.py
+++ b/tests/backend/test_chat_upload_tool.py
@@ -374,3 +374,41 @@ class TestForwardAttachmentToPaperless:
             assert result["data"]["task_id"] is None
         finally:
             Path(tmp_path).unlink(missing_ok=True)
+
+
+# ===========================================================================
+# Tool registry — both halves of the cold-start confirm flow must register
+# ===========================================================================
+
+
+@pytest.mark.unit
+def test_chat_upload_tools_declares_both_confirm_flow_steps():
+    """Regression for the prod 'Unbekanntes Tool: internal.paperless_commit_upload'
+    error. The cold-start confirm flow has TWO steps:
+
+      1. internal.forward_attachment_to_paperless (creates pending row)
+      2. internal.paperless_commit_upload (reads the pending row + commits)
+
+    action_executor.py dispatches both, but the agent's tool registry
+    builds its tool list from CHAT_UPLOAD_TOOLS. Step 2 was missing
+    from the registry, so the agent never saw it as a valid action and
+    the flow got stuck at "Unbekanntes Tool" after step 1's preview.
+
+    This test fails fast if either tool is removed from CHAT_UPLOAD_TOOLS.
+    """
+    from services.chat_upload_tool import CHAT_UPLOAD_TOOLS
+
+    assert "internal.forward_attachment_to_paperless" in CHAT_UPLOAD_TOOLS, (
+        "forward_attachment_to_paperless missing from CHAT_UPLOAD_TOOLS"
+    )
+    assert "internal.paperless_commit_upload" in CHAT_UPLOAD_TOOLS, (
+        "paperless_commit_upload missing from CHAT_UPLOAD_TOOLS — "
+        "the agent will fail with 'Unbekanntes Tool' after the user "
+        "replies to a paperless_confirm preview."
+    )
+
+    commit = CHAT_UPLOAD_TOOLS["internal.paperless_commit_upload"]
+    # The two parameters the action_executor reads from `params`:
+    # confirm_token (required) and user_response_text.
+    assert "confirm_token" in commit["parameters"]
+    assert "user_response_text" in commit["parameters"]


### PR DESCRIPTION
## Summary

User hit two stacked errors in the chat→Paperless flow tonight:

\`\`\`
paperless_commit_upload — Unbekanntes Tool: internal.paperless_commit_upload
MCP tool mcp.paperless.list_correspondents returned non-JSON message: '{"items": [...'
\`\`\`

Three independent fixes shipped together:

### 1. Missing tool registration (the user-facing dead-end)

The cold-start confirm flow has two steps: \`forward_attachment_to_paperless\` (creates pending row) and \`paperless_commit_upload\` (commits on user reply). \`action_executor.py\` dispatches both, but \`CHAT_UPLOAD_TOOLS\` only declared step 1. Agent sees the preview, relays it, user replies "ja", agent hits \`Unbekanntes Tool\` because \`resolve_tool_name\` returns nothing.

Fix: add \`internal.paperless_commit_upload\` to \`CHAT_UPLOAD_TOOLS\` with \`confirm_token\` + \`user_response_text\` parameters. Regression test \`test_chat_upload_tools_declares_both_confirm_flow_steps\` pins it.

### 2. MCP truncation breaks downstream JSON parsing

\`_truncate_response\` was appending \`"[... Showing N of M results]"\` AFTER the closing brace, producing output that fails \`json.loads\`. \`paperless_metadata_extractor._list_via_mcp\` then logged \`returned non-JSON message\` and silently fell through to an EMPTY taxonomy — masking the real bug for months.

Fix: embed the truncation note INSIDE the JSON envelope as a \`"_truncation": {showing, total, note}\` key.

### 3. 10KB truncation cap too tight for real corpora

\`mcp_max_response_size\` defaulted to 10KB. \`list_correspondents\` on this user's corpus returns ~903 entries / ~70KB — well past the cap. Bumped default to 128KB (fits 1500+ entries).

## Why they showed up together

Bugs 2 and 3 had been silently degrading metadata extraction for ages — the empty-taxonomy fall-through is exactly why the LLM kept proposing "X-idra Systems GmbH" as a NEW correspondent (no fuzzy-match anchor to correct it). The fix in PR #467 made extraction actually populate the metadata, which then triggered the cold-start confirm flow that exposed Bug 1.

## Test plan

- [ ] Rebuild + rollout
- [ ] Chat upload → confirm preview → user replies "ja" → no \`Unbekanntes Tool\`, document lands in Paperless
- [ ] Backend log no longer shows \`returned non-JSON message\` warnings on \`list_correspondents\` / \`list_document_types\` / \`list_tags\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)