### PR TITLE
fix(k8s): dlna-mcp imagePullPolicy Always (match other deployments)

### DIFF
--- a/k8s/dlna-mcp.yaml
+++ b/k8s/dlna-mcp.yaml
@@ -52,7 +52,7 @@ spec:
       containers:
         - name: dlna-mcp
           image: registry.treehouse.x-idra.de/renfield/backend:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           command: ["/opt/venv/bin/renfield-mcp-dlna"]
           env:
             - name: MCP_TRANSPORT


### PR DESCRIPTION
## Summary

One-line fix: flip `deploy/dlna-mcp` from `imagePullPolicy: IfNotPresent` to `Always` so it matches the other three renfield deployments (backend, document-worker, frontend).

## Why

Discovered during the v2.2.0 deploy. After pushing fresh `:latest` to Harbor and running `kubectl rollout restart deploy/{backend,dlna-mcp,document-worker,frontend}`:

| Deploy | Image digest after rollout | New image? |
|---|---|---|
| backend | `sha256:a1b7c2ba76d9…` | ✓ |
| document-worker | `sha256:a1b7c2ba76d9…` | ✓ |
| frontend | `sha256:37263b7d5dd7…` | ✓ |
| **dlna-mcp** | `sha256:1de18b208075…` | **✗ stale** |

`dlna-mcp` was reusing the cached `:latest` from its node because `IfNotPresent` says "don't pull if any image with this name is already present locally." The other three deployments use `Always`, which forces a registry pull on every container start — that's how `:latest` is supposed to work in this cluster (the `deploy-production` SKILL doc explicitly relies on this).

The asymmetry was a silent footgun: `rollout restart` returned success, the pod went `Running 1/1`, but the new code never landed.

Workaround used during the v2.2.0 deploy was `kubectl set image deploy/dlna-mcp dlna-mcp=registry.treehouse.x-idra.de/renfield/backend:v2.2.0` — works because the explicit version tag isn't in the node's cache. After this fix, plain `rollout restart` will Just Work.

## What landed

- `k8s/dlna-mcp.yaml`: `imagePullPolicy: IfNotPresent` → `Always`
- Live cluster also patched via `kubectl patch` so the fix is real now, not waiting on the next `kubectl apply`.

## Test plan

- [x] Verified `kubectl get deploy dlna-mcp -o jsonpath='{.spec.template.spec.containers[0].imagePullPolicy}'` returns `Always` on the live cluster.
- [ ] Next deploy that pushes a fresh `:latest`: confirm `rollout restart deploy/dlna-mcp` actually picks up the new digest without needing the explicit tag override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)