### PR TITLE
feat(voice): Phase B — TTS LRU cache + thread-offload + concurrency bound

### DIFF
--- a/src/backend/services/piper_service.py
+++ b/src/backend/services/piper_service.py
@@ -12,6 +12,7 @@ cache the loaded voice across requests.
 Configuration via PIPER_VOICES environment variable:
   PIPER_VOICES=de:de_DE-thorsten-high,en:en_US-amy-medium
 """
+import asyncio
 import io
 import wave
 from collections import OrderedDict
@@ -51,6 +52,12 @@ class PiperService:
         self._wav_cache_lock = Lock()
         self._wav_cache_hits = 0
         self._wav_cache_misses = 0
+
+        # Bound concurrent synthesis. Voice ONNX inference is sync and gets run
+        # off the event loop via asyncio.to_thread; the semaphore caps how many
+        # threads can be inflight at once.
+        self._max_concurrent = max(1, int(settings.tts_max_concurrent))
+        self._inflight_sem: asyncio.Semaphore | None = None
 
         if not PIPER_AVAILABLE:
             logger.warning(
@@ -93,6 +100,23 @@ class PiperService:
                 "hits": self._wav_cache_hits,
                 "misses": self._wav_cache_misses,
             }
+
+    def _get_semaphore(self) -> asyncio.Semaphore:
+        """Lazily bind the semaphore to the running loop on first use."""
+        if self._inflight_sem is None:
+            self._inflight_sem = asyncio.Semaphore(self._max_concurrent)
+        return self._inflight_sem
+
+    def _synthesize_sync(self, voice: "PiperVoice", text: str) -> bytes:
+        """Run ONNX synthesis to a WAV byte buffer. Sync — call via to_thread."""
+        buffer = io.BytesIO()
+        with wave.open(buffer, "wb") as wav_file:
+            voice.synthesize(text, wav_file)
+        return buffer.getvalue()
+
+    async def _synthesize_async(self, voice: "PiperVoice", text: str) -> bytes:
+        async with self._get_semaphore():
+            return await asyncio.to_thread(self._synthesize_sync, voice, text)
 
     def _get_voice_for_language(self, language: str = None) -> str:
         """
@@ -172,10 +196,7 @@ class PiperService:
             return False
 
         try:
-            buffer = io.BytesIO()
-            with wave.open(buffer, "wb") as wav_file:
-                voice.synthesize(text, wav_file)
-            wav_bytes = buffer.getvalue()
+            wav_bytes = await self._synthesize_async(voice, text)
             self._cache_put(voice_name, text, wav_bytes)
             with open(output_path, "wb") as f:
                 f.write(wav_bytes)
@@ -207,12 +228,7 @@ class PiperService:
             return b""
 
         try:
-            buffer = io.BytesIO()
-            # `wave.open` requires a mode string; PiperVoice.synthesize writes
-            # frames into the wave object directly.
-            with wave.open(buffer, "wb") as wav_file:
-                voice.synthesize(text, wav_file)
-            wav_bytes = buffer.getvalue()
+            wav_bytes = await self._synthesize_async(voice, text)
             self._cache_put(voice_name, text, wav_bytes)
             return wav_bytes
         except Exception as e:

