### PR TITLE
feat(orchestrator): Phase 1 uplift — sub-agent hooks + plugin role extension

### DIFF
--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -921,17 +921,61 @@ async def websocket_endpoint(
                     not sub_intent_handled
                     and settings.agent_orchestrator_enabled
                     and mcp_manager is not None
-                    and role.name not in ("conversation", "knowledge")
                 ):
+                    # Fire pre_orchestration UNCONDITIONALLY — even for the
+                    # `conversation` and `knowledge` roles. Plugins (e.g.
+                    # Reva's QueryPlan) can return a pre-computed plan here
+                    # to opt vague conversational queries into orchestration
+                    # without depending on the LLM planner. Returning None
+                    # means "no pre-computed plan, defer to the planner";
+                    # returning list[dict] means "use this plan, skip the
+                    # planner".
+                    sub_queries = None
                     try:
+                        from utils.hooks import run_hooks
+                        hook_results = await run_hooks(
+                            "pre_orchestration",
+                            plan=None,
+                            message=content,
+                            role=role,
+                            lang=ollama.default_lang,
+                            user_id=user_id,
+                            session_id=msg_session_id,
+                        )
+                        for hr in hook_results:
+                            if isinstance(hr, list) and hr:
+                                sub_queries = hr
+                                logger.info(
+                                    f"🎼 pre_orchestration hook returned plan with "
+                                    f"{len(hr)} sub-queries → {[sq.get('role') for sq in hr]}"
+                                )
+                                break
+                    except Exception as e:
+                        logger.warning(f"pre_orchestration hook raised, falling back to planner: {e}")
+
+                    # No pre-computed plan? Run the LLM planner — but only
+                    # for orchestrator-eligible roles (everything that has
+                    # an agent loop and is not pure-conversation). The
+                    # planner is expensive (~3-10s); skipping it for
+                    # conversation/knowledge keeps chitchat fast.
+                    if sub_queries is None and role.name not in ("conversation", "knowledge"):
+                        try:
+                            from services.orchestrator import QueryOrchestrator
+                            orchestrator = QueryOrchestrator(agent_router, mcp_manager)
+                            sub_queries = await orchestrator.detect_multi_domain(
+                                content, ollama, lang=ollama.default_lang,
+                            )
+                        except Exception as _orch_err:
+                            logger.warning(f"Orchestrator detection failed, falling back to single-role: {_orch_err}")
+                            sub_queries = None
+                    elif sub_queries is None:
+                        # Conversation / knowledge role with no plugin-supplied plan:
+                        # explicitly skip the planner (cheap path, no LLM call).
+                        pass
+                    else:
+                        # Plugin supplied a plan — instantiate orchestrator for run_orchestrated below.
                         from services.orchestrator import QueryOrchestrator
                         orchestrator = QueryOrchestrator(agent_router, mcp_manager)
-                        sub_queries = await orchestrator.detect_multi_domain(
-                            content, ollama, lang=ollama.default_lang,
-                        )
-                    except Exception as _orch_err:
-                        logger.warning(f"Orchestrator detection failed, falling back to single-role: {_orch_err}")
-                        sub_queries = None
 
                     if sub_queries and len(sub_queries) >= 2:
                         agent_used = True
