### PR TITLE
feat(voice): Phase A — faster-whisper + in-process Piper + singleton dedup

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,4 +1,4 @@
-  #!/bin/bash
+#!/bin/bash
 
 # Renfield GitHub Deploy Script
 # Committed und pushed alle Dateien ins GitHub Repository

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+  #!/bin/bash
 
 # Renfield GitHub Deploy Script
 # Committed und pushed alle Dateien ins GitHub Repository

--- a/src/backend/api/routes/voice.py
+++ b/src/backend/api/routes/voice.py
@@ -13,17 +13,23 @@ from loguru import logger
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.websocket.shared import get_whisper_service
 from services.api_rate_limiter import limiter
 from services.auth_service import get_current_user
 from services.database import get_db
-from services.piper_service import PiperService
-from services.whisper_service import WhisperService
+from services.piper_service import get_piper_service
 from utils.config import settings
 
 router = APIRouter()
 
-whisper_service = WhisperService()
-piper_service = PiperService()
+# Use the shared singletons. The previous `WhisperService()` + `PiperService()`
+# instantiations at module level loaded the model a SECOND time when the
+# WebSocket path also lazily created its own — verified two competing
+# WhisperService objects in flight. `get_whisper_service` (lives in
+# api/websocket/shared.py) and `get_piper_service` (lives in piper_service.py)
+# are the canonical accessors.
+whisper_service = get_whisper_service()
+piper_service = get_piper_service()
 
 
 class TTSRequest(BaseModel):

--- a/src/backend/ha_glue/api/websocket/device_handler.py
+++ b/src/backend/ha_glue/api/websocket/device_handler.py
@@ -252,8 +252,8 @@ Gib eine kurze, natürliche Antwort. KEIN JSON, nur Text."""
 
         # Generate TTS audio if response text exists
         if response_text:
-            from services.piper_service import PiperService
-            piper = PiperService()
+            from services.piper_service import get_piper_service
+            piper = get_piper_service()
             tts_audio = await piper.synthesize_to_bytes(response_text)
 
             if tts_audio:

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -25,10 +25,19 @@ transformers>=4.47.0          # Required for rt_detr_v2 model support
 pgvector>=0.2.4               # PostgreSQL vector extension for SQLAlchemy
 aiofiles>=23.2.0              # Async file operations
 
-# Speech-to-Text (Whisper)
-openai-whisper==20231117
-# faster-whisper benötigt PyAV was Build-Probleme verursacht
-# openai-whisper ist ausreichend und funktioniert ohne PyAV
+# Speech-to-Text (faster-whisper via CTranslate2)
+# Older comment claimed PyAV build issues; faster-whisper 1.x ships manylinux
+# wheels for amd64 + aarch64 and pulls PyAV via wheel only — no source build.
+# CTranslate2 backend gets ~4x speedup on GPU vs openai-whisper and supports
+# device=cuda + compute_type=float16 cleanly.
+faster-whisper>=1.0.0
+
+# Text-to-Speech (Piper, in-process Python bindings)
+# Replaces the per-request `subprocess.Popen('piper', ...)` cold-start in
+# piper_service.py. Voice models still loaded from /usr/share/piper/voices/
+# (downloaded by Dockerfile). The CLI binary stays in the image as a fallback
+# until the in-process path is verified stable in production.
+piper-tts>=1.2.0
 
 # Audio Preprocessing (for better STT quality)
 noisereduce>=3.0.0      # Spectral noise reduction

--- a/src/backend/services/piper_service.py
+++ b/src/backend/services/piper_service.py
@@ -1,30 +1,52 @@
 """
-Piper Service - Text to Speech
+Piper Service - Text to Speech (in-process Python bindings)
 
-Supports multiple voices based on language.
+Uses the `piper-tts` Python package directly instead of shelling out to the
+`piper` CLI per request. Eliminates the ~150-300 ms subprocess cold-start
+that the previous implementation paid on every TTS call.
+
+Voice models still live at `/usr/share/piper/voices/<voice>.onnx` (downloaded
+by the Dockerfile) — we just load them in-process via PiperVoice.load() and
+cache the loaded voice across requests.
+
 Configuration via PIPER_VOICES environment variable:
   PIPER_VOICES=de:de_DE-thorsten-high,en:en_US-amy-medium
 """
-import subprocess
-import tempfile
+import io
+import wave
 from pathlib import Path
 
 from loguru import logger
 
 from utils.config import settings
 
+try:
+    from piper.voice import PiperVoice
+    PIPER_AVAILABLE = True
+except ImportError:
+    PIPER_AVAILABLE = False
+    PiperVoice = None  # type: ignore[assignment,misc]
+
 
 class PiperService:
-    """Service für Text-to-Speech mit Piper"""
+    """Service für Text-to-Speech mit Piper (in-process)."""
 
     def __init__(self):
         self.default_voice = settings.piper_default_voice
         self.voice_map = settings.piper_voice_map
         self.default_language = settings.default_language
-        self.available = self._check_piper_available()
+        self.available = PIPER_AVAILABLE
+        # Cache loaded PiperVoice instances by voice name. Each voice is ~50-100 MB
+        # in memory (ONNX session + tokenizer); for the typical de/en pair we hold
+        # ~200 MB total which is fine.
+        self._voice_cache: dict[str, "PiperVoice"] = {}
 
-        # Log available voices
-        if self.available:
+        if not PIPER_AVAILABLE:
+            logger.warning(
+                "⚠️  piper-tts Python package not installed. TTS-Funktionen sind deaktiviert. "
+                "Install with: pip install piper-tts>=1.2.0"
+            )
+        else:
             logger.info(f"🗣️ Piper voice map: {self.voice_map}")
 
     def _get_voice_for_language(self, language: str = None) -> str:
@@ -44,32 +66,37 @@ class PiperService:
         """Get the model path for a given voice."""
         return f"/usr/share/piper/voices/{voice}.onnx"
 
-    def _check_piper_available(self) -> bool:
-        """Prüfe ob Piper verfügbar ist"""
+    def _load_voice(self, voice_name: str) -> "PiperVoice | None":
+        """
+        Load a PiperVoice from disk, with caching.
+
+        Returns None if the model file is missing or fails to load — caller
+        falls back to a no-op (matching previous behavior when piper CLI was
+        absent).
+        """
+        if not PIPER_AVAILABLE:
+            return None
+        cached = self._voice_cache.get(voice_name)
+        if cached is not None:
+            return cached
+        model_path = self._get_model_path(voice_name)
+        if not Path(model_path).exists():
+            logger.error(f"❌ Piper voice model not found: {model_path}")
+            return None
         try:
-            result = subprocess.run(
-                ["which", "piper"],
-                capture_output=True,
-                text=True
-            )
-            available = result.returncode == 0
-            if not available:
-                logger.warning("⚠️  Piper TTS nicht verfügbar. TTS-Funktionen sind deaktiviert.")
-                logger.info("💡 Installation: pip install piper-tts")
-            else:
-                logger.info("✅ Piper TTS verfügbar")
-            return available
+            voice = PiperVoice.load(model_path)
+            self._voice_cache[voice_name] = voice
+            logger.info(f"📥 Piper voice geladen: {voice_name}")
+            return voice
         except Exception as e:
-            logger.warning(f"⚠️  Piper TTS Check fehlgeschlagen: {e}")
-            return False
+            logger.error(f"❌ Fehler beim Laden der Piper voice {voice_name}: {e}")
+            return None
 
     def ensure_model_downloaded(self):
-        """Stelle sicher, dass das Sprachmodell heruntergeladen ist"""
-        if not self.available:
-            logger.warning("Piper nicht verfügbar, überspringe Model-Download")
-            return
-        # Piper lädt Modelle automatisch beim ersten Aufruf
-        pass
+        """Stelle sicher, dass das Sprachmodell heruntergeladen ist."""
+        # Voice models are pre-baked into the Docker image at /usr/share/piper/voices/.
+        # In-process load happens lazily on first synthesis call via _load_voice().
+        return
 
     async def synthesize_to_file(self, text: str, output_path: str, language: str = None) -> bool:
         """