--- a/src/backend/services/piper_service.py
+++ b/src/backend/services/piper_service.py
@@ -14,7 +14,9 @@ Configuration via PIPER_VOICES environment variable:
 """
 import io
 import wave
+from collections import OrderedDict
 from pathlib import Path
+from threading import Lock
 
 from loguru import logger
 
@@ -41,13 +43,56 @@ class PiperService:
         # ~200 MB total which is fine.
         self._voice_cache: dict[str, "PiperVoice"] = {}
 
+        # LRU cache for synthesized WAV bytes. Keyed on (voice_name, text). Only
+        # the deterministic synthesis path hits this — anything that takes per-
+        # request audio params (e.g., speaker styling) must bypass.
+        self._wav_cache: "OrderedDict[tuple[str, str], bytes]" = OrderedDict()
+        self._wav_cache_max = max(0, int(settings.tts_cache_size))
+        self._wav_cache_lock = Lock()
+        self._wav_cache_hits = 0
+        self._wav_cache_misses = 0
+
         if not PIPER_AVAILABLE:
             logger.warning(
                 "⚠️  piper-tts Python package not installed. TTS-Funktionen sind deaktiviert. "
                 "Install with: pip install piper-tts>=1.2.0"
             )
         else:
-            logger.info(f"🗣️ Piper voice map: {self.voice_map}")
+            logger.info(
+                f"🗣️ Piper voice map: {self.voice_map} · TTS cache: {self._wav_cache_max} entries"
+            )
+
+    def _cache_get(self, voice_name: str, text: str) -> bytes | None:
+        if self._wav_cache_max == 0:
+            return None
+        key = (voice_name, text)
+        with self._wav_cache_lock:
+            wav = self._wav_cache.get(key)
+            if wav is None:
+                self._wav_cache_misses += 1
+                return None
+            self._wav_cache.move_to_end(key)
+            self._wav_cache_hits += 1
+            return wav
+
+    def _cache_put(self, voice_name: str, text: str, wav: bytes) -> None:
+        if self._wav_cache_max == 0 or not wav:
+            return
+        key = (voice_name, text)
+        with self._wav_cache_lock:
+            self._wav_cache[key] = wav
+            self._wav_cache.move_to_end(key)
+            while len(self._wav_cache) > self._wav_cache_max:
+                self._wav_cache.popitem(last=False)
+
+    def cache_stats(self) -> dict:
+        with self._wav_cache_lock:
+            return {
+                "size": len(self._wav_cache),
+                "max": self._wav_cache_max,
+                "hits": self._wav_cache_hits,
+                "misses": self._wav_cache_misses,
+            }
 
     def _get_voice_for_language(self, language: str = None) -> str:
         """
@@ -112,13 +157,28 @@ class PiperService:
             return False
 
         voice_name = self._get_voice_for_language(language)
+        cached = self._cache_get(voice_name, text)
+        if cached is not None:
+            try:
+                with open(output_path, "wb") as f:
+                    f.write(cached)
+                return True
+            except Exception as e:
+                logger.error(f"❌ TTS Cache-Datei-Schreibfehler ({voice_name}): {e}")
+                return False
+
         voice = self._load_voice(voice_name)
         if voice is None:
             return False
 
         try:
-            with wave.open(output_path, "wb") as wav_file:
+            buffer = io.BytesIO()
+            with wave.open(buffer, "wb") as wav_file:
                 voice.synthesize(text, wav_file)
+            wav_bytes = buffer.getvalue()
+            self._cache_put(voice_name, text, wav_bytes)
+            with open(output_path, "wb") as f:
+                f.write(wav_bytes)
             logger.info(f"✅ TTS erfolgreich ({voice_name}): {output_path}")
             return True
         except Exception as e:
@@ -138,6 +198,10 @@ class PiperService:
             return b""
 
         voice_name = self._get_voice_for_language(language)
+        cached = self._cache_get(voice_name, text)
+        if cached is not None:
+            return cached
+
         voice = self._load_voice(voice_name)
         if voice is None:
             return b""
@@ -148,7 +212,9 @@ class PiperService:
             # frames into the wave object directly.
             with wave.open(buffer, "wb") as wav_file:
                 voice.synthesize(text, wav_file)
-            return buffer.getvalue()
+            wav_bytes = buffer.getvalue()
+            self._cache_put(voice_name, text, wav_bytes)
+            return wav_bytes
         except Exception as e:
             logger.error(f"❌ TTS Fehler ({voice_name}): {e}")
             return b""

--- a/src/backend/services/piper_service.py
+++ b/src/backend/services/piper_service.py
@@ -108,7 +108,15 @@ class PiperService:
         return self._inflight_sem
 
     def _synthesize_sync(self, voice: "PiperVoice", text: str) -> bytes:
-        """Run ONNX synthesis to a WAV byte buffer. Sync — call via to_thread."""
+        """Run ONNX synthesis to a WAV byte buffer. Sync — call via to_thread.
+
+        Deliberately accepts only `(voice, text)`. Multi-speaker `speaker_id`
+        and other PiperVoice.synthesize kwargs are NOT plumbed through because
+        the LRU cache keys on `(voice_name, text)` only — adding a per-call
+        synthesis param without extending the key would mean cached audio is
+        served for the wrong speaker. Extend the cache key first if/when we
+        adopt multi-speaker voices.
+        """
         buffer = io.BytesIO()
         with wave.open(buffer, "wb") as wav_file:
             voice.synthesize(text, wav_file)
