### PR TITLE
feat(paperless): drop taxonomy from prompt; resolve server-side with user choice

### DIFF
--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -347,8 +347,12 @@ class PaperlessPendingConfirm(Base):
     # Post-fuzzy, post-validation. This is what the user sees and
     # approves in the confirm preview.
     post_fuzzy_output = Column(JSON, nullable=False)
-    # new_entry_proposals[] — surfaces in the confirm message as
-    # "Neu anlegen: Stadtwerke Köln".
+    # FieldResolution[] (column name kept for legacy reasons) — one per
+    # extracted field that did NOT resolve to an exact taxonomy hit.
+    # Carries extracted_value + near-match candidates the user picks
+    # from in the confirm preview. The commit tool reads this back to
+    # turn the user's response into final field values + create_*
+    # calls.
     proposals = Column(JSON, nullable=False, default=list, server_default="[]")
     # Caps the ambiguous-response loop so a user who keeps typing
     # "hmmm" can't pin the row indefinitely.

--- a/src/backend/prompts/paperless_metadata.yaml
+++ b/src/backend/prompts/paperless_metadata.yaml
@@ -2,49 +2,49 @@
 #
 # Used by PaperlessMetadataExtractor.extract() to produce a structured
 # metadata dict (correspondent, document_type, tags, storage_path,
-# created_date) from a document's OCR'd text, constrained to the user's
-# current Paperless taxonomy.
+# created_date) directly from a document's OCR'd text.
 #
-# Prompt structure: system + user. The user prompt receives the pruned
-# taxonomy (top 20 correspondents + top 20 tags by recency, full
-# doc_types + storage_paths) plus three worked examples plus the
-# document text. LLM returns a JSON object matching the PaperlessMetadata
-# pydantic model.
+# Prompt structure: system + user. The user prompt receives only the
+# document text plus optional learned examples (past confirm-diffs).
+# The taxonomy is NOT injected into the prompt — it would balloon the
+# context (903 correspondents + 383 doc-types + 1461 tags is typical
+# for a real household instance) and force the LLM to hallucinate a
+# taxonomy match instead of extracting the value the document actually
+# carries. Server-side fuzzy resolution + user-driven near-match
+# disambiguation does that comparison post-extraction.
 #
 # Design reference: docs/design/paperless-llm-metadata.md §Prompt template.
 
 de:
   system: |
     Du hilfst beim Ablegen von Dokumenten in Paperless-NGX. Lies den
-    extrahierten Dokumenttext und waehle die passendsten Felder aus der
-    vorhandenen Paperless-Taxonomie.
+    extrahierten Dokumenttext und gib die wesentlichen Metadaten als
+    JSON zurueck.
 
     Regeln:
-    - Verwende nur Werte aus der unten aufgefuehrten Taxonomie. Wenn
-      nichts passt, gib null zurueck — erfinde nichts.
+    - Extrahiere die Werte direkt aus dem Dokument (Briefkopf,
+      Rechnungssteller, Betreffzeile usw.). Erfinde nichts. Wenn ein
+      Feld im Dokument nicht klar steht, gib null zurueck.
     - title: beschreibend und dateisystemtauglich. Format: "<Dokumenttyp>
       <Zeitraum/Bezug> - <Korrespondent>". Beispiel:
       "Nebenkostenabrechnung 2025 - Stadtwerke Korschenbroich".
+    - correspondent: der Absender des Dokuments. Firmenname so wie er
+      im Briefkopf steht (mit Rechtsform falls aufgefuehrt).
+    - document_type: knapp und generisch ("Rechnung", "Steuerbescheid",
+      "Vertrag", "Mahnung"). NICHT die spezifische Bezeichnung des
+      Dokuments — die gehoert in den title.
+    - storage_path: thematischer Pfad ("/wohnung/betriebskosten",
+      "/steuer/2024", "/handwerker"). Optional.
+    - tags: maximal 5, thematisch relevant.
     - created_date: das Ausstellungsdatum laut Dokument (Rechnungsdatum,
       Ausstellungsdatum, Vertragsdatum — NICHT Zahlungsziel, NICHT das
       heutige Datum). Format YYYY-MM-DD.
-    - tags: maximal 5, thematisch relevant.
     - confidence: 0.0 bis 1.0 pro Feld, deine Selbsteinschaetzung.
-    - new_entry_proposals: optional. Nur wenn du sehr sicher bist, dass
-      der Wert nicht in der Taxonomie steht und einen neuen Eintrag
-      rechtfertigt. Ein Vorschlag pro Feld — drei neue Tags werden als
-      drei Eintraege emittiert.
 
     Antworte ausschliesslich mit einem JSON-Objekt, kein Fliesstext,
     keine Markdown-Code-Fences.
 
   user: |
-    Paperless-Taxonomie (nach Relevanz gekuerzt):
-    correspondents: {correspondents}
-    document_types: {document_types}
-    tags: {tags}
-    storage_paths: {storage_paths}
-
     Beispiele:
 
     ---
@@ -56,7 +56,7 @@ de:
     Antwort:
     {{
       "title": "Nebenkostenabrechnung 2025 - Stadtwerke Korschenbroich",
-      "correspondent": "Stadtwerke Korschenbroich",
+      "correspondent": "Stadtwerke Korschenbroich GmbH",
       "document_type": "Nebenkostenabrechnung",
       "tags": ["wohnung", "nebenkosten-2025"],
       "storage_path": "/wohnung/betriebskosten",
@@ -64,8 +64,7 @@ de:
       "confidence": {{
         "title": 0.95, "correspondent": 0.98, "document_type": 0.95,
         "storage_path": 0.85, "created_date": 0.98
-      }},
-      "new_entry_proposals": []
+      }}
     }}
 
     ---
@@ -84,8 +83,7 @@ de:
       "confidence": {{
         "title": 0.92, "correspondent": 0.98, "document_type": 0.94,
         "storage_path": 0.88, "created_date": 0.99
-      }},
-      "new_entry_proposals": []
+      }}
     }}
 
     ---
@@ -93,27 +91,18 @@ de:
     "Schreiner Meier ... Rechnung Nr. 2026-0042 ... Einbau Fensterbank
     Esszimmer ... 380,00 EUR ... Rechnungsdatum: 18.03.2026"
 
-    (Taxonomie enthaelt "Schreiner Meier" NICHT.)
-
     Antwort:
     {{
       "title": "Rechnung 2026-0042 - Schreiner Meier",
-      "correspondent": null,
+      "correspondent": "Schreiner Meier",
       "document_type": "Rechnung",
       "tags": ["wohnung", "handwerker"],
       "storage_path": "/wohnung/handwerker",
       "created_date": "2026-03-18",
       "confidence": {{
-        "title": 0.9, "document_type": 0.97, "storage_path": 0.7,
-        "created_date": 0.99
-      }},
-      "new_entry_proposals": [
-        {{
-          "field": "correspondent",
-          "value": "Schreiner Meier",
-          "reasoning": "Rechnungskopf nennt den Korrespondenten eindeutig; nicht in Taxonomie."
-        }}
-      ]
+        "title": 0.9, "correspondent": 0.95, "document_type": 0.97,
+        "storage_path": 0.7, "created_date": 0.99
+      }}
     }}
 
     {learned_examples}
@@ -127,33 +116,31 @@ de:
 en:
   system: |
     You help archive documents in Paperless-NGX. Read the extracted
-    document text and pick the best-matching fields from the existing
-    Paperless taxonomy.
+    document text and return the essential metadata as JSON.
 
     Rules:
-    - Use only values from the taxonomy listed below. If nothing fits,
-      return null — do not invent entries.
+    - Extract values directly from the document (letterhead, sender,
+      subject line, etc.). Do not invent. If a field is not clearly
+      stated in the document, return null.
     - title: descriptive, filesystem-safe. Format: "<document_type>
       <period/reference> - <correspondent>". Example:
-      "Utility Bill 2025 - Municipal Utilities".
+      "Utility Bill 2025 - Acme Utilities".
+    - correspondent: the sender of the document. Company name as it
+      appears in the letterhead (with legal form if listed).
+    - document_type: concise and generic ("Invoice", "Tax Notice",
+      "Contract", "Reminder"). NOT the specific document name — that
+      belongs in the title.
+    - storage_path: thematic path ("/home/utilities", "/tax/2024",
+      "/contractor"). Optional.
+    - tags: at most 5, thematically relevant.
     - created_date: the document's issue date (invoice date, issue
       date, contract date — NOT the payment deadline, NOT today's
       date). Format YYYY-MM-DD.
-    - tags: at most 5, thematically relevant.
     - confidence: 0.0 to 1.0 per field, your own estimate.
-    - new_entry_proposals: optional. Only when you are highly confident
-      the value is not in the taxonomy and a new entry is warranted.
-      One proposal per field — three new tags become three entries.
 
     Respond with a JSON object only — no prose, no markdown fences.
 
   user: |
-    Paperless taxonomy (pruned by relevance):
-    correspondents: {correspondents}
-    document_types: {document_types}
-    tags: {tags}
-    storage_paths: {storage_paths}
-
     Examples:
 
     ---
@@ -164,7 +151,7 @@ en:
     Answer:
     {{
       "title": "Utility Bill 2025 - Acme Utilities",
-      "correspondent": "Acme Utilities",
+      "correspondent": "Acme Utilities Inc",
       "document_type": "Utility Bill",
       "tags": ["home", "utilities-2025"],
       "storage_path": "/home/utilities",
@@ -172,8 +159,7 @@ en:
       "confidence": {{
         "title": 0.95, "correspondent": 0.98, "document_type": 0.95,
         "storage_path": 0.85, "created_date": 0.98
-      }},
-      "new_entry_proposals": []
+      }}
     }}
 
     ---
@@ -192,8 +178,7 @@ en:
       "confidence": {{
         "title": 0.92, "correspondent": 0.98, "document_type": 0.94,
         "storage_path": 0.88, "created_date": 0.99
-      }},
-      "new_entry_proposals": []
+      }}
     }}
 
     ---
@@ -201,27 +186,18 @@ en:
     "Meier Carpentry ... Invoice 2026-0042 ... Install windowsill in
     dining room ... USD 380.00 ... Invoice date: 2026-03-18"
 
-    (Taxonomy does NOT contain "Meier Carpentry".)
-
     Answer:
     {{
       "title": "Invoice 2026-0042 - Meier Carpentry",
-      "correspondent": null,
+      "correspondent": "Meier Carpentry",
       "document_type": "Invoice",
       "tags": ["home", "contractor"],
       "storage_path": "/home/contractor",
       "created_date": "2026-03-18",
       "confidence": {{
-        "title": 0.9, "document_type": 0.97, "storage_path": 0.7,
-        "created_date": 0.99
-      }},
-      "new_entry_proposals": [
-        {{
-          "field": "correspondent",
-          "value": "Meier Carpentry",
-          "reasoning": "Invoice header names the correspondent unambiguously; not in taxonomy."
-        }}
-      ]
+        "title": 0.9, "correspondent": 0.95, "document_type": 0.97,
+        "storage_path": 0.7, "created_date": 0.99
+      }}
     }}
 
     {learned_examples}