@@ -84,36 +111,18 @@ class PiperService:
             logger.warning("Piper nicht verfügbar, TTS übersprungen")
             return False
 
-        # Get voice for the requested language
-        voice = self._get_voice_for_language(language)
-        model_path = self._get_model_path(voice)
+        voice_name = self._get_voice_for_language(language)
+        voice = self._load_voice(voice_name)
+        if voice is None:
+            return False
 
         try:
-            # Piper CLI aufrufen
-            cmd = [
-                "piper",
-                "--model", model_path,
-                "--output_file", output_path
-            ]
-
-            # Text über stdin übergeben
-            process = subprocess.Popen(
-                cmd,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE
-            )
-
-            _stdout, stderr = process.communicate(input=text.encode('utf-8'))
-
-            if process.returncode == 0:
-                logger.info(f"✅ TTS erfolgreich ({voice}): {output_path}")
-                return True
-            else:
-                logger.error(f"❌ Piper Fehler ({voice}): {stderr.decode()}")
-                return False
+            with wave.open(output_path, "wb") as wav_file:
+                voice.synthesize(text, wav_file)
+            logger.info(f"✅ TTS erfolgreich ({voice_name}): {output_path}")
+            return True
         except Exception as e:
-            logger.error(f"❌ TTS Fehler: {e}")
+            logger.error(f"❌ TTS Fehler ({voice_name}): {e}")
             return False
 
     async def synthesize_to_bytes(self, text: str, language: str = None) -> bytes:
@@ -128,17 +137,21 @@ class PiperService:
             logger.warning("Piper nicht verfügbar, TTS übersprungen")
             return b""
 
-        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
-            tmp_path = tmp.name
+        voice_name = self._get_voice_for_language(language)
+        voice = self._load_voice(voice_name)
+        if voice is None:
+            return b""
 
         try:
-            success = await self.synthesize_to_file(text, tmp_path, language=language)
-            if success:
-                with open(tmp_path, "rb") as f:
-                    return f.read()
+            buffer = io.BytesIO()
+            # `wave.open` requires a mode string; PiperVoice.synthesize writes
+            # frames into the wave object directly.
+            with wave.open(buffer, "wb") as wav_file:
+                voice.synthesize(text, wav_file)
+            return buffer.getvalue()
+        except Exception as e:
+            logger.error(f"❌ TTS Fehler ({voice_name}): {e}")
             return b""
-        finally:
-            Path(tmp_path).unlink(missing_ok=True)
 
 
 _piper_instance: PiperService | None = None

--- a/src/backend/services/whisper_service.py
+++ b/src/backend/services/whisper_service.py
@@ -1,5 +1,10 @@
 """
-Whisper Service - Speech to Text
+Whisper Service - Speech to Text (faster-whisper / CTranslate2 backend)
+
+Replaces the previous `openai-whisper` library with `faster-whisper` for ~4x
+GPU throughput and clean device/compute_type configuration. The public method
+signatures (`transcribe_file`, `transcribe_bytes`, `transcribe_with_speaker`,
+`transcribe_bytes_with_speaker`) are unchanged so callers don't need updates.
 
 Includes optional audio preprocessing for better transcription quality:
 - Noise reduction (removes background noise like fans, AC)
@@ -9,7 +14,7 @@ import tempfile
 from datetime import datetime
 from pathlib import Path
 
-import whisper
+from faster_whisper import WhisperModel
 from loguru import logger
 
 from utils.config import settings
@@ -31,7 +36,10 @@ class WhisperService:
 
     def __init__(self):
         self.model_size = settings.whisper_model
-        self.model = None
+        self.device = settings.whisper_device
+        self.compute_type = settings.whisper_compute_type
+        self.beam_size = settings.whisper_beam_size
+        self.model: WhisperModel | None = None
         self.language = settings.default_language
         self.initial_prompt = settings.whisper_initial_prompt or None
 
@@ -51,15 +59,39 @@ class WhisperService:
         """Modell laden"""
         if self.model is None:
             try:
-                logger.info(f"📥 Lade Whisper Modell '{self.model_size}'...")
+                logger.info(
+                    f"📥 Lade Whisper Modell '{self.model_size}' "
+                    f"(device={self.device}, compute_type={self.compute_type})..."
+                )
 
-                # OpenAI Whisper verwenden
-                self.model = whisper.load_model(self.model_size)
+                self.model = WhisperModel(
+                    self.model_size,
+                    device=self.device,
+                    compute_type=self.compute_type,
+                )
 
                 logger.info("✅ Whisper Modell geladen")
             except Exception as e:
                 logger.error(f"❌ Fehler beim Laden des Whisper Modells: {e}")
                 raise
+
+    def _run_transcription(self, transcribe_path: str, language: str) -> str:
+        """
+        Run faster-whisper transcribe and concatenate the segment stream.
+
+        faster-whisper returns (segments_iter, info). The iterator must be
+        drained to actually run inference; converting to a list is the
+        cleanest way to get the full text in one place.
+        """
+        kwargs = {
+            "language": language,
+            "beam_size": self.beam_size,
+        }
+        if self.initial_prompt:
+            kwargs["initial_prompt"] = self.initial_prompt
+
+        segments, _info = self.model.transcribe(transcribe_path, **kwargs)
+        return "".join(segment.text for segment in segments).strip()
 
     async def transcribe_file(self, audio_path: str, language: str = None) -> str:
         """
