### PR TITLE
fix(agent): W6 — route all LLM options through prompts/agent.yaml

### DIFF
--- a/src/backend/prompts/agent.yaml
+++ b/src/backend/prompts/agent.yaml
@@ -1142,3 +1142,11 @@ llm_options_summary:
   temperature: 0.3
   num_predict: 1500
   num_ctx: 32768
+
+# Tool pre-selection — short JSON-only response, small context window.
+# Used by AgentService._preselect_tools() to ask the LLM for a small list of
+# tool names it expects to need this turn. Temperature 0 = deterministic.
+llm_options_tool_preselect:
+  temperature: 0
+  num_predict: 120
+  num_ctx: 4096

--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -363,6 +363,24 @@ def _serialize_for_prompt(data: any, budget_chars: int = 0) -> str:
     return serialized
 
 
+# LLM option defaults — used as fallback if prompts/agent.yaml lacks the key.
+# YAML always wins when present (keys defined at the bottom of agent.yaml).
+# Centralizing the defaults here so they aren't duplicated as inline literals
+# at each call site, where they previously read like the source of truth.
+_DEFAULT_LLM_OPTIONS = {
+    "temperature": 0.1, "top_p": 0.2, "num_predict": 2048, "num_ctx": 32768,
+}
+_DEFAULT_LLM_OPTIONS_RETRY = {
+    "temperature": 0.3, "top_p": 0.4, "num_predict": 2048, "num_ctx": 32768,
+}
+_DEFAULT_LLM_OPTIONS_SUMMARY = {
+    "temperature": 0.3, "num_predict": 1500, "num_ctx": 32768,
+}
+_DEFAULT_LLM_OPTIONS_TOOL_PRESELECT = {
+    "temperature": 0, "num_predict": 120, "num_ctx": 4096,
+}
+
+
 # Fields that contain large binary data (base64-encoded)
 _BLOB_FIELDS = {"content_base64"}
 
@@ -716,11 +734,15 @@ class AgentService:
 
         try:
             classification_kwargs = get_classification_chat_kwargs(agent_model)
+            preselect_options = (
+                prompt_manager.get_config("agent", "llm_options_tool_preselect")
+                or _DEFAULT_LLM_OPTIONS_TOOL_PRESELECT
+            )
             raw_response = await asyncio.wait_for(
                 agent_client.chat(
                     model=agent_model,
                     messages=[{"role": "user", "content": preselect_prompt}],
-                    options={"temperature": 0, "num_predict": 120, "num_ctx": 4096},
+                    options=preselect_options,
                     **classification_kwargs,
                 ),
                 timeout=10.0,
@@ -1163,13 +1185,12 @@ class AgentService:
             content=prompt_manager.get("agent", "thinking_message", lang=lang),
         )
 
-        # Get LLM options from config
-        llm_options = prompt_manager.get_config("agent", "llm_options") or {
-            "temperature": 0.1, "top_p": 0.2, "num_predict": 2048, "num_ctx": 32768
-        }
-        llm_options_retry = prompt_manager.get_config("agent", "llm_options_retry") or {
-            "temperature": 0.3, "top_p": 0.4, "num_predict": 2048, "num_ctx": 32768
-        }
+        # Get LLM options from config (YAML wins; module-level constants are
+        # the fallback if a key is missing from prompts/agent.yaml).
+        llm_options = prompt_manager.get_config("agent", "llm_options") or _DEFAULT_LLM_OPTIONS
+        llm_options_retry = (
+            prompt_manager.get_config("agent", "llm_options_retry") or _DEFAULT_LLM_OPTIONS_RETRY
+        )
         json_system_message = prompt_manager.get("agent", "json_system_message", lang=lang)
 
         # Native function calling — opt-in per role AND requires the agent client
@@ -1722,10 +1743,10 @@ class AgentService:
             results=results_text
         )
 
-        # Get LLM options for summary
-        llm_options_summary = prompt_manager.get_config("agent", "llm_options_summary") or {
-            "temperature": 0.3, "num_predict": 1500, "num_ctx": 32768
-        }
+        # Get LLM options for summary (YAML wins; module-level constant is fallback)
+        llm_options_summary = (
+            prompt_manager.get_config("agent", "llm_options_summary") or _DEFAULT_LLM_OPTIONS_SUMMARY
+        )
         summary_system = prompt_manager.get("agent", "summary_system_message", lang=lang)
 
         client = agent_client or ollama.client

