### PR TITLE
fix(config): W5 + W13 — config-hygiene bundle (timeouts to Settings + changeme detection)

### DIFF
--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -723,7 +723,7 @@ class AgentService:
                     options={"temperature": 0, "num_predict": 120, "num_ctx": 4096},
                     **classification_kwargs,
                 ),
-                timeout=10.0,
+                timeout=settings.agent_preselect_timeout,
             )
             response_text = extract_response_content(raw_response) or ""
 

--- a/src/backend/services/federation_query_responder.py
+++ b/src/backend/services/federation_query_responder.py
@@ -534,7 +534,7 @@ class FederationQueryResponder:
                         "num_predict": 512,    # hard cap on generated tokens
                     },
                 ),
-                timeout=30.0,  # responder TTL is 60s; synthesis + retrieval + poll-reply must fit
+                timeout=settings.federation_synthesis_timeout,  # constraint validated in config: must be <60 (responder TTL)
             )
             answer = extract_response_content(response) or ""
         except Exception as e:

--- a/src/backend/services/mcp_client.py
+++ b/src/backend/services/mcp_client.py
@@ -152,7 +152,7 @@ _geocode_client: Any = None
 def _get_geocode_client() -> Any:
     global _geocode_client
     if _geocode_client is None:
-        _geocode_client = httpx.AsyncClient(timeout=8.0)
+        _geocode_client = httpx.AsyncClient(timeout=settings.geocode_http_timeout)
     return _geocode_client
 
 

--- a/src/backend/services/orchestrator.py
+++ b/src/backend/services/orchestrator.py
@@ -499,7 +499,7 @@ class QueryOrchestrator:
                     options={"temperature": 0.3, "num_predict": 500},
                     **classification_kwargs,
                 ),
-                timeout=30.0,
+                timeout=settings.orchestrator_synthesis_timeout,
             )
             return extract_response_content(raw_response) or None
 

--- a/src/backend/services/rag_eval_service.py
+++ b/src/backend/services/rag_eval_service.py
@@ -139,7 +139,7 @@ class RAGEvalService:
                     prompt=prompt,
                     options={"temperature": 0.3, "num_predict": 500},
                 ),
-                timeout=60,
+                timeout=settings.rag_eval_answer_timeout,
             )
             return response.response.strip()
         except Exception as e:
@@ -160,7 +160,7 @@ class RAGEvalService:
                     prompt=prompt,
                     options={"temperature": 0.0, "num_predict": 5},
                 ),
-                timeout=30,
+                timeout=settings.rag_eval_score_timeout,
             )
             # Extract number from response
             text = response.response.strip()

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -3,8 +3,24 @@ Konfiguration und Settings
 """
 from functools import lru_cache
 
+from loguru import logger
 from pydantic import Field, SecretStr, model_validator
 from pydantic_settings import BaseSettings
+
+
+# W13 — Fields whose default value is a placeholder ("changeme") meant to
+# fail loudly when running against any real environment. The
+# Settings.warn_on_changeme_defaults() validator below loops over this map
+# and emits a single WARN line per match at startup, with the field's
+# placeholder value spelled out for grep-ability.
+#
+# Map shape: {field_name: placeholder_default_value}
+# Update this when introducing a new placeholder-defaulted secret.
+_CHANGEME_DEFAULTS: dict[str, str] = {
+    "postgres_password": "changeme",
+    "secret_key": "changeme-in-production-use-strong-random-key",
+    "default_admin_password": "changeme",
+}
 
 
 class Settings(BaseSettings):
@@ -131,6 +147,12 @@ class Settings(BaseSettings):
     agent_router_model: str | None = None  # Dedicated router model (default: ollama_intent_model)
     agent_router_url: str | None = None    # Dedicated Ollama URL for router (default: agent_ollama_url)
     agent_orchestrator_enabled: bool = False  # Enable cross-MCP query orchestration (opt-in)
+    # W5 — previously hardcoded timeouts now configurable
+    agent_preselect_timeout: float = Field(default=10.0, ge=1.0, le=60.0)
+    """Timeout for tool pre-selection LLM call in agent_service.py:_preselect_tools.
+    Short JSON-only response, deterministic — keep low to fail fast."""
+    orchestrator_synthesis_timeout: float = Field(default=30.0, ge=5.0, le=300.0)
+    """Timeout for orchestrator's synthesis call (combine sub-agent results into one answer)."""
 
     # MCP Client (Model Context Protocol)
     mcp_enabled: bool = False             # Opt-in, disabled by default
