### PR TITLE
feat(mcp): auto-reconnect + universal probe_server() for streamable_http

### DIFF
--- a/src/backend/services/mcp_client.py
+++ b/src/backend/services/mcp_client.py
@@ -30,6 +30,7 @@ from typing import Any
 # (the default path — non-chat callers don't need progress relay).
 ProgressSink = Callable[[dict], Awaitable[None]]
 
+import anyio
 import httpx
 import yaml
 from loguru import logger
@@ -614,6 +615,24 @@ def _detect_inner_error(message: str) -> bool:
     return False
 
 
+# Exceptions that indicate the MCP transport itself is broken (session
+# died, stream closed, server bounced). These — and only these — trigger
+# a single auto-reconnect-and-retry inside execute_tool(). MCP application
+# errors (mcp.shared.exceptions.McpError, validation, schema mismatch)
+# must NOT be in this list: reconnecting wouldn't help and would tear
+# down a perfectly healthy session over a malformed argument.
+_SESSION_DEAD_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    anyio.ClosedResourceError,
+    anyio.BrokenResourceError,
+    anyio.EndOfStream,
+    httpx.RemoteProtocolError,
+    httpx.ReadError,
+    httpx.WriteError,
+    httpx.ConnectError,
+    ConnectionError,
+)
+
+
 class MCPTransportType(str, Enum):
     STREAMABLE_HTTP = "streamable_http"
     SSE = "sse"
@@ -689,6 +708,12 @@ class MCPServerState:
     exit_stack: AsyncExitStack | None = None
     rate_limiter: TokenBucketRateLimiter | None = None
     backoff: ExponentialBackoff | None = None  # Reconnection backoff tracker
+    # Serializes concurrent reconnect attempts per server. Initialized
+    # synchronously via default_factory so concurrent first-callers can't
+    # each construct their own Lock and end up reconnecting in parallel
+    # (which would race exit_stack teardown against re-entry).
+    reconnect_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    last_successful_call: float = 0.0  # monotonic timestamp; 0 = never
 
 
 def _substitute_env_vars(value: str) -> str:
@@ -1030,6 +1055,85 @@ class MCPManager:
                     pass
                 state.exit_stack = None
 
+    async def _reconnect_server(self, state: MCPServerState) -> bool:
+        """Tear down a stale session and re-establish.
+
+        Single concurrent reconnect per server: callers contend on
+        ``state.reconnect_lock`` (initialised synchronously on the dataclass).
+        Whoever wins the lock first does the actual work; subsequent
+        callers see ``state.connected == True`` and short-circuit. Caller-
+        side: invoke when a tool call raises a session-shape error, then
+        retry the operation once.
+        """
+        async with state.reconnect_lock:
+            # Another caller may have already restored the session.
+            if state.connected and state.session is not None:
+                return True
+            # Tear down old session/streams. Failures here are expected
+            # (the resource is half-broken — that's why we're here).
+            if state.exit_stack is not None:
+                try:
+                    await state.exit_stack.__aexit__(None, None, None)
+                except Exception:
+                    pass
+                state.exit_stack = None
+                state.session = None
+            logger.info(f"MCP reconnecting to '{state.config.name}'...")
+            await self._connect_server(state)
+            return state.connected
+
+    async def probe_server(self, server_name: str) -> dict:
+        """Active probe for an MCP server's session via the universal
+        ``tools/list`` method.
+
+        Vendor-agnostic: every conformant MCP server supports
+        ``tools/list``, so this works against servers we don't control.
+
+        Auto-reconnects on probe failure (single-shot) so a /api/health
+        call from Reva not only reports the live state but also drives
+        recovery without waiting for the next ``refresh_tools`` tick.
+
+        Returns ``{"ok": bool, "latency_ms": float | None, "detail": str | None}``.
+        """
+        state = self._servers.get(server_name)
+        if state is None:
+            return {"ok": False, "latency_ms": None, "detail": "unknown server"}
+
+        async def _probe_once() -> tuple[bool, float | None, str | None]:
+            if state.session is None:
+                return False, None, "no session"
+            t0 = time.monotonic()
+            try:
+                await asyncio.wait_for(state.session.list_tools(), timeout=2.0)
+            except asyncio.TimeoutError:
+                return False, None, "timeout >2s"
+            except Exception as exc:  # noqa: BLE001 - surface the type
+                return False, None, f"{type(exc).__name__}: {exc}"[:200]
+            latency_ms = (time.monotonic() - t0) * 1000
+            return True, round(latency_ms, 1), None
+
+        ok, latency, detail = await _probe_once()
+        if ok:
+            state.last_successful_call = time.monotonic()
+            return {"ok": True, "latency_ms": latency, "detail": None}
+
+        # Probe failed → mark stale and try one reconnect, then re-probe.
+        state.connected = False
+        state.last_error = detail
+        reconnected = await self._reconnect_server(state)
+        if not reconnected:
+            return {"ok": False, "latency_ms": None, "detail": f"reconnect failed: {state.last_error}"}
+        ok, latency, detail = await _probe_once()
+        if ok:
+            state.last_successful_call = time.monotonic()
+        else:
+            # Reconnect succeeded but the fresh session still can't list_tools.
+            # Don't leave state.connected=True after we've seen evidence of
+            # breakage — next caller would try to use a known-bad session.
+            state.connected = False
+            state.last_error = detail
+        return {"ok": ok, "latency_ms": latency, "detail": detail}
+
     def _check_tool_permission(
         self,
         tool_info: MCPToolInfo,
@@ -1241,69 +1345,105 @@ class MCPManager:
                 "data": None,
             }
 
