### PR TITLE
fix(chat): wait briefly for WS handshake before falling back to REST

### DIFF
--- a/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
+++ b/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
@@ -856,6 +856,24 @@ export function ChatProvider({ children }: ChatProviderProps) {
       });
     }
 
+    // Brief grace period for the WebSocket handshake. The WS path runs the
+    // full chat pipeline (orchestrator, sub-agents, cards); the REST
+    // fallback at /api/chat/send skips orchestration and produces inferior
+    // answers for cross-domain queries. Without this wait, a user who
+    // submits immediately after page load races the WS handshake and
+    // silently lands on REST. Wait up to ~3s — long enough to cover normal
+    // handshake latency, short enough that genuinely WS-blocked clients
+    // (proxies, extensions) still get a usable fallback in perceptible time.
+    if (!isReady()) {
+      const WS_WAIT_TIMEOUT_MS = 3000;
+      const POLL_INTERVAL_MS = 50;
+      const start = Date.now();
+      while (!isReady() && Date.now() - start < WS_WAIT_TIMEOUT_MS) {
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+      }
+    }
+
     if (isReady()) {
       const message = {
         type: 'text',

--- a/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
+++ b/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
@@ -31,6 +31,11 @@ import type { Conversation } from '../../../types/chat';
 import { useConfirmDialog } from '../../../components/ConfirmDialog';
 
 const SESSION_STORAGE_KEY = 'renfield_current_session';
+// How long sendMessageInternal waits for the WebSocket handshake before
+// falling back to /api/chat/send. Long enough to cover normal handshake
+// latency on first paint, short enough to stay within human-perceptible
+// time-to-first-byte for clients where the WS is genuinely blocked.
+const WS_HANDSHAKE_GRACE_MS = 3000;
 
 type WakeWordStatus = 'idle' | 'listening' | 'recording' | 'activated';
 
@@ -351,6 +356,16 @@ export function ChatProvider({ children }: ChatProviderProps) {
   const sendMessageInternalRef = useRef<(text: string, fromVoice?: boolean) => Promise<void>>(
     async () => undefined,
   );
+
+  // AbortController used to cancel any in-flight WebSocket-handshake wait
+  // (see sendMessageInternal). Aborted on unmount so we don't continue to
+  // touch state from a destroyed component.
+  const wsWaitAbortRef = useRef<AbortController | null>(null);
+  useEffect(() => {
+    return () => {
+      wsWaitAbortRef.current?.abort();
+    };
+  }, []);
 
   // Handle wake word detection
   const handleWakeWordDetected = useCallback(async (keyword: string, score: number) => {
@@ -690,7 +705,7 @@ export function ChatProvider({ children }: ChatProviderProps) {
   }, []);
 
   // WebSocket hook
-  const { wsConnected, sendMessage: wsSendMessage, isReady } = useChatWebSocket({
+  const { wsConnected, sendMessage: wsSendMessage, isReady, whenReady } = useChatWebSocket({
     onStreamChunk: handleStreamChunk,
     onStreamDone: handleStreamDone,
     onAction: handleAction,
@@ -856,34 +871,35 @@ export function ChatProvider({ children }: ChatProviderProps) {
       });
     }
 
-    // Brief grace period for the WebSocket handshake. The WS path runs the
-    // full chat pipeline (orchestrator, sub-agents, cards); the REST
-    // fallback at /api/chat/send skips orchestration and produces inferior
-    // answers for cross-domain queries. Without this wait, a user who
-    // submits immediately after page load races the WS handshake and
-    // silently lands on REST. Wait up to ~3s — long enough to cover normal
-    // handshake latency, short enough that genuinely WS-blocked clients
-    // (proxies, extensions) still get a usable fallback in perceptible time.
+    // Brief grace period for the WebSocket handshake before falling back
+    // to REST. The two paths are not equivalent: the WS handler runs the
+    // full pipeline (cross-MCP orchestrator, sub-agents, Adaptive Card
+    // protocol); /api/chat/send is a leaner ranked-intents path that
+    // never invokes the orchestrator. Without this wait, a client that
+    // submits within the first ~50 ms of page load races its own WS
+    // handshake and silently lands on REST — producing inferior answers
+    // for cross-domain queries. The wait resolves immediately when the
+    // socket is already OPEN, so steady-state UX is unaffected.
+    wsWaitAbortRef.current?.abort();
+    const ac = new AbortController();
+    wsWaitAbortRef.current = ac;
     if (!isReady()) {
-      const WS_WAIT_TIMEOUT_MS = 3000;
-      const POLL_INTERVAL_MS = 50;
-      const start = Date.now();
-      while (!isReady() && Date.now() - start < WS_WAIT_TIMEOUT_MS) {
-        // eslint-disable-next-line no-await-in-loop
-        await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
-      }
+      await whenReady(WS_HANDSHAKE_GRACE_MS, ac.signal);
     }
 
-    if (isReady()) {
-      const message = {
-        type: 'text',
-        content: text,
-        session_id: sessionId,
-        use_rag: useRag,
-        knowledge_base_id: selectedKnowledgeBase,
-        ...(completedIds.length > 0 && { attachment_ids: completedIds }),
-      };
-      wsSendMessage(message);
+    const wsMessage = {
+      type: 'text',
+      content: text,
+      session_id: sessionId,
+      use_rag: useRag,
+      knowledge_base_id: selectedKnowledgeBase,
+      ...(completedIds.length > 0 && { attachment_ids: completedIds }),
+    };
+
+    // wsSendMessage re-checks readyState before .send() and returns false
+    // if the socket isn't OPEN, so we close the race between whenReady()
+    // resolving true and the actual transmit.
+    if (isReady() && wsSendMessage(wsMessage)) {
       setRagSources([]);
     } else {
       try {
@@ -900,7 +916,7 @@ export function ChatProvider({ children }: ChatProviderProps) {
         setLoading(false);
       }
     }
-  }, [sessionId, messages.length, useRag, selectedKnowledgeBase, isReady, wsSendMessage, addConversation, attachments, t]);
+  }, [sessionId, messages.length, useRag, selectedKnowledgeBase, isReady, whenReady, wsSendMessage, addConversation, attachments, t]);
 
   // Wire ref so handleTranscription (declared above) can call sendMessageInternal
   useEffect(() => {

--- a/src/frontend/src/pages/ChatPage/hooks/useChatWebSocket.ts
+++ b/src/frontend/src/pages/ChatPage/hooks/useChatWebSocket.ts
@@ -129,6 +129,8 @@ export function useChatWebSocket({
   const [wsConnected, setWsConnected] = useState(false);
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Pending whenReady() resolvers, drained on the next onopen/onclose.
+  const readyResolversRef = useRef<Array<(ok: boolean) => void>>([]);
 
   const connectWebSocket = useCallback(() => {
     if (reconnectTimeoutRef.current) {
@@ -148,6 +150,9 @@ export function useChatWebSocket({
     ws.onopen = () => {
       debug.log('WebSocket verbunden');
       setWsConnected(true);
+      // Wake any callers waiting on whenReady().
+      const pending = readyResolversRef.current.splice(0);
+      pending.forEach((resolve) => resolve(true));
     };
 
     ws.onmessage = (event: MessageEvent) => {
@@ -206,6 +211,10 @@ export function useChatWebSocket({
     ws.onclose = () => {
       debug.log('WebSocket getrennt');
       setWsConnected(false);
+      // Don't leave whenReady() callers hanging across a closed socket; the
+      // next reconnect will create a fresh ws with its own onopen drain.
+      const pending = readyResolversRef.current.splice(0);
+      pending.forEach((resolve) => resolve(false));
       reconnectTimeoutRef.current = setTimeout(connectWebSocket, 3000);
     };
 
@@ -241,10 +250,45 @@ export function useChatWebSocket({
     return Boolean(wsRef.current && wsRef.current.readyState === WebSocket.OPEN);
   }, []);
 
+  /**
+   * Resolve `true` once the WebSocket reaches OPEN, or `false` on timeout
+   * or abort. Resolves immediately if already OPEN. Used by callers that
+   * need to wait through the page-load handshake before falling back to
+   * a non-WebSocket path.
+   */
+  const whenReady = useCallback(
+    (timeoutMs: number = 3000, signal?: AbortSignal): Promise<boolean> => {
+      if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
+        return Promise.resolve(true);
+      }
+      if (signal?.aborted) {
+        return Promise.resolve(false);
+      }
+      return new Promise<boolean>((resolve) => {
+        let settled = false;
+        const settle = (ok: boolean) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          if (signal && onAbort) signal.removeEventListener('abort', onAbort);
+          resolve(ok);
+        };
+        const onAbort = () => settle(false);
+        const timer = setTimeout(() => settle(false), timeoutMs);
+        if (signal) signal.addEventListener('abort', onAbort, { once: true });
+        // The resolver registry is drained by ws.onopen (true) and
+        // ws.onclose (false). Already-settled entries are no-ops.
+        readyResolversRef.current.push(settle);
+      });
+    },
+    [],
+  );
+
   return {
     wsConnected,
     sendMessage,
     isReady,
+    whenReady,
     reconnect: connectWebSocket,
   };
 }

--- a/tests/frontend/react/hooks/useChatWebSocket.test.jsx
+++ b/tests/frontend/react/hooks/useChatWebSocket.test.jsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useChatWebSocket } from '../../../../src/frontend/src/pages/ChatPage/hooks/useChatWebSocket';
+
+// Mock WebSocket whose readyState starts as CONNECTING and becomes OPEN
+// only when fireOpen() is called externally. Lets us model the
+// page-load race: the hook constructs the socket but onopen hasn't fired
+// yet when sendMessage / whenReady are called.
+class ControllableWebSocket {
+  constructor(url) {
+    this.url = url;
+    this.readyState = 0; // CONNECTING
+    this.OPEN = 1;
+    this.CONNECTING = 0;
+    this.CLOSED = 3;
+    this.sent = [];
+    this.onopen = null;
+    this.onclose = null;
+    this.onmessage = null;
+    this.onerror = null;
+    ControllableWebSocket.instances.push(this);
+  }
+  fireOpen() {
+    this.readyState = 1;
+    this.onopen?.({});
+  }
+  fireClose() {
+    this.readyState = 3;
+    this.onclose?.({});
+  }
+  send(data) {
+    this.sent.push(data);
+  }
+  close() {
+    this.fireClose();
+  }
+}
+ControllableWebSocket.instances = [];
+
+beforeEach(() => {
+  ControllableWebSocket.instances = [];
+  ControllableWebSocket.OPEN = 1;
+  ControllableWebSocket.CONNECTING = 0;
+  ControllableWebSocket.CLOSED = 3;
+  vi.stubGlobal('WebSocket', ControllableWebSocket);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('useChatWebSocket', () => {
+  describe('whenReady', () => {
+    it('resolves immediately to true when socket is already OPEN', async () => {
+      const { result } = renderHook(() => useChatWebSocket());
+      const ws = ControllableWebSocket.instances[0];
+
+      act(() => ws.fireOpen());
+
+      const ok = await result.current.whenReady(1000);
+      expect(ok).toBe(true);
+    });
+
+    it('resolves to true once onopen fires after the call', async () => {
+      const { result } = renderHook(() => useChatWebSocket());
+      const ws = ControllableWebSocket.instances[0];
+
+      // Socket not yet OPEN — call whenReady, then fire onopen.
+      const promise = result.current.whenReady(2000);
+
+      // Yield to React, then open the socket.
+      await act(async () => {
+        ws.fireOpen();
+      });
+
+      await expect(promise).resolves.toBe(true);
+    });
+
+    it('resolves to false when the timeout elapses without onopen', async () => {
+      vi.useFakeTimers();
+      try {
+        const { result } = renderHook(() => useChatWebSocket());
+
+        const promise = result.current.whenReady(500);
+        await act(async () => {
+          vi.advanceTimersByTime(600);
+        });
+        await expect(promise).resolves.toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('resolves to false when the abort signal fires', async () => {
+      const { result } = renderHook(() => useChatWebSocket());
+
+      const ac = new AbortController();
+      const promise = result.current.whenReady(5000, ac.signal);
+      ac.abort();
+
+      await expect(promise).resolves.toBe(false);
+    });
+
+    it('resolves to false if the socket closes before opening', async () => {
+      const { result } = renderHook(() => useChatWebSocket());
+      const ws = ControllableWebSocket.instances[0];
+
+      const promise = result.current.whenReady(5000);
+      await act(async () => {
+        ws.fireClose();
+      });
+
+      await expect(promise).resolves.toBe(false);
+    });
+  });
+
+  describe('sendMessage', () => {
+    it('returns true and transmits when socket is OPEN', () => {
+      const { result } = renderHook(() => useChatWebSocket());
+      const ws = ControllableWebSocket.instances[0];
+      act(() => ws.fireOpen());
+
+      const ok = result.current.sendMessage({ type: 'text', content: 'hi' });
+      expect(ok).toBe(true);
+      expect(ws.sent).toHaveLength(1);
+      expect(JSON.parse(ws.sent[0])).toMatchObject({ type: 'text', content: 'hi' });
+    });
+
+    it('returns false and does not transmit when socket is not OPEN', () => {
+      const { result } = renderHook(() => useChatWebSocket());
+      const ws = ControllableWebSocket.instances[0];
+      // Socket left in CONNECTING state.
+
+      const ok = result.current.sendMessage({ type: 'text', content: 'hi' });
+      expect(ok).toBe(false);
+      expect(ws.sent).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Web chat `ChatContext.sendMessageInternal` previously branched straight to the `/api/chat/send` REST fallback whenever the WebSocket wasn't `OPEN` at submit time.
- The two paths are not equivalent: the WS handler runs the full pipeline (cross-MCP orchestrator, sub-agents, Adaptive Card protocol). The REST endpoint runs the leaner ranked-intents path and never invokes the orchestrator.
- A client that submits within ~50 ms of page load (or any E2E test driving the UI directly) races the WS handshake and silently lands on REST, producing inferior answers — most visibly hallucinated output for cross-domain "overview"/"status" queries.
- This change adds a short grace period (≤3 s, polled every 50 ms) before falling back to REST. The page-load race is covered transparently, while clients where the WS is genuinely blocked (corp proxy, browser extension) still get a usable fallback within human-perceptible time-to-answer.

Single-file change: `src/frontend/src/pages/ChatPage/context/ChatContext.tsx` (+18 lines).

## Background

Found while investigating a Reva E2E failure (`web/cross_domain/test_cross_domain.py::test_overview_all_integrations`):

- `Gib mir einen vollständigen Überblick über den aktuellen Status` returned hallucinated weather/time/news instead of any real domain data.
- Server-side trace showed the WS connecting at `12.461 s` and the REST `/api/chat/send` request arriving at `12.493 s` — 32 ms later. The frontend lost the race against its own handshake.
- Same query via Direct Line (the Teams transport, which doesn't have this REST fallback) succeeds: orchestrator detects multi-role and runs `release` + `jira` + `itsm` sub-agents.

## Test plan

- [ ] Verify with the Reva E2E suite that the cross-domain overview test now hits the WS path (look for `🎼 Orchestrator: N sub-queries` in the server log instead of `api.routes.chat:send_message`).
- [ ] Manual sanity check: with WS disabled (e.g. browser DevTools → block `wss://`), confirm the REST fallback still works after ~3 s and a non-empty response is rendered.
- [ ] Manual sanity check: normal page load + immediate send still feels instantaneous — we never block while the WS is already `OPEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)