### PR TITLE
feat(hooks): pre_mcp_call event for plugin tool-call rewriting

### DIFF
--- a/src/backend/services/action_executor.py
+++ b/src/backend/services/action_executor.py
@@ -131,6 +131,21 @@ class ActionExecutor:
         # MCP tool intents (mcp.* prefix — handles HA, n8n, weather, search, etc.)
         if self.mcp_manager and intent.startswith("mcp."):
             logger.info(f"🔌 Executing MCP tool: {intent}")
+            # Plugin pre-call rewrite. Plugins may repair malformed LLM
+            # tool calls here (e.g. substitute a release id when the LLM
+            # passed a title). First well-shaped non-None dict replaces
+            # parameters; everything else is ignored.
+            from utils.hooks import run_hooks
+            pre_call_results = await run_hooks(
+                "pre_mcp_call",
+                intent=intent,
+                parameters=parameters,
+                user_id=user_id,
+            )
+            for rewritten in pre_call_results:
+                if isinstance(rewritten, dict):
+                    parameters = rewritten
+                    break
             # `user_id` is passed as a kwarg to `execute_tool()` (used for
             # permission checks + audit), NOT merged into `parameters`. MCP
             # tools have strict Pydantic schemas; every unknown key triggers

--- a/src/backend/utils/hooks.py
+++ b/src/backend/utils/hooks.py
@@ -211,6 +211,16 @@ HOOK_EVENTS: frozenset[str] = frozenset({
     # plugin returning ``handled=True`` wins. This is the web-chat
     # equivalent of the Teams transport's ``_DISPATCH_HANDLERS`` table.
     "dispatch_sub_intent",
+    # Pre-MCP tool call rewrite — fired by ActionExecutor right before
+    # ``MCPManager.execute_tool`` for any ``mcp.*`` intent. Handlers
+    # receive ``intent: str, parameters: dict, user_id: int | None`` and
+    # may return a ``dict`` to **replace** the parameters before the MCP
+    # call, or ``None`` to leave them unchanged. First well-shaped
+    # non-None result wins — registration order determines precedence.
+    # Used by plugins to repair LLM tool calls (e.g. resolve a release
+    # title to its API id when the LLM passed the wrong parameter
+    # shape). Platform default (no handler) is a no-op.
+    "pre_mcp_call",
 })
 
 HookFn = Callable[..., Coroutine[Any, Any, Any]]

--- a/tests/backend/test_action_executor.py
+++ b/tests/backend/test_action_executor.py
@@ -221,6 +221,85 @@ class TestActionExecutorMCP:
 
 
 # ============================================================================
