### PR TITLE
fix(alembic): widen baseline-create alembic_version to VARCHAR(64)

### DIFF
--- a/src/backend/services/database.py
+++ b/src/backend/services/database.py
@@ -56,7 +56,7 @@ async def _ensure_alembic_baseline():
         else:
             await conn.execute(text(
                 "CREATE TABLE alembic_version ("
-                "version_num VARCHAR(32) NOT NULL, "
+                "version_num VARCHAR(64) NOT NULL, "
                 "CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num))"
             ))
         await conn.execute(

--- a/src/backend/services/database.py
+++ b/src/backend/services/database.py
@@ -59,6 +59,25 @@ async def _ensure_alembic_baseline():
                 "version_num VARCHAR(64) NOT NULL, "
                 "CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num))"
             ))
+        # Idempotent widen — covers the partial-state path: alembic_version
+        # exists but is empty (e.g. prior crashed init, manual recovery ops)
+        # with a pre-existing VARCHAR(32) column. The CREATE above only runs
+        # when the table is fully absent. Without this ALTER the INSERT below
+        # crashes with StringDataRightTruncationError on a >32-char head_rev.
+        # Mirrors the same pattern in alembic/env.py (PR #462) so both
+        # creation paths converge on VARCHAR(64). Postgres-only by design;
+        # this function is never invoked against SQLite/test engines.
+        await conn.execute(text(
+            "DO $$ BEGIN "
+            "  IF (SELECT character_maximum_length "
+            "      FROM information_schema.columns "
+            "      WHERE table_name='alembic_version' "
+            "        AND column_name='version_num') < 64 "
+            "  THEN ALTER TABLE alembic_version "
+            "    ALTER COLUMN version_num TYPE VARCHAR(64); "
+            "  END IF; "
+            "END $$;"
+        ))
         await conn.execute(
             text("INSERT INTO alembic_version (version_num) VALUES (:v)"),
             {"v": head_rev},

--- a/tests/backend/test_database_alembic_baseline.py
+++ b/tests/backend/test_database_alembic_baseline.py
@@ -1,0 +1,102 @@
+"""
+Regression guards for `_ensure_alembic_baseline` in services/database.py.
+
+Background — prod incident 2026-04-25 (Reva submodule bump):
+    The head revision `pc20260426_paperless_upload_tracking` (38 chars)
+    crashed with StringDataRightTruncationError when inserted into the
+    default VARCHAR(32) `alembic_version.version_num` column on a fresh
+    Reva DB.
+
+    PR #462 fixed the column width in `alembic/env.py` for the alembic
+    upgrade flow. PR #477 fixed the same bug in `services/database.py`
+    for the SQLAlchemy `create_all` bootstrap path.
+
+The function has three execution paths through its main `if/else`:
+    A. Table exists + has row    → early return; no INSERT
+    B. Table absent              → CREATE w/ VARCHAR(64), then INSERT
+    C. Table exists, empty       → falls through; widen ALTER, then INSERT
+
+These tests guard against the two width-related regressions:
+  1. CREATE statement must declare VARCHAR(64), not VARCHAR(32)  (path B)
+  2. Idempotent widen ALTER must run before INSERT               (path C)
+
+Source-file inspection is used (rather than runtime invocation) because
+the function is Postgres-only — it uses `DO $$ ... $$` blocks and
+`information_schema`. SQLite test engines don't enforce VARCHAR length,
+so a runtime check would pass even with the bug present. Reading the
+source also avoids importing `services.database` — that module triggers
+SQLAlchemy engine creation and asyncpg import at module load.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DATABASE_PY = REPO_ROOT / "src" / "backend" / "services" / "database.py"
+
+
+def _baseline_function_source() -> str:
+    """Return only the body of `_ensure_alembic_baseline` from the source file.
+
+    Slices from `async def _ensure_alembic_baseline` to the next top-level
+    `async def` so unrelated functions in the same file can't pass the
+    string assertions by accident.
+    """
+    src = DATABASE_PY.read_text()
+    start = src.index("async def _ensure_alembic_baseline")
+    rest = src[start + len("async def _ensure_alembic_baseline"):]
+    end = rest.index("\nasync def ")
+    return rest[:end]
+
+
+@pytest.mark.unit
+def test_ensure_alembic_baseline_create_uses_varchar_64():
+    """CREATE TABLE alembic_version must declare VARCHAR(64) for version_num.
+
+    Path B (table absent) regression — VARCHAR(32) is too narrow for
+    Renfield revision IDs which run up to ~40 characters.
+    """
+    body = _baseline_function_source()
+    # Match the literal SQL declaration so comments mentioning the legacy
+    # width (e.g. "...with a pre-existing VARCHAR(32) column") don't
+    # falsely trip the assertion.
+    forbidden = '"version_num VARCHAR(32) NOT NULL'
+    required = '"version_num VARCHAR(64) NOT NULL'
+    assert forbidden not in body, (
+        "_ensure_alembic_baseline CREATE must NOT declare "
+        "version_num VARCHAR(32) — Renfield revision IDs run up to "
+        "~40 chars (see PR #477)"
+    )
+    assert required in body, (
+        "_ensure_alembic_baseline CREATE must declare "
+        "version_num VARCHAR(64)"
+    )
+
+
+@pytest.mark.unit
+def test_ensure_alembic_baseline_widens_before_insert():
+    """An idempotent widen ALTER must run before INSERT.
+
+    Path C (table exists but empty) regression — without this ALTER the
+    INSERT crashes when an existing alembic_version table still carries
+    the legacy VARCHAR(32) column. Mirrors `alembic/env.py` from PR #462
+    so both creation paths converge on the wider column.
+    """
+    body = _baseline_function_source()
+    widen_idx = body.find("ALTER COLUMN version_num TYPE VARCHAR(64)")
+    insert_idx = body.find("INSERT INTO alembic_version")
+
+    assert widen_idx >= 0, (
+        "_ensure_alembic_baseline must include an idempotent "
+        "ALTER COLUMN widen to VARCHAR(64) (path C protection)"
+    )
+    assert insert_idx >= 0, (
+        "_ensure_alembic_baseline must execute INSERT INTO alembic_version"
+    )
+    assert widen_idx < insert_idx, (
+        "Widen ALTER must run BEFORE the INSERT — otherwise the INSERT "
+        "still crashes when the column was VARCHAR(32)"
+    )


### PR DESCRIPTION
## Summary
Companion to #462 (`fix(alembic): auto-widen alembic_version.version_num to VARCHAR(64)`). That PR widened the column in `alembic/env.py` for the alembic upgrade flow but missed the parallel fresh-install path in `services/database.py:_ensure_alembic_baseline`, which still hardcoded VARCHAR(32) when the table doesn't exist yet.

## Repro (and prod incident 2026-04-25)
On a truly fresh DB (no `alembic_version` table), `_ensure_alembic_baseline` runs:

1. `CREATE TABLE alembic_version (... VARCHAR(32) ...)` — old width
2. `INSERT INTO alembic_version VALUES ('pc20260426_paperless_upload_tracking')` (38 chars)

Step 2 crashes with `StringDataRightTruncationError` before alembic env.py ever runs its widen.

Hit during the Reva submodule bump deploy (Apr 25): prod DB had no `alembic_version` table, fresh-install path ran, crash on first INSERT. Manual recovery was creating the table by hand with VARCHAR(64).

## Fix — covers both fresh-install AND partial-state

The function has three execution paths through its `if/else`:

| Path | State | Pre-PR | This PR |
|---|---|---|---|
| A | Table + row | early return; safe | unchanged |
| B | Table absent (fresh install) | CREATE w/ 32, then INSERT crashes | CREATE w/ 64 |
| C | Table exists, empty (partial state) | falls through; INSERT crashes against legacy 32 | idempotent ALTER widen, then INSERT |

Path C wasn't obvious from the original incident (prod hit path B), but it can occur after a prior crashed init, manual recovery ops, or any flow that creates the table without inserting a row. Without an explicit ALTER, INSERT still crashes on a legacy VARCHAR(32) column.

The fix mirrors `alembic/env.py` (PR #462) so all three creation paths converge on VARCHAR(64):

- alembic upgrade flow (env.py) — already widened by PR #462
- SQLAlchemy `create_all` bootstrap, fresh — CREATE w/ 64
- SQLAlchemy `create_all` bootstrap, partial — idempotent ALTER widen, then INSERT

## Test plan
- `tests/backend/test_database_alembic_baseline.py` — two regression guards:
  - `test_ensure_alembic_baseline_create_uses_varchar_64` — CREATE statement must declare VARCHAR(64) (path B regression).
  - `test_ensure_alembic_baseline_widens_before_insert` — idempotent ALTER widen must run before INSERT in source order (path C regression).
- Verified manually in prod (Reva bump deploy): with `alembic_version` pre-created at VARCHAR(64) by hand, the bumped Reva starts cleanly. With this PR merged, that hand step is no longer required.
- Tests use static-source inspection rather than runtime invocation. The function uses Postgres-only `DO $$ ... $$` blocks and `information_schema`; SQLite test engines don't enforce VARCHAR length, so a runtime check would pass even with the bug present.

## History
- `bc2715b` — initial one-line fix (CREATE width). Addressed path B only.
- `379d3e8` — code-review feedback: extended to cover path C with idempotent ALTER widen, plus regression tests.