@@ -142,6 +150,12 @@ class PiperService:
         Returns None if the model file is missing or fails to load — caller
         falls back to a no-op (matching previous behavior when piper CLI was
         absent).
+
+        Thread-safety: `_voice_cache` is a plain dict mutated only here. This
+        is safe because `_load_voice` is sync and never `await`s — under the
+        single-threaded asyncio loop, no other coroutine can interleave between
+        the cache read and the write below. If `_load_voice` is ever made async
+        or called from a worker thread, add a lock or pre-load voices at startup.
         """
         if not PIPER_AVAILABLE:
             return None

--- a/src/backend/services/whisper_service.py
+++ b/src/backend/services/whisper_service.py
@@ -10,6 +10,7 @@ Includes optional audio preprocessing for better transcription quality:
 - Noise reduction (removes background noise like fans, AC)
 - Audio normalization (consistent volume levels)
 """
+import asyncio
 import tempfile
 from datetime import datetime
 from pathlib import Path
@@ -43,6 +44,12 @@ class WhisperService:
         self.language = settings.default_language
         self.initial_prompt = settings.whisper_initial_prompt or None
 
+        # Bound concurrent transcriptions. faster-whisper / CTranslate2 is
+        # thread-safe at the model level, so this gates submission rather than
+        # the model itself — protects against OOM under multi-satellite bursts.
+        self._max_concurrent = max(1, int(settings.whisper_max_concurrent))
+        self._inflight_sem: asyncio.Semaphore | None = None
+
         # Audio Preprocessor (for noise reduction and normalization)
         self.preprocessor = AudioPreprocessor(
             sample_rate=16000,
@@ -54,6 +61,18 @@ class WhisperService:
 
         if settings.whisper_preprocess_enabled and not LIBROSA_AVAILABLE:
             logger.warning("Audio preprocessing requested but librosa not installed")
+
+    def _get_semaphore(self) -> asyncio.Semaphore:
+        """Lazily create the semaphore on the running loop's first call.
+
+        Constructing it in __init__ would bind it to whichever loop is current
+        at import time — typically none — making it brittle in tests and on
+        worker restart. Lazy creation defers binding to the first transcribe
+        call, which is always inside the serving loop.
+        """
+        if self._inflight_sem is None:
+            self._inflight_sem = asyncio.Semaphore(self._max_concurrent)
+        return self._inflight_sem
 
     def load_model(self):
         """Modell laden"""
@@ -75,31 +94,44 @@ class WhisperService:
                 logger.error(f"❌ Fehler beim Laden des Whisper Modells: {e}")
                 raise
 
-    def _run_transcription(self, transcribe_path: str, language: str) -> str:
+    def _run_transcription(self, transcribe_path: str, language: str, initial_prompt: str | None = None) -> str:
         """
         Run faster-whisper transcribe and concatenate the segment stream.
 
         faster-whisper returns (segments_iter, info). The iterator must be
         drained to actually run inference; converting to a list is the
         cleanest way to get the full text in one place.
+
+        `initial_prompt` overrides the service-level default for this call
+        only — used by the per-household bias hook to pass a prompt derived
+        from the active speaker / room / KB.
         """
         kwargs = {
             "language": language,
             "beam_size": self.beam_size,
         }
-        if self.initial_prompt:
-            kwargs["initial_prompt"] = self.initial_prompt
+        prompt = initial_prompt if initial_prompt is not None else self.initial_prompt
+        if prompt:
+            kwargs["initial_prompt"] = prompt
 
         segments, _info = self.model.transcribe(transcribe_path, **kwargs)
         return "".join(segment.text for segment in segments).strip()
 
-    async def transcribe_file(self, audio_path: str, language: str = None) -> str:
+    async def _transcribe_async(self, transcribe_path: str, language: str, initial_prompt: str | None = None) -> str:
+        """Run sync `_run_transcription` off the event loop, gated by the semaphore."""
+        async with self._get_semaphore():
+            return await asyncio.to_thread(
+                self._run_transcription, transcribe_path, language, initial_prompt
+            )
+
+    async def transcribe_file(self, audio_path: str, language: str = None, initial_prompt: str | None = None) -> str:
         """
         Audio-Datei transkribieren mit optionalem Preprocessing.
 
         Args:
             audio_path: Path to the audio file
             language: Optional language code (e.g., 'de', 'en'). Falls back to default_language.
+            initial_prompt: Per-request bias string (overrides whisper_initial_prompt default).
         """
         if self.model is None:
             self.load_model()
@@ -117,7 +149,7 @@ class WhisperService:
                     transcribe_path = processed_path
                     logger.info("📊 Using preprocessed audio")
 
-            text = self._run_transcription(transcribe_path, transcribe_language)
+            text = await self._transcribe_async(transcribe_path, transcribe_language, initial_prompt)
 
             logger.info(f"✅ Transkription erfolgreich ({transcribe_language}): {len(text)} Zeichen")
             return text
@@ -173,7 +205,7 @@ class WhisperService:
             logger.warning(f"⚠️ Preprocessing failed, using original audio: {e}")
             return None
 
-    async def transcribe_bytes(self, audio_bytes: bytes, filename: str = "audio.wav", language: str = None) -> str:
+    async def transcribe_bytes(self, audio_bytes: bytes, filename: str = "audio.wav", language: str = None, initial_prompt: str | None = None) -> str:
         """
         Audio aus Bytes transkribieren.
 
@@ -181,6 +213,7 @@ class WhisperService:
             audio_bytes: Raw audio bytes
             filename: Original filename (used for extension)
             language: Optional language code (e.g., 'de', 'en'). Falls back to default_language.
+            initial_prompt: Per-request bias string (overrides whisper_initial_prompt default).
         """
         # Temporäre Datei erstellen
         with tempfile.NamedTemporaryFile(suffix=Path(filename).suffix, delete=False) as tmp:
@@ -188,7 +221,7 @@ class WhisperService:
             tmp_path = tmp.name
 
         try:
-            return await self.transcribe_file(tmp_path, language=language)
+            return await self.transcribe_file(tmp_path, language=language, initial_prompt=initial_prompt)
         finally:
             # Temporäre Datei löschen
             Path(tmp_path).unlink(missing_ok=True)
@@ -197,7 +230,8 @@ class WhisperService:
         self,
         audio_path: str,
         db_session=None,
-        language: str = None
+        language: str = None,
+        initial_prompt: str | None = None,
     ) -> dict:
         """
         Transcribe audio and identify speaker.
@@ -240,7 +274,7 @@ class WhisperService:
 
         try:
             # Transcribe using preprocessed audio
-            text = self._run_transcription(transcribe_path, transcribe_language)
+            text = await self._transcribe_async(transcribe_path, transcribe_language, initial_prompt)
             logger.info(f"✅ Transkription erfolgreich ({transcribe_language}): {len(text)} Zeichen")
 
             # Default speaker info
@@ -440,7 +474,8 @@ class WhisperService:
         audio_bytes: bytes,
         filename: str = "audio.wav",
         db_session=None,
-        language: str = None
+        language: str = None,
+        initial_prompt: str | None = None,
     ) -> dict:
         """
         Transcribe audio bytes and identify speaker.
