### PR TITLE
chore(config): E16 — rename piper_voice→piper_default_voice, close legacy-fields audit item

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,8 +94,8 @@ WHISPER_MODEL=base
 # WHISPER_PREPROCESS_NOISE_REDUCE=true
 # WHISPER_PREPROCESS_NORMALIZE=true
 # WHISPER_PREPROCESS_TARGET_DB=-20.0
-PIPER_VOICE=de_DE-thorsten-high
 PIPER_VOICES=de:de_DE-thorsten-high,en:en_US-amy-medium
+PIPER_DEFAULT_VOICE=de_DE-thorsten-high  # Fallback when requested language has no entry in PIPER_VOICES
 
 # Speaker Recognition (pyannote-based voice identification)
 # SPEAKER_RECOGNITION_ENABLED=true

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -91,7 +91,8 @@ FRIGATE_URL=http://192.168.1.100:5000
 DEFAULT_LANGUAGE=de
 OLLAMA_MODEL=llama3.2:3b
 WHISPER_MODEL=base
-PIPER_VOICE=de_DE-thorsten-high
+PIPER_VOICES=de:de_DE-thorsten-high,en:en_US-amy-medium
+PIPER_DEFAULT_VOICE=de_DE-thorsten-high
 
 # Externe Ollama-Instanz (optional)
 # OLLAMA_URL=http://cuda.local:11434

--- a/TODOS.md
+++ b/TODOS.md
@@ -49,7 +49,7 @@ If ui_sweep noise shows up in real use, mark original sweep row `superseded=true
 ### EMPFEHLUNG audit findings — modernization + cleanup
 - **Primary source:** `tasks/audit-findings-plan.md` §EMPFEHLUNG, §Priorisierte Roadmap Phase 4-5
 - **Frontend:** W9 React.lazy code-splitting for admin pages · W11 Prettier · E11 React Query · E12 13 hardcoded German strings · E13 ChatPage prop drilling → Context · E14 ESLint React version · E15 enable `tsconfig` strict mode (W10 closed via #487 on 2026-04-27)
-- **Backend/config:** E1-E3 speaker-loading + eager-load cleanup + FK indexes · E4-E9 remaining hardcoded values (MCP 40KB cap, backoff constants, agent history limit, agent response truncation, embedding dim, similarity threshold) · E10 frontend localhost fallbacks · E16 legacy config field removal (`ollama_model`, `piper_voice`, `plugins_*`, `spotify_*`) · E17 Redis URL parameterization · E18 Frigate MQTT defaults
+- **Backend/config:** E1-E3 speaker-loading + eager-load cleanup + FK indexes · E4-E9 remaining hardcoded values (MCP 40KB cap, backoff constants, agent history limit, agent response truncation, embedding dim, similarity threshold) · E10 frontend localhost fallbacks · ~~E16 legacy config field removal~~ (closed: `plugins_*`/`music_enabled`/`spotify_*` already gone; `piper_voice`→`piper_default_voice` rename; `ollama_model` is intentional fallback) · E17 Redis URL parameterization · E18 Frigate MQTT defaults
 
 ### Run `/design-consultation` to formalize DESIGN.md (BEFORE next major frontend surface)
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -147,7 +147,8 @@ OLLAMA_NUM_CTX=32768
 DEFAULT_LANGUAGE=de
 SUPPORTED_LANGUAGES=de,en
 WHISPER_MODEL=base
-PIPER_VOICE=de_DE-thorsten-high
+PIPER_VOICES=de:de_DE-thorsten-high,en:en_US-amy-medium
+PIPER_DEFAULT_VOICE=de_DE-thorsten-high
 
 # -----------------------------------------------------------------------------
 # Home Assistant Integration

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -144,19 +144,19 @@ SUPPORTED_LANGUAGES=de,en
 # Whisper STT Modell
 WHISPER_MODEL=base
 
-# Piper TTS Voice (Standard-Stimme)
-PIPER_VOICE=de_DE-thorsten-high
-
 # Piper Multi-Voice Konfiguration (pro Sprache)
 PIPER_VOICES=de:de_DE-thorsten-high,en:en_US-amy-medium
+
+# Fallback-Stimme, wenn die angeforderte Sprache nicht in PIPER_VOICES enthalten ist
+PIPER_DEFAULT_VOICE=de_DE-thorsten-high
 ```
 
 **Defaults:**
 - `DEFAULT_LANGUAGE`: `de`
 - `SUPPORTED_LANGUAGES`: `de,en`
 - `WHISPER_MODEL`: `base`