--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -381,6 +381,18 @@ _DEFAULT_LLM_OPTIONS_TOOL_PRESELECT = {
 }
 
 
+def _llm_options_or_default(prompt_key: str, fallback: dict) -> dict:
+    """Resolve LLM options from prompts/agent.yaml, falling back to a default.
+
+    Uses explicit `is None` rather than truthiness so an empty/falsy YAML
+    value (`{}`, `None` from a missing key, etc.) is distinguished — an
+    explicit `{}` from YAML is honoured (no inherited options),
+    while a missing key falls through to the in-code fallback.
+    """
+    cfg = prompt_manager.get_config("agent", prompt_key)
+    return cfg if cfg is not None else fallback
+
+
 # Fields that contain large binary data (base64-encoded)
 _BLOB_FIELDS = {"content_base64"}
 
@@ -734,9 +746,8 @@ class AgentService:
 
         try:
             classification_kwargs = get_classification_chat_kwargs(agent_model)
-            preselect_options = (
-                prompt_manager.get_config("agent", "llm_options_tool_preselect")
-                or _DEFAULT_LLM_OPTIONS_TOOL_PRESELECT
+            preselect_options = _llm_options_or_default(
+                "llm_options_tool_preselect", _DEFAULT_LLM_OPTIONS_TOOL_PRESELECT,
             )
             raw_response = await asyncio.wait_for(
                 agent_client.chat(
@@ -1187,10 +1198,8 @@ class AgentService:
 
         # Get LLM options from config (YAML wins; module-level constants are
         # the fallback if a key is missing from prompts/agent.yaml).
-        llm_options = prompt_manager.get_config("agent", "llm_options") or _DEFAULT_LLM_OPTIONS
-        llm_options_retry = (
-            prompt_manager.get_config("agent", "llm_options_retry") or _DEFAULT_LLM_OPTIONS_RETRY
-        )
+        llm_options = _llm_options_or_default("llm_options", _DEFAULT_LLM_OPTIONS)
+        llm_options_retry = _llm_options_or_default("llm_options_retry", _DEFAULT_LLM_OPTIONS_RETRY)
         json_system_message = prompt_manager.get("agent", "json_system_message", lang=lang)
 
         # Native function calling — opt-in per role AND requires the agent client
@@ -1744,8 +1753,8 @@ class AgentService:
         )
 
         # Get LLM options for summary (YAML wins; module-level constant is fallback)
-        llm_options_summary = (
-            prompt_manager.get_config("agent", "llm_options_summary") or _DEFAULT_LLM_OPTIONS_SUMMARY
+        llm_options_summary = _llm_options_or_default(
+            "llm_options_summary", _DEFAULT_LLM_OPTIONS_SUMMARY,
         )
         summary_system = prompt_manager.get("agent", "summary_system_message", lang=lang)
 

--- a/tests/backend/test_agent_llm_options_yaml.py
+++ b/tests/backend/test_agent_llm_options_yaml.py
@@ -1,0 +1,109 @@
+"""
+Regression guards for W6 fix — LLM options must be sourced from
+`prompts/agent.yaml`, not hardcoded inline literals at call sites.
+
+Background — WICHTIG audit W6: temperature/top_p/num_predict were
+hardcoded as inline-literal fallbacks at four locations in
+`services/agent_service.py`. Three of those (main, retry, summary)
+already had a `prompt_manager.get_config(...) or {literal}` pattern
+where YAML actually wins, but the inline literals duplicated the YAML
+values and risked drift. The fourth (tool pre-selection at line 723
+pre-fix) had no YAML route at all — pure hardcoded literal.
+
+The fix:
+  - Add `llm_options_tool_preselect` block to agent.yaml.
+  - Extract the four fallback literals to module-level
+    `_DEFAULT_LLM_OPTIONS*` constants in agent_service.py.
+  - Route all four call sites through
+    `prompt_manager.get_config(...) or _DEFAULT_LLM_OPTIONS_*`.
+
+These tests check the contract: agent.yaml must declare all four
+`llm_options*` keys with the expected shape, and agent_service.py
+must not reintroduce inline literal `temperature/top_p/num_predict`
+dicts at call sites.
+
+Source-file inspection rather than runtime invocation — test environment
+doesn't reliably load services.agent_service (engine + asyncpg).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENT_YAML = REPO_ROOT / "src" / "backend" / "prompts" / "agent.yaml"
+AGENT_SERVICE_PY = REPO_ROOT / "src" / "backend" / "services" / "agent_service.py"
+
+_REQUIRED_KEYS = (
+    "llm_options",
+    "llm_options_retry",
+    "llm_options_summary",
+    "llm_options_tool_preselect",
+)
+
+
+@pytest.mark.unit
+def test_agent_yaml_declares_all_llm_option_blocks():
+    """agent.yaml must declare all four llm_options* keys.
+
+    Each block must be a dict with at least `temperature` and `num_predict`.
+    The pre-selection block intentionally omits `top_p` (deterministic
+    classification call), so we don't require it here.
+    """
+    config = yaml.safe_load(AGENT_YAML.read_text())
+
+    for key in _REQUIRED_KEYS:
+        assert key in config, (
+            f"prompts/agent.yaml is missing required LLM-options block "
+            f"`{key}` — call sites in agent_service.py read it via "
+            f"prompt_manager.get_config(); without the YAML key, callers "
+            f"silently fall back to module-level _DEFAULT_LLM_OPTIONS_*"
+        )
+        block = config[key]
+        assert isinstance(block, dict), f"`{key}` must be a dict, got {type(block).__name__}"
+        assert "temperature" in block, f"`{key}` must declare temperature"
+        assert "num_predict" in block, f"`{key}` must declare num_predict"
+
+
+@pytest.mark.unit
+def test_agent_service_has_no_inline_llm_option_literals_at_call_sites():
+    """agent_service.py call sites must not reintroduce inline literal
+    `{"temperature": ..., "num_predict": ...}` dicts.
+
+    The only acceptable place for such literals is inside the
+    `_DEFAULT_LLM_OPTIONS*` module-level constant blocks.
+    """
+    src = AGENT_SERVICE_PY.read_text()
+
+    # Find every line that contains both "temperature" and "num_predict"
+    # in a dict literal — the tell-tale shape for an LLM options dict.
+    offending: list[tuple[int, str]] = []
+    in_default_block = False
+    for lineno, line in enumerate(src.splitlines(), start=1):
+        stripped = line.strip()
+
+        # Track entry/exit of _DEFAULT_LLM_OPTIONS_* dict definitions —
+        # those are the only place inline literal LLM options are allowed.
+        if stripped.startswith("_DEFAULT_LLM_OPTIONS"):
+            in_default_block = True
+            continue
+        if in_default_block and stripped == "}":
+            in_default_block = False
+            continue
+        if in_default_block:
+            continue
+
+        # Outside _DEFAULT_LLM_OPTIONS blocks: flag any line with the
+        # literal-LLM-options shape.
+        if '"temperature"' in stripped and '"num_predict"' in stripped:
+            offending.append((lineno, stripped))
+
+    assert not offending, (
+        "agent_service.py contains inline literal LLM options dicts at "
+        "call sites — these must route through prompt_manager.get_config() "
+        "with module-level _DEFAULT_LLM_OPTIONS_* as the fallback. "
+        f"Offending lines: {offending}"
+    )

--- a/tests/backend/test_agent_llm_options_yaml.py
+++ b/tests/backend/test_agent_llm_options_yaml.py
@@ -73,37 +73,59 @@ def test_agent_service_has_no_inline_llm_option_literals_at_call_sites():
     """agent_service.py call sites must not reintroduce inline literal
     `{"temperature": ..., "num_predict": ...}` dicts.
 
-    The only acceptable place for such literals is inside the
-    `_DEFAULT_LLM_OPTIONS*` module-level constant blocks.
+    The only acceptable place for such literals is inside the module-level
+    `_DEFAULT_LLM_OPTIONS*` constant assignments. We use an AST walk
+    (rather than line-by-line brace tracking) so the test is robust to
+    single-line dict refactors, comments, and stylistic edits.
     """
+    import ast
+
     src = AGENT_SERVICE_PY.read_text()
+    tree = ast.parse(src)
 
-    # Find every line that contains both "temperature" and "num_predict"
-    # in a dict literal — the tell-tale shape for an LLM options dict.
-    offending: list[tuple[int, str]] = []
-    in_default_block = False
-    for lineno, line in enumerate(src.splitlines(), start=1):
-        stripped = line.strip()
+    # Step 1 — collect line ranges of every module-level
+    # `_DEFAULT_LLM_OPTIONS*` assignment. Any literal dict whose lineno
+    # falls inside one of these ranges is allowed (it's the constant
+    # itself).
+    allowed_ranges: list[tuple[int, int]] = []
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if (
+                    isinstance(target, ast.Name)
+                    and target.id.startswith("_DEFAULT_LLM_OPTIONS")
+                ):
+                    end_lineno = getattr(node, "end_lineno", node.lineno)
+                    allowed_ranges.append((node.lineno, end_lineno))
 
-        # Track entry/exit of _DEFAULT_LLM_OPTIONS_* dict definitions —
-        # those are the only place inline literal LLM options are allowed.
-        if stripped.startswith("_DEFAULT_LLM_OPTIONS"):
-            in_default_block = True
-            continue
-        if in_default_block and stripped == "}":
-            in_default_block = False
-            continue
-        if in_default_block:
-            continue
+    assert allowed_ranges, (
+        "Expected at least one module-level _DEFAULT_LLM_OPTIONS* "
+        "assignment in agent_service.py — these are the canonical home "
+        "for the fallback dicts. None found."
+    )
 
-        # Outside _DEFAULT_LLM_OPTIONS blocks: flag any line with the
-        # literal-LLM-options shape.
-        if '"temperature"' in stripped and '"num_predict"' in stripped:
-            offending.append((lineno, stripped))
+    def _is_allowed(lineno: int) -> bool:
+        return any(lo <= lineno <= hi for lo, hi in allowed_ranges)
+
+    # Step 2 — walk every dict literal in the file. Flag any whose keys
+    # include "temperature" AND "num_predict" (the LLM-options shape) and
+    # whose location is NOT inside a _DEFAULT_LLM_OPTIONS* assignment.
+    offending: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Dict):
+            continue
+        keys = {
+            k.value
+            for k in node.keys
+            if isinstance(k, ast.Constant) and isinstance(k.value, str)
+        }
+        if {"temperature", "num_predict"}.issubset(keys) and not _is_allowed(node.lineno):
+            offending.append(node.lineno)
 
     assert not offending, (
-        "agent_service.py contains inline literal LLM options dicts at "
-        "call sites — these must route through prompt_manager.get_config() "
-        "with module-level _DEFAULT_LLM_OPTIONS_* as the fallback. "
+        "agent_service.py contains inline literal LLM-options dicts "
+        "(keys: temperature + num_predict) at call sites. These must "
+        "route through `_llm_options_or_default()` with the module-level "
+        "_DEFAULT_LLM_OPTIONS_* constants as the fallback. "
         f"Offending lines: {offending}"
     )


### PR DESCRIPTION
## Summary
WICHTIG audit W6: `temperature`/`top_p`/`num_predict` were hardcoded in 4 locations in `services/agent_service.py`. Three (main, retry, summary) already had a `prompt_manager.get_config(...) or {literal}` pattern where YAML actually wins, but the inline literals duplicated the YAML values and risked drift. The fourth — tool pre-selection (line 723 pre-fix) — had **no YAML route at all**; pure hardcoded literal.

## Change
- Add `llm_options_tool_preselect` block to `prompts/agent.yaml` (same shape as the 3 existing keys).
- Extract the 4 fallback literals to module-level constants `_DEFAULT_LLM_OPTIONS`, `_DEFAULT_LLM_OPTIONS_RETRY`, `_DEFAULT_LLM_OPTIONS_SUMMARY`, `_DEFAULT_LLM_OPTIONS_TOOL_PRESELECT`. Clear naming makes it obvious YAML is the source of truth and these are pure fallbacks.
- Route all 4 call sites through `prompt_manager.get_config(...) or _DEFAULT_LLM_OPTIONS_*`.

## Test plan
`tests/backend/test_agent_llm_options_yaml.py` — 2 regression guards:
1. `test_agent_yaml_declares_all_llm_option_blocks` — `agent.yaml` must declare all 4 `llm_options*` blocks with `temperature` + `num_predict` keys.
2. `test_agent_service_has_no_inline_llm_option_literals_at_call_sites` — `agent_service.py` must not reintroduce inline literal `{"temperature": ..., "num_predict": ...}` dicts at call sites; only the `_DEFAULT_LLM_OPTIONS_*` module constants are allowed.

Both pass locally.

## Audit-doc accuracy note
W6 also cited `agent_service.py:529-532` and `agent_router.py:219` as hits. Those line numbers are stale — current code at those locations is JSON-parser escape logic and a method def respectively, no LLM options. The 4 actual hits are at lines ~723, 1167, 1170, 1726 (pre-fix).

Part of a series closing the WICHTIG audit batch (W3, W5, W13, W2 to follow).