### PR TITLE
chore(i18n): E12 — translate ChatMessages alt + English-ify 5 dev logs

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -48,7 +48,8 @@ If ui_sweep noise shows up in real use, mark original sweep row `superseded=true
 
 ### EMPFEHLUNG audit findings — modernization + cleanup
 - **Primary source:** `tasks/audit-findings-plan.md` §EMPFEHLUNG, §Priorisierte Roadmap Phase 4-5
-- **Frontend:** W9 React.lazy code-splitting for admin pages · W11 Prettier · E11 React Query · E12 13 hardcoded German strings · E13 ChatPage prop drilling → Context · E14 ESLint React version · E15 enable `tsconfig` strict mode (W10 closed via #487 on 2026-04-27)
+- **Frontend:** W9 React.lazy code-splitting for admin pages · W11 Prettier · E11 React Query · ~~E12 13 hardcoded German strings~~ (closed: ErrorBoundary/ConfirmDialog cleared by W10, ChatMessages alt + 5 dev logs translated; RoomOutputSettings filed as separate follow-up below) · E13 ChatPage prop drilling → Context · E14 ESLint React version · E15 enable `tsconfig` strict mode (W10 closed via #487 on 2026-04-27)
+- **i18n follow-up (out of E12 scope):** `src/frontend/src/components/RoomOutputSettings.tsx` has ~10 hardcoded German strings (modal labels, button titles, type-selector text). Was not in the original audit; surfaced during the E12 sweep. Not blocking; pick up alongside the next room-management UI revision.
 - **Backend/config:** E1-E3 speaker-loading + eager-load cleanup + FK indexes · E4-E9 remaining hardcoded values (MCP 40KB cap, backoff constants, agent history limit, agent response truncation, embedding dim, similarity threshold) · E10 frontend localhost fallbacks · ~~E16 legacy config field removal~~ (closed: `plugins_*`/`music_enabled`/`spotify_*` already gone; `piper_voice`→`piper_default_voice` rename; `ollama_model` is intentional fallback) · E17 Redis URL parameterization · E18 Frigate MQTT defaults
 
 ### Run `/design-consultation` to formalize DESIGN.md (BEFORE next major frontend surface)

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -106,6 +106,7 @@
     "yourMessage": "Deine Nachricht",
     "assistantResponse": "Antwort von {{appName}}",
     "readAloud": "Vorlesen",
+    "albumArt": "Albumcover",
     "intent": "Intent",
     "startConversation": "Starte ein Gespräch mit {{appName}}",
     "useTextOrMic": "Du kannst Text eingeben oder das Mikrofon nutzen",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -106,6 +106,7 @@
     "yourMessage": "Your message",
     "assistantResponse": "Response from {{appName}}",
     "readAloud": "Read aloud",
+    "albumArt": "Album art",
     "intent": "Intent",
     "startConversation": "Start a conversation with {{appName}}",
     "useTextOrMic": "You can type text or use the microphone",

--- a/src/frontend/src/pages/CameraPage.tsx
+++ b/src/frontend/src/pages/CameraPage.tsx
@@ -26,7 +26,7 @@ export default function CameraPage() {
       const response = await apiClient.get<{ cameras: string[] }>('/api/camera/cameras');
       setCameras(response.data.cameras);
     } catch (error) {
-      console.error('Fehler beim Laden der Kameras:', error);
+      console.error('Failed to load cameras:', error);
     }
   }, []);
 
@@ -36,7 +36,7 @@ export default function CameraPage() {
       const response = await apiClient.get<{ events: CameraEvent[] }>('/api/camera/events', { params });
       setEvents(response.data.events);
     } catch (error) {
-      console.error('Fehler beim Laden der Events:', error);
+      console.error('Failed to load camera events:', error);
     } finally {
       setLoading(false);
     }

--- a/src/frontend/src/pages/ChatPage/ChatMessages.tsx
+++ b/src/frontend/src/pages/ChatPage/ChatMessages.tsx
@@ -19,7 +19,7 @@ type ContentPart =
   | { type: 'link'; label: string; url: string }
   | { type: 'image'; url: string };
 
-function renderMessageContent(text: string): ReactElement {
+function renderMessageContent(text: string, imageAlt: string): ReactElement {
   // Combined pattern: markdown links [text](url), image URLs, or plain URLs
   const pattern = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)|https?:\/\/[^\s)]+?\/Items\/[^\s)]+?\/Images\/[^\s)]+|https?:\/\/[^\s)]+\.(?:jpg|jpeg|png|gif|webp)(?:\?[^\s)]*)?|https?:\/\/[^\s)]+/gi;
 
@@ -58,7 +58,7 @@ function renderMessageContent(text: string): ReactElement {
           <img
             key={i}
             src={part.url}
-            alt="Album Art"
+            alt={imageAlt}
             className="rounded-lg max-w-[200px] max-h-[200px] my-2 shadow-md"
             loading="lazy"
             onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
@@ -234,7 +234,7 @@ export default function ChatMessages() {
               </ul>
             )}
 
-            {message.role === 'assistant' ? renderMessageContent(message.content) : <p className="whitespace-pre-wrap">{message.content}</p>}
+            {message.role === 'assistant' ? renderMessageContent(message.content, t('chat.albumArt')) : <p className="whitespace-pre-wrap">{message.content}</p>}
 
             {/* Adaptive Card (from WebSocket card message) */}
             {message.card && (

--- a/src/frontend/src/pages/ChatPage/hooks/useChatWebSocket.ts
+++ b/src/frontend/src/pages/ChatPage/hooks/useChatWebSocket.ts
@@ -219,7 +219,7 @@ export function useChatWebSocket({
     };
 
     ws.onerror = (error: Event) => {
-      console.error('WebSocket Fehler:', error);
+      console.error('WebSocket error:', error);
     };
 
     wsRef.current = ws;

--- a/src/frontend/src/pages/HomeAssistantPage.tsx
+++ b/src/frontend/src/pages/HomeAssistantPage.tsx
@@ -44,7 +44,7 @@ export default function HomeAssistantPage() {
       const response = await apiClient.get<{ states: HaEntity[] }>('/api/homeassistant/states');
       setEntities(response.data.states);
     } catch (error) {
-      console.error('Fehler beim Laden der Entities:', error);
+      console.error('Failed to load Home Assistant entities:', error);
     } finally {
       setLoading(false);
     }
@@ -78,7 +78,7 @@ export default function HomeAssistantPage() {
       await apiClient.post(`/api/homeassistant/toggle/${entityId}`);
       await loadEntities();
     } catch (error) {
-      console.error('Fehler beim Umschalten:', error);
+      console.error('Failed to toggle Home Assistant entity:', error);
     }
   };
 

--- a/src/frontend/src/pages/TasksPage.tsx
+++ b/src/frontend/src/pages/TasksPage.tsx
@@ -30,7 +30,7 @@ export default function TasksPage() {
         const response = await apiClient.get<{ tasks: Task[] }>('/api/tasks/list', { params });
         setTasks(response.data.tasks);
       } catch (error) {
-        console.error('Fehler beim Laden der Tasks:', error);
+        console.error('Failed to load tasks:', error);
       } finally {
         setLoading(false);
       }

--- a/tasks/audit-findings-plan.md
+++ b/tasks/audit-findings-plan.md
@@ -175,9 +175,11 @@ Status nach Branch `audit/k1-k7` (PR aus diesem Branch schliesst K1-K7 komplett)
 - All pages use raw `apiClient.get()` + `useState` + `setLoading`
 - Fix: Adopt React Query for caching, deduplication, error retry
 
-### E12. i18n: 13 hardcoded German strings
-- `ErrorBoundary.jsx` (5), `ConfirmDialog.jsx` (4), `ChatMessages.jsx` (1), logs (3)
-- Fix: Move to i18n translation files
+### E12. i18n: 13 hardcoded German strings — RESOLVED
+- ErrorBoundary (5) and ConfirmDialog (4) — resolved during W10 TypeScript migration (#487); both files now use `useTranslation()` for every user-facing string.
+- ChatMessages alt text (1) — `alt="Album Art"` → `t('chat.albumArt')`; new key added to both `de.json` (Albumcover) and `en.json` (Album art).
+- German `console.error` logs (5 found, audit said 3) — converted to English in `CameraPage.tsx`, `HomeAssistantPage.tsx`, `TasksPage.tsx`. Logs are dev-facing, so English consistency with the rest of the codebase is the right fix (no i18n needed for dev logs).
+- Out of E12 scope: `RoomOutputSettings.tsx` has its own substantial i18n debt (~10 hardcoded German strings); filed separately as it was not in the original audit list.
 
 ### E13. ChatPage prop drilling (12+ props)
 - `ChatPage/index.jsx` passes 12 props to ChatInput
@@ -253,7 +255,7 @@ Status nach Branch `audit/k1-k7` (PR aus diesem Branch schliesst K1-K7 komplett)
 - [x] W10: TypeScript migration — 100% `.tsx`/`.ts` coverage in `src/frontend/src/` (#487)
 - [ ] W11: Add Prettier
 - [ ] E11: React Query for data fetching
-- [ ] E12: i18n hardcoded strings
+- [x] E12: i18n hardcoded strings — ErrorBoundary/ConfirmDialog cleared by W10; ChatMessages alt + 5 dev logs translated; RoomOutputSettings filed as separate follow-up
 - [ ] E14: ESLint React version
 
 ### Phase 5: Cleanup


### PR DESCRIPTION
## Summary

Closes audit finding **E12** (13 hardcoded German strings).

The W10 TypeScript migration (#487) already cleaned up the 9 strings in `ErrorBoundary` and `ConfirmDialog`. This PR closes the remaining 4 audit items:

- **ChatMessages alt text** — `alt="Album Art"` → `t('chat.albumArt')` (used by Jellyfin/Spotify image-link replies). Threaded the alt in as a parameter so the function stays pure.
- **5 German `console.error` logs** in CameraPage, HomeAssistantPage, TasksPage — translated to English for codebase-wide consistency (dev logs don't benefit from i18n; English makes grepping log output easier).

New i18n key `chat.albumArt`: "Albumcover" (de) / "Album art" (en).

## Out of scope (filed as follow-up in TODOS.md)

`RoomOutputSettings.tsx` has ~10 hardcoded German strings not in the original audit. Picked up alongside the next room-management UI revision.

## Test plan

- [x] `tests/frontend/react/pages/ChatMessages.federationProgress.test.jsx` (5/5 pass)
- [x] `npx tsc --noEmit` — no new errors in touched files
- [x] JSON lint pass on both locale files
- [x] Manual confirmation: `grep` shows no remaining `'Fehler beim …'` or `alt="Album Art"` in `src/frontend/src/`
- [ ] Manual: switch language to en, send a chat that returns an album image, hover image — check alt is "Album art"

🤖 Generated with [Claude Code](https://claude.com/claude-code)