-- `PIPER_VOICE`: `de_DE-thorsten-high`
-- `PIPER_VOICES`: (nicht gesetzt, nutzt `PIPER_VOICE` für alle Sprachen)
+- `PIPER_VOICES`: `de:de_DE-thorsten-high,en:en_US-amy-medium`
+- `PIPER_DEFAULT_VOICE`: `de_DE-thorsten-high` (Fallback, wenn die Sprache nicht in `PIPER_VOICES` ist)
 
 **Whisper Modelle:**
 - `tiny` - Sehr schnell, niedrige Qualität
@@ -1174,8 +1174,8 @@ OLLAMA_MODEL=qwen3:14b
 DEFAULT_LANGUAGE=de
 SUPPORTED_LANGUAGES=de,en
 WHISPER_MODEL=base
-PIPER_VOICE=de_DE-thorsten-high
-# PIPER_VOICES=de:de_DE-thorsten-high,en:en_US-amy-medium  # Multi-Voice
+PIPER_VOICES=de:de_DE-thorsten-high,en:en_US-amy-medium
+PIPER_DEFAULT_VOICE=de_DE-thorsten-high  # Fallback for languages not in PIPER_VOICES
 
 # -----------------------------------------------------------------------------
 # Integrationen

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -39,7 +39,8 @@ data:
   AGENT_MODEL: "qwen3:14b"
   EMBEDDING_DIMENSION: "2560"
   WHISPER_MODEL: "small"
-  PIPER_VOICE: "de_DE-thorsten-high"
+  PIPER_VOICES: "de:de_DE-thorsten-high,en:en_US-amy-medium"
+  PIPER_DEFAULT_VOICE: "de_DE-thorsten-high"
 
   # RAG
   RAG_ENABLED: "true"

--- a/src/backend/services/piper_service.py
+++ b/src/backend/services/piper_service.py
@@ -18,7 +18,7 @@ class PiperService:
     """Service für Text-to-Speech mit Piper"""
 
     def __init__(self):
-        self.default_voice = settings.piper_voice
+        self.default_voice = settings.piper_default_voice
         self.voice_map = settings.piper_voice_map
         self.default_language = settings.default_language
         self.available = self._check_piper_available()

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -103,8 +103,8 @@ class Settings(BaseSettings):
     supported_languages: str = "de,en"  # Comma-separated list of supported languages
     whisper_model: str = "base"
     whisper_initial_prompt: str = ""  # Leer = kein Kontext-Bias (Renfield ist ein offenes System)
-    piper_voice: str = "de_DE-thorsten-high"  # Default voice (legacy)
     piper_voices: str = "de:de_DE-thorsten-high,en:en_US-amy-medium"  # Language:Voice mapping
+    piper_default_voice: str = "de_DE-thorsten-high"  # Fallback voice when requested language has no entry in piper_voices
 
     # Audio Preprocessing (for better STT quality)
     whisper_preprocess_enabled: bool = True       # Enable audio preprocessing before Whisper
@@ -463,9 +463,9 @@ class Settings(BaseSettings):
             if ":" in pair:
                 lang, voice = pair.strip().split(":", 1)
                 voice_map[lang.strip().lower()] = voice.strip()
-        # Ensure default language has a voice (fallback to piper_voice)
+        # Ensure default language has a voice (fallback to piper_default_voice)
         if self.default_language not in voice_map:
-            voice_map[self.default_language] = self.piper_voice
+            voice_map[self.default_language] = self.piper_default_voice
         return voice_map
 
     @model_validator(mode="after")

--- a/tasks/audit-findings-plan.md
+++ b/tasks/audit-findings-plan.md
@@ -191,10 +191,10 @@ Status nach Branch `audit/k1-k7` (PR aus diesem Branch schliesst K1-K7 komplett)
 - `tsconfig.json` has `strict: false`
 - Fix: Enable strict mode gradually (start with new files)
 