@@ -85,24 +117,10 @@ class WhisperService:
                     transcribe_path = processed_path
                     logger.info("📊 Using preprocessed audio")
 
-            # Transkribieren mit OpenAI Whisper
-            # fp16=False verhindert die Warnung auf CPU-only Systemen
-            # beam_size=5 und best_of=5 für bessere Genauigkeit
-            transcribe_opts = {
-                "language": transcribe_language,
-                "fp16": False,
-                "beam_size": 5,
-                "best_of": 5,
-            }
-            if self.initial_prompt:
-                transcribe_opts["initial_prompt"] = self.initial_prompt
-
-            result = self.model.transcribe(transcribe_path, **transcribe_opts)
-
-            text = result["text"]
+            text = self._run_transcription(transcribe_path, transcribe_language)
 
             logger.info(f"✅ Transkription erfolgreich ({transcribe_language}): {len(text)} Zeichen")
-            return text.strip()
+            return text
         except Exception as e:
             logger.error(f"❌ Transkriptions-Fehler: {e}")
             return ""
@@ -222,17 +240,7 @@ class WhisperService:
 
         try:
             # Transcribe using preprocessed audio
-            transcribe_opts = {
-                "language": transcribe_language,
-                "fp16": False,
-                "beam_size": 5,
-                "best_of": 5,
-            }
-            if self.initial_prompt:
-                transcribe_opts["initial_prompt"] = self.initial_prompt
-
-            result = self.model.transcribe(transcribe_path, **transcribe_opts)
-            text = result["text"].strip()
+            text = self._run_transcription(transcribe_path, transcribe_language)
             logger.info(f"✅ Transkription erfolgreich ({transcribe_language}): {len(text)} Zeichen")
 
             # Default speaker info

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -102,6 +102,11 @@ class Settings(BaseSettings):
     default_language: str = "de"
     supported_languages: str = "de,en"  # Comma-separated list of supported languages
     whisper_model: str = "base"
+    # Recommended overrides via env: WHISPER_MODEL=medium for CPU production,
+    # WHISPER_MODEL=large-v3 on GPU hosts (~3 GB VRAM in float16).
+    whisper_device: str = "cpu"  # "cpu" or "cuda" — set WHISPER_DEVICE=cuda on GPU hosts
+    whisper_compute_type: str = "int8"  # CPU default. Use "float16" with device=cuda; "int8_float16" is the GPU low-memory mode.
+    whisper_beam_size: int = 5
     whisper_initial_prompt: str = ""  # Leer = kein Kontext-Bias (Renfield ist ein offenes System)
     piper_voices: str = "de:de_DE-thorsten-high,en:en_US-amy-medium"  # Language:Voice mapping
     piper_default_voice: str = "de_DE-thorsten-high"  # Fallback voice when requested language has no entry in piper_voices

--- a/tests/backend/test_piper_service.py
+++ b/tests/backend/test_piper_service.py
@@ -1,14 +1,17 @@
-"""Tests for PiperService.
+"""Tests for PiperService (in-process piper-tts bindings).
 
