### PR TITLE
build(backend): split pip install layers to fit Harbor proxy timeout

### DIFF
--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -32,23 +32,44 @@ RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 # Upgrade pip to fix CVE-2025-8869 (tar extraction vulnerability)
-# setuptools required for openai-whisper (uses pkg_resources)
 RUN pip install --no-cache-dir --upgrade pip>=25.3 setuptools
 
-# Install all Python dependencies with a constraints file that pins torch/torchaudio/torchvision
-# to +cpu wheels from the PyTorch CPU index. This prevents transitive deps (docling, easyocr,
-# transformers) from resolving torch to a full CUDA build which adds ~3GB of nvidia/* wheels.
+# Install Python dependencies. Split across multiple RUN layers so each pushed
+# layer stays well under Harbor's external proxy timeout (the 2.66 GB monolithic
+# layer reliably 504'd on the registry.treehouse.x-idra.de Telekom proxy).
+# The constraints file pins torch/torchaudio/torchvision to +cpu wheels from the
+# PyTorch CPU index — prevents transitive deps (docling, easyocr, transformers)
+# from resolving torch to a full CUDA build (saves ~3 GB of nvidia/* wheels).
 COPY requirements.txt constraints.txt ./
 RUN grep -v "github.com" requirements.txt > requirements-pypi.txt \
-    && (grep "github.com" requirements.txt > requirements-github.txt || true) \
-    && (grep -v "^openai-whisper" requirements-pypi.txt > requirements-pypi-filtered.txt || true) \
-    && pip install --no-cache-dir \
-         --extra-index-url https://download.pytorch.org/whl/cpu \
-         --constraint constraints.txt \
-         -r requirements-pypi-filtered.txt \
-    && pip install --no-cache-dir --no-deps openai-whisper \
-    && pip install --no-cache-dir tiktoken more-itertools \
-    && if [ -s requirements-github.txt ]; then pip install --no-cache-dir --force-reinstall --no-deps -r requirements-github.txt; fi
+    && (grep "github.com" requirements.txt > requirements-github.txt || true)
+
+# Layer 1: torch ecosystem (~700 MB) — biggest single chunk; isolated so the
+# rest of the deps can re-use it from the layer cache on subsequent builds.
+RUN pip install --no-cache-dir \
+      --extra-index-url https://download.pytorch.org/whl/cpu \
+      --constraint constraints.txt \
+      torch torchaudio torchvision
+
+# Layer 2: heavy ML/CV deps (~800 MB) — transformers, easyocr, docling, speechbrain, opencv.
+RUN pip install --no-cache-dir \
+      --extra-index-url https://download.pytorch.org/whl/cpu \
+      --constraint constraints.txt \
+      transformers easyocr docling docling-core speechbrain opencv-python-headless
+
+# Layer 3: voice/audio stack (~400 MB) — faster-whisper (ctranslate2), piper-tts, librosa.
+RUN pip install --no-cache-dir \
+      --constraint constraints.txt \
+      faster-whisper piper-tts librosa soundfile noisereduce
+
+# Layer 4: remaining pypi reqs (~600 MB) — fastapi, sqlalchemy, ollama, mcp, etc.
+RUN pip install --no-cache-dir \
+      --extra-index-url https://download.pytorch.org/whl/cpu \
+      --constraint constraints.txt \
+      -r requirements-pypi.txt
+
+# Layer 5: github archive deps (small, slow to resolve — kept in its own layer).
+RUN if [ -s requirements-github.txt ]; then pip install --no-cache-dir --force-reinstall --no-deps -r requirements-github.txt; fi
 
 
 # ============================================================================

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -71,6 +71,16 @@ RUN pip install --no-cache-dir \
 # Layer 5: github archive deps (small, slow to resolve — kept in its own layer).
 RUN if [ -s requirements-github.txt ]; then pip install --no-cache-dir --force-reinstall --no-deps -r requirements-github.txt; fi
 
+# Stage the heaviest packages OUTSIDE /opt/venv so the runtime stage can COPY
+# them individually. A single `COPY --from=builder /opt/venv /opt/venv` would
+# otherwise collapse the split RUN layers into one ~2.65 GB layer that 504s on
+# the external Harbor proxy.
+RUN cd /opt/venv/lib/python3.11/site-packages \
+    && mkdir -p /opt/staging/torch /opt/staging/ml /opt/staging/audio \
+    && mv torch torchaudio torchvision /opt/staging/torch/ \
+    && mv transformers easyocr docling docling_core docling_ibm_models speechbrain cv2 /opt/staging/ml/ \
+    && mv ctranslate2 librosa /opt/staging/audio/
+
 
 # ============================================================================
 # Stage 2: Runtime
@@ -101,7 +111,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
-# Copy Python virtual environment from builder
+# Copy Python virtual environment from builder. Split into multiple COPY layers
+# so each pushed layer fits under the external Harbor proxy timeout. The heavy
+# packages were moved out of /opt/venv in the builder; here we copy them back
+# into site-packages individually before the catch-all COPY of the slim venv.
+COPY --from=builder /opt/staging/torch/. /opt/venv/lib/python3.11/site-packages/
+COPY --from=builder /opt/staging/ml/. /opt/venv/lib/python3.11/site-packages/
+COPY --from=builder /opt/staging/audio/. /opt/venv/lib/python3.11/site-packages/
 COPY --from=builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
## Summary

- Splits the monolithic 2.66 GB pip-install layer into 5 smaller layers so each push body fits under the external Harbor proxy timeout
- Drops the orphaned `openai-whisper` / `tiktoken` / `more-itertools` install path (replaced by faster-whisper in #509)

## Motivation

During the v2.3.0 deploy, the backend image reliably failed to push at the same `ed85…` 2.66 GB layer with `504 Gateway Timeout` / `Client Closed Request` after exactly ~3.9 s and 45.9 MB transferred. Investigation traced the bottleneck to the external HTTPS proxy at `93.241.252.154` (Telekom) fronting `registry.treehouse.x-idra.de`, not to k8s/Harbor itself. Smaller layers should each push within the proxy's body-buffering window. Documented in the `deploy-production` skill's "Harbor 504" section.

## Layer split

1. `torch torchaudio torchvision` (~700 MB)
2. `transformers easyocr docling docling-core speechbrain opencv-python-headless` (~800 MB)
3. `faster-whisper piper-tts librosa soundfile noisereduce` (~400 MB)
4. Remaining pypi requirements (~600 MB)
5. github archive packages (small, isolated for cache hygiene)

The constraint file still pins torch to `+cpu` wheels — final image stays ~3.5 GB.

## Test plan

- [ ] Build on .159 succeeds and produces an image of comparable total size
- [ ] `docker push` to Harbor pushes each layer individually without 504
- [ ] Pod starts cleanly (no missing imports)
- [ ] `/health` returns 200 once rolled

🤖 Generated with [Claude Code](https://claude.com/claude-code)