### PR TITLE
feat(frontend): E11 — migrate PaperlessAuditPage to React Query (final)

### DIFF
--- a/src/frontend/src/api/resources/paperlessAudit.ts
+++ b/src/frontend/src/api/resources/paperlessAudit.ts
@@ -1,0 +1,342 @@
+import { useQueryClient } from '@tanstack/react-query';
+
+import apiClient from '../../utils/axios';
+import { useApiQuery, useApiMutation } from '../hooks';
+import { keys, STALE } from '../keys';
+
+export type AuditMode = 'new_only' | 'full';
+export type FixMode = 'review' | 'auto_threshold' | 'auto_all';
+
+export interface AuditStatus {
+  running: boolean;
+  progress?: number;
+  total?: number;
+}
+
+export interface AuditResult {
+  id: number;
+  paperless_doc_id: number;
+  current_title?: string | null;
+  suggested_title?: string | null;
+  current_correspondent?: string | null;
+  suggested_correspondent?: string | null;
+  current_document_type?: string | null;
+  suggested_document_type?: string | null;
+  current_date?: string | null;
+  suggested_date?: string | null;
+  current_storage_path?: string | null;
+  suggested_storage_path?: string | null;
+  detected_language?: string | null;
+  suggested_tags?: string[];
+  missing_fields?: string[];
+  confidence?: number | null;
+  ocr_quality?: number;
+  ocr_issues?: string;
+  content_completeness?: number;
+  completeness_issues?: string;
+}
+
+export interface AuditStats {
+  total_audited?: number;
+  changes_needed?: number;
+  applied?: number;
+  skipped?: number;
+  pending?: number;
+  failed?: number;
+  missing_metadata_count?: number;
+  duplicate_groups?: number;
+  avg_confidence?: number;
+  ocr_quality_distribution?: Record<string, number>;
+  ocr_distribution?: Record<string, number>;
+  language_distribution?: Record<string, number>;
+  completeness_distribution?: Record<string, number>;
+}
+
+export interface DuplicateDoc {
+  id: number;
+  paperless_doc_id: number;
+  current_title?: string | null;
+  current_correspondent?: string | null;
+  duplicate_score?: number | null;
+}
+
+export interface DuplicateGroup {
+  group_id: string;
+  documents: DuplicateDoc[];
+}
+
+export interface CorrespondentVariant {
+  name: string;
+  similarity: number;
+}
+
+export interface CorrespondentCluster {
+  canonical: string;
+  variants: CorrespondentVariant[];
+}
+
+interface ResultsListResponse {
+  results: AuditResult[];
+  total: number;
+}
+
+async function fetchStatus(): Promise<AuditStatus> {
+  const response = await apiClient.get<AuditStatus>('/api/admin/paperless-audit/status');
+  return response.data;
+}
+
+async function fetchResults(params: Record<string, unknown>): Promise<ResultsListResponse> {
+  const response = await apiClient.get<{ results?: AuditResult[]; total?: number } | AuditResult[]>(
+    '/api/admin/paperless-audit/results',
+    { params },
+  );
+  const data = response.data;
+  if (Array.isArray(data)) {
+    return { results: data, total: data.length };
+  }
+  const results = data.results ?? [];
+  return { results, total: data.total ?? results.length };
+}
+
+async function fetchStats(): Promise<AuditStats> {
+  const response = await apiClient.get<AuditStats>('/api/admin/paperless-audit/stats');
+  return response.data;
+}
+
+async function fetchDuplicateGroups(): Promise<DuplicateGroup[]> {
+  const response = await apiClient.get<DuplicateGroup[]>('/api/admin/paperless-audit/duplicate-groups');
+  return response.data ?? [];
+}
+
+async function fetchCorrespondentClusters(threshold: number): Promise<CorrespondentCluster[]> {
+  const response = await apiClient.get<{ clusters?: CorrespondentCluster[] }>(
+    '/api/admin/paperless-audit/correspondent-normalization',
+    { params: { threshold } },
+  );
+  return response.data.clusters ?? [];
+}
+
+interface StartAuditInput {
+  mode: AuditMode;
+  fix_mode: FixMode;
+  confidence_threshold: number;
+}
+
+async function startAuditRequest(input: StartAuditInput): Promise<void> {
+  await apiClient.post('/api/admin/paperless-audit/start', input);
+}
+
+async function stopAuditRequest(): Promise<void> {
+  await apiClient.post('/api/admin/paperless-audit/stop', {});
+}
+
+async function applyResultsRequest(ids: number[]): Promise<void> {
+  await apiClient.post('/api/admin/paperless-audit/apply', { result_ids: ids });
+}
+
+async function skipResultsRequest(ids: number[]): Promise<void> {
+  await apiClient.post('/api/admin/paperless-audit/skip', { result_ids: ids });
+}
+
+async function reOcrRequest(ids: number[]): Promise<void> {
+  await apiClient.post('/api/admin/paperless-audit/re-ocr', { result_ids: ids });
+}
+
+async function detectDuplicatesRequest(): Promise<void> {
+  await apiClient.post('/api/admin/paperless-audit/detect-duplicates', {});
+}
+
+export interface ReviewFilter {
+  page: number;
+  perPage: number;
+  sortBy: string | null;
+  sortOrder: 'asc' | 'desc';
+  search: string;
+}
+
+export interface OcrFilter {
+  page: number;
+  perPage: number;
+}
+
+export interface CompletenessFilter {
+  page: number;
+  perPage: number;
+}
+
+function reviewParams(filter: ReviewFilter): Record<string, unknown> {
+  const params: Record<string, unknown> = {
+    status: 'pending',
+    changes_needed: true,
+    per_page: filter.perPage,
+    page: filter.page + 1,
+  };
+  if (filter.sortBy) {
+    params.sort_by = filter.sortBy;
+    params.sort_order = filter.sortOrder;
+  }
+  if (filter.search.trim()) {
+    params.search = filter.search.trim();
+  }
+  return params;
+}
+
+export function useAuditStatusQuery() {
+  return useApiQuery(
+    {
+      queryKey: keys.paperlessAudit.status(),
+      queryFn: fetchStatus,
+      staleTime: STALE.LIVE,
+      // refetchInterval reads from the query's own data — when an audit is
+      // running, poll every 2s; otherwise stay idle. RQ re-evaluates this
+      // callback after each fetch, so polling automatically stops when the
+      // audit completes.
+      refetchInterval: (query) => (query.state.data?.running ? 2000 : false),
+    },
+    'paperlessAudit.error',
+  );
+}
+
+export function useReviewResultsQuery(filter: ReviewFilter, enabled: boolean) {
+  return useApiQuery(
+    {
+      queryKey: [...keys.paperlessAudit.results(), 'review', filter] as const,
+      queryFn: () => fetchResults(reviewParams(filter)),
+      staleTime: STALE.DEFAULT,
+      enabled,
+    },
+    'paperlessAudit.error',
+  );
+}
+
+export function useOcrResultsQuery(filter: OcrFilter, enabled: boolean) {
+  return useApiQuery(
+    {
+      queryKey: [...keys.paperlessAudit.results(), 'ocr', filter] as const,
+      queryFn: () =>
+        fetchResults({ ocr_quality_max: 2, per_page: filter.perPage, page: filter.page + 1 }),
+      staleTime: STALE.DEFAULT,
+      enabled,
+    },
+    'paperlessAudit.error',
+  );
+}
+
+export function useCompletenessResultsQuery(filter: CompletenessFilter, enabled: boolean) {
+  return useApiQuery(
+    {
+      queryKey: [...keys.paperlessAudit.results(), 'completeness', filter] as const,
+      queryFn: () =>
+        fetchResults({ completeness_max: 2, per_page: filter.perPage, page: filter.page + 1 }),
+      staleTime: STALE.DEFAULT,
+      enabled,
+    },
+    'paperlessAudit.error',
+  );
+}
+
+export function useAuditStatsQuery(enabled: boolean) {
+  return useApiQuery(
+    {
+      queryKey: keys.paperlessAudit.stats(),
+      queryFn: fetchStats,
+      staleTime: STALE.LIVE,
+      enabled,
+    },
+    'paperlessAudit.error',
+  );
+}
+
+export function useDuplicateGroupsQuery(enabled: boolean) {
+  return useApiQuery(
+    {
+      queryKey: keys.paperlessAudit.duplicateGroups(),
+      queryFn: fetchDuplicateGroups,
+      staleTime: STALE.DEFAULT,
+      enabled,
+    },
+    'paperlessAudit.error',
+  );
+}
+
+export function useCorrespondentClustersQuery(threshold: number, enabled: boolean) {
+  return useApiQuery(
+    {
+      queryKey: [...keys.paperlessAudit.all, 'correspondents', threshold] as const,
+      queryFn: () => fetchCorrespondentClusters(threshold),
+      staleTime: STALE.DEFAULT,
+      enabled,
+    },
+    'paperlessAudit.error',
+  );
+}
+
+function invalidateAudit(queryClient: ReturnType<typeof useQueryClient>) {
+  queryClient.invalidateQueries({ queryKey: keys.paperlessAudit.all });
+}
+
+export function useStartAudit() {
+  const queryClient = useQueryClient();
+  return useApiMutation(
+    {
+      mutationFn: startAuditRequest,
+      onSuccess: () => invalidateAudit(queryClient),
+    },
+    'paperlessAudit.error',
+  );
+}
+
+export function useStopAudit() {
+  const queryClient = useQueryClient();
+  return useApiMutation(
+    {
+      mutationFn: stopAuditRequest,
+      onSuccess: () => invalidateAudit(queryClient),
+    },
+    'paperlessAudit.error',
+  );
+}
+
+export function useApplyResults() {
+  const queryClient = useQueryClient();
+  return useApiMutation(
+    {
+      mutationFn: applyResultsRequest,
+      onSuccess: () => invalidateAudit(queryClient),
+    },
+    'paperlessAudit.error',
+  );
+}
+
+export function useSkipResults() {
+  const queryClient = useQueryClient();
+  return useApiMutation(
+    {
+      mutationFn: skipResultsRequest,
+      onSuccess: () => invalidateAudit(queryClient),
+    },
+    'paperlessAudit.error',
+  );
+}
+
+export function useReOcr() {
+  const queryClient = useQueryClient();
+  return useApiMutation(
+    {
+      mutationFn: reOcrRequest,
+      onSuccess: () => invalidateAudit(queryClient),
+    },
+    'paperlessAudit.error',
+  );
+}
+
+export function useDetectDuplicates() {
+  const queryClient = useQueryClient();
+  return useApiMutation(
+    {
+      mutationFn: detectDuplicatesRequest,
+      onSuccess: () => invalidateAudit(queryClient),
+    },
+    'paperlessAudit.error',
+  );
+}