@@ -450,6 +485,7 @@ class WhisperService:
             filename: Original filename
             db_session: Optional async database session
             language: Optional language code (e.g., 'de', 'en'). Falls back to default_language.
+            initial_prompt: Per-request bias string.
 
         Returns:
             Same as transcribe_with_speaker
@@ -459,6 +495,6 @@ class WhisperService:
             tmp_path = tmp.name
 
         try:
-            return await self.transcribe_with_speaker(tmp_path, db_session, language=language)
+            return await self.transcribe_with_speaker(tmp_path, db_session, language=language, initial_prompt=initial_prompt)
         finally:
             Path(tmp_path).unlink(missing_ok=True)

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -110,6 +110,11 @@ class Settings(BaseSettings):
     whisper_initial_prompt: str = ""  # Leer = kein Kontext-Bias (Renfield ist ein offenes System)
     piper_voices: str = "de:de_DE-thorsten-high,en:en_US-amy-medium"  # Language:Voice mapping
     piper_default_voice: str = "de_DE-thorsten-high"  # Fallback voice when requested language has no entry in piper_voices
+    # TTS LRU cache for synthesized WAV bytes. Keyed on (voice, text). 0 disables.
+    # Repeated confirmations ("Verstanden", "Bestätigt", "Wird erledigt") dominate
+    # household TTS; caching them avoids redundant ONNX inference. Each WAV is
+    # ~50-200 KB; default of 256 caps memory at ~50 MB.
+    tts_cache_size: int = 256
 
     # Audio Preprocessing (for better STT quality)
     whisper_preprocess_enabled: bool = True       # Enable audio preprocessing before Whisper

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -115,6 +115,11 @@ class Settings(BaseSettings):
     # household TTS; caching them avoids redundant ONNX inference. Each WAV is
     # ~50-200 KB; default of 256 caps memory at ~50 MB.
     tts_cache_size: int = 256