-        try:
-            user_info = f" (user_id={user_id})" if user_id is not None else ""
-            logger.debug(f"MCP call: {namespaced_name}{user_info}")
-            result = await asyncio.wait_for(
+        user_info = f" (user_id={user_id})" if user_id is not None else ""
+        logger.debug(f"MCP call: {namespaced_name}{user_info}")
+
+        async def _do_call() -> Any:
+            return await asyncio.wait_for(
                 state.session.call_tool(tool_info.original_name, arguments),
                 timeout=settings.mcp_call_timeout,
             )
 
-            # Convert CallToolResult to our format
-            is_error = getattr(result, "isError", False)
-            content_parts = []
-            raw_data = []
-
-            for item in result.content:
-                text = getattr(item, "text", None)
-                if text:
-                    # === Response Truncation ===
-                    truncated_text = _truncate_response(text)
-                    content_parts.append(truncated_text)
-                raw_data.append(
-                    {"type": getattr(item, "type", "unknown"), "text": text}
+        # Try once; on a session-shape exception (transport-layer death —
+        # see _SESSION_DEAD_EXCEPTIONS) reconnect and retry once. Application
+        # errors (McpError, validation) and timeouts fall through immediately:
+        # reconnecting wouldn't help and would tear down a healthy session.
+        result = None
+        last_exc: BaseException | None = None
+        for attempt in range(2):
+            try:
+                result = await _do_call()
+                last_exc = None
+                break
+            except TimeoutError:
+                logger.error(f"MCP tool call timeout: {namespaced_name}")
+                return {
+                    "success": False,
+                    "message": f"Tool-Aufruf Timeout: {namespaced_name}",
+                    "data": None,
+                }
+            except _SESSION_DEAD_EXCEPTIONS as e:
+                last_exc = e
+                if attempt == 0:
+                    logger.warning(
+                        f"MCP session died on {namespaced_name}: {type(e).__name__}: {e}; "
+                        f"reconnecting and retrying once"
+                    )
+                    state.connected = False
+                    state.last_error = str(e)
+                    reconnected = await self._reconnect_server(state)
+                    if not reconnected:
+                        break
+                    continue
+                logger.error(
+                    f"MCP tool call failed after reconnect: {namespaced_name}: {e}"
                 )
+                state.connected = False
+                state.last_error = str(e)
+            except Exception as e:  # noqa: BLE001 - bubble in last_exc
+                # Application-level error (McpError, schema, etc.). The
+                # session is fine; just surface the failure.
+                last_exc = e
+                logger.error(f"MCP tool call failed: {namespaced_name}: {e}")
+                state.last_error = str(e)
+                break
 
-            message = "\n".join(content_parts) if content_parts else "Tool executed"
-
-            # Truncate final message if still too large
-            message = _truncate_response(message)
-
-            # NOTE: Credential sanitization is NOT done here — the agent loop
-            # needs real API keys in tool results (e.g. Jellyfin stream URLs
-            # passed to play_in_room). Sanitization happens in
-            # step_to_ws_message() before sending to the frontend.
-
-            # Some MCP servers (e.g. n8n-mcp) wrap responses in their own
-            # JSON envelope: {"success": false, "error": "..."}. The MCP-level
-            # isError flag stays False even on application errors, so we check
-            # the inner JSON to detect real failures.
-            if not is_error:
-                is_error = _detect_inner_error(message)
-
-            return {
-                "success": not is_error,
-                "message": message,
-                "data": raw_data if raw_data else None,
-            }
-
-        except TimeoutError:
-            logger.error(f"MCP tool call timeout: {namespaced_name}")
+        if result is None:
             return {
                 "success": False,
-                "message": f"Tool-Aufruf Timeout: {namespaced_name}",
+                "message": f"Tool-Aufruf fehlgeschlagen: {last_exc}",
                 "data": None,
             }
-        except Exception as e:
-            logger.error(f"MCP tool call failed: {namespaced_name}: {e}")
-            # Mark server as disconnected on session errors
-            state.connected = False
-            state.last_error = str(e)
-            return {
-                "success": False,
-                "message": f"Tool-Aufruf fehlgeschlagen: {e}",
-                "data": None,
-            }
+
+        state.last_successful_call = time.monotonic()
+
+        # Convert CallToolResult to our format
+        is_error = getattr(result, "isError", False)
+        content_parts = []
+        raw_data = []
+
+        for item in result.content:
+            text = getattr(item, "text", None)
+            if text:
+                # === Response Truncation ===
+                truncated_text = _truncate_response(text)
+                content_parts.append(truncated_text)
+            raw_data.append(
+                {"type": getattr(item, "type", "unknown"), "text": text}
+            )
+
+        message = "\n".join(content_parts) if content_parts else "Tool executed"
+
+        # Truncate final message if still too large
+        message = _truncate_response(message)
+
+        # NOTE: Credential sanitization is NOT done here — the agent loop
+        # needs real API keys in tool results (e.g. Jellyfin stream URLs
+        # passed to play_in_room). Sanitization happens in
+        # step_to_ws_message() before sending to the frontend.
+
+        # Some MCP servers (e.g. n8n-mcp) wrap responses in their own
+        # JSON envelope: {"success": false, "error": "..."}. The MCP-level
+        # isError flag stays False even on application errors, so we check
+        # the inner JSON to detect real failures.
+        if not is_error:
+            is_error = _detect_inner_error(message)
+
+        return {
+            "success": not is_error,
+            "message": message,
+            "data": raw_data if raw_data else None,
+        }
 
     async def execute_tool_streaming(
         self,

--- a/tests/backend/test_mcp_reconnect.py
+++ b/tests/backend/test_mcp_reconnect.py
@@ -1,0 +1,212 @@
+"""Reconnect + probe tests for MCPManager.
+
+Covers the regressions raised in the 2026-04-28 health-check redesign review:
+- C1: lock-creation race in _reconnect_server (50 concurrent callers must
+       trigger exactly one _connect_server invocation).
+- C3: execute_tool retries once on session-shape exceptions but NOT on
+       application errors like McpError.
+- I4: probe_server marks state.connected=False when the post-reconnect
+       probe still fails.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import anyio
+import httpx
+import pytest
+
+from services.mcp_client import (
+    MCPManager,
+    MCPServerConfig,
+    MCPServerState,
+    MCPToolInfo,
+    MCPTransportType,
+)
+
+
+def _make_state(name: str = "demo") -> MCPServerState:
+    cfg = MCPServerConfig(
+        name=name,
+        url="http://localhost:9999/mcp",
+        transport=MCPTransportType.STREAMABLE_HTTP,
+    )
+    return MCPServerState(config=cfg, connected=True)
+
+
+def _make_manager(state: MCPServerState) -> MCPManager:
+    mgr = MCPManager()
+    mgr._servers[state.config.name] = state
+    return mgr
+
+
+# ---------------------------------------------------------------------------
+# C1 — _reconnect_server must serialize concurrent callers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_reconnect_server_serialises_concurrent_callers():
+    """50 concurrent callers must result in exactly one _connect_server call.
+
+    Pre-fix, lazy lock creation under contention let multiple callers each
+    construct their own asyncio.Lock and reconnect in parallel — the bug the
+    redesign exists to fix would silently linger.
+    """
+    state = _make_state()
+    state.session = MagicMock()  # pretend it's connected
+    mgr = _make_manager(state)
+
+    invocations = 0
+    connect_started = asyncio.Event()
+    can_finish = asyncio.Event()
+
+    async def _fake_connect(s: MCPServerState) -> None:
+        nonlocal invocations
+        invocations += 1
+        connect_started.set()
+        await can_finish.wait()
+        s.connected = True
+        s.session = MagicMock()
+
+    mgr._connect_server = _fake_connect  # type: ignore[assignment]
+
+    # Force "needs reconnect" state (drop session)
+    state.connected = False
+    state.session = None
+    state.exit_stack = None
+
+    # Spawn 50 concurrent callers
+    tasks = [asyncio.create_task(mgr._reconnect_server(state)) for _ in range(50)]
+    await connect_started.wait()
+    can_finish.set()
+    results = await asyncio.gather(*tasks)
+
+    assert all(results), "every caller should observe a successful reconnect"
+    assert invocations == 1, (
+        f"expected 1 _connect_server call, got {invocations} — concurrent reconnect"
+    )
+
+
+# ---------------------------------------------------------------------------
+# C3 — execute_tool retries on session-shape errors only
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def manager_with_tool():
+    state = _make_state(name="srv")
+    tool = MCPToolInfo(
+        server_name="srv",
+        original_name="ping",
+        namespaced_name="mcp.srv.ping",
+        description="ping",
+        input_schema={"type": "object", "properties": {}},
+    )
+    state.tools = [tool]
+    state.session = AsyncMock()
+    state.session.call_tool = AsyncMock()
+    mgr = _make_manager(state)
+    mgr._tool_index["mcp.srv.ping"] = tool
+    return mgr, state
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_tool_retries_on_session_dead(manager_with_tool):
+    """ClosedResourceError → reconnect, retry, success."""
+    mgr, state = manager_with_tool
+    # First call dies, second call succeeds.
+    success_result = MagicMock(content=[MagicMock(type="text", text="ok")], isError=False)
+    state.session.call_tool.side_effect = [
+        anyio.ClosedResourceError(),
+        success_result,
+    ]
+    reconnect_calls = 0
+
+    async def _fake_reconnect(s):
+        nonlocal reconnect_calls
+        reconnect_calls += 1
+        s.connected = True
+        return True
+
+    mgr._reconnect_server = _fake_reconnect  # type: ignore[assignment]
+
+    out = await mgr.execute_tool("mcp.srv.ping", {}, user_permissions=None)
+    assert out["success"] is True, out
+    assert reconnect_calls == 1
+    assert state.session.call_tool.await_count == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_tool_does_not_retry_on_application_error(manager_with_tool):
+    """ValueError (stand-in for McpError / app-level exception) must NOT trigger reconnect.
+
+    Pre-fix, any non-timeout Exception triggered reconnect — tearing down
+    healthy sessions over malformed arguments.
+    """
+    mgr, state = manager_with_tool
+    state.session.call_tool.side_effect = [ValueError("invalid argument")]
+    reconnect_calls = 0
+
+    async def _fake_reconnect(s):
+        nonlocal reconnect_calls
+        reconnect_calls += 1
+        return True
+
+    mgr._reconnect_server = _fake_reconnect  # type: ignore[assignment]
+
+    out = await mgr.execute_tool("mcp.srv.ping", {}, user_permissions=None)
+    assert out["success"] is False
+    assert reconnect_calls == 0
+    assert state.session.call_tool.await_count == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_tool_retries_on_httpx_remote_protocol_error(manager_with_tool):
+    """httpx.RemoteProtocolError is the typical streamable_http stream-died signal."""
+    mgr, state = manager_with_tool
+    success_result = MagicMock(content=[MagicMock(type="text", text="ok")], isError=False)
+    state.session.call_tool.side_effect = [
+        httpx.RemoteProtocolError("stream closed"),
+        success_result,
+    ]
+    mgr._reconnect_server = AsyncMock(return_value=True)  # type: ignore[assignment]
+
+    out = await mgr.execute_tool("mcp.srv.ping", {}, user_permissions=None)
+    assert out["success"] is True
+    mgr._reconnect_server.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# I4 — probe_server marks connected=False when post-reconnect probe fails
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_probe_server_marks_disconnected_when_reconnect_doesnt_fix_it():
+    state = _make_state(name="srv")
+    state.session = AsyncMock()
+    state.session.list_tools = AsyncMock(side_effect=anyio.ClosedResourceError())
+    mgr = _make_manager(state)
+
+    # Reconnect "succeeds" but the new session also fails list_tools.
+    async def _fake_reconnect(s):
+        s.connected = True  # _connect_server would set this
+        # session still raises
+        return True
+
+    mgr._reconnect_server = _fake_reconnect  # type: ignore[assignment]
+
+    result = await mgr.probe_server("srv")
+    assert result["ok"] is False
+    assert state.connected is False, (
+        "probe_server must clear connected=True when the fresh session also fails"
+    )
+    assert state.last_error is not None


### PR DESCRIPTION
## Background

When an upstream MCP server bounces (CI deploy, OOM, node drain) the streamable_http session held by `MCPManager` goes dead, but `state.connected` stays `True` until the next `refresh_tools` tick — which runs every `refresh_interval` seconds (default 300). In that window every tool call fails. Recovery, today, requires restarting the consuming pod.

A real production cascade hit a downstream consumer (Reva) on 2026-04-28: `usu-mcp` restart → `reva.itsm` session drops → readiness probe flips to 503 → kube-proxy stopped sending traffic → ~30 min outage despite release/jira/confluence being healthy.

## What this changes

1. **`_reconnect_server(state)`** — single-concurrent-reconnect helper guarded by `state.reconnect_lock`. Tears down the stale `exit_stack` (ignoring teardown failures — the resource is already half-broken) and re-runs `_connect_server`. Subsequent contenders observe `state.connected == True` after the lock and short-circuit.

2. **`probe_server(name) -> dict`** — public liveness probe via the universal MCP `tools/list` method. Two-shot: first probe; on failure mark stale, drive `_reconnect_server`, re-probe. **Vendor-agnostic by design** — `tools/list` is the universal MCP discovery method; no server-side cooperation required.

3. **`execute_tool` retry-once-on-session-death** with a typed `_SESSION_DEAD_EXCEPTIONS` tuple (anyio `ClosedResourceError`/`BrokenResourceError`/`EndOfStream`, httpx `RemoteProtocolError`/`ReadError`/`WriteError`/`ConnectError`, `ConnectionError`). Application-level errors (McpError, validation) and timeouts fall through immediately — reconnecting wouldn't help and would tear down a healthy session over a malformed argument.

4. **`MCPServerState`** adds `reconnect_lock: asyncio.Lock = field(default_factory=asyncio.Lock)` (initialised synchronously, not lazily — concurrent first-callers would otherwise each construct their own Lock and race) and `last_successful_call: float` (monotonic, updated on every successful call/probe).

## Tests

`tests/backend/test_mcp_reconnect.py` — 4 unit tests:

- 50 concurrent `_reconnect_server` callers → exactly 1 `_connect_server` invocation (regression guard for the lazy-lock race).
- `ClosedResourceError` + `RemoteProtocolError` trigger one retry with success on the second call.
- Plain `ValueError` (stand-in for application-level error) does NOT trigger reconnect.
- `probe_server` clears `state.connected` when the post-reconnect probe also fails.

Verified all four against a local Renfield install — all pass.

## Coordinated change

This is the upstream half of a coordinated change with a downstream consumer that calls `probe_server()` from its `/api/health` endpoint. The downstream PR has a backwards-compat fallback path (direct probe through the cached session reference, no reconnect) so it works against either old or new Renfield during partial rollout.

## No breaking change

- Existing `execute_tool` call sites unaffected — same return shape.
- `get_status()` shape unchanged.
- `MCPServerState` only gains fields with defaults.
- `_connect_server`, `refresh_tools`, all transport branches untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)