--- a/src/backend/services/chat_upload_tool.py
+++ b/src/backend/services/chat_upload_tool.py
@@ -715,8 +715,9 @@ def _render_confirm_message(
 
     lines.append("")
     lines.append(
-        "Antworte mit `ja` (Vorschläge übernehmen — bei `near` Wahl 1, "
-        "sonst NEU), `nein` zum Abbrechen, oder gib pro Feld eine Wahl an, "
-        "z.B. `1: 2, 2: neu, 3: x`."
+        "Antworte mit `ja` (vorgeschlagene Treffer übernehmen, ungelöste "
+        "Felder leer lassen), `nein` zum Abbrechen, oder gib pro Feld eine "
+        "Wahl an, z.B. `1: 2, 2: neu, 3: x`. Neue Taxonomie-Einträge nur "
+        "auf ausdrücklichen Wunsch (`neu`)."
     )
     return "\n".join(lines)

--- a/src/backend/services/chat_upload_tool.py
+++ b/src/backend/services/chat_upload_tool.py
@@ -315,6 +315,16 @@ async def forward_attachment_to_paperless(
         # extraction run.
         llm_output_for_persist["_doc_text"] = extraction_result.doc_text
 
+        # Resolutions carry the user-facing decision list (extracted
+        # value + near-match candidates per field that didn't resolve
+        # to an exact taxonomy hit). Persisted into the pending row's
+        # JSON column (named `proposals` for legacy reasons) so the
+        # commit tool can read them back in the next turn.
+        resolutions_payload = [
+            r.model_dump(mode="json")
+            for r in extraction_result.metadata.resolutions
+        ]
+
         async with AsyncSessionLocal() as db:
             pending = PaperlessPendingConfirm(
                 confirm_token=confirm_token,
@@ -326,10 +336,7 @@ async def forward_attachment_to_paperless(
                 user_id=user_id,
                 llm_output=llm_output_for_persist,
                 post_fuzzy_output=post_fuzzy,
-                proposals=[
-                    p.model_dump(mode="json")
-                    for p in extraction_result.metadata.new_entry_proposals
-                ],
+                proposals=resolutions_payload,
             )
             db.add(pending)
             await db.commit()
@@ -337,7 +344,7 @@ async def forward_attachment_to_paperless(
         preview_text = _render_confirm_message(
             filename=upload.filename,
             metadata=post_fuzzy,
-            proposals=extraction_result.metadata.new_entry_proposals,
+            resolutions=extraction_result.metadata.resolutions,
         )
 
         return {
@@ -627,17 +634,29 @@ def _infer_lang(upload) -> str:
     return "de"
 
 
+_FIELD_LABELS_DE = {
+    "correspondent": "Korrespondent",
+    "document_type": "Dokumenttyp",
+    "storage_path": "Speicherpfad",
+    "tag": "Tag",
+}
+
+
 def _render_confirm_message(
     *,
     filename: str,
     metadata: dict,
-    proposals: list,
+    resolutions: list,
 ) -> str:
     """Build the German confirm preview the agent relays to the user.
 
-    Matches the shape documented in the design doc § 5 confirm UX.
-    Missing fields render as "—" so the user sees what the LLM couldn't
-    decide and can either approve the gaps or abort.
+    Resolved fields (LLM extracted + server matched a taxonomy entry)
+    appear plainly. Anything that didn't resolve to an exact hit shows
+    up under "Folgende Felder benötigen Klärung" with a numbered list
+    of near-match candidates plus a "neu" option.
+
+    Empty / null fields render as "—" so the user sees what's missing
+    and can either approve the gaps with `ja` or abort with `nein`.
     """
     def _display(value):
         if value is None or value == "":
@@ -646,27 +665,58 @@ def _render_confirm_message(
             return ", ".join(str(v) for v in value) if value else "—"
         return str(value)
 
-    proposals_line = "keine"
-    if proposals:
-        parts = []
-        for p in proposals:
-            field = p.field if hasattr(p, "field") else p.get("field")
-            value = p.value if hasattr(p, "value") else p.get("value")
-            parts.append(f"{field}: {value}")
-        proposals_line = "; ".join(parts)
+    decisions = [
+        r for r in (resolutions or [])
+        if (r.requires_user_decision if hasattr(r, "requires_user_decision")
+            else r.get("status") != "exact" or bool(r.get("near_matches")))
+    ]
 
-    return (
-        f"Ich möchte das Dokument so ablegen:\n"
-        f"\n"
-        f"  Datei:             {filename}\n"
-        f"  Titel:             {_display(metadata.get('title'))}\n"
-        f"  Korrespondent:     {_display(metadata.get('correspondent'))}\n"
-        f"  Dokumenttyp:       {_display(metadata.get('document_type'))}\n"
-        f"  Tags:              {_display(metadata.get('tags'))}\n"
-        f"  Speicherpfad:      {_display(metadata.get('storage_path'))}\n"
-        f"  Ausstellungsdatum: {_display(metadata.get('created_date'))}\n"
-        f"\n"
-        f"  Neu anzulegen:     {proposals_line}\n"
-        f"\n"
-        f"Passt das so? Antworte mit `ja` zum Ablegen oder `nein` zum Abbrechen."
+    lines = [
+        "Ich möchte das Dokument so ablegen:",
+        "",
+        f"  Datei:             {filename}",
+        f"  Titel:             {_display(metadata.get('title'))}",
+        f"  Korrespondent:     {_display(metadata.get('correspondent'))}",
+        f"  Dokumenttyp:       {_display(metadata.get('document_type'))}",
+        f"  Tags:              {_display(metadata.get('tags'))}",
+        f"  Speicherpfad:      {_display(metadata.get('storage_path'))}",
+        f"  Ausstellungsdatum: {_display(metadata.get('created_date'))}",
+    ]
+
+    if not decisions:
+        lines.append("")
+        lines.append(
+            "Passt das so? Antworte mit `ja` zum Ablegen oder `nein` zum Abbrechen."
+        )
+        return "\n".join(lines)
+
+    lines.append("")
+    lines.append("Folgende Felder benötigen Klärung:")
+
+    for idx, res in enumerate(decisions, start=1):
+        field = res.field if hasattr(res, "field") else res.get("field")
+        extracted = (
+            res.extracted_value if hasattr(res, "extracted_value")
+            else res.get("extracted_value")
+        )
+        near = (
+            list(res.near_matches) if hasattr(res, "near_matches")
+            else list(res.get("near_matches") or [])
+        )
+        label = _FIELD_LABELS_DE.get(field, field)
+        lines.append("")
+        lines.append(f"  [{idx}] {label}: aus dem Dokument: \"{extracted}\"")
+        for j, candidate in enumerate(near, start=1):
+            marker = " (Vorschlag)" if j == 1 else ""
+            lines.append(f"        {j}. {candidate}{marker}")
+        lines.append(f"        n. NEU anlegen: \"{extracted}\"")
+        if not near:
+            lines.append("        x. Feld leer lassen")
+
+    lines.append("")
+    lines.append(
+        "Antworte mit `ja` (Vorschläge übernehmen — bei `near` Wahl 1, "
+        "sonst NEU), `nein` zum Abbrechen, oder gib pro Feld eine Wahl an, "
+        "z.B. `1: 2, 2: neu, 3: x`."
     )
+    return "\n".join(lines)

--- a/src/backend/services/paperless_commit_tool.py
+++ b/src/backend/services/paperless_commit_tool.py
@@ -54,16 +54,21 @@ _APPROVE_TOKENS = {"ja", "j", "ok", "okay", "passt", "passt so", "yes", "y", "su
 _ABORT_TOKENS = {"nein", "n", "abbrechen", "stopp", "stop", "no", "cancel"}
 
 # Per-resolution choice tokens. Only used as the right-hand side of a
-# "<idx>: <choice>" pair, so collision with top-level abort tokens
-# ("n", "no") is fine — but we keep them disjoint to avoid surprising
-# the user who reads them in either context.
-_NEW_TOKENS = {"neu", "new", "anlegen", "create"}
+# "<idx>: <choice>" pair, so the collision between "n" here and the
+# top-level abort token "n" never fires (different parsing contexts).
+# The preview marker "n. NEU anlegen" needs "n" to be valid here.
+_NEW_TOKENS = {"n", "neu", "new", "anlegen", "create"}
 _SKIP_TOKENS = {"x", "skip", "leer", "weglassen", "ueberspringen", "überspringen"}
 
 # Pair format in the user reply: "1: 2, 2: neu, 3: x". Index is the
 # [N] number from the confirm preview; value is a candidate index,
-# "neu", or "x". Whitespace-tolerant.
-_CHOICE_RE = re.compile(r"\s*(\d+)\s*[:=]\s*([^,;\n]+?)\s*(?=,|;|$)")
+# "neu", or "x". Whitespace-tolerant. The lookahead also stops on the
+# next "<digit>:" pair so phone-typed replies like "1:2 2:neu" (no
+# comma) still split into two decisions instead of swallowing the
+# second pair into the first value.
+_CHOICE_RE = re.compile(
+    r"\s*(\d+)\s*[:=]\s*([^,;\n]+?)\s*(?=,|;|$|\d+\s*[:=])"
+)
 
 _MAX_EDIT_ROUNDS = 3
 
@@ -188,13 +193,31 @@ async def paperless_commit_upload(
     return await _handle_ambiguous_response(pending)
 
 
+def _resolution_value(res: dict[str, Any]) -> str:
+    """Extracted value of a resolution. Falls back to legacy ``value``
+    so pending rows persisted under the old NewEntryProposal shape
+    (``{field, value, reasoning}``) still carry signal — without this
+    fallback the user's "ja" silently drops the LLM's pick because the
+    new shape's ``extracted_value`` key is absent."""
+    return (
+        res.get("extracted_value")
+        or res.get("value")
+        or ""
+    )
+
+
 def _default_decisions(
     resolutions: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     """Build the default decision per resolution for the `ja` path.
 
-    - near_matches non-empty → pick the first candidate.
-    - near_matches empty     → "neu" (create extracted_value).
+    - near_matches non-empty → pick the first candidate (safe: the user
+      sees it as the "(Vorschlag)" entry in the preview).
+    - near_matches empty     → SKIP. Auto-creating a new taxonomy
+      entry from a single OCR'd value without explicit user consent
+      pollutes the user's Paperless instance with typos and one-off
+      misreads forever. The user must explicitly type "<idx>: neu"
+      to opt in to creating an entry.
 
     Each decision dict has shape:
         {"resolution": <res>, "action": "use" | "create" | "skip",
@@ -212,8 +235,8 @@ def _default_decisions(
         else:
             out.append({
                 "resolution": res,
-                "action": "create",
-                "value": res.get("extracted_value") or "",
+                "action": "skip",
+                "value": "",
             })
     return out
 
@@ -250,7 +273,9 @@ def _parse_user_choices(
 
         if choice in _NEW_TOKENS:
             decision["action"] = "create"
-            decision["value"] = res.get("extracted_value") or ""
+            decision["value"] = _resolution_value(res)
+            if not decision["value"]:
+                return [], f"resolution {idx} has no value to create"
         elif choice in _SKIP_TOKENS:
             decision["action"] = "skip"
             decision["value"] = ""

--- a/src/backend/services/paperless_commit_tool.py
+++ b/src/backend/services/paperless_commit_tool.py
@@ -9,32 +9,35 @@ German confirm preview; their next chat message is their response.
 
 This tool handles that second turn:
 
-    user message "ja" / "nein" / "ändere X"
+    user message "ja" / "nein" / "1: 2, 2: neu"
         │
         ▼
     paperless_commit_upload(confirm_token, user_response_text)
         │   1. SELECT pending_confirms row (session-scoped per #442)
         │   2. Parse user_response_text:
-        │        - "ja" family → approve as-is
+        │        - "ja" family → apply defaults to every resolution
+        │          (pick #1 if near_matches non-empty, else "neu")
         │        - "nein" family → abort (delete ChatUpload + row, done)
-        │        - anything else (v1) → ask again, bump edit_rounds
-        │   3. If approved with new-entry proposals:
-        │        - For each proposal, call mcp.paperless.create_*
-        │        - Invalidate the extractor's taxonomy cache so the
-        │          next extraction sees the new entries
-        │   4. Call mcp.paperless.upload_document with final fields
-        │   5. On success:
+        │        - "<idx>: <choice>" pairs → per-resolution decision
+        │          where idx is the [N] number from the preview and
+        │          choice is one of: a number from the candidate
+        │          list, "neu", or "x" (skip the field).
+        │   3. For each "neu" decision, call mcp.paperless.create_*
+        │      and invalidate the extractor's taxonomy cache.
+        │   4. Build final field values: post_fuzzy from extraction +
+        │      resolved-by-user fields layered on top.
+        │   5. Call mcp.paperless.upload_document with final fields.
+        │   6. On success:
         │        - Write (doc_text, llm_output, user_approved) into
-        │          paperless_extraction_examples if the user's
-        │          approved fields differ from the LLM's post-fuzzy
-        │          output (confirm-diff signal for PR 3).
+        │          paperless_extraction_examples (confirm-diff signal).
         │        - Increment users.paperless_confirms_used.
         │        - Delete the pending_confirms row.
-        │   6. Return success with a user-facing message.
+        │   7. Return success with a user-facing message.
 """
 from __future__ import annotations
 
 import json
+import re
 from typing import Any
 
 from loguru import logger
@@ -50,10 +53,18 @@ from loguru import logger
 _APPROVE_TOKENS = {"ja", "j", "ok", "okay", "passt", "passt so", "yes", "y", "sure"}
 _ABORT_TOKENS = {"nein", "n", "abbrechen", "stopp", "stop", "no", "cancel"}
 
-# v1 keeps edit-parsing dumb: ja/nein only; anything else gets an error
-# message. Smarter correction parsing lands with PR 5 (interactive card)
-# or a separate follow-up. The cold-start confirm is capped at 10
-# uploads per user so this rough UX has a bounded impact.
+# Per-resolution choice tokens. Only used as the right-hand side of a
+# "<idx>: <choice>" pair, so collision with top-level abort tokens
+# ("n", "no") is fine — but we keep them disjoint to avoid surprising
+# the user who reads them in either context.
+_NEW_TOKENS = {"neu", "new", "anlegen", "create"}
+_SKIP_TOKENS = {"x", "skip", "leer", "weglassen", "ueberspringen", "überspringen"}
+
+# Pair format in the user reply: "1: 2, 2: neu, 3: x". Index is the
+# [N] number from the confirm preview; value is a candidate index,
+# "neu", or "x". Whitespace-tolerant.
+_CHOICE_RE = re.compile(r"\s*(\d+)\s*[:=]\s*([^,;\n]+?)\s*(?=,|;|$)")
+
 _MAX_EDIT_ROUNDS = 3
 
 
@@ -142,17 +153,118 @@ async def paperless_commit_upload(
         }
 
     # Classify the user's response.
-    normalised = user_response.strip().lower()
-    if normalised in _APPROVE_TOKENS:
-        return await _commit_approved(
-            pending, mcp_manager=mcp_manager, user_id=user_id,
-        )
+    raw_response = user_response.strip()
+    normalised = raw_response.lower()
+    resolutions: list[dict[str, Any]] = list(pending.proposals or [])
+
     if normalised in _ABORT_TOKENS:
         return await _abort_pending(pending)
 
-    # Unrecognised response. v1 behaviour: count the round, re-prompt if
-    # we still have budget, otherwise force-abort.
+    if normalised in _APPROVE_TOKENS:
+        # "ja" → defaults: pick #1 for resolutions with near matches,
+        # "neu" for resolutions without. No-op when there are none.
+        decisions = _default_decisions(resolutions)
+        return await _commit_approved(
+            pending,
+            mcp_manager=mcp_manager,
+            user_id=user_id,
+            decisions=decisions,
+        )
+
+    # Try to parse per-field choices. Only meaningful when we actually
+    # have resolutions to assign decisions to.
+    if resolutions:
+        decisions, parse_error = _parse_user_choices(raw_response, resolutions)
+        if parse_error is None:
+            return await _commit_approved(
+                pending,
+                mcp_manager=mcp_manager,
+                user_id=user_id,
+                decisions=decisions,
+            )
+
+    # Unrecognised response. Count the round, re-prompt if we still have
+    # budget, otherwise force-abort.
     return await _handle_ambiguous_response(pending)
+
+
+def _default_decisions(
+    resolutions: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Build the default decision per resolution for the `ja` path.
+
+    - near_matches non-empty → pick the first candidate.
+    - near_matches empty     → "neu" (create extracted_value).
+
+    Each decision dict has shape:
+        {"resolution": <res>, "action": "use" | "create" | "skip",
+         "value": <str>}
+    """
+    out: list[dict[str, Any]] = []
+    for res in resolutions:
+        near = list(res.get("near_matches") or [])
+        if near:
+            out.append({
+                "resolution": res,
+                "action": "use",
+                "value": near[0],
+            })
+        else:
+            out.append({
+                "resolution": res,
+                "action": "create",
+                "value": res.get("extracted_value") or "",
+            })
+    return out
+
+
+def _parse_user_choices(
+    text: str,
+    resolutions: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], str | None]:
+    """Parse a "1: 2, 2: neu, 3: x" reply into a decision per resolution.
+
+    Resolutions not addressed in the user reply fall back to their
+    default (same as the `ja` path). Indices outside 1..len(resolutions)
+    or candidate indices outside 1..len(near_matches) → parse error
+    (caller treats as ambiguous and re-prompts).
+    """
+    matches = _CHOICE_RE.findall(text)
+    if not matches:
+        return [], "no choices found"
+
+    # Seed with defaults so unaddressed resolutions still get a value.
+    decisions = _default_decisions(resolutions)
+    by_idx = {i + 1: d for i, d in enumerate(decisions)}
+
+    for raw_idx, raw_choice in matches:
+        try:
+            idx = int(raw_idx)
+        except ValueError:
+            return [], f"bad index {raw_idx!r}"
+        if idx not in by_idx:
+            return [], f"index {idx} out of range"
+        decision = by_idx[idx]
+        res = decision["resolution"]
+        choice = raw_choice.strip().lower()
+
+        if choice in _NEW_TOKENS:
+            decision["action"] = "create"
+            decision["value"] = res.get("extracted_value") or ""
+        elif choice in _SKIP_TOKENS:
+            decision["action"] = "skip"
+            decision["value"] = ""
+        elif choice.isdigit():
+            cand_idx = int(choice)
+            near = list(res.get("near_matches") or [])
+            if cand_idx < 1 or cand_idx > len(near):
+                return [], f"candidate {cand_idx} out of range for field {idx}"
+            decision["action"] = "use"
+            decision["value"] = near[cand_idx - 1]
+        else:
+            return [], f"unrecognised choice {raw_choice!r} for field {idx}"
+
+    return decisions, None
 
 
 async def _commit_approved(
@@ -160,10 +272,18 @@ async def _commit_approved(
     *,
     mcp_manager: Any,
     user_id: int | None,
+    decisions: list[dict[str, Any]] | None = None,
 ) -> dict:
-    """User said 'ja'. Fire creates for approved proposals, then
-    upload_document, then write the confirm-diff, increment the
-    cold-start counter, and delete the pending row.
+    """User approved. Fire creates for "create" decisions, set
+    "use" decisions on the final field set, skip "skip" decisions,
+    then upload_document, write the confirm-diff, bump the cold-start
+    counter, and delete the pending row.
+
+    ``decisions`` carries one entry per resolution from the pending row
+    in the same order, with shape
+    ``{"resolution": <dict>, "action": "use"|"create"|"skip", "value": str}``.
+    None / empty when the pending row had no resolutions (every field
+    resolved exactly during extraction).
     """
     from sqlalchemy import delete, update
 
@@ -176,18 +296,39 @@ async def _commit_approved(
     from services.database import AsyncSessionLocal
 
     post_fuzzy = pending.post_fuzzy_output or {}
-    proposals = pending.proposals or []
     llm_output = pending.llm_output or {}
+    decisions = decisions or []
 
-    # Step 1 — approve new-entry proposals by calling the matching
-    # create_* MCP tool. Each success invalidates the extractor's
-    # taxonomy cache so subsequent extractions see the new entry.
-    created_entries: dict[str, str] = {}
-    for proposal in proposals:
-        field = proposal.get("field")
-        value = proposal.get("value")
-        if not field or not value:
+    # Step 1 — fire create_* for every "create" decision. Singleton
+    # fields (correspondent / document_type / storage_path) trigger
+    # one create per decision; tag decisions trigger one create per
+    # tag. Successful creates feed `resolved_fields` so the upload
+    # picks up the new value.
+    created_entries: dict[str, list[str]] = {}
+    resolved_fields: dict[str, list[str]] = {
+        "correspondent": [],
+        "document_type": [],
+        "storage_path": [],
+        "tag": [],
+    }
+
+    for decision in decisions:
+        action = decision.get("action")
+        value = (decision.get("value") or "").strip()
+        res = decision.get("resolution") or {}
+        field = res.get("field")
+        if not field or action == "skip" or not value:
             continue
+
+        if action == "use":
+            resolved_fields.setdefault(field, []).append(value)
+            continue
+
+        if action != "create":
+            logger.warning("Unknown decision action, skipping: %r", action)
+            continue
+
+        # action == "create"
         create_tool = {
             "correspondent": "mcp.paperless.create_correspondent",
             "document_type": "mcp.paperless.create_document_type",
@@ -195,37 +336,34 @@ async def _commit_approved(
             "storage_path": "mcp.paperless.create_storage_path",
         }.get(field)
         if create_tool is None:
-            logger.warning("Unknown proposal field, skipping: %r", field)
+            logger.warning("Unknown decision field, skipping: %r", field)
             continue
 
         create_params: dict[str, Any] = {"name": value}
         if field == "storage_path":
-            # Storage paths need a path template. Use the LLM's suggested
-            # value for both name and path — crude v1 fallback, user can
-            # rename in Paperless UI if needed.
+            # Storage paths need a path template. Use the value for
+            # both name and path; user can rename in Paperless UI.
             create_params["path"] = value
 
         try:
             result = await mcp_manager.execute_tool(create_tool, create_params)
         except Exception as exc:
-            logger.warning(
-                "Failed to create %s %r: %s", field, value, exc,
-            )
+            logger.warning("Failed to create %s %r: %s", field, value, exc)
             continue
 
         if not result or not result.get("success"):
             inner = (result or {}).get("message") or "no detail"
             if "already_exists" in str(inner):
-                # Raced against another extraction — someone else already
-                # created this entry. Treat as success.
                 logger.info("%s %r already exists, reusing", field, value)
-                created_entries[field] = value
+                resolved_fields.setdefault(field, []).append(value)
+                created_entries.setdefault(field, []).append(value)
             else:
                 logger.warning(
                     "Create %s %r failed: %s", field, value, str(inner)[:120],
                 )
             continue
-        created_entries[field] = value
+        resolved_fields.setdefault(field, []).append(value)
+        created_entries.setdefault(field, []).append(value)
 
     # Flush the extractor's taxonomy cache so future extractions see
     # the new entries.
@@ -272,18 +410,39 @@ async def _commit_approved(
             "action_taken": False,
         }
 
+    # Build the final field set: post_fuzzy (the exact-resolved fields
+    # from extraction) + resolved_fields (singletons set by user
+    # decision OR newly-created entries). For singletons we take the
+    # last value the user picked / created (only one decision per
+    # field is meaningful). For tags we union the resolved set with
+    # what came out of extraction.
+    final_fields: dict[str, Any] = {}
+    for key in ("correspondent", "document_type", "storage_path"):
+        decided = resolved_fields.get(key) or []
+        if decided:
+            final_fields[key] = decided[-1]
+        elif post_fuzzy.get(key):
+            final_fields[key] = post_fuzzy[key]
+
+    tags_out: list[str] = list(post_fuzzy.get("tags") or [])
+    for tag_value in resolved_fields.get("tag") or []:
+        if tag_value not in tags_out:
+            tags_out.append(tag_value)
+    if tags_out:
+        final_fields["tags"] = tags_out
+
+    if post_fuzzy.get("created_date"):
+        final_fields["created_date"] = post_fuzzy["created_date"]
+
     tool_params: dict[str, Any] = {
         "title": post_fuzzy.get("title") or upload.filename,
         "filename": upload.filename,
         "file_content_base64": file_content_base64,
     }
-    for key in ("correspondent", "document_type", "tags", "storage_path"):
-        val = post_fuzzy.get(key)
+    for key in ("correspondent", "document_type", "tags", "storage_path", "created_date"):
+        val = final_fields.get(key)
         if val:
             tool_params[key] = val
-    created = post_fuzzy.get("created_date")
-    if created:
-        tool_params["created_date"] = created
 
     try:
         mcp_result = await mcp_manager.execute_tool(
@@ -324,20 +483,16 @@ async def _commit_approved(
     # Step 3 — compute the approved field set + embed the doc_text
     # BEFORE opening the write session. The embed call is up to 5 s
     # (see retriever ``_EMBED_TIMEOUT_S``); holding a DB connection
-    # across it would tie up the pool for no reason. Post-PR-3 the
-    # session is only open for the actual writes.
+    # across it would tie up the pool for no reason.
     user_approved = dict(post_fuzzy)
-    for field, value in created_entries.items():
-        if field == "tag":
-            # Tag proposals feed the tags list — append if not already
-            # there. Post-fuzzy tags list carries the taxonomy-hit
-            # tags; the new tag is one we just created.
-            existing_tags = list(user_approved.get("tags") or [])
-            if value not in existing_tags:
-                existing_tags.append(value)
-            user_approved["tags"] = existing_tags
+    user_approved["title"] = tool_params["title"]
+    for key in ("correspondent", "document_type", "storage_path", "created_date"):
+        if key in final_fields:
+            user_approved[key] = final_fields[key]
         else:
-            user_approved[field] = value
+            # User explicitly skipped (or extraction produced nothing).
+            user_approved.pop(key, None)
+    user_approved["tags"] = list(final_fields.get("tags") or [])
 
     diff_row: PaperlessExtractionExample | None = None
     if user_approved != post_fuzzy:
@@ -421,8 +576,11 @@ async def _commit_approved(
 
     created_note = ""
     if created_entries:
-        names = ", ".join(sorted(created_entries.values()))
-        created_note = f" (Neu angelegt: {names})"
+        flat: list[str] = []
+        for values in created_entries.values():
+            flat.extend(values)
+        if flat:
+            created_note = f" (Neu angelegt: {', '.join(sorted(set(flat)))})"
 
     return {
         "success": True,

--- a/src/backend/services/paperless_metadata_extractor.py
+++ b/src/backend/services/paperless_metadata_extractor.py
@@ -1,20 +1,22 @@
 """
 PaperlessMetadataExtractor — LLM-driven metadata extraction for Paperless-NGX uploads.
 
-Reads a chat-attached document via Docling, fetches the user's current
-Paperless taxonomy from the MCP server, asks the LLM to pick the best
-metadata fields from that taxonomy (with worked examples baked into the
-prompt), validates via pydantic + fuzzy-match + taxonomy-membership, and
-returns a structured result the caller can feed into
-``mcp.paperless.upload_document``.
+Reads a chat-attached document via Docling, asks the LLM to extract the
+essential metadata directly from the document text (NOT constrained to
+any taxonomy — the LLM's job is reading the doc, not knowing what's in
+Paperless), then resolves each extracted value against the user's live
+Paperless taxonomy on the server side. Returns a structured result the
+caller feeds into ``mcp.paperless.upload_document``.
+
+Why no taxonomy in the prompt: a real household instance has
+~900 correspondents, ~400 doc-types, ~1500 tags. Stuffing that list into
+every prompt blows the context budget AND pushes the LLM toward
+hallucinating taxonomy matches instead of extracting the value the
+document actually carries. Server-side fuzzy matching + user-driven
+near-match disambiguation is far cheaper and more accurate.
 
 Design reference:
     docs/design/paperless-llm-metadata.md
-
-This is PR 2a of the feature: the atomic extraction unit, independently
-testable, no dependency on the confirm flow. PR 2b wires this into the
-``forward_attachment_to_paperless`` tool + cold-start-only confirm state
-machine.
 
 ASCII flow — single extraction call:
 
@@ -25,33 +27,34 @@ ASCII flow — single extraction call:
         │
         ▼
     OCR / text-layer extraction via DocumentProcessor.extract_text_only
-    (Docling HybridChunker + EasyOCR fallback; vision-model path is a
-    PR 2b refinement once the agent-client wiring supports it)
         │
         ▼
-    fetch_taxonomy(mcp_manager)
-        │   calls mcp.paperless.list_* tools, prunes top-20 correspondents
-        │   and top-20 tags by recency from the `/api/documents/?ordering=-modified`
-        │   window provided by PR 1's MCP server.
+    fetch_taxonomy(mcp_manager) — used post-extraction for resolution,
+    NOT injected into the prompt
         │
         ▼
-    render prompt (paperless_metadata.yaml) with taxonomy + doc_text
+    render prompt (paperless_metadata.yaml) with doc_text + learned
+    examples only
         │
         ▼
-    LLM call (settings.paperless_extraction_model || vision || chat)
+    LLM call (settings.paperless_extraction_model || chat)
         │
         ▼
-    validate(response)
+    validate(response, taxonomy)
         │   1. pydantic parse
-        │   2. rapidfuzz near-match against taxonomy (rewrites silently
-        │      on one-candidate-within-threshold, flags ambiguous)
-        │   3. strict membership check (drops misses that weren't
-        │      flagged as new_entry_proposals)
+        │   2. resolve each singleton field:
+        │        - exact / strong-fuzzy hit → canonical value, no
+        │          decision needed
+        │        - 1-3 near matches → resolution with candidates,
+        │          requires user decision
+        │        - no match → resolution with empty near_matches
+        │          (user picks "neu" or skips)
+        │   3. resolve each tag the same way
         │   4. clamp created_date (today-10y ... today+1y)
-        │   5. cap tags at 5
         │
         ▼
-    ExtractionResult(metadata, proposals, confidence, source_text)
+    ExtractionResult(metadata, doc_text, error)
+        — metadata.resolutions carries everything needing user input.
 """
 from __future__ import annotations
 
@@ -113,11 +116,13 @@ _CORPORATE_SUFFIX_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
-# Per-field confidence gate for new_entry_proposals. Below this the LLM
-# is too uncertain to justify surfacing a create-proposal to the user —
-# drop the proposal silently. Matches the design doc's § Validation
-# step 3 wording.
-_PROPOSAL_CONFIDENCE_MIN = 0.6
+# Looser thresholds for the "near match" candidate list. _fuzzy_match
+# only returns a single high-confidence canonical hit (Levenshtein <= 2);
+# _fuzzy_top_candidates expands the radius so the user can pick from a
+# small shortlist when no high-confidence hit exists.
+_NEAR_MAX_DISTANCE = 6
+_NEAR_MAX_RATIO = 0.4
+_NEAR_LIMIT = 3
 
 # Taxonomy cache TTL (in memory, per-process). 10 min balances freshness
 # with API-call cost. Invalidated on successful create_* via the MCP
@@ -162,22 +167,53 @@ def _invalidate_taxonomy_cache() -> None:
 # ---------------------------------------------------------------------------
 
 
-class NewEntryProposal(BaseModel):
-    """Singleton proposal for a not-in-taxonomy value. Three new tags
-    become three separate proposals, not one entry with a list."""
-    field: Literal["correspondent", "document_type", "tag", "storage_path"]
-    value: str
-    reasoning: str
+class FieldResolution(BaseModel):
+    """Server-side resolution of one LLM-extracted value against the
+    user's live Paperless taxonomy.
+
+    Three states (read off ``status``):
+      - ``exact``: ``canonical`` is set, ``near_matches`` empty.
+        No user input needed; the singleton field carries the
+        canonical value already.
+      - ``near``: ``canonical`` is None, ``near_matches`` has 1-3
+        candidate entries from the taxonomy. User picks one OR
+        creates the extracted value as new.
+      - ``none``: ``canonical`` is None, ``near_matches`` empty.
+        Either the user creates the extracted value as new, or
+        skips the field entirely.
+
+    For singleton fields we emit at most one resolution per field;
+    for tags we emit one per LLM-extracted tag that didn't resolve to
+    an exact taxonomy hit.
+    """
+    field: Literal["correspondent", "document_type", "storage_path", "tag"]
+    extracted_value: str
+    canonical: str | None = None
+    near_matches: list[str] = Field(default_factory=list)
+
+    @property
+    def status(self) -> Literal["exact", "near", "none"]:
+        if self.canonical is not None:
+            return "exact"
+        if self.near_matches:
+            return "near"
+        return "none"
+
+    @property
+    def requires_user_decision(self) -> bool:
+        return self.status != "exact"
 
 
 class PaperlessMetadata(BaseModel):
     """Output of the extractor.
 
-    Every taxonomy field is either ``None`` (LLM couldn't decide or
-    nothing matched) or a string guaranteed to be present in the user's
-    live Paperless taxonomy (because the validator checks exactly that).
-    ``new_entry_proposals`` carries LLM's confidence-gated suggestions
-    for values it thinks deserve a new taxonomy entry.
+    Singleton taxonomy fields (correspondent / document_type /
+    storage_path) carry a value ONLY when the validator resolved an
+    exact / strong-fuzzy match against the live taxonomy. Anything
+    needing user input lives in ``resolutions``.
+
+    ``tags`` carries only exact-resolved tags; LLM-extracted tags that
+    didn't match get individual entries in ``resolutions``.
     """
     title: str | None = None
     correspondent: str | None = None
@@ -186,7 +222,7 @@ class PaperlessMetadata(BaseModel):
     storage_path: str | None = None
     created_date: date | None = None
     confidence: dict[str, float] = Field(default_factory=dict)
-    new_entry_proposals: list[NewEntryProposal] = Field(default_factory=list)
+    resolutions: list[FieldResolution] = Field(default_factory=list)
 
 
 class ExtractionResult(BaseModel):
@@ -321,9 +357,66 @@ def _fuzzy_match(llm_value: str, taxonomy: list[str]) -> str | None:
 
     if len(candidates) == 1:
         return candidates[0]
-    # Zero candidates OR ambiguous multi-match → caller handles as
-    # proposal (ambiguity surfaces in the confirm UI).
+    # Zero candidates OR ambiguous multi-match → caller surfaces a
+    # FieldResolution with the top-N candidates instead.
     return None
+
+
+def _fuzzy_top_candidates(
+    llm_value: str,
+    taxonomy: list[str],
+    *,
+    limit: int = _NEAR_LIMIT,
+    max_distance: int = _NEAR_MAX_DISTANCE,
+    max_ratio: float = _NEAR_MAX_RATIO,
+) -> list[str]:
+    """Return up to ``limit`` taxonomy entries closest to ``llm_value``.
+
+    Looser than :func:`_fuzzy_match`: shortlists candidates the user can
+    pick from when no high-confidence single hit exists. Sorted by
+    distance ascending — closest match first.
+
+    Compares both the raw normalised form and the corporate-suffix-
+    stripped form, takes the smaller distance. Catches cases like
+    "Stadtwerke X GmbH" vs "Stadtwerke X" without forcing them to
+    pass the strict 2-edit gate.
+    """
+    if not llm_value or not taxonomy:
+        return []
+    normalised = _normalise(llm_value)
+    if not normalised:
+        return []
+    stripped = _strip_corporate_suffix(normalised)
+
+    scored: list[tuple[int, str]] = []
+    for entry in taxonomy:
+        entry_n = _normalise(entry)
+        if not entry_n:
+            continue
+        entry_stripped = _strip_corporate_suffix(entry_n)
+        d_raw = Levenshtein.distance(normalised, entry_n)
+        d_stripped = (
+            Levenshtein.distance(stripped, entry_stripped)
+            if stripped and entry_stripped
+            else d_raw
+        )
+        d = min(d_raw, d_stripped)
+        max_len = max(len(normalised), len(entry_n), 1)
+        if d > max_distance or d / max_len > max_ratio:
+            continue
+        scored.append((d, entry))
+
+    scored.sort(key=lambda pair: (pair[0], pair[1]))
+    seen: set[str] = set()
+    out: list[str] = []
+    for _, entry in scored:
+        if entry in seen:
+            continue
+        seen.add(entry)
+        out.append(entry)
+        if len(out) >= limit:
+            break
+    return out
 
 
 def prune_taxonomy(
@@ -411,99 +504,73 @@ def validate_extraction(
     """Full validation pipeline. Caller passes the parsed LLM JSON dict.
 
     1. Pydantic shape check — malformed → ValidationError raises up.
-    2. Fuzzy match against each taxonomy dimension. One-candidate wins
-       silently (rewrites llm value to canonical); zero or ambiguous
-       drops the field to ``None`` — unless the LLM simultaneously
-       emitted a ``new_entry_proposal`` for that field, in which case
-       the proposal survives for user review.
-    3. Strict taxonomy membership — after fuzzy, assert the value is in
-       the list. Defence-in-depth; should never drop here.
+    2. For each singleton field (correspondent / document_type /
+       storage_path), resolve the LLM value against the taxonomy:
+         - exact / strong-fuzzy hit → set field to canonical, no
+           resolution emitted.
+         - else → field stays None, a FieldResolution is appended with
+           the extracted value + up to 3 near-match candidates.
+    3. For each tag, the same resolution: exact hits land in
+       ``metadata.tags``, anything else gets one resolution per tag.
     4. ``created_date`` clamped to [today-10y, today+1y].
-    5. ``tags`` truncated at 5.
+    5. ``tags`` capped at 5.
+
+    The caller surfaces ``metadata.resolutions`` to the user as a
+    decision list; the commit tool turns the user's response into
+    final field values + create_* calls.
     """
-    # Step 1 — parse. Any shape error raises; caller catches.
+    # Step 1 — parse. Drop fields the legacy prompt may still emit
+    # (new_entry_proposals) so old payloads don't poison the new shape.
+    payload = dict(raw_output)
+    payload.pop("new_entry_proposals", None)
+    payload.pop("resolutions", None)  # server-owned; ignore any LLM input
     try:
-        metadata = PaperlessMetadata(**raw_output)
+        metadata = PaperlessMetadata(**payload)
     except ValidationError as exc:
-        # Add the raw dict to the exception note so debugging shows what
-        # the LLM actually emitted. pydantic's own error is verbose
-        # enough that appending is more useful than replacing.
         raise ValueError(f"Malformed LLM output: {exc}") from exc
 
-    # Confidence-gate the proposals first. Design § Validation step 3:
-    # proposals below _PROPOSAL_CONFIDENCE_MIN (0.6) are dropped
-    # silently — the LLM is too uncertain to justify surfacing a
-    # create-proposal to the user. Check confidence per-field: a low
-    # confidence on the FIELD (e.g. confidence.correspondent = 0.2)
-    # drops any proposals for that field.
-    high_confidence_proposals: list[NewEntryProposal] = []
-    for proposal in metadata.new_entry_proposals:
-        # The LLM emits confidence keyed by field name (singular for
-        # fields, plural "tags" for the list). Proposal.field is always
-        # singular ("correspondent", "document_type", "tag",
-        # "storage_path") per the Literal typing.
-        confidence_key = proposal.field
-        # For tag proposals, the LLM's confidence is usually keyed
-        # "tags" in its response. Accept either.
-        confidence = metadata.confidence.get(confidence_key)
-        if confidence is None and proposal.field == "tag":
-            confidence = metadata.confidence.get("tags")
-        if confidence is None:
-            # LLM didn't emit confidence for this field. Be permissive
-            # — drop-silent would lose useful signal when the model
-            # forgets the confidence block. Let the proposal survive.
-            high_confidence_proposals.append(proposal)
-            continue
-        if confidence >= _PROPOSAL_CONFIDENCE_MIN:
-            high_confidence_proposals.append(proposal)
-        else:
-            logger.debug(
-                "Dropping low-confidence proposal (%.2f < %.2f): %s=%r",
-                confidence, _PROPOSAL_CONFIDENCE_MIN,
-                proposal.field, proposal.value,
-            )
-    metadata.new_entry_proposals = high_confidence_proposals
+    resolutions: list[FieldResolution] = []
 
-    # Group the surviving proposals by field for quick lookup during
-    # fuzzy fallback — if the LLM flagged "correspondent" as proposal,
-    # we don't need to silently drop the field value too.
-    proposed_fields = {p.field for p in metadata.new_entry_proposals}
+    # Step 2 — singleton fields.
+    metadata.correspondent, res = _resolve_singleton_field(
+        metadata.correspondent, taxonomy.correspondents, field="correspondent",
+    )
+    if res is not None:
+        resolutions.append(res)
 
-    # Step 2 + 3 — fuzzy + strict membership.
-    metadata.correspondent = _validate_singleton_field(
-        metadata.correspondent,
-        taxonomy.correspondents,
-        field_name="correspondent",
-        has_proposal=("correspondent" in proposed_fields),
+    metadata.document_type, res = _resolve_singleton_field(
+        metadata.document_type, taxonomy.document_types, field="document_type",
     )
-    metadata.document_type = _validate_singleton_field(
-        metadata.document_type,
-        taxonomy.document_types,
-        field_name="document_type",
-        has_proposal=("document_type" in proposed_fields),
-    )
-    metadata.storage_path = _validate_singleton_field(
-        metadata.storage_path,
-        taxonomy.storage_paths,
-        field_name="storage_path",
-        has_proposal=("storage_path" in proposed_fields),
-    )
+    if res is not None:
+        resolutions.append(res)
 
-    # Tags are list-valued; each element goes through fuzzy-then-strict
-    # independently, misses are dropped silently (proposals work at
-    # field-not-element granularity — a tag proposal covers one missing
-    # tag, not the whole list).
+    metadata.storage_path, res = _resolve_singleton_field(
+        metadata.storage_path, taxonomy.storage_paths, field="storage_path",
+    )
+    if res is not None:
+        resolutions.append(res)
+
+    # Step 3 — tags. Each LLM tag resolved independently. Cap input at
+    # 5 so the resolution list can't explode if the LLM gets verbose.
     validated_tags: list[str] = []
-    for tag in metadata.tags:
+    seen_canonical: set[str] = set()
+    for tag in (metadata.tags or [])[:5]:
+        if not tag:
+            continue
         canonical = _fuzzy_match(tag, taxonomy.tags)
         if canonical is not None:
-            validated_tags.append(canonical)
+            if canonical not in seen_canonical:
+                seen_canonical.add(canonical)
+                validated_tags.append(canonical)
         else:
-            logger.debug("Dropping tag not in taxonomy: %r", tag)
-    metadata.tags = validated_tags[:5]  # Step 5 — cap
+            resolutions.append(FieldResolution(
+                field="tag",
+                extracted_value=tag,
+                near_matches=_fuzzy_top_candidates(tag, taxonomy.tags),
+            ))
+    metadata.tags = validated_tags
 
-    # Step 4 — date clamps. Both bounds are computed fresh per call so
-    # tests with a frozen clock see the window they expect.
+    # Step 4 — date clamps.
     if metadata.created_date is not None:
         if metadata.created_date < _date_min() or metadata.created_date > _date_max():
             logger.warning(
@@ -512,39 +579,40 @@ def validate_extraction(
             )
             metadata.created_date = None
 
+    metadata.resolutions = resolutions
     return metadata
 
 
-def _validate_singleton_field(
+def _resolve_singleton_field(
     value: str | None,
     taxonomy: list[str],
     *,
-    field_name: str,
-    has_proposal: bool,
-) -> str | None:
-    """Apply fuzzy+strict validation to one taxonomy-constrained field.
+    field: str,
+) -> tuple[str | None, FieldResolution | None]:
+    """Resolve one LLM-extracted singleton against the taxonomy.
 
-    If the LLM also emitted a new_entry_proposal for this field, we keep
-    ``None`` as the field value (the proposal carries the intent).
-    Otherwise we log the dropped value for later debugging.
+    Returns ``(canonical_value, None)`` when an exact / strong-fuzzy
+    hit exists — the field is set, no user input needed.
+
+    Returns ``(None, FieldResolution(...))`` when no high-confidence
+    hit exists. The resolution carries the extracted value plus up to
+    3 near-match candidates the user picks from (or chooses "neu").
+
+    ``value`` of None / empty → ``(None, None)``: nothing to ask the
+    user about.
     """
-    if value is None:
-        return None
+    if not value:
+        return None, None
 
     canonical = _fuzzy_match(value, taxonomy)
     if canonical is not None:
-        return canonical
+        return canonical, None
 
-    # Not in taxonomy. If there's a matching proposal, that's intended —
-    # silently return None (the caller surfaces the proposal in the
-    # confirm UI). If not, the LLM hallucinated; log for debugging.
-    if not has_proposal:
-        logger.debug(
-            "Dropping %s not in taxonomy (no proposal): %r",
-            field_name,
-            value,
-        )
-    return None
+    return None, FieldResolution(
+        field=field,
+        extracted_value=value,
+        near_matches=_fuzzy_top_candidates(value, taxonomy),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -555,22 +623,23 @@ def _validate_singleton_field(
 def render_prompt(
     *,
     doc_text: str,
-    taxonomy: PaperlessTaxonomy,
+    taxonomy: PaperlessTaxonomy | None = None,  # accepted for back-compat; unused
     lang: str = "de",
     learned_examples: list[dict[str, Any]] | None = None,
 ) -> tuple[str, str]:
     """Build (system, user) messages for the LLM call.
 
-    Taxonomy lists render as comma-separated inline strings; the prompt
-    template doesn't try to pretty-print them because LLMs tolerate
-    either shape and CSV keeps the token count down.
+    The taxonomy is intentionally NOT injected into the prompt — see
+    module docstring. The parameter remains in the signature so existing
+    call sites and tests don't break, but it's discarded here.
 
-    *learned_examples* are confirm-diff entries fetched by the
-    PR 3 retriever. They get rendered into a small block between the
-    seed examples and the input document so the LLM can mimic the
-    correction patterns. ``None`` or empty list = no learned-example
-    block (placeholder collapses).
+    *learned_examples* are confirm-diff entries fetched by the example
+    retriever. They get rendered into a small block between the seed
+    examples and the input document so the LLM can mimic the correction
+    patterns. ``None`` or empty list = no learned-example block
+    (placeholder collapses).
     """
+    del taxonomy  # accepted for back-compat; resolution is server-side
     system = prompt_manager.get(
         "paperless_metadata", "system",
         default="Extract Paperless metadata.", lang=lang,
@@ -579,10 +648,6 @@ def render_prompt(
         "paperless_metadata", "user",
         default="{document_text}",
         lang=lang,
-        correspondents=", ".join(taxonomy.correspondents) or "(none)",
-        document_types=", ".join(taxonomy.document_types) or "(none)",
-        tags=", ".join(taxonomy.tags) or "(none)",
-        storage_paths=", ".join(taxonomy.storage_paths) or "(none)",
         document_text=doc_text[:_MAX_DOC_CHARS],
         learned_examples=_format_learned_examples(learned_examples or [], lang=lang),
     )
@@ -653,9 +718,11 @@ def _strip_example_noise(payload: dict[str, Any]) -> dict[str, Any]:
     """Drop noisy fields from a stored llm_output before showing it as
     a worked example.
 
-    - ``confidence`` / ``new_entry_proposals`` reflect the historical
-      extraction's state, not the corrected outcome — keeping them
-      would reinforce uncertainty rather than the correction itself.
+    - ``confidence`` / ``resolutions`` / ``new_entry_proposals`` reflect
+      the historical extraction's state, not the corrected outcome —
+      keeping them would reinforce uncertainty rather than the
+      correction itself. ``new_entry_proposals`` is dropped for legacy
+      payloads written before the resolution shape landed.
     - ``_doc_text`` is the pending-confirm scratchpad copy of the full
       (up to 8 KB) document text. Leaving it in would double the
       document inside the prompt (once as the snippet, once inside the
@@ -663,6 +730,7 @@ def _strip_example_noise(payload: dict[str, Any]) -> dict[str, Any]:
     """
     out = dict(payload)
     out.pop("confidence", None)
+    out.pop("resolutions", None)
     out.pop("new_entry_proposals", None)
     out.pop("_doc_text", None)
     return out

--- a/src/backend/services/paperless_ui_edit_sweeper.py
+++ b/src/backend/services/paperless_ui_edit_sweeper.py
@@ -56,7 +56,7 @@ _sweep_lock = asyncio.Lock()
 # Fields we diff between what we uploaded and what's in Paperless now.
 # Order matters for the deterministic doc-diff summary — covers every
 # field ``PaperlessMetadata`` persists minus the metadata-only ones
-# (``confidence``, ``new_entry_proposals``).
+# (``confidence``, ``resolutions``).
 _TRACKED_FIELDS: tuple[str, ...] = (
     "title",
     "correspondent",

--- a/tests/backend/test_chat_upload_tool_paperless.py
+++ b/tests/backend/test_chat_upload_tool_paperless.py
@@ -164,7 +164,7 @@ class TestRenderConfirmMessage:
                 "storage_path": "/wohnung/betriebskosten",
                 "created_date": "2026-02-14",
             },
-            proposals=[],
+            resolutions=[],
         )
         assert "rechnung.pdf" in msg
         assert "Stadtwerke Korschenbroich" in msg
@@ -172,7 +172,6 @@ class TestRenderConfirmMessage:
         assert "wohnung, nebenkosten-2025" in msg
         assert "/wohnung/betriebskosten" in msg
         assert "2026-02-14" in msg
-        assert "keine" in msg  # no proposals
         assert "ja" in msg and "nein" in msg
 
     @pytest.mark.unit
@@ -187,34 +186,63 @@ class TestRenderConfirmMessage:
                 "storage_path": None,
                 "created_date": None,
             },
-            proposals=[],
+            resolutions=[],
         )
         # Five "—" markers (one per missing field).
         assert msg.count("—") >= 5
 
     @pytest.mark.unit
-    def test_proposals_listed(self):
-        # Use dict-shaped proposals (pending_confirms JSONB form).
-        proposals = [
-            {"field": "correspondent", "value": "Schreiner Meier",
-             "reasoning": "..."},
-            {"field": "tag", "value": "handwerker", "reasoning": "..."},
+    def test_resolutions_with_near_matches_listed(self):
+        """Resolutions with near matches show numbered candidate options
+        plus the "neu" path."""
+        # Dict shape — matches what's persisted in pending_confirms.proposals.
+        resolutions = [
+            {
+                "field": "correspondent",
+                "extracted_value": "Schreiner Meier",
+                "canonical": None,
+                "near_matches": ["Schreiner Müller", "Schreinerei Bauer"],
+            },
         ]
         msg = _render_confirm_message(
-            filename="f.pdf", metadata={"title": "T"}, proposals=proposals,
+            filename="f.pdf", metadata={"title": "T"}, resolutions=resolutions,
         )
         assert "Schreiner Meier" in msg
-        assert "handwerker" in msg
-        assert "correspondent" in msg
-        assert "tag" in msg
+        assert "Schreiner Müller" in msg
+        assert "Schreinerei Bauer" in msg
+        assert "NEU" in msg
+        assert "Korrespondent" in msg
 
     @pytest.mark.unit
-    def test_proposals_from_pydantic_objects(self):
-        """Confirm message also accepts pydantic NewEntryProposal objects
+    def test_resolution_no_near_matches_offers_neu_and_skip(self):
+        resolutions = [
+            {
+                "field": "correspondent",
+                "extracted_value": "Völlig Unbekannte GmbH",
+                "canonical": None,
+                "near_matches": [],
+            },
+        ]
+        msg = _render_confirm_message(
+            filename="f.pdf", metadata={"title": "T"}, resolutions=resolutions,
+        )
+        assert "Völlig Unbekannte GmbH" in msg
+        assert "NEU" in msg
+        assert "leer lassen" in msg
+
+    @pytest.mark.unit
+    def test_resolutions_from_pydantic_objects(self):
+        """Confirm message also accepts pydantic FieldResolution objects
         (the raw extractor output shape). Duck-typed via hasattr."""
-        p = SimpleNamespace(field="correspondent", value="Test", reasoning="x")
-        msg = _render_confirm_message(filename="f", metadata={}, proposals=[p])
+        from services.paperless_metadata_extractor import FieldResolution
+        r = FieldResolution(
+            field="correspondent", extracted_value="Test", near_matches=["Test Inc"],
+        )
+        msg = _render_confirm_message(
+            filename="f", metadata={"title": "X"}, resolutions=[r],
+        )
         assert "Test" in msg
+        assert "Test Inc" in msg
 
 
 # ===========================================================================
@@ -314,7 +342,7 @@ class TestForwardAttachmentColdStart:
                 tags=["wohnung"],
                 storage_path="/x",
                 created_date=None,
-                new_entry_proposals=[],
+                resolutions=[],
                 model_dump=lambda **_kw: {
                     "title": "T",
                     "correspondent": "Stadtwerke",
@@ -322,7 +350,7 @@ class TestForwardAttachmentColdStart:
                     "tags": ["wohnung"],
                     "storage_path": "/x",
                     "created_date": None,
-                    "new_entry_proposals": [],
+                    "resolutions": [],
                 },
             ),
             doc_text="doc text",
@@ -373,12 +401,12 @@ class TestForwardAttachmentColdStart:
                 title="T", correspondent="Stadtwerke",
                 document_type="Rechnung", tags=["wohnung"],
                 storage_path="/x", created_date=None,
-                new_entry_proposals=[],
+                resolutions=[],
                 model_dump=lambda **_kw: {
                     "title": "T", "correspondent": "Stadtwerke",
                     "document_type": "Rechnung", "tags": ["wohnung"],
                     "storage_path": "/x", "created_date": None,
-                    "new_entry_proposals": [],
+                    "resolutions": [],
                 },
             ),
             doc_text="doc",
@@ -450,7 +478,7 @@ class TestForwardAttachmentColdStart:
                 document_type="Rechnung",
                 tags=["Rechnung", "2026"],
                 created_date=date(2026, 4, 24),
-                new_entry_proposals=[],
+                resolutions=[],
             ),
             doc_text="doc",
             error=None,
@@ -510,7 +538,7 @@ class TestForwardAttachmentColdStart:
                 title="T", correspondent="Stadtwerke",
                 document_type="Rechnung", tags=["wohnung"],
                 storage_path="/x", created_date=None,
-                new_entry_proposals=[],
+                resolutions=[],
                 model_dump=lambda **_kw: {
                     "title": "T", "correspondent": "Stadtwerke",
                     "document_type": "Rechnung", "tags": ["wohnung"],
@@ -565,7 +593,7 @@ class TestForwardAttachmentExtractionFailure:
             metadata=SimpleNamespace(
                 title=None, correspondent=None, document_type=None,
                 tags=[], storage_path=None, created_date=None,
-                new_entry_proposals=[],
+                resolutions=[],
                 model_dump=lambda **_kw: {},
             ),
             doc_text="",
@@ -617,7 +645,7 @@ class TestPaperlessTaskPolling:
             metadata=SimpleNamespace(
                 title=None, correspondent=None, document_type=None,
                 tags=[], storage_path=None, created_date=None,
-                new_entry_proposals=[],
+                resolutions=[],
                 model_dump=lambda **_kw: {},
             ),
             doc_text="",
@@ -675,7 +703,7 @@ class TestPaperlessTaskPolling:
             metadata=SimpleNamespace(
                 title=None, correspondent=None, document_type=None,
                 tags=[], storage_path=None, created_date=None,
-                new_entry_proposals=[],
+                resolutions=[],
                 model_dump=lambda **_kw: {},
             ),
             doc_text="",

--- a/tests/backend/test_paperless_commit_tool.py
+++ b/tests/backend/test_paperless_commit_tool.py
@@ -204,9 +204,10 @@ class TestApprovePath:
                 "storage_path": None, "document_type": None,
             },
             proposals=[
-                {"field": "correspondent", "value": "Schreiner Meier",
-                 "reasoning": "..."},
-                {"field": "tag", "value": "handwerker", "reasoning": "..."},
+                {"field": "correspondent", "extracted_value": "Schreiner Meier",
+                 "near_matches": []},
+                {"field": "tag", "extracted_value": "handwerker",
+                 "near_matches": []},
             ],
         )
         upload = MagicMock(id=42, filename="f.pdf", file_path=str(file))
@@ -262,7 +263,7 @@ class TestApprovePath:
             llm_output={},
             post_fuzzy={"title": "T"},
             proposals=[
-                {"field": "correspondent", "value": "Stadtwerke", "reasoning": "..."},
+                {"field": "correspondent", "extracted_value": "Stadtwerke", "near_matches": []},
             ],
         )
         upload = MagicMock(id=42, filename="f.pdf", file_path=str(file))
@@ -314,8 +315,8 @@ class TestApprovePath:
             post_fuzzy={"title": "T", "correspondent": None, "tags": [],
                         "storage_path": None, "document_type": None},
             proposals=[
-                {"field": "correspondent", "value": "Stadtwerke",
-                 "reasoning": "..."},
+                {"field": "correspondent", "extracted_value": "Stadtwerke",
+                 "near_matches": []},
             ],
         )
         upload = MagicMock(id=42, filename="f.pdf", file_path=str(file))
@@ -382,8 +383,8 @@ class TestApprovePath:
             post_fuzzy={"title": "T", "correspondent": None, "tags": [],
                         "storage_path": None, "document_type": None},
             proposals=[
-                {"field": "correspondent", "value": "Stadtwerke",
-                 "reasoning": "..."},
+                {"field": "correspondent", "extracted_value": "Stadtwerke",
+                 "near_matches": []},
             ],
         )
         upload = MagicMock(id=42, filename="f.pdf", file_path=str(file))
@@ -677,6 +678,87 @@ class TestAmbiguousResponse:
         assert result["data"]["action_required"] == "paperless_confirm"
         # No MCP call.
         assert mcp.execute_tool.await_count == 0
+
+
+# ===========================================================================
+# Per-field choice parser
+# ===========================================================================
+
+
+class TestChoiceParser:
+    @pytest.mark.unit
+    def test_default_decisions_pick_first_near_match(self):
+        from services.paperless_commit_tool import _default_decisions
+
+        resolutions = [
+            {"field": "correspondent", "extracted_value": "Foo",
+             "near_matches": ["Foo Inc", "Foo GmbH"]},
+            {"field": "tag", "extracted_value": "bar", "near_matches": []},
+        ]
+        decisions = _default_decisions(resolutions)
+        assert decisions[0]["action"] == "use"
+        assert decisions[0]["value"] == "Foo Inc"
+        assert decisions[1]["action"] == "create"
+        assert decisions[1]["value"] == "bar"
+
+    @pytest.mark.unit
+    def test_parse_user_choices_per_field(self):
+        from services.paperless_commit_tool import _parse_user_choices
+
+        resolutions = [
+            {"field": "correspondent", "extracted_value": "Foo",
+             "near_matches": ["Foo Inc", "Foo GmbH"]},
+            {"field": "tag", "extracted_value": "bar", "near_matches": []},
+        ]
+        decisions, err = _parse_user_choices("1: 2, 2: neu", resolutions)
+        assert err is None
+        assert decisions[0]["action"] == "use"
+        assert decisions[0]["value"] == "Foo GmbH"
+        assert decisions[1]["action"] == "create"
+        assert decisions[1]["value"] == "bar"
+
+    @pytest.mark.unit
+    def test_parse_user_choices_skip_token(self):
+        from services.paperless_commit_tool import _parse_user_choices
+
+        resolutions = [
+            {"field": "correspondent", "extracted_value": "X",
+             "near_matches": ["Y"]},
+        ]
+        decisions, err = _parse_user_choices("1: x", resolutions)
+        assert err is None
+        assert decisions[0]["action"] == "skip"
+
+    @pytest.mark.unit
+    def test_parse_user_choices_invalid_index(self):
+        from services.paperless_commit_tool import _parse_user_choices
+
+        resolutions = [
+            {"field": "correspondent", "extracted_value": "X", "near_matches": []},
+        ]
+        _, err = _parse_user_choices("9: neu", resolutions)
+        assert err is not None and "out of range" in err
+
+    @pytest.mark.unit
+    def test_parse_user_choices_invalid_candidate(self):
+        from services.paperless_commit_tool import _parse_user_choices
+
+        resolutions = [
+            {"field": "correspondent", "extracted_value": "X",
+             "near_matches": ["Y"]},
+        ]
+        _, err = _parse_user_choices("1: 5", resolutions)
+        assert err is not None and "out of range" in err
+
+    @pytest.mark.unit
+    def test_parse_user_choices_no_pairs_returns_error(self):
+        from services.paperless_commit_tool import _parse_user_choices
+
+        resolutions = [
+            {"field": "correspondent", "extracted_value": "X", "near_matches": []},
+        ]
+        _, err = _parse_user_choices("hmm vielleicht", resolutions)
+        assert err is not None
 
 
 # ===========================================================================

--- a/tests/backend/test_paperless_commit_tool.py
+++ b/tests/backend/test_paperless_commit_tool.py
@@ -191,7 +191,10 @@ class TestApprovePath:
 
     @pytest.mark.asyncio
     @pytest.mark.unit
-    async def test_ja_fires_creates_for_approved_proposals(self, tmp_path):
+    async def test_explicit_neu_fires_creates_for_approved_resolutions(self, tmp_path):
+        """User opts into creating new taxonomy entries via "<idx>: neu"
+        per resolution. Default `ja` would skip these (safer), so the
+        test passes the explicit choices."""
         file = tmp_path / "f.pdf"
         file.write_bytes(b"%PDF-1.4 " + b"x" * 200)
 
@@ -227,14 +230,13 @@ class TestApprovePath:
             "services.database.AsyncSessionLocal",
             _make_session_factory(pending=pending, upload=upload),
         ):
-            # Patch the taxonomy-cache invalidation import so it doesn't
-            # try to touch the real module's state during the test.
             with patch(
                 "services.paperless_metadata_extractor._invalidate_taxonomy_cache",
                 MagicMock(),
             ):
                 result = await paperless_commit_upload(
-                    {"confirm_token": "tok-b", "user_response_text": "ja"},
+                    {"confirm_token": "tok-b",
+                     "user_response_text": "1: neu, 2: neu"},
                     mcp_manager=mcp, session_id="s", user_id=1,
                 )
 
@@ -250,7 +252,7 @@ class TestApprovePath:
 
     @pytest.mark.asyncio
     @pytest.mark.unit
-    async def test_ja_treats_already_exists_as_success(self, tmp_path):
+    async def test_already_exists_is_success(self, tmp_path):
         """If a create_* says the entry already exists (raced against
         another extraction), treat it as success and use the existing id
         rather than aborting."""
@@ -289,7 +291,8 @@ class TestApprovePath:
                 MagicMock(),
             ):
                 result = await paperless_commit_upload(
-                    {"confirm_token": "tok-c", "user_response_text": "ja"},
+                    {"confirm_token": "tok-c",
+                     "user_response_text": "1: neu"},
                     mcp_manager=mcp, session_id="s", user_id=1,
                 )
 
@@ -355,7 +358,8 @@ class TestApprovePath:
                     MagicMock(),
                 ):
                     result = await paperless_commit_upload(
-                        {"confirm_token": "tok-emb", "user_response_text": "ja"},
+                        {"confirm_token": "tok-emb",
+                         "user_response_text": "1: neu"},
                         mcp_manager=mcp, session_id="s", user_id=1,
                     )
 
@@ -420,7 +424,8 @@ class TestApprovePath:
                     MagicMock(),
                 ):
                     result = await paperless_commit_upload(
-                        {"confirm_token": "tok-no-emb", "user_response_text": "ja"},
+                        {"confirm_token": "tok-no-emb",
+                         "user_response_text": "1: neu"},
                         mcp_manager=mcp, session_id="s", user_id=1,
                     )
 
@@ -687,7 +692,11 @@ class TestAmbiguousResponse:
 
 class TestChoiceParser:
     @pytest.mark.unit
-    def test_default_decisions_pick_first_near_match(self):
+    def test_default_decisions_pick_first_near_match_else_skip(self):
+        """Safety default: only auto-pick when the user has seen
+        candidates. No-match fields skip rather than auto-create —
+        creating a taxonomy entry from a single OCR'd value without
+        explicit consent pollutes the user's Paperless instance."""
         from services.paperless_commit_tool import _default_decisions
 
         resolutions = [
@@ -698,6 +707,75 @@ class TestChoiceParser:
         decisions = _default_decisions(resolutions)
         assert decisions[0]["action"] == "use"
         assert decisions[0]["value"] == "Foo Inc"
+        assert decisions[1]["action"] == "skip"
+        assert decisions[1]["value"] == ""
+
+    @pytest.mark.unit
+    def test_default_decisions_legacy_proposal_shape_survives(self):
+        """Legacy pending rows persisted under the old NewEntryProposal
+        shape carry ``value`` instead of ``extracted_value`` and never
+        ``near_matches``. The default-decision builder must read both
+        keys so a "ja" reply on an old pending row still works."""
+        from services.paperless_commit_tool import _default_decisions
+
+        legacy = [
+            {"field": "correspondent", "value": "Schreiner Meier",
+             "reasoning": "..."},
+        ]
+        decisions = _default_decisions(legacy)
+        # Legacy row had no near matches → safe default is skip.
+        # The value must not silently disappear, though — the user
+        # can still type "1: neu" to opt into creating it.
+        assert decisions[0]["action"] == "skip"
+
+    @pytest.mark.unit
+    def test_parse_user_choices_neu_on_legacy_proposal(self):
+        """Legacy proposal {field, value, reasoning} → "1: neu" must
+        create the value, not crash on the missing extracted_value."""
+        from services.paperless_commit_tool import _parse_user_choices
+
+        legacy = [
+            {"field": "correspondent", "value": "Schreiner Meier",
+             "reasoning": "..."},
+        ]
+        decisions, err = _parse_user_choices("1: neu", legacy)
+        assert err is None
+        assert decisions[0]["action"] == "create"
+        assert decisions[0]["value"] == "Schreiner Meier"
+
+    @pytest.mark.unit
+    def test_parse_user_choices_n_marker_treated_as_create(self):
+        """The preview shows users `n. NEU anlegen` so the parser must
+        accept "n" as the create token — not just the spelled-out
+        "neu". Otherwise users following the on-screen contract get a
+        re-prompt loop."""
+        from services.paperless_commit_tool import _parse_user_choices
+
+        resolutions = [
+            {"field": "correspondent", "extracted_value": "Foo",
+             "near_matches": ["Foo Inc"]},
+        ]
+        decisions, err = _parse_user_choices("1: n", resolutions)
+        assert err is None
+        assert decisions[0]["action"] == "create"
+        assert decisions[0]["value"] == "Foo"
+
+    @pytest.mark.unit
+    def test_parse_user_choices_handles_missing_separator(self):
+        """Phone-typed reply without a comma between pairs ("1:2 2:neu")
+        must still split into two decisions — losing the second pair
+        silently is the worst possible failure mode."""
+        from services.paperless_commit_tool import _parse_user_choices
+
+        resolutions = [
+            {"field": "correspondent", "extracted_value": "Foo",
+             "near_matches": ["Foo Inc", "Foo GmbH"]},
+            {"field": "tag", "extracted_value": "bar", "near_matches": []},
+        ]
+        decisions, err = _parse_user_choices("1:2 2:neu", resolutions)
+        assert err is None
+        assert decisions[0]["action"] == "use"
+        assert decisions[0]["value"] == "Foo GmbH"
         assert decisions[1]["action"] == "create"
         assert decisions[1]["value"] == "bar"
 

--- a/tests/backend/test_paperless_metadata_extractor.py
+++ b/tests/backend/test_paperless_metadata_extractor.py
@@ -18,11 +18,12 @@ import pytest
 
 from services.paperless_metadata_extractor import (
     ExtractionResult,
-    NewEntryProposal,
+    FieldResolution,
     PaperlessMetadata,
     PaperlessMetadataExtractor,
     PaperlessTaxonomy,
     _fuzzy_match,
+    _fuzzy_top_candidates,
     _normalise,
     _parse_llm_json,
     prune_taxonomy,
@@ -276,7 +277,8 @@ class TestValidateExtraction:
         assert result.tags == ["wohnung", "nebenkosten-2025"]
         assert result.storage_path == "/wohnung/betriebskosten"
         assert result.created_date == date(2026, 2, 14)
-        assert result.new_entry_proposals == []
+        # All fields exact-resolved → no decisions surfaced.
+        assert result.resolutions == []
 
     @pytest.mark.unit
     def test_fuzzy_rewrite_silent_on_near_match(self):
@@ -292,9 +294,10 @@ class TestValidateExtraction:
         assert result.correspondent == "Stadtwerke Korschenbroich"
 
     @pytest.mark.unit
-    def test_non_taxonomy_value_dropped_when_no_proposal(self):
-        """LLM hallucinates a correspondent not in taxonomy, no
-        proposal flagged — field drops to None, nothing surfaces."""
+    def test_non_taxonomy_value_emits_resolution(self):
+        """LLM extracts a correspondent not in the taxonomy. The field
+        drops to None and a FieldResolution surfaces so the user can
+        pick a near match or create a new entry."""
         raw = {
             "title": "Test",
             "correspondent": "Gibt Es Nicht GmbH",
@@ -303,31 +306,44 @@ class TestValidateExtraction:
         }
         result = validate_extraction(raw, _taxonomy())
         assert result.correspondent is None
-        assert result.new_entry_proposals == []
+        assert len(result.resolutions) == 1
+        res = result.resolutions[0]
+        assert res.field == "correspondent"
+        assert res.extracted_value == "Gibt Es Nicht GmbH"
+        # Truly unrelated string → no near matches, only "neu" path.
+        assert res.near_matches == []
 
     @pytest.mark.unit
-    def test_non_taxonomy_value_survives_as_proposal(self):
-        """LLM emits a value not in taxonomy AND flags it as a proposal.
-        Field stays None (proposal carries the intent), proposal
-        survives for user review."""
+    def test_non_taxonomy_value_with_near_match_surfaces_candidates(self):
+        """LLM extracts a value the strict-fuzzy pass can't pin down
+        but that has a few plausible neighbours. The resolution lists
+        them so the user picks a canonical entry."""
+        # Add a couple of plausible neighbours so the looser top-N
+        # matcher has something to surface.
+        taxonomy = _taxonomy()
+        taxonomy.correspondents.extend([
+            "Schreiner Müller",
+            "Schreinerei Bauer",
+            "Schmiede Meier",
+        ])
         raw = {
             "title": "Test",
             "correspondent": "Schreiner Meier",
             "document_type": "Rechnung",
             "tags": [],
-            "new_entry_proposals": [
-                {"field": "correspondent", "value": "Schreiner Meier",
-                 "reasoning": "Rechnungskopf, nicht in Taxonomie."},
-            ],
         }
-        result = validate_extraction(raw, _taxonomy())
+        result = validate_extraction(raw, taxonomy)
         assert result.correspondent is None
-        assert len(result.new_entry_proposals) == 1
-        assert result.new_entry_proposals[0].value == "Schreiner Meier"
+        assert len(result.resolutions) == 1
+        res = result.resolutions[0]
+        assert res.field == "correspondent"
+        assert res.extracted_value == "Schreiner Meier"
+        assert res.near_matches  # at least one neighbour shortlisted
 
     @pytest.mark.unit
-    def test_tags_non_taxonomy_entries_dropped(self):
-        """Tags are list-valued — misses drop silently, hits are kept."""
+    def test_tags_non_taxonomy_entries_emit_resolutions(self):
+        """Tags are list-valued — exact hits land in result.tags,
+        misses each emit a FieldResolution so the user can decide."""
         raw = {
             "title": "Test",
             "correspondent": None,
@@ -338,6 +354,10 @@ class TestValidateExtraction:
         assert "wohnung" in result.tags
         assert "steuer-2025" in result.tags
         assert "made-up-tag" not in result.tags
+        # The miss surfaces as its own resolution.
+        tag_res = [r for r in result.resolutions if r.field == "tag"]
+        assert len(tag_res) == 1
+        assert tag_res[0].extracted_value == "made-up-tag"
 
     @pytest.mark.unit
     def test_tags_capped_at_5(self):
@@ -485,36 +505,45 @@ class TestParseLLMJson:
 
 class TestRenderPrompt:
     @pytest.mark.unit
-    def test_injects_taxonomy_and_doc_text(self):
+    def test_doc_text_in_user_prompt_taxonomy_excluded(self):
+        """The user prompt carries the document text. The taxonomy is
+        intentionally NOT injected — server-side fuzzy resolution
+        replaces what the LLM used to do, and burning context on a
+        ~3000-entry taxonomy was the whole reason this redesign
+        landed."""
         taxonomy = PaperlessTaxonomy(
-            correspondents=["Stadtwerke", "Finanzamt"],
-            document_types=["Rechnung"],
-            tags=["wohnung"],
-            storage_paths=["/x"],
+            correspondents=["Stadtwerke Sentinel"],
+            document_types=["DocTypeSentinel"],
+            tags=["TagSentinel"],
+            storage_paths=["/StorageSentinel"],
         )
         system, user = render_prompt(
             doc_text="Hello world", taxonomy=taxonomy, lang="de",
         )
         assert "JSON" in system or "json" in system.lower()
-        assert "Stadtwerke" in user
-        assert "Rechnung" in user
-        assert "/x" in user
         assert "Hello world" in user
+        # None of the taxonomy entries leak into the prompt.
+        for sentinel in (
+            "Stadtwerke Sentinel",
+            "DocTypeSentinel",
+            "TagSentinel",
+            "/StorageSentinel",
+        ):
+            assert sentinel not in user, (
+                f"taxonomy entry {sentinel!r} leaked into prompt"
+            )
 
     @pytest.mark.unit
-    def test_empty_taxonomy_renders_gracefully(self):
-        """Cold-start, no taxonomy yet — prompt should still render,
-        just noting (none) for each dimension."""
-        taxonomy = PaperlessTaxonomy()
-        _, user = render_prompt(doc_text="doc", taxonomy=taxonomy)
-        assert "(none)" in user
+    def test_render_prompt_works_without_taxonomy(self):
+        """Taxonomy is optional now — render works with None."""
+        _, user = render_prompt(doc_text="doc text here", taxonomy=None)
+        assert "doc text here" in user
 
     @pytest.mark.unit
     def test_doc_text_truncated_past_cap(self):
         """Very long documents get truncated to the LLM-context cap."""
         long_doc = "A" * 20_000
-        taxonomy = PaperlessTaxonomy()
-        _, user = render_prompt(doc_text=long_doc, taxonomy=taxonomy)
+        _, user = render_prompt(doc_text=long_doc, taxonomy=PaperlessTaxonomy())
         # User prompt must not contain the full 20k A's.
         assert "A" * 20_000 not in user
 
@@ -1061,80 +1090,103 @@ class TestExtractorIntegration:
 
 
 # ===========================================================================
-# Confidence-gated proposals
+# _fuzzy_top_candidates + FieldResolution
 # ===========================================================================
 
 
-class TestConfidenceGating:
+class TestFuzzyTopCandidates:
     @pytest.mark.unit
-    def test_high_confidence_proposal_survives(self):
-        """Confidence ≥ 0.6 on the field name → proposal passes."""
+    def test_returns_closest_first(self):
+        taxonomy = ["Stadtwerke A", "Stadtwerke B", "Andere GmbH"]
+        out = _fuzzy_top_candidates("Stadtwerke A", taxonomy)
+        assert out[0] == "Stadtwerke A"
+
+    @pytest.mark.unit
+    def test_caps_at_limit(self):
+        taxonomy = [f"X{i}" for i in range(10)]
+        out = _fuzzy_top_candidates("X1", taxonomy, limit=3)
+        assert len(out) <= 3
+
+    @pytest.mark.unit
+    def test_empty_inputs(self):
+        assert _fuzzy_top_candidates("", ["A"]) == []
+        assert _fuzzy_top_candidates("A", []) == []
+
+    @pytest.mark.unit
+    def test_excludes_far_strings(self):
+        out = _fuzzy_top_candidates(
+            "Stadtwerke", ["Vollkommen Anders", "Noch Anders"],
+        )
+        assert out == []
+
+
+class TestFieldResolution:
+    @pytest.mark.unit
+    def test_status_exact(self):
+        r = FieldResolution(
+            field="correspondent",
+            extracted_value="Foo",
+            canonical="Foo Inc.",
+        )
+        assert r.status == "exact"
+        assert r.requires_user_decision is False
+
+    @pytest.mark.unit
+    def test_status_near(self):
+        r = FieldResolution(
+            field="correspondent",
+            extracted_value="Foo",
+            near_matches=["Foo GmbH", "Foo AG"],
+        )
+        assert r.status == "near"
+        assert r.requires_user_decision is True
+
+    @pytest.mark.unit
+    def test_status_none(self):
+        r = FieldResolution(field="tag", extracted_value="x")
+        assert r.status == "none"
+        assert r.requires_user_decision is True
+
+
+# ===========================================================================
+# Resolutions surfaced for non-exact extractions
+# ===========================================================================
+
+
+class TestResolutionDecisions:
+    @pytest.mark.unit
+    def test_legacy_new_entry_proposals_in_payload_ignored(self):
+        """Older LLM responses (or replayed pending rows) may still carry
+        the obsolete ``new_entry_proposals`` field. validate_extraction
+        strips it silently so the new shape stays clean."""
         raw = {
             "title": "T",
             "correspondent": "Schreiner Meier",
             "document_type": "Rechnung",
             "tags": [],
-            "confidence": {"correspondent": 0.85},
             "new_entry_proposals": [
                 {"field": "correspondent", "value": "Schreiner Meier",
-                 "reasoning": "Rechnungskopf."},
+                 "reasoning": "irrelevant"},
             ],
         }
+        # Should not raise (legacy field is dropped before pydantic).
         result = validate_extraction(raw, _taxonomy())
-        assert len(result.new_entry_proposals) == 1
-        assert result.new_entry_proposals[0].value == "Schreiner Meier"
+        # Server still emits a resolution because correspondent is not
+        # an exact taxonomy hit.
+        assert any(r.field == "correspondent" for r in result.resolutions)
 
     @pytest.mark.unit
-    def test_low_confidence_proposal_dropped(self):
-        """Confidence < 0.6 on the proposal field → dropped."""
+    def test_resolution_status_exact_omitted(self):
+        """When every singleton + tag resolves to an exact / strong-fuzzy
+        hit, no resolutions are emitted."""
         raw = {
             "title": "T",
-            "correspondent": "Unsichtbar Ltd",
+            "correspondent": "Stadtwerke Korschenbroich",
             "document_type": "Rechnung",
-            "tags": [],
-            "confidence": {"correspondent": 0.3},
-            "new_entry_proposals": [
-                {"field": "correspondent", "value": "Unsichtbar Ltd",
-                 "reasoning": "Unsicher, ob so gelesen."},
-            ],
+            "tags": ["wohnung"],
         }
         result = validate_extraction(raw, _taxonomy())
-        assert result.new_entry_proposals == []
-
-    @pytest.mark.unit
-    def test_missing_confidence_permissive(self):
-        """No confidence entry for the proposal field → be permissive
-        (don't drop). Keeps the signal when the LLM forgets the
-        confidence block entirely."""
-        raw = {
-            "title": "T",
-            "correspondent": "Schreiner Meier",
-            "document_type": "Rechnung",
-            "tags": [],
-            # No confidence entry at all.
-            "new_entry_proposals": [
-                {"field": "correspondent", "value": "Schreiner Meier",
-                 "reasoning": "..."},
-            ],
-        }
-        result = validate_extraction(raw, _taxonomy())
-        assert len(result.new_entry_proposals) == 1
-
-    @pytest.mark.unit
-    def test_tag_proposal_uses_plural_confidence_key(self):
-        """The LLM often keys confidence as 'tags' (plural list) even
-        though proposals are singular 'tag'. Accept either."""
-        raw = {
-            "title": "T",
-            "tags": [],
-            "confidence": {"tags": 0.9},
-            "new_entry_proposals": [
-                {"field": "tag", "value": "new-tag",
-                 "reasoning": "..."},
-            ],
-        }
-        result = validate_extraction(raw, _taxonomy())
-        assert len(result.new_entry_proposals) == 1
+        assert result.resolutions == []
 
 
 # ===========================================================================
@@ -1151,19 +1203,6 @@ class TestPartialShapeFailures:
             "title": "T",
             "tags": [],
             "created_date": "not-a-date",
-        }
-        with pytest.raises(ValueError):
-            validate_extraction(raw, _taxonomy())
-
-    @pytest.mark.unit
-    def test_malformed_proposal_shape_raises(self):
-        """Proposal with a wrong field name (not in Literal)."""
-        raw = {
-            "title": "T",
-            "tags": [],
-            "new_entry_proposals": [
-                {"field": "not-a-real-field", "value": "x", "reasoning": "y"},
-            ],
         }
         with pytest.raises(ValueError):
             validate_extraction(raw, _taxonomy())
@@ -1301,20 +1340,19 @@ class TestListViaMcpLogging:
 
 class TestDataModels:
     @pytest.mark.unit
-    def test_new_entry_proposal_rejects_invalid_field(self):
+    def test_field_resolution_rejects_invalid_field(self):
         from pydantic import ValidationError
         with pytest.raises(ValidationError):
-            NewEntryProposal(
+            FieldResolution(
                 field="not-a-valid-field",
-                value="X",
-                reasoning="...",
+                extracted_value="X",
             )
 
     @pytest.mark.unit
-    def test_new_entry_proposal_accepts_all_four_dimensions(self):
+    def test_field_resolution_accepts_all_four_dimensions(self):
         for field in ("correspondent", "document_type", "tag", "storage_path"):
-            p = NewEntryProposal(field=field, value="X", reasoning="...")
-            assert p.field == field
+            r = FieldResolution(field=field, extracted_value="X")
+            assert r.field == field
 
     @pytest.mark.unit
     def test_extraction_result_defaults(self):


### PR DESCRIPTION
## Summary

Reworks Paperless metadata extraction so the LLM no longer receives the user's full taxonomy. The server resolves each extracted value against the live Paperless taxonomy and surfaces ambiguous cases to the user as numbered choices.

**Old design:** the user's full Paperless taxonomy (~900 correspondents + ~400 doc-types + ~1500 tags for a real household) was injected into every extraction prompt. The LLM was asked to pick from that list, with a `new_entry_proposals[]` carve-out for "value not in taxonomy". A strict-fuzzy validator either rewrote the LLM's pick to canonical or dropped the field. In prod this resulted in routine LLM hallucinations the validator couldn't repair, plus 3000+ entries of token bloat per call.

**New design:**
1. The LLM extracts raw values straight from the document text — no taxonomy in the prompt.
2. The server resolves each extracted value against the live taxonomy:
   - exact / strong-fuzzy hit → field set, no decision needed
   - 1–3 near matches → `FieldResolution` with candidate shortlist
   - no match → `FieldResolution` with empty `near_matches` (user picks "neu" or skip)
3. The cold-start confirm preview shows numbered `[N]` options per decision-needed field plus "neu" / "x".
4. The commit tool parses replies like `"1: 2, 2: neu, 3: x"` — and `"ja"` applies the safer default (#1 if near matches exist, else **skip**).

## Why it matters

- ~10x token reduction per extraction (3000 entries → handful of seed examples)
- Higher accuracy: the LLM no longer guesses at a taxonomy it cannot see
- User has explicit control over disambiguation instead of the LLM betting wrong
- Auto-creating taxonomy entries from OCR'd values now requires explicit consent

## Architecture

- `FieldResolution` model with `status` (`exact` / `near` / `none`) replaces `NewEntryProposal`
- `_fuzzy_top_candidates` helper for the looser top-N near-match shortlist (Levenshtein ≤ 6, ratio ≤ 0.4)
- `validate_extraction` populates `metadata.resolutions` for fields needing user input
- `chat_upload_tool._render_confirm_message` shows numbered `[N]` decisions with candidates + "neu" + "x"
- `paperless_commit_tool._parse_user_choices` parses per-field replies; `_default_decisions` applies safe defaults
- `paperless_pending_confirms.proposals` JSON column repurposed to carry `FieldResolution` payloads (column kept for backward compat with in-flight pending rows)

## Review fixes (commit 2)

Independent code review found four issues, all addressed:

1. **Backward compat** — legacy pending rows persisted under the old `{field, value, reasoning}` shape now survive via `_resolution_value()` fallback
2. **Preview-token contract** — added `"n"` to `_NEW_TOKENS` to match the on-screen `n. NEU anlegen` marker
3. **Regex robustness** — `"1:2 2:neu"` (phone-typed reply, no comma) now splits correctly via lookahead
4. **Safer `ja` default** — no-match resolutions default to `skip`, not auto-create. User must type `<idx>: neu` to opt into pollution-prone taxonomy mutations.

## Test plan

- [x] 134 paperless tests pass on backend container (extractor, commit_tool, chat_upload_tool)
- [x] Coverage for `_fuzzy_top_candidates`, `FieldResolution.status`, `_default_decisions`, `_parse_user_choices`
- [x] Coverage for the four review fixes (legacy shape, n. token, missing-separator regex, safer default)
- [x] Live smoke test: render_prompt against real backend confirms taxonomy no longer leaks into prompt
- [ ] Post-deploy: end-to-end browser test against k8s prod with a real invoice

🤖 Generated with [Claude Code](https://claude.com/claude-code)