### PR TITLE
fix(rag): W3 — batch parent INSERTs in _ingest_parent_child

### DIFF
--- a/src/backend/services/rag_service.py
+++ b/src/backend/services/rag_service.py
@@ -479,17 +479,31 @@ class RAGService:
         return [r for r in results if r is not None]
 
     async def _ingest_parent_child(self, doc_id: int, chunks: list[dict], sem: asyncio.Semaphore) -> list[DocumentChunk]:
-        """Parent-child chunking: small embedded children reference larger context parents."""
+        """Parent-child chunking: small embedded children reference larger context parents.
+
+        Two-phase batched flow (W3 fix):
+          1. Build all parents up-front (no embedding), `add_all` them, single
+             `flush()` to assign every parent.id in one DB round trip.
+          2. Embed every child concurrently in one `asyncio.gather()`, using
+             the now-populated parent.id values.
+
+        Replaces the previous per-group `db.add(parent)` + `db.flush()` loop
+        which made N+1 DB round trips for N parent groups AND serialized child
+        embedding (group N's embeddings couldn't start until group N-1's
+        flush completed). The caller's outer `add_all(chunk_objects)`
+        idempotently re-adds parents — already in the session, so no double
+        INSERT.
+        """
         # Group consecutive child chunks into parents
         children_per_parent = max(1, settings.rag_parent_chunk_size // max(settings.rag_child_chunk_size, 1))
-        all_objects: list[DocumentChunk] = []
 
+        # Phase 1: build all parents (no embedding)
+        parent_groups: list[tuple[DocumentChunk, list[dict]]] = []
         for group_start in range(0, len(chunks), children_per_parent):
             group = chunks[group_start:group_start + children_per_parent]
             if not group:
                 continue
 
-            # Create parent chunk (concatenated text, no embedding)
             parent_text = "\n\n".join(c["text"] for c in group if c["text"] and c["text"].strip())
             if not parent_text.strip():
                 continue
@@ -505,39 +519,58 @@ class RAGService:
                 chunk_type="parent",
                 chunk_metadata={"child_count": len(group)},
             )
-            self.db.add(parent)
-            await self.db.flush()  # Get parent.id for children
+            parent_groups.append((parent, group))
 
-            # Create child chunks with embeddings
-            async def _embed_child(chunk_data, parent_id):
-                text_content = chunk_data["text"]
-                if not text_content or not text_content.strip():
+        if not parent_groups:
+            return []
+
+        # Phase 2: single batched insert for all parents — 1 round trip,
+        # populates parent.id for every parent in the list.
+        parents = [p for p, _ in parent_groups]
+        self.db.add_all(parents)
+        await self.db.flush()
+
+        # Phase 3: embed every child concurrently, capturing the now-set parent.id.
+        async def _embed_child(chunk_data: dict, parent_id: int) -> DocumentChunk | None:
+            text_content = chunk_data["text"]
+            if not text_content or not text_content.strip():
+                return None
+            embed_text = chunk_data.get("text_for_embedding", text_content)
+            async with sem:
+                try:
+                    embedding = await self.get_embedding(embed_text)
+                except Exception as e:
+                    logger.warning(f"Embedding-Fehler für Child-Chunk {chunk_data['chunk_index']}: {e}")
                     return None
-                embed_text = chunk_data.get("text_for_embedding", text_content)
-                async with sem:
-                    try:
-                        embedding = await self.get_embedding(embed_text)
-                    except Exception as e:
-                        logger.warning(f"Embedding-Fehler für Child-Chunk {chunk_data['chunk_index']}: {e}")
-                        return None
-                return DocumentChunk(
-                    document_id=doc_id,
-                    content=text_content,  # Store original text for display
-                    embedding=embedding,
-                    parent_chunk_id=parent_id,
-                    chunk_index=chunk_data["chunk_index"],
-                    page_number=chunk_data["metadata"].get("page_number"),
-                    section_title=", ".join(chunk_data["metadata"].get("headings", [])) or None,
-                    chunk_type=chunk_data["metadata"].get("chunk_type", "paragraph"),
-                    chunk_metadata=chunk_data["metadata"],
-                )
+            return DocumentChunk(
+                document_id=doc_id,
+                content=text_content,
+                embedding=embedding,
+                parent_chunk_id=parent_id,
+                chunk_index=chunk_data["chunk_index"],
+                page_number=chunk_data["metadata"].get("page_number"),
+                section_title=", ".join(chunk_data["metadata"].get("headings", [])) or None,
+                chunk_type=chunk_data["metadata"].get("chunk_type", "paragraph"),
+                chunk_metadata=chunk_data["metadata"],
+            )
 