@@ -139,6 +161,13 @@ class Settings(BaseSettings):
     mcp_connect_timeout: float = 10.0     # Connection timeout per server (seconds)
     mcp_call_timeout: float = 30.0        # Tool call timeout (seconds)
     mcp_max_response_size: int = Field(default=131072, ge=1024, le=524288)  # 128KB max response — accommodates list_correspondents on real corpora (~70KB at ~900 entries) without truncating mid-payload
+
+    # W5 — previously hardcoded timeouts now configurable
+    geocode_http_timeout: float = Field(default=8.0, ge=1.0, le=30.0)
+    """HTTP timeout for the Nominatim geocode httpx client in mcp_client.py."""
+    federation_synthesis_timeout: float = Field(default=30.0, ge=5.0, le=120.0)
+    """Federation responder synthesis timeout. Constraint: must fit inside the
+    responder TTL (60s) along with retrieval and poll-reply overhead — keep <60."""
 
     # Agent Advanced
     agent_history_limit: int = Field(default=20, ge=1, le=100)       # Max history steps in agent loop
@@ -166,6 +195,12 @@ class Settings(BaseSettings):
 
     # Embedding
     rag_embedding_timeout: float = 30.0       # Timeout in seconds for embedding calls
+
+    # W5 — RAG eval LLM timeouts (previously hardcoded as 60 / 30 in rag_eval_service.py)
+    rag_eval_answer_timeout: float = Field(default=60.0, ge=10.0, le=300.0)
+    """Timeout for the eval pipeline's answer-generation LLM call."""
+    rag_eval_score_timeout: float = Field(default=30.0, ge=5.0, le=180.0)
+    """Timeout for the eval pipeline's per-criterion LLM-as-judge scoring call."""
 
     # Context Window Retrieval
     rag_context_window: int = 1               # Adjacent chunks per direction (0=disabled)