-### E16. Legacy config fields (dead code)
-- `ollama_model` (replaced by ollama_chat_model), `piper_voice` (replaced by piper_voices)
-- `plugins_enabled`, `plugins_dir`, `music_enabled`, `spotify_*` (MCP replaced plugins)
-- Fix: Deprecate and remove in next major version
+### E16. Legacy config fields (dead code) — RESOLVED
+- `plugins_enabled`, `plugins_dir`, `music_enabled`, `spotify_*` — already removed from `config.py` and `.env.example` in earlier work; no usages remained.
+- `piper_voice` — renamed to `piper_default_voice` (env: `PIPER_DEFAULT_VOICE`) to make its role explicit: fallback voice when the requested language has no entry in `piper_voices`. Not dead code, just a misleading name.
+- `ollama_model` — re-classified: NOT dead. It is the global model fallback referenced by 13+ services as `settings.X_model or settings.ollama_model` (chat_handler, knowledge_graph_service, kg_retrieval, conversation_memory_service, agent_service, agent_router, orchestrator, notification_service, federation_query_responder, paperless_audit_service, ollama_service, main health check). The original audit's claim that `ollama_chat_model` replaces it is wrong — the two coexist as fallback-chain roles.
 
 ### E17. Redis URL not parameterized in docker-compose
 - `docker-compose.yml:77` — hardcoded `redis://redis:6379`
@@ -257,7 +257,7 @@ Status nach Branch `audit/k1-k7` (PR aus diesem Branch schliesst K1-K7 komplett)
 - [ ] E14: ESLint React version
 
 ### Phase 5: Cleanup
-- [ ] E16: Remove legacy config fields
+- [x] E16: Legacy config fields — `plugins_*`/`music_enabled`/`spotify_*` already gone; `piper_voice` renamed to `piper_default_voice`; `ollama_model` re-classified as intentional fallback infrastructure (not dead)
 - [ ] E4-E9: Remaining hardcoded values to Settings
 - [ ] E13: ChatPage prop drilling → Context
 - [ ] E15: Enable TypeScript strict mode

--- a/tests/backend/test_multilang.py
+++ b/tests/backend/test_multilang.py
@@ -333,7 +333,7 @@ class TestPiperServiceMultiVoice:
 
         with patch.object(PiperService, '_check_piper_available', return_value=True):
             with patch('services.piper_service.settings') as mock_settings:
-                mock_settings.piper_voice = "de_DE-thorsten-high"
+                mock_settings.piper_default_voice = "de_DE-thorsten-high"
                 mock_settings.piper_voice_map = {
                     "de": "de_DE-thorsten-high",
                     "en": "en_US-amy-medium"

--- a/tests/backend/test_piper_service.py
+++ b/tests/backend/test_piper_service.py
@@ -24,12 +24,12 @@ from services.piper_service import PiperService
 
 
 def _make_mock_settings(
-    piper_voice="de_DE-thorsten-high",
+    piper_default_voice="de_DE-thorsten-high",
     piper_voice_map=None,
     default_language="de",
 ):
     s = MagicMock()
-    s.piper_voice = piper_voice
+    s.piper_default_voice = piper_default_voice
     s.piper_voice_map = piper_voice_map or {"de": "de_DE-thorsten-high", "en": "en_US-amy-medium"}
     s.default_language = default_language
     return s


### PR DESCRIPTION
## Summary

Closes audit finding **E16** (legacy config fields). The original audit was partially stale and partially mis-classified:

- `plugins_*`, `music_enabled`, `spotify_*` — already removed in earlier work, verified absent.
- `piper_voice` → renamed to **`piper_default_voice`** (env: `PIPER_DEFAULT_VOICE`). It was never dead code — it's the fallback voice when the requested language has no entry in `piper_voices`. Old name was misleading.
- `ollama_model` — re-classified as **NOT dead**. It's the global model fallback used by 13+ services as `settings.X_model or settings.ollama_model` (chat, KG, agent, router, orchestrator, notifications, federation, paperless audit, health check, ...). The audit's claim that `ollama_chat_model` replaces it was wrong; the two coexist as a fallback chain.

## Why

The two non-removable fields had a real role hidden behind misleading framing. Renaming `piper_voice` makes its purpose obvious to future readers; documenting `ollama_model` as intentional infrastructure prevents a future "cleanup" PR from breaking 13 services.

## Test plan

- [x] All 27 piper-related tests pass on .159 build box (`test_piper_service.py` + `test_multilang.py` minus 2 pre-existing `services.satellite_manager` import failures unrelated to this change)
- [x] `grep` confirms no stragglers reference old `piper_voice` / `PIPER_VOICE` outside the documented `piper_voices` / `piper_voice_map` / `piper_default_voice` names
- [ ] Manual: TTS still synthesizes correctly on dev (request a `de` and an `en` chat response, check Piper voice file selection in logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)