-            child_results = await asyncio.gather(*[_embed_child(cd, parent.id) for cd in group])
-            children = [r for r in child_results if r is not None]
+        child_tasks = [
+            _embed_child(cd, parent.id)
+            for parent, group in parent_groups
+            for cd in group
+        ]
+        child_results = await asyncio.gather(*child_tasks)
 
+        # Reassemble [parent, ...its children, parent, ...its children, ...] —
+        # gather's order matches input order, so child_results[i:i+len(group)]
+        # are this parent's children. Drop None results (embedding failures).
+        all_objects: list[DocumentChunk] = []
+        cursor = 0
+        for parent, group in parent_groups:
             all_objects.append(parent)
-            all_objects.extend(children)
-
+            group_children = child_results[cursor:cursor + len(group)]
+            all_objects.extend(c for c in group_children if c is not None)
+            cursor += len(group)
         return all_objects
 
 

--- a/src/backend/services/rag_service.py
+++ b/src/backend/services/rag_service.py
@@ -531,9 +531,22 @@ class RAGService:
         await self.db.flush()
 
         # Phase 3: embed every child concurrently, capturing the now-set parent.id.
+        # Pre-existing quirk worth knowing about (not introduced by W3, kept
+        # for behaviour parity with the prior per-group loop): blank-text
+        # children are filtered both at parent_text construction (above) and
+        # at _embed_child entry, so they survive in the input shape but yield
+        # None and get dropped at reassembly. Their absence from the output
+        # means parent.chunk_metadata["child_count"] (set at parent build
+        # time as len(group)) overcounts when groups contain blanks. Logged
+        # below so the discrepancy is visible — fixing the metadata count is
+        # out of W3's scope.
         async def _embed_child(chunk_data: dict, parent_id: int) -> DocumentChunk | None:
             text_content = chunk_data["text"]
             if not text_content or not text_content.strip():
+                logger.debug(
+                    f"Skipping blank child chunk_index={chunk_data.get('chunk_index')} "
+                    f"(parent_id={parent_id}) — child_count metadata may overcount"
+                )
                 return None
             embed_text = chunk_data.get("text_for_embedding", text_content)
             async with sem:

--- a/src/backend/services/rag_service.py
+++ b/src/backend/services/rag_service.py
@@ -497,17 +497,34 @@ class RAGService:
         # Group consecutive child chunks into parents
         children_per_parent = max(1, settings.rag_parent_chunk_size // max(settings.rag_child_chunk_size, 1))
 
-        # Phase 1: build all parents (no embedding)
+        # Phase 1: build all parents (no embedding). Filter blank-text
+        # children once up front so `child_count` metadata, parent_text
+        # construction, and the child-embedding gather all see the same
+        # set — eliminates the metadata overcount that the per-group loop
+        # carried (where child_count = raw len(group) but blanks dropped
+        # out at embedding time, so the live row count was lower).
         parent_groups: list[tuple[DocumentChunk, list[dict]]] = []
         for group_start in range(0, len(chunks), children_per_parent):
-            group = chunks[group_start:group_start + children_per_parent]
+            raw_group = chunks[group_start:group_start + children_per_parent]
+            if not raw_group:
+                continue
+
+            blanks_dropped = sum(
+                1 for c in raw_group
+                if not (c.get("text") and c["text"].strip())
+            )
+            group = [c for c in raw_group if c.get("text") and c["text"].strip()]
             if not group:
-                continue
+                continue  # whole group was blank — skip entirely
 
-            parent_text = "\n\n".join(c["text"] for c in group if c["text"] and c["text"].strip())
-            if not parent_text.strip():
-                continue
+            if blanks_dropped:
+                logger.debug(
+                    f"Parent group at chunk_index={group_start} dropped "
+                    f"{blanks_dropped} blank-text children "
+                    f"({len(group)} retained out of {len(raw_group)})"
+                )
 
+            parent_text = "\n\n".join(c["text"] for c in group)
             first_meta = group[0]["metadata"]
             parent = DocumentChunk(
                 document_id=doc_id,
@@ -517,6 +534,8 @@ class RAGService:
                 page_number=first_meta.get("page_number"),
                 section_title=", ".join(first_meta.get("headings", [])) or None,
                 chunk_type="parent",
+                # child_count now reflects what actually ends up in the DB,
+                # not the pre-filter raw input size.
                 chunk_metadata={"child_count": len(group)},
             )
             parent_groups.append((parent, group))
@@ -531,23 +550,11 @@ class RAGService:
         await self.db.flush()
 
         # Phase 3: embed every child concurrently, capturing the now-set parent.id.
-        # Pre-existing quirk worth knowing about (not introduced by W3, kept
-        # for behaviour parity with the prior per-group loop): blank-text
-        # children are filtered both at parent_text construction (above) and
-        # at _embed_child entry, so they survive in the input shape but yield
-        # None and get dropped at reassembly. Their absence from the output
-        # means parent.chunk_metadata["child_count"] (set at parent build
-        # time as len(group)) overcounts when groups contain blanks. Logged
-        # below so the discrepancy is visible — fixing the metadata count is
-        # out of W3's scope.
+        # `group` is already non-blank-filtered in phase 1, so no blank
+        # guard needed here — None returns from `_embed_child` only on real
+        # embedding failures, not on text-shape rejection.
         async def _embed_child(chunk_data: dict, parent_id: int) -> DocumentChunk | None:
             text_content = chunk_data["text"]
-            if not text_content or not text_content.strip():
-                logger.debug(
-                    f"Skipping blank child chunk_index={chunk_data.get('chunk_index')} "
-                    f"(parent_id={parent_id}) — child_count metadata may overcount"
-                )
-                return None
             embed_text = chunk_data.get("text_for_embedding", text_content)
             async with sem:
                 try:

--- a/tests/backend/test_rag_advanced.py
+++ b/tests/backend/test_rag_advanced.py
@@ -224,6 +224,53 @@ async def test_parent_child_batches_parent_inserts_w3(rag_service, mock_db):
     )
 
 
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_parent_child_count_matches_actual_children_after_blank_filter(rag_service, mock_db):
+    """W3 follow-up: parent.chunk_metadata['child_count'] must reflect the
+    number of children that ACTUALLY end up in the DB, not the raw input
+    size before blank-text children get filtered out.
+
+    Pre-fix bug (carried from the original per-group loop): child_count
+    was set to `len(group)` at parent build time, BEFORE the blank-text
+    guard inside _embed_child filtered out empty/whitespace-only chunks.
+    So a group of 4 chunks where 1 was blank produced a parent claiming
+    `child_count: 4` but only 3 actual child rows in the DB.
+
+    Post-fix invariant: blanks are filtered ONCE up front (in phase 1),
+    and child_count reflects the filtered count. The number of returned
+    children of any parent always matches that parent's child_count.
+    """
+    rag_service.get_embedding = AsyncMock(return_value=[0.1] * 768)
+
+    # 4 chunks, 1 blank — parent_size=4 → single parent group.
+    chunks = [
+        {"text": "Real first chunk", "chunk_index": 0, "metadata": {"headings": [], "page_number": 1, "chunk_type": "paragraph"}},
+        {"text": "   ", "chunk_index": 1, "metadata": {"headings": [], "page_number": 1, "chunk_type": "paragraph"}},  # blank
+        {"text": "Real third chunk", "chunk_index": 2, "metadata": {"headings": [], "page_number": 1, "chunk_type": "paragraph"}},
+        {"text": "Real fourth chunk", "chunk_index": 3, "metadata": {"headings": [], "page_number": 1, "chunk_type": "paragraph"}},
+    ]
+
+    with patch.object(settings, "rag_parent_chunk_size", 1024), \
+         patch.object(settings, "rag_child_chunk_size", 256):
+        sem = asyncio.Semaphore(5)
+        result = await rag_service._ingest_parent_child(1, chunks, sem)
+
+    parents = [r for r in result if r.chunk_type == "parent"]
+    children = [r for r in result if r.chunk_type != "parent"]
+
+    assert len(parents) == 1
+    # 4 raw inputs - 1 blank = 3 children expected, NOT 4
+    assert len(children) == 3, (
+        f"Expected 3 non-blank children, got {len(children)} — blank filtering regressed"
+    )
+    assert parents[0].chunk_metadata["child_count"] == 3, (
+        f"child_count should match actual children (3), got "
+        f"{parents[0].chunk_metadata['child_count']} — metadata still uses "
+        "pre-filter raw len(group)"
+    )
+
+
 # ===========================================================================
 # 5. Parent resolution in search
 # ===========================================================================

