### PR TITLE
chore(frontend): E10 — centralize VITE_API_URL/VITE_WS_URL fallback with warnings

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -50,7 +50,7 @@ If ui_sweep noise shows up in real use, mark original sweep row `superseded=true
 - **Primary source:** `tasks/audit-findings-plan.md` §EMPFEHLUNG, §Priorisierte Roadmap Phase 4-5
 - **Frontend:** W9 React.lazy code-splitting for admin pages · W11 Prettier · E11 React Query · ~~E12 13 hardcoded German strings~~ (closed: ErrorBoundary/ConfirmDialog cleared by W10, ChatMessages alt + 5 dev logs translated; RoomOutputSettings filed as separate follow-up below) · E13 ChatPage prop drilling → Context · ~~E14 ESLint React version~~ (verified already done — `'detect'` already set) · E15 enable `tsconfig` strict mode (W10 closed via #487 on 2026-04-27)
 - **i18n follow-up (out of E12 scope):** `src/frontend/src/components/RoomOutputSettings.tsx` has ~10 hardcoded German strings (modal labels, button titles, type-selector text). Was not in the original audit; surfaced during the E12 sweep. Not blocking; pick up alongside the next room-management UI revision.
-- **Backend/config:** E1-E3 speaker-loading + eager-load cleanup + FK indexes · ~~E4-E9 remaining hardcoded values~~ (closed: E4/E6/E7/E8 already in earlier work; E5 MCP backoff + E9 intent-feedback dual thresholds promoted to Settings) · E10 frontend localhost fallbacks · ~~E16 legacy config field removal~~ · ~~E17 Redis URL parameterization~~ · ~~E18 Frigate MQTT defaults~~
+- **Backend/config:** E1-E3 speaker-loading + eager-load cleanup + FK indexes · ~~E4-E9~~ · ~~E10 frontend localhost fallbacks~~ (closed: centralized `getApiBaseUrl`/`getWebSocketUrl` helper warns when env vars missing) · ~~E16 legacy config field removal~~ · ~~E17 Redis URL parameterization~~ · ~~E18 Frigate MQTT defaults~~
 
 ### Run `/design-consultation` to formalize DESIGN.md (BEFORE next major frontend surface)
 

--- a/src/frontend/src/hooks/useDeviceConnection.ts
+++ b/src/frontend/src/hooks/useDeviceConnection.ts
@@ -9,6 +9,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { debug } from '../utils/debug';
+import { getWebSocketUrl } from '../utils/env';
 import type {
   DeviceType,
   DeviceState,
@@ -166,11 +167,10 @@ export function useDeviceConnection({
   const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const heartbeatIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // Get WebSocket URL
+  // Get WebSocket URL — strip the conventional `/ws` suffix from the env
+  // value (or warning-emitting fallback) and append the device endpoint.
   const getWsUrl = useCallback((): string => {
-    const baseUrl = import.meta.env.VITE_WS_URL || 'ws://localhost:8000';
-    // Replace /ws with /ws/device for the device endpoint
-    return baseUrl.replace(/\/ws$/, '') + '/ws/device';
+    return getWebSocketUrl().replace(/\/ws$/, '') + '/ws/device';
   }, []);
 
   // Stop heartbeat

--- a/src/frontend/src/pages/ChatPage/hooks/useChatWebSocket.ts
+++ b/src/frontend/src/pages/ChatPage/hooks/useChatWebSocket.ts
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { debug } from '../../../utils/debug';
+import { getWebSocketUrl } from '../../../utils/env';
 
 export interface BaseWsMessage {
   type: string;
@@ -138,7 +139,7 @@ export function useChatWebSocket({
       reconnectTimeoutRef.current = null;
     }
 
-    let wsUrl = import.meta.env.VITE_WS_URL || 'ws://localhost:8000/ws';
+    let wsUrl = getWebSocketUrl();
     // Append JWT token for WebSocket authentication (falls back to device-token cookie if absent)
     const accessToken = localStorage.getItem('renfield_access_token');
     if (accessToken) {

--- a/src/frontend/src/utils/axios.ts
+++ b/src/frontend/src/utils/axios.ts
@@ -1,8 +1,10 @@
 import axios, { AxiosInstance, InternalAxiosRequestConfig, AxiosResponse, AxiosError } from 'axios';
 
+import { getApiBaseUrl } from './env';
+
 // Axios Instance mit Base URL
 const apiClient: AxiosInstance = axios.create({
-  baseURL: import.meta.env.VITE_API_URL ?? 'http://localhost:8000',
+  baseURL: getApiBaseUrl(),
   timeout: 30000,
   headers: {
     'Content-Type': 'application/json',

--- a/src/frontend/src/utils/env.ts
+++ b/src/frontend/src/utils/env.ts
@@ -1,0 +1,63 @@
+/**
+ * Environment-variable resolution with explicit warnings when fallbacks kick in.
+ *
+ * Vite injects build-time env vars via `import.meta.env`. When `VITE_API_URL` or
+ * `VITE_WS_URL` is unset, every consumer used to silently fall back to
+ * `http://localhost:8000` — fine for `npm run dev` but a silent footgun in any
+ * other deployment (containerized prod, mobile build, served-from-nginx).
+ *
+ * These helpers centralize the fallback and warn — at error level in PROD
+ * builds, at warn level in DEV — so a misconfigured deploy is visible in the
+ * browser console instead of looking like a backend that's just unreachable.
+ *
+ * Each helper warns at most once per page load.
+ */
+
+const FALLBACK_API_URL = 'http://localhost:8000';
+// VITE_WS_URL convention (per .env.example + docker-compose.*.yml): the env
+// value includes the `/ws` path suffix. The Dockerfile appends `/ws` to
+// EXTERNAL_WS_URL automatically. Consumers that need a different endpoint
+// (e.g. /ws/device) strip the trailing `/ws` and append their own path.
+const FALLBACK_WS_URL = 'ws://localhost:8000/ws';
+
+const _warned = new Set<string>();
+
+function warnFallback(varName: string, fallbackValue: string): void {
+  if (_warned.has(varName)) return;
+  _warned.add(varName);
+  const message =
+    `[env] ${varName} is not set; falling back to ${fallbackValue}. ` +
+    `This is expected for \`npm run dev\` but indicates a misconfigured build for any other deployment.`;
+  if (import.meta.env.PROD) {
+    console.error(message);
+  } else {
+    console.warn(message);
+  }
+}
+
+/**
+ * REST API base URL for the Renfield backend. Falls back to localhost:8000
+ * when `VITE_API_URL` is unset, with a console warning.
+ */
+export function getApiBaseUrl(): string {
+  const value = import.meta.env.VITE_API_URL as string | undefined;
+  if (value && value.length > 0) return value;
+  warnFallback('VITE_API_URL', FALLBACK_API_URL);
+  return FALLBACK_API_URL;
+}
+
+/**
+ * WebSocket URL for the Renfield backend (includes `/ws` path per convention).
+ * Falls back to `ws://localhost:8000/ws` when `VITE_WS_URL` is unset, with a
+ * console warning.
+ *
+ * Consumers that need a different endpoint (e.g. `/ws/device`) should strip
+ * the trailing `/ws` from the return value and append their own path —
+ * `useDeviceConnection.getWsUrl()` is the canonical example.
+ */
+export function getWebSocketUrl(): string {
+  const value = import.meta.env.VITE_WS_URL as string | undefined;
+  if (value && value.length > 0) return value;
+  warnFallback('VITE_WS_URL', FALLBACK_WS_URL);
+  return FALLBACK_WS_URL;
+}