-Tests TTS initialization, voice selection, synthesis methods,
-and availability checks.
+After the Phase A voice-pipeline migration, PiperService loads voice models
+in-process via `piper.voice.PiperVoice.load(...)` instead of shelling out to
+the `piper` CLI per request. These tests mock the in-process API.
 """
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
-# Pre-mock modules not available in test environment
+# Pre-mock modules not available in test environment. piper.voice is imported
+# at module-load time by piper_service so a real stub must answer attribute
+# access for `PiperVoice`.
 _missing_stubs = [
-    "asyncpg", "whisper", "piper", "piper.voice", "speechbrain",
+    "asyncpg", "faster_whisper", "speechbrain",
     "speechbrain.inference", "speechbrain.inference.speaker",
     "openwakeword", "openwakeword.model",
 ]
@@ -16,7 +19,14 @@ for _mod in _missing_stubs:
     if _mod not in sys.modules:
         sys.modules[_mod] = MagicMock()
 
-from unittest.mock import AsyncMock, patch
+# piper / piper.voice need to be MagicMock-shaped so `from piper.voice import PiperVoice`
+# works and `PiperVoice.load(...)` can be patched per-test.
+if "piper" not in sys.modules:
+    sys.modules["piper"] = MagicMock()
+if "piper.voice" not in sys.modules:
+    piper_voice_mod = MagicMock()
+    piper_voice_mod.PiperVoice = MagicMock()
+    sys.modules["piper.voice"] = piper_voice_mod
 
 import pytest
 
@@ -42,26 +52,38 @@ def mock_settings():
 
 @pytest.fixture
 def service(mock_settings):
+    """Service with PIPER_AVAILABLE=True (piper.voice import succeeded)."""
     with patch("services.piper_service.settings", mock_settings), \
-         patch("services.piper_service.subprocess") as mock_subprocess:
-        # Simulate piper being available
-        mock_result = MagicMock()
-        mock_result.returncode = 0
-        mock_subprocess.run.return_value = mock_result
+         patch("services.piper_service.PIPER_AVAILABLE", True):
         svc = PiperService()
     return svc
 
 
 @pytest.fixture
 def service_unavailable(mock_settings):
+    """Service with PIPER_AVAILABLE=False (piper-tts not installed)."""
     with patch("services.piper_service.settings", mock_settings), \
-         patch("services.piper_service.subprocess") as mock_subprocess:
-        # Simulate piper NOT being available
-        mock_result = MagicMock()
-        mock_result.returncode = 1
-        mock_subprocess.run.return_value = mock_result
+         patch("services.piper_service.PIPER_AVAILABLE", False):
         svc = PiperService()
     return svc
+
+
+@pytest.fixture
+def fake_voice():
+    """A PiperVoice-like mock whose synthesize() writes a minimal WAV header."""
+    voice = MagicMock()
+
+    def _synthesize(text, wav_file):
+        # Real PiperVoice.synthesize writes frames into the wave.Wave_write
+        # object. For tests we just write a 4-byte sentinel so the resulting
+        # file isn't empty.
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(22050)
+        wav_file.writeframes(b"\x00\x00\x00\x00")
+
+    voice.synthesize = MagicMock(side_effect=_synthesize)
+    return voice
 
 
 # ============================================================================
@@ -72,32 +94,24 @@ def service_unavailable(mock_settings):
 class TestPiperServiceInit:
 
     def test_init_with_piper_available(self, service):
-        """Service is available when piper binary exists."""
+        """Service is available when piper-tts package is installed."""
         assert service.available is True
 
     def test_init_with_piper_unavailable(self, service_unavailable):
-        """Service is not available when piper binary missing."""
+        """Service is not available when piper-tts is missing."""
         assert service_unavailable.available is False
 
     def test_init_sets_voice_map(self, service):
-        """Voice map is loaded from settings."""
         assert service.voice_map == {"de": "de_DE-thorsten-high", "en": "en_US-amy-medium"}
 
     def test_init_sets_default_voice(self, service):
-        """Default voice is loaded from settings."""
         assert service.default_voice == "de_DE-thorsten-high"
 
     def test_init_sets_default_language(self, service):
         assert service.default_language == "de"
 
-    def test_check_piper_handles_exception(self):
-        """Graceful handling when subprocess.run raises."""
-        mock_s = _make_mock_settings()
-        with patch("services.piper_service.settings", mock_s), \
-             patch("services.piper_service.subprocess") as mock_sub:
-            mock_sub.run.side_effect = FileNotFoundError("which not found")
-            svc = PiperService()
-        assert svc.available is False
+    def test_init_starts_with_empty_voice_cache(self, service):
+        assert service._voice_cache == {}
 
 
 # ============================================================================
@@ -114,24 +128,66 @@ class TestVoiceSelection:
         assert service._get_voice_for_language("en") == "en_US-amy-medium"
 
     def test_get_voice_for_unknown_language_falls_back(self, service):
-        """Unknown language falls back to default voice."""
         result = service._get_voice_for_language("fr")
         assert result == "de_DE-thorsten-high"  # Falls back to default_voice
 
     def test_get_voice_for_none_uses_default_language(self, service):
-        """None language uses default_language setting."""
         result = service._get_voice_for_language(None)
-        assert result == "de_DE-thorsten-high"  # de is default_language
+        assert result == "de_DE-thorsten-high"
 
     def test_get_voice_case_insensitive(self, service):
-        """Language lookup is case-insensitive."""
         result = service._get_voice_for_language("DE")
         assert result == "de_DE-thorsten-high"
 
     def test_get_model_path(self, service):
-        """Model path follows expected convention."""
         path = service._get_model_path("de_DE-thorsten-high")
         assert path == "/usr/share/piper/voices/de_DE-thorsten-high.onnx"
+
+
+# ============================================================================
+# Voice Loading + Caching
+# ============================================================================
+
+@pytest.mark.unit
+class TestVoiceLoading:
+
+    def test_load_voice_caches_result(self, service, fake_voice):
+        """Subsequent calls reuse the cached PiperVoice instance."""
+        with patch("services.piper_service.Path") as mock_path, \
+             patch("services.piper_service.PiperVoice") as mock_pv:
+            mock_path.return_value.exists.return_value = True
+            mock_pv.load.return_value = fake_voice
+
+            v1 = service._load_voice("de_DE-thorsten-high")
+            v2 = service._load_voice("de_DE-thorsten-high")
+
+        assert v1 is fake_voice
+        assert v2 is fake_voice
+        mock_pv.load.assert_called_once()
+
+    def test_load_voice_returns_none_when_model_missing(self, service):
+        """Missing .onnx file → returns None."""
+        with patch("services.piper_service.Path") as mock_path:
+            mock_path.return_value.exists.return_value = False
+            result = service._load_voice("nonexistent-voice")
+
+        assert result is None
+
+    def test_load_voice_returns_none_on_exception(self, service):
+        """PiperVoice.load() raising → returns None, doesn't crash."""
+        with patch("services.piper_service.Path") as mock_path, \
+             patch("services.piper_service.PiperVoice") as mock_pv:
+            mock_path.return_value.exists.return_value = True
+            mock_pv.load.side_effect = RuntimeError("ONNX session init failed")
+
+            result = service._load_voice("broken-voice")
+
+        assert result is None
+
+    def test_load_voice_returns_none_when_unavailable(self, service_unavailable):
+        """When PIPER_AVAILABLE=False, _load_voice short-circuits."""
+        result = service_unavailable._load_voice("de_DE-thorsten-high")
+        assert result is None
 
 
 # ============================================================================
@@ -142,115 +198,72 @@ class TestVoiceSelection:
 class TestSynthesis:
 
     @pytest.mark.asyncio