@@ -437,6 +472,36 @@ class Settings(BaseSettings):
             self.database_url = (
                 f"postgresql://{self.postgres_user}:{self.postgres_password.get_secret_value()}"
                 f"@{self.postgres_host}:{self.postgres_port}/{self.postgres_db}"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def warn_on_changeme_defaults(self) -> "Settings":
+        """W13 — Emit a loud WARNING for any secret/password field still set
+        to its placeholder `changeme*` default.
+
+        Soft fail (warning, not exception) so dev/test environments aren't
+        broken — they often legitimately use placeholder credentials. The
+        warning is structured with the field name + placeholder spelled out
+        so deploy tooling can grep production logs for it.
+
+        See _CHANGEME_DEFAULTS at module top for the list of guarded fields.
+        """
+        offenders: list[str] = []
+        for field_name, placeholder in _CHANGEME_DEFAULTS.items():
+            value = getattr(self, field_name, None)
+            if value is None:
+                continue
+            current = value.get_secret_value() if isinstance(value, SecretStr) else value
+            if current == placeholder:
+                offenders.append(field_name)
+
+        if offenders:
+            logger.warning(
+                "⚠ INSECURE DEFAULT(S) IN USE — fields still set to placeholder "
+                f"defaults: {', '.join(offenders)}. Set these via env vars "
+                "(POSTGRES_PASSWORD, SECRET_KEY, DEFAULT_ADMIN_PASSWORD) or "
+                "Docker Secrets before deploying to a non-dev environment."
             )
         return self
 

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -1,6 +1,7 @@
 """
 Konfiguration und Settings
 """
+import os
 from functools import lru_cache
 
 from loguru import logger
@@ -8,19 +9,19 @@ from pydantic import Field, SecretStr, model_validator
 from pydantic_settings import BaseSettings
 
 
-# W13 — Fields whose default value is a placeholder ("changeme") meant to
-# fail loudly when running against any real environment. The
-# Settings.warn_on_changeme_defaults() validator below loops over this map
-# and emits a single WARN line per match at startup, with the field's
-# placeholder value spelled out for grep-ability.
+# W13 — Names of fields whose Settings-class default is a placeholder
+# meant to fail loudly when running against any real environment. The
+# `Settings.warn_on_changeme_defaults()` validator reads each name's
+# CURRENT default off `Settings.model_fields[name].default` at runtime
+# and compares to the resolved value — no hand-maintained mirror string
+# that can silently drift if someone changes the default literal.
 #
-# Map shape: {field_name: placeholder_default_value}
-# Update this when introducing a new placeholder-defaulted secret.
-_CHANGEME_DEFAULTS: dict[str, str] = {
-    "postgres_password": "changeme",
-    "secret_key": "changeme-in-production-use-strong-random-key",
-    "default_admin_password": "changeme",
-}
+# Update this list when introducing a new placeholder-defaulted secret.
+_CHANGEME_FIELDS: tuple[str, ...] = (
+    "postgres_password",
+    "secret_key",
+    "default_admin_password",
+)
 
 
 class Settings(BaseSettings):
@@ -165,9 +166,11 @@ class Settings(BaseSettings):
     # W5 — previously hardcoded timeouts now configurable
     geocode_http_timeout: float = Field(default=8.0, ge=1.0, le=30.0)
     """HTTP timeout for the Nominatim geocode httpx client in mcp_client.py."""
-    federation_synthesis_timeout: float = Field(default=30.0, ge=5.0, le=120.0)
-    """Federation responder synthesis timeout. Constraint: must fit inside the
-    responder TTL (60s) along with retrieval and poll-reply overhead — keep <60."""
+    federation_synthesis_timeout: float = Field(default=30.0, ge=5.0, le=59.0)
+    """Federation responder synthesis timeout. Hard upper bound 59s because the
+    responder TTL is 60s and synthesis must fit inside that along with
+    retrieval and the poll-reply round trip. The Field constraint enforces
+    this, not just the comment."""
 
     # Agent Advanced
     agent_history_limit: int = Field(default=20, ge=1, le=100)       # Max history steps in agent loop
@@ -478,30 +481,46 @@ class Settings(BaseSettings):
     @model_validator(mode="after")
     def warn_on_changeme_defaults(self) -> "Settings":
         """W13 — Emit a loud WARNING for any secret/password field still set
-        to its placeholder `changeme*` default.
+        to its placeholder default.
 
-        Soft fail (warning, not exception) so dev/test environments aren't
-        broken — they often legitimately use placeholder credentials. The
-        warning is structured with the field name + placeholder spelled out
-        so deploy tooling can grep production logs for it.
+        For each field name in `_CHANGEME_FIELDS`, compare the current
+        resolved value to the field's class-level default (read live from
+        `Settings.model_fields[name].default`). If they match, the env
+        override didn't take effect — i.e. the placeholder is in use.
 
-        See _CHANGEME_DEFAULTS at module top for the list of guarded fields.
+        Gated to non-development environments so dev/test runs aren't
+        spammed with a warning that exists to catch production-deploy
+        regressions. Trigger condition: `RENFIELD_ENV` is set to anything
+        other than the default `"development"` (e.g. `"production"`,
+        `"staging"`, or `"prod"`). Tests can opt in to the warning path
+        by setting RENFIELD_ENV explicitly.
         """
+        env = os.getenv("RENFIELD_ENV", "development").lower()
+        if env in {"development", "dev", "test"}:
+            return self
+
         offenders: list[str] = []
-        for field_name, placeholder in _CHANGEME_DEFAULTS.items():
+        for field_name in _CHANGEME_FIELDS:
+            field_info = type(self).model_fields.get(field_name)
+            if field_info is None:
+                continue  # field renamed/removed — silent skip is intentional
+            placeholder_default = field_info.default
+            if isinstance(placeholder_default, SecretStr):
+                placeholder_default = placeholder_default.get_secret_value()
             value = getattr(self, field_name, None)
             if value is None:
                 continue
             current = value.get_secret_value() if isinstance(value, SecretStr) else value
-            if current == placeholder:
+            if current == placeholder_default:
                 offenders.append(field_name)
 
         if offenders:
             logger.warning(
-                "⚠ INSECURE DEFAULT(S) IN USE — fields still set to placeholder "
-                f"defaults: {', '.join(offenders)}. Set these via env vars "
+                f"⚠ INSECURE DEFAULT(S) IN USE — RENFIELD_ENV={env!r} but the "
+                f"following fields are still on their class-level placeholder "
+                f"default: {', '.join(offenders)}. Set them via env vars "
                 "(POSTGRES_PASSWORD, SECRET_KEY, DEFAULT_ADMIN_PASSWORD) or "
-                "Docker Secrets before deploying to a non-dev environment."
+                "Docker Secrets."
             )
         return self
 

--- a/tests/backend/test_config_w5_w13.py
+++ b/tests/backend/test_config_w5_w13.py
@@ -16,12 +16,9 @@ real environments don't silently run with insecure credentials.
 from __future__ import annotations
 
 import io
-import os
-from contextlib import redirect_stderr
 
 import pytest
 from loguru import logger
-from pydantic import Field as PydField  # for type-only checks
 
 
 # --- W5 — timeout settings exist with the right defaults + ranges ---
@@ -68,35 +65,51 @@ def test_w5_timeout_fields_exist_on_settings():
 def test_w5_call_sites_use_settings_not_literals():
     """The 6 call sites the audit identified must reference settings.<name>
     instead of an inline literal. Catches accidental reverts.
+
+    Asserts BOTH conditions: the settings reference must be present AND
+    the matching `await asyncio.wait_for(... timeout=<literal>)` form
+    must NOT be present, so a partial revert that adds back the literal
+    while leaving the settings ref also fails the test.
     """
+    import re
     from pathlib import Path
 
     repo_root = Path(__file__).resolve().parents[2]
     cases = [
-        ("src/backend/services/agent_service.py", "settings.agent_preselect_timeout", "timeout=10.0"),
-        ("src/backend/services/orchestrator.py", "settings.orchestrator_synthesis_timeout", "timeout=30.0"),
-        ("src/backend/services/mcp_client.py", "settings.geocode_http_timeout", "timeout=8.0"),
-        ("src/backend/services/federation_query_responder.py", "settings.federation_synthesis_timeout", "timeout=30.0"),
-        ("src/backend/services/rag_eval_service.py", "settings.rag_eval_answer_timeout", "timeout=60"),
-        ("src/backend/services/rag_eval_service.py", "settings.rag_eval_score_timeout", "timeout=30"),
+        ("src/backend/services/agent_service.py", "settings.agent_preselect_timeout", r"\btimeout=10\.0\b"),
+        ("src/backend/services/orchestrator.py", "settings.orchestrator_synthesis_timeout", r"\btimeout=30\.0\b"),
+        ("src/backend/services/mcp_client.py", "settings.geocode_http_timeout", r"\btimeout=8\.0\b"),
+        ("src/backend/services/federation_query_responder.py", "settings.federation_synthesis_timeout", r"\btimeout=30\.0\b"),
+        ("src/backend/services/rag_eval_service.py", "settings.rag_eval_answer_timeout", r"\btimeout=60\b"),
+        ("src/backend/services/rag_eval_service.py", "settings.rag_eval_score_timeout", r"\btimeout=30\b"),
     ]
-    for rel_path, must_contain, must_not_contain_at_callsite in cases:
+    for rel_path, must_contain, banned_literal_re in cases:
         src = (repo_root / rel_path).read_text()
         assert must_contain in src, (
             f"{rel_path}: missing reference `{must_contain}` — "
             "W5 fix expects this call site to use the Settings field"
         )
+        # Strip out comments before checking — historical "previously timeout=10.0"
+        # comments are accurate and shouldn't trigger a regression failure.
+        src_no_comments = "\n".join(
+            line.split("#", 1)[0] for line in src.splitlines()
+        )
+        assert not re.search(banned_literal_re, src_no_comments), (
+            f"{rel_path}: literal matching `{banned_literal_re}` reappeared "
+            "in non-comment code — W5 expects all call sites to use the "
+            "Settings field, not a hardcoded number"
+        )
 
 
-# --- W13 — placeholder defaults trigger a loud warning ---
+# --- W13 — placeholder defaults trigger a loud warning (in production env) ---
 
 @pytest.mark.unit
-def test_w13_warns_when_postgres_password_is_changeme(monkeypatch):
-    """Default Settings instantiation (no env override) leaves
-    postgres_password = 'changeme'. The model_validator must emit a
-    WARN-level message naming the offending field.
+def test_w13_warns_in_production_when_postgres_password_is_changeme(monkeypatch):
+    """In a production-style RENFIELD_ENV with placeholder defaults still
+    in place, the validator must emit a WARN-level message naming the
+    offending field.
     """
-    # Strip env so we hit the placeholder default deterministically.
+    monkeypatch.setenv("RENFIELD_ENV", "production")
     for var in ("POSTGRES_PASSWORD", "SECRET_KEY", "DEFAULT_ADMIN_PASSWORD"):
         monkeypatch.delenv(var, raising=False)
 
@@ -111,8 +124,8 @@ def test_w13_warns_when_postgres_password_is_changeme(monkeypatch):
 
     output = captured.getvalue()
     assert "INSECURE DEFAULT" in output, (
-        "warn_on_changeme_defaults must emit a clearly-marked WARN line. "
-        f"Got: {output!r}"
+        "warn_on_changeme_defaults must emit a clearly-marked WARN line "
+        f"in production. Got: {output!r}"
     )
     assert "postgres_password" in output, (
         "Warning must name the offending field for grep-ability. "
@@ -121,10 +134,38 @@ def test_w13_warns_when_postgres_password_is_changeme(monkeypatch):
 
 
 @pytest.mark.unit
-def test_w13_no_warning_when_password_is_set(monkeypatch):
-    """When all three placeholder fields are overridden via env,
-    the validator must stay silent.
+def test_w13_silent_in_development_even_with_placeholders(monkeypatch):
+    """In dev (default RENFIELD_ENV), the validator must stay silent even
+    when placeholder defaults are in place — the warning is a
+    production-deploy guard, not a dev-environment annoyance.
     """
+    monkeypatch.delenv("RENFIELD_ENV", raising=False)  # default → "development"
+    for var in ("POSTGRES_PASSWORD", "SECRET_KEY", "DEFAULT_ADMIN_PASSWORD"):
+        monkeypatch.delenv(var, raising=False)
+
+    captured = io.StringIO()
+    sink_id = logger.add(captured, level="WARNING", format="{level}|{message}")
+    try:
+        from utils.config import Settings
+
+        Settings()
+    finally:
+        logger.remove(sink_id)
+
+    output = captured.getvalue()
+    assert "INSECURE DEFAULT" not in output, (
+        "Validator must stay silent in development env (this is the "
+        "default-case behaviour to avoid spamming dev/test logs). "
+        f"Got unexpected warning: {output!r}"
+    )
+
+
+@pytest.mark.unit
+def test_w13_no_warning_in_production_when_secrets_are_set(monkeypatch):
+    """When all three placeholder fields are overridden via env in a
+    production-style RENFIELD_ENV, the validator must stay silent.
+    """
+    monkeypatch.setenv("RENFIELD_ENV", "production")
     monkeypatch.setenv("POSTGRES_PASSWORD", "real-strong-password-from-secret")
     monkeypatch.setenv("SECRET_KEY", "5c5e93b6f7c4a8d2e1f3b9a4c8d6e0f2")
     monkeypatch.setenv("DEFAULT_ADMIN_PASSWORD", "another-real-password")
@@ -141,5 +182,31 @@ def test_w13_no_warning_when_password_is_set(monkeypatch):
     output = captured.getvalue()
     assert "INSECURE DEFAULT" not in output, (
         "Validator should NOT warn when all placeholder defaults are "
-        f"overridden. Got unexpected warning: {output!r}"
+        f"overridden in production. Got unexpected warning: {output!r}"
     )
+
+
+@pytest.mark.unit
+def test_w13_changeme_fields_match_settings_defaults():
+    """Drift guard: every field listed in `_CHANGEME_FIELDS` must exist on
+    the Settings class, AND its class-level default must be a string-like
+    placeholder (resolved via SecretStr unwrap if applicable). If a
+    future commit renames the field or replaces the placeholder default
+    without updating `_CHANGEME_FIELDS`, this test catches it.
+    """
+    from utils.config import _CHANGEME_FIELDS, Settings
+    from pydantic import SecretStr
+
+    fields = Settings.model_fields
+    for name in _CHANGEME_FIELDS:
+        assert name in fields, (
+            f"_CHANGEME_FIELDS lists `{name}` but Settings has no such field. "
+            "Was it renamed? Update _CHANGEME_FIELDS to match."
+        )
+        default = fields[name].default
+        if isinstance(default, SecretStr):
+            default = default.get_secret_value()
+        assert isinstance(default, str) and default, (
+            f"`{name}` should ship with a string placeholder default (so the "
+            f"validator has a known value to compare against), got: {default!r}"
+        )

--- a/tests/backend/test_config_w5_w13.py
+++ b/tests/backend/test_config_w5_w13.py
@@ -1,0 +1,145 @@
+"""
+Regression guards for W5 (hardcoded timeouts → Settings) and W13
+(changeme defaults detection) in utils/config.py.
+
+W5: six previously-hardcoded timeout literals across services/ were
+moved to Settings fields. The audit found them as values 8.0, 10.0,
+30.0, 60.0 in agent_service.py, orchestrator.py, mcp_client.py,
+federation_query_responder.py, rag_eval_service.py.
+
+W13: three secret/password fields (postgres_password, secret_key,
+default_admin_password) ship with `changeme` placeholder defaults
+that must trigger a startup WARNING when in use, so deploys against
+real environments don't silently run with insecure credentials.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+from contextlib import redirect_stderr
+
+import pytest
+from loguru import logger
+from pydantic import Field as PydField  # for type-only checks
+
+
+# --- W5 — timeout settings exist with the right defaults + ranges ---
+
+@pytest.mark.unit
+def test_w5_timeout_fields_exist_on_settings():
+    """The 6 W5 settings must be defined on the Settings class with the
+    correct defaults. Pre-fix these values lived as literals at the call
+    sites (timeout=10.0, etc.).
+    """
+    from utils.config import Settings
+
+    expected = {
+        "agent_preselect_timeout": 10.0,
+        "orchestrator_synthesis_timeout": 30.0,
+        "geocode_http_timeout": 8.0,
+        "federation_synthesis_timeout": 30.0,
+        "rag_eval_answer_timeout": 60.0,
+        "rag_eval_score_timeout": 30.0,
+    }
+    fields = Settings.model_fields
+    for field_name, expected_default in expected.items():
+        assert field_name in fields, (
+            f"Settings is missing W5 field `{field_name}`. Pre-fix this value "
+            f"({expected_default}) was a literal at the call site."
+        )
+        info = fields[field_name]
+        assert info.default == expected_default, (
+            f"`{field_name}` default changed: expected {expected_default}, "
+            f"got {info.default}. If intentional, update this test."
+        )
+        # All W5 fields use Field(ge=, le=) — i.e. constraints attached
+        constraints = getattr(info, "metadata", []) or []
+        has_ge = any(getattr(c, "ge", None) is not None for c in constraints)
+        has_le = any(getattr(c, "le", None) is not None for c in constraints)
+        assert has_ge and has_le, (
+            f"`{field_name}` must use Field(ge=, le=) to validate range"
+        )
+
+
+# --- W5 — call sites no longer carry hardcoded literals ---
+
+@pytest.mark.unit
+def test_w5_call_sites_use_settings_not_literals():
+    """The 6 call sites the audit identified must reference settings.<name>
+    instead of an inline literal. Catches accidental reverts.
+    """
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[2]
+    cases = [
+        ("src/backend/services/agent_service.py", "settings.agent_preselect_timeout", "timeout=10.0"),
+        ("src/backend/services/orchestrator.py", "settings.orchestrator_synthesis_timeout", "timeout=30.0"),
+        ("src/backend/services/mcp_client.py", "settings.geocode_http_timeout", "timeout=8.0"),
+        ("src/backend/services/federation_query_responder.py", "settings.federation_synthesis_timeout", "timeout=30.0"),
+        ("src/backend/services/rag_eval_service.py", "settings.rag_eval_answer_timeout", "timeout=60"),
+        ("src/backend/services/rag_eval_service.py", "settings.rag_eval_score_timeout", "timeout=30"),
+    ]
+    for rel_path, must_contain, must_not_contain_at_callsite in cases:
+        src = (repo_root / rel_path).read_text()
+        assert must_contain in src, (
+            f"{rel_path}: missing reference `{must_contain}` — "
+            "W5 fix expects this call site to use the Settings field"
+        )
+
+
+# --- W13 — placeholder defaults trigger a loud warning ---
+
+@pytest.mark.unit
+def test_w13_warns_when_postgres_password_is_changeme(monkeypatch):
+    """Default Settings instantiation (no env override) leaves
+    postgres_password = 'changeme'. The model_validator must emit a
+    WARN-level message naming the offending field.
+    """
+    # Strip env so we hit the placeholder default deterministically.
+    for var in ("POSTGRES_PASSWORD", "SECRET_KEY", "DEFAULT_ADMIN_PASSWORD"):
+        monkeypatch.delenv(var, raising=False)
+
+    captured = io.StringIO()
+    sink_id = logger.add(captured, level="WARNING", format="{level}|{message}")
+    try:
+        from utils.config import Settings
+
+        Settings()  # instantiation triggers the validator
+    finally:
+        logger.remove(sink_id)
+
+    output = captured.getvalue()
+    assert "INSECURE DEFAULT" in output, (
+        "warn_on_changeme_defaults must emit a clearly-marked WARN line. "
+        f"Got: {output!r}"
+    )
+    assert "postgres_password" in output, (
+        "Warning must name the offending field for grep-ability. "
+        f"Got: {output!r}"
+    )
+
+
+@pytest.mark.unit
+def test_w13_no_warning_when_password_is_set(monkeypatch):
+    """When all three placeholder fields are overridden via env,
+    the validator must stay silent.
+    """
+    monkeypatch.setenv("POSTGRES_PASSWORD", "real-strong-password-from-secret")
+    monkeypatch.setenv("SECRET_KEY", "5c5e93b6f7c4a8d2e1f3b9a4c8d6e0f2")
+    monkeypatch.setenv("DEFAULT_ADMIN_PASSWORD", "another-real-password")
+
+    captured = io.StringIO()
+    sink_id = logger.add(captured, level="WARNING", format="{level}|{message}")
+    try:
+        from utils.config import Settings
+
+        Settings()
+    finally:
+        logger.remove(sink_id)
+
+    output = captured.getvalue()
+    assert "INSECURE DEFAULT" not in output, (
+        "Validator should NOT warn when all placeholder defaults are "
+        f"overridden. Got unexpected warning: {output!r}"
+    )


### PR DESCRIPTION
## Summary
Bundle PR closing two related WICHTIG audit findings, both touching `utils/config.py`.

### W5 — 6 hardcoded timeouts moved to Settings

| File | Line (pre-fix) | Old literal | New Settings field |
|---|---|---|---|
| `services/agent_service.py` | 726 | `timeout=10.0` | `agent_preselect_timeout` |
| `services/orchestrator.py` | 502 | `timeout=30.0` | `orchestrator_synthesis_timeout` |
| `services/mcp_client.py` | 155 | `timeout=8.0` | `geocode_http_timeout` |
| `services/federation_query_responder.py` | 537 | `timeout=30.0` | `federation_synthesis_timeout` |
| `services/rag_eval_service.py` | 142 | `timeout=60` | `rag_eval_answer_timeout` |
| `services/rag_eval_service.py` | 163 | `timeout=30` | `rag_eval_score_timeout` |

All 6 use `Field(default=, ge=, le=)` so out-of-range overrides fail at startup instead of silently wreaking havoc at runtime — also satisfies the W13 *"config validation (ranges, formats)"* coverage for these specific fields.

The federation timeout's important constraint comment (must stay <60 to fit inside the responder TTL) moved into the Field docstring where it lives with the validation range.

### W13 — `changeme` default detection

- Module-level `_CHANGEME_DEFAULTS` map names the 3 placeholder-defaulted secret fields (`postgres_password`, `secret_key`, `default_admin_password`) and their literal placeholder values.
- New `Settings.warn_on_changeme_defaults` `model_validator` loops over the map after instantiation and emits a single WARN line per match, naming each offending field for log grep-ability.
- **Soft fail by design** — dev/test environments legitimately use placeholder credentials. Warning, not exception. Production deploy tooling can grep `"INSECURE DEFAULT"` in startup logs to gate rollout.

## Test plan
`tests/backend/test_config_w5_w13.py` — 4 guards (all pass locally):

1. `test_w5_timeout_fields_exist_on_settings` — 6 fields exist on Settings with correct defaults and `Field(ge=, le=)` constraints attached.
2. `test_w5_call_sites_use_settings_not_literals` — each call site references `settings.<field>` (regression guard against accidental revert).
3. `test_w13_warns_when_postgres_password_is_changeme` — default instantiation fires the warning naming `postgres_password`.
4. `test_w13_no_warning_when_password_is_set` — env-overridden secrets stay silent.

Part of the WICHTIG audit batch (W6 in #482, W3 in #483, W2 to follow).