### PR TITLE
feat(orchestrator): Phase 1.5 — synthesis hooks for plugin extension

### DIFF
--- a/src/backend/services/orchestrator.py
+++ b/src/backend/services/orchestrator.py
@@ -10,6 +10,7 @@ Opt-in via AGENT_ORCHESTRATOR_ENABLED=true.
 
 import asyncio
 import json
+import re
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from typing import TYPE_CHECKING
 
@@ -18,6 +19,22 @@ from loguru import logger
 from services.prompt_manager import prompt_manager
 from utils.config import settings
 from utils.llm_client import extract_response_content, get_agent_client, get_classification_chat_kwargs
+
+
+# Strip "_Quelle: ..._" / "_Source: ..._" lines that synthesizer LLMs
+# sometimes write alongside the actual answer. Transports/plugins that
+# attach their own canonical source footer (Reva's transport.py) expect
+# the LLM not to duplicate it. The pattern tolerates italic/bold markers,
+# both DE and EN variants, and trailing whitespace. Anchored to line
+# start; multi-line mode so the regex acts per-line.
+_SOURCE_LINE_RE: re.Pattern[str] = re.compile(
+    r"(?im)^\s*[_*]*\s*(quelle|source|sources|quellen)\s*[:：][^\n]*[_*]*\s*$",
+)
+
+
+def _strip_source_line(answer: str) -> str:
+    """Remove any trailing ``_Quelle: ..._`` / ``_Source: ..._`` line."""
+    return _SOURCE_LINE_RE.sub("", answer).rstrip()
 
 if TYPE_CHECKING:
     from services.action_executor import ActionExecutor
@@ -685,16 +702,66 @@ class QueryOrchestrator:
         ollama: "OllamaService",
         lang: str,
     ) -> str | None:
-        """Combine sub-results into a unified answer via LLM."""
+        """Combine sub-results into a unified answer via LLM.
+
+        Plugin extension points:
+
+        - ``build_synthesis_context`` — fires before the prompt is built.
+          Plugins return a text block to append to ``collected_data`` so
+          the synthesizer can reference plugin-specific context (e.g.
+          Reva's contacts engine emits a ``<contacts>...</contacts>``
+          block for the synthesizer to mention contact persons in prose).
+          First non-None result wins.
+
+        - ``synthesis_prompt_override`` — fires after ``collected_data``
+          is finalized. Plugins return a fully-templated synth prompt
+          to replace Renfield's default. First non-None result wins.
+
+        - Source-line stripping is applied unconditionally to the synth
+          output: ``_Quelle: ..._`` / ``_Source: ..._`` lines are removed
+          (DE+EN, italic markers tolerated). Transports/plugins that
+          attach their own canonical source footer expect the LLM not to
+          duplicate it; this is generic enough to be a default.
+        """
+        from utils.hooks import run_hooks
+
         results_text = "\n".join(
             f"- [{r['role']}] {r['query']}: {r['answer']}"
             for r in sub_results
         )
 
-        synthesize_prompt = prompt_manager.get(
-            "agent", "orchestrator_synthesize_prompt", lang=lang,
-            message=message, sub_results=results_text,
+        # Hook: plugins may append plugin-specific context to the
+        # collected sub-results before the synthesizer sees them.
+        context_results = await run_hooks(
+            "build_synthesis_context",
+            message=message,
+            sub_results=sub_results,
+            lang=lang,
         )
+        for cr in context_results:
+            if isinstance(cr, str) and cr:
+                results_text = f"{results_text}\n\n{cr}"
+                break
+
+        # Hook: plugins may override the synthesizer prompt entirely.
+        synthesize_prompt: str | None = None
+        override_results = await run_hooks(
+            "synthesis_prompt_override",
+            message=message,
+            collected_data=results_text,
+            lang=lang,
+        )
+        for op in override_results:
+            if isinstance(op, str) and op:
+                synthesize_prompt = op
+                break
+
+        if synthesize_prompt is None:
+            synthesize_prompt = prompt_manager.get(
+                "agent", "orchestrator_synthesize_prompt", lang=lang,
+                message=message, sub_results=results_text,
+            )
+
         if not synthesize_prompt:
             # Fallback: concatenate
             return "\n\n".join(r["answer"] for r in sub_results if r["answer"])
@@ -712,7 +779,8 @@ class QueryOrchestrator:
                 ),
                 timeout=settings.orchestrator_synthesis_timeout,
             )
-            return extract_response_content(raw_response) or None
+            answer = extract_response_content(raw_response) or None
+            return _strip_source_line(answer) if answer else None
 
         except Exception as e:
             logger.warning(f"Orchestrator synthesis failed: {e}")