-    async def test_synthesize_to_file_success(self, service, tmp_path):
-        """Successful synthesis writes file and returns True."""
+    async def test_synthesize_to_file_success(self, service, fake_voice, tmp_path):
+        """Successful synthesis writes a WAV and returns True."""
         output_path = str(tmp_path / "output.wav")
-
-        mock_proc = MagicMock()
-        mock_proc.returncode = 0
-        mock_proc.communicate.return_value = (b"", b"")
-
-        with patch("services.piper_service.subprocess.Popen", return_value=mock_proc) as mock_popen:
+        with patch.object(service, "_load_voice", return_value=fake_voice):
             result = await service.synthesize_to_file("Hallo Welt", output_path)
 
         assert result is True
-        mock_popen.assert_called_once()
-        # Verify command includes model and output_file
-        call_args = mock_popen.call_args[0][0]
-        assert "piper" in call_args
-        assert "--model" in call_args
-        assert "--output_file" in call_args
+        fake_voice.synthesize.assert_called_once()
+        call_args = fake_voice.synthesize.call_args[0]
+        assert call_args[0] == "Hallo Welt"
+        assert tmp_path.joinpath("output.wav").stat().st_size > 0
 
     @pytest.mark.asyncio
-    async def test_synthesize_to_file_failure(self, service, tmp_path):
-        """Failed synthesis returns False."""
+    async def test_synthesize_to_file_uses_correct_voice_for_language(self, service, fake_voice, tmp_path):
+        """Correct voice is loaded based on language parameter."""
         output_path = str(tmp_path / "output.wav")
+        with patch.object(service, "_load_voice", return_value=fake_voice) as mock_load:
+            await service.synthesize_to_file("Hello world", output_path, language="en")
 
-        mock_proc = MagicMock()
-        mock_proc.returncode = 1
-        mock_proc.communicate.return_value = (b"", b"Error: model not found")
+        mock_load.assert_called_once_with("en_US-amy-medium")
 
-        with patch("services.piper_service.subprocess.Popen", return_value=mock_proc):
+    @pytest.mark.asyncio
+    async def test_synthesize_to_file_returns_false_when_voice_missing(self, service, tmp_path):
+        """When _load_voice returns None, synthesize returns False."""
+        output_path = str(tmp_path / "output.wav")
+        with patch.object(service, "_load_voice", return_value=None):
             result = await service.synthesize_to_file("Hallo", output_path)
 
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_synthesize_to_file_exception(self, service, tmp_path):
-        """Exception during synthesis returns False."""
+    async def test_synthesize_to_file_returns_false_on_exception(self, service, tmp_path):
+        """Exception during synthesize() returns False."""
         output_path = str(tmp_path / "output.wav")
-
-        with patch("services.piper_service.subprocess.Popen", side_effect=OSError("spawn failed")):
+        bad_voice = MagicMock()
+        bad_voice.synthesize.side_effect = RuntimeError("inference error")
+        with patch.object(service, "_load_voice", return_value=bad_voice):
             result = await service.synthesize_to_file("Hallo", output_path)
 
         assert result is False
 
     @pytest.mark.asyncio
     async def test_synthesize_to_file_when_unavailable(self, service_unavailable, tmp_path):
-        """Returns False immediately when piper is not available."""
         result = await service_unavailable.synthesize_to_file("Hello", str(tmp_path / "out.wav"))
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_synthesize_to_file_uses_correct_voice_for_language(self, service, tmp_path):
-        """Correct voice model is used based on language parameter."""
-        output_path = str(tmp_path / "output.wav")
-
-        mock_proc = MagicMock()
-        mock_proc.returncode = 0
-        mock_proc.communicate.return_value = (b"", b"")
-
-        with patch("services.piper_service.subprocess.Popen", return_value=mock_proc) as mock_popen:
-            await service.synthesize_to_file("Hello world", output_path, language="en")
-
-        call_args = mock_popen.call_args[0][0]
-        # Should use en_US-amy-medium model
-        assert "/usr/share/piper/voices/en_US-amy-medium.onnx" in call_args
-
-    @pytest.mark.asyncio
-    async def test_synthesize_to_bytes_success(self, service, tmp_path):
-        """synthesize_to_bytes returns audio bytes on success."""
-        fake_wav = b"RIFF\x00\x00\x00\x00WAVEfmt "
-
-        with patch.object(service, "synthesize_to_file", new_callable=AsyncMock) as mock_synth:
-            # Simulate synthesize_to_file writing content
-            async def write_and_return(text, path, language=None):
-                from pathlib import Path
-                Path(path).write_bytes(fake_wav)
-                return True
-            mock_synth.side_effect = write_and_return
-
+    async def test_synthesize_to_bytes_success(self, service, fake_voice):
+        """synthesize_to_bytes returns audio bytes when synthesis succeeds."""
+        with patch.object(service, "_load_voice", return_value=fake_voice):
             result = await service.synthesize_to_bytes("Hallo")
 
-        assert result == fake_wav
+        # WAV file should have at least the header (44 bytes) plus our sentinel
+        assert len(result) >= 44
+        assert result[:4] == b"RIFF"
 
     @pytest.mark.asyncio
-    async def test_synthesize_to_bytes_failure_returns_empty(self, service):
-        """synthesize_to_bytes returns empty bytes on failure."""
-        with patch.object(service, "synthesize_to_file", new_callable=AsyncMock, return_value=False):
+    async def test_synthesize_to_bytes_returns_empty_when_voice_missing(self, service):
+        with patch.object(service, "_load_voice", return_value=None):
             result = await service.synthesize_to_bytes("Hallo")
-
         assert result == b""
 
     @pytest.mark.asyncio
     async def test_synthesize_to_bytes_when_unavailable(self, service_unavailable):
-        """Returns empty bytes when piper unavailable."""
         result = await service_unavailable.synthesize_to_bytes("Hello")
         assert result == b""