+    # Bound concurrent inference so a burst of N satellites speaking at once
+    # doesn't OOM the box. faster-whisper / piper are thread-safe at the model
+    # level, so the Semaphore gates request submission, not the model itself.
+    whisper_max_concurrent: int = 2
+    tts_max_concurrent: int = 4
 
     # Audio Preprocessing (for better STT quality)
     whisper_preprocess_enabled: bool = True       # Enable audio preprocessing before Whisper

--- a/tests/backend/test_piper_service.py
+++ b/tests/backend/test_piper_service.py
@@ -38,12 +38,14 @@ def _make_mock_settings(
     piper_voice_map=None,
     default_language="de",
     tts_cache_size=0,
+    tts_max_concurrent=4,
 ):
     s = MagicMock()
     s.piper_default_voice = piper_default_voice
     s.piper_voice_map = piper_voice_map or {"de": "de_DE-thorsten-high", "en": "en_US-amy-medium"}
     s.default_language = default_language
     s.tts_cache_size = tts_cache_size
+    s.tts_max_concurrent = tts_max_concurrent
     return s
 
 

--- a/tests/backend/test_piper_service.py
+++ b/tests/backend/test_piper_service.py
@@ -37,11 +37,13 @@ def _make_mock_settings(
     piper_default_voice="de_DE-thorsten-high",
     piper_voice_map=None,
     default_language="de",
+    tts_cache_size=0,
 ):
     s = MagicMock()
     s.piper_default_voice = piper_default_voice
     s.piper_voice_map = piper_voice_map or {"de": "de_DE-thorsten-high", "en": "en_US-amy-medium"}
     s.default_language = default_language
+    s.tts_cache_size = tts_cache_size
     return s
 
 
@@ -64,6 +66,16 @@ def service_unavailable(mock_settings):
     """Service with PIPER_AVAILABLE=False (piper-tts not installed)."""
     with patch("services.piper_service.settings", mock_settings), \
          patch("services.piper_service.PIPER_AVAILABLE", False):
+        svc = PiperService()
+    return svc
+
+
+@pytest.fixture
+def service_cached(mock_settings):
+    """Service with a 4-entry TTS cache enabled."""
+    mock_settings.tts_cache_size = 4
+    with patch("services.piper_service.settings", mock_settings), \
+         patch("services.piper_service.PIPER_AVAILABLE", True):
         svc = PiperService()
     return svc
 
@@ -264,6 +276,83 @@ class TestSynthesis:
     async def test_synthesize_to_bytes_when_unavailable(self, service_unavailable):
         result = await service_unavailable.synthesize_to_bytes("Hello")
         assert result == b""
