### PR TITLE
fix(paperless): poll consume task and surface real ingestion outcome

### DIFF
--- a/src/backend/services/chat_upload_tool.py
+++ b/src/backend/services/chat_upload_tool.py
@@ -447,6 +447,43 @@ async def _direct_upload(
             # success path — it's purely a learning-loop concern.
             logger.warning(f"Upload-tracking persist failed: {exc}")
 
+    # Poll Paperless's task endpoint to learn the REAL ingestion outcome.
+    #
+    # Without this, the MCP returned "task accepted" (HTTP 200 + task_id)
+    # gets blindly reported as "Sent to Paperless" — even though the
+    # consume task can fail asynchronously with e.g.
+    # "Not consuming X.pdf: It is a duplicate of <existing> (#NNN)".
+    # The user then sees "successfully uploaded" but the doc never lands.
+    # That was the prod symptom on 2026-04-25.
+    #
+    # We only poll when (a) we got a task_id back AND (b) the MCP didn't
+    # already produce a document_id (it does that itself when PATCH-style
+    # metadata is set, by polling internally). Skip the poll without a
+    # task_id (nothing to look up).
+    consume_failure: str | None = None
+    if task_id and document_id is None:
+        consume_failure, polled_doc_id = await _poll_paperless_task(task_id)
+        if polled_doc_id is not None:
+            document_id = polled_doc_id
+
+    if consume_failure:
+        # The POST landed but the consume queue rejected it. Surface the
+        # exact reason to the user so the agent's final answer doesn't
+        # claim success when Paperless silently dropped the doc.
+        return {
+            "success": False,
+            "message": (
+                f"Paperless lehnte das Dokument ab: {consume_failure}"
+            ),
+            "action_taken": False,
+            "data": {
+                "attachment_id": upload.id,
+                "filename": upload.filename,
+                "task_id": task_id,
+                "rejection_reason": consume_failure,
+            },
+        }
+
     return {
         "success": True,
         "message": f"Sent to Paperless: {upload.filename}",
@@ -459,6 +496,59 @@ async def _direct_upload(
             "post_upload_patch": patch_state,
         },
     }
+
+
+async def _poll_paperless_task(
+    task_id: str, *, timeout_s: float = 30.0, interval_s: float = 1.0,
+) -> tuple[str | None, int | None]:
+    """Poll Paperless's /api/tasks/?task_id= until terminal state.
+
+    Returns (failure_reason, document_id). Failure reason is the
+    `result` field from Paperless when status=FAILURE (e.g.
+    "It is a duplicate of <other> (#1661)"). Document id is the
+    `related_document` field from Paperless when status=SUCCESS.
+    Either or both may be None on timeout / unexpected shape.
+
+    Reads PAPERLESS_API_URL + PAPERLESS_API_TOKEN from env (the same
+    way the MCP server resolves them, since chat_upload_tool runs
+    in-process and shares the env).
+    """
+    import asyncio
+    import os
+
+    import httpx
+
+    base = os.environ.get("PAPERLESS_API_URL")
+    token = os.environ.get("PAPERLESS_API_TOKEN")
+    if not (base and token):
+        return None, None
+
+    url = f"{base.rstrip('/')}/api/tasks/?task_id={task_id}"
+    headers = {"Authorization": f"Token {token}"}
+    deadline = asyncio.get_running_loop().time() + timeout_s
+
+    async with httpx.AsyncClient(verify=False, timeout=10.0) as client:  # noqa: S501
+        while asyncio.get_running_loop().time() < deadline:
+            try:
+                r = await client.get(url, headers=headers)
+                r.raise_for_status()
+                data = r.json()
+                tasks = data if isinstance(data, list) else data.get("results", [])
+                if tasks:
+                    t = tasks[0]
+                    status = (t.get("status") or "").upper()
+                    if status == "SUCCESS":
+                        rd = t.get("related_document")
+                        return None, int(rd) if rd is not None else None
+                    if status == "FAILURE":
+                        return (t.get("result") or "Paperless rejected the upload"), None
+                    # Still PENDING / STARTED → keep polling.
+            except (httpx.HTTPError, ValueError) as exc:
+                logger.warning(
+                    f"Paperless task poll {task_id} transient error: {exc}"
+                )
+            await asyncio.sleep(interval_s)
+    return None, None
 
 
 async def _run_extraction(

--- a/tests/backend/test_chat_upload_tool_paperless.py
+++ b/tests/backend/test_chat_upload_tool_paperless.py
@@ -595,6 +595,119 @@ class TestForwardAttachmentExtractionFailure:
         mcp.execute_tool.assert_awaited_once()
 
 
+class TestPaperlessTaskPolling:
+    """Bare-upload path must wait for Paperless's consume task to reach
+    a terminal state, then surface the real outcome to the user. Without
+    the poll, an asynchronous "duplicate / file too small / unparseable"
+    rejection is silently masked behind 'Sent to Paperless: …' and the
+    user sees 'success' in chat while Paperless drops the file. Real
+    prod symptom on 2026-04-25.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_bare_upload_surfaces_consume_failure(self, tmp_path):
+        upload = _upload_stub(tmp_path)
+        mcp = MagicMock()
+        mcp.execute_tool = AsyncMock(return_value={
+            "success": True, "message": '{"task_id": "tid-fail-1"}',
+        })
+
+        extractor_result = SimpleNamespace(
+            metadata=SimpleNamespace(
+                title=None, correspondent=None, document_type=None,
+                tags=[], storage_path=None, created_date=None,
+                new_entry_proposals=[],
+                model_dump=lambda **_kw: {},
+            ),
+            doc_text="",
+            error="OCR lieferte keinen Text.",
+        )
+
+        # Mock the polling helper to simulate Paperless rejecting the
+        # consume task as a duplicate.
+        async def _fake_poll(task_id, **_kw):
+            assert task_id == "tid-fail-1"
+            return (
+                "It is a duplicate of Rechnung NEW Niederrhein (#1661).",
+                None,
+            )
+
+        with patch(
+            "services.chat_upload_tool._run_extraction",
+            AsyncMock(return_value=extractor_result),
+        ), patch(
+            "services.chat_upload_tool._get_confirms_used",
+            AsyncMock(return_value=0),
+        ), patch(
+            "services.database.AsyncSessionLocal",
+            _make_session_factory(upload),
+        ), patch(
+            "services.chat_upload_tool._poll_paperless_task",
+            new=_fake_poll,
+        ):
+            result = await forward_attachment_to_paperless(
+                {"attachment_id": 42},
+                mcp_manager=mcp, session_id="s", user_id=1,
+            )
+
+        assert result["success"] is False, (
+            "Consume failure must propagate as success=False so the "
+            f"agent doesn't claim success. Got: {result}"
+        )
+        assert "duplicate" in result["message"].lower()
+        assert "1661" in result["message"]
+        assert result["data"]["rejection_reason"]
+        assert result["data"]["task_id"] == "tid-fail-1"
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_bare_upload_success_when_consume_succeeds(self, tmp_path):
+        """The poll resolves to (None, document_id) on success — the
+        return must propagate document_id so the UI can link to it."""
+        upload = _upload_stub(tmp_path)
+        mcp = MagicMock()
+        mcp.execute_tool = AsyncMock(return_value={
+            "success": True, "message": '{"task_id": "tid-ok-1"}',
+        })
+
+        extractor_result = SimpleNamespace(
+            metadata=SimpleNamespace(
+                title=None, correspondent=None, document_type=None,
+                tags=[], storage_path=None, created_date=None,
+                new_entry_proposals=[],
+                model_dump=lambda **_kw: {},
+            ),
+            doc_text="",
+            error="OCR lieferte keinen Text.",
+        )
+
+        async def _fake_poll(task_id, **_kw):
+            return (None, 9999)  # Paperless says SUCCESS, doc id 9999
+
+        with patch(
+            "services.chat_upload_tool._run_extraction",
+            AsyncMock(return_value=extractor_result),
+        ), patch(
+            "services.chat_upload_tool._get_confirms_used",
+            AsyncMock(return_value=0),
+        ), patch(
+            "services.database.AsyncSessionLocal",
+            _make_session_factory(upload),
+        ), patch(
+            "services.chat_upload_tool._poll_paperless_task",
+            new=_fake_poll,
+        ):
+            result = await forward_attachment_to_paperless(
+                {"attachment_id": 42},
+                mcp_manager=mcp, session_id="s", user_id=1,
+            )
+
+        assert result["success"] is True
+        assert result["data"]["document_id"] == 9999
+        assert result["data"]["task_id"] == "tid-ok-1"
+
+
 class TestForwardAttachmentValidation:
     @pytest.mark.asyncio
     @pytest.mark.unit


### PR DESCRIPTION
## Summary

User uploaded a doc + asked to forward to Paperless. Chat reported "successfully uploaded". User opened Paperless, doc wasn't there, asked "Ich sehe das Dokument nicht in Paperless".

Backend trace:
\`\`\`
task_id: 265582c6-39ab-4f30-9859-d0e6c847d4cc
status:  FAILURE
result:  "Not consuming X.pdf: It is a duplicate of
          Rechnung NEW Niederrhein Energie und Wasser GmbH (#1661)"
\`\`\`

The MCP \`upload_document\` returned HTTP 200 + task_id, \`_direct_upload\` immediately reported success, but Paperless's consume queue rejected the task asynchronously. Chat said "uploaded", reality said "duplicate".

## Fix

After the MCP POST succeeds, poll \`GET /api/tasks/?task_id=<id>\` until terminal state:
- **FAILURE** → return \`success=False\` with the rejection reason in the chat-visible message + \`data.rejection_reason\`. Agent's final answer now reads "Paperless lehnte das Dokument ab: It is a duplicate of …" instead of "Sent to Paperless".
- **SUCCESS** → propagate \`document_id\` into \`data\` for UI linking.
- **timeout / no env** → falls through to old success path (no behaviour change).

Skips the poll when the MCP already populated \`document_id\` (PATCH-style metadata path) — no double-work.

## Tests

- \`test_bare_upload_surfaces_consume_failure\` — duplicate rejection propagates as success=False with the reason in the message
- \`test_bare_upload_success_when_consume_succeeds\` — happy path propagates document_id

## Test plan

- [ ] Rebuild + rollout
- [ ] Re-upload the Niederrhein invoice → chat now says "Paperless lehnte das Dokument ab: It is a duplicate of …" instead of "Sent to Paperless"
- [ ] Upload a fresh doc → chat says "Sent to Paperless" with a real document_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)