-
-    @pytest.mark.asyncio
-    async def test_synthesize_sends_text_via_stdin(self, service, tmp_path):
-        """Text is passed to piper via stdin."""
-        output_path = str(tmp_path / "output.wav")
-
-        mock_proc = MagicMock()
-        mock_proc.returncode = 0
-        mock_proc.communicate.return_value = (b"", b"")
-
-        with patch("services.piper_service.subprocess.Popen", return_value=mock_proc):
-            await service.synthesize_to_file("Hallo Welt", output_path)
-
-        mock_proc.communicate.assert_called_once_with(input=b"Hallo Welt")
 
 
 # ============================================================================
@@ -261,9 +274,8 @@ class TestSynthesis:
 class TestEnsureModelDownloaded:
 
     def test_noop_when_available(self, service):
-        """Does nothing when piper is available (piper auto-downloads)."""
+        """Voice models are baked into the image; nothing to do."""
         service.ensure_model_downloaded()  # Should not raise
 
     def test_noop_when_unavailable(self, service_unavailable):
-        """Does nothing when piper is unavailable."""
         service_unavailable.ensure_model_downloaded()  # Should not raise

--- a/tests/backend/test_whisper_service_unit.py
+++ b/tests/backend/test_whisper_service_unit.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 
 # Pre-mock modules not available in test environment
 _missing_stubs = [
-    "asyncpg", "whisper", "piper", "piper.voice", "speechbrain",
+    "asyncpg", "faster_whisper", "piper", "piper.voice", "speechbrain",
     "speechbrain.inference", "speechbrain.inference.speaker",
     "openwakeword", "openwakeword.model",
     "librosa", "soundfile",
@@ -16,6 +16,18 @@ _missing_stubs = [
 for _mod in _missing_stubs:
     if _mod not in sys.modules:
         sys.modules[_mod] = MagicMock()
+
+
+def _segments_result(text: str):
+    """Build the (segments_iter, info) tuple that faster-whisper's transcribe returns.
+
+    The real API returns a generator of Segment-like objects each carrying a
+    `.text` attribute, plus an info object. For unit tests we use a single
+    segment with the supplied text — the service joins all segments verbatim.
+    """
+    seg = MagicMock()
+    seg.text = text
+    return ([seg], MagicMock())
 
 from unittest.mock import AsyncMock, patch
 
@@ -26,6 +38,9 @@ from services.whisper_service import WhisperService
 
 def _make_mock_settings(
     whisper_model="base",
+    whisper_device="cpu",
+    whisper_compute_type="int8",
+    whisper_beam_size=5,
     default_language="de",
     whisper_initial_prompt=None,
     whisper_preprocess_enabled=False,
@@ -36,6 +51,9 @@ def _make_mock_settings(
 ):
     s = MagicMock()
     s.whisper_model = whisper_model
+    s.whisper_device = whisper_device
+    s.whisper_compute_type = whisper_compute_type
+    s.whisper_beam_size = whisper_beam_size
     s.default_language = default_language
     s.whisper_initial_prompt = whisper_initial_prompt
     s.whisper_preprocess_enabled = whisper_preprocess_enabled
@@ -96,29 +114,42 @@ class TestWhisperServiceInit:
 @pytest.mark.unit
 class TestModelLoading:
 
-    def test_load_model_calls_whisper(self, service):
+    def test_load_model_calls_whisper_model(self, service):
         mock_model = MagicMock()
-        with patch("services.whisper_service.whisper") as mock_whisper:
-            mock_whisper.load_model.return_value = mock_model
+        with patch("services.whisper_service.WhisperModel") as mock_ctor:
+            mock_ctor.return_value = mock_model
             service.load_model()
 
         assert service.model is mock_model
-        mock_whisper.load_model.assert_called_once_with("base")
+        mock_ctor.assert_called_once_with("base", device="cpu", compute_type="int8")
 
     def test_load_model_only_once(self, service):
         mock_model = MagicMock()
-        with patch("services.whisper_service.whisper") as mock_whisper:
-            mock_whisper.load_model.return_value = mock_model
+        with patch("services.whisper_service.WhisperModel") as mock_ctor:
+            mock_ctor.return_value = mock_model
             service.load_model()
             service.load_model()  # Second call should be noop
 
-        mock_whisper.load_model.assert_called_once()
+        mock_ctor.assert_called_once()
 
     def test_load_model_raises_on_error(self, service):
-        with patch("services.whisper_service.whisper") as mock_whisper:
-            mock_whisper.load_model.side_effect = RuntimeError("CUDA OOM")
+        with patch("services.whisper_service.WhisperModel") as mock_ctor:
+            mock_ctor.side_effect = RuntimeError("CUDA OOM")
             with pytest.raises(RuntimeError, match="CUDA OOM"):
                 service.load_model()
+
+    def test_load_model_passes_gpu_settings(self):
+        """When configured for cuda+float16, settings flow into the constructor."""
+        mock_s = _make_mock_settings(whisper_device="cuda", whisper_compute_type="float16")
+        with patch("services.whisper_service.settings", mock_s), \
+             patch("services.whisper_service.AudioPreprocessor"):
+            svc = WhisperService()
+
+        with patch("services.whisper_service.WhisperModel") as mock_ctor:
+            mock_ctor.return_value = MagicMock()
+            svc.load_model()
+
+        mock_ctor.assert_called_once_with("base", device="cuda", compute_type="float16")
 
 
 # ============================================================================
@@ -132,7 +163,7 @@ class TestTranscription:
     async def test_transcribe_file_success(self, service):
         """Successful transcription returns text."""
         mock_model = MagicMock()
-        mock_model.transcribe.return_value = {"text": "  Hallo Welt  "}
+        mock_model.transcribe.return_value = _segments_result("  Hallo Welt  ")
         service.model = mock_model
 
         result = await service.transcribe_file("/tmp/test.wav")
@@ -144,20 +175,20 @@ class TestTranscription:
     async def test_transcribe_file_auto_loads_model(self, service):
         """Model is loaded on first transcription if not yet loaded."""
         mock_model = MagicMock()
-        mock_model.transcribe.return_value = {"text": "Test"}
+        mock_model.transcribe.return_value = _segments_result("Test")
 
-        with patch("services.whisper_service.whisper") as mock_whisper:
-            mock_whisper.load_model.return_value = mock_model
+        with patch("services.whisper_service.WhisperModel") as mock_ctor:
+            mock_ctor.return_value = mock_model
             result = await service.transcribe_file("/tmp/test.wav")
 
         assert result == "Test"
-        mock_whisper.load_model.assert_called_once()
+        mock_ctor.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_transcribe_file_uses_default_language(self, service):
         """Uses default language when none specified."""
         mock_model = MagicMock()
-        mock_model.transcribe.return_value = {"text": "Hallo"}
+        mock_model.transcribe.return_value = _segments_result("Hallo")
         service.model = mock_model
 
         await service.transcribe_file("/tmp/test.wav")
@@ -169,7 +200,7 @@ class TestTranscription:
     async def test_transcribe_file_uses_explicit_language(self, service):
         """Uses explicitly provided language."""
         mock_model = MagicMock()
-        mock_model.transcribe.return_value = {"text": "Hello"}
+        mock_model.transcribe.return_value = _segments_result("Hello")
         service.model = mock_model
 
         await service.transcribe_file("/tmp/test.wav", language="en")
@@ -186,7 +217,7 @@ class TestTranscription:
             svc = WhisperService()
 
         mock_model = MagicMock()
-        mock_model.transcribe.return_value = {"text": "Turn on lights"}
+        mock_model.transcribe.return_value = _segments_result("Turn on lights")
         svc.model = mock_model
 
         await svc.transcribe_file("/tmp/test.wav")
@@ -206,29 +237,29 @@ class TestTranscription:
         assert result == ""
 
     @pytest.mark.asyncio
-    async def test_transcribe_file_sets_fp16_false(self, service):
-        """fp16 is set to False for CPU compatibility."""
+    async def test_transcribe_file_does_not_pass_fp16(self, service):
+        """faster-whisper uses compute_type at model-load time, not per-call fp16."""
         mock_model = MagicMock()
-        mock_model.transcribe.return_value = {"text": "Test"}
+        mock_model.transcribe.return_value = _segments_result("Test")
         service.model = mock_model
 
         await service.transcribe_file("/tmp/test.wav")
 
         call_kwargs = mock_model.transcribe.call_args
-        assert call_kwargs[1]["fp16"] is False
+        assert "fp16" not in call_kwargs[1]
+        assert "best_of" not in call_kwargs[1]
 
     @pytest.mark.asyncio
     async def test_transcribe_file_sets_beam_params(self, service):
-        """Beam search parameters are set for accuracy."""
+        """Beam search parameter is set for accuracy."""
         mock_model = MagicMock()
-        mock_model.transcribe.return_value = {"text": "Test"}
+        mock_model.transcribe.return_value = _segments_result("Test")
         service.model = mock_model
 
         await service.transcribe_file("/tmp/test.wav")
 
         call_kwargs = mock_model.transcribe.call_args
         assert call_kwargs[1]["beam_size"] == 5
-        assert call_kwargs[1]["best_of"] == 5
 
 
 # ============================================================================
@@ -292,7 +323,7 @@ class TestPreprocessing:
         """Preprocessing is not called when disabled."""
         service.preprocess_enabled = False
         mock_model = MagicMock()
-        mock_model.transcribe.return_value = {"text": "Test"}
+        mock_model.transcribe.return_value = _segments_result("Test")
         service.model = mock_model
 
         await service.transcribe_file("/tmp/test.wav")
@@ -307,7 +338,7 @@ class TestPreprocessing:
         service.preprocess_enabled = True
         service._preprocess_audio = MagicMock(return_value="/tmp/preprocessed.wav")
         mock_model = MagicMock()
-        mock_model.transcribe.return_value = {"text": "Test"}
+        mock_model.transcribe.return_value = _segments_result("Test")
         service.model = mock_model
 
         await service.transcribe_file("/tmp/test.wav")
@@ -322,7 +353,7 @@ class TestPreprocessing:
         service.preprocess_enabled = True
         service._preprocess_audio = MagicMock(return_value=None)
         mock_model = MagicMock()
-        mock_model.transcribe.return_value = {"text": "Test"}
+        mock_model.transcribe.return_value = _segments_result("Test")
         service.model = mock_model
 
         await service.transcribe_file("/tmp/test.wav")
@@ -341,7 +372,7 @@ class TestTranscribeWithSpeaker:
     async def test_returns_text_and_speaker_info(self, service):
         """Returns dict with text and speaker fields."""
         mock_model = MagicMock()
-        mock_model.transcribe.return_value = {"text": "Hello"}
+        mock_model.transcribe.return_value = _segments_result("Hello")
         service.model = mock_model
 
         result = await service.transcribe_with_speaker("/tmp/test.wav")
@@ -368,7 +399,7 @@ class TestTranscribeWithSpeaker:
     async def test_skips_speaker_when_disabled(self, service):
         """Speaker recognition skipped when disabled in settings."""
         mock_model = MagicMock()
-        mock_model.transcribe.return_value = {"text": "Test"}
+        mock_model.transcribe.return_value = _segments_result("Test")
         service.model = mock_model
 
         # speaker_recognition_enabled defaults to False in our mock
@@ -385,7 +416,7 @@ class TestTranscribeWithSpeaker:
             svc = WhisperService()
 
         mock_model = MagicMock()
-        mock_model.transcribe.return_value = {"text": "Test"}
+        mock_model.transcribe.return_value = _segments_result("Test")
         svc.model = mock_model
 
         result = await svc.transcribe_with_speaker("/tmp/test.wav", db_session=None)

--- a/tests/backend/test_whisper_service_unit.py
+++ b/tests/backend/test_whisper_service_unit.py
@@ -21,13 +21,33 @@ for _mod in _missing_stubs:
 def _segments_result(text: str):
     """Build the (segments_iter, info) tuple that faster-whisper's transcribe returns.
 
-    The real API returns a generator of Segment-like objects each carrying a
-    `.text` attribute, plus an info object. For unit tests we use a single
-    segment with the supplied text — the service joins all segments verbatim.
+    The real API returns a one-shot generator of Segment-like objects each
+    carrying a `.text` attribute, plus an info object. We wrap the segment
+    list in `iter(...)` so that test code accidentally relying on list
+    semantics (`len()`, `[0]`, double-iteration) fails the same way
+    production would — faster-whisper drains the generator on first
+    iteration and a second pass yields nothing.
     """
     seg = MagicMock()
     seg.text = text
-    return ([seg], MagicMock())
+    return (iter([seg]), MagicMock())
+
+
+def _multi_segment_result(*texts: str):
+    """Multi-segment variant of _segments_result.
+
+    faster-whisper splits long audio into multiple segments. Each segment's
+    `.text` typically begins with a space when the tokenizer emits a word
+    boundary, so plain "".join() over `seg.text` produces correctly spaced
+    output. Use this helper to verify the join contract holds for >1
+    segment.
+    """
+    segments = []
+    for t in texts:
+        seg = MagicMock()
+        seg.text = t
+        segments.append(seg)
+    return (iter(segments), MagicMock())
 
 from unittest.mock import AsyncMock, patch
 
@@ -235,6 +255,25 @@ class TestTranscription:
         result = await service.transcribe_file("/tmp/test.wav")
 
         assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_transcribe_file_joins_multiple_segments(self, service):
+        """Long audio produces multiple segments — verify the join contract.
+
+        faster-whisper segment text typically starts with a space when the
+        tokenizer emits a word boundary, so "".join(...) produces correctly
+        spaced output. Test that we don't accidentally double-space or drop
+        whitespace between segments.
+        """
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = _multi_segment_result(
+            " Hallo", " Welt", " wie", " geht", " es", " dir",
+        )
+        service.model = mock_model
+
+        result = await service.transcribe_file("/tmp/long.wav")
+
+        assert result == "Hallo Welt wie geht es dir"
 
     @pytest.mark.asyncio
     async def test_transcribe_file_does_not_pass_fp16(self, service):


### PR DESCRIPTION
## Summary

Phase A of the voice-pipeline upgrade described in [`../reva/docs/architecture/voice-pipeline-enhancements.md`](../reva/docs/architecture/voice-pipeline-enhancements.md), scoped for Renfield's needs.

Renfield benefits identically to Reva. Reva picks this up via the next submodule bump (per the framework-unification policy). The Renfield-specific Phase B work (TTS cache, worker pool, per-household prompt bias) is deferred to follow-up PRs.

## What landed

| Change | File | Why |
|---|---|---|
| `openai-whisper` → `faster-whisper` | `services/whisper_service.py` + `requirements.txt` | ~4x GPU throughput, clean `device` + `compute_type` config |
| Piper subprocess → in-process bindings | `services/piper_service.py` + `requirements.txt` | Eliminates ~150-300 ms cold-start per TTS turn |
| Singleton dedup | `api/routes/voice.py` | Two competing `WhisperService()` instances at module-level + lazy was a real bug |
| New config knobs | `utils/config.py` | `whisper_device`, `whisper_compute_type`, `whisper_beam_size` |

The old comment about *"faster-whisper benötigt PyAV was Build-Probleme verursacht"* is no longer accurate — faster-whisper 1.x ships manylinux wheels for amd64 + aarch64 and pulls PyAV via wheel, no source build.

## Speaker-recognition compatibility

The `transcribe_with_speaker` path consumes the audio FILE PATH (not Whisper's output dict), so the SpeechBrain ECAPA-TDNN embeddings work unchanged. The auto-enrollment + continuous-learning logic is untouched.

## Test changes

- **test_whisper_service_unit.py:** rewritten to mock `WhisperModel(...)` + the `(segments_iter, info)` tuple shape. `fp16`/`best_of` assertions dropped (openai-whisper concepts; faster-whisper uses `compute_type` at load time). New test asserts cuda+float16 settings flow through.
- **test_piper_service.py:** rewritten to mock `PiperVoice.load(...)` and `voice.synthesize(...)` instead of subprocess. New tests cover voice caching (load once, reuse), missing-model file → None, exception paths.
- **test_voice.py:** untouched (the module-level `whisper_service`/`piper_service` attributes still exist, just bound to the canonical singletons now).

## Config recipes

```bash
# CPU dev/build box (default)
WHISPER_MODEL=base
WHISPER_DEVICE=cpu
WHISPER_COMPUTE_TYPE=int8

# CPU production (better accuracy)
WHISPER_MODEL=medium
WHISPER_DEVICE=cpu
WHISPER_COMPUTE_TYPE=int8

# PRD GPU node (best accuracy + speed)
WHISPER_MODEL=large-v3
WHISPER_DEVICE=cuda
WHISPER_COMPUTE_TYPE=float16
```

## Phase B (deferred to follow-up PRs)

Per the analysis on this session, the Renfield-specific value lives in Phase B:
- TTS LRU cache for repeated household confirmations (\"OK\", \"Erledigt\", \"Erinnerung gesetzt\")
- Worker pool around WhisperService for multi-satellite concurrency
- Per-household `initial_prompt` hook (rooms + KB top-titles + speaker aliases)
- Backend audio-preprocessing offload from Pi Zero 2 W (already on `src/satellite/TECHNICAL_DEBT.md`)

These are independent, signal-gated, and can ship one at a time.

## Test plan

- [x] Python syntax check for all modified files
- [ ] `make lint` (Docker-based locally; CI is non-functional)
- [ ] Run `tests/backend/test_whisper_service_unit.py` and `tests/backend/test_piper_service.py` on `.159` build box (per project policy)
- [ ] Build backend image on `.159`, push to Harbor, deploy to PRD with `WHISPER_DEVICE=cuda + WHISPER_COMPUTE_TYPE=float16 + WHISPER_MODEL=large-v3` env, smoke-test STT round-trip from a satellite
- [ ] Verify speaker-recognition auto-enrollment still works against the new STT path
- [ ] Confirm TTS round-trip latency drop (subprocess → in-process) — qualitative \"feels faster\" baseline check via web chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)