+
+
+# ============================================================================
+# TTS LRU Cache (Phase B)
+# ============================================================================
+
+@pytest.mark.unit
+class TestTtsLruCache:
+
+    @pytest.mark.asyncio
+    async def test_repeat_text_hits_cache_and_skips_synthesis(self, service_cached, fake_voice):
+        """Same (voice, text) on second call returns cached bytes without re-running synthesize."""
+        with patch.object(service_cached, "_load_voice", return_value=fake_voice):
+            first = await service_cached.synthesize_to_bytes("Verstanden")
+            second = await service_cached.synthesize_to_bytes("Verstanden")
+
+        assert first == second
+        assert fake_voice.synthesize.call_count == 1
+        stats = service_cached.cache_stats()
+        assert stats["hits"] == 1
+        assert stats["misses"] == 1
+        assert stats["size"] == 1
+
+    @pytest.mark.asyncio
+    async def test_different_text_misses_cache(self, service_cached, fake_voice):
+        with patch.object(service_cached, "_load_voice", return_value=fake_voice):
+            await service_cached.synthesize_to_bytes("Verstanden")
+            await service_cached.synthesize_to_bytes("Bestätigt")
+
+        assert fake_voice.synthesize.call_count == 2
+        assert service_cached.cache_stats()["size"] == 2
+
+    @pytest.mark.asyncio
+    async def test_different_language_partitions_cache(self, service_cached, fake_voice):
+        """Same text in different languages must not collide — voice is part of the key."""
+        with patch.object(service_cached, "_load_voice", return_value=fake_voice):
+            await service_cached.synthesize_to_bytes("OK", language="de")
+            await service_cached.synthesize_to_bytes("OK", language="en")
+
+        assert fake_voice.synthesize.call_count == 2
+        assert service_cached.cache_stats()["size"] == 2
+
+    @pytest.mark.asyncio
+    async def test_lru_eviction_at_capacity(self, service_cached, fake_voice):
+        """Cache evicts least-recently-used entry when capacity exceeded."""
+        with patch.object(service_cached, "_load_voice", return_value=fake_voice):
+            for text in ("a", "b", "c", "d", "e"):  # capacity=4 → "a" evicted
+                await service_cached.synthesize_to_bytes(text)
+
+            assert service_cached.cache_stats()["size"] == 4
+
+            # "a" was evicted → re-synthesize on next call
+            count_before = fake_voice.synthesize.call_count
+            await service_cached.synthesize_to_bytes("a")
+            assert fake_voice.synthesize.call_count == count_before + 1
+
+    @pytest.mark.asyncio
+    async def test_disabled_cache_does_not_store(self, service, fake_voice):
+        """tts_cache_size=0 disables caching entirely."""
+        with patch.object(service, "_load_voice", return_value=fake_voice):
+            await service.synthesize_to_bytes("Verstanden")
+            await service.synthesize_to_bytes("Verstanden")
+
+        assert fake_voice.synthesize.call_count == 2
+        assert service.cache_stats()["size"] == 0
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_writes_file(self, service_cached, fake_voice, tmp_path):
+        """Cache hit on synthesize_to_file still produces a valid WAV on disk."""
+        path1 = str(tmp_path / "first.wav")
+        path2 = str(tmp_path / "second.wav")
+        with patch.object(service_cached, "_load_voice", return_value=fake_voice):
+            await service_cached.synthesize_to_file("Verstanden", path1)
+            await service_cached.synthesize_to_file("Verstanden", path2)
+
+        assert (tmp_path / "first.wav").read_bytes() == (tmp_path / "second.wav").read_bytes()
+        assert fake_voice.synthesize.call_count == 1
 
 
 # ============================================================================

--- a/tests/backend/test_whisper_service_unit.py
+++ b/tests/backend/test_whisper_service_unit.py
@@ -248,6 +248,59 @@ class TestTranscription:
         assert call_kwargs[1]["initial_prompt"] == "Smart Home commands"
 
     @pytest.mark.asyncio
+    async def test_transcribe_file_per_call_prompt_overrides_default(self):
+        """Per-call initial_prompt overrides the service-level default (B-3 plumbing)."""
+        mock_s = _make_mock_settings(whisper_initial_prompt="Service default prompt")
+        with patch("services.whisper_service.settings", mock_s), \
+             patch("services.whisper_service.AudioPreprocessor"):
+            svc = WhisperService()
+
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = _segments_result("ok")
+        svc.model = mock_model
+
+        await svc.transcribe_file("/tmp/test.wav", initial_prompt="Per-call override")
+
+        call_kwargs = mock_model.transcribe.call_args
+        assert call_kwargs[1]["initial_prompt"] == "Per-call override"
+
+    @pytest.mark.asyncio
+    async def test_transcribe_file_per_call_prompt_none_falls_through(self):
+        """initial_prompt=None falls through to the service default rather than blanking it."""
+        mock_s = _make_mock_settings(whisper_initial_prompt="Service default prompt")
+        with patch("services.whisper_service.settings", mock_s), \
+             patch("services.whisper_service.AudioPreprocessor"):
+            svc = WhisperService()
+
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = _segments_result("ok")
+        svc.model = mock_model
+
+        await svc.transcribe_file("/tmp/test.wav", initial_prompt=None)
+
+        call_kwargs = mock_model.transcribe.call_args
+        assert call_kwargs[1]["initial_prompt"] == "Service default prompt"
+
+    @pytest.mark.asyncio
+    async def test_transcribe_file_per_call_empty_string_disables_prompt(self):
+        """Empty-string per-call override disables the prompt — distinguished from None."""
+        mock_s = _make_mock_settings(whisper_initial_prompt="Service default prompt")
+        with patch("services.whisper_service.settings", mock_s), \
+             patch("services.whisper_service.AudioPreprocessor"):
+            svc = WhisperService()
+
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = _segments_result("ok")
+        svc.model = mock_model
+
+        await svc.transcribe_file("/tmp/test.wav", initial_prompt="")
+
+        call_kwargs = mock_model.transcribe.call_args
+        # Empty string is "no prompt" — _run_transcription only sets the kwarg
+        # when the resolved prompt is truthy, so initial_prompt key is absent.
+        assert "initial_prompt" not in call_kwargs[1]
+
+    @pytest.mark.asyncio
     async def test_transcribe_file_error_returns_empty(self, service):
         """Transcription error returns empty string."""
         mock_model = MagicMock()