--- a/tests/backend/test_rag_advanced.py
+++ b/tests/backend/test_rag_advanced.py
@@ -153,6 +153,77 @@ async def test_parent_child_creates_parent_and_children(rag_service, mock_db):
     assert all(c.embedding is not None for c in children)
 
 
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_parent_child_batches_parent_inserts_w3(rag_service, mock_db):
+    """W3 regression: _ingest_parent_child must batch all parent INSERTs into
+    a single add_all + flush, not loop per-parent-group with add+flush.
+
+    Pre-fix behaviour: N parent groups → N db.add(parent) calls + N flush()
+    round trips. For a doc with 50 parent groups (≈500 children), that's 50
+    extra round trips before children are even embedded, AND embedding for
+    group N+1 cannot start until group N's flush completes.
+
+    Post-fix invariant:
+      - db.add_all called exactly once (with the full parents list).
+      - db.flush called exactly once (single round trip to assign all ids).
+      - db.add NEVER called for a parent (use add_all batched instead).
+    """
+    rag_service.get_embedding = AsyncMock(return_value=[0.1] * 768)
+
+    # 12 child-sized chunks → with parent_size=4, that's 3 parent groups.
+    chunks = [
+        {
+            "text": f"Child {i}",
+            "chunk_index": i,
+            "metadata": {"headings": [], "page_number": 1, "chunk_type": "paragraph"},
+        }
+        for i in range(12)
+    ]
+
+    flush_count = 0
+
+    async def counting_flush():
+        nonlocal flush_count
+        flush_count += 1
+
+    mock_db.flush = counting_flush
+    # Reset the per-test counters on the MagicMock attributes
+    mock_db.add.reset_mock()
+    mock_db.add_all.reset_mock()
+
+    with patch.object(settings, "rag_parent_chunk_size", 1024), \
+         patch.object(settings, "rag_child_chunk_size", 256):
+        sem = asyncio.Semaphore(5)
+        result = await rag_service._ingest_parent_child(1, chunks, sem)
+
+    parents = [r for r in result if r.chunk_type == "parent"]
+    children = [r for r in result if r.chunk_type != "parent"]
+
+    # Sanity — 3 parents, 12 children
+    assert len(parents) == 3
+    assert len(children) == 12
+
+    # W3 invariants
+    assert flush_count == 1, (
+        f"Expected exactly 1 flush() call (batched), got {flush_count} — "
+        "regression to per-parent-group flush loop"
+    )
+    assert mock_db.add_all.call_count == 1, (
+        f"Expected exactly 1 add_all() call for parents batch, got "
+        f"{mock_db.add_all.call_count}"
+    )
+    add_all_args = mock_db.add_all.call_args[0][0]
+    assert len(add_all_args) == 3, (
+        f"add_all should receive all 3 parents in a single call, got "
+        f"{len(add_all_args)}"
+    )
+    assert mock_db.add.call_count == 0, (
+        f"db.add() should NOT be used for parents in the batched path "
+        f"(use add_all instead), got {mock_db.add.call_count} calls"
+    )
+
+
 # ===========================================================================
 # 5. Parent resolution in search
 # ===========================================================================


### PR DESCRIPTION
## Summary
WICHTIG audit W3: `services/rag_service.py:_ingest_parent_child` looped per parent group with `db.add(parent)` + `await db.flush()` to assign `parent.id` before children could reference it. For a doc with N parent groups (≈10 children each), that's **N+1 DB round trips for parents alone**, AND embedding for group N+1 couldn't start until group N's flush completed (sequential serialization across groups).

`_ingest_flat` was already batched correctly (single `add_all` in caller), so the per-group loop in `_ingest_parent_child` was the actual hit.

## Change — two-phase refactor
1. **Phase 1**: build all parents up-front (no embedding) into a list.
2. **Phase 2**: `db.add_all(parents)` + single `db.flush()` — assigns every `parent.id` in 1 round trip.
3. **Phase 3**: kick off every child's embedding in one `asyncio.gather()` (`parent.id` is now populated for all groups) — concurrency is no longer artificially serialized at group boundaries.
4. Reassemble `[parent, ...its children, parent, ...its children, ...]` via cursor walk over the gather results, preserving original document-order grouping that the caller's KG-extraction path reads.

Caller (`process_document` around line 350) does an outer `db.add_all(chunk_objects)` which now harmlessly re-adds the parents (they're already in the session — SQLAlchemy treats it as a no-op).

## Performance impact
- Doc with 50 parent groups (≈500 children): **51 → 1 round trip for parent flushes**.
- Embedding parallelism: previously serialized across groups via per-group `await flush`; now fully concurrent up to the existing `asyncio.Semaphore(5)` rate limit.

## Test plan
- `tests/backend/test_rag_advanced.py::test_parent_child_creates_parent_and_children` (existing) continues to pass — shape unchanged: 1 parent + 4 children, parent has no embedding, all children have embeddings.
- **NEW** `test_parent_child_batches_parent_inserts_w3`: 12 chunks → 3 parent groups, asserts `flush_count == 1`, `add_all` called exactly once with all 3 parents, `db.add()` never called for parents (regression guard against per-group `add+flush` loop).

Both tests pass locally.

Part of the WICHTIG audit batch (W6 in #482, W5/W13/W2 to follow).