--- a/tasks/audit-findings-plan.md
+++ b/tasks/audit-findings-plan.md
@@ -10,10 +10,10 @@ Consolidated results from 4 systematic audits (DB Performance, Config Hardcodes,
 |----------|-------|----------|----------|
 | KRITISCH | 7 | 7 / 7 | Must fix — performance bottlenecks, security gaps |
 | WICHTIG | 14 | 14 / 14 | Should fix — inconsistencies, missing optimizations |
-| EMPFEHLUNG | 18 | 11 / 18 | Nice to have — modernization, cleanup |
+| EMPFEHLUNG | 18 | 12 / 18 | Nice to have — modernization, cleanup |
 | GUT | 12 | — | Already well-implemented |
 
-**Status (2026-04-30):** All KRITISCH and WICHTIG items closed. EMPFEHLUNG closed: E4, E5, E6, E7, E8, E9, E12, E14, E16, E17, E18. Open: E1-E3 (backend perf), E10 (frontend localhost fallbacks), E11/E13/E15 (frontend modernization). See `TODOS.md` P2 for active queue.
+**Status (2026-04-30):** All KRITISCH and WICHTIG items closed. EMPFEHLUNG closed: E4, E5, E6, E7, E8, E9, E10, E12, E14, E16, E17, E18. Open: E1-E3 (backend perf), E11/E13/E15 (frontend modernization). See `TODOS.md` P2 for active queue.
 
 ---
 
@@ -142,9 +142,9 @@ All 14 WICHTIG items closed as of 2026-04-27. Re-verified 2026-04-30 against cur
 - The two thresholds were intentionally different — 0.75 for general past-correction matching, 0.80 for the stricter "is this query simple or complex?" routing decision (fewer false positives wanted on complexity routing). The audit framed this as a unify-into-one fix; that would have collapsed two real decision bars.
 - Fix: Both thresholds promoted to Settings (`intent_feedback_similarity_threshold` = 0.75, `intent_feedback_complexity_threshold` = 0.80). `find_similar_corrections(threshold=None)` falls back to the general bar; the complexity-routing call site explicitly passes the complexity bar. Operators can now tune recall/precision per environment.
 
-### E10. Frontend hardcoded localhost fallbacks
-- `utils/axios.ts:5`, `useChatWebSocket.js:34`, `useDeviceConnection.ts:171`
-- Fix: Add validation/warning when VITE_API_URL not set
+### E10. Frontend hardcoded localhost fallbacks — RESOLVED
+- New `src/frontend/src/utils/env.ts` centralizes the fallback with `getApiBaseUrl()` and `getWebSocketUrl()`. Both warn on console (error level in PROD builds, warn in DEV) when the env var is unset, and warn at most once per page load.
+- All three call sites migrated: `utils/axios.ts:5`, `pages/ChatPage/hooks/useChatWebSocket.ts:141`, `hooks/useDeviceConnection.ts:170`. The `VITE_WS_URL` "includes-/ws" convention (per `.env.example` + 4 compose files) is preserved.
 
 ### E11. React Query / SWR for data fetching
 - All pages use raw `apiClient.get()` + `useState` + `setLoading`


### PR DESCRIPTION
## Summary

Closes audit finding **E10** (frontend hardcoded localhost fallbacks).

Three call sites used to silently fall back to `localhost:8000` when the env var was unset — fine for `npm run dev` but a footgun in any other deployment. A misconfigured deploy looked like an unreachable backend instead of "you forgot to set the env var".

Centralized in `src/frontend/src/utils/env.ts`:

```ts
getApiBaseUrl()    →  VITE_API_URL || 'http://localhost:8000'
getWebSocketUrl()  →  VITE_WS_URL  || 'ws://localhost:8000/ws'
```

Both warn on console (**error** level in PROD builds, **warn** in DEV) when the env var is unset, and warn **at most once per page load**. A misconfigured deploy is now visible in the browser console rather than silent.

## VITE_WS_URL convention preserved

Per `.env.example` + the 4 docker-compose files, `VITE_WS_URL` already includes the `/ws` path suffix (the Dockerfile appends it to `EXTERNAL_WS_URL` automatically). The helper preserves that semantic. Consumers needing a different endpoint (e.g. `useDeviceConnection`'s `/ws/device`) keep the `replace(/\/ws$/, '') + '/ws/...'` pattern, just sourcing the URL from the helper.

## Migrated

- `src/frontend/src/utils/axios.ts` (apiClient.baseURL)
- `src/frontend/src/pages/ChatPage/hooks/useChatWebSocket.ts` (chat WS)
- `src/frontend/src/hooks/useDeviceConnection.ts` (device WS)

## Test plan

- [x] `tests/frontend/react/hooks/useChatWebSocket.test.jsx` 7/7 pass
- [x] `tsc --noEmit` shows no new errors in touched files (the 2 errors at `useDeviceConnection.ts:371,373` are pre-existing notification/state-machine type issues unrelated to this PR)
- [x] grep confirms no remaining raw `VITE_API_URL` / `VITE_WS_URL` reads or `localhost:8000` fallbacks outside `env.ts` itself
- [ ] Manual: dev server still works (no env vars set → localhost fallback + warn-level console)
- [ ] Manual: prod build with no env vars → error-level console message

🤖 Generated with [Claude Code](https://claude.com/claude-code)