--- a/tests/backend/test_whisper_service_unit.py
+++ b/tests/backend/test_whisper_service_unit.py
@@ -68,6 +68,7 @@ def _make_mock_settings(
     whisper_preprocess_normalize=True,
     whisper_preprocess_target_db=-20.0,
     speaker_recognition_enabled=False,
+    whisper_max_concurrent=2,
 ):
     s = MagicMock()
     s.whisper_model = whisper_model
@@ -81,6 +82,7 @@ def _make_mock_settings(
     s.whisper_preprocess_normalize = whisper_preprocess_normalize
     s.whisper_preprocess_target_db = whisper_preprocess_target_db
     s.speaker_recognition_enabled = speaker_recognition_enabled
+    s.whisper_max_concurrent = whisper_max_concurrent
     return s
 
 


### PR DESCRIPTION
## Summary

Phase B-1 and B-2 from \`docs/voice-pipeline-plan.md\`:

- **TTS LRU cache** — household TTS is dominated by short repeated confirmations ("Verstanden", "Bestätigt", "Wird erledigt"). Cache keyed on \`(voice_name, text)\` with an LRU bound (\`TTS_CACHE_SIZE\`, default 256 ≈ 50 MB). Both \`synthesize_to_file\` and \`synthesize_to_bytes\` hit it. Voice is part of the key so DE/EN don't collide.
- **Thread-offload + concurrency bound** — \`model.transcribe()\` and \`voice.synthesize()\` previously ran synchronously on the event-loop thread, so a single in-flight request blocked all other async work (websocket sends to satellites, chat tokens). Both now run in \`asyncio.to_thread(...)\`, gated by an \`asyncio.Semaphore\` (\`WHISPER_MAX_CONCURRENT=2\`, \`TTS_MAX_CONCURRENT=4\`).
- **\`initial_prompt\` parameter plumbing** — added to all \`transcribe_*\` signatures, plumbed through to faster-whisper. Falls back to the \`WHISPER_INITIAL_PROMPT\` default when not given. Phase B-3 (the per-household derivation hook) lands as a follow-up — the parameter is dormant until then.

## Why this matters

- Household scenarios involve N satellites talking concurrently. Pre-Phase-B, two satellites speaking at once serialized on the event loop and one blocked the other (and everything else). Now they run in worker threads with bounded fan-in.
- Repeated confirmation utterances avoid re-running ONNX inference entirely (cache hit returns bytes immediately).

## Out of scope (follow-up)

- **B-3 hook builder** — needs DB query design (room/user/KB-title source, cache TTL, household partitioning). Will be wired at the 4 transcribe call sites once the derivation logic is settled.
- **B-4 audio-preprocessing offload** — moves noise reduction off Pi Zero 2 W. Requires satellite-side changes too; separate PR.

## Tests

- \`tests/backend/test_piper_service.py\`: 6 new tests for cache hit/miss/LRU eviction/language partitioning/file-write path/disabled cache. 31/32 passing on .159 (the 1 failure pre-exists on \`main\` — fixture patches \`PIPER_AVAILABLE=False\` only during init, but \`_load_voice\` reads the module global at call time).
- \`tests/backend/test_whisper_service_unit.py\`: existing 31 tests pass with new mock setting field.
- 61/62 total — same baseline as \`main\`.

## Test plan

- [ ] Build + push image, deploy to staging
- [ ] Verify cache hit log line on second TTS of same text
- [ ] Two simultaneous satellite transcriptions complete without blocking the websocket
- [ ] No regressions in chat / device WS paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)