--- a/src/backend/utils/hooks.py
+++ b/src/backend/utils/hooks.py
@@ -175,6 +175,19 @@ HOOK_EVENTS: frozenset[str] = frozenset({
     #       results. Reva's transport.py uses an inline equivalent today;
     #       this hook will be wired in chat_handler in Phase 2 of the
     #       orchestrator-uplift project.
+    #   build_synthesis_context: (message, sub_results, lang) -> str | None
+    #       Fired inside QueryOrchestrator._synthesize before the synth
+    #       prompt is templated. Plugins return a text block that gets
+    #       APPENDED to the collected sub-results before the synthesizer
+    #       LLM sees it. Reva uses this to inject a <contacts> block so
+    #       the synthesized prose can mention contact persons. First
+    #       non-None result wins (deterministic ordering by registration).
+    #   synthesis_prompt_override: (message, collected_data, lang) -> str | None
+    #       Fired inside QueryOrchestrator._synthesize to let plugins
+    #       fully replace the default synthesizer prompt template. Plugins
+    #       return the FINAL TEMPLATED PROMPT (already formatted with
+    #       message + collected_data), not a template. None defers to
+    #       Renfield's default. First non-None result wins.
     "load_entity_patterns",
     "post_routing",
     "extend_orchestrator_roles",
@@ -184,6 +197,8 @@ HOOK_EVENTS: frozenset[str] = frozenset({
     "post_sub_agent",
     "check_output",
     "extract_context_vars",
+    "build_synthesis_context",
+    "synthesis_prompt_override",
     # Sub-intent dispatch — fired by chat_handler after AgentRouter
     # classification when the matched role declares a sub_intent with a
     # ``dispatch: {type: handler, handler: <name>}`` config. Handlers

--- a/tests/backend/test_orchestrator.py
+++ b/tests/backend/test_orchestrator.py
@@ -2178,5 +2178,232 @@ class TestPostSubAgentFiresAfterCrash:
 
 
 # ============================================================================
+# Phase 1.5 — synthesis hooks (build_synthesis_context, synthesis_prompt_override)
+#               + source-line stripping
+# ============================================================================
+
+class TestSynthesisHooks:
+    """``_synthesize`` exposes two extension points and one default behavior:
+    ``build_synthesis_context`` (append plugin context to the synth prompt's
+    collected_data block), ``synthesis_prompt_override`` (replace the entire
+    templated prompt), and source-line stripping on the LLM output."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_hooks(self):
+        from utils.hooks import clear_hooks
+        clear_hooks()
+        yield
+        clear_hooks()
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_build_synthesis_context_appended_to_collected_data(self):
+        """Plugin's returned text block must be appended to the prompt's collected data."""
+        from utils.hooks import register_hook
+
+        captured: dict[str, str] = {}
+
+        async def context_handler(message, sub_results, lang, **_):
+            return "<contacts>\n  - Alice\n  - Bob\n</contacts>"
+
+        register_hook("build_synthesis_context", context_handler)
+
+        orchestrator = QueryOrchestrator(_make_router([]), MagicMock())
+
+        # Capture the templated prompt by stubbing prompt_manager.get.
+        with patch("services.orchestrator.prompt_manager") as pm, \
+             patch("services.orchestrator.settings") as s, \
+             patch("services.orchestrator.get_classification_chat_kwargs", return_value={}):
+            pm.get.return_value = "DEFAULT_PROMPT"
+            s.agent_router_model = "test-model"
+            s.ollama_intent_model = "test-model"
+            s.ollama_model = "test-model"
+            s.orchestrator_synthesis_timeout = 10.0
+
+            sub_results = [
+                {"role": "release", "query": "status", "answer": "ok"},
+                {"role": "jira", "query": "tickets", "answer": "no tickets"},
+            ]
+
+            await orchestrator._synthesize("msg", sub_results, _make_ollama("synthesized"), "de")
+
+            kwargs = pm.get.call_args.kwargs
+            captured["sub_results"] = kwargs.get("sub_results", "")
+
+        # Plugin's contacts block must appear after the per-role bullets.
+        assert "<contacts>" in captured["sub_results"]
+        assert "Alice" in captured["sub_results"]
+        # Original bullets still present.
+        assert "[release]" in captured["sub_results"]
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_build_synthesis_context_first_non_none_wins(self):
+        """When two handlers return text, the first registration wins."""
+        from utils.hooks import register_hook
+
+        async def first_handler(message, sub_results, lang, **_):
+            return "BLOCK_FIRST"
+
+        async def second_handler(message, sub_results, lang, **_):
+            return "BLOCK_SECOND"
+
+        register_hook("build_synthesis_context", first_handler)
+        register_hook("build_synthesis_context", second_handler)
+
+        orchestrator = QueryOrchestrator(_make_router([]), MagicMock())
+
+        with patch("services.orchestrator.prompt_manager") as pm, \
+             patch("services.orchestrator.settings") as s, \
+             patch("services.orchestrator.get_classification_chat_kwargs", return_value={}):
+            pm.get.return_value = "X"
+            s.agent_router_model = s.ollama_intent_model = s.ollama_model = "test-model"
+            s.orchestrator_synthesis_timeout = 10.0
+
+            await orchestrator._synthesize(
+                "msg",
+                [{"role": "release", "query": "q", "answer": "a"}],
+                _make_ollama("synthesized"), "de",
+            )
+
+            sr = pm.get.call_args.kwargs.get("sub_results", "")
+
+        assert "BLOCK_FIRST" in sr
+        assert "BLOCK_SECOND" not in sr
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_synthesis_prompt_override_replaces_template(self):
+        """Plugin-supplied prompt is sent verbatim to the LLM; default template is skipped."""
+        from utils.hooks import register_hook
+
+        async def override_handler(message, collected_data, lang, **_):
+            return f"PLUGIN_PROMPT[message={message}]"
+
+        register_hook("synthesis_prompt_override", override_handler)
+
+        orchestrator = QueryOrchestrator(_make_router([]), MagicMock())
+
+        ollama = _make_ollama("synth output")
+
+        with patch("services.orchestrator.prompt_manager") as pm, \
+             patch("services.orchestrator.settings") as s, \
+             patch("services.orchestrator.get_classification_chat_kwargs", return_value={}):
+            pm.get.return_value = "DEFAULT_PROMPT_NEVER_USED"
+            s.agent_router_model = s.ollama_intent_model = s.ollama_model = "test-model"
+            s.orchestrator_synthesis_timeout = 10.0
+
+            await orchestrator._synthesize(
+                "what is the status",
+                [{"role": "release", "query": "q", "answer": "a"}],
+                ollama, "de",
+            )
+
+        # ollama.client.chat received the plugin's prompt, not the default.
+        chat_kwargs = ollama.client.chat.call_args.kwargs
+        sent_messages = chat_kwargs["messages"]
+        assert sent_messages[0]["content"] == "PLUGIN_PROMPT[message=what is the status]"
+        # prompt_manager.get was never reached because the override returned non-None.
+        assert pm.get.called is False
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_synthesis_prompt_override_none_falls_through_to_default(self):
+        """When all plugins return None, Renfield uses prompt_manager.get default."""
+        from utils.hooks import register_hook
+
+        async def noop_handler(message, collected_data, lang, **_):
+            return None
+
+        register_hook("synthesis_prompt_override", noop_handler)
+
+        orchestrator = QueryOrchestrator(_make_router([]), MagicMock())
+
+        with patch("services.orchestrator.prompt_manager") as pm, \
+             patch("services.orchestrator.settings") as s, \
+             patch("services.orchestrator.get_classification_chat_kwargs", return_value={}):
+            pm.get.return_value = "DEFAULT_PROMPT"
+            s.agent_router_model = s.ollama_intent_model = s.ollama_model = "test-model"
+            s.orchestrator_synthesis_timeout = 10.0
+
+            await orchestrator._synthesize(
+                "msg",
+                [{"role": "release", "query": "q", "answer": "a"}],
+                _make_ollama("synth"), "de",
+            )
+
+            assert pm.get.called
+
+    @pytest.mark.unit
+    def test_strip_source_line_de(self):
+        """The DE _Quelle: ..._ pattern is stripped."""
+        from services.orchestrator import _strip_source_line
+        text = (
+            "Hier ist die Antwort.\n"
+            "\n"
+            "_Quelle: Digital.ai Release_"
+        )
+        result = _strip_source_line(text)
+        assert "Quelle" not in result
+        assert "Hier ist die Antwort." in result
+
+    @pytest.mark.unit
+    def test_strip_source_line_en(self):
+        """The EN _Source: ..._ pattern is stripped."""
+        from services.orchestrator import _strip_source_line
+        text = "Here is the answer.\n\n_Source: Digital.ai Release_"
+        result = _strip_source_line(text)
+        assert "Source" not in result
+        assert "Here is the answer." in result
+
+    @pytest.mark.unit
+    def test_strip_source_line_plural_quellen(self):
+        """The DE plural ``Quellen:`` variant is also stripped."""
+        from services.orchestrator import _strip_source_line
+        text = "Antwort hier.\n\n_Quellen: Release, Jira_"
+        assert "Quellen" not in _strip_source_line(text)
+
+    @pytest.mark.unit
+    def test_strip_source_line_no_match_passthrough(self):
+        """Text without a source line is returned unmodified (modulo trailing ws)."""
+        from services.orchestrator import _strip_source_line
+        text = "Just an answer with no source line."
+        assert _strip_source_line(text) == text
+
+    @pytest.mark.unit
+    def test_strip_source_line_inline_quelle_not_stripped(self):
+        """Only line-anchored Quelle: matches are stripped — inline mentions stay."""
+        from services.orchestrator import _strip_source_line
+        text = "Die Quelle: ist offiziell und vertrauenswürdig."
+        # Inline (not at line start with surrounding markers) — should pass through.
+        # Note: regex is anchored to ^\s* so a sentence starting "Die Quelle:" doesn't match.
+        assert "Quelle" in _strip_source_line(text)
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_strip_applied_after_synthesis(self):
+        """End-to-end: a synth response containing _Quelle: ..._ is stripped before return."""
+        orchestrator = QueryOrchestrator(_make_router([]), MagicMock())
+
+        ollama = _make_ollama("Here is the synthesized answer.\n\n_Quelle: Test_")
+
+        with patch("services.orchestrator.prompt_manager") as pm, \
+             patch("services.orchestrator.settings") as s, \
+             patch("services.orchestrator.get_classification_chat_kwargs", return_value={}):
+            pm.get.return_value = "PROMPT"
+            s.agent_router_model = s.ollama_intent_model = s.ollama_model = "test-model"
+            s.orchestrator_synthesis_timeout = 10.0
+
+            answer = await orchestrator._synthesize(
+                "msg",
+                [{"role": "release", "query": "q", "answer": "a"}],
+                ollama, "de",
+            )
+
+        assert "Quelle" not in (answer or "")
+        assert "synthesized answer" in (answer or "")
+
+
+# ============================================================================
 # Phase 1 (orchestrator-uplift) — backwards compat: vanilla Renfield deploy
 # ============================================================================


### PR DESCRIPTION
## Summary

Adds two hook events and one default-on behavior to `QueryOrchestrator._synthesize` so plugins can extend the synthesis stage without forking the orchestrator.

Surfaced by Reva's Phase 2 attempt to delete `src/reva/teams/orchestrator.py` and route through Renfield's: the unified path's E2E showed Reva's synthesizer had **three Reva-specific tweaks** Renfield's orchestrator didn't replicate:
- `<contacts>...</contacts>` context block injected into the synth prompt
- Reva-specific prompt template (different LLM instructions)
- Duplicated source-line stripping (the canonical source footer is added by transport.py; the synth LLM was writing its own, causing visible duplicates)

Without those, the synthesizer produced different prose that broke ~14 content-asserting Reva E2E tests. This PR adds the extension points to close that gap.

## Hooks added

| Hook | When | Plugin returns | Wins |
|---|---|---|---|
| `build_synthesis_context` | After `collected_data` is built, before the synth prompt is templated | A text block to APPEND to collected_data (e.g. Reva's `<contacts>` block) | First non-None |
| `synthesis_prompt_override` | After `collected_data` is finalized | A FULLY-TEMPLATED prompt replacing Renfield's default | First non-None |

Hook events declared in `utils/hooks.py` `HOOK_EVENTS` with full docstrings.

## Default behavior added

Source-line stripping in `_synthesize` removes lines matching `_Quelle: ..._` / `_Source: ..._` / `_Quellen: ..._` / `_Sources: ..._` (DE+EN, italic markers tolerated, anchored to line start so inline mentions like "Die Quelle: ist offiziell" pass through). No hook, no opt-in — generic post-processing that benefits any orchestrator caller. Transports/plugins that attach their own canonical source footer (Reva's transport.py + `add_source_footer`) expect the LLM not to duplicate one.

## Tests

10 new unit tests in `TestSynthesisHooks`:
- `build_synthesis_context` appends to collected_data
- `build_synthesis_context` first-wins across multiple handlers
- `synthesis_prompt_override` replaces default template
- `synthesis_prompt_override` None falls through to default
- 5 source-line stripping variants (DE, EN, plural Quellen, no-match passthrough, inline-not-stripped)
- End-to-end strip applied to synthesizer output

**Run on .159 build box:** 66/66 pass (Phase 1's 56 + Phase 1.5's 10).

## Backwards compatibility

Vanilla Renfield deploys (no plugin handlers registered) hit the same `prompt_manager.get` default as before; only the source-line stripping is a behavior change, and it's generic post-processing that benefits any orchestrator output (any LLM that writes a "_Source: …_" footer would have been duplicating with the canonical footer; this is a quiet quality fix).

## Why now

Reva's Phase 2 PR (delete `src/reva/teams/orchestrator.py`, route through Renfield) is blocked on these hooks. With this Phase 1.5 in main, Reva can register handlers for the two hooks, restore its synth quality, and finally remove its parallel-implementation code.

## Test plan

- [x] `make test-backend` style test on .159: 66/66 pass
- [x] Vanilla Renfield (no plugin handlers): same prompt_manager default applies
- [x] Source-line stripping doesn't false-positive on inline German "Quelle:" mentions
- [ ] Reva-side smoke deploy after Reva registers the new handlers (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)