--- a/src/frontend/src/api/resources/paperlessAudit.ts
+++ b/src/frontend/src/api/resources/paperlessAudit.ts
@@ -240,7 +240,11 @@ export function useAuditStatsQuery(enabled: boolean) {
     {
       queryKey: keys.paperlessAudit.stats(),
       queryFn: fetchStats,
-      staleTime: STALE.LIVE,
+      // Stats are an aggregate that only changes after a mutation — the
+      // mutations already invalidate keys.paperlessAudit.all on success,
+      // so STALE.DEFAULT is correct here. STALE.LIVE would refetch every
+      // 5s for no benefit.
+      staleTime: STALE.DEFAULT,
       enabled,
     },
     'paperlessAudit.error',

--- a/src/frontend/src/pages/PaperlessAuditPage.tsx
+++ b/src/frontend/src/pages/PaperlessAuditPage.tsx
@@ -4,13 +4,11 @@
  * Admin page for auditing Paperless documents using LLM analysis.
  * Provides audit control, review queue, OCR issue tracking, and statistics.
  */
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import type { TFunction } from 'i18next';
 import type { AxiosError } from 'axios';
 import type { LucideIcon } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { useAuth } from '../context/AuthContext';
-import apiClient from '../utils/axios';
 import {
   FileSearch, Play, Square, Loader, Check, X,
   RotateCcw, BarChart3, ClipboardList, Eye, ChevronLeft, ChevronRight,
@@ -19,11 +17,30 @@ import {
 import PageHeader from '../components/PageHeader';
 import Alert from '../components/Alert';
 import Badge from '../components/Badge';
+import {
+  useAuditStatusQuery,
+  useReviewResultsQuery,
+  useOcrResultsQuery,
+  useCompletenessResultsQuery,
+  useAuditStatsQuery,
+  useDuplicateGroupsQuery,
+  useCorrespondentClustersQuery,
+  useStartAudit,
+  useStopAudit,
+  useApplyResults,
+  useSkipResults,
+  useReOcr,
+  useDetectDuplicates,
+  type AuditMode,
+  type FixMode,
+  type AuditStatus,
+  type AuditResult,
+  type AuditStats,
+  type DuplicateGroup,
+  type CorrespondentCluster,
+} from '../api/resources/paperlessAudit';
 
 type AuditTab = 'control' | 'review' | 'ocr' | 'completeness' | 'duplicates' | 'correspondents' | 'stats';
-type AuditMode = 'new_only' | 'full';
-type FixMode = 'review' | 'auto_threshold' | 'auto_all';
-type OcrLevel = 1 | 2 | 3 | 4 | 5;
 
 const TABS: AuditTab[] = ['control', 'review', 'ocr', 'completeness', 'duplicates', 'correspondents', 'stats'];
 const PAGE_SIZE = 20;
@@ -44,244 +61,156 @@ const OCR_TEXT_COLORS: Partial<Record<number, string>> = {
   5: 'text-green-700 dark:text-green-300',
 };
 
-interface AuditStatus {
-  running: boolean;
-  progress?: number;
-  total?: number;
-}
-
-interface AuditResult {
-  id: number;
-  paperless_doc_id: number;
-  current_title?: string | null;
-  suggested_title?: string | null;
-  current_correspondent?: string | null;
-  suggested_correspondent?: string | null;
-  current_document_type?: string | null;
-  suggested_document_type?: string | null;
-  current_date?: string | null;
-  suggested_date?: string | null;
-  current_storage_path?: string | null;
-  suggested_storage_path?: string | null;
-  detected_language?: string | null;
-  suggested_tags?: string[];
-  missing_fields?: string[];
-  confidence?: number | null;
-  ocr_quality?: number;
-  ocr_issues?: string;
-  content_completeness?: number;
-  completeness_issues?: string;
-}
-
-interface AuditStats {
-  total_audited?: number;
-  changes_needed?: number;
-  applied?: number;
-  skipped?: number;
-  pending?: number;
-  failed?: number;
-  missing_metadata_count?: number;
-  duplicate_groups?: number;
-  avg_confidence?: number;
-  ocr_quality_distribution?: Record<string, number>;
-  ocr_distribution?: Record<string, number>;
-  language_distribution?: Record<string, number>;
-  completeness_distribution?: Record<string, number>;
-}
-
-interface DuplicateDoc {
-  id: number;
-  paperless_doc_id: number;
-  current_title?: string | null;
-  current_correspondent?: string | null;
-  duplicate_score?: number | null;
-}
-
-interface DuplicateGroup {
-  group_id: string;
-  documents: DuplicateDoc[];
-}
-
-interface CorrespondentVariant {
-  name: string;
-  similarity: number;
-}
-
-interface CorrespondentCluster {
-  canonical: string;
-  variants: CorrespondentVariant[];
-}
-
 export default function PaperlessAuditPage() {
   const { t } = useTranslation();
-  const { getAccessToken } = useAuth();
 
   const [activeTab, setActiveTab] = useState<AuditTab>('control');
-  const [notConfigured, setNotConfigured] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   // Control tab state
-  const [auditStatus, setAuditStatus] = useState<AuditStatus | null>(null);
   const [mode, setMode] = useState<AuditMode>('new_only');
   const [fixMode, setFixMode] = useState<FixMode>('review');
   const [confidenceThreshold, setConfidenceThreshold] = useState(0.8);
-  const [starting, setStarting] = useState(false);
-  const [stopping, setStopping] = useState(false);
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   // Review tab state
-  const [reviewResults, setReviewResults] = useState<AuditResult[]>([]);
-  const [reviewLoading, setReviewLoading] = useState(false);
   const [reviewPage, setReviewPage] = useState(0);
-  const [reviewTotal, setReviewTotal] = useState(0);
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [actionLoading, setActionLoading] = useState<Set<number>>(new Set());
   const [reviewSortBy, setReviewSortBy] = useState<string | null>(null);
   const [reviewSortOrder, setReviewSortOrder] = useState<'asc' | 'desc'>('desc');
   const [reviewSearch, setReviewSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
   const reviewSearchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // OCR tab state
-  const [ocrResults, setOcrResults] = useState<AuditResult[]>([]);
-  const [ocrLoading, setOcrLoading] = useState(false);
   const [ocrPage, setOcrPage] = useState(0);
-  const [ocrTotal, setOcrTotal] = useState(0);
   const [ocrActionLoading, setOcrActionLoading] = useState<Set<number>>(new Set());
 
-  // Stats tab state
-  const [stats, setStats] = useState<AuditStats | null>(null);
-  const [statsLoading, setStatsLoading] = useState(false);
-
   // Completeness tab state
-  const [completenessResults, setCompletenessResults] = useState<AuditResult[]>([]);
-  const [completenessLoading, setCompletenessLoading] = useState(false);
   const [completenessPage, setCompletenessPage] = useState(0);
-  const [completenessTotal, setCompletenessTotal] = useState(0);
-
-  // Duplicates tab state
-  const [duplicateGroups, setDuplicateGroups] = useState<DuplicateGroup[]>([]);
-  const [duplicatesLoading, setDuplicatesLoading] = useState(false);
-  const [detectingDuplicates, setDetectingDuplicates] = useState(false);
 
   // Correspondents tab state
-  const [correspondentClusters, setCorrespondentClusters] = useState<CorrespondentCluster[]>([]);
-  const [correspondentsLoading, setCorrespondentsLoading] = useState(false);
   const [corrThreshold, setCorrThreshold] = useState(0.82);
+  const [scanCorrespondents, setScanCorrespondents] = useState(false);
 
-  const authHeaders = useCallback(async (): Promise<Record<string, string>> => {
-    const token = await getAccessToken();
-    return token ? { Authorization: `Bearer ${token}` } : {};
-  }, [getAccessToken]);
+  // Status query (always on; polls every 2s while running via the query's
+  // own refetchInterval callback that reads from the response data).
+  const statusQuery = useAuditStatusQuery();
+  const auditStatus = statusQuery.data ?? null;
 
-  const handleApiError = useCallback((err: unknown) => {
-    const status = (err as AxiosError | undefined)?.response?.status;
-    if (status === 503) {
-      setNotConfigured(true);
-      return;
-    }
-    setError(t('paperlessAudit.error'));
-  }, [t]);
+  // Tab-gated data queries
+  const reviewQuery = useReviewResultsQuery(
+    {
+      page: reviewPage,
+      perPage: PAGE_SIZE,
+      sortBy: reviewSortBy,
+      sortOrder: reviewSortOrder,
+      search: debouncedSearch,
+    },
+    activeTab === 'review',
+  );
+  const reviewResults: AuditResult[] = reviewQuery.data?.results ?? [];
+  const reviewTotal = reviewQuery.data?.total ?? 0;
+  const reviewLoading = reviewQuery.isLoading;
 
-  // --- Control Tab ---
-  const loadStatus = useCallback(async () => {
-    try {
-      const headers = await authHeaders();
-      const res = await apiClient.get<AuditStatus>('/api/admin/paperless-audit/status', { headers });
-      setAuditStatus(res.data);
-      setNotConfigured(false);
-    } catch (err) {
-      handleApiError(err);
-    }
-  }, [authHeaders, handleApiError]);
+  const ocrQuery = useOcrResultsQuery(
+    { page: ocrPage, perPage: PAGE_SIZE },
+    activeTab === 'ocr',
+  );
+  const ocrResults: AuditResult[] = ocrQuery.data?.results ?? [];
+  const ocrTotal = ocrQuery.data?.total ?? 0;
+  const ocrLoading = ocrQuery.isLoading;
 
+  const completenessQuery = useCompletenessResultsQuery(
+    { page: completenessPage, perPage: PAGE_SIZE },
+    activeTab === 'completeness',
+  );
+  const completenessResults: AuditResult[] = completenessQuery.data?.results ?? [];
+  const completenessTotal = completenessQuery.data?.total ?? 0;
+  const completenessLoading = completenessQuery.isLoading;
+
+  const statsQuery = useAuditStatsQuery(activeTab === 'stats');
+  const stats: AuditStats | null = statsQuery.data ?? null;
+  const statsLoading = statsQuery.isLoading;
+
+  const duplicatesQuery = useDuplicateGroupsQuery(activeTab === 'duplicates');
+  const duplicateGroups: DuplicateGroup[] = duplicatesQuery.data ?? [];
+  const duplicatesLoading = duplicatesQuery.isLoading;
+
+  const correspondentsQuery = useCorrespondentClustersQuery(
+    corrThreshold,
+    activeTab === 'correspondents' && scanCorrespondents,
+  );
+  const correspondentClusters: CorrespondentCluster[] = correspondentsQuery.data ?? [];
+  const correspondentsLoading = correspondentsQuery.isFetching;
+
+  // Mutations
+  const startMutation = useStartAudit();
+  const stopMutation = useStopAudit();
+  const applyMutation = useApplyResults();
+  const skipMutation = useSkipResults();
+  const reOcrMutation = useReOcr();
+  const detectDuplicatesMutation = useDetectDuplicates();
+
+  const starting = startMutation.isPending;
+  const stopping = stopMutation.isPending;
+  const detectingDuplicates = detectDuplicatesMutation.isPending;
+
+  // 503 → "not configured" surface. Any query returning 503 means the
+  // Paperless integration isn't wired up; the page collapses to a banner.
+  const queryErrors = [
+    statusQuery.error,
+    reviewQuery.error,
+    ocrQuery.error,
+    completenessQuery.error,
+    statsQuery.error,
+    duplicatesQuery.error,
+    correspondentsQuery.error,
+  ];
+  const notConfigured = queryErrors.some(
+    (e) => (e as AxiosError | null)?.response?.status === 503,
+  );
+
+  // Reset selectedIds whenever a fresh review fetch lands. Tracking
+  // reviewQuery.data (the actual query result) avoids the infinite-loop
+  // trap that comes from depending on reviewResults, which gets a new
+  // array reference every render thanks to the `?? []` fallback.
   useEffect(() => {
-    loadStatus();
-  }, [loadStatus]);
-
-  // Poll status while running
-  useEffect(() => {
-    if (auditStatus?.running) {
-      pollRef.current = setInterval(loadStatus, 2000);
-    } else if (pollRef.current) {
-      clearInterval(pollRef.current);
-      pollRef.current = null;
+    if (reviewQuery.data !== undefined) {
+      setSelectedIds(new Set());
     }
-    return () => {
-      if (pollRef.current) clearInterval(pollRef.current);
-    };
-  }, [auditStatus?.running, loadStatus]);
+  }, [reviewQuery.data]);
 
   const startAudit = async () => {
-    setStarting(true);
     setError(null);
     try {
-      const headers = await authHeaders();
-      await apiClient.post('/api/admin/paperless-audit/start', {
+      await startMutation.mutateAsync({
         mode,
         fix_mode: fixMode,
         confidence_threshold: confidenceThreshold,
-      }, { headers });
-      await loadStatus();
+      });
     } catch (err) {
-      handleApiError(err);
-    } finally {
-      setStarting(false);
+      const status = (err as AxiosError | undefined)?.response?.status;
+      if (status !== 503) setError(t('paperlessAudit.error'));
     }
   };
 
   const stopAudit = async () => {
-    setStopping(true);
     try {
-      const headers = await authHeaders();
-      await apiClient.post('/api/admin/paperless-audit/stop', {}, { headers });
-      await loadStatus();
+      await stopMutation.mutateAsync(undefined);
     } catch (err) {
-      handleApiError(err);
-    } finally {
-      setStopping(false);
+      const status = (err as AxiosError | undefined)?.response?.status;
+      if (status !== 503) setError(t('paperlessAudit.error'));
     }
   };
-
-  // --- Review Tab ---
-  const loadReview = useCallback(async () => {
-    setReviewLoading(true);
-    setError(null);
-    try {
-      const headers = await authHeaders();
-      const params: Record<string, unknown> = { status: 'pending', changes_needed: true, per_page: PAGE_SIZE, page: reviewPage + 1 };
-      if (reviewSortBy) {
-        params.sort_by = reviewSortBy;
-        params.sort_order = reviewSortOrder;
-      }
-      if (reviewSearch.trim()) {
-        params.search = reviewSearch.trim();
-      }
-      const res = await apiClient.get<{ results?: AuditResult[]; total?: number } | AuditResult[]>('/api/admin/paperless-audit/results', { headers, params });
-      const data = res.data;
-      const results: AuditResult[] = Array.isArray(data) ? data : (data.results ?? []);
-      setReviewResults(results);
-      setReviewTotal(Array.isArray(data) ? results.length : (data.total ?? results.length));
-      setSelectedIds(new Set());
-      setNotConfigured(false);
-    } catch (err) {
-      handleApiError(err);
-    } finally {
-      setReviewLoading(false);
-    }
-  }, [authHeaders, handleApiError, reviewPage, reviewSortBy, reviewSortOrder, reviewSearch]);
-
-  useEffect(() => {
-    if (activeTab === 'review') loadReview();
-  }, [activeTab, loadReview]);
 
   const approveResults = async (ids: number[]) => {
     setActionLoading((prev) => new Set([...prev, ...ids]));
     try {
-      const headers = await authHeaders();
-      await apiClient.post('/api/admin/paperless-audit/apply', { result_ids: ids }, { headers });
-      await loadReview();
+      await applyMutation.mutateAsync(ids);
     } catch (err) {
-      handleApiError(err);
+      const status = (err as AxiosError | undefined)?.response?.status;
+      if (status !== 503) setError(t('paperlessAudit.error'));
     } finally {
       setActionLoading((prev) => {
         const next = new Set(prev);
@@ -294,11 +223,10 @@ export default function PaperlessAuditPage() {
   const skipResults = async (ids: number[]) => {
     setActionLoading((prev) => new Set([...prev, ...ids]));
     try {
-      const headers = await authHeaders();
-      await apiClient.post('/api/admin/paperless-audit/skip', { result_ids: ids }, { headers });
-      await loadReview();
+      await skipMutation.mutateAsync(ids);
     } catch (err) {
-      handleApiError(err);
+      const status = (err as AxiosError | undefined)?.response?.status;
+      if (status !== 503) setError(t('paperlessAudit.error'));
     } finally {
       setActionLoading((prev) => {
         const next = new Set(prev);
@@ -339,44 +267,18 @@ export default function PaperlessAuditPage() {
     setReviewSearch(value);
     if (reviewSearchTimer.current) clearTimeout(reviewSearchTimer.current);
     reviewSearchTimer.current = setTimeout(() => {
+      setDebouncedSearch(value);
       setReviewPage(0);
     }, 300);
   };
 
-  // --- OCR Tab ---
-  const loadOcr = useCallback(async () => {
-    setOcrLoading(true);
-    setError(null);
-    try {
-      const headers = await authHeaders();
-      const res = await apiClient.get<{ results?: AuditResult[]; total?: number } | AuditResult[]>('/api/admin/paperless-audit/results', {
-        headers,
-        params: { ocr_quality_max: 2, per_page: PAGE_SIZE, page: ocrPage + 1 },
-      });
-      const data = res.data;
-      const results: AuditResult[] = Array.isArray(data) ? data : (data.results ?? []);
-      setOcrResults(results);
-      setOcrTotal(Array.isArray(data) ? results.length : (data.total ?? results.length));
-      setNotConfigured(false);
-    } catch (err) {
-      handleApiError(err);
-    } finally {
-      setOcrLoading(false);
-    }
-  }, [authHeaders, handleApiError, ocrPage]);
-
-  useEffect(() => {
-    if (activeTab === 'ocr') loadOcr();
-  }, [activeTab, loadOcr]);
-
   const reOcr = async (ids: number[]) => {
     setOcrActionLoading((prev) => new Set([...prev, ...ids]));
     try {
-      const headers = await authHeaders();
-      await apiClient.post('/api/admin/paperless-audit/re-ocr', { result_ids: ids }, { headers });
-      await loadOcr();
+      await reOcrMutation.mutateAsync(ids);
     } catch (err) {
-      handleApiError(err);
+      const status = (err as AxiosError | undefined)?.response?.status;
+      if (status !== 503) setError(t('paperlessAudit.error'));
     } finally {
       setOcrActionLoading((prev) => {
         const next = new Set(prev);
@@ -386,108 +288,20 @@ export default function PaperlessAuditPage() {
     }
   };
 
-  // --- Stats Tab ---
-  const loadStats = useCallback(async () => {
-    setStatsLoading(true);
-    setError(null);
-    try {
-      const headers = await authHeaders();
-      const res = await apiClient.get<AuditStats>('/api/admin/paperless-audit/stats', { headers });
-      setStats(res.data);
-      setNotConfigured(false);
-    } catch (err) {
-      handleApiError(err);
-    } finally {
-      setStatsLoading(false);
-    }
-  }, [authHeaders, handleApiError]);
-
-  useEffect(() => {
-    if (activeTab === 'stats') loadStats();
-  }, [activeTab, loadStats]);
-
-  // --- Completeness Tab ---
-  const loadCompleteness = useCallback(async () => {
-    setCompletenessLoading(true);
-    setError(null);
-    try {
-      const headers = await authHeaders();
-      const res = await apiClient.get<{ results?: AuditResult[]; total?: number } | AuditResult[]>('/api/admin/paperless-audit/results', {
-        headers,
-        params: { completeness_max: 2, per_page: PAGE_SIZE, page: completenessPage + 1 },
-      });
-      const data = res.data;
-      const results: AuditResult[] = Array.isArray(data) ? data : (data.results ?? []);
-      setCompletenessResults(results);
-      setCompletenessTotal(Array.isArray(data) ? results.length : (data.total ?? results.length));
-      setNotConfigured(false);
-    } catch (err) {
-      handleApiError(err);
-    } finally {
-      setCompletenessLoading(false);
-    }
-  }, [authHeaders, handleApiError, completenessPage]);
-
-  useEffect(() => {
-    if (activeTab === 'completeness') loadCompleteness();
-  }, [activeTab, loadCompleteness]);
-
-  // --- Duplicates Tab ---
-  const loadDuplicates = useCallback(async () => {
-    setDuplicatesLoading(true);
-    setError(null);
-    try {
-      const headers = await authHeaders();
-      const res = await apiClient.get<DuplicateGroup[]>('/api/admin/paperless-audit/duplicate-groups', { headers });
-      setDuplicateGroups(res.data || []);
-      setNotConfigured(false);
-    } catch (err) {
-      handleApiError(err);
-    } finally {
-      setDuplicatesLoading(false);
-    }
-  }, [authHeaders, handleApiError]);
-
-  useEffect(() => {
-    if (activeTab === 'duplicates') loadDuplicates();
-  }, [activeTab, loadDuplicates]);
-
   const detectDuplicates = async () => {
-    setDetectingDuplicates(true);
     setError(null);
     try {
-      const headers = await authHeaders();
-      await apiClient.post('/api/admin/paperless-audit/detect-duplicates', {}, { headers });
-      await loadDuplicates();
+      await detectDuplicatesMutation.mutateAsync(undefined);
     } catch (err) {
-      handleApiError(err);
-    } finally {
-      setDetectingDuplicates(false);
+      const status = (err as AxiosError | undefined)?.response?.status;
+      if (status !== 503) setError(t('paperlessAudit.error'));
     }
   };
 
-  // --- Correspondents Tab ---
-  const loadCorrespondents = useCallback(async () => {
-    setCorrespondentsLoading(true);
-    setError(null);
-    try {
-      const headers = await authHeaders();
-      const res = await apiClient.get<{ clusters?: CorrespondentCluster[] }>('/api/admin/paperless-audit/correspondent-normalization', {
-        headers,
-        params: { threshold: corrThreshold },
-      });
-      setCorrespondentClusters(res.data.clusters || []);
-      setNotConfigured(false);
-    } catch (err) {
-      handleApiError(err);
-    } finally {
-      setCorrespondentsLoading(false);
-    }
-  }, [authHeaders, handleApiError, corrThreshold]);
-
-  useEffect(() => {
-    if (activeTab === 'correspondents') loadCorrespondents();
-  }, [activeTab, loadCorrespondents]);
+  const loadCorrespondents = () => {
+    setScanCorrespondents(true);
+    correspondentsQuery.refetch();
+  };
 
   // --- Not Configured State ---
   if (notConfigured) {

--- a/src/frontend/src/pages/PaperlessAuditPage.tsx
+++ b/src/frontend/src/pages/PaperlessAuditPage.tsx
@@ -299,8 +299,11 @@ export default function PaperlessAuditPage() {
   };
 
   const loadCorrespondents = () => {
+    // Flipping `enabled` to true is sufficient — RQ fetches automatically
+    // on the next render when the query has no cached data for the current
+    // queryKey. No manual refetch() needed (and calling it on a disabled
+    // query relies on a behavior we shouldn't depend on).
     setScanCorrespondents(true);
-    correspondentsQuery.refetch();
   };
 
   // --- Not Configured State ---

--- a/tasks/audit-findings-plan.md
+++ b/tasks/audit-findings-plan.md
@@ -13,7 +13,7 @@ Consolidated results from 4 systematic audits (DB Performance, Config Hardcodes,
 | EMPFEHLUNG | 18 | 16 / 18 | Nice to have — modernization, cleanup |
 | GUT | 12 | — | Already well-implemented |
 
-**Status (2026-04-30):** All KRITISCH and WICHTIG items closed. EMPFEHLUNG closed: E1, E2, E3, E4, E5, E6, E7, E8, E9, E10, E12, E13, E14, E16, E17, E18. **E11** foundation + 22 of 23 list-fetching surfaces migrated (#504 reference pages + e11-react-query branch); only `PaperlessAuditPage` remains for a dedicated follow-up session. Open: **E15** (TS strict mode — 31 errors to fix, ~70% null-check additions; warrants its own dedicated session). See `TODOS.md` P2 for active queue.
+**Status (2026-04-30):** All KRITISCH and WICHTIG items closed. EMPFEHLUNG closed: E1, E2, E3, E4, E5, E6, E7, E8, E9, E10, E11, E12, E13, E14, E16, E17, E18. Open: **E15** (TS strict mode — 31 errors to fix, ~70% null-check additions; warrants its own dedicated session). See `TODOS.md` P2 for active queue.
 
 ---
 
@@ -151,7 +151,7 @@ All 14 WICHTIG items closed as of 2026-04-27. Re-verified 2026-04-30 against cur
 - New `src/frontend/src/utils/env.ts` centralizes the fallback with `getApiBaseUrl()` and `getWebSocketUrl()`. Both warn on console (error level in PROD builds, warn in DEV) when the env var is unset, and warn at most once per page load.
 - All three call sites migrated: `utils/axios.ts:5`, `pages/ChatPage/hooks/useChatWebSocket.ts:141`, `hooks/useDeviceConnection.ts:170`. The `VITE_WS_URL` "includes-/ws" convention (per `.env.example` + 4 compose files) is preserved.
 
-### E11. React Query / SWR for data fetching — IN PROGRESS (foundation + 22 of 23 list-fetching surfaces migrated)
+### E11. React Query / SWR for data fetching — RESOLVED (all 23 list-fetching surfaces migrated)
 - #504 on 2026-04-30 landed `@tanstack/react-query` v5 with hardened defaults (mutations.retry: 0, queries.retry bails on 4xx, refetchOnWindowFocus: false), `src/api/queryClient.ts` + `keys.ts` (centralized factories with STALE.{LIVE,DEFAULT,CONFIG} taxonomy) + `hooks.ts` (`useApiQuery`/`useApiMutation` wrappers binding `extractApiError`/`extractFieldErrors` + i18n into RQ's surface).
 - Provider order: `ErrorBoundary → ThemeProvider → AuthProvider → QueryClientProvider → DeviceProvider` so `AuthContext.tsx:226-263` interceptors install before any RQ fetcher fires.
 - Reference pages from #504: `MemoryPage`, `RolesPage`, `IntentsPage`, `SettingsPage`, `MaintenancePage`.
@@ -160,8 +160,8 @@ All 14 WICHTIG items closed as of 2026-04-27. Re-verified 2026-04-30 against cur
 - `useChatSessions`: rewritten on top of React Query at `src/frontend/src/api/resources/chatSessions.ts` with the public shape preserved exactly (`{ conversations, loading, error, refreshConversations, deleteConversation, loadConversationHistory, addConversation, updateConversationPreview }`). Mutations use `setQueryData` for optimistic add/update/delete. `src/frontend/src/hooks/useChatSessions.ts` is now a thin re-export shim so consumers (`ChatContext`, `ChatSidebar`) need no changes; `groupConversationsByDate` lives there.
 - Convention: error fallbacks. `useApiQuery`/`useApiMutation` return server-side `detail` when present, falling back to the i18n key only when the server didn't supply one. Two existing tests (RoomsPage, SpeakersPage) sent `{ detail }` in 500 responses and expected the localized fallback — those were updated to send a null body so the fallback path actually runs (consistent with FederationAuditPage's pattern from #504).
 - Out of scope (skipped intentionally): `useDocumentPolling.ts`, `useDocumentUpload.ts`, `useChatWebSocket.ts`, `AuthContext` core, `PairResponderModal`, `PairInitiatorModal`, `knowledge-graph/GraphView` — multi-step state machines, file-upload `onUploadProgress`, or WebSocket-driven update models that don't fit RQ's request/response shape.
-- Remaining: **PaperlessAuditPage** (1450 LOC, 7 tabs, polling, multiple endpoints). Pragmatic deferral — the handover already ordered this last and a dedicated session is the cleanest way to land it without churn.
-- Plan: `~/.claude/plans/pure-questing-blanket.md` (eng review CLEAR + outside-voice addressed). Branch: `e11-react-query`.
+- 2026-04-30 final: `PaperlessAuditPage` (1450 LOC, 7 tabs) migrated on its own branch `e11-paperless-audit`. Status query uses `refetchInterval` driven by the query's own `running` flag (polls 2s while running, idle otherwise — no manual setInterval). Review/OCR/Completeness tabs share the `/results` endpoint with distinct queryKey segments. Review search is debounced via a separate `debouncedSearch` state so the query key only changes after 300ms. Stats/DuplicateGroups/CorrespondentClusters gated by `activeTab`. 503 ("Paperless not configured") detection inspects each query's `AxiosError` so the page collapses to a banner when the integration isn't wired up.
+- Plan: `~/.claude/plans/pure-questing-blanket.md` (eng review CLEAR + outside-voice addressed).
 
 ### E12. i18n: 13 hardcoded German strings — RESOLVED
 - ErrorBoundary (5) and ConfirmDialog (4) — resolved during W10 TypeScript migration (#487); both files now use `useTranslation()` for every user-facing string.
@@ -243,7 +243,7 @@ All 14 WICHTIG items closed as of 2026-04-27. Re-verified 2026-04-30 against cur
 - [x] W9: `React.lazy` + `Suspense` for admin pages — `App.tsx:1,15-23+`
 - [x] W10: TypeScript migration — 100% `.tsx`/`.ts` coverage in `src/frontend/src/` (#487)
 - [x] W11: `.prettierrc` + `.prettierignore` + `format` script in `package.json`
-- [~] E11: React Query for data fetching — foundation + 22 of 23 list-fetching surfaces migrated (#504 + e11-react-query branch); only PaperlessAuditPage remains
+- [x] E11: React Query for data fetching — all 23 list-fetching surfaces migrated (#504 reference pages + e11-react-query bulk + e11-paperless-audit final)
 - [x] E12: i18n hardcoded strings — ErrorBoundary/ConfirmDialog cleared by W10; ChatMessages alt + 5 dev logs translated; RoomOutputSettings filed as separate follow-up
 - [x] E14: ESLint React version — verified `'detect'` already in `.eslintrc.cjs:22` (audit was stale)
 
@@ -255,4 +255,4 @@ All 14 WICHTIG items closed as of 2026-04-27. Re-verified 2026-04-30 against cur
 - [x] E18: Frigate MQTT broker/port from Settings — defensive hygiene before MQTT consumer ships
 - [x] E13: ChatPage prop drilling — ChatProvider wraps the page, ChatInput takes 0 props (verified, audit was stale)
 - [ ] E15: Enable TypeScript strict mode (~31 errors mostly null-checks; deferred to dedicated session)
-- [~] E11: React Query for data fetching — foundation + 22 of 23 list-fetching surfaces migrated (#504 + e11-react-query branch); only PaperlessAuditPage remains
+- [x] E11: React Query for data fetching — all 23 list-fetching surfaces migrated (#504 reference pages + e11-react-query bulk + e11-paperless-audit final)


### PR DESCRIPTION
## Summary

Closes the **last** remaining list-fetching surface for the E11 audit item. PaperlessAuditPage (1450 LOC, 7 tabs) now uses React Query for all data fetching, status polling, and mutations.

Builds on #504 which landed the foundation + the other 22 surfaces.

## Plan and reviews

- Plan: `~/.claude/plans/pure-questing-blanket.md` — same conventions as the bulk migration
- Audit item: `tasks/audit-findings-plan.md:154` — now marked RESOLVED

## What this PR does

### New resource: `src/api/resources/paperlessAudit.ts`
- 7 query hooks (status, review-results, ocr-results, completeness-results, stats, duplicate-groups, correspondent-clusters)
- 6 mutation hooks (start, stop, apply, skip, re-ocr, detect-duplicates)
- All write mutations invalidate `keys.paperlessAudit.all` on success (prefix-match invalidates every page-level query)

### Page rewrite: `src/pages/PaperlessAuditPage.tsx`
- 7 tabs each `enabled`-gated by `activeTab === <tab>` so a fresh mount only fires the visible tab's request
- Status query uses `refetchInterval: (query) => query.state.data?.running ? 2000 : false` — polling starts/stops automatically based on the query's own response data, no manual `setInterval` + cleanup ref
- Review/OCR/Completeness tabs share the `/results` endpoint with distinct queryKey segments so they don't collide
- Review search debounced via a separate `debouncedSearch` state; the query key only changes after the 300ms timeout, not on every keystroke
- Correspondents tab gated behind a manual `scanCorrespondents` flag because the original code never auto-loaded — only on threshold-change after the user clicked scan
- 503 detection: any query returning 503 sets `notConfigured`, collapsing the page to a banner ("Paperless not wired up")
- Mutation catch blocks pass the caught `AxiosError` directly — no reading stale mutation state — per the locked-in catch-block rule

### Subtle correctness fix
The `selectedIds` reset effect now depends on `reviewQuery.data` (a stable RQ-controlled reference) rather than the derived `reviewResults` array. Depending on `reviewResults` would have triggered an infinite render loop because of the `?? []` fallback creating a fresh array reference every render.

## Test suite delta

|         | Pass | Fail |
|---------|------|------|
| Before  | 343  | 39   |
| After   | 352  | 30   |

Net **+9 passing**. PaperlessAuditPage has no existing test file, so no specs to break here. Improvements come from natural test-suite stabilization.

## Test plan

- [x] `cd src/frontend && npx tsc --noEmit` — clean (pre-existing TS errors unaffected)
- [x] `cd src/frontend && npm run lint` — no NEW errors or warnings on changed files
- [x] `cd tests/frontend/react && npx vitest run` — 352/382 pass
- [ ] Manual smoke in dev (deferred): `/admin/paperless-audit` — verify start/stop polls every 2s, tab-switching loads on demand, 503 (Paperless disabled) shows banner, review apply/skip refreshes the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)