### PR TITLE
fix(agent-tools): async create() classmethod replaces _hook_task workaround

### DIFF
--- a/src/backend/api/routes/chat.py
+++ b/src/backend/api/routes/chat.py
@@ -112,7 +112,7 @@ async def send_message(
                 from services.agent_tools import AgentToolRegistry
 
                 mcp_manager = getattr(app.state, 'mcp_manager', None)
-                tool_registry = AgentToolRegistry(mcp_manager=mcp_manager)
+                tool_registry = await AgentToolRegistry.create(mcp_manager=mcp_manager)
                 agent = AgentService(tool_registry)
                 executor = ActionExecutor(mcp_manager=mcp_manager)
 

--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -1152,7 +1152,7 @@ async def websocket_endpoint(
                 else:
                     # Specialized agent loop (smart_home, documents, media, research, workflow, general)
                     agent_used = True
-                    tool_registry = AgentToolRegistry(
+                    tool_registry = await AgentToolRegistry.create(
                         mcp_manager=mcp_manager,
                         server_filter=role.mcp_servers,
                         internal_filter=role.internal_tools,

--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -1162,14 +1162,6 @@ class AgentService:
 
         start_time = time.monotonic()
 
-        # Ensure plugin tools (register_tools hook) are ready before we read
-        # the tool list.  The hook is scheduled as a background task in
-        # AgentToolRegistry.__init__; without this await, _preselect_tools
-        # captures only MCP/internal tools and misses plugin-provided ones.
-        hook_task = getattr(self.tool_registry, "_hook_task", None)
-        if hook_task is not None:
-            await hook_task
-
         # Per-role model/URL override > global agent settings > default
         role_model = self.role.model if self.role else None
         role_url = self.role.ollama_url if self.role else None

--- a/src/backend/services/agent_tools.py
+++ b/src/backend/services/agent_tools.py
@@ -79,8 +79,23 @@ class AgentToolRegistry:
         mcp_manager: Optional["MCPManager"] = None,
         server_filter: list[str] | None = None,
         internal_filter: list[str] | None = None,
+        _init_only: bool = False,
     ):
-        """Initialize the tool registry.
+        """Initialize the tool registry with MCP + platform-internal tools.
+
+        Direct construction is restricted: ``__init__`` does NOT run the
+        ``register_tools`` hook, so plugin tools (Reva's
+        ``resolve_team_members`` etc.) are absent. Production code must use
+        :meth:`AgentToolRegistry.create` instead — it runs the hook in-line
+        and returns a fully populated registry. Tests that don't need
+        plugin tools may opt into direct construction by passing
+        ``_init_only=True``.
+
+        The guard exists because TD-13 (Reva P0.5) was a silent-failure
+        regression caused by exactly this gap — a caller that constructed
+        the registry without awaiting the plugin hook lost plugin tools
+        with no signal in the logs. We trade a flagged ``RuntimeError`` at
+        the wrong call site for that class of mistake.
 
         Args:
             mcp_manager: MCP server manager
@@ -88,7 +103,22 @@ class AgentToolRegistry:
                           None means include all servers.
             internal_filter: If set, only include these internal tool names.
                             None means include all internal tools.
+            _init_only: Test-only escape hatch. Set to True to construct a
+                registry without plugin tools. Production code must not
+                pass this — use :meth:`create` instead.
+
+        Raises:
+            RuntimeError: if ``_init_only`` is False (the default).
         """
+        if not _init_only:
+            raise RuntimeError(
+                "Direct AgentToolRegistry(...) construction is restricted "
+                "because it skips plugin-tool registration "
+                "(the register_tools hook). Production code must use "
+                "`await AgentToolRegistry.create(...)`. Tests that don't "
+                "need plugin tools may pass `_init_only=True`."
+            )
+
         self._tools: dict[str, ToolDefinition] = {}
 
         # Expose the construction filters as public attributes so the
@@ -106,8 +136,38 @@ class AgentToolRegistry:
         # Register internal agent tools (room resolution, media playback)
         self._register_internal_tools(internal_filter=internal_filter)
 
-        # Hook: register_tools — plugins can add their own tool definitions
-        self._schedule_register_tools_hook()
+    @classmethod
+    async def create(
+        cls,
+        mcp_manager: Optional["MCPManager"] = None,
+        server_filter: list[str] | None = None,
+        internal_filter: list[str] | None = None,
+    ) -> "AgentToolRegistry":
+        """Async constructor — builds the registry AND awaits plugin tools.
+
+        Replaces the previous pattern where ``__init__`` scheduled a
+        background task and every call site had to remember
+        ``await tool_registry._hook_task``. With ``create()`` the registry
+        returned to the caller is fully populated.
+
+        Plugin hooks are awaited directly here (not via ``run_hooks``) so
+        that a failing handler propagates as a real exception. Caller code
+        — notably the orchestrator — relies on this to fail fast with a
+        diagnosable error instead of silently using a half-populated
+        registry. ``run_hooks`` swallows handler exceptions for fire-and-
+        forget event sites; ``register_tools`` is fail-loud.
+        """
+        from utils.hooks import _hooks
+
+        registry = cls(
+            mcp_manager=mcp_manager,
+            server_filter=server_filter,
+            internal_filter=internal_filter,
+            _init_only=True,
+        )
+        for hook in _hooks.get("register_tools", []):
+            await hook(registry=registry)
+        return registry
 
     def _register_internal_tools(self, internal_filter: list[str] | None = None) -> None:
         """Register platform-owned internal agent tools.
@@ -138,22 +198,6 @@ class AgentToolRegistry:
             )
             self._tools[tool.name] = tool
             logger.debug(f"Internal agent tool registered: {tool.name}")
-
-    def _schedule_register_tools_hook(self) -> None:
-        """Fire the register_tools hook so plugins can add tool definitions."""
-        import asyncio
-
-        from utils.hooks import run_hooks
-
-        async def _run():
-            await run_hooks("register_tools", registry=self)
-
-        try:
-            loop = asyncio.get_running_loop()
-            # Store reference to prevent GC (RUF006)
-            self._hook_task = loop.create_task(_run())
-        except RuntimeError:
-            pass  # No event loop (e.g. sync tests) — skip
 
     def _register_mcp_tools(self, mcp_manager: "MCPManager", server_filter: list[str] | None = None) -> None:
         """Register MCP tools as agent tools.

--- a/src/backend/services/orchestrator.py
+++ b/src/backend/services/orchestrator.py
@@ -390,30 +390,23 @@ class QueryOrchestrator:
         logger.info(f"Orchestrator: launching sub-agent [{role_name}]: {query[:60]}")
 
         try:
-            tool_registry = AgentToolRegistry(
-                mcp_manager=self.mcp_manager,
-                server_filter=role.mcp_servers,
-                internal_filter=role.internal_tools,
-            )
-
-            # Plugin-registered tools attach asynchronously via _hook_task.
-            # Without this await the agent reads a half-populated registry
-            # and "tool not found" errors don't trace back to the failure.
-            hook_task = getattr(tool_registry, "_hook_task", None)
-            if hook_task is not None:
-                try:
-                    await hook_task
-                except Exception as e:
-                    logger.opt(exception=True).error(
-                        f"Tool registry init failed for [{role_name}]: "
-                        f"{type(e).__name__}: {e}"
-                    )
-                    msg = (
-                        f"Tools für Rolle '{role_name}' konnten nicht geladen werden."
-                        if lang.startswith("de") else
-                        f"Tools for role '{role_name}' failed to load."
-                    )
-                    return _failed_sub_result(role_name, query, error=msg)
+            try:
+                tool_registry = await AgentToolRegistry.create(
+                    mcp_manager=self.mcp_manager,
+                    server_filter=role.mcp_servers,
+                    internal_filter=role.internal_tools,
+                )
+            except Exception as e:
+                logger.opt(exception=True).error(
+                    f"Tool registry init failed for [{role_name}]: "
+                    f"{type(e).__name__}: {e}"
+                )
+                msg = (
+                    f"Tools für Rolle '{role_name}' konnten nicht geladen werden."
+                    if lang.startswith("de") else
+                    f"Tools for role '{role_name}' failed to load."
+                )
+                return _failed_sub_result(role_name, query, error=msg)
 
             agent = AgentService(tool_registry, role=role)
 

--- a/tests/backend/test_agent_router.py
+++ b/tests/backend/test_agent_router.py
@@ -724,6 +724,7 @@ class TestRouterToolIntegration:
         registry = AgentToolRegistry(
             server_filter=role.mcp_servers,
             internal_filter=role.internal_tools,
+            _init_only=True,
         )
 
         # With no MCP manager, only internal tools should be registered
@@ -748,7 +749,7 @@ class TestRouterToolIntegration:
         roles = _parse_roles(SAMPLE_CONFIG)
         role = roles["smart_home"]
 
-        registry = AgentToolRegistry()
+        registry = AgentToolRegistry(_init_only=True)
         agent = AgentService(registry, role=role)
 
         assert agent.max_steps == 4
@@ -765,6 +766,7 @@ class TestRouterToolIntegration:
         registry = AgentToolRegistry(
             server_filter=role.mcp_servers,
             internal_filter=role.internal_tools,
+            _init_only=True,
         )
 
         tool_names = registry.get_tool_names()
@@ -780,7 +782,7 @@ class TestRouterToolIntegration:
         from services.agent_service import AgentService
         from services.agent_tools import AgentToolRegistry
 
-        registry = AgentToolRegistry()
+        registry = AgentToolRegistry(_init_only=True)
         agent = AgentService(registry)
 
         # Should use settings.agent_max_steps (12 by default)

--- a/tests/backend/test_agent_service.py
+++ b/tests/backend/test_agent_service.py
@@ -581,7 +581,7 @@ class TestAgentServiceRun:
 
     def _make_registry(self, tools=None):
         """Create a tool registry with MCP tools."""
-        registry = AgentToolRegistry(mcp_manager=_make_mock_mcp_manager())
+        registry = AgentToolRegistry(mcp_manager=_make_mock_mcp_manager(), _init_only=True)
         return registry
 
     def _make_ollama_mock(self, responses):
@@ -958,7 +958,7 @@ class TestAgentServiceSafety:
     @pytest.mark.unit
     async def test_total_timeout(self):
         """Total timeout should stop the agent even if steps are within per-step limit."""
-        registry = AgentToolRegistry(mcp_manager=_make_mock_mcp_manager())
+        registry = AgentToolRegistry(mcp_manager=_make_mock_mcp_manager(), _init_only=True)
         ollama = MagicMock()
         ollama.client = MagicMock()
 
@@ -1004,7 +1004,7 @@ class TestAgentServiceSafety:
     @pytest.mark.unit
     async def test_build_summary_answer_with_results(self):
         """Summary answer should call LLM to produce natural language from tool results."""
-        registry = AgentToolRegistry(mcp_manager=_make_mock_mcp_manager())
+        registry = AgentToolRegistry(mcp_manager=_make_mock_mcp_manager(), _init_only=True)
         agent = AgentService(registry)
 
         ctx = AgentContext(original_message="Wie ist das Wetter?")
@@ -1039,7 +1039,7 @@ class TestAgentServiceSafety:
     @pytest.mark.unit
     async def test_build_summary_answer_no_results(self):
         """Summary answer without any results should give generic message."""
-        registry = AgentToolRegistry(mcp_manager=_make_mock_mcp_manager())
+        registry = AgentToolRegistry(mcp_manager=_make_mock_mcp_manager(), _init_only=True)
         agent = AgentService(registry)
 
         ctx = AgentContext(original_message="test")
@@ -1051,7 +1051,7 @@ class TestAgentServiceSafety:
     @pytest.mark.unit
     async def test_build_summary_answer_llm_failure_fallback(self):
         """When LLM summary fails, should return a fallback message."""
-        registry = AgentToolRegistry(mcp_manager=_make_mock_mcp_manager())
+        registry = AgentToolRegistry(mcp_manager=_make_mock_mcp_manager(), _init_only=True)
         agent = AgentService(registry)
 
         ctx = AgentContext(original_message="test")
@@ -1076,7 +1076,7 @@ class TestAgentServiceSafety:
     @pytest.mark.unit
     def test_build_fallback_answer(self):
         """Fallback answer should include the error message."""
-        registry = AgentToolRegistry(mcp_manager=_make_mock_mcp_manager())
+        registry = AgentToolRegistry(mcp_manager=_make_mock_mcp_manager(), _init_only=True)
         agent = AgentService(registry)
 
         ctx = AgentContext(original_message="test")
@@ -1093,7 +1093,7 @@ class TestAgentServiceRetry:
     """Test the retry-on-empty-response mechanism."""
 
     def _make_registry(self):
-        return AgentToolRegistry(mcp_manager=_make_mock_mcp_manager())
+        return AgentToolRegistry(mcp_manager=_make_mock_mcp_manager(), _init_only=True)
 
     def _make_executor_mock(self, results=None):
         executor = AsyncMock()
@@ -1218,7 +1218,7 @@ class TestToolResultDataInclusion:
     """Test that tool results include actual data for LLM reasoning."""
 
     def _make_registry(self):
-        return AgentToolRegistry(mcp_manager=_make_mock_mcp_manager())
+        return AgentToolRegistry(mcp_manager=_make_mock_mcp_manager(), _init_only=True)
 
     @pytest.mark.unit
     async def test_tool_result_includes_data(self):
@@ -1313,7 +1313,7 @@ class TestAgentInfiniteLoopDetection:
     """Test that the agent detects and breaks out of infinite loops."""
 
     def _make_registry(self):
-        return AgentToolRegistry(mcp_manager=_make_mock_mcp_manager())
+        return AgentToolRegistry(mcp_manager=_make_mock_mcp_manager(), _init_only=True)
 
     def _make_executor_mock(self):
         executor = AsyncMock()
@@ -1376,7 +1376,7 @@ class TestAgentCircuitBreakerIntegration:
     """Test circuit breaker integration in agent service."""
 
     def _make_registry(self):
-        return AgentToolRegistry(mcp_manager=_make_mock_mcp_manager())
+        return AgentToolRegistry(mcp_manager=_make_mock_mcp_manager(), _init_only=True)
 
     @pytest.mark.unit
     async def test_circuit_breaker_blocks_when_open(self):
@@ -1551,7 +1551,7 @@ class TestAgentMusicPlaybackChain:
             tools.append(mock_tool)
         mock_mcp.get_all_tools.return_value = tools
 
-        registry = AgentToolRegistry(mcp_manager=mock_mcp)
+        registry = AgentToolRegistry(mcp_manager=mock_mcp, _init_only=True)
         # play_in_room and resolve_room_player moved to ha_glue hook;
         # register them manually for the test.
         from services.agent_tools import ToolDefinition
@@ -1788,7 +1788,7 @@ class TestAgentBreaksOnRepeatedEmptyResults:
     """Test that the agent loop breaks after repeated empty results."""
 
     def _make_registry(self):
-        return AgentToolRegistry(mcp_manager=_make_mock_mcp_manager())
+        return AgentToolRegistry(mcp_manager=_make_mock_mcp_manager(), _init_only=True)
 
     @pytest.mark.unit
     async def test_agent_breaks_after_repeated_empty_results(self):
@@ -1860,7 +1860,7 @@ class TestTokenContextVars:
 
     def _make_registry(self):
         from services.agent_tools import AgentToolRegistry
-        return AgentToolRegistry(mcp_manager=_make_mock_mcp_manager())
+        return AgentToolRegistry(mcp_manager=_make_mock_mcp_manager(), _init_only=True)
 
     def _make_ollama_mock(self, responses):
         ollama = MagicMock()
@@ -2141,7 +2141,7 @@ class TestShouldUseNativeFC:
 
     def _make_registry(self):
         from services.agent_tools import AgentToolRegistry
-        return AgentToolRegistry(mcp_manager=_make_mock_mcp_manager())
+        return AgentToolRegistry(mcp_manager=_make_mock_mcp_manager(), _init_only=True)
 
     @pytest.mark.unit
     def test_default_off_when_no_role_flag(self):

--- a/tests/backend/test_agent_tools.py
+++ b/tests/backend/test_agent_tools.py
@@ -39,19 +39,109 @@ class TestAgentToolRegistryConstruction:
         """The server_filter parameter must be exposed so plugins (e.g. the
         register_tools hook) can scope their additions to the same set of
         servers the caller selected for MCP/internal tools."""
-        registry = AgentToolRegistry(server_filter=["jira", "confluence"])
+        registry = AgentToolRegistry(server_filter=["jira", "confluence"], _init_only=True)
         assert registry.server_filter == ["jira", "confluence"]
 
     @pytest.mark.unit
     def test_server_filter_default_none(self):
         """When no server_filter is passed, the attribute is None (= all servers)."""
-        registry = AgentToolRegistry()
+        registry = AgentToolRegistry(_init_only=True)
         assert registry.server_filter is None
 
     @pytest.mark.unit
     def test_internal_filter_stored_as_attribute(self):
         """The internal_filter parameter is exposed for the same reason."""
-        registry = AgentToolRegistry(internal_filter=["internal.knowledge_search"])
+        registry = AgentToolRegistry(internal_filter=["internal.knowledge_search"], _init_only=True)
+        assert registry.internal_filter == ["internal.knowledge_search"]
+
+
+class TestAgentToolRegistryAsyncCreate:
+    """Test the async ``create()`` classmethod that runs ``register_tools`` in-line.
+
+    This is the production constructor — it replaces the old pattern where
+    ``__init__`` scheduled a background task and every call site had to
+    remember ``await tool_registry._hook_task``. With ``create()`` the
+    registry returned to the caller is fully populated, eliminating the
+    race condition that caused intermittent missing-plugin-tool failures.
+    """
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_create_awaits_register_tools_hook(self):
+        """``create()`` must await the ``register_tools`` hook before returning,
+        so plugin-registered tools are present in the registry the caller receives."""
+        from utils.hooks import _hooks, register_hook
+
+        # Save original hook state for cleanup
+        original = list(_hooks.get("register_tools", []))
+        try:
+            registered_during_create: list[bool] = []
+
+            async def _plugin_hook(registry, **_kw):
+                # Add a plugin tool — caller must see this in the returned registry.
+                registry._tools["plugin.test_tool"] = ToolDefinition(
+                    name="plugin.test_tool",
+                    description="Plugin-registered tool",
+                )
+                registered_during_create.append(True)
+
+            register_hook("register_tools", _plugin_hook)
+
+            registry = await AgentToolRegistry.create()
+
+            # Hook ran synchronously during create() — not deferred.
+            assert registered_during_create == [True]
+            # Plugin tool is visible immediately on the returned registry.
+            assert "plugin.test_tool" in registry._tools
+        finally:
+            _hooks["register_tools"] = original
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_create_propagates_hook_failure(self):
+        """If a ``register_tools`` hook raises, ``create()`` must propagate the
+        exception so callers (e.g. the orchestrator) can fail fast with a
+        diagnosable error instead of silently using a half-populated registry.
+
+        This is the contract that ``run_hooks``'s swallow-and-log semantics
+        would break — ``create()`` deliberately bypasses ``run_hooks`` to
+        keep ``register_tools`` fail-loud."""
+        from utils.hooks import _hooks, register_hook
+
+        original = list(_hooks.get("register_tools", []))
+        try:
+            async def _broken_hook(**_kw):
+                raise RuntimeError("plugin tool registration failed")
+
+            register_hook("register_tools", _broken_hook)
+
+            with pytest.raises(RuntimeError, match="plugin tool registration failed"):
+                await AgentToolRegistry.create()
+        finally:
+            _hooks["register_tools"] = original
+
+    @pytest.mark.unit
+    def test_direct_init_without_opt_in_raises(self):
+        """Direct ``AgentToolRegistry(...)`` construction must raise — it
+        skips the ``register_tools`` hook and would silently lose plugin
+        tools (Reva's resolve_team_members, resolve_role, etc.). This is
+        the structural guard that prevents a regression of TD-13."""
+        with pytest.raises(RuntimeError, match="AgentToolRegistry.create"):
+            AgentToolRegistry()
+
+        with pytest.raises(RuntimeError, match="AgentToolRegistry.create"):
+            AgentToolRegistry(server_filter=["jira"])
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_create_passes_filters_to_init(self):
+        """``create()`` must thread ``server_filter`` / ``internal_filter`` through
+        to the underlying ``__init__`` so plugins can scope their additions."""
+        registry = await AgentToolRegistry.create(
+            server_filter=["jira"],
+            internal_filter=["internal.knowledge_search"],
+        )
+        assert registry.server_filter == ["jira"]
         assert registry.internal_filter == ["internal.knowledge_search"]
 
 
@@ -75,7 +165,7 @@ class TestAgentToolRegistryMCPTools:
 
         mock_mcp.get_all_tools.return_value = [mock_tool]
 
-        registry = AgentToolRegistry(mcp_manager=mock_mcp)
+        registry = AgentToolRegistry(mcp_manager=mock_mcp, _init_only=True)
         assert registry.is_valid_tool("mcp.homeassistant.turn_on") is True
 
         tool = registry.get_tool("mcp.homeassistant.turn_on")
@@ -98,7 +188,7 @@ class TestAgentToolRegistryMCPTools:
 
         mock_mcp.get_all_tools.return_value = tools
 
-        registry = AgentToolRegistry(mcp_manager=mock_mcp)
+        registry = AgentToolRegistry(mcp_manager=mock_mcp, _init_only=True)
         names = registry.get_tool_names()
         assert len(names) == 3
         assert "mcp.homeassistant.turn_on" in names
@@ -108,12 +198,12 @@ class TestAgentToolRegistryMCPTools:
     @pytest.mark.unit
     def test_empty_registry_no_mcp(self):
         """Without MCP or plugins, registry should be empty."""
-        registry = AgentToolRegistry()
+        registry = AgentToolRegistry(_init_only=True)
         assert len(registry.get_tool_names()) == 0
 
     @pytest.mark.unit
     def test_get_tool_returns_none_for_unknown(self):
-        registry = AgentToolRegistry()
+        registry = AgentToolRegistry(_init_only=True)
         tool = registry.get_tool("nonexistent.tool")
         assert tool is None
 
@@ -126,7 +216,7 @@ class TestAgentToolRegistryMCPTools:
         mock_tool.input_schema = {"properties": {}, "required": []}
         mock_mcp.get_all_tools.return_value = [mock_tool]
 
-        registry = AgentToolRegistry(mcp_manager=mock_mcp)
+        registry = AgentToolRegistry(mcp_manager=mock_mcp, _init_only=True)
         assert registry.is_valid_tool("mcp.test.tool") is True
         assert registry.is_valid_tool("nonexistent.tool") is False
 
@@ -140,7 +230,7 @@ class TestAgentToolRegistryMCPTools:
         mock_tool.input_schema = {"properties": {}, "required": []}
         mock_mcp.get_all_tools.return_value = [mock_tool]
 
-        registry = AgentToolRegistry(mcp_manager=mock_mcp)
+        registry = AgentToolRegistry(mcp_manager=mock_mcp, _init_only=True)
         assert registry.resolve_tool_name("mcp.homeassistant.GetLiveContext") == "mcp.homeassistant.GetLiveContext"
 
     @pytest.mark.unit
@@ -153,7 +243,7 @@ class TestAgentToolRegistryMCPTools:
         mock_tool.input_schema = {"properties": {}, "required": []}
         mock_mcp.get_all_tools.return_value = [mock_tool]
 
-        registry = AgentToolRegistry(mcp_manager=mock_mcp)
+        registry = AgentToolRegistry(mcp_manager=mock_mcp, _init_only=True)
         assert registry.resolve_tool_name("GetLiveContext") == "mcp.homeassistant.GetLiveContext"
 
     @pytest.mark.unit
@@ -170,7 +260,7 @@ class TestAgentToolRegistryMCPTools:
         tool2.input_schema = {"properties": {}, "required": []}
         mock_mcp.get_all_tools.return_value = [tool1, tool2]
 
-        registry = AgentToolRegistry(mcp_manager=mock_mcp)
+        registry = AgentToolRegistry(mcp_manager=mock_mcp, _init_only=True)
         assert registry.resolve_tool_name("search") is None
 
     @pytest.mark.unit
@@ -179,7 +269,7 @@ class TestAgentToolRegistryMCPTools:
         mock_mcp = MagicMock()
         mock_mcp.get_all_tools.return_value = []
 
-        registry = AgentToolRegistry(mcp_manager=mock_mcp)
+        registry = AgentToolRegistry(mcp_manager=mock_mcp, _init_only=True)
         assert registry.resolve_tool_name("nonexistent") is None
 
     @pytest.mark.unit
@@ -192,7 +282,7 @@ class TestAgentToolRegistryMCPTools:
         mock_tool.input_schema = {"properties": {}, "required": []}
         mock_mcp.get_all_tools.return_value = [mock_tool]
 
-        registry = AgentToolRegistry(mcp_manager=mock_mcp)
+        registry = AgentToolRegistry(mcp_manager=mock_mcp, _init_only=True)
         assert registry.is_valid_tool("HassTurnOn") is True
         assert registry.is_valid_tool("mcp.homeassistant.HassTurnOn") is True
         assert registry.is_valid_tool("NonExistent") is False
@@ -203,7 +293,7 @@ class TestAgentToolRegistryPrompt:
 
     @pytest.mark.unit
     def test_empty_registry_prompt(self):
-        registry = AgentToolRegistry()
+        registry = AgentToolRegistry(_init_only=True)
         prompt = registry.build_tools_prompt()
         assert "KEINE TOOLS" in prompt
 
@@ -225,7 +315,7 @@ class TestAgentToolRegistryPrompt:
             tools.append(mock_tool)
         mock_mcp.get_all_tools.return_value = tools
 
-        registry = AgentToolRegistry(mcp_manager=mock_mcp)
+        registry = AgentToolRegistry(mcp_manager=mock_mcp, _init_only=True)
         prompt = registry.build_tools_prompt()
         assert "mcp.homeassistant.turn_on" in prompt
         assert "mcp.weather.get_forecast" in prompt
@@ -240,7 +330,7 @@ class TestAgentToolRegistryPrompt:
         mock_tool.input_schema = {"properties": {}, "required": []}
         mock_mcp.get_all_tools.return_value = [mock_tool]
 
-        registry = AgentToolRegistry(mcp_manager=mock_mcp)
+        registry = AgentToolRegistry(mcp_manager=mock_mcp, _init_only=True)
         prompt = registry.build_tools_prompt()
         assert "A very specific description" in prompt
 
@@ -256,7 +346,7 @@ class TestAgentToolRegistryPrompt:
         }
         mock_mcp.get_all_tools.return_value = [mock_tool]
 
-        registry = AgentToolRegistry(mcp_manager=mock_mcp)
+        registry = AgentToolRegistry(mcp_manager=mock_mcp, _init_only=True)
         prompt = registry.build_tools_prompt()
         assert "entity_id" in prompt
 
@@ -290,7 +380,7 @@ def _build_multi_server_registry():
         mock_tool.input_schema = {"properties": {"q": {"type": "string", "description": "Query"}}, "required": []}
         tools.append(mock_tool)
     mock_mcp.get_all_tools.return_value = tools
-    return AgentToolRegistry(mcp_manager=mock_mcp)
+    return AgentToolRegistry(mcp_manager=mock_mcp, _init_only=True)
 
 
 class TestSelectRelevantTools:
@@ -340,7 +430,7 @@ class TestSelectRelevantTools:
     @pytest.mark.unit
     def test_empty_registry_returns_empty(self):
         """Empty registry should return empty dict."""
-        registry = AgentToolRegistry()
+        registry = AgentToolRegistry(_init_only=True)
         selected = registry.select_relevant_tools("Test query")
         assert selected == {}
 
@@ -431,7 +521,7 @@ class TestBuildToolsSchema:
     def _make_registry_with_tools(self, tools):
         mcp_manager = MagicMock()
         mcp_manager.get_all_tools.return_value = tools
-        return AgentToolRegistry(mcp_manager=mcp_manager)
+        return AgentToolRegistry(mcp_manager=mcp_manager, _init_only=True)
 
     @pytest.mark.unit
     def test_returns_openai_tools_format(self):
@@ -486,7 +576,7 @@ class TestBuildToolsSchema:
     @pytest.mark.unit
     def test_tool_without_input_schema_gets_synthesised_schema(self):
         """ToolDefinition with only flattened parameters gets a minimal fallback."""
-        registry = AgentToolRegistry()
+        registry = AgentToolRegistry(_init_only=True)
         registry._tools["plugin.custom"] = ToolDefinition(
             name="plugin.custom",
             description="Plugin-registered tool",
@@ -522,7 +612,7 @@ class TestToolDefinitionInputSchema:
 
         mcp_manager = MagicMock()
         mcp_manager.get_all_tools.return_value = [mcp_tool]
-        registry = AgentToolRegistry(mcp_manager=mcp_manager)
+        registry = AgentToolRegistry(mcp_manager=mcp_manager, _init_only=True)
 
         tool = registry.get_tool("mcp.homeassistant.turn_on")
         assert tool is not None

--- a/tests/backend/test_mcp_client.py
+++ b/tests/backend/test_mcp_client.py
@@ -706,7 +706,7 @@ class TestMCPToolsInRegistry:
             ),
         ]
 
-        registry = AgentToolRegistry(mcp_manager=mock_manager)
+        registry = AgentToolRegistry(mcp_manager=mock_manager, _init_only=True)
 
         assert registry.is_valid_tool("mcp.n8n.send_email") is True
         tool = registry.get_tool("mcp.n8n.send_email")
@@ -734,7 +734,7 @@ class TestMCPToolsInRegistry:
             ),
         ]
 
-        registry = AgentToolRegistry(mcp_manager=mock_manager)
+        registry = AgentToolRegistry(mcp_manager=mock_manager, _init_only=True)
         prompt = registry.build_tools_prompt()
 
         assert "mcp.test.greet" in prompt
@@ -746,7 +746,7 @@ class TestMCPToolsInRegistry:
         """Registry should work fine without mcp_manager."""
         from services.agent_tools import AgentToolRegistry
 
-        registry = AgentToolRegistry(mcp_manager=None)
+        registry = AgentToolRegistry(mcp_manager=None, _init_only=True)
         assert len(registry.get_tool_names()) == 0
         assert registry.is_valid_tool("mcp.anything") is False
 

--- a/tests/backend/test_orchestrator.py
+++ b/tests/backend/test_orchestrator.py
@@ -483,13 +483,8 @@ class TestRunSubAgentListData:
             mock_agent = MagicMock()
             mock_agent.run = _fake_run
             MockAS.return_value = mock_agent
-            # _hook_task explicitly None so the orchestrator's "wait for plugin
-            # tools" path stays a no-op (MagicMock would auto-create a non-None,
-            # non-awaitable attribute that the orchestrator now correctly
-            # treats as a hook_task crash → fail-the-sub-agent).
             mock_registry = MagicMock()
-            mock_registry._hook_task = None
-            MockReg.return_value = mock_registry
+            MockReg.create = AsyncMock(return_value=mock_registry)
 
             result = await orchestrator._run_sub_agent(
                 {"role": "jira", "query": "find tickets"},
@@ -531,8 +526,7 @@ class TestRunSubAgentListData:
             mock_agent.run = _fake_run
             MockAS.return_value = mock_agent
             mock_registry = MagicMock()
-            mock_registry._hook_task = None
-            MockReg.return_value = mock_registry
+            MockReg.create = AsyncMock(return_value=mock_registry)
 
             result = await orchestrator._run_sub_agent(
                 {"role": "release", "query": "status"},
@@ -738,8 +732,7 @@ class TestSubAgentHooks:
             mock_agent.run = _fake_run
             MockAS.return_value = mock_agent
             mock_registry = MagicMock()
-            mock_registry._hook_task = None
-            MockReg.return_value = mock_registry
+            MockReg.create = AsyncMock(return_value=mock_registry)
 
             await orchestrator._run_sub_agent(
                 {"role": "smart_home", "query": "Mach Licht an"},
@@ -780,8 +773,7 @@ class TestSubAgentHooks:
             mock_agent.run = _fake_run
             MockAS.return_value = mock_agent
             mock_registry = MagicMock()
-            mock_registry._hook_task = None
-            MockReg.return_value = mock_registry
+            MockReg.create = AsyncMock(return_value=mock_registry)
 
             await orchestrator._run_sub_agent(
                 {"role": "media", "query": "Spiel Musik"},
@@ -828,8 +820,7 @@ class TestSubAgentHooks:
             mock_agent.run = _fake_run
             MockAS.return_value = mock_agent
             mock_registry = MagicMock()
-            mock_registry._hook_task = None
-            MockReg.return_value = mock_registry
+            MockReg.create = AsyncMock(return_value=mock_registry)
 
             result = await orchestrator._run_sub_agent(
                 {"role": "release", "query": "status"},
@@ -863,14 +854,14 @@ class TestSubAgentHooks:
         async def _fake_run(*args, **kwargs):
             yield AgentStep(step_number=1, step_type="final_answer", content="ok")
 
-        # Use a real namespace object so attribute mutation sticks.
         class _Registry:
-            _hook_task = None
+            pass
 
         registry_instance = _Registry()
 
         with patch("services.agent_service.AgentService") as MockAS, \
-             patch("services.agent_tools.AgentToolRegistry", return_value=registry_instance):
+             patch("services.agent_tools.AgentToolRegistry") as MockReg:
+            MockReg.create = AsyncMock(return_value=registry_instance)
             mock_agent = MagicMock()
             mock_agent.run = _fake_run
             MockAS.return_value = mock_agent
@@ -884,136 +875,32 @@ class TestSubAgentHooks:
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_hook_task_awaited_before_agent_run(self):
-        """If the registry has a ``_hook_task`` awaitable, it must be awaited
-        before the agent loop runs.
-
-        Reva's plugin tools register asynchronously via ``_hook_task``.
-        Without this await the agent loop reads the registry before
-        plugin-registered tools are present — intermittent "tool not found"
-        failures on the first orchestrated call after startup.
-
-        The test uses a custom awaitable whose ``__await__`` flips a flag
-        only when the orchestrator explicitly awaits it. An ``asyncio.Task``
-        would be unsuitable here: the event loop schedules tasks on the
-        next yield, and the orchestrator's other ``await`` calls
-        (``run_hooks`` for ``pre_sub_agent``) would let the task complete
-        even if our code never awaited ``_hook_task`` directly. The
-        custom awaitable closes that gap.
-        """
-        from services.agent_service import AgentStep
-
-        events: list[str] = []
-
-        class _AwaitTracker:
-            """Awaitable that records when (and only when) it is explicitly awaited."""
-            def __init__(self):
-                self.awaited = False
-
-            def __await__(self):
-                self.awaited = True
-                events.append("hook_task_awaited")
-                # Empty generator — resolves immediately with no value.
-                if False:
-                    yield  # pragma: no cover
-
-        primary = _make_role("release", servers=["release"])
-        router = _make_router([primary])
-        orchestrator = QueryOrchestrator(router, MagicMock())
-
-        hook_task = _AwaitTracker()
-
-        async def _fake_run(*args, **kwargs):
-            events.append("agent_run_called")
-            yield AgentStep(step_number=1, step_type="final_answer", content="ok")
-
-        class _Registry:
-            pass
-
-        registry_instance = _Registry()
-        registry_instance._hook_task = hook_task
-
-        with patch("services.agent_service.AgentService") as MockAS, \
-             patch("services.agent_tools.AgentToolRegistry", return_value=registry_instance):
-            mock_agent = MagicMock()
-            mock_agent.run = _fake_run
-            MockAS.return_value = mock_agent
-
-            await orchestrator._run_sub_agent(
-                {"role": "release", "query": "status"},
-                _make_ollama("ok"), MagicMock(), "de",
-            )
-
-        # The custom awaitable was actually awaited.
-        assert hook_task.awaited is True
-        # And it was awaited BEFORE the agent loop ran (strict ordering).
-        assert events.index("hook_task_awaited") < events.index("agent_run_called")
-
-    @pytest.mark.unit
-    @pytest.mark.asyncio
-    async def test_no_hook_task_attribute_does_not_raise(self):
-        """If the registry has no ``_hook_task`` attribute, the sub-agent runs cleanly."""
-        from services.agent_service import AgentStep
-
-        primary = _make_role("release", servers=["release"])
-        router = _make_router([primary])
-        orchestrator = QueryOrchestrator(router, MagicMock())
-
-        async def _fake_run(*args, **kwargs):
-            yield AgentStep(step_number=1, step_type="final_answer", content="ok")
-
-        # Registry without the _hook_task attribute (vanilla AgentToolRegistry has no such field).
-        class _Registry:
-            pass
-
-        with patch("services.agent_service.AgentService") as MockAS, \
-             patch("services.agent_tools.AgentToolRegistry", return_value=_Registry()):
-            mock_agent = MagicMock()
-            mock_agent.run = _fake_run
-            MockAS.return_value = mock_agent
-
-            result = await orchestrator._run_sub_agent(
-                {"role": "release", "query": "status"},
-                _make_ollama("ok"), MagicMock(), "de",
-            )
-
-        assert result["answer"] == "ok"
-
-    @pytest.mark.unit
-    @pytest.mark.asyncio
-    async def test_hook_task_failure_returns_failed_result(self):
-        """A raising ``_hook_task`` fails the sub-agent cleanly with a localized error.
+    async def test_create_failure_returns_failed_result(self):
+        """A raising ``AgentToolRegistry.create()`` fails the sub-agent cleanly
+        with a localized error.
 
         Continuing with a half-populated registry would cause hard-to-diagnose
         "tool not found" errors downstream that don't trace back to the
-        original hook_task failure. Better to surface the error here.
+        original tool-registry init failure. Better to surface the error here.
         """
         from services.agent_service import AgentStep
-
-        async def _broken_hook_task():
-            raise RuntimeError("plugin tool registration failed")
 
         primary = _make_role("release", servers=["release"])
         router = _make_router([primary])
         orchestrator = QueryOrchestrator(router, MagicMock())
 
-        # The mock agent.run should NOT be called when hook_task fails.
+        # The mock agent.run should NOT be called when create() fails.
         agent_run_called = {"value": False}
 
         async def _fake_run(*args, **kwargs):
             agent_run_called["value"] = True
             yield AgentStep(step_number=1, step_type="final_answer", content="ok")
 
-        import asyncio as _asyncio
-
-        class _Registry:
-            pass
-
-        registry_instance = _Registry()
-        registry_instance._hook_task = _asyncio.create_task(_broken_hook_task())
-
         with patch("services.agent_service.AgentService") as MockAS, \
-             patch("services.agent_tools.AgentToolRegistry", return_value=registry_instance):
+             patch("services.agent_tools.AgentToolRegistry") as MockReg:
+            MockReg.create = AsyncMock(
+                side_effect=RuntimeError("plugin tool registration failed")
+            )
             mock_agent = MagicMock()
             mock_agent.run = _fake_run
             MockAS.return_value = mock_agent
@@ -1023,7 +910,7 @@ class TestSubAgentHooks:
                 _make_ollama("ok"), MagicMock(), "de",
             )
 
-        # Sub-agent did NOT run (registry was broken).
+        # Sub-agent did NOT run (registry creation failed).
         assert agent_run_called["value"] is False
         # Result has the canonical failure shape with a localized error.
         assert result["answer"] == ""
@@ -1034,12 +921,9 @@ class TestSubAgentHooks:
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_hook_task_failure_localized_english(self):
+    async def test_create_failure_localized_english(self):
         """Localized error message picks English for ``lang='en'``."""
         from services.agent_service import AgentStep
-
-        async def _broken_hook_task():
-            raise RuntimeError("registration failed")
 
         primary = _make_role("release", servers=["release"])
         router = _make_router([primary])
@@ -1048,16 +932,11 @@ class TestSubAgentHooks:
         async def _fake_run(*args, **kwargs):
             yield AgentStep(step_number=1, step_type="final_answer", content="ok")
 
-        import asyncio as _asyncio
-
-        class _Registry:
-            pass
-
-        registry_instance = _Registry()
-        registry_instance._hook_task = _asyncio.create_task(_broken_hook_task())
-
         with patch("services.agent_service.AgentService") as MockAS, \
-             patch("services.agent_tools.AgentToolRegistry", return_value=registry_instance):
+             patch("services.agent_tools.AgentToolRegistry") as MockReg:
+            MockReg.create = AsyncMock(
+                side_effect=RuntimeError("registration failed")
+            )
             mock_agent = MagicMock()
             mock_agent.run = _fake_run
             MockAS.return_value = mock_agent
@@ -1094,8 +973,7 @@ class TestSubAgentHooks:
             mock_agent.run = _fake_run
             MockAS.return_value = mock_agent
             mock_registry = MagicMock()
-            mock_registry._hook_task = None
-            MockReg.return_value = mock_registry
+            MockReg.create = AsyncMock(return_value=mock_registry)
 
             result = await orchestrator._run_sub_agent(
                 {"role": "release", "query": "status"},
@@ -1129,8 +1007,7 @@ class TestSubAgentHooks:
             mock_agent.run = _fake_run
             MockAS.return_value = mock_agent
             mock_registry = MagicMock()
-            mock_registry._hook_task = None
-            MockReg.return_value = mock_registry
+            MockReg.create = AsyncMock(return_value=mock_registry)
 
             result = await orchestrator._run_sub_agent(
                 {"role": "release", "query": "status"},
@@ -1430,8 +1307,7 @@ class TestParallelExecution:
             mock_agent.run = _no_final
             MockAS.return_value = mock_agent
             mock_registry = MagicMock()
-            mock_registry._hook_task = None
-            MockReg.return_value = mock_registry
+            MockReg.create = AsyncMock(return_value=mock_registry)
 
             result = await orchestrator._run_sub_agent(
                 {"role": "release", "query": "test"},
@@ -1557,10 +1433,11 @@ class TestVanillaRenfieldBackwardsCompat:
             yield AgentStep(step_number=1, step_type="final_answer", content="ok")
 
         class _Registry:
-            _hook_task = None
+            pass
 
         with patch("services.agent_service.AgentService") as MockAS, \
-             patch("services.agent_tools.AgentToolRegistry", return_value=_Registry()):
+             patch("services.agent_tools.AgentToolRegistry") as MockReg:
+            MockReg.create = AsyncMock(return_value=_Registry())
             mock_agent = MagicMock()
             mock_agent.run = _fake_run
             MockAS.return_value = mock_agent
@@ -1943,8 +1820,7 @@ class TestPluginDataMergeSemantics:
             mock_agent.run = _fake_run
             MockAS.return_value = mock_agent
             mock_registry = MagicMock()
-            mock_registry._hook_task = None
-            MockReg.return_value = mock_registry
+            MockReg.create = AsyncMock(return_value=mock_registry)
 
             result = await orchestrator._run_sub_agent(
                 {"role": "release", "query": "status"},
@@ -1984,8 +1860,7 @@ class TestPluginDataMergeSemantics:
             mock_agent.run = _fake_run
             MockAS.return_value = mock_agent
             mock_registry = MagicMock()
-            mock_registry._hook_task = None
-            MockReg.return_value = mock_registry
+            MockReg.create = AsyncMock(return_value=mock_registry)
 
             result = await orchestrator._run_sub_agent(
                 {"role": "release", "query": "status"},
@@ -2162,8 +2037,7 @@ class TestPostSubAgentFiresAfterCrash:
             mock_agent.run = _crashing_run
             MockAS.return_value = mock_agent
             mock_registry = MagicMock()
-            mock_registry._hook_task = None
-            MockReg.return_value = mock_registry
+            MockReg.create = AsyncMock(return_value=mock_registry)
 
             result = await orchestrator._run_sub_agent(
                 {"role": "release", "query": "status"},

--- a/tests/backend/test_routine_agent.py
+++ b/tests/backend/test_routine_agent.py
@@ -153,6 +153,7 @@ class TestRoutineRoleConfig:
 
         registry = AgentToolRegistry(
             internal_filter=role.internal_tools,
+            _init_only=True,
         )
         agent = AgentService(registry, role=role)
 
@@ -168,6 +169,7 @@ class TestRoutineRoleConfig:
         registry = AgentToolRegistry(
             server_filter=role.mcp_servers,
             internal_filter=role.internal_tools,
+            _init_only=True,
         )
 
         tool_names = registry.get_tool_names()
@@ -187,7 +189,7 @@ class TestRoutineAgentExecution:
         """Create an AgentService configured with the routine role."""
         roles = _parse_roles(ROUTINE_ROLE_CONFIG)
         role = roles["routine"]
-        registry = AgentToolRegistry(internal_filter=role.internal_tools)
+        registry = AgentToolRegistry(internal_filter=role.internal_tools, _init_only=True)
         return AgentService(registry, role=role)
 
     def _patch_agent_deps(self, llm_responses: list[str]):


### PR DESCRIPTION
## Summary

`AgentToolRegistry.__init__` previously scheduled the `register_tools` hook as a fire-and-forget background task via `loop.create_task()`. Every caller had to remember `await tool_registry._hook_task` before reading the tool list, and the race surfaced as intermittent missing-plugin-tool failures on the first orchestrated call after startup, with no signal in the logs. Reva tracked this as TD-13 / P0.5 (silently lost `resolve_team_members`, `resolve_role`, etc.).

This PR replaces the background-task pattern with an async classmethod:

```python
tool_registry = await AgentToolRegistry.create(
    mcp_manager=...,
    server_filter=...,
    internal_filter=...,
)
```

`create()` constructs the registry and awaits the `register_tools` hook in-line. The instance returned to the caller is fully populated — the race is structurally eliminated.

### Three structural decisions worth flagging

1. **`create()` bypasses `run_hooks()`.** It iterates `_hooks["register_tools"]` and awaits each handler directly. `run_hooks` swallows handler exceptions for fire-and-forget event sites; `register_tools` is fail-loud — a plugin failure must propagate so the orchestrator can surface its localized "Tools für Rolle X konnten nicht geladen werden" failure card instead of silently producing a half-populated registry.

2. **`__init__` is structurally guarded.** It raises `RuntimeError` unless the caller passes `_init_only=True`. `create()` passes the sentinel internally; tests that don't need plugin tools opt in explicitly. This makes a future regression of TD-13 impossible to introduce without a flagged failure at the call site.

3. **`agent_service.py::run()` no longer awaits `_hook_task` defensively.** With `create()` doing the work synchronously, the central guard added in 2026-04-17 is obsolete.

### Call sites updated

- `chat_handler.py:1155` — specialized agent loop (web chat sub-agent)
- `chat.py:115` — REST chat endpoint
- `orchestrator.py:393` — sub-agent launches; the inner `try/except` wraps `create()` to preserve the localized failure path
- `agent_service.py::run()` — defensive `_hook_task` await removed

### Tests

- `tests/backend/test_agent_tools.py`: new `TestAgentToolRegistryAsyncCreate` covering hook execution, failure propagation, the `_init_only` guard, and filter threading. All 46 existing direct-construction sites migrated to pass `_init_only=True`.
- `tests/backend/test_orchestrator.py`: replace four obsolete `_hook_task` tests with two `test_create_failure_*` tests that exercise the new error path; rewrite ~15 mock setups to use `AsyncMock` for the new classmethod.

64/64 orchestrator tests pass; 4 new async create tests pass; no regressions vs main (37 pre-existing test failures unchanged).

### Pairs with

[X-idra-Systems-GmbH/reva#TBD](https://github.com/X-idra-Systems-GmbH/reva/pull/new/fix/td-13-async-create) — migrates Reva's two call sites and bumps the submodule to this commit.

## Test plan

- [ ] CI: backend test suite green
- [ ] Verify `make test-backend` passes locally if you have the Docker stack
- [ ] Manual smoke: spin up Renfield + a plugin (e.g. Reva on the paired branch) and confirm plugin tools register on first orchestrated call after startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)