### PR TITLE
fix(alembic): explicit commit after run_sync so DDL persists

### DIFF
--- a/src/backend/alembic/env.py
+++ b/src/backend/alembic/env.py
@@ -223,6 +223,16 @@ async def run_async_migrations() -> None:
 
     async with connectable.connect() as connection:
         await connection.run_sync(do_run_migrations)
+        # Explicit commit — `connectable.connect()` does not auto-commit on
+        # exit. Alembic's `context.begin_transaction()` inside
+        # do_run_migrations runs synchronously via greenlet and its commit
+        # does not propagate through the asyncpg adapter, so DDL silently
+        # rolls back when the async connection closes. Without this line,
+        # `alembic upgrade head` logs every migration as "Running upgrade…"
+        # but nothing persists. The contrast: `engine.begin()` (used by
+        # `_ensure_alembic_baseline` in services/database.py) auto-commits
+        # on exit and works correctly.
+        await connection.commit()
 
     await connectable.dispose()
 


### PR DESCRIPTION
## Summary

`alembic upgrade head` was reporting success across all migrations while silently rolling back every DDL change. Adds the missing `await connection.commit()` after `run_sync` in `run_async_migrations()`.

## Root cause

`async with connectable.connect() as connection:` does not auto-commit on exit (SQLAlchemy 2.x async semantics). `context.begin_transaction()` inside `do_run_migrations` runs synchronously via greenlet — its commit does not propagate through the asyncpg adapter, so when the async connection closes, every BEGIN…DDL goes with it.

## Reproduction

Surfaced by Reva PRD during the circles+paperless bump:

1. `_ensure_alembic_baseline` (in `services/database.py`) stamps `pc20260426_paperless_upload_tracking` cleanly — uses `engine.begin()` which auto-commits.
2. PRD has a real existing schema, so the stamp leaves alembic believing all 49 migrations are applied while the live schema is still pre-circles.
3. Reset `alembic_version` to `pc20260402a1` (last revision before the new work) and run `alembic upgrade head`.
4. Output shows 8 `Running upgrade …` lines, exit code 0 — looks fine.
5. `SELECT * FROM alembic_version` still returns `pc20260402a1`. Index from migration 419 absent. `kg_entities.scope` still present. `kb_permissions` still present. `atoms` empty (back-fill discarded). Every migration silently rolled back.

After the patch, the same command persists everything — alembic advances to head and the schema reflects the migrations (including 2000 atoms back-filled from existing kg_entities + conversation_memories rows).

## Why this hadn't bitten before

Fresh installs go through `_ensure_alembic_baseline` (which uses `engine.begin()` and commits correctly) and `Base.metadata.create_all`. Neither path goes through `run_async_migrations()`. The only callers that exercise it are:

- Manual `alembic upgrade head` invocations on databases that pre-date the latest revision — i.e. existing prod databases on a new image.
- Future migrations that extend an already-stamped DB.

Companion to #477 — same family of issue ("alembic + DDL on a real existing database"), different commit path.

## Test plan

- [x] Manual: `alembic upgrade head` from `pc20260402a1` against PRD applies all 8 migrations and persists the schema (verified via `pg_dump`-style column/table inspection).
- [x] `_ensure_alembic_baseline` path still works on fresh installs (uses `engine.begin()`, unaffected).
- [ ] Add a smoke-test that asserts schema state after `alembic upgrade head` on a non-empty DB — currently no test exercises `run_async_migrations()` end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)