+# pre_mcp_call hook Tests
+# ============================================================================
+
+class TestActionExecutorPreMCPCall:
+    """Tests for the pre_mcp_call plugin hook."""
+
+    @pytest.mark.unit
+    async def test_pre_mcp_call_replaces_parameters(self, action_executor):
+        """Hook handler returning a dict replaces parameters before execute_tool."""
+        from utils.hooks import register_hook, _hooks
+
+        async def rewrite(intent, parameters, user_id=None, **_):
+            if intent == "mcp.release.get_release":
+                return {"id": "Applications/Folder/Release1"}
+            return None
+
+        register_hook("pre_mcp_call", rewrite)
+        try:
+            await action_executor.execute({
+                "intent": "mcp.release.get_release",
+                "parameters": {"title": "Product A 1.3.5"},
+                "confidence": 0.9,
+            })
+        finally:
+            _hooks["pre_mcp_call"].remove(rewrite)
+
+        action_executor.mcp_manager.execute_tool.assert_called_once()
+        call_args = action_executor.mcp_manager.execute_tool.call_args
+        assert call_args.args[1] == {"id": "Applications/Folder/Release1"}
+
+    @pytest.mark.unit
+    async def test_pre_mcp_call_none_leaves_parameters_unchanged(self, action_executor):
+        """Hook returning None leaves the original parameters intact."""
+        from utils.hooks import register_hook, _hooks
+
+        async def noop(intent, parameters, user_id=None, **_):
+            return None
+
+        register_hook("pre_mcp_call", noop)
+        try:
+            await action_executor.execute({
+                "intent": "mcp.release.get_release",
+                "parameters": {"id": "Applications/Folder/Release1"},
+                "confidence": 0.9,
+            })
+        finally:
+            _hooks["pre_mcp_call"].remove(noop)
+
+        call_args = action_executor.mcp_manager.execute_tool.call_args
+        assert call_args.args[1] == {"id": "Applications/Folder/Release1"}
+
+    @pytest.mark.unit
+    async def test_pre_mcp_call_first_dict_wins(self, action_executor):
+        """When multiple handlers return dicts, the first one wins."""
+        from utils.hooks import register_hook, _hooks
+
+        async def first(intent, parameters, user_id=None, **_):
+            return {"id": "first"}
+
+        async def second(intent, parameters, user_id=None, **_):
+            return {"id": "second"}
+
+        register_hook("pre_mcp_call", first)
+        register_hook("pre_mcp_call", second)
+        try:
+            await action_executor.execute({
+                "intent": "mcp.release.get_release",
+                "parameters": {"title": "x"},
+                "confidence": 0.9,
+            })
+        finally:
+            _hooks["pre_mcp_call"].remove(first)
+            _hooks["pre_mcp_call"].remove(second)
+
+        call_args = action_executor.mcp_manager.execute_tool.call_args
+        assert call_args.args[1] == {"id": "first"}
+
+
+# ============================================================================
 # ActionExecutor Edge Cases Tests
 # ============================================================================
 


### PR DESCRIPTION
## Summary

- New `pre_mcp_call` hook event in `utils/hooks.py::HOOK_EVENTS`
- Fires from `services/action_executor.py` right before `MCPManager.execute_tool` for any `mcp.*` intent
- Handlers receive `intent: str, parameters: dict, user_id: int | None` and may return a `dict` to replace parameters, or `None` to no-op. First well-shaped non-None dict wins — same contract as `intent_fallback_resolve`, `synthesis_prompt_override`, etc.

## Why

LLMs regularly produce malformed MCP tool calls (wrong parameter names, bogus envelopes, missing required fields). Today the only recovery is a full retry loop after schema validation rejects the call — costing ~10s of latency per malformed call. This hook lets plugins repair the call in-process.

Concrete consumer: Reva will register a handler that, for `mcp.release.get_release`, substitutes the API `id` from a request-scoped ContextVar when the LLM passed a `title` instead. See [X-idra-Systems-GmbH/reva#120](https://github.com/X-idra-Systems-GmbH/reva/issues/120) for the failure trace.

## Notes for the reviewer

- The hook fires BEFORE `_coerce_arguments` (the existing schema-coercion layer in `mcp_client.py`), so handlers see raw LLM output. This is intentional: a handler may want to inspect the LLM's exact malformation (e.g. detect a `{"request": {...}}` envelope) before coercion strips it. Handlers that want flat shapes can unwrap themselves.
- Platform default (no handler registered) is a no-op — backward compatible.
- `run_hooks` already swallows handler exceptions and logs at WARNING, so a plugin crash can't break MCP execution.
- One new fire site, ~10 lines. No changes to `mcp_client.py` or any tool implementation.

## Test plan

- [x] Three new unit tests in `tests/backend/test_action_executor.py::TestActionExecutorPreMCPCall`:
  - `test_pre_mcp_call_replaces_parameters` — handler returning a dict replaces params
  - `test_pre_mcp_call_none_leaves_parameters_unchanged` — None is a no-op
  - `test_pre_mcp_call_first_dict_wins` — registration order determines precedence
- [ ] Existing `TestActionExecutorRouting` / `TestActionExecutorMCP` / `TestActionExecutorUserIdPropagation` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)