@@ -967,6 +1011,35 @@ async def websocket_endpoint(
                             action_result = _build_agent_action_result(agent_tool_results)
                         if not intent:
                             intent = {"intent": "agent.orchestrated", "confidence": 1.0, "parameters": {}}
+
+                        # check_output: plugins can validate/redact the
+                        # synthesized response before it is persisted.
+                        # The streamed websocket text was already sent
+                        # unmodified (UX preserved); this updates
+                        # `full_response` so the persisted message and
+                        # any downstream logging see the redacted form.
+                        # A future iteration can buffer the synthesis and
+                        # only send after redaction completes.
+                        if full_response:
+                            try:
+                                from utils.hooks import run_hooks
+                                redaction_results = await run_hooks(
+                                    "check_output",
+                                    content=full_response,
+                                    role=role.name if role else None,
+                                    user_id=user_id,
+                                )
+                                for rr in redaction_results:
+                                    if isinstance(rr, str) and rr and rr != full_response:
+                                        logger.info(
+                                            f"check_output redacted orchestrated response "
+                                            f"({len(full_response)} → {len(rr)} chars)"
+                                        )
+                                        full_response = rr
+                                        break
+                            except Exception as e:
+                                logger.warning(f"check_output hook raised, ignoring: {e}")
+
                         logger.info(f"🎼 Orchestrator abgeschlossen: {agent_steps_count} Steps across {len(sub_queries)} sub-agents")
 
                 if sub_intent_handled:

--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -922,17 +922,19 @@ async def websocket_endpoint(
                     and settings.agent_orchestrator_enabled
                     and mcp_manager is not None
                 ):
-                    # Fire pre_orchestration UNCONDITIONALLY — even for the
-                    # `conversation` and `knowledge` roles. Plugins (e.g.
-                    # Reva's QueryPlan) can return a pre-computed plan here
-                    # to opt vague conversational queries into orchestration
-                    # without depending on the LLM planner. Returning None
-                    # means "no pre-computed plan, defer to the planner";
-                    # returning list[dict] means "use this plan, skip the
-                    # planner".
+                    from services.orchestrator import QueryOrchestrator
+                    from utils.hooks import run_hooks
+
+                    orchestrator = QueryOrchestrator(agent_router, mcp_manager)
                     sub_queries = None
+
+                    # Step 1 — ask plugins for a pre-computed plan.
+                    # Fires UNCONDITIONALLY (every role, including
+                    # `conversation` / `knowledge`) so a plugin can opt
+                    # vague queries into orchestration without depending
+                    # on the LLM planner. A handler returning ``None``
+                    # defers; a non-empty ``list[dict]`` is the plan.
                     try:
-                        from utils.hooks import run_hooks
                         hook_results = await run_hooks(
                             "pre_orchestration",
                             plan=None,
@@ -953,29 +955,18 @@ async def websocket_endpoint(
                     except Exception as e:
                         logger.warning(f"pre_orchestration hook raised, falling back to planner: {e}")
 
-                    # No pre-computed plan? Run the LLM planner — but only
-                    # for orchestrator-eligible roles (everything that has
-                    # an agent loop and is not pure-conversation). The
-                    # planner is expensive (~3-10s); skipping it for
-                    # conversation/knowledge keeps chitchat fast.
+                    # Step 2 — if no plan, run the LLM planner. Skip it
+                    # for chitchat roles where the ~3-10s planner cost
+                    # would not pay off. Plugins that want orchestration
+                    # for those roles should supply a plan in step 1.
                     if sub_queries is None and role.name not in ("conversation", "knowledge"):
                         try:
-                            from services.orchestrator import QueryOrchestrator
-                            orchestrator = QueryOrchestrator(agent_router, mcp_manager)
                             sub_queries = await orchestrator.detect_multi_domain(
                                 content, ollama, lang=ollama.default_lang,
                             )
                         except Exception as _orch_err:
                             logger.warning(f"Orchestrator detection failed, falling back to single-role: {_orch_err}")
                             sub_queries = None
-                    elif sub_queries is None:
-                        # Conversation / knowledge role with no plugin-supplied plan:
-                        # explicitly skip the planner (cheap path, no LLM call).
-                        pass
-                    else:
-                        # Plugin supplied a plan — instantiate orchestrator for run_orchestrated below.
-                        from services.orchestrator import QueryOrchestrator
-                        orchestrator = QueryOrchestrator(agent_router, mcp_manager)
 
                     if sub_queries and len(sub_queries) >= 2:
                         agent_used = True
@@ -983,6 +974,12 @@ async def websocket_endpoint(
                         logger.info(f"🎼 Orchestrator: {len(sub_queries)} sub-queries → {[sq.get('role') for sq in sub_queries]}")
                         executor = ActionExecutor(mcp_manager=mcp_manager, session_id=msg_session_id)
                         agent_tool_results = []
+                        # Buffer the final_answer step instead of streaming it,
+                        # so `check_output` (below) can redact before the user
+                        # sees the synthesized text. Tool steps + cards still
+                        # stream as they happen — only the synthesizer's
+                        # combined answer is held back.
+                        deferred_final_answer: str | None = None
                         async for step in orchestrator.run_orchestrated(
                             sub_queries=sub_queries,
                             message=content,
@@ -999,30 +996,23 @@ async def websocket_endpoint(
                             context_vars_text=_context_vars_text,
                             summary_text=_summary_text,
                         ):
-                            await websocket.send_json(step_to_ws_message(step))
                             if step.step_type == "final_answer":
-                                full_response = step.content
+                                deferred_final_answer = step.content
+                                # Don't send to websocket yet — held for redaction.
+                            else:
+                                await websocket.send_json(step_to_ws_message(step))
                             if step.step_type == "tool_result" and step.success and step.data:
                                 agent_tool_results.append((step.tool, step.data))
                             if step.step_type in ("tool_call", "tool_result"):
                                 agent_steps_count += 1
 
-                        if agent_tool_results:
-                            action_result = _build_agent_action_result(agent_tool_results)
-                        if not intent:
-                            intent = {"intent": "agent.orchestrated", "confidence": 1.0, "parameters": {}}
-
-                        # check_output: plugins can validate/redact the
-                        # synthesized response before it is persisted.
-                        # The streamed websocket text was already sent
-                        # unmodified (UX preserved); this updates
-                        # `full_response` so the persisted message and
-                        # any downstream logging see the redacted form.
-                        # A future iteration can buffer the synthesis and
-                        # only send after redaction completes.
+                        # check_output BEFORE sending the synthesized
+                        # answer to the client. Plugins (e.g. Reva's GDPR
+                        # output_guard) can return a redacted version;
+                        # the user sees only the redacted text.
+                        full_response = deferred_final_answer or ""
                         if full_response:
                             try:
-                                from utils.hooks import run_hooks
                                 redaction_results = await run_hooks(
                                     "check_output",
                                     content=full_response,
@@ -1039,6 +1029,22 @@ async def websocket_endpoint(
                                         break
                             except Exception as e:
                                 logger.warning(f"check_output hook raised, ignoring: {e}")
+
+                            # Now send the (possibly redacted) final answer.
+                            # Frontend handles `type: "stream"` for assistant text,
+                            # the same shape `step_to_ws_message` produces for a
+                            # final_answer AgentStep — so this matches the existing
+                            # contract. We send the whole thing in one message
+                            # (one chunk equals the complete redacted text).
+                            await websocket.send_json({
+                                "type": "stream",
+                                "content": full_response,
+                            })
+
+                        if agent_tool_results:
+                            action_result = _build_agent_action_result(agent_tool_results)
+                        if not intent:
+                            intent = {"intent": "agent.orchestrated", "confidence": 1.0, "parameters": {}}
 
                         logger.info(f"🎼 Orchestrator abgeschlossen: {agent_steps_count} Steps across {len(sub_queries)} sub-agents")
 

--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -922,44 +922,64 @@ async def websocket_endpoint(
                     and settings.agent_orchestrator_enabled
                     and mcp_manager is not None
                 ):
-                    from services.orchestrator import QueryOrchestrator
-                    from utils.hooks import run_hooks
+                    from utils.hooks import run_hooks, run_hooks_with_errors
 
-                    orchestrator = QueryOrchestrator(agent_router, mcp_manager)
-                    sub_queries = None
+                    sub_queries: list[dict] | None = None
 
                     # Step 1 — ask plugins for a pre-computed plan.
-                    # Fires UNCONDITIONALLY (every role, including
-                    # `conversation` / `knowledge`) so a plugin can opt
-                    # vague queries into orchestration without depending
-                    # on the LLM planner. A handler returning ``None``
-                    # defers; a non-empty ``list[dict]`` is the plan.
-                    try:
-                        hook_results = await run_hooks(
-                            "pre_orchestration",
-                            plan=None,
-                            message=content,
-                            role=role,
-                            lang=ollama.default_lang,
-                            user_id=user_id,
-                            session_id=msg_session_id,
+                    # Fires UNCONDITIONALLY so a plugin can opt vague
+                    # queries into orchestration. None ⇒ defer; non-empty
+                    # list[dict] ⇒ use this plan, skip the planner.
+                    hook_results = await run_hooks(
+                        "pre_orchestration",
+                        plan=None,
+                        message=content,
+                        role=role,
+                        lang=ollama.default_lang,
+                        user_id=user_id,
+                        session_id=msg_session_id,
+                    )
+                    for hr in hook_results:
+                        if not (isinstance(hr, list) and hr):
+                            continue
+                        # Validate per-element shape — plugin plans are
+                        # untrusted input. Drop entries missing role/query
+                        # or referencing unknown roles; warn on any drop.
+                        validated = [
+                            sq for sq in hr
+                            if isinstance(sq, dict)
+                            and isinstance(sq.get("role"), str)
+                            and isinstance(sq.get("query"), str)
+                            and sq["role"] in agent_router.roles
+                        ]
+                        if len(validated) != len(hr):
+                            logger.warning(
+                                f"pre_orchestration plan: {len(hr)} entries, "
+                                f"{len(validated)} valid — discarded malformed entries"
+                            )
+                        if not validated:
+                            continue
+                        if len(validated) < 2:
+                            logger.info(
+                                f"🎼 pre_orchestration plan has only "
+                                f"{len(validated)} entry — orchestrator requires "
+                                f"≥2 sub-queries; falling through to single-role"
+                            )
+                            continue
+                        sub_queries = validated
+                        logger.info(
+                            f"🎼 pre_orchestration plan accepted: "
+                            f"{len(validated)} sub-queries → "
+                            f"{[sq['role'] for sq in validated]}"
                         )
-                        for hr in hook_results:
-                            if isinstance(hr, list) and hr:
-                                sub_queries = hr
-                                logger.info(
-                                    f"🎼 pre_orchestration hook returned plan with "
-                                    f"{len(hr)} sub-queries → {[sq.get('role') for sq in hr]}"
-                                )
-                                break
-                    except Exception as e:
-                        logger.warning(f"pre_orchestration hook raised, falling back to planner: {e}")
+                        break
 
-                    # Step 2 — if no plan, run the LLM planner. Skip it
-                    # for chitchat roles where the ~3-10s planner cost
-                    # would not pay off. Plugins that want orchestration
-                    # for those roles should supply a plan in step 1.
+                    # Step 2 — if no plan, run the LLM planner. Skip the
+                    # ~3-10s planner round-trip for chitchat roles.
+                    orchestrator = None
                     if sub_queries is None and role.name not in ("conversation", "knowledge"):
+                        from services.orchestrator import QueryOrchestrator
+                        orchestrator = QueryOrchestrator(agent_router, mcp_manager)
                         try:
                             sub_queries = await orchestrator.detect_multi_domain(
                                 content, ollama, lang=ollama.default_lang,
@@ -969,23 +989,31 @@ async def websocket_endpoint(
                             sub_queries = None
 
                     if sub_queries and len(sub_queries) >= 2:
+                        if orchestrator is None:
+                            from services.orchestrator import QueryOrchestrator
+                            orchestrator = QueryOrchestrator(agent_router, mcp_manager)
                         agent_used = True
                         orchestrated = True
                         logger.info(f"🎼 Orchestrator: {len(sub_queries)} sub-queries → {[sq.get('role') for sq in sub_queries]}")
                         executor = ActionExecutor(mcp_manager=mcp_manager, session_id=msg_session_id)
                         agent_tool_results = []
-                        # Buffer the final_answer step instead of streaming it,
-                        # so `check_output` (below) can redact before the user
-                        # sees the synthesized text. Tool steps + cards still
-                        # stream as they happen — only the synthesizer's
-                        # combined answer is held back.
+                        # Buffer final_answer AND card steps so check_output
+                        # can redact before send AND the card arrives after
+                        # the assistant message bubble it should attach to.
+                        # Tool steps still stream live for in-progress UX.
                         deferred_final_answer: str | None = None
+                        deferred_card: dict | None = None
+
+                        async def _typing_callback() -> None:
+                            await websocket.send_json({"type": "typing"})
+
                         async for step in orchestrator.run_orchestrated(
                             sub_queries=sub_queries,
                             message=content,
                             ollama=ollama,
                             executor=executor,
                             lang=ollama.default_lang,
+                            typing_callback=_typing_callback,
                             conversation_history=session_state.conversation_history if session_state.conversation_history else None,
                             room_context=room_context,
                             memory_context=memory_context,
@@ -998,7 +1026,11 @@ async def websocket_endpoint(
                         ):
                             if step.step_type == "final_answer":
                                 deferred_final_answer = step.content
-                                # Don't send to websocket yet — held for redaction.
+                            elif step.step_type == "card":
+                                # Hold the card until the assistant text
+                                # is on the wire — frontend attaches the
+                                # card to the latest assistant message.
+                                deferred_card = (step.data or {}).get("card")
                             else:
                                 await websocket.send_json(step_to_ws_message(step))
                             if step.step_type == "tool_result" and step.success and step.data:
@@ -1006,39 +1038,74 @@ async def websocket_endpoint(
                             if step.step_type in ("tool_call", "tool_result"):
                                 agent_steps_count += 1
 
-                        # check_output BEFORE sending the synthesized
-                        # answer to the client. Plugins (e.g. Reva's GDPR
-                        # output_guard) can return a redacted version;
-                        # the user sees only the redacted text.
+                        # check_output: fail-closed gate. If any handler
+                        # crashes, refuse to send unredacted text. The
+                        # GDPR/output-guard contract requires that a
+                        # broken redactor cannot leak data — silently
+                        # falling through with the original synthesis
+                        # would defeat the gate.
                         full_response = deferred_final_answer or ""
                         if full_response:
-                            try:
-                                redaction_results = await run_hooks(
-                                    "check_output",
-                                    content=full_response,
-                                    role=role.name if role else None,
-                                    user_id=user_id,
+                            redaction_results, redaction_errors = await run_hooks_with_errors(
+                                "check_output",
+                                content=full_response,
+                                role=role.name if role else None,
+                                user_id=user_id,
+                            )
+                            if redaction_errors:
+                                logger.error(
+                                    f"check_output handlers crashed "
+                                    f"({len(redaction_errors)} failures) — refusing to send "
+                                    f"unredacted response. Failed: "
+                                    f"{[fn.__qualname__ for fn, _ in redaction_errors]}"
                                 )
+                                full_response = (
+                                    "Antwort konnte nicht vollständig geprüft werden. "
+                                    "Bitte versuche es erneut."
+                                    if ollama.default_lang.startswith("de") else
+                                    "Response could not be fully validated. Please try again."
+                                )
+                            else:
                                 for rr in redaction_results:
-                                    if isinstance(rr, str) and rr and rr != full_response:
+                                    if not (isinstance(rr, str) and rr and rr != full_response):
+                                        continue
+                                    # Sanity check: extreme reduction (>95%)
+                                    # is more likely a redactor bug than
+                                    # legitimate redaction. Fail-closed.
+                                    ratio = len(rr) / max(1, len(full_response))
+                                    if ratio < 0.05:
+                                        logger.error(
+                                            f"check_output extreme redaction: "
+                                            f"{len(full_response)} → {len(rr)} chars "
+                                            f"(ratio={ratio:.3f}) — treating as fail-closed"
+                                        )
+                                        full_response = (
+                                            "[Inhalt zur Datenschutzprüfung zurückgehalten]"
+                                            if ollama.default_lang.startswith("de") else
+                                            "[content withheld for privacy review]"
+                                        )
+                                    else:
                                         logger.info(
-                                            f"check_output redacted orchestrated response "
+                                            f"check_output redacted "
                                             f"({len(full_response)} → {len(rr)} chars)"
                                         )
                                         full_response = rr
-                                        break
-                            except Exception as e:
-                                logger.warning(f"check_output hook raised, ignoring: {e}")
+                                    break
 
-                            # Now send the (possibly redacted) final answer.
-                            # Frontend handles `type: "stream"` for assistant text,
-                            # the same shape `step_to_ws_message` produces for a
-                            # final_answer AgentStep — so this matches the existing
-                            # contract. We send the whole thing in one message
-                            # (one chunk equals the complete redacted text).
+                            # Send the (possibly redacted/replaced) final
+                            # answer first, then the card. type: "stream"
+                            # mirrors step_to_ws_message's final_answer
+                            # shape — frontend treats the whole content
+                            # as one chunk.
                             await websocket.send_json({
                                 "type": "stream",
                                 "content": full_response,
+                            })
+
+                        if deferred_card:
+                            await websocket.send_json({
+                                "type": "card",
+                                "card": deferred_card,
                             })
 
                         if agent_tool_results:

--- a/src/backend/services/orchestrator.py
+++ b/src/backend/services/orchestrator.py
@@ -450,55 +450,30 @@ class QueryOrchestrator:
         sub_results_out: list[dict] | None = None,
         **agent_kwargs,
     ) -> AsyncGenerator["AgentStep", None]:
-        """Run sub-agents sequentially (original behavior).
+        """Run sub-agents sequentially.
 
-        `sub_results_out` (when provided) is appended to as each sub-agent
-        completes, giving the caller access to the structured per-role answers
-        for the post_orchestration hook.
+        Delegates to ``_run_sub_agent`` per query so ``pre_sub_agent`` /
+        ``post_sub_agent`` hooks and the ``_hook_task`` await fire
+        identically to parallel mode. ``sub_results_out`` is appended to
+        as each sub-agent completes (same contract as ``_run_parallel``).
         """
-        from services.agent_service import AgentService, AgentStep
-        from services.agent_tools import AgentToolRegistry
-
         sub_results: list[dict] = sub_results_out if sub_results_out is not None else []
 
         for i, sq in enumerate(sub_queries):
-            role_name = sq["role"]
-            query = sq["query"]
-            role = self.router.roles.get(role_name)
-
-            if not role or not role.has_agent_loop:
-                logger.warning(f"Orchestrator: skipping invalid role '{role_name}'")
-                continue
-
-            logger.info(f"Orchestrator: running sub-agent {i+1}/{len(sub_queries)} [{role_name}]: {query[:60]}")
-
-            tool_registry = AgentToolRegistry(
-                mcp_manager=self.mcp_manager,
-                server_filter=role.mcp_servers,
-                internal_filter=role.internal_tools,
+            logger.info(
+                f"Orchestrator: running sub-agent {i+1}/{len(sub_queries)} "
+                f"[{sq['role']}]: {sq['query'][:60]}"
             )
-            agent = AgentService(tool_registry, role=role)
+            result = await self._run_sub_agent(sq, ollama, executor, lang, **agent_kwargs)
 
-            # Same suppression rule as _run_parallel — only the
-            # combined answer should be surfaced to the user.
-            final_answer = None
-            async for step in agent.run(
-                message=query,
-                ollama=ollama,
-                executor=executor,
-                lang=lang,
-                **agent_kwargs,
-            ):
+            # Same suppression rule as _run_parallel — only the combined
+            # answer is surfaced to the user.
+            for step in result["steps"]:
                 if step.step_type == "final_answer":
-                    final_answer = step.content
                     continue
                 yield step
 
-            sub_results.append({
-                "role": role_name,
-                "query": query,
-                "answer": final_answer or "",
-            })
+            sub_results.append(result)
 
         async for step in self._emit_combined_answer(message, sub_results, ollama, lang):
             yield step

--- a/src/backend/services/orchestrator.py
+++ b/src/backend/services/orchestrator.py
@@ -47,11 +47,48 @@ class QueryOrchestrator:
         """Detect if a message needs multi-domain handling.
 
         Returns list of sub-queries [{role: str, query: str}] or None.
+
+        Plugin extension: the ``extend_orchestrator_roles`` hook runs
+        before the planner prompt is built. Each handler returns an
+        iterable of additional role *names* to include in the planner's
+        role list (the role's existing description from ``self.router.roles``
+        is used; unknown names are silently ignored). This lets a plugin
+        promote a non-``has_agent_loop`` role into the planner's vocabulary
+        without modifying the agent_router.
         """
+        from utils.hooks import run_hooks
+
+        # Default eligibility: any role with an agent loop. Plugins can
+        # extend this set via the extend_orchestrator_roles hook.
+        eligible_names: set[str] = {
+            role.name for role in self.router.roles.values() if role.has_agent_loop
+        }
+        try:
+            extra_results = await run_hooks(
+                "extend_orchestrator_roles",
+                roles=self.router.roles,
+                lang=lang,
+            )
+        except Exception as e:
+            logger.warning(f"extend_orchestrator_roles hook raised, ignoring: {e}")
+            extra_results = []
+
+        for er in extra_results:
+            if er is None:
+                continue
+            try:
+                eligible_names.update(name for name in er if name in self.router.roles)
+            except TypeError:
+                logger.warning(
+                    f"extend_orchestrator_roles handler returned non-iterable "
+                    f"(type={type(er).__name__}); ignoring"
+                )
+
         # Build role descriptions for the detection prompt
         role_lines = []
-        for role in self.router.roles.values():
-            if not role.has_agent_loop:
+        for name in sorted(eligible_names):
+            role = self.router.roles.get(name)
+            if role is None:
                 continue
             desc = role.description.get(lang, role.description.get("de", ""))
             role_lines.append(f"- {role.name}: {desc}")
@@ -164,23 +201,22 @@ class QueryOrchestrator:
         When agent_orchestrator_parallel is True, sub-agents run in parallel
         with isolated contexts. Otherwise falls back to sequential execution.
 
-        Fires `pre_orchestration` before sub-agents launch and
-        `post_orchestration` after synthesis. If any post_orchestration handler
-        returns a dict containing a `card` key, an additional AgentStep with
+        Fires ``post_orchestration`` after synthesis. If any handler
+        returns a dict containing a ``card`` key, an additional AgentStep with
         step_type="card" is yielded so the WebSocket layer can forward it to
         the client. First well-shaped card wins.
+
+        ``pre_orchestration`` is *not* fired here — it fires upstream in the
+        caller (chat_handler / Teams transport) before sub_queries are
+        determined, so plugins can inject a pre-computed plan. By the time
+        we reach this method, the plan is already final. Firing again here
+        would create double-firing semantics that handlers would have to
+        guard against.
 
         Yields AgentStep objects for real-time feedback.
         """
         from services.agent_service import AgentStep
         from utils.hooks import run_hooks
-
-        plan = {"sub_queries": list(sub_queries), "message": message, "lang": lang}
-        try:
-            await run_hooks("pre_orchestration", message=message, plan=plan, lang=lang)
-        except Exception as e:
-            # Hook failures must never break orchestration.
-            logger.warning(f"pre_orchestration hook raised, ignoring: {e}")
 
         sub_results: list[dict] = []
         final_answer: str | None = None
@@ -233,10 +269,18 @@ class QueryOrchestrator:
     ) -> dict:
         """Run a single sub-agent to completion with isolated context.
 
-        Returns dict with role, query, answer, and collected steps.
+        Fires ``pre_sub_agent`` before the agent loop (after the per-task
+        tool registry is built — handlers may mutate it, e.g. to pre-select
+        a narrower tool list) and ``post_sub_agent`` after the loop
+        completes. Each handler's return-dict is merged into the result's
+        ``plugin_data`` field so callers downstream (``post_orchestration``)
+        see a single accumulated dict per sub-agent.
+
+        Returns dict with role, query, answer, steps, and plugin_data.
         """
         from services.agent_service import AgentService
         from services.agent_tools import AgentToolRegistry
+        from utils.hooks import run_hooks
 
         role_name = sq["role"]
         query = sq["query"]
@@ -244,7 +288,7 @@ class QueryOrchestrator:
 
         if not role or not role.has_agent_loop:
             logger.warning(f"Orchestrator: skipping invalid role '{role_name}'")
-            return {"role": role_name, "query": query, "answer": "", "steps": []}
+            return {"role": role_name, "query": query, "answer": "", "steps": [], "plugin_data": {}}
 
         logger.info(f"Orchestrator: launching sub-agent [{role_name}]: {query[:60]}")
 
@@ -254,7 +298,36 @@ class QueryOrchestrator:
             server_filter=role.mcp_servers,
             internal_filter=role.internal_tools,
         )
+
+        # Wait for plugin-registered tools to be ready before the agent
+        # loop reads the registry. ``register_tools`` hooks attach tools
+        # asynchronously via ``_hook_task``; without this await the agent
+        # may run before plugin tools are registered, causing intermittent
+        # "tool not found" failures on the first orchestrated call after
+        # startup. The single-agent path in chat_handler also lacks this
+        # await — fixing it here is part of the orchestrator uplift.
+        hook_task = getattr(tool_registry, "_hook_task", None)
+        if hook_task is not None:
+            try:
+                await hook_task
+            except Exception as e:
+                logger.warning(f"tool_registry._hook_task raised, continuing: {e}")
+
         agent = AgentService(tool_registry, role=role)
+
+        # Fire pre_sub_agent — plugins receive the registry and may mutate
+        # it (e.g. tool pre-selection, contact accumulator init). Hook
+        # exceptions never break the sub-agent.
+        try:
+            await run_hooks(
+                "pre_sub_agent",
+                step=sq,
+                role=role_name,
+                tool_registry=tool_registry,
+                lang=lang,
+            )
+        except Exception as e:
+            logger.warning(f"pre_sub_agent hook raised, continuing: {e}")
 
         steps = []
         final_answer = None
@@ -279,8 +352,36 @@ class QueryOrchestrator:
             if step.step_type == "final_answer":
                 final_answer = step.content
 
+        result = {
+            "role": role_name,
+            "query": query,
+            "answer": final_answer or "",
+            "steps": steps,
+            "plugin_data": {},
+        }
+
+        # Fire post_sub_agent — plugins receive the completed result and
+        # may attach side-channel data (drained contact accumulators,
+        # provenance entries, telemetry). Each handler's return-dict is
+        # merged into result["plugin_data"]; later handlers' keys win.
+        try:
+            hook_results = await run_hooks(
+                "post_sub_agent",
+                step=sq,
+                role=role_name,
+                result=result,
+                lang=lang,
+            )
+        except Exception as e:
+            logger.warning(f"post_sub_agent hook raised, continuing: {e}")
+            hook_results = []
+
+        for hr in hook_results:
+            if isinstance(hr, dict):
+                result["plugin_data"].update(hr)
+
         logger.info(f"Orchestrator: sub-agent [{role_name}] completed ({len(steps)} steps)")
-        return {"role": role_name, "query": query, "answer": final_answer or "", "steps": steps}
+        return result
 
     async def _run_parallel(
         self,

--- a/src/backend/services/orchestrator.py
+++ b/src/backend/services/orchestrator.py
@@ -10,7 +10,7 @@ Opt-in via AGENT_ORCHESTRATOR_ENABLED=true.
 
 import asyncio
 import json
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from typing import TYPE_CHECKING
 
 from loguru import logger
@@ -27,6 +27,38 @@ if TYPE_CHECKING:
     from services.ollama_service import OllamaService
 
 
+# Plugin-data fields that are list-shaped by convention. When multiple
+# post_sub_agent handlers contribute to one of these keys, results are
+# concatenated rather than overwritten — matching how Reva's contact
+# accumulator and provenance trail expect to merge across plugins.
+# Other keys still follow last-writer-wins with a collision warning.
+_LIST_SHAPED_PLUGIN_DATA_FIELDS: frozenset[str] = frozenset(
+    {"contacts", "provenance", "warnings"}
+)
+
+
+def _failed_sub_result(role: str, query: str, error: str | None = None) -> dict:
+    """Empty-shape result for a sub-agent that failed before producing output.
+
+    Centralizing this keeps the success-path and failure-path dict shapes
+    in sync. A drift would silently break ``post_orchestration`` handlers
+    that walk ``sub_results`` and read ``plugin_data`` / ``steps``.
+
+    The optional ``error`` field carries a user-displayable message; when
+    present it triggers an ``error`` AgentStep in ``_run_parallel`` /
+    ``_run_sequential`` so the user sees that one of their sub-agents
+    failed (and the synthesizer's combined answer omits it).
+    """
+    return {
+        "role": role,
+        "query": query,
+        "answer": "",
+        "steps": [],
+        "plugin_data": {},
+        "error": error,
+    }
+
+
 class QueryOrchestrator:
     """Orchestrates multi-domain queries across specialized agents."""
 
@@ -37,6 +69,50 @@ class QueryOrchestrator:
     ):
         self.router = agent_router
         self.mcp_manager = mcp_manager
+        # Cache of orchestrator-eligible role names. Populated lazily on
+        # first detect_multi_domain call so plugins that register
+        # extend_orchestrator_roles handlers AFTER this constructor runs
+        # (typical: Renfield's lifecycle does plugin registration before
+        # the first user request) are still picked up. Subsequent calls
+        # use the cached value, avoiding per-request hook fires.
+        self._eligible_roles_cache: set[str] | None = None
+
+    async def _resolve_eligible_roles(self, lang: str) -> set[str]:
+        """Build the planner's eligible-role set, cached after first call.
+
+        Default: any role with ``has_agent_loop=True``. Plugins can extend
+        the set via the ``extend_orchestrator_roles`` hook (returning an
+        iterable of role names; unknown names are silently dropped). The
+        result is cached on the instance so plugin hooks fire only once
+        per orchestrator lifetime, not per request.
+        """
+        if self._eligible_roles_cache is not None:
+            return self._eligible_roles_cache
+
+        eligible: set[str] = {
+            role.name for role in self.router.roles.values() if role.has_agent_loop
+        }
+
+        # run_hooks never raises (utils/hooks.py contract).
+        from utils.hooks import run_hooks
+        extra_results = await run_hooks(
+            "extend_orchestrator_roles",
+            roles=self.router.roles,
+            lang=lang,
+        )
+        for er in extra_results:
+            if er is None:
+                continue
+            try:
+                eligible.update(name for name in er if name in self.router.roles)
+            except TypeError:
+                logger.warning(
+                    f"extend_orchestrator_roles handler returned non-iterable "
+                    f"(type={type(er).__name__}); ignoring"
+                )
+
+        self._eligible_roles_cache = eligible
+        return eligible
 
     async def detect_multi_domain(
         self,
@@ -48,41 +124,11 @@ class QueryOrchestrator:
 
         Returns list of sub-queries [{role: str, query: str}] or None.
 
-        Plugin extension: the ``extend_orchestrator_roles`` hook runs
-        before the planner prompt is built. Each handler returns an
-        iterable of additional role *names* to include in the planner's
-        role list (the role's existing description from ``self.router.roles``
-        is used; unknown names are silently ignored). This lets a plugin
-        promote a non-``has_agent_loop`` role into the planner's vocabulary
-        without modifying the agent_router.
+        The planner's role vocabulary comes from ``_resolve_eligible_roles``
+        (cached after first call). Plugins extend it via the
+        ``extend_orchestrator_roles`` hook.
         """
-        from utils.hooks import run_hooks
-
-        # Default eligibility: any role with an agent loop. Plugins can
-        # extend this set via the extend_orchestrator_roles hook.
-        eligible_names: set[str] = {
-            role.name for role in self.router.roles.values() if role.has_agent_loop
-        }
-        try:
-            extra_results = await run_hooks(
-                "extend_orchestrator_roles",
-                roles=self.router.roles,
-                lang=lang,
-            )
-        except Exception as e:
-            logger.warning(f"extend_orchestrator_roles hook raised, ignoring: {e}")
-            extra_results = []
-
-        for er in extra_results:
-            if er is None:
-                continue
-            try:
-                eligible_names.update(name for name in er if name in self.router.roles)
-            except TypeError:
-                logger.warning(
-                    f"extend_orchestrator_roles handler returned non-iterable "
-                    f"(type={type(er).__name__}); ignoring"
-                )
+        eligible_names = await self._resolve_eligible_roles(lang)
 
         # Build role descriptions for the detection prompt
         role_lines = []
@@ -183,8 +229,17 @@ class QueryOrchestrator:
             )
             return valid
 
-        except (asyncio.TimeoutError, json.JSONDecodeError, Exception) as e:
-            logger.warning(f"Orchestrator detection failed: {e}")
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"Orchestrator detection timed out after "
+                f"{settings.agent_router_timeout}s — falling back to single-role"
+            )
+            return None
+        except (ConnectionError, json.JSONDecodeError) as e:
+            # Network/parse failures: log and fall back. JSON decode is
+            # belt-and-braces — the response_text path above already handles
+            # malformed JSON via the `start/end` slice + try/except.
+            logger.warning(f"Orchestrator detection: {type(e).__name__}: {e}")
             return None
 
     async def run_orchestrated(
@@ -194,29 +249,34 @@ class QueryOrchestrator:
         ollama: "OllamaService",
         executor: "ActionExecutor",
         lang: str = "de",
+        typing_callback: "Callable[[], Awaitable[None]] | None" = None,
         **agent_kwargs,
     ) -> AsyncGenerator["AgentStep", None]:
         """Run sub-agents and synthesize results.
 
-        When agent_orchestrator_parallel is True, sub-agents run in parallel
-        with isolated contexts. Otherwise falls back to sequential execution.
+        ``pre_orchestration`` fires upstream in the caller (chat_handler
+        / Teams transport) before sub_queries are determined, so plugins
+        can inject a pre-computed plan. Firing again here would create
+        double-firing semantics that handlers would have to guard against.
 
-        Fires ``post_orchestration`` after synthesis. If any handler
-        returns a dict containing a ``card`` key, an additional AgentStep with
-        step_type="card" is yielded so the WebSocket layer can forward it to
-        the client. First well-shaped card wins.
+        ``typing_callback`` (optional, design Resolved-Q2) is invoked once
+        before sub-agents launch so transports can emit a generic typing
+        indicator before the planner-and-fan-out work begins. Teams
+        passes ``context.send_activity(typing)``; web passes a websocket
+        send. Failure to invoke is logged but doesn't break the run.
 
-        ``pre_orchestration`` is *not* fired here — it fires upstream in the
-        caller (chat_handler / Teams transport) before sub_queries are
-        determined, so plugins can inject a pre-computed plan. By the time
-        we reach this method, the plan is already final. Firing again here
-        would create double-firing semantics that handlers would have to
-        guard against.
-
-        Yields AgentStep objects for real-time feedback.
+        Yields AgentStep objects for real-time feedback. After synthesis,
+        ``post_orchestration`` fires; the first handler returning a dict
+        with a ``card`` key contributes an extra ``card`` step.
         """
         from services.agent_service import AgentStep
         from utils.hooks import run_hooks
+
+        if typing_callback is not None:
+            try:
+                await typing_callback()
+            except Exception as e:
+                logger.warning(f"typing_callback raised, ignoring: {e}")
 
         sub_results: list[dict] = []
         final_answer: str | None = None
@@ -237,18 +297,14 @@ class QueryOrchestrator:
                 final_answer = step.content
             yield step
 
-        try:
-            hook_results = await run_hooks(
-                "post_orchestration",
-                message=message,
-                sub_results=sub_results,
-                final_answer=final_answer,
-                lang=lang,
-            )
-        except Exception as e:
-            logger.warning(f"post_orchestration hook raised, ignoring: {e}")
-            hook_results = []
-
+        # run_hooks never raises — direct call.
+        hook_results = await run_hooks(
+            "post_orchestration",
+            message=message,
+            sub_results=sub_results,
+            final_answer=final_answer,
+            lang=lang,
+        )
         for hr in hook_results:
             if isinstance(hr, dict) and hr.get("card"):
                 yield AgentStep(
@@ -269,56 +325,82 @@ class QueryOrchestrator:
     ) -> dict:
         """Run a single sub-agent to completion with isolated context.
 
-        Fires ``pre_sub_agent`` before the agent loop (after the per-task
-        tool registry is built — handlers may mutate it, e.g. to pre-select
-        a narrower tool list) and ``post_sub_agent`` after the loop
-        completes. Each handler's return-dict is merged into the result's
-        ``plugin_data`` field so callers downstream (``post_orchestration``)
-        see a single accumulated dict per sub-agent.
+        Acts as the **exception sink** for both parallel and sequential
+        modes: every code path returns a dict with the canonical shape
+        (see :func:`_failed_sub_result`). Crashes are caught, logged, and
+        surfaced as the result's ``error`` field. Both modes can therefore
+        treat sub-agent failures uniformly without their own try/except.
 
-        Returns dict with role, query, answer, steps, and plugin_data.
+        Hook lifecycle:
+        - ``pre_sub_agent`` fires once after ``tool_registry`` is built
+          (handlers may mutate it, e.g. for tool pre-selection).
+        - ``post_sub_agent`` fires unconditionally if ``pre_sub_agent``
+          fired — even if ``agent.run`` raises mid-stream — so plugin
+          accumulators (contacts, provenance) always get drained.
+        - Plugin contributions to ``result["plugin_data"]`` from
+          ``post_sub_agent`` follow per-key merge semantics: keys in
+          :data:`_LIST_SHAPED_PLUGIN_DATA_FIELDS` are concatenated;
+          non-list keys follow last-writer-wins with a warning on
+          collision.
         """
         from services.agent_service import AgentService
         from services.agent_tools import AgentToolRegistry
         from utils.hooks import run_hooks
 
-        role_name = sq["role"]
-        query = sq["query"]
-        role = self.router.roles.get(role_name)
+        # Validate sub-query shape — buggy plugin-supplied plans (from
+        # pre_orchestration) and detect_multi_domain bugs both flow here.
+        if not isinstance(sq, dict):
+            logger.error(f"Orchestrator: malformed sub-query (not a dict): {sq!r}")
+            return _failed_sub_result(
+                "?", "",
+                error=f"Malformed sub-query: not a dict (got {type(sq).__name__})",
+            )
+        role_name = sq.get("role")
+        query = sq.get("query")
+        if not isinstance(role_name, str) or not isinstance(query, str):
+            logger.error(f"Orchestrator: malformed sub-query (missing role/query): {sq!r}")
+            return _failed_sub_result(
+                role_name if isinstance(role_name, str) else "?",
+                query if isinstance(query, str) else "",
+                error="Malformed sub-query: missing role or query",
+            )
 
+        role = self.router.roles.get(role_name)
         if not role or not role.has_agent_loop:
             logger.warning(f"Orchestrator: skipping invalid role '{role_name}'")
-            return {"role": role_name, "query": query, "answer": "", "steps": [], "plugin_data": {}}
+            return _failed_sub_result(role_name, query)
 
         logger.info(f"Orchestrator: launching sub-agent [{role_name}]: {query[:60]}")
 
-        # Each sub-agent gets its own tool registry (isolated context)
-        tool_registry = AgentToolRegistry(
-            mcp_manager=self.mcp_manager,
-            server_filter=role.mcp_servers,
-            internal_filter=role.internal_tools,
-        )
-
-        # Wait for plugin-registered tools to be ready before the agent
-        # loop reads the registry. ``register_tools`` hooks attach tools
-        # asynchronously via ``_hook_task``; without this await the agent
-        # may run before plugin tools are registered, causing intermittent
-        # "tool not found" failures on the first orchestrated call after
-        # startup. The single-agent path in chat_handler also lacks this
-        # await — fixing it here is part of the orchestrator uplift.
-        hook_task = getattr(tool_registry, "_hook_task", None)
-        if hook_task is not None:
-            try:
-                await hook_task
-            except Exception as e:
-                logger.warning(f"tool_registry._hook_task raised, continuing: {e}")
-
-        agent = AgentService(tool_registry, role=role)
-
-        # Fire pre_sub_agent — plugins receive the registry and may mutate
-        # it (e.g. tool pre-selection, contact accumulator init). Hook
-        # exceptions never break the sub-agent.
         try:
+            tool_registry = AgentToolRegistry(
+                mcp_manager=self.mcp_manager,
+                server_filter=role.mcp_servers,
+                internal_filter=role.internal_tools,
+            )
+
+            # Plugin-registered tools attach asynchronously via _hook_task.
+            # Without this await the agent reads a half-populated registry
+            # and "tool not found" errors don't trace back to the failure.
+            hook_task = getattr(tool_registry, "_hook_task", None)
+            if hook_task is not None:
+                try:
+                    await hook_task
+                except Exception as e:
+                    logger.opt(exception=True).error(
+                        f"Tool registry init failed for [{role_name}]: "
+                        f"{type(e).__name__}: {e}"
+                    )
+                    msg = (
+                        f"Tools für Rolle '{role_name}' konnten nicht geladen werden."
+                        if lang.startswith("de") else
+                        f"Tools for role '{role_name}' failed to load."
+                    )
+                    return _failed_sub_result(role_name, query, error=msg)
+
+            agent = AgentService(tool_registry, role=role)
+
+            # run_hooks never raises (utils/hooks.py contract) — direct call.
             await run_hooks(
                 "pre_sub_agent",
                 step=sq,
@@ -326,45 +408,50 @@ class QueryOrchestrator:
                 tool_registry=tool_registry,
                 lang=lang,
             )
-        except Exception as e:
-            logger.warning(f"pre_sub_agent hook raised, continuing: {e}")
 
-        steps = []
-        final_answer = None
-        async for step in agent.run(
-            message=query,
-            ollama=ollama,
-            executor=executor,
-            lang=lang,
-            **agent_kwargs,
-        ):
-            # Tag step with sub-agent role for frontend grouping. Some MCP
-            # tools return list-shaped step.data (e.g. JQL search results) —
-            # only inject the marker when data is dict-shaped or unset, never
-            # convert a list into a dict (would lose the result payload).
-            if step.data is None:
-                step.data = {"sub_agent_role": role_name}
-            elif isinstance(step.data, dict):
-                step.data["sub_agent_role"] = role_name
-            # list/scalar data stays as-is; sub_agent_role is then unavailable
-            # for frontend grouping on that step but the data itself survives.
-            steps.append(step)
-            if step.step_type == "final_answer":
-                final_answer = step.content
+            steps: list = []
+            final_answer: str | None = None
+            try:
+                async for step in agent.run(
+                    message=query,
+                    ollama=ollama,
+                    executor=executor,
+                    lang=lang,
+                    **agent_kwargs,
+                ):
+                    # Tag step with sub-agent role for frontend grouping.
+                    # Only inject when data is dict-shaped or unset — list
+                    # data (JQL results) and scalars must stay as-is so
+                    # downstream callers reading raw payloads don't break.
+                    # Tradeoff: list-shaped steps lose the role marker
+                    # (frontend grouping degrades for those), but the
+                    # data payload is preserved.
+                    if step.data is None:
+                        step.data = {"sub_agent_role": role_name}
+                    elif isinstance(step.data, dict):
+                        step.data["sub_agent_role"] = role_name
+                    steps.append(step)
+                    if step.step_type == "final_answer":
+                        final_answer = step.content
+                agent_run_error: str | None = None
+            except Exception as e:
+                logger.opt(exception=True).error(
+                    f"Sub-agent [{role_name}] agent.run crashed: {e}"
+                )
+                agent_run_error = str(e)
+                final_answer = None
 
-        result = {
-            "role": role_name,
-            "query": query,
-            "answer": final_answer or "",
-            "steps": steps,
-            "plugin_data": {},
-        }
+            result: dict = {
+                "role": role_name,
+                "query": query,
+                "answer": final_answer or "",
+                "steps": steps,
+                "plugin_data": {},
+                "error": agent_run_error,
+            }
 
-        # Fire post_sub_agent — plugins receive the completed result and
-        # may attach side-channel data (drained contact accumulators,
-        # provenance entries, telemetry). Each handler's return-dict is
-        # merged into result["plugin_data"]; later handlers' keys win.
-        try:
+            # post_sub_agent: fire even on agent.run crash so plugins can
+            # drain accumulators that pre_sub_agent populated.
             hook_results = await run_hooks(
                 "post_sub_agent",
                 step=sq,
@@ -372,13 +459,27 @@ class QueryOrchestrator:
                 result=result,
                 lang=lang,
             )
-        except Exception as e:
-            logger.warning(f"post_sub_agent hook raised, continuing: {e}")
-            hook_results = []
+            for hr in hook_results:
+                if not isinstance(hr, dict):
+                    continue
+                for k, v in hr.items():
+                    if k in _LIST_SHAPED_PLUGIN_DATA_FIELDS and isinstance(v, list):
+                        result["plugin_data"].setdefault(k, []).extend(v)
+                    elif k in result["plugin_data"]:
+                        logger.warning(
+                            f"post_sub_agent: key '{k}' contributed by multiple "
+                            f"handlers (last writer wins) — registration order "
+                            f"determines outcome"
+                        )
+                        result["plugin_data"][k] = v
+                    else:
+                        result["plugin_data"][k] = v
 
-        for hr in hook_results:
-            if isinstance(hr, dict):
-                result["plugin_data"].update(hr)
+        except Exception as e:
+            logger.opt(exception=True).error(
+                f"Sub-agent [{role_name}] crashed in setup/teardown: {e}"
+            )
+            return _failed_sub_result(role_name, query, error=str(e))
 
         logger.info(f"Orchestrator: sub-agent [{role_name}] completed ({len(steps)} steps)")
         return result
@@ -395,45 +496,66 @@ class QueryOrchestrator:
     ) -> AsyncGenerator["AgentStep", None]:
         """Run all sub-agents in parallel, then synthesize.
 
-        `sub_results_out` (when provided) is appended to as sub-agents complete,
-        giving the caller access to the structured per-role answers needed for
-        the post_orchestration hook.
+        ``sub_results_out`` (when provided) is appended to as sub-agents
+        complete. ``_run_sub_agent`` is the exception sink — gather should
+        only see dicts, but ``return_exceptions=True`` is kept as
+        belt-and-braces against future regressions.
+
+        On ``CancelledError`` (e.g. WebSocket client disconnects), pending
+        sub-agents are cancelled to free LLM/MCP resources rather than
+        running to completion with a discarded result.
         """
         from services.agent_service import AgentStep
 
         logger.info(f"⚡ Orchestrator: parallel execution of {len(sub_queries)} sub-agents")
 
-        # Launch all sub-agents in parallel (isolated contexts)
         tasks = [
-            self._run_sub_agent(sq, ollama, executor, lang, **agent_kwargs)
+            asyncio.create_task(
+                self._run_sub_agent(sq, ollama, executor, lang, **agent_kwargs)
+            )
             for sq in sub_queries
         ]
-        raw_results = await asyncio.gather(*tasks, return_exceptions=True)
+        try:
+            raw_results = await asyncio.gather(*tasks, return_exceptions=True)
+        except asyncio.CancelledError:
+            for t in tasks:
+                if not t.done():
+                    t.cancel()
+            # Wait briefly for cancellation to propagate, but don't block
+            # the cancellation chain on uncooperative sub-agents.
+            await asyncio.gather(*tasks, return_exceptions=True)
+            raise
 
-        # Yield steps grouped by sub-agent + collect results for synthesis.
-        # IMPORTANT: per-sub-agent `final_answer` steps are suppressed
-        # here — they are intermediate artifacts, not the combined
-        # response. The user sees exactly one final answer: either the
-        # synthesizer's output (for 2+ successful sub-agents) or the
-        # single surviving sub-agent's answer (1 sub-agent, or fallback).
-        # Without this filter, the web chat would render 1 + N answers
-        # (each with its own greeting), which duplicates content and
-        # confuses the user.
+        # Per-sub-agent final_answer steps are suppressed — only the
+        # synthesizer's combined answer (or the single-survivor fallback)
+        # reaches the user. Without this, the UI would render 1 + N
+        # answers each with their own greeting.
         sub_results: list[dict] = sub_results_out if sub_results_out is not None else []
         for sq, result in zip(sub_queries, raw_results):
-            if isinstance(result, Exception):
-                logger.error(f"Orchestrator: sub-agent [{sq['role']}] failed: {result}")
+            if isinstance(result, BaseException):
+                # Defensive: _run_sub_agent shouldn't raise. If it ever does,
+                # fall back to a canonical-shape failure record so post_orchestration
+                # handlers don't trip over a missing plugin_data/steps key.
+                logger.error(
+                    f"Orchestrator: sub-agent [{sq.get('role','?')}] raised "
+                    f"unexpectedly (sink contract violated): {result!r}"
+                )
+                result = _failed_sub_result(
+                    sq.get("role") if isinstance(sq, dict) else "?",
+                    sq.get("query") if isinstance(sq, dict) else "",
+                    error=str(result),
+                )
+
+            if result.get("error"):
                 yield AgentStep(
                     step_number=0,
                     step_type="error",
-                    content=f"Sub-Agent [{sq['role']}] fehlgeschlagen: {result}",
+                    content=f"Sub-Agent [{result['role']}] fehlgeschlagen: {result['error']}",
                 )
-                sub_results.append({"role": sq["role"], "query": sq["query"], "answer": ""})
-                continue
 
             for step in result["steps"]:
                 if step.step_type == "final_answer":
-                    continue  # see note above
+                    continue
                 yield step
             sub_results.append(result)
 
@@ -452,22 +574,35 @@ class QueryOrchestrator:
     ) -> AsyncGenerator["AgentStep", None]:
         """Run sub-agents sequentially.
 
-        Delegates to ``_run_sub_agent`` per query so ``pre_sub_agent`` /
-        ``post_sub_agent`` hooks and the ``_hook_task`` await fire
-        identically to parallel mode. ``sub_results_out`` is appended to
-        as each sub-agent completes (same contract as ``_run_parallel``).
+        Delegates to ``_run_sub_agent`` per query so hooks fire
+        identically to parallel mode. Exception isolation is also
+        identical: ``_run_sub_agent`` is the sink and returns a
+        canonical-shape failure record (with ``error`` set) instead of
+        propagating, so a single failed sub-agent does not abort the
+        sequential run.
         """
+        from services.agent_service import AgentStep
+
         sub_results: list[dict] = sub_results_out if sub_results_out is not None else []
 
         for i, sq in enumerate(sub_queries):
+            role_preview = sq.get("role", "?") if isinstance(sq, dict) else "?"
+            query_preview = sq.get("query", "") if isinstance(sq, dict) else ""
             logger.info(
                 f"Orchestrator: running sub-agent {i+1}/{len(sub_queries)} "
-                f"[{sq['role']}]: {sq['query'][:60]}"
+                f"[{role_preview}]: {query_preview[:60]}"
             )
             result = await self._run_sub_agent(sq, ollama, executor, lang, **agent_kwargs)
 
-            # Same suppression rule as _run_parallel — only the combined
-            # answer is surfaced to the user.
+            if result.get("error"):
+                yield AgentStep(
+                    step_number=0,
+                    step_type="error",
+                    content=f"Sub-Agent [{result['role']}] fehlgeschlagen: {result['error']}",
+                )
+
+            # Suppress per-sub-agent final_answer — only the synthesizer's
+            # combined answer reaches the user.
             for step in result["steps"]:
                 if step.step_type == "final_answer":
                     continue

--- a/src/backend/utils/hooks.py
+++ b/src/backend/utils/hooks.py
@@ -159,10 +159,22 @@ HOOK_EVENTS: frozenset[str] = frozenset({
     #       in parallel. Plugins can inspect or annotate the plan.
     #   pre_sub_agent / post_sub_agent: (role, query, result)
     #       Fired around each sub-agent step inside the orchestrator.
-    #   check_output: (role, response) -> dict | None
-    #       Final gate before returning a response to the user. Plugins
-    #       can reject or rewrite outputs that violate guardrails (e.g.
-    #       Reva's GDPR / prompt-leakage checks).
+    #   check_output: (content: str, role: str | None, user_id: int | None) -> str | None
+    #       Final gate before returning a response to the user. Handlers
+    #       receive the synthesized response and may return a redacted
+    #       string (used in place of `content`) or None to defer. Used
+    #       by Reva's GDPR / prompt-leakage output guard.
+    #
+    #       SECURITY-CRITICAL: callers should treat handler crashes as
+    #       fail-closed (refuse to send the unredacted text). Use
+    #       `run_hooks_with_errors` instead of `run_hooks` to surface
+    #       failures, then choose a fail-closed response.
+    #   extract_context_vars: (tool_summaries: list, session_id, user_id)
+    #       Fired fire-and-forget after persistence to extract
+    #       per-conversation state (e.g. current_release_id) from tool
+    #       results. Reva's transport.py uses an inline equivalent today;
+    #       this hook will be wired in chat_handler in Phase 2 of the
+    #       orchestrator-uplift project.
     "load_entity_patterns",
     "post_routing",
     "extend_orchestrator_roles",
@@ -171,6 +183,7 @@ HOOK_EVENTS: frozenset[str] = frozenset({
     "pre_sub_agent",
     "post_sub_agent",
     "check_output",
+    "extract_context_vars",
     # Sub-intent dispatch — fired by chat_handler after AgentRouter
     # classification when the matched role declares a sub_intent with a
     # ``dispatch: {type: handler, handler: <name>}`` config. Handlers
@@ -199,7 +212,14 @@ def register_hook(event: str, fn: HookFn) -> None:
 
 
 async def run_hooks(event: str, **kwargs: Any) -> list[Any]:
-    """Run all hooks for *event*, return non-None results. Never raises."""
+    """Run all hooks for *event*, return non-None results. Never raises.
+
+    Handler exceptions are caught and logged with full traceback at warning
+    level; the result list contains only successful, non-None contributions.
+    Callers cannot distinguish "no handler registered" from "handler crashed"
+    via the return value alone — use ``run_hooks_with_errors`` when the
+    distinction matters (e.g. fail-closed gates like ``check_output``).
+    """
     results: list[Any] = []
     for fn in _hooks.get(event, []):
         try:
@@ -211,6 +231,34 @@ async def run_hooks(event: str, **kwargs: Any) -> list[Any]:
                 f"Hook {getattr(fn, '__qualname__', repr(fn))} failed for {event}"
             )
     return results
+
+
+async def run_hooks_with_errors(
+    event: str, **kwargs: Any,
+) -> tuple[list[Any], list[tuple[HookFn, BaseException]]]:
+    """Like ``run_hooks`` but also returns a list of (handler, exception) pairs.
+
+    Use this for fail-closed semantics: when a handler crash means the
+    caller should refuse the operation rather than silently degrade. The
+    GDPR ``check_output`` gate is the canonical example — a redactor crash
+    must not cause unredacted text to ship.
+
+    Failures are still logged at warning level via the same path as
+    ``run_hooks``; this only changes whether the caller can observe them.
+    """
+    results: list[Any] = []
+    errors: list[tuple[HookFn, BaseException]] = []
+    for fn in _hooks.get(event, []):
+        try:
+            result = await fn(**kwargs)
+            if result is not None:
+                results.append(result)
+        except Exception as e:
+            errors.append((fn, e))
+            logger.opt(exception=True).warning(
+                f"Hook {getattr(fn, '__qualname__', repr(fn))} failed for {event}"
+            )
+    return results, errors
 
 
 def clear_hooks() -> None:

--- a/tests/backend/test_orchestrator.py
+++ b/tests/backend/test_orchestrator.py
@@ -483,7 +483,13 @@ class TestRunSubAgentListData:
             mock_agent = MagicMock()
             mock_agent.run = _fake_run
             MockAS.return_value = mock_agent
-            MockReg.return_value = MagicMock()
+            # _hook_task explicitly None so the orchestrator's "wait for plugin
+            # tools" path stays a no-op (MagicMock would auto-create a non-None,
+            # non-awaitable attribute that the orchestrator now correctly
+            # treats as a hook_task crash → fail-the-sub-agent).
+            mock_registry = MagicMock()
+            mock_registry._hook_task = None
+            MockReg.return_value = mock_registry
 
             result = await orchestrator._run_sub_agent(
                 {"role": "jira", "query": "find tickets"},
@@ -524,7 +530,9 @@ class TestRunSubAgentListData:
             mock_agent = MagicMock()
             mock_agent.run = _fake_run
             MockAS.return_value = mock_agent
-            MockReg.return_value = MagicMock()
+            mock_registry = MagicMock()
+            mock_registry._hook_task = None
+            MockReg.return_value = mock_registry
 
             result = await orchestrator._run_sub_agent(
                 {"role": "release", "query": "status"},
@@ -1859,9 +1867,9 @@ class TestEmitCombinedAllFailed:
         finals = [s for s in steps if s.step_type == "final_answer"]
         assert len(finals) == 1
         assert finals[0].content  # non-empty
-        # Localized — German indicators
+        # Localized — German indicators from the actual all-failed message
         assert any(token in finals[0].content.lower()
-                   for token in ("anfrage", "fehl", "leider", "konnte"))
+                   for token in ("keine", "antwort", "versuch", "betroffen"))
 
     @pytest.mark.unit
     @pytest.mark.asyncio

--- a/tests/backend/test_orchestrator.py
+++ b/tests/backend/test_orchestrator.py
@@ -877,31 +877,46 @@ class TestSubAgentHooks:
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_hook_task_awaited_before_agent_run(self):
-        """If the registry has a `_hook_task` future, it must be awaited first.
+        """If the registry has a ``_hook_task`` awaitable, it must be awaited
+        before the agent loop runs.
 
-        Reva's plugin tools register asynchronously via `_hook_task`. Without
-        this await the agent loop reads the registry before plugin-registered
-        tools are present — intermittent "tool not found" failures on the
-        first orchestrated call after startup.
+        Reva's plugin tools register asynchronously via ``_hook_task``.
+        Without this await the agent loop reads the registry before
+        plugin-registered tools are present — intermittent "tool not found"
+        failures on the first orchestrated call after startup.
+
+        The test uses a custom awaitable whose ``__await__`` flips a flag
+        only when the orchestrator explicitly awaits it. An ``asyncio.Task``
+        would be unsuitable here: the event loop schedules tasks on the
+        next yield, and the orchestrator's other ``await`` calls
+        (``run_hooks`` for ``pre_sub_agent``) would let the task complete
+        even if our code never awaited ``_hook_task`` directly. The
+        custom awaitable closes that gap.
         """
         from services.agent_service import AgentStep
 
-        run_after_await = {"value": False}
-        await_observed = {"awaited": False}
+        events: list[str] = []
+
+        class _AwaitTracker:
+            """Awaitable that records when (and only when) it is explicitly awaited."""
+            def __init__(self):
+                self.awaited = False
+
+            def __await__(self):
+                self.awaited = True
+                events.append("hook_task_awaited")
+                # Empty generator — resolves immediately with no value.
+                if False:
+                    yield  # pragma: no cover
 
         primary = _make_role("release", servers=["release"])
         router = _make_router([primary])
         orchestrator = QueryOrchestrator(router, MagicMock())
 
-        async def _hook_task_coro():
-            await_observed["awaited"] = True
-
-        # Wrap as an awaitable Task so getattr returns it directly.
-        import asyncio as _asyncio
-        hook_task = _asyncio.create_task(_hook_task_coro())
+        hook_task = _AwaitTracker()
 
         async def _fake_run(*args, **kwargs):
-            run_after_await["value"] = await_observed["awaited"]
+            events.append("agent_run_called")
             yield AgentStep(step_number=1, step_type="final_answer", content="ok")
 
         class _Registry:
@@ -921,8 +936,77 @@ class TestSubAgentHooks:
                 _make_ollama("ok"), MagicMock(), "de",
             )
 
-        # The agent ran AFTER the hook_task was observed as awaited.
-        assert run_after_await["value"] is True
+        # The custom awaitable was actually awaited.
+        assert hook_task.awaited is True
+        # And it was awaited BEFORE the agent loop ran (strict ordering).
+        assert events.index("hook_task_awaited") < events.index("agent_run_called")
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_no_hook_task_attribute_does_not_raise(self):
+        """If the registry has no ``_hook_task`` attribute, the sub-agent runs cleanly."""
+        from services.agent_service import AgentStep
+
+        primary = _make_role("release", servers=["release"])
+        router = _make_router([primary])
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        async def _fake_run(*args, **kwargs):
+            yield AgentStep(step_number=1, step_type="final_answer", content="ok")
+
+        # Registry without the _hook_task attribute (vanilla AgentToolRegistry has no such field).
+        class _Registry:
+            pass
+
+        with patch("services.agent_service.AgentService") as MockAS, \
+             patch("services.agent_tools.AgentToolRegistry", return_value=_Registry()):
+            mock_agent = MagicMock()
+            mock_agent.run = _fake_run
+            MockAS.return_value = mock_agent
+
+            result = await orchestrator._run_sub_agent(
+                {"role": "release", "query": "status"},
+                _make_ollama("ok"), MagicMock(), "de",
+            )
+
+        assert result["answer"] == "ok"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_hook_task_failure_does_not_break_sub_agent(self):
+        """A raising ``_hook_task`` is logged and ignored — sub-agent still runs."""
+        from services.agent_service import AgentStep
+
+        async def _broken_hook_task():
+            raise RuntimeError("plugin tool registration failed")
+
+        primary = _make_role("release", servers=["release"])
+        router = _make_router([primary])
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        async def _fake_run(*args, **kwargs):
+            yield AgentStep(step_number=1, step_type="final_answer", content="ok")
+
+        import asyncio as _asyncio
+
+        class _Registry:
+            pass
+
+        registry_instance = _Registry()
+        registry_instance._hook_task = _asyncio.create_task(_broken_hook_task())
+
+        with patch("services.agent_service.AgentService") as MockAS, \
+             patch("services.agent_tools.AgentToolRegistry", return_value=registry_instance):
+            mock_agent = MagicMock()
+            mock_agent.run = _fake_run
+            MockAS.return_value = mock_agent
+
+            result = await orchestrator._run_sub_agent(
+                {"role": "release", "query": "status"},
+                _make_ollama("ok"), MagicMock(), "de",
+            )
+
+        assert result["answer"] == "ok"
 
     @pytest.mark.unit
     @pytest.mark.asyncio
@@ -1322,7 +1406,20 @@ class TestParallelExecution:
 # ============================================================================
 
 class TestVanillaRenfieldBackwardsCompat:
-    """With no plugins registered, behavior must match pre-uplift."""
+    """With no plugins registered, behavior must match pre-uplift.
+
+    These tests use *spy* handlers — registered hooks that record their
+    invocations and return ``None`` (i.e. they do not mutate any state).
+    Spies prove two properties at once:
+
+    1. The new hook fires *do* fire (they are wired up correctly).
+    2. With no state-mutating handler in place, the orchestrator's
+       behavior is unchanged from the pre-uplift baseline.
+
+    Asserting outcomes alone (e.g. "no card step") would be circumstantial
+    — those outcomes also hold if the hook fires don't fire at all. The
+    spies make the assertion direct.
+    """
 
     @pytest.fixture(autouse=True)
     def _clear_hooks(self):
@@ -1333,13 +1430,21 @@ class TestVanillaRenfieldBackwardsCompat:
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_no_extend_orchestrator_roles_handler_uses_default_set(self):
-        """Without a hook handler, planner sees only roles with has_agent_loop=True."""
+    async def test_extend_orchestrator_roles_fires_with_zero_handlers(self):
+        """The hook event fires with no handlers — default eligibility wins."""
+        from utils.hooks import register_hook
+
+        spy_calls: list[dict] = []
+
+        async def spy(**kw):
+            spy_calls.append(kw)
+            return None  # observation only — no role extension
+
+        register_hook("extend_orchestrator_roles", spy)
+
         smart = _make_role("smart_home", has_loop=True, servers=["homeassistant"])
-        # Roles without agent loops are skipped by default.
         chat = _make_role("conversation", has_loop=False)
         router = _make_router([smart, chat])
-
         ollama = _make_ollama("null")
         orchestrator = QueryOrchestrator(router, MagicMock())
 
@@ -1353,15 +1458,35 @@ class TestVanillaRenfieldBackwardsCompat:
 
             await orchestrator.detect_multi_domain("test", ollama)
 
+            # Spy received exactly one call — the hook fired.
+            assert len(spy_calls) == 1
+            assert "roles" in spy_calls[0] and "lang" in spy_calls[0]
+
+            # Default eligibility preserved (spy returned None → no extension).
             descriptions = pm.get.call_args.kwargs.get("role_descriptions", "")
             assert "smart_home" in descriptions
             assert "conversation" not in descriptions
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_no_pre_sub_agent_handler_keeps_default_registry(self):
-        """Without a pre_sub_agent handler, the registry is untouched between create and run."""
+    async def test_pre_and_post_sub_agent_each_fire_once_per_sub_agent(self):
+        """pre_sub_agent and post_sub_agent each fire exactly once per ``_run_sub_agent`` call."""
+        from utils.hooks import register_hook
         from services.agent_service import AgentStep
+
+        pre_calls: list[dict] = []
+        post_calls: list[dict] = []
+
+        async def pre_spy(**kw):
+            pre_calls.append(kw)
+            return None  # no mutation, no plugin_data contribution
+
+        async def post_spy(**kw):
+            post_calls.append(kw)
+            return None  # no plugin_data contribution
+
+        register_hook("pre_sub_agent", pre_spy)
+        register_hook("post_sub_agent", post_spy)
 
         primary = _make_role("release", servers=["release"])
         router = _make_router([primary])
@@ -1372,12 +1497,9 @@ class TestVanillaRenfieldBackwardsCompat:
 
         class _Registry:
             _hook_task = None
-            preselected = None  # default — no plugin mutation
-
-        registry_instance = _Registry()
 
         with patch("services.agent_service.AgentService") as MockAS, \
-             patch("services.agent_tools.AgentToolRegistry", return_value=registry_instance):
+             patch("services.agent_tools.AgentToolRegistry", return_value=_Registry()):
             mock_agent = MagicMock()
             mock_agent.run = _fake_run
             MockAS.return_value = mock_agent
@@ -1387,14 +1509,29 @@ class TestVanillaRenfieldBackwardsCompat:
                 _make_ollama("ok"), MagicMock(), "de",
             )
 
-        assert registry_instance.preselected is None
-        assert result["plugin_data"] == {}  # no post_sub_agent → empty
+        # Each hook fired exactly once (one sub-agent → one fire).
+        assert len(pre_calls) == 1
+        assert len(post_calls) == 1
+        # Post fires AFTER pre (state at post-fire reflects sub-agent completion).
+        assert pre_calls[0]["role"] == "release"
+        assert post_calls[0]["result"]["answer"] == "ok"
+        # Spy returned None → no plugin_data contribution → empty dict preserved.
+        assert result["plugin_data"] == {}
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_no_post_orchestration_handler_no_card_step(self):
-        """Without a post_orchestration handler, no card step is yielded."""
+    async def test_post_orchestration_fires_with_zero_handlers_no_card_step(self):
+        """post_orchestration fires once; with no handler returning a card, no card step yields."""
+        from utils.hooks import register_hook
         from services.agent_service import AgentStep
+
+        spy_calls: list[dict] = []
+
+        async def spy(**kw):
+            spy_calls.append(kw)
+            return None  # no card
+
+        register_hook("post_orchestration", spy)
 
         orchestrator = QueryOrchestrator(_make_router([]), MagicMock())
 
@@ -1413,7 +1550,171 @@ class TestVanillaRenfieldBackwardsCompat:
             ):
                 steps.append(step)
 
+        # Hook fired once.
+        assert len(spy_calls) == 1
+        # No card step yielded (spy returned None, no card payload).
         assert not any(s.step_type == "card" for s in steps)
+        # final_answer still streamed normally.
+        assert any(s.step_type == "final_answer" for s in steps)
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_pre_orchestration_does_not_fire_inside_run_orchestrated(self):
+        """``run_orchestrated`` no longer fires ``pre_orchestration`` itself.
+
+        The hook is owned by the upstream caller (chat_handler / Teams
+        transport) so plugins can inject a pre-computed plan before
+        sub_queries are determined. This test pins that contract: a
+        registered ``pre_orchestration`` handler is NOT called from
+        within ``run_orchestrated``.
+        """
+        from utils.hooks import register_hook
+        from services.agent_service import AgentStep
+
+        pre_calls: list[dict] = []
+
+        async def pre_spy(**kw):
+            pre_calls.append(kw)
+            return None
+
+        register_hook("pre_orchestration", pre_spy)
+
+        orchestrator = QueryOrchestrator(_make_router([]), MagicMock())
+
+        async def _empty(*args, **kwargs):
+            yield AgentStep(step_number=1, step_type="final_answer", content="ok")
+
+        with patch.object(orchestrator, "_run_parallel", _empty), \
+             patch("services.orchestrator.settings") as s:
+            s.agent_orchestrator_parallel = True
+
+            async for _ in orchestrator.run_orchestrated(
+                sub_queries=[{"role": "smart_home", "query": "x"}],
+                message="m", ollama=_make_ollama("ok"),
+                executor=MagicMock(), lang="de",
+            ):
+                pass
+
+        # The spy was registered but never invoked from inside run_orchestrated.
+        assert len(pre_calls) == 0
+
+
+# ============================================================================
+# Phase 1 (orchestrator-uplift) — sequential mode parity with parallel mode
+# ============================================================================
+
+class TestSequentialMode:
+    """``_run_sequential`` delegates to ``_run_sub_agent`` so the new hook
+    surface fires identically to parallel mode."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_hooks(self):
+        from utils.hooks import clear_hooks
+        clear_hooks()
+        yield
+        clear_hooks()
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_sequential_fires_pre_and_post_sub_agent(self):
+        """Sequential mode must fire the new hooks per sub-agent (parity with parallel)."""
+        from utils.hooks import register_hook
+
+        pre_calls: list[dict] = []
+        post_calls: list[dict] = []
+
+        async def pre_spy(**kw):
+            pre_calls.append(kw)
+            return None
+
+        async def post_spy(**kw):
+            post_calls.append(kw)
+            return None
+
+        register_hook("pre_sub_agent", pre_spy)
+        register_hook("post_sub_agent", post_spy)
+
+        smart = _make_role("smart_home", servers=["homeassistant"])
+        media = _make_role("media", servers=["jellyfin"])
+        router = _make_router([smart, media])
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        # Stub _run_sub_agent so the test focuses on hook firing — the
+        # real pre/post fires are exercised by TestSubAgentHooks. Here we
+        # only verify _run_sequential reaches them via delegation.
+        call_count = {"value": 0}
+
+        async def _fake_sub_agent(sq, *a, **kw):
+            call_count["value"] += 1
+            # Mimic real _run_sub_agent firing the hooks.
+            from utils.hooks import run_hooks
+            await run_hooks("pre_sub_agent", step=sq, role=sq["role"],
+                            tool_registry=MagicMock(), lang="de")
+            result = {
+                "role": sq["role"], "query": sq["query"],
+                "answer": "done", "steps": [], "plugin_data": {},
+            }
+            await run_hooks("post_sub_agent", step=sq, role=sq["role"],
+                            result=result, lang="de")
+            return result
+
+        async def _fake_combined(*a, **kw):
+            if False:
+                yield  # pragma: no cover
+
+        with patch.object(orchestrator, "_run_sub_agent", _fake_sub_agent), \
+             patch.object(orchestrator, "_emit_combined_answer", return_value=_fake_combined()):
+            sub_results: list[dict] = []
+            async for _ in orchestrator._run_sequential(
+                sub_queries=[
+                    {"role": "smart_home", "query": "Licht"},
+                    {"role": "media", "query": "Musik"},
+                ],
+                message="m", ollama=_make_ollama("ok"),
+                executor=MagicMock(), lang="de",
+                sub_results_out=sub_results,
+            ):
+                pass
+
+        # Both hooks fired twice (one per sub-agent), in the right order.
+        assert call_count["value"] == 2
+        assert len(pre_calls) == 2
+        assert len(post_calls) == 2
+        assert {c["role"] for c in pre_calls} == {"smart_home", "media"}
+        assert {c["role"] for c in post_calls} == {"smart_home", "media"}
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_sequential_collects_plugin_data(self):
+        """Sequential mode collects the same ``plugin_data`` shape as parallel."""
+        smart = _make_role("smart_home", servers=["homeassistant"])
+        router = _make_router([smart])
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        async def _fake_sub_agent(sq, *a, **kw):
+            return {
+                "role": sq["role"], "query": sq["query"],
+                "answer": "ok", "steps": [],
+                "plugin_data": {"contacts": [{"name": "Test"}]},
+            }
+
+        async def _fake_combined(*a, **kw):
+            if False:
+                yield  # pragma: no cover
+
+        with patch.object(orchestrator, "_run_sub_agent", _fake_sub_agent), \
+             patch.object(orchestrator, "_emit_combined_answer", return_value=_fake_combined()):
+            sub_results: list[dict] = []
+            async for _ in orchestrator._run_sequential(
+                sub_queries=[{"role": "smart_home", "query": "x"}],
+                message="m", ollama=_make_ollama("ok"),
+                executor=MagicMock(), lang="de",
+                sub_results_out=sub_results,
+            ):
+                pass
+
+        assert len(sub_results) == 1
+        assert sub_results[0]["plugin_data"] == {"contacts": [{"name": "Test"}]}
 
 
 # ============================================================================

--- a/tests/backend/test_orchestrator.py
+++ b/tests/backend/test_orchestrator.py
@@ -973,12 +973,65 @@ class TestSubAgentHooks:
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_hook_task_failure_does_not_break_sub_agent(self):
-        """A raising ``_hook_task`` is logged and ignored — sub-agent still runs."""
+    async def test_hook_task_failure_returns_failed_result(self):
+        """A raising ``_hook_task`` fails the sub-agent cleanly with a localized error.
+
+        Continuing with a half-populated registry would cause hard-to-diagnose
+        "tool not found" errors downstream that don't trace back to the
+        original hook_task failure. Better to surface the error here.
+        """
         from services.agent_service import AgentStep
 
         async def _broken_hook_task():
             raise RuntimeError("plugin tool registration failed")
+
+        primary = _make_role("release", servers=["release"])
+        router = _make_router([primary])
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        # The mock agent.run should NOT be called when hook_task fails.
+        agent_run_called = {"value": False}
+
+        async def _fake_run(*args, **kwargs):
+            agent_run_called["value"] = True
+            yield AgentStep(step_number=1, step_type="final_answer", content="ok")
+
+        import asyncio as _asyncio
+
+        class _Registry:
+            pass
+
+        registry_instance = _Registry()
+        registry_instance._hook_task = _asyncio.create_task(_broken_hook_task())
+
+        with patch("services.agent_service.AgentService") as MockAS, \
+             patch("services.agent_tools.AgentToolRegistry", return_value=registry_instance):
+            mock_agent = MagicMock()
+            mock_agent.run = _fake_run
+            MockAS.return_value = mock_agent
+
+            result = await orchestrator._run_sub_agent(
+                {"role": "release", "query": "status"},
+                _make_ollama("ok"), MagicMock(), "de",
+            )
+
+        # Sub-agent did NOT run (registry was broken).
+        assert agent_run_called["value"] is False
+        # Result has the canonical failure shape with a localized error.
+        assert result["answer"] == ""
+        assert result["error"] is not None
+        assert "release" in result["error"].lower() or "Tools" in result["error"]
+        assert result["plugin_data"] == {}
+        assert result["steps"] == []
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_hook_task_failure_localized_english(self):
+        """Localized error message picks English for ``lang='en'``."""
+        from services.agent_service import AgentStep
+
+        async def _broken_hook_task():
+            raise RuntimeError("registration failed")
 
         primary = _make_role("release", servers=["release"])
         router = _make_router([primary])
@@ -1003,10 +1056,10 @@ class TestSubAgentHooks:
 
             result = await orchestrator._run_sub_agent(
                 {"role": "release", "query": "status"},
-                _make_ollama("ok"), MagicMock(), "de",
+                _make_ollama("ok"), MagicMock(), "en",
             )
 
-        assert result["answer"] == "ok"
+        assert "failed to load" in result["error"]
 
     @pytest.mark.unit
     @pytest.mark.asyncio
@@ -1383,7 +1436,7 @@ class TestParallelExecution:
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_invalid_role_returns_empty_result_with_plugin_data(self):
-        """A sub-query referring to a role with no agent loop yields empty plugin_data."""
+        """A sub-query referring to a role with no agent loop yields the canonical failure shape."""
         primary = _make_role("release", has_loop=False, servers=["release"])
         router = _make_router([primary])
         orchestrator = QueryOrchestrator(router, MagicMock())
@@ -1393,11 +1446,11 @@ class TestParallelExecution:
             _make_ollama("ok"), MagicMock(), "de",
         )
 
-        # The early-return path (no agent loop) must still return the new
-        # plugin_data field so callers can blindly read result["plugin_data"].
+        # Early-return must include all canonical-shape keys (plugin_data,
+        # error) so downstream callers can blindly read them.
         assert result == {
             "role": "release", "query": "test",
-            "answer": "", "steps": [], "plugin_data": {},
+            "answer": "", "steps": [], "plugin_data": {}, "error": None,
         }
 
 
@@ -1718,22 +1771,404 @@ class TestSequentialMode:
 
 
 # ============================================================================
-# Phase 2 (Reva-side adaptation) — DEFERRED tests
+# Sub-query shape validation (B5 sink-side)
 # ============================================================================
-# The following test categories from the design's Phase 1 plan are deferred
-# to Phase 2 (Reva adaptation), because the corresponding code lives in the
-# Reva chat_handler integration path that does not yet exist:
-#
-# - check_output hook fires before WebSocket response sent (chat_handler-level)
-# - post_message hook fires after persistence (chat_handler-level)
-# - extract_context_vars hook fires for tool results (chat_handler-level;
-#   also requires adding extract_context_vars to HOOK_EVENTS)
-# - pre_orchestration unconditional fire from chat_handler (the wiring
-#   exists in chat_handler.py from this PR but the tests should run with a
-#   live WebSocket fixture which lives in the Reva e2e suite)
-# - Synthesizer _strip_llm_source_line regex (the function does not yet
-#   exist in Renfield's orchestrator — it is part of Reva's separate
-#   orchestrator and lands in Phase 2 when that file is deleted)
-# - Sub-agent prompts via role.prompt_key (no Renfield-side prompts exist
-#   for the orchestrator-eligible roles yet; Reva supplies them)
+
+class TestSubQueryValidation:
+    """Buggy plugin plans must not crash _run_sub_agent — return failed result."""
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_non_dict_subquery_returns_failed_result(self):
+        primary = _make_role("release", servers=["release"])
+        router = _make_router([primary])
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        # Plugin returned a string instead of a dict.
+        result = await orchestrator._run_sub_agent(
+            "this is not a dict",  # type: ignore[arg-type]
+            _make_ollama("ok"), MagicMock(), "de",
+        )
+
+        assert result["error"] is not None
+        assert "not a dict" in result["error"]
+        assert result["role"] == "?"
+        assert result["plugin_data"] == {}
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_subquery_missing_role_returns_failed_result(self):
+        primary = _make_role("release", servers=["release"])
+        router = _make_router([primary])
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        result = await orchestrator._run_sub_agent(
+            {"query": "no role key"},
+            _make_ollama("ok"), MagicMock(), "de",
+        )
+
+        assert result["error"] is not None
+        assert "missing role" in result["error"].lower()
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_subquery_missing_query_returns_failed_result(self):
+        primary = _make_role("release", servers=["release"])
+        router = _make_router([primary])
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        result = await orchestrator._run_sub_agent(
+            {"role": "release"},
+            _make_ollama("ok"), MagicMock(), "de",
+        )
+
+        assert result["error"] is not None
+        assert "missing role or query" in result["error"].lower()
+
+
+# ============================================================================
+# B4 — _emit_combined_answer "all sub-agents failed" branch
+# ============================================================================
+
+class TestEmitCombinedAllFailed:
+    """The all-failed branch must yield a localized final_answer step.
+
+    Returning silently here would leave full_response="", which gates
+    both the WebSocket final bubble AND DB persistence — losing the
+    whole turn including the user's message. Tests pin both languages.
+    """
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_all_failed_yields_localized_de_message(self):
+        orchestrator = QueryOrchestrator(_make_router([]), MagicMock())
+        ollama = _make_ollama("")
+
+        # All sub_results have empty answer (all-failed signal).
+        sub_results = [
+            _failed_sub_result_dict("smart_home", "Licht", "boom"),
+            _failed_sub_result_dict("media", "Musik", "boom"),
+        ]
+
+        steps = []
+        async for step in orchestrator._emit_combined_answer(
+            "msg", sub_results, ollama, "de",
+        ):
+            steps.append(step)
+
+        finals = [s for s in steps if s.step_type == "final_answer"]
+        assert len(finals) == 1
+        assert finals[0].content  # non-empty
+        # Localized — German indicators
+        assert any(token in finals[0].content.lower()
+                   for token in ("anfrage", "fehl", "leider", "konnte"))
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_all_failed_yields_localized_en_message(self):
+        orchestrator = QueryOrchestrator(_make_router([]), MagicMock())
+        ollama = _make_ollama("")
+
+        sub_results = [
+            _failed_sub_result_dict("smart_home", "lights", "boom"),
+            _failed_sub_result_dict("media", "music", "boom"),
+        ]
+
+        steps = []
+        async for step in orchestrator._emit_combined_answer(
+            "msg", sub_results, ollama, "en",
+        ):
+            steps.append(step)
+
+        finals = [s for s in steps if s.step_type == "final_answer"]
+        assert len(finals) == 1
+        assert finals[0].content  # non-empty
+
+
+def _failed_sub_result_dict(role: str, query: str, error: str | None = None) -> dict:
+    """Local helper mirroring orchestrator._failed_sub_result for test setup."""
+    from services.orchestrator import _failed_sub_result
+    return _failed_sub_result(role, query, error=error)
+
+
+# ============================================================================
+# I4 — list-shaped plugin_data fields are concatenated, not overwritten
+# ============================================================================
+
+class TestPluginDataMergeSemantics:
+    """post_sub_agent contributions: list-shaped fields concatenate; non-list
+    fields follow last-writer-wins with a warning."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_hooks(self):
+        from utils.hooks import clear_hooks
+        clear_hooks()
+        yield
+        clear_hooks()
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_list_shaped_field_concatenated_across_handlers(self):
+        """Two handlers contributing to ``contacts`` produce a merged list."""
+        from utils.hooks import register_hook
+        from services.agent_service import AgentStep
+
+        async def first(**kw):
+            return {"contacts": [{"name": "Alice"}]}
+
+        async def second(**kw):
+            return {"contacts": [{"name": "Bob"}]}
+
+        register_hook("post_sub_agent", first)
+        register_hook("post_sub_agent", second)
+
+        primary = _make_role("release", servers=["release"])
+        router = _make_router([primary])
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        async def _fake_run(*args, **kwargs):
+            yield AgentStep(step_number=1, step_type="final_answer", content="ok")
+
+        with patch("services.agent_service.AgentService") as MockAS, \
+             patch("services.agent_tools.AgentToolRegistry") as MockReg:
+            mock_agent = MagicMock()
+            mock_agent.run = _fake_run
+            MockAS.return_value = mock_agent
+            mock_registry = MagicMock()
+            mock_registry._hook_task = None
+            MockReg.return_value = mock_registry
+
+            result = await orchestrator._run_sub_agent(
+                {"role": "release", "query": "status"},
+                _make_ollama("ok"), MagicMock(), "de",
+            )
+
+        # BOTH contacts present — not last-writer-wins.
+        names = [c["name"] for c in result["plugin_data"]["contacts"]]
+        assert names == ["Alice", "Bob"]
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_non_list_field_collision_last_writer_wins(self):
+        """Non-list keys: second handler overwrites first."""
+        from utils.hooks import register_hook
+        from services.agent_service import AgentStep
+
+        async def first(**kw):
+            return {"telemetry_run_id": "run-1"}
+
+        async def second(**kw):
+            return {"telemetry_run_id": "run-2"}
+
+        register_hook("post_sub_agent", first)
+        register_hook("post_sub_agent", second)
+
+        primary = _make_role("release", servers=["release"])
+        router = _make_router([primary])
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        async def _fake_run(*args, **kwargs):
+            yield AgentStep(step_number=1, step_type="final_answer", content="ok")
+
+        with patch("services.agent_service.AgentService") as MockAS, \
+             patch("services.agent_tools.AgentToolRegistry") as MockReg:
+            mock_agent = MagicMock()
+            mock_agent.run = _fake_run
+            MockAS.return_value = mock_agent
+            mock_registry = MagicMock()
+            mock_registry._hook_task = None
+            MockReg.return_value = mock_registry
+
+            result = await orchestrator._run_sub_agent(
+                {"role": "release", "query": "status"},
+                _make_ollama("ok"), MagicMock(), "de",
+            )
+
+        assert result["plugin_data"]["telemetry_run_id"] == "run-2"
+
+
+# ============================================================================
+# I7 — extend_orchestrator_roles caching
+# ============================================================================
+
+class TestExtendOrchestratorRolesCaching:
+    """The hook fires once per QueryOrchestrator lifetime, not per request."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_hooks(self):
+        from utils.hooks import clear_hooks
+        clear_hooks()
+        yield
+        clear_hooks()
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_extend_orchestrator_roles_cached_after_first_call(self):
+        from utils.hooks import register_hook
+
+        call_count = {"value": 0}
+
+        async def counting_handler(**kw):
+            call_count["value"] += 1
+            return None
+
+        register_hook("extend_orchestrator_roles", counting_handler)
+
+        smart = _make_role("smart_home", servers=["homeassistant"])
+        router = _make_router([smart])
+        ollama = _make_ollama("null")
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        with patch("services.orchestrator.prompt_manager") as pm, \
+             patch("services.orchestrator.settings") as s, \
+             patch("services.orchestrator.get_classification_chat_kwargs", return_value={}):
+            pm.get.return_value = "detect prompt"
+            s.agent_ollama_url = None
+            s.ollama_model = "test-model"
+            s.agent_router_timeout = 10.0
+
+            # Three detect calls — the hook should fire only once.
+            await orchestrator.detect_multi_domain("a", ollama)
+            await orchestrator.detect_multi_domain("b", ollama)
+            await orchestrator.detect_multi_domain("c", ollama)
+
+        assert call_count["value"] == 1
+
+
+# ============================================================================
+# typing_callback (design Resolved-Q2)
+# ============================================================================
+
+class TestTypingCallback:
+    """run_orchestrated invokes typing_callback once before sub-agents launch."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_hooks(self):
+        from utils.hooks import clear_hooks
+        clear_hooks()
+        yield
+        clear_hooks()
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_typing_callback_fires_before_sub_agents(self):
+        from services.agent_service import AgentStep
+
+        events: list[str] = []
+
+        async def typing_cb():
+            events.append("typing")
+
+        orchestrator = QueryOrchestrator(_make_router([]), MagicMock())
+
+        async def _empty_runner(*args, **kwargs):
+            events.append("sub_agents")
+            yield AgentStep(step_number=1, step_type="final_answer", content="ok")
+
+        with patch.object(orchestrator, "_run_parallel", _empty_runner), \
+             patch("services.orchestrator.settings") as s:
+            s.agent_orchestrator_parallel = True
+
+            async for _ in orchestrator.run_orchestrated(
+                sub_queries=[{"role": "smart_home", "query": "x"}],
+                message="m", ollama=_make_ollama("ok"),
+                executor=MagicMock(), lang="de",
+                typing_callback=typing_cb,
+            ):
+                pass
+
+        assert events == ["typing", "sub_agents"]
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_typing_callback_failure_does_not_break_orchestration(self):
+        from services.agent_service import AgentStep
+
+        async def broken_typing():
+            raise RuntimeError("websocket dead")
+
+        orchestrator = QueryOrchestrator(_make_router([]), MagicMock())
+
+        async def _empty(*args, **kwargs):
+            yield AgentStep(step_number=1, step_type="final_answer", content="ok")
+
+        with patch.object(orchestrator, "_run_parallel", _empty), \
+             patch("services.orchestrator.settings") as s:
+            s.agent_orchestrator_parallel = True
+
+            steps = []
+            async for step in orchestrator.run_orchestrated(
+                sub_queries=[{"role": "smart_home", "query": "x"}],
+                message="m", ollama=_make_ollama("ok"),
+                executor=MagicMock(), lang="de",
+                typing_callback=broken_typing,
+            ):
+                steps.append(step)
+
+        # Orchestration completed despite typing_callback failure.
+        assert any(s.step_type == "final_answer" for s in steps)
+
+
+# ============================================================================
+# post_sub_agent fires after agent.run crash (try/finally semantics)
+# ============================================================================
+
+class TestPostSubAgentFiresAfterCrash:
+    """post_sub_agent must fire even when agent.run raises mid-stream."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_hooks(self):
+        from utils.hooks import clear_hooks
+        clear_hooks()
+        yield
+        clear_hooks()
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_post_sub_agent_fires_on_agent_run_crash(self):
+        """If agent.run raises after pre_sub_agent fired, post must still fire so
+        plugin accumulators (contacts, provenance) get drained instead of leaking."""
+        from utils.hooks import register_hook
+
+        post_calls: list[dict] = []
+
+        async def post_spy(**kw):
+            post_calls.append(kw)
+            return None
+
+        register_hook("post_sub_agent", post_spy)
+
+        primary = _make_role("release", servers=["release"])
+        router = _make_router([primary])
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        async def _crashing_run(*args, **kwargs):
+            # Yield one tool_call step before crashing — simulates partial work.
+            from services.agent_service import AgentStep
+            yield AgentStep(step_number=1, step_type="tool_call", tool="t1")
+            raise RuntimeError("agent crashed mid-stream")
+
+        with patch("services.agent_service.AgentService") as MockAS, \
+             patch("services.agent_tools.AgentToolRegistry") as MockReg:
+            mock_agent = MagicMock()
+            mock_agent.run = _crashing_run
+            MockAS.return_value = mock_agent
+            mock_registry = MagicMock()
+            mock_registry._hook_task = None
+            MockReg.return_value = mock_registry
+
+            result = await orchestrator._run_sub_agent(
+                {"role": "release", "query": "status"},
+                _make_ollama("ok"), MagicMock(), "de",
+            )
+
+        # post_sub_agent fired despite agent.run crashing.
+        assert len(post_calls) == 1
+        # The result reflects the crash via the error field.
+        assert result["error"] is not None
+        assert "agent crashed" in result["error"]
+
+
+# ============================================================================
+# Phase 1 (orchestrator-uplift) — backwards compat: vanilla Renfield deploy
 # ============================================================================

--- a/tests/backend/test_orchestrator.py
+++ b/tests/backend/test_orchestrator.py
@@ -262,8 +262,16 @@ class TestOrchestrationHooks:
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_pre_and_post_hooks_fire(self):
-        """Both hook events fire with the expected kwargs."""
+    async def test_post_hook_fires(self):
+        """post_orchestration fires with synthesized final_answer + sub_results.
+
+        Note: pre_orchestration does NOT fire inside ``run_orchestrated``.
+        It is fired upstream by the caller (chat_handler / Teams transport)
+        before sub_queries are determined, so plugins can inject a
+        pre-computed plan. Firing again here would create double-firing
+        semantics handlers would have to guard against. See the
+        orchestrator-uplift design doc for the rationale.
+        """
         from utils.hooks import register_hook
         from services.agent_service import AgentStep
 
@@ -299,10 +307,8 @@ class TestOrchestrationHooks:
             ):
                 steps.append(step)
 
-        assert len(captured["pre"]) == 1
-        assert captured["pre"][0]["message"] == "Mach Licht an und spiel Musik"
-        assert captured["pre"][0]["lang"] == "de"
-        assert "plan" in captured["pre"][0]
+        # pre_orchestration is NOT fired inside run_orchestrated anymore.
+        assert len(captured["pre"]) == 0
 
         assert len(captured["post"]) == 1
         assert captured["post"][0]["message"] == "Mach Licht an und spiel Musik"
@@ -529,3 +535,904 @@ class TestRunSubAgentListData:
 
         assert result["steps"][0].data["sub_agent_role"] == "release"
         assert result["steps"][0].data["id"] == "REL-100"
+
+
+# ============================================================================
+# Phase 1 (orchestrator-uplift) — extend_orchestrator_roles hook
+# ============================================================================
+
+class TestExtendOrchestratorRolesHook:
+    """Plugins can extend the planner's role list via extend_orchestrator_roles."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_hooks(self):
+        from utils.hooks import clear_hooks
+        clear_hooks()
+        yield
+        clear_hooks()
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_handler_role_names_added_to_planner_prompt(self):
+        """A handler returning extra role names must merge them into the role list."""
+        from utils.hooks import register_hook
+
+        # Two roles: smart_home (has_loop=True) and release (has_loop=False, would
+        # be excluded by the default agent-loop filter). The hook adds "release"
+        # so it appears in the planner prompt.
+        smart = _make_role("smart_home", has_loop=True, servers=["homeassistant"])
+        release = _make_role("release", has_loop=False, servers=["release"])
+        router = _make_router([smart, release])
+
+        async def role_extender(**kw):
+            return {"release"}
+
+        register_hook("extend_orchestrator_roles", role_extender)
+
+        ollama = _make_ollama("null")
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        with patch("services.orchestrator.prompt_manager") as pm, \
+             patch("services.orchestrator.settings") as s, \
+             patch("services.orchestrator.get_classification_chat_kwargs", return_value={}):
+            pm.get.return_value = "detect prompt"
+            s.agent_ollama_url = None
+            s.ollama_model = "test-model"
+            s.agent_router_timeout = 10.0
+
+            await orchestrator.detect_multi_domain("test", ollama)
+
+            # Inspect the kwargs passed to prompt_manager.get — role_descriptions
+            # should mention BOTH smart_home and release even though release has
+            # no agent loop.
+            kwargs = pm.get.call_args.kwargs
+            descriptions = kwargs.get("role_descriptions", "")
+            assert "smart_home" in descriptions
+            assert "release" in descriptions
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_handler_unknown_role_name_silently_ignored(self):
+        """Names that don't exist in router.roles must be dropped without error."""
+        from utils.hooks import register_hook
+
+        smart = _make_role("smart_home", has_loop=True, servers=["homeassistant"])
+        router = _make_router([smart])
+
+        async def role_extender(**kw):
+            return {"smart_home", "made_up_role_name", "another_unknown"}
+
+        register_hook("extend_orchestrator_roles", role_extender)
+
+        ollama = _make_ollama("null")
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        with patch("services.orchestrator.prompt_manager") as pm, \
+             patch("services.orchestrator.settings") as s, \
+             patch("services.orchestrator.get_classification_chat_kwargs", return_value={}):
+            pm.get.return_value = "detect prompt"
+            s.agent_ollama_url = None
+            s.ollama_model = "test-model"
+            s.agent_router_timeout = 10.0
+
+            await orchestrator.detect_multi_domain("test", ollama)
+
+            descriptions = pm.get.call_args.kwargs.get("role_descriptions", "")
+            assert "smart_home" in descriptions
+            assert "made_up_role_name" not in descriptions
+            assert "another_unknown" not in descriptions
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_handler_non_iterable_return_does_not_crash(self):
+        """A misbehaving handler returning a non-iterable must be ignored."""
+        from utils.hooks import register_hook
+
+        smart = _make_role("smart_home", has_loop=True, servers=["homeassistant"])
+        router = _make_router([smart])
+
+        async def bad_extender(**kw):
+            return 42  # non-iterable, non-None
+
+        register_hook("extend_orchestrator_roles", bad_extender)
+
+        ollama = _make_ollama("null")
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        with patch("services.orchestrator.prompt_manager") as pm, \
+             patch("services.orchestrator.settings") as s, \
+             patch("services.orchestrator.get_classification_chat_kwargs", return_value={}):
+            pm.get.return_value = "detect prompt"
+            s.agent_ollama_url = None
+            s.ollama_model = "test-model"
+            s.agent_router_timeout = 10.0
+
+            # Must not raise — non-iterable handler return is logged and ignored.
+            result = await orchestrator.detect_multi_domain("test", ollama)
+            assert result is None  # planner returned "null"
+
+            descriptions = pm.get.call_args.kwargs.get("role_descriptions", "")
+            assert "smart_home" in descriptions  # default eligibility still applies
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_handler_returns_none_uses_default_set(self):
+        """A handler returning None means 'no extension' — default eligibility wins."""
+        from utils.hooks import register_hook
+
+        smart = _make_role("smart_home", has_loop=True, servers=["homeassistant"])
+        media = _make_role("media", has_loop=True, servers=["jellyfin"])
+        router = _make_router([smart, media])
+
+        async def noop_extender(**kw):
+            return None
+
+        register_hook("extend_orchestrator_roles", noop_extender)
+
+        ollama = _make_ollama("null")
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        with patch("services.orchestrator.prompt_manager") as pm, \
+             patch("services.orchestrator.settings") as s, \
+             patch("services.orchestrator.get_classification_chat_kwargs", return_value={}):
+            pm.get.return_value = "detect prompt"
+            s.agent_ollama_url = None
+            s.ollama_model = "test-model"
+            s.agent_router_timeout = 10.0
+
+            await orchestrator.detect_multi_domain("test", ollama)
+
+            descriptions = pm.get.call_args.kwargs.get("role_descriptions", "")
+            assert "smart_home" in descriptions
+            assert "media" in descriptions
+
+
+# ============================================================================
+# Phase 1 (orchestrator-uplift) — pre_sub_agent / post_sub_agent hooks
+# ============================================================================
+
+class TestSubAgentHooks:
+    """``_run_sub_agent`` fires pre_sub_agent (with mutable tool_registry) and
+    post_sub_agent (whose return-dicts merge into result.plugin_data)."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_hooks(self):
+        from utils.hooks import clear_hooks
+        clear_hooks()
+        yield
+        clear_hooks()
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_pre_sub_agent_fires_with_step_role_registry(self):
+        """pre_sub_agent receives the step dict, role name, and tool_registry."""
+        from utils.hooks import register_hook
+        from services.agent_service import AgentStep
+
+        captured = []
+
+        async def pre_handler(**kw):
+            captured.append(kw)
+            return None
+
+        register_hook("pre_sub_agent", pre_handler)
+
+        primary = _make_role("smart_home", servers=["homeassistant"])
+        router = _make_router([primary])
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        async def _fake_run(*args, **kwargs):
+            yield AgentStep(step_number=1, step_type="final_answer", content="done")
+
+        with patch("services.agent_service.AgentService") as MockAS, \
+             patch("services.agent_tools.AgentToolRegistry") as MockReg:
+            mock_agent = MagicMock()
+            mock_agent.run = _fake_run
+            MockAS.return_value = mock_agent
+            mock_registry = MagicMock()
+            mock_registry._hook_task = None
+            MockReg.return_value = mock_registry
+
+            await orchestrator._run_sub_agent(
+                {"role": "smart_home", "query": "Mach Licht an"},
+                _make_ollama("ok"), MagicMock(), "de",
+            )
+
+        assert len(captured) == 1
+        assert captured[0]["step"] == {"role": "smart_home", "query": "Mach Licht an"}
+        assert captured[0]["role"] == "smart_home"
+        assert captured[0]["tool_registry"] is not None
+        assert captured[0]["lang"] == "de"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_post_sub_agent_fires_with_completed_result(self):
+        """post_sub_agent receives the populated result dict (role, query, answer, steps)."""
+        from utils.hooks import register_hook
+        from services.agent_service import AgentStep
+
+        captured = []
+
+        async def post_handler(**kw):
+            captured.append(kw)
+            return None
+
+        register_hook("post_sub_agent", post_handler)
+
+        primary = _make_role("media", servers=["jellyfin"])
+        router = _make_router([primary])
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        async def _fake_run(*args, **kwargs):
+            yield AgentStep(step_number=1, step_type="final_answer", content="abgespielt")
+
+        with patch("services.agent_service.AgentService") as MockAS, \
+             patch("services.agent_tools.AgentToolRegistry") as MockReg:
+            mock_agent = MagicMock()
+            mock_agent.run = _fake_run
+            MockAS.return_value = mock_agent
+            mock_registry = MagicMock()
+            mock_registry._hook_task = None
+            MockReg.return_value = mock_registry
+
+            await orchestrator._run_sub_agent(
+                {"role": "media", "query": "Spiel Musik"},
+                _make_ollama("ok"), MagicMock(), "de",
+            )
+
+        assert len(captured) == 1
+        result = captured[0]["result"]
+        assert result["role"] == "media"
+        assert result["query"] == "Spiel Musik"
+        assert result["answer"] == "abgespielt"
+        assert len(result["steps"]) == 1
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_post_sub_agent_return_dicts_merged_into_plugin_data(self):
+        """Each handler's return-dict is merged into result.plugin_data."""
+        from utils.hooks import register_hook
+        from services.agent_service import AgentStep
+
+        async def first(**kw):
+            return {"contacts": [{"name": "Alice"}]}
+
+        async def second(**kw):
+            return {"provenance": ["release@1.3.5"]}
+
+        async def third(**kw):
+            return None  # non-dict return values are skipped
+
+        register_hook("post_sub_agent", first)
+        register_hook("post_sub_agent", second)
+        register_hook("post_sub_agent", third)
+
+        primary = _make_role("release", servers=["release"])
+        router = _make_router([primary])
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        async def _fake_run(*args, **kwargs):
+            yield AgentStep(step_number=1, step_type="final_answer", content="ok")
+
+        with patch("services.agent_service.AgentService") as MockAS, \
+             patch("services.agent_tools.AgentToolRegistry") as MockReg:
+            mock_agent = MagicMock()
+            mock_agent.run = _fake_run
+            MockAS.return_value = mock_agent
+            mock_registry = MagicMock()
+            mock_registry._hook_task = None
+            MockReg.return_value = mock_registry
+
+            result = await orchestrator._run_sub_agent(
+                {"role": "release", "query": "status"},
+                _make_ollama("ok"), MagicMock(), "de",
+            )
+
+        assert result["plugin_data"] == {
+            "contacts": [{"name": "Alice"}],
+            "provenance": ["release@1.3.5"],
+        }
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_pre_sub_agent_can_mutate_tool_registry(self):
+        """A handler can mutate the per-task registry (e.g. tool pre-selection)."""
+        from utils.hooks import register_hook
+        from services.agent_service import AgentStep
+
+        async def preselect_handler(**kw):
+            registry = kw["tool_registry"]
+            # Simulate a tool-pre-selection mutation.
+            registry.preselected = ["get_release", "list_releases"]
+            return None
+
+        register_hook("pre_sub_agent", preselect_handler)
+
+        primary = _make_role("release", servers=["release"])
+        router = _make_router([primary])
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        async def _fake_run(*args, **kwargs):
+            yield AgentStep(step_number=1, step_type="final_answer", content="ok")
+
+        # Use a real namespace object so attribute mutation sticks.
+        class _Registry:
+            _hook_task = None
+
+        registry_instance = _Registry()
+
+        with patch("services.agent_service.AgentService") as MockAS, \
+             patch("services.agent_tools.AgentToolRegistry", return_value=registry_instance):
+            mock_agent = MagicMock()
+            mock_agent.run = _fake_run
+            MockAS.return_value = mock_agent
+
+            await orchestrator._run_sub_agent(
+                {"role": "release", "query": "status"},
+                _make_ollama("ok"), MagicMock(), "de",
+            )
+
+        assert registry_instance.preselected == ["get_release", "list_releases"]
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_hook_task_awaited_before_agent_run(self):
+        """If the registry has a `_hook_task` future, it must be awaited first.
+
+        Reva's plugin tools register asynchronously via `_hook_task`. Without
+        this await the agent loop reads the registry before plugin-registered
+        tools are present — intermittent "tool not found" failures on the
+        first orchestrated call after startup.
+        """
+        from services.agent_service import AgentStep
+
+        run_after_await = {"value": False}
+        await_observed = {"awaited": False}
+
+        primary = _make_role("release", servers=["release"])
+        router = _make_router([primary])
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        async def _hook_task_coro():
+            await_observed["awaited"] = True
+
+        # Wrap as an awaitable Task so getattr returns it directly.
+        import asyncio as _asyncio
+        hook_task = _asyncio.create_task(_hook_task_coro())
+
+        async def _fake_run(*args, **kwargs):
+            run_after_await["value"] = await_observed["awaited"]
+            yield AgentStep(step_number=1, step_type="final_answer", content="ok")
+
+        class _Registry:
+            pass
+
+        registry_instance = _Registry()
+        registry_instance._hook_task = hook_task
+
+        with patch("services.agent_service.AgentService") as MockAS, \
+             patch("services.agent_tools.AgentToolRegistry", return_value=registry_instance):
+            mock_agent = MagicMock()
+            mock_agent.run = _fake_run
+            MockAS.return_value = mock_agent
+
+            await orchestrator._run_sub_agent(
+                {"role": "release", "query": "status"},
+                _make_ollama("ok"), MagicMock(), "de",
+            )
+
+        # The agent ran AFTER the hook_task was observed as awaited.
+        assert run_after_await["value"] is True
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_pre_sub_agent_failure_does_not_break_sub_agent(self):
+        """A raising pre_sub_agent is logged and ignored — the agent still runs."""
+        from utils.hooks import register_hook
+        from services.agent_service import AgentStep
+
+        async def broken(**kw):
+            raise RuntimeError("preselect failed")
+
+        register_hook("pre_sub_agent", broken)
+
+        primary = _make_role("release", servers=["release"])
+        router = _make_router([primary])
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        async def _fake_run(*args, **kwargs):
+            yield AgentStep(step_number=1, step_type="final_answer", content="ok")
+
+        with patch("services.agent_service.AgentService") as MockAS, \
+             patch("services.agent_tools.AgentToolRegistry") as MockReg:
+            mock_agent = MagicMock()
+            mock_agent.run = _fake_run
+            MockAS.return_value = mock_agent
+            mock_registry = MagicMock()
+            mock_registry._hook_task = None
+            MockReg.return_value = mock_registry
+
+            result = await orchestrator._run_sub_agent(
+                {"role": "release", "query": "status"},
+                _make_ollama("ok"), MagicMock(), "de",
+            )
+
+        assert result["answer"] == "ok"  # sub-agent still completed
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_post_sub_agent_failure_does_not_break_sub_agent(self):
+        """A raising post_sub_agent leaves plugin_data empty but doesn't crash."""
+        from utils.hooks import register_hook
+        from services.agent_service import AgentStep
+
+        async def broken(**kw):
+            raise RuntimeError("drain failed")
+
+        register_hook("post_sub_agent", broken)
+
+        primary = _make_role("release", servers=["release"])
+        router = _make_router([primary])
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        async def _fake_run(*args, **kwargs):
+            yield AgentStep(step_number=1, step_type="final_answer", content="ok")
+
+        with patch("services.agent_service.AgentService") as MockAS, \
+             patch("services.agent_tools.AgentToolRegistry") as MockReg:
+            mock_agent = MagicMock()
+            mock_agent.run = _fake_run
+            MockAS.return_value = mock_agent
+            mock_registry = MagicMock()
+            mock_registry._hook_task = None
+            MockReg.return_value = mock_registry
+
+            result = await orchestrator._run_sub_agent(
+                {"role": "release", "query": "status"},
+                _make_ollama("ok"), MagicMock(), "de",
+            )
+
+        assert result["answer"] == "ok"
+        assert result["plugin_data"] == {}
+
+
+# ============================================================================
+# Phase 1 (orchestrator-uplift) — extended planner detection coverage
+# ============================================================================
+
+class TestPlannerDetectionExtended:
+    """Coverage gaps from the design's Phase 1 test plan."""
+
+    def _patch(self, pm, s):
+        pm.get.return_value = "detect prompt"
+        s.agent_ollama_url = None
+        s.ollama_model = "test-model"
+        s.agent_router_timeout = 10.0
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_three_role_plan_detected(self):
+        """Planner can return a 3-role plan."""
+        roles = [
+            _make_role("release", servers=["release"]),
+            _make_role("jira", servers=["jira"]),
+            _make_role("confluence", servers=["confluence"]),
+        ]
+        router = _make_router(roles)
+        response = json.dumps([
+            {"role": "release", "query": "Status Release 1.3.5"},
+            {"role": "jira", "query": "Jira-Tickets zu 1.3.5"},
+            {"role": "confluence", "query": "Doku zu 1.3.5"},
+        ])
+        ollama = _make_ollama(response)
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        with patch("services.orchestrator.prompt_manager") as pm, \
+             patch("services.orchestrator.settings") as s, \
+             patch("services.orchestrator.get_classification_chat_kwargs", return_value={}):
+            self._patch(pm, s)
+            result = await orchestrator.detect_multi_domain("Bericht 1.3.5", ollama)
+
+        assert result is not None
+        assert {sq["role"] for sq in result} == {"release", "jira", "confluence"}
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_four_role_plan_detected(self):
+        """Planner can return a 4-role plan (release + jira + itsm + confluence)."""
+        roles = [
+            _make_role("release", servers=["release"]),
+            _make_role("jira", servers=["jira"]),
+            _make_role("itsm", servers=["itsm"]),
+            _make_role("confluence", servers=["confluence"]),
+        ]
+        router = _make_router(roles)
+        response = json.dumps([
+            {"role": "release", "query": "Status"},
+            {"role": "jira", "query": "Tickets"},
+            {"role": "itsm", "query": "Incidents"},
+            {"role": "confluence", "query": "Doku"},
+        ])
+        ollama = _make_ollama(response)
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        with patch("services.orchestrator.prompt_manager") as pm, \
+             patch("services.orchestrator.settings") as s, \
+             patch("services.orchestrator.get_classification_chat_kwargs", return_value={}):
+            self._patch(pm, s)
+            result = await orchestrator.detect_multi_domain(
+                "Vollständiger Status für 1.3.5", ollama,
+            )
+
+        assert result is not None
+        assert len(result) == 4
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_explicit_null_sentinel_returns_none(self):
+        """The planner may emit the literal string 'null' to mean single-role."""
+        roles = [_make_role("release"), _make_role("jira")]
+        router = _make_router(roles)
+        ollama = _make_ollama("null")
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        with patch("services.orchestrator.prompt_manager") as pm, \
+             patch("services.orchestrator.settings") as s, \
+             patch("services.orchestrator.get_classification_chat_kwargs", return_value={}):
+            self._patch(pm, s)
+            result = await orchestrator.detect_multi_domain("test", ollama)
+
+        assert result is None
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_empty_response_returns_none(self):
+        """An empty model response is treated as single-role."""
+        roles = [_make_role("release"), _make_role("jira")]
+        router = _make_router(roles)
+        ollama = _make_ollama("")
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        with patch("services.orchestrator.prompt_manager") as pm, \
+             patch("services.orchestrator.settings") as s, \
+             patch("services.orchestrator.get_classification_chat_kwargs", return_value={}):
+            self._patch(pm, s)
+            result = await orchestrator.detect_multi_domain("test", ollama)
+
+        assert result is None
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_truncated_json_in_prose_returns_none(self):
+        """Truncated JSON (no closing bracket) is rejected gracefully."""
+        roles = [_make_role("release", servers=["release"]), _make_role("jira", servers=["jira"])]
+        router = _make_router(roles)
+        # Closing bracket missing — extractor finds no `]`.
+        truncated = '[{"role": "release", "query": "Status"}, {"role": "jira"'
+        ollama = _make_ollama(truncated)
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        with patch("services.orchestrator.prompt_manager") as pm, \
+             patch("services.orchestrator.settings") as s, \
+             patch("services.orchestrator.get_classification_chat_kwargs", return_value={}):
+            self._patch(pm, s)
+            result = await orchestrator.detect_multi_domain("test", ollama)
+
+        assert result is None
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_backslash_in_query_field_handled(self):
+        """JSON with backslash-escaped characters in the query field parses cleanly."""
+        roles = [_make_role("release", servers=["release"]), _make_role("jira", servers=["jira"])]
+        router = _make_router(roles)
+        # Query string contains an escaped quote — must round-trip through json.loads.
+        response = '[{"role": "release", "query": "Pfad mit \\"Quotes\\""}, ' \
+                   '{"role": "jira", "query": "Tickets"}]'
+        ollama = _make_ollama(response)
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        with patch("services.orchestrator.prompt_manager") as pm, \
+             patch("services.orchestrator.settings") as s, \
+             patch("services.orchestrator.get_classification_chat_kwargs", return_value={}):
+            self._patch(pm, s)
+            result = await orchestrator.detect_multi_domain("test", ollama)
+
+        assert result is not None
+        assert len(result) == 2
+        assert "Quotes" in result[0]["query"]
+
+
+# ============================================================================
+# Phase 1 (orchestrator-uplift) — parallel sub-agent execution + isolation
+# ============================================================================
+
+class TestParallelExecution:
+    """``_run_parallel`` covers error isolation and partial-failure metadata."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_hooks(self):
+        from utils.hooks import clear_hooks
+        clear_hooks()
+        yield
+        clear_hooks()
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_one_failing_sub_agent_does_not_kill_others(self):
+        """If one sub-agent raises, the other still completes and yields its answer."""
+        from services.agent_service import AgentStep
+
+        smart = _make_role("smart_home", servers=["homeassistant"])
+        media = _make_role("media", servers=["jellyfin"])
+        router = _make_router([smart, media])
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        async def _ok(sq, *a, **kw):
+            return {
+                "role": sq["role"], "query": sq["query"], "answer": "done",
+                "steps": [AgentStep(step_number=1, step_type="final_answer", content="done")],
+                "plugin_data": {},
+            }
+
+        async def _boom(sq, *a, **kw):
+            raise RuntimeError("sub-agent failed")
+
+        # First call returns OK, second raises — using gather so this exercises
+        # the return_exceptions=True branch.
+        async def _fake(sq, *args, **kwargs):
+            if sq["role"] == "media":
+                return await _boom(sq)
+            return await _ok(sq)
+
+        sub_results: list[dict] = []
+        with patch.object(orchestrator, "_run_sub_agent", _fake), \
+             patch.object(orchestrator, "_emit_combined_answer") as ec:
+            async def _empty_combined(*a, **kw):
+                if False:
+                    yield  # pragma: no cover — generator stub
+            ec.return_value = _empty_combined()
+
+            steps = []
+            async for step in orchestrator._run_parallel(
+                sub_queries=[
+                    {"role": "smart_home", "query": "Licht an"},
+                    {"role": "media", "query": "Musik"},
+                ],
+                message="m", ollama=_make_ollama("ok"),
+                executor=MagicMock(), lang="de",
+                sub_results_out=sub_results,
+            ):
+                steps.append(step)
+
+        # The failing sub-agent emits an error step but doesn't stop the other.
+        error_steps = [s for s in steps if s.step_type == "error"]
+        assert len(error_steps) == 1
+        assert "media" in error_steps[0].content
+        # Both sub-results recorded (even the failed one — with empty answer).
+        assert len(sub_results) == 2
+        assert any(r["role"] == "smart_home" and r["answer"] == "done" for r in sub_results)
+        assert any(r["role"] == "media" and r["answer"] == "" for r in sub_results)
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_all_sub_agents_succeed_collects_all_results(self):
+        """When every sub-agent returns, all results land in sub_results_out."""
+        from services.agent_service import AgentStep
+
+        smart = _make_role("smart_home", servers=["homeassistant"])
+        media = _make_role("media", servers=["jellyfin"])
+        router = _make_router([smart, media])
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        async def _ok(sq, *a, **kw):
+            return {
+                "role": sq["role"], "query": sq["query"], "answer": f"{sq['role']} ok",
+                "steps": [
+                    AgentStep(step_number=1, step_type="tool_call", tool="t"),
+                    AgentStep(step_number=2, step_type="final_answer", content=f"{sq['role']} ok"),
+                ],
+                "plugin_data": {},
+            }
+
+        sub_results: list[dict] = []
+        with patch.object(orchestrator, "_run_sub_agent", _ok), \
+             patch.object(orchestrator, "_emit_combined_answer") as ec:
+            async def _empty(*a, **kw):
+                if False:
+                    yield
+            ec.return_value = _empty()
+
+            steps = []
+            async for step in orchestrator._run_parallel(
+                sub_queries=[
+                    {"role": "smart_home", "query": "Licht an"},
+                    {"role": "media", "query": "Musik"},
+                ],
+                message="m", ollama=_make_ollama("ok"),
+                executor=MagicMock(), lang="de",
+                sub_results_out=sub_results,
+            ):
+                steps.append(step)
+
+        assert {r["role"] for r in sub_results} == {"smart_home", "media"}
+        # Tool calls forwarded but per-sub-agent final_answer is suppressed.
+        assert any(s.step_type == "tool_call" for s in steps)
+        assert not any(s.step_type == "final_answer" for s in steps)
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_max_steps_abort_yields_empty_answer_not_exception(self):
+        """An agent that hits max_steps without final_answer produces empty answer.
+
+        The convention is: empty `answer` string with a non-empty `steps` list,
+        not a raised exception. Synthesizer + post-processing must tolerate this.
+        """
+        from services.agent_service import AgentStep
+
+        primary = _make_role("release", servers=["release"])
+        router = _make_router([primary])
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        async def _no_final(*args, **kwargs):
+            # Yields tool calls but never a final_answer (max_steps abort).
+            yield AgentStep(step_number=1, step_type="tool_call", tool="t1")
+            yield AgentStep(step_number=2, step_type="tool_call", tool="t2")
+
+        with patch("services.agent_service.AgentService") as MockAS, \
+             patch("services.agent_tools.AgentToolRegistry") as MockReg:
+            mock_agent = MagicMock()
+            mock_agent.run = _no_final
+            MockAS.return_value = mock_agent
+            mock_registry = MagicMock()
+            mock_registry._hook_task = None
+            MockReg.return_value = mock_registry
+
+            result = await orchestrator._run_sub_agent(
+                {"role": "release", "query": "test"},
+                _make_ollama("ok"), MagicMock(), "de",
+            )
+
+        assert result["answer"] == ""  # not None, not an exception
+        assert len(result["steps"]) == 2
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_invalid_role_returns_empty_result_with_plugin_data(self):
+        """A sub-query referring to a role with no agent loop yields empty plugin_data."""
+        primary = _make_role("release", has_loop=False, servers=["release"])
+        router = _make_router([primary])
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        result = await orchestrator._run_sub_agent(
+            {"role": "release", "query": "test"},
+            _make_ollama("ok"), MagicMock(), "de",
+        )
+
+        # The early-return path (no agent loop) must still return the new
+        # plugin_data field so callers can blindly read result["plugin_data"].
+        assert result == {
+            "role": "release", "query": "test",
+            "answer": "", "steps": [], "plugin_data": {},
+        }
+
+
+# ============================================================================
+# Phase 1 (orchestrator-uplift) — backwards compat: vanilla Renfield deploy
+# ============================================================================
+
+class TestVanillaRenfieldBackwardsCompat:
+    """With no plugins registered, behavior must match pre-uplift."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_hooks(self):
+        from utils.hooks import clear_hooks
+        clear_hooks()
+        yield
+        clear_hooks()
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_no_extend_orchestrator_roles_handler_uses_default_set(self):
+        """Without a hook handler, planner sees only roles with has_agent_loop=True."""
+        smart = _make_role("smart_home", has_loop=True, servers=["homeassistant"])
+        # Roles without agent loops are skipped by default.
+        chat = _make_role("conversation", has_loop=False)
+        router = _make_router([smart, chat])
+
+        ollama = _make_ollama("null")
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        with patch("services.orchestrator.prompt_manager") as pm, \
+             patch("services.orchestrator.settings") as s, \
+             patch("services.orchestrator.get_classification_chat_kwargs", return_value={}):
+            pm.get.return_value = "detect prompt"
+            s.agent_ollama_url = None
+            s.ollama_model = "test-model"
+            s.agent_router_timeout = 10.0
+
+            await orchestrator.detect_multi_domain("test", ollama)
+
+            descriptions = pm.get.call_args.kwargs.get("role_descriptions", "")
+            assert "smart_home" in descriptions
+            assert "conversation" not in descriptions
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_no_pre_sub_agent_handler_keeps_default_registry(self):
+        """Without a pre_sub_agent handler, the registry is untouched between create and run."""
+        from services.agent_service import AgentStep
+
+        primary = _make_role("release", servers=["release"])
+        router = _make_router([primary])
+        orchestrator = QueryOrchestrator(router, MagicMock())
+
+        async def _fake_run(*args, **kwargs):
+            yield AgentStep(step_number=1, step_type="final_answer", content="ok")
+
+        class _Registry:
+            _hook_task = None
+            preselected = None  # default — no plugin mutation
+
+        registry_instance = _Registry()
+
+        with patch("services.agent_service.AgentService") as MockAS, \
+             patch("services.agent_tools.AgentToolRegistry", return_value=registry_instance):
+            mock_agent = MagicMock()
+            mock_agent.run = _fake_run
+            MockAS.return_value = mock_agent
+
+            result = await orchestrator._run_sub_agent(
+                {"role": "release", "query": "status"},
+                _make_ollama("ok"), MagicMock(), "de",
+            )
+
+        assert registry_instance.preselected is None
+        assert result["plugin_data"] == {}  # no post_sub_agent → empty
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_no_post_orchestration_handler_no_card_step(self):
+        """Without a post_orchestration handler, no card step is yielded."""
+        from services.agent_service import AgentStep
+
+        orchestrator = QueryOrchestrator(_make_router([]), MagicMock())
+
+        async def _empty(*args, **kwargs):
+            yield AgentStep(step_number=1, step_type="final_answer", content="ok")
+
+        with patch.object(orchestrator, "_run_parallel", _empty), \
+             patch("services.orchestrator.settings") as s:
+            s.agent_orchestrator_parallel = True
+
+            steps = []
+            async for step in orchestrator.run_orchestrated(
+                sub_queries=[{"role": "smart_home", "query": "x"}],
+                message="m", ollama=_make_ollama("ok"),
+                executor=MagicMock(), lang="de",
+            ):
+                steps.append(step)
+
+        assert not any(s.step_type == "card" for s in steps)
+
+
+# ============================================================================
+# Phase 2 (Reva-side adaptation) — DEFERRED tests
+# ============================================================================
+# The following test categories from the design's Phase 1 plan are deferred
+# to Phase 2 (Reva adaptation), because the corresponding code lives in the
+# Reva chat_handler integration path that does not yet exist:
+#
+# - check_output hook fires before WebSocket response sent (chat_handler-level)
+# - post_message hook fires after persistence (chat_handler-level)
+# - extract_context_vars hook fires for tool results (chat_handler-level;
+#   also requires adding extract_context_vars to HOOK_EVENTS)
+# - pre_orchestration unconditional fire from chat_handler (the wiring
+#   exists in chat_handler.py from this PR but the tests should run with a
+#   live WebSocket fixture which lives in the Reva e2e suite)
+# - Synthesizer _strip_llm_source_line regex (the function does not yet
+#   exist in Renfield's orchestrator — it is part of Reva's separate
+#   orchestrator and lands in Phase 2 when that file is deleted)
+# - Sub-agent prompts via role.prompt_key (no Renfield-side prompts exist
+#   for the orchestrator-eligible roles yet; Reva supplies them)
+# ============================================================================


### PR DESCRIPTION
## Summary

Phase 1 of the orchestrator-uplift project ([design doc](https://github.com/X-idra-Systems-GmbH/reva/blob/main/docs/architecture/design-orchestrator-uplift.md), APPROVED 2026-04-12). Adds the platform-side hook surface that lets Reva (and any future plugin) extend Renfield's cross-MCP orchestrator without maintaining a parallel implementation.

The user's standing constraint: *"Ich möchte keine 2 verschiedenen Implementationen haben."* This PR is the Renfield-side prerequisite for deleting Reva's `src/reva/teams/orchestrator.py` in Phase 2.

## What changes

### `services/orchestrator.py`

| Change | Why |
|---|---|
| `_run_sub_agent` fires `pre_sub_agent` (mutable `tool_registry`) and `post_sub_agent` (return-dicts merge into `result["plugin_data"]`) | Reva's contact accumulator + tool pre-selection plug in here |
| `_run_sub_agent` awaits `tool_registry._hook_task` before agent loop | Plugin tools register asynchronously; without this await, intermittent "tool not found" on first orchestrated call after startup |
| `detect_multi_domain` calls `extend_orchestrator_roles` hook | Plugins (Reva) can promote non-`has_agent_loop` roles into the planner's vocabulary |
| Removed redundant internal `pre_orchestration` fire | Now fires upstream in `chat_handler` so plugins can inject a pre-computed plan |

### `api/websocket/chat_handler.py`

| Change | Why |
|---|---|
| Drops `role.name not in ("conversation", "knowledge")` gate | Vague queries can now reach the orchestrator via plugin-supplied plans |
| Fires `pre_orchestration` unconditionally before detection | Plugins can return a pre-computed plan (Reva's QueryPlan / Layer 0); LLM planner still gated on the conversation/knowledge exclusion to keep chitchat fast |
| Fires `check_output` on synthesized response | Plugins (Reva's GDPR `output_guard`) can redact persisted/logged content. Streamed text is unmodified for now (UX tradeoff documented in code) |

### `tests/backend/test_orchestrator.py`

22 new tests covering:

| Group | Count | Coverage |
|---|---|---|
| `extend_orchestrator_roles` | 4 | merge, unknown names ignored, non-iterable handler return, None return |
| `pre_sub_agent` / `post_sub_agent` | 7 | fire kwargs, plugin_data merge, registry mutation, `_hook_task` await, hook failures don't break sub-agent (×2) |
| Planner detection coverage extension | 6 | 3-role plan, 4-role plan, null sentinel, empty response, truncated JSON, backslash in query field |
| Parallel sub-agent execution | 4 | error isolation, all-success, max_steps abort yields empty answer (not exception), invalid-role early-return preserves new `plugin_data` field |
| Vanilla-Renfield backwards compat | 3 | no plugins → default eligibility / untouched registry / no card step |

Plus 1 updated test reflecting the removal of the redundant `pre_orchestration` fire.

Tests deferred to Phase 2 (where Reva's chat_handler-WebSocket-fixture wiring lands): `check_output` end-to-end fire from chat_handler, `post_message` after persistence, `extract_context_vars` (also requires adding to `HOOK_EVENTS`), anaphoric `Nr. 3` resolution into the planner, `_strip_llm_source_line` regex (the function lives in Reva's separate orchestrator and lands in Phase 2 when that file is deleted), sub-agent prompts via `role.prompt_key` (no Renfield-side prompts exist for orchestrator-eligible roles yet — Reva supplies them).

## Backwards compatibility

Vanilla Renfield deploys (no plugin handlers registered) behave exactly as before:
- New hook fires are no-ops
- Planner sees the same role set (default = any `has_agent_loop` role)
- `_run_sub_agent` returns a result with `plugin_data = {}` (one additive key)
- `chat_handler` skips the planner for `conversation` / `knowledge` roles, so chitchat performance is preserved

The new test class `TestVanillaRenfieldBackwardsCompat` pins this contract.

## Test plan

- [ ] `make test-unit` — all unit tests pass (22 new + existing 17 = 39 in `test_orchestrator.py`)
- [ ] `make test-backend` — full backend suite green
- [ ] Existing Renfield orchestrator E2E unaffected
- [ ] Manual: vanilla Renfield install (no plugin) routes "How's the weather?" without spurious orchestration

## Followups

- Phase 2 (Reva-side, [reva#TBD](https://github.com/X-idra-Systems-GmbH/reva)): register Reva's `pre_sub_agent` / `post_sub_agent` / `extend_orchestrator_roles` / `pre_orchestration` / `post_orchestration` handlers, bridge `transport.py` to Renfield's streaming API, delete `src/reva/teams/orchestrator.py`.
- Add `extract_context_vars` to `HOOK_EVENTS` (Phase 2 requirement; chat_handler integration for it lands with Reva-side adaptation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)