### PR TITLE
fix(orchestrator): diagnosable synthesis-fallback warnings

### DIFF
--- a/src/backend/services/orchestrator.py
+++ b/src/backend/services/orchestrator.py
@@ -775,7 +775,15 @@ class QueryOrchestrator:
             answer = extract_response_content(raw_response) or None
             return _strip_source_line(answer) if answer else None
 
+        except asyncio.TimeoutError:
+            # str(TimeoutError()) is empty — log the configured timeout
+            # explicitly so ops can see why the fallback triggered.
+            logger.warning(
+                f"Orchestrator synthesis timed out after "
+                f"{settings.orchestrator_synthesis_timeout}s — using fallback"
+            )
+            return "\n\n".join(r["answer"] for r in sub_results if r["answer"])
         except Exception as e:
-            logger.warning(f"Orchestrator synthesis failed: {e}")
-            # Fallback: concatenate
+            # repr() carries the type name even when str(e) is empty.
+            logger.warning(f"Orchestrator synthesis failed: {e!r}")
             return "\n\n".join(r["answer"] for r in sub_results if r["answer"])

--- a/tests/backend/test_orchestrator.py
+++ b/tests/backend/test_orchestrator.py
@@ -2277,6 +2277,78 @@ class TestSynthesisHooks:
         assert "Quelle" not in (answer or "")
         assert "synthesized answer" in (answer or "")
 
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_synthesis_timeout_logs_configured_timeout_and_falls_back(self):
+        """When the synth call times out, the warning must name the configured
+        timeout (str(asyncio.TimeoutError()) is empty) and the fallback path
+        must concatenate sub-agent answers so the user still gets a response.
+        Regression guard for issue #182."""
+        import asyncio
+
+        orchestrator = QueryOrchestrator(_make_router([]), MagicMock())
+
+        ollama = MagicMock()
+        ollama.client = AsyncMock()
+        ollama.client.chat = AsyncMock(side_effect=asyncio.TimeoutError())
+
+        sub_results = [
+            {"role": "release", "query": "q1", "answer": "release answer"},
+            {"role": "jira", "query": "q2", "answer": "jira answer"},
+        ]
+
+        with patch("services.orchestrator.prompt_manager") as pm, \
+             patch("services.orchestrator.settings") as s, \
+             patch("services.orchestrator.get_classification_chat_kwargs", return_value={}), \
+             patch("services.orchestrator.logger") as mock_logger:
+            pm.get.return_value = "PROMPT"
+            s.agent_router_model = s.ollama_intent_model = s.ollama_model = "test-model"
+            s.orchestrator_synthesis_timeout = 30.0
+
+            answer = await orchestrator._synthesize("msg", sub_results, ollama, "de")
+
+        assert answer is not None
+        assert "release answer" in answer
+        assert "jira answer" in answer
+        assert mock_logger.warning.called
+        warning_msg = mock_logger.warning.call_args.args[0]
+        # The configured timeout must appear in the message — empty
+        # str(TimeoutError()) was the original bug.
+        assert "timed out" in warning_msg.lower()
+        assert "30.0" in warning_msg
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_synthesis_generic_exception_logs_type_and_message(self):
+        """Non-timeout exceptions must log both the type name and the message
+        so silent failures (#182) become diagnosable."""
+        orchestrator = QueryOrchestrator(_make_router([]), MagicMock())
+
+        ollama = MagicMock()
+        ollama.client = AsyncMock()
+        ollama.client.chat = AsyncMock(side_effect=RuntimeError("boom"))
+
+        sub_results = [{"role": "release", "query": "q", "answer": "fallback"}]
+
+        with patch("services.orchestrator.prompt_manager") as pm, \
+             patch("services.orchestrator.settings") as s, \
+             patch("services.orchestrator.get_classification_chat_kwargs", return_value={}), \
+             patch("services.orchestrator.logger") as mock_logger:
+            pm.get.return_value = "PROMPT"
+            s.agent_router_model = s.ollama_intent_model = s.ollama_model = "test-model"
+            s.orchestrator_synthesis_timeout = 30.0
+
+            answer = await orchestrator._synthesize("msg", sub_results, ollama, "de")
+
+        assert answer is not None
+        assert "fallback" in answer
+        assert mock_logger.warning.called
+        warning_msg = mock_logger.warning.call_args.args[0]
+        # repr() form: "RuntimeError('boom')" — carries type name and message
+        # even when str(e) would have been empty (the #182 bug).
+        assert "RuntimeError" in warning_msg
+        assert "boom" in warning_msg
+
 
 # ============================================================================
 # Phase 1 (orchestrator-uplift) — backwards compat: vanilla Renfield deploy


### PR DESCRIPTION
## Summary

- Split `asyncio.TimeoutError` from the generic `Exception` handler in
  `QueryOrchestrator._synthesize`. The timeout branch now logs the configured
  `orchestrator_synthesis_timeout` value; the generic branch uses `{e!r}` so
  the exception type name is preserved.
- Adds two regression tests in `TestSynthesisHooks` covering both branches.

## Why

`str(asyncio.TimeoutError())` is `""`, so the existing
`logger.warning(f"Orchestrator synthesis failed: {e}")` produced warnings
with empty exception messages in production — fallback path worked (user
got a response from concatenated sub-agent answers), but ops had no
diagnosable signal.

Discovered while verifying #491 in production: a 2-domain orchestrated
query produced `Orchestrator synthesis failed: ` (trailing space, empty
message) ~30s after the last sub-agent finished — matching the configured
30s synthesis timeout. Tracking issue:
https://github.com/X-idra-Systems-GmbH/reva/issues/182.

## Behavior change

Before:
```
WARNING | Orchestrator synthesis failed: 
```

After (timeout):
```
WARNING | Orchestrator synthesis timed out after 30.0s — using fallback
```

After (other exceptions):
```
WARNING | Orchestrator synthesis failed: RuntimeError('boom')
```

Fallback behavior is unchanged — sub-agent answers are still concatenated
on either failure path, so this is a logging-only fix from the user's
perspective.

## Test plan

- [x] `pytest tests/backend/test_orchestrator.py::TestSynthesisHooks` — 12/12 green locally
- [x] New `test_synthesis_timeout_logs_configured_timeout_and_falls_back` asserts the timeout branch produces a non-empty warning naming the configured timeout, and that the fallback concatenation still runs
- [x] New `test_synthesis_generic_exception_logs_type_and_message` asserts the generic branch carries the exception type name (regression guard for the `str(TimeoutError())` empty-message bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)