### PR TITLE
feat(voice): Phase B-3 follow-ups — cache invalidation broadcast + frequency vocabulary

### DIFF
--- a/src/backend/alembic/versions/a0b1c2d3e4f5_add_speaker_vocabulary.py
+++ b/src/backend/alembic/versions/a0b1c2d3e4f5_add_speaker_vocabulary.py
@@ -1,0 +1,55 @@
+"""Add speaker_vocabulary_corpus + speaker_vocabulary tables.
+
+Phase B-3 follow-up: per-user frequency-ranked vocabulary for STT bias.
+- `speaker_vocabulary_corpus`: raw confirmed-speaker transcripts. Privacy
+  tier defaults to 0 (self) — never leaks across users.
+- `speaker_vocabulary`: computed term frequencies, periodically rebuilt
+  by the batch tokenizer.
+
+Revision ID: a0b1c2d3e4f5
+Revises: z9a0b1c2d3e4
+Create Date: 2026-05-02
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers
+revision = "a0b1c2d3e4f5"
+down_revision = "z9a0b1c2d3e4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "speaker_vocabulary_corpus",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True),
+        sa.Column("text", sa.Text(), nullable=False),
+        sa.Column("language", sa.String(length=10), nullable=False, server_default="de"),
+        sa.Column("circle_tier", sa.SmallInteger(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now(), index=True),
+    )
+
+    op.create_table(
+        "speaker_vocabulary",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True),
+        sa.Column("term", sa.String(length=100), nullable=False),
+        sa.Column("frequency", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("language", sa.String(length=10), nullable=False, server_default="de"),
+        sa.Column("circle_tier", sa.SmallInteger(), nullable=False, server_default="0"),
+        sa.Column("last_updated", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.UniqueConstraint("user_id", "term", "language", name="uq_speaker_vocab_user_term_lang"),
+    )
+    op.create_index(
+        "ix_speaker_vocab_user_lang_freq",
+        "speaker_vocabulary",
+        ["user_id", "language", sa.text("frequency DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_speaker_vocab_user_lang_freq", table_name="speaker_vocabulary")
+    op.drop_table("speaker_vocabulary")
+    op.drop_table("speaker_vocabulary_corpus")

--- a/src/backend/api/lifecycle.py
+++ b/src/backend/api/lifecycle.py
@@ -143,6 +143,34 @@ def _schedule_reminder_checker():
     )
 
 
+def _schedule_speaker_vocab_rebuild():
+    """Periodically rebuild the per-user STT vocabulary table (Phase B-3 follow-up)."""
+    if not settings.speaker_vocab_capture_enabled:
+        return
+
+    interval = settings.speaker_vocab_rebuild_interval_seconds
+
+    async def vocab_rebuild_loop():
+        # Sleep first so a freshly-restarted pod doesn't hammer the DB on every
+        # boot. The first rebuild happens after one interval; cold-start callers
+        # see the platform default until then.
+        while True:
+            try:
+                await asyncio.sleep(interval)
+                from services.speaker_vocabulary_service import rebuild_vocabulary
+                async with AsyncSessionLocal() as session:
+                    stats = await rebuild_vocabulary(db_session=session)
+                logger.info(f"📚 Speaker vocab rebuilt: {stats}")
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.warning(f"⚠️  Speaker vocab rebuild failed: {e}")
+
+    task = asyncio.create_task(vocab_rebuild_loop())
+    _startup_tasks.append(task)
+    logger.info(f"✅ Speaker vocab rebuild scheduled (interval={interval}s)")
+
+
 def _schedule_memory_cleanup():
     """Schedule periodic cleanup of expired/decayed memories."""
     if not settings.memory_enabled:
@@ -594,6 +622,7 @@ async def lifespan(app: "FastAPI"):
     # from ha_glue.bootstrap.ha_glue_on_startup via the `startup` hook).
     if settings.features["voice"]:
         _schedule_whisper_preload()
+        _schedule_speaker_vocab_rebuild()
     _schedule_notification_cleanup()
     _schedule_reminder_checker()
     _schedule_notification_poller(app)
@@ -629,6 +658,17 @@ async def lifespan(app: "FastAPI"):
 
     _register_hook("household_graph_changed", whisper_prompt_household_changed)
     logger.info("✅ Whisper prompt-cache invalidation hook registered")
+
+    # Speaker vocabulary handler. Registered BEFORE the platform default has a
+    # chance to run (no platform default registers on this hook — the default
+    # is the inline fallback inside WhisperPromptBuilder._resolve, only used
+    # when all hook handlers return None). The vocab handler returns None on
+    # cold-start (no rows yet) so the platform default kicks in transparently.
+    if settings.speaker_vocab_capture_enabled:
+        from services.speaker_vocabulary_service import vocab_initial_prompt_handler
+
+        _register_hook("build_whisper_initial_prompt", vocab_initial_prompt_handler)
+        logger.info("✅ Speaker vocabulary STT-bias hook registered")
 
     # Backend i18n
     from utils.i18n import load_translations

--- a/src/backend/api/lifecycle.py
+++ b/src/backend/api/lifecycle.py
@@ -623,6 +623,13 @@ async def lifespan(app: "FastAPI"):
         register_hook("post_document_ingest", kg_post_document_ingest_hook)
         logger.info("✅ Knowledge Graph hooks registered")
 
+    # Whisper prompt cache invalidation — listen on household_graph_changed.
+    from services.whisper_prompt_builder import whisper_prompt_household_changed
+    from utils.hooks import register_hook as _register_hook
+
+    _register_hook("household_graph_changed", whisper_prompt_household_changed)
+    logger.info("✅ Whisper prompt-cache invalidation hook registered")
+
     # Backend i18n
     from utils.i18n import load_translations
     load_translations()

--- a/src/backend/api/routes/users.py
+++ b/src/backend/api/routes/users.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm import selectinload
 
 from models.database import Speaker, User
 from models.permissions import Permission
+from utils.hooks import run_hooks
 from services.auth_service import (
     get_password_hash,
     get_role_by_id,
@@ -286,6 +287,7 @@ async def create_user(
     await db.commit()
     await db.refresh(user, ["role"])
 
+    await run_hooks("household_graph_changed", kind="user", mutation="created")
     logger.info(f"Created user: {user.username} by {current_user.username if current_user else 'system'}")
 
     return UserResponse(
@@ -389,6 +391,7 @@ async def update_user(
     await db.commit()
     await db.refresh(user, ["role", "speaker"])
 
+    await run_hooks("household_graph_changed", kind="user", mutation="updated")
     logger.info(f"Updated user: {user.username} by {current_user.username if current_user else 'system'}")
 
     return UserResponse(
@@ -444,6 +447,7 @@ async def delete_user(
     await db.delete(user)
     await db.commit()
 
+    await run_hooks("household_graph_changed", kind="user", mutation="deleted")
     logger.info(f"Deleted user: {username} by {current_user.username if current_user else 'system'}")
 
     return {"message": f"User '{username}' deleted successfully"}

--- a/src/backend/ha_glue/api/routes/rooms.py
+++ b/src/backend/ha_glue/api/routes/rooms.py
@@ -14,6 +14,7 @@ from models.database import User
 from models.permissions import Permission
 from services.auth_service import require_permission
 from services.database import get_db
+from utils.hooks import run_hooks
 from ha_glue.services.room_service import RoomService
 
 # Import all schemas from separate file
@@ -66,6 +67,7 @@ async def create_room(
         icon=room.icon
     )
 
+    await run_hooks("household_graph_changed", kind="room", mutation="created")
     return service.room_to_dict(new_room)
 
 
@@ -121,6 +123,7 @@ async def update_room(
     if not room:
         raise HTTPException(status_code=404, detail="Room not found")
 
+    await run_hooks("household_graph_changed", kind="room", mutation="updated")
     return service.room_to_dict(room)
 
 
@@ -164,10 +167,11 @@ async def delete_room(
     room_name = room.name
     success = await service.delete_room(room_id)
 
-    if success:
-        return {"message": f"Room '{room_name}' deleted"}
-    else:
+    if not success:
         raise HTTPException(status_code=500, detail="Failed to delete room")
+
+    await run_hooks("household_graph_changed", kind="room", mutation="deleted")
+    return {"message": f"Room '{room_name}' deleted"}
 
 
 # --- Home Assistant Sync Endpoints ---
@@ -243,6 +247,8 @@ async def import_ha_areas(
         conflict_resolution=request.conflict_resolution
     )
 
+    if results.get("imported") or results.get("linked") or results.get("overwritten"):
+        await run_hooks("household_graph_changed", kind="room", mutation="created")
     return HAImportResponse(**results)
 
 
@@ -341,6 +347,9 @@ async def sync_with_ha(
         ha_areas=areas,
         conflict_resolution=conflict_resolution
     )
+
+    if import_results.get("imported") or import_results.get("linked") or import_results.get("overwritten"):
+        await run_hooks("household_graph_changed", kind="room", mutation="created")
 
     # Export (rooms without HA link)
     rooms_to_export = await service.get_rooms_for_export()

--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -3,7 +3,7 @@ Datenbank Models
 """
 from datetime import UTC, datetime
 
-from sqlalchemy import JSON, Boolean, Column, DateTime, Float, ForeignKey, Index, Integer, String, Text, UniqueConstraint
+from sqlalchemy import JSON, Boolean, Column, DateTime, Float, ForeignKey, Index, Integer, SmallInteger, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import TSVECTOR
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
@@ -111,6 +111,44 @@ class SpeakerEmbedding(Base):
 
     # Beziehungen
     speaker = relationship("Speaker", back_populates="embeddings")
+
+
+class SpeakerVocabularyCorpus(Base):
+    """Raw confirmed-speaker transcripts mined for per-user STT bias.
+
+    Privacy: `circle_tier` defaults to 0 (self) — these are private speech
+    samples and must never cross-bias other users' STT. Only persisted for
+    real (non-auto-enrolled) users with confidence above the recognition
+    threshold. The batch tokenizer reads from here and writes summaries
+    into `SpeakerVocabulary`.
+    """
+    __tablename__ = "speaker_vocabulary_corpus"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    text = Column(Text, nullable=False)
+    language = Column(String(10), nullable=False, default="de")
+    circle_tier = Column(SmallInteger, nullable=False, default=0)
+    created_at = Column(DateTime, default=_utcnow, nullable=False, index=True)
+
+
+class SpeakerVocabulary(Base):
+    """Per-user term frequencies, periodically rebuilt by the batch tokenizer.
+
+    The Whisper prompt builder's vocab handler queries the top-N terms by
+    frequency for the active speaker and folds them into the initial_prompt.
+    Cold start (no rows) means the handler returns None → platform default
+    fixed-structure prompt is used instead.
+    """
+    __tablename__ = "speaker_vocabulary"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    term = Column(String(100), nullable=False)
+    frequency = Column(Integer, nullable=False, default=0)
+    language = Column(String(10), nullable=False, default="de")
+    circle_tier = Column(SmallInteger, nullable=False, default=0)
+    last_updated = Column(DateTime, default=_utcnow, nullable=False)
 
 
 # --- Room management, device, and output-device models ---

--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -150,6 +150,18 @@ class SpeakerVocabulary(Base):
     circle_tier = Column(SmallInteger, nullable=False, default=0)
     last_updated = Column(DateTime, default=_utcnow, nullable=False)
 
+    # Composite index used by the prompt-builder's read path (top-N terms by
+    # frequency for a given user+language). Declared here so Alembic
+    # autogenerate sees it on subsequent revisions and doesn't emit spurious
+    # diffs for a "missing" index.
+    __table_args__ = (
+        UniqueConstraint("user_id", "term", "language", name="uq_speaker_vocab_user_term_lang"),
+        Index(
+            "ix_speaker_vocab_user_lang_freq",
+            "user_id", "language", frequency.desc(),
+        ),
+    )
+
 
 # --- Room management, device, and output-device models ---
 #

--- a/src/backend/services/speaker_vocabulary_service.py
+++ b/src/backend/services/speaker_vocabulary_service.py
@@ -1,0 +1,281 @@
+"""
+Speaker Vocabulary Service — per-user frequency-ranked STT bias.
+
+Phase B-3 follow-up. Mines confirmed-speaker transcripts to build a per-user
+vocabulary frequency table that the Whisper prompt builder folds into the
+`initial_prompt` for that user's future utterances. Helps the decoder pick
+household-specific names (Frigate, Paperless, Konferenzraum, technical
+German compound words) without needing a static configuration list.
+
+Pipeline:
+
+1. **Capture**: After `transcribe_with_speaker` confirms a real (not auto-
+   enrolled) speaker above the recognition threshold, the linked `User.id`
+   is looked up and the transcript is appended to `SpeakerVocabularyCorpus`.
+   Called fire-and-forget — capture failure must not break STT.
+
+2. **Tokenize**: A daily batch task pulls each user's recent corpus rows,
+   tokenizes them, and writes the top-N terms to `SpeakerVocabulary` keyed
+   on `(user_id, term, language)`. The tokenizer is deliberately simple
+   (regex split, lowercase, drop-short, drop-stopwords, drop-numerics).
+
+3. **Bias**: A `build_whisper_initial_prompt` hook handler queries the top-N
+   terms for the active speaker and language, fits them into the
+   ~200-char prompt budget, and returns it. If the user has no vocab yet
+   (cold start), the handler returns None and the platform default takes
+   over — no degradation.
+
+Privacy: corpus rows are tier-0 (self) by default. Frequency rows inherit
+the same tier. The query path filters by `user_id` only, never crosses
+speakers, so no circle_sql filter is needed at v1. If we ever expose vocab
+across users (e.g. household-common terms), the tier filter becomes load-
+bearing.
+"""
+from __future__ import annotations
+
+import re
+from collections import Counter
+from datetime import datetime, timedelta
+from typing import Optional
+
+from loguru import logger
+from sqlalchemy import delete, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from models.database import (
+    Speaker,
+    SpeakerVocabulary,
+    SpeakerVocabularyCorpus,
+    User,
+)
+# Re-exported at module level so tests can patch the symbol directly. The
+# capture + handler functions resolve `AsyncSessionLocal` from this module's
+# namespace, which means a `patch("services.speaker_vocabulary_service.AsyncSessionLocal", ...)`
+# replacement is honored. Lazy local imports inside the functions would hide
+# the symbol from monkeypatching and force tests to know about
+# `services.database` internals.
+from services.database import AsyncSessionLocal
+
+# Tokenization config
+_MIN_TOKEN_LENGTH = 3
+_MAX_TOKEN_LENGTH = 64
+_TOP_N_TERMS = 200
+_PROMPT_TERMS_INCLUDED = 30
+_CORPUS_LOOKBACK_DAYS = 60
+
+# Conservative German + English stopwords. Kept short on purpose — the
+# tokenizer otherwise drops anything < 3 chars and pure numbers, which
+# already eliminates most function words.
+_STOPWORDS_DE = frozenset({
+    "und", "oder", "aber", "ist", "sind", "war", "waren", "wird", "werden", "wurde",
+    "wurden", "habe", "hat", "hatte", "haben", "kann", "kannst", "können", "konnte",
+    "muss", "musst", "müssen", "sollte", "sollten", "darf", "dürfen", "möchte",
+    "der", "die", "das", "den", "dem", "des", "ein", "eine", "einen", "einem",
+    "einer", "eines", "kein", "keine", "keinen", "nicht", "doch", "noch", "nur",
+    "auch", "auf", "aus", "bei", "für", "mit", "nach", "über", "unter", "vor",
+    "von", "zu", "zur", "zum", "in", "im", "an", "am", "als", "wie", "wo",
+    "ich", "du", "er", "sie", "wir", "ihr", "mein", "dein", "sein", "ihr",
+    "mich", "dich", "uns", "euch", "sich", "diese", "diesem", "diesen", "dieses",
+})
+_STOPWORDS_EN = frozenset({
+    "the", "and", "but", "for", "with", "from", "this", "that", "these", "those",
+    "there", "here", "have", "has", "had", "are", "was", "were", "been", "being",
+    "you", "your", "yours", "they", "them", "their", "what", "when", "where",
+    "which", "who", "whom", "would", "could", "should", "into", "onto", "about",
+})
+
+_TOKEN_RE = re.compile(r"[A-Za-zÄÖÜäöüß][A-Za-zÄÖÜäöüß0-9-]{2,}")
+
+
+def _tokenize(text: str, language: str) -> list[str]:
+    """Conservative tokenizer: regex split, lowercase, filter stopwords + nums."""
+    stopwords = _STOPWORDS_DE if language.startswith("de") else _STOPWORDS_EN
+    out: list[str] = []
+    for match in _TOKEN_RE.finditer(text):
+        token = match.group(0).lower()
+        if not (_MIN_TOKEN_LENGTH <= len(token) <= _MAX_TOKEN_LENGTH):
+            continue
+        if token in stopwords:
+            continue
+        if token.isdigit():
+            continue
+        out.append(token)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Capture
+# ---------------------------------------------------------------------------
+
+async def capture_transcript(
+    *,
+    speaker_id: int,
+    text: str,
+    language: str,
+    is_new_speaker: bool,
+) -> None:
+    """Append a confirmed-speaker transcript to the corpus.
+
+    No-op if the speaker is auto-enrolled (we don't accumulate vocab for
+    "Unbekannter Sprecher #N") or if no User links to the speaker. Opens a
+    short-lived session so the caller's session lifecycle isn't entangled.
+    Failures are swallowed — capture must not break STT.
+    """
+    if is_new_speaker or not text.strip():
+        return
+    try:
+        async with AsyncSessionLocal() as session:
+            # Resolve the linked user. Speaker has no user FK; we look up
+            # the user that links to this speaker via User.speaker_id.
+            result = await session.execute(
+                select(User.id).where(User.speaker_id == speaker_id).limit(1)
+            )
+            user_id = result.scalar_one_or_none()
+            if user_id is None:
+                return  # Identified speaker, but no user account linked
+
+            row = SpeakerVocabularyCorpus(
+                user_id=user_id,
+                text=text.strip(),
+                language=language,
+                circle_tier=0,
+            )
+            session.add(row)
+            await session.commit()
+    except Exception as e:
+        logger.debug(f"speaker_vocabulary_service.capture_transcript failed: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Batch tokenizer
+# ---------------------------------------------------------------------------
+
+async def rebuild_vocabulary(*, db_session) -> dict[str, int]:
+    """Rebuild the per-user vocabulary table from recent corpus rows.
+
+    Idempotent: deletes old vocab rows for each user/language with new corpus
+    activity, then inserts the top-N terms. Languages with no corpus activity
+    in the lookback window are left alone.
+
+    Returns counters {users_processed, terms_written, corpus_rows_consumed}.
+    """
+    cutoff = datetime.utcnow() - timedelta(days=_CORPUS_LOOKBACK_DAYS)
+    result = await db_session.execute(
+        select(SpeakerVocabularyCorpus.user_id, SpeakerVocabularyCorpus.language, SpeakerVocabularyCorpus.text)
+        .where(SpeakerVocabularyCorpus.created_at >= cutoff)
+    )
+    rows = result.all()
+
+    by_key: dict[tuple[int, str], Counter] = {}
+    for user_id, language, text in rows:
+        counter = by_key.setdefault((user_id, language), Counter())
+        counter.update(_tokenize(text, language))
+
+    users_processed = 0
+    terms_written = 0
+
+    for (user_id, language), counter in by_key.items():
+        # Replace existing vocab for (user, language) — idempotent rebuild.
+        await db_session.execute(
+            delete(SpeakerVocabulary)
+            .where(SpeakerVocabulary.user_id == user_id)
+            .where(SpeakerVocabulary.language == language)
+        )
+
+        top = counter.most_common(_TOP_N_TERMS)
+        if not top:
+            continue
+        now = datetime.utcnow()
+        rows_to_insert = [
+            {
+                "user_id": user_id,
+                "term": term,
+                "frequency": freq,
+                "language": language,
+                "circle_tier": 0,
+                "last_updated": now,
+            }
+            for term, freq in top
+        ]
+        # ON CONFLICT DO NOTHING is defense-in-depth; the DELETE above
+        # should already have cleared the keyspace for this (user, lang).
+        stmt = pg_insert(SpeakerVocabulary).values(rows_to_insert)
+        stmt = stmt.on_conflict_do_nothing(
+            index_elements=["user_id", "term", "language"]
+        )
+        await db_session.execute(stmt)
+        users_processed += 1
+        terms_written += len(rows_to_insert)
+
+    await db_session.commit()
+    return {
+        "users_processed": users_processed,
+        "terms_written": terms_written,
+        "corpus_rows_consumed": len(rows),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Hook handler — build_whisper_initial_prompt
+# ---------------------------------------------------------------------------
+
+async def vocab_initial_prompt_handler(
+    *,
+    user_id: int | None,
+    room_id: int | None,
+    language: str,
+) -> Optional[str]:
+    """Hook handler that returns a vocab-biased prompt or None.
+
+    Falls through to the platform default whenever:
+    - user_id is None (no identity to bias toward)
+    - the user has no vocab rows yet (cold start)
+    - DB access fails for any reason
+    """
+    if user_id is None:
+        return None
+    try:
+        # Open a short-lived session so this handler doesn't depend on a
+        # caller-supplied db_session.
+        async with AsyncSessionLocal() as session:
+            result = await session.execute(
+                select(SpeakerVocabulary.term)
+                .where(SpeakerVocabulary.user_id == user_id)
+                .where(SpeakerVocabulary.language == language)
+                .order_by(SpeakerVocabulary.frequency.desc())
+                .limit(_PROMPT_TERMS_INCLUDED)
+            )
+            terms = [t for (t,) in result.all()]
+
+            if not terms:
+                return None
+
+            # Resolve the speaker name for the prefix.
+            user_result = await session.execute(
+                select(User.first_name, User.username).where(User.id == user_id)
+            )
+            user_row = user_result.first()
+            speaker_label = ""
+            if user_row:
+                first_name, username = user_row
+                speaker_label = (first_name or username or "").strip()
+
+        labels = _PROMPT_LABELS.get(language, _PROMPT_LABELS["de"])
+        head = f"{labels['speaker']}: {speaker_label}. " if speaker_label else ""
+        prompt = f"{head}{labels['frequent']}: {', '.join(terms)}."
+        return prompt[:220].rstrip()
+    except Exception as e:
+        logger.debug(f"vocab_initial_prompt_handler failed: {e}")
+        return None
+
+
+_PROMPT_LABELS = {
+    "de": {"speaker": "Sprecher", "frequent": "Häufige Begriffe"},
+    "en": {"speaker": "Speaker", "frequent": "Frequent terms"},
+}
+
+
+# Speaker model is imported only for symbol-availability — referenced by the
+# capture path's User-by-speaker_id query. Keeps the migration dependency
+# graph honest.
+_ = Speaker

--- a/src/backend/services/speaker_vocabulary_service.py
+++ b/src/backend/services/speaker_vocabulary_service.py
@@ -88,7 +88,11 @@ _TOKEN_RE = re.compile(r"[A-Za-zÄÖÜäöüß][A-Za-zÄÖÜäöüß0-9-]{2,}")
 
 
 def _tokenize(text: str, language: str) -> list[str]:
-    """Conservative tokenizer: regex split, lowercase, filter stopwords + nums."""
+    """Conservative tokenizer: regex split, lowercase, filter stopwords.
+
+    `_TOKEN_RE` requires a leading letter, so pure-numeric runs are filtered
+    at the regex level — no separate `isdigit()` guard needed downstream.
+    """
     stopwords = _STOPWORDS_DE if language.startswith("de") else _STOPWORDS_EN
     out: list[str] = []
     for match in _TOKEN_RE.finditer(text):
@@ -96,8 +100,6 @@ def _tokenize(text: str, language: str) -> list[str]:
         if not (_MIN_TOKEN_LENGTH <= len(token) <= _MAX_TOKEN_LENGTH):
             continue
         if token in stopwords:
-            continue
-        if token.isdigit():
             continue
         out.append(token)
     return out
@@ -174,40 +176,49 @@ async def rebuild_vocabulary(*, db_session) -> dict[str, int]:
     users_processed = 0
     terms_written = 0
 
+    # Per-user commits so a failure on user N doesn't roll back users 1..N-1.
+    # The rebuild is meant to be idempotent — partial progress is fine.
     for (user_id, language), counter in by_key.items():
-        # Replace existing vocab for (user, language) — idempotent rebuild.
-        await db_session.execute(
-            delete(SpeakerVocabulary)
-            .where(SpeakerVocabulary.user_id == user_id)
-            .where(SpeakerVocabulary.language == language)
-        )
+        try:
+            # Replace existing vocab for (user, language) — idempotent rebuild.
+            await db_session.execute(
+                delete(SpeakerVocabulary)
+                .where(SpeakerVocabulary.user_id == user_id)
+                .where(SpeakerVocabulary.language == language)
+            )
 
-        top = counter.most_common(_TOP_N_TERMS)
-        if not top:
-            continue
-        now = datetime.utcnow()
-        rows_to_insert = [
-            {
-                "user_id": user_id,
-                "term": term,
-                "frequency": freq,
-                "language": language,
-                "circle_tier": 0,
-                "last_updated": now,
-            }
-            for term, freq in top
-        ]
-        # ON CONFLICT DO NOTHING is defense-in-depth; the DELETE above
-        # should already have cleared the keyspace for this (user, lang).
-        stmt = pg_insert(SpeakerVocabulary).values(rows_to_insert)
-        stmt = stmt.on_conflict_do_nothing(
-            index_elements=["user_id", "term", "language"]
-        )
-        await db_session.execute(stmt)
-        users_processed += 1
-        terms_written += len(rows_to_insert)
+            top = counter.most_common(_TOP_N_TERMS)
+            if not top:
+                await db_session.commit()
+                continue
+            now = datetime.utcnow()
+            rows_to_insert = [
+                {
+                    "user_id": user_id,
+                    "term": term,
+                    "frequency": freq,
+                    "language": language,
+                    "circle_tier": 0,
+                    "last_updated": now,
+                }
+                for term, freq in top
+            ]
+            # ON CONFLICT DO NOTHING is defense-in-depth; the DELETE above
+            # should already have cleared the keyspace for this (user, lang).
+            stmt = pg_insert(SpeakerVocabulary).values(rows_to_insert)
+            stmt = stmt.on_conflict_do_nothing(
+                index_elements=["user_id", "term", "language"]
+            )
+            await db_session.execute(stmt)
+            await db_session.commit()
+            users_processed += 1
+            terms_written += len(rows_to_insert)
+        except Exception as e:
+            await db_session.rollback()
+            logger.warning(
+                f"speaker_vocabulary rebuild failed for user_id={user_id} lang={language}: {e}"
+            )
 
-    await db_session.commit()
     return {
         "users_processed": users_processed,
         "terms_written": terms_written,

--- a/src/backend/services/whisper_prompt_builder.py
+++ b/src/backend/services/whisper_prompt_builder.py
@@ -210,6 +210,20 @@ def get_whisper_prompt_builder() -> WhisperPromptBuilder:
     return _instance
 
 
+async def whisper_prompt_household_changed(
+    *, kind: str, mutation: str
+) -> None:
+    """Hook handler for `household_graph_changed` — drops the prompt cache.
+
+    Fire-and-forget. The cost of an extra DB roundtrip on the next STT call is
+    cheap (5 ms) compared to keeping a stale "Personen" / "Räume" list around
+    for up to 5 minutes after a rename or member change.
+    """
+    get_whisper_prompt_builder().invalidate()
+    logger.debug(f"WhisperPromptBuilder cache invalidated ({kind} {mutation})")
+    return None
+
+
 async def resolve_first_speaker_from_room(
     *, room_id: int | None
 ) -> Optional[int]:

--- a/src/backend/services/whisper_service.py
+++ b/src/backend/services/whisper_service.py
@@ -394,6 +394,21 @@ class WhisperService:
                             db_session, identified_speaker.id, embedding, service
                         )
 
+                    # Vocabulary corpus capture (B-3 follow-up): fire-and-forget.
+                    # Opens its own session, swallows errors. Skips auto-enrolled
+                    # speakers and ones not linked to a User account.
+                    if settings.speaker_vocab_capture_enabled and text:
+                        from services.speaker_vocabulary_service import capture_transcript
+
+                        asyncio.create_task(
+                            capture_transcript(
+                                speaker_id=identified_speaker.id,
+                                text=text,
+                                language=transcribe_language,
+                                is_new_speaker=False,
+                            )
+                        )
+
                 # Case 2: No speaker identified - auto-enroll if enabled
                 elif settings.speaker_auto_enroll:
                     # Count existing "Unbekannter Sprecher" entries

--- a/src/backend/services/whisper_service.py
+++ b/src/backend/services/whisper_service.py
@@ -20,6 +20,19 @@ from loguru import logger
 
 from utils.config import settings
 
+# Strong-reference set for fire-and-forget background tasks. Without this,
+# Python's asyncio is free to garbage-collect tasks not held anywhere — see
+# https://docs.python.org/3.11/library/asyncio-task.html#asyncio.create_task
+# Tasks remove themselves from the set when they finish via add_done_callback.
+_background_tasks: set[asyncio.Task] = set()
+
+
+def _spawn_background(coro) -> None:
+    """Schedule a fire-and-forget coroutine that won't be GC'd before completion."""
+    task = asyncio.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+
 # Optional: librosa and soundfile for audio preprocessing
 try:
     import librosa
@@ -397,10 +410,13 @@ class WhisperService:
                     # Vocabulary corpus capture (B-3 follow-up): fire-and-forget.
                     # Opens its own session, swallows errors. Skips auto-enrolled
                     # speakers and ones not linked to a User account.
+                    # Use _spawn_background to keep a strong reference — bare
+                    # asyncio.create_task lets the GC eat short-lived tasks
+                    # before the DB commit completes (silent data loss).
                     if settings.speaker_vocab_capture_enabled and text:
                         from services.speaker_vocabulary_service import capture_transcript
 
-                        asyncio.create_task(
+                        _spawn_background(
                             capture_transcript(
                                 speaker_id=identified_speaker.id,
                                 text=text,

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -133,6 +133,11 @@ class Settings(BaseSettings):
     speaker_recognition_device: str = "cpu"      # Device for inference: "cpu" or "cuda"
     speaker_auto_enroll: bool = True             # Auto-create unknown speakers and save embeddings
     speaker_continuous_learning: bool = True     # Add embeddings to known speakers on each interaction
+    # Per-user vocabulary corpus capture (Phase B-3 follow-up). Confirmed-
+    # speaker transcripts are appended to speaker_vocabulary_corpus and a
+    # daily batch job rebuilds the per-user vocab table for STT bias.
+    speaker_vocab_capture_enabled: bool = True
+    speaker_vocab_rebuild_interval_seconds: int = 86400  # Daily
 
     # Room Management / Satellite OTA moved to ha_glue/utils/config.py.
 

--- a/src/backend/utils/hooks.py
+++ b/src/backend/utils/hooks.py
@@ -110,6 +110,16 @@ HOOK_EVENTS: frozenset[str] = frozenset({
     # The platform default builder pulls user/room names from the DB; see
     # services/whisper_prompt_builder.py.
     "build_whisper_initial_prompt",
+    # Broadcast — the household graph (users / rooms) mutated. Fired by
+    # user/room mutation routes (POST/PATCH/DELETE on /api/users, /api/rooms)
+    # and by ha_glue's HA-area sync paths when they auto-create or rename
+    # rooms. Kwargs: `kind: str` ("user" | "room"), `mutation: str`
+    # ("created" | "updated" | "deleted"). Handlers are fire-and-forget;
+    # exceptions are swallowed. Currently consumed by the WhisperPromptBuilder
+    # to drop its 5-min TTL cache so renamed rooms / new users land in the
+    # next STT prompt immediately. Other listeners (future entity-list
+    # caches, intent-context builders) plug in here without further wiring.
+    "household_graph_changed",
     # Route a chat response's TTS audio to a device output. Fired by
     # `api/websocket/chat_handler.py` when an LLM response is ready and
     # the chat session has a room context. Kwargs: `room_context: dict,

--- a/tests/backend/test_speaker_vocabulary_service.py
+++ b/tests/backend/test_speaker_vocabulary_service.py
@@ -1,0 +1,245 @@
+"""Tests for speaker_vocabulary_service (Phase B-3 follow-up)."""
+import sys
+from collections import Counter
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Pre-mock optional native deps that the import chain pulls in.
+_missing_stubs = [
+    "asyncpg", "faster_whisper", "speechbrain",
+    "speechbrain.inference", "speechbrain.inference.speaker",
+    "openwakeword", "openwakeword.model",
+    "piper", "piper.voice",
+]
+for _mod in _missing_stubs:
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+import pytest
+
+from services.speaker_vocabulary_service import (
+    _tokenize,
+    capture_transcript,
+    vocab_initial_prompt_handler,
+)
+
+
+@pytest.mark.unit
+class TestTokenizer:
+
+    def test_drops_short_tokens(self):
+        tokens = _tokenize("Ja so ist das", "de")
+        # "Ja", "so", "ist", "das" — all <= 3 chars or stopwords
+        assert tokens == []
+
+    def test_keeps_meaningful_de_words(self):
+        tokens = _tokenize("Schalte das Licht im Wohnzimmer an", "de")
+        assert "schalte" in tokens
+        assert "licht" in tokens
+        assert "wohnzimmer" in tokens
+
+    def test_drops_german_stopwords(self):
+        tokens = _tokenize("Der Hund läuft schnell", "de")
+        assert "der" not in tokens
+        assert "hund" in tokens
+
+    def test_drops_english_stopwords(self):
+        tokens = _tokenize("The dog runs fast", "en")
+        assert "the" not in tokens
+        assert "dog" in tokens
+
+    def test_drops_pure_numbers(self):
+        tokens = _tokenize("Frigate 12345 Konferenzraum 2026", "de")
+        assert "frigate" in tokens
+        assert "konferenzraum" in tokens
+        # The regex requires a leading letter so pure digit runs are already
+        # filtered at the regex level, not by the isdigit() branch.
+        assert "12345" not in tokens
+        assert "2026" not in tokens
+
+    def test_lowercases(self):
+        tokens = _tokenize("Frigate Paperless Treehouse", "de")
+        assert tokens == ["frigate", "paperless", "treehouse"]
+
+    def test_preserves_umlauts(self):
+        tokens = _tokenize("Schlüssel Übergabe Mahnung", "de")
+        assert "schlüssel" in tokens
+        assert "übergabe" in tokens
+        assert "mahnung" in tokens
+
+
+@pytest.mark.unit
+class TestCaptureTranscript:
+
+    @pytest.mark.asyncio
+    async def test_skips_new_speakers(self):
+        """Auto-enrolled 'Unbekannter Sprecher' rows must not feed the corpus."""
+        with patch("services.speaker_vocabulary_service.AsyncSessionLocal") as mock_factory:
+            await capture_transcript(
+                speaker_id=42, text="hello", language="de", is_new_speaker=True
+            )
+        mock_factory.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_empty_text(self):
+        with patch("services.speaker_vocabulary_service.AsyncSessionLocal") as mock_factory:
+            await capture_transcript(
+                speaker_id=42, text="   ", language="de", is_new_speaker=False
+            )
+        mock_factory.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_when_no_user_linked(self):
+        """Identified speaker but no User account → no corpus row written."""
+        session = MagicMock()
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=result)
+        session.add = MagicMock()
+        session.commit = AsyncMock()
+
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=session)
+        ctx.__aexit__ = AsyncMock(return_value=None)
+        with patch("services.speaker_vocabulary_service.AsyncSessionLocal", return_value=ctx):
+            await capture_transcript(
+                speaker_id=42, text="something", language="de", is_new_speaker=False
+            )
+        session.add.assert_not_called()
+        session.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_appends_corpus_row_for_known_user(self):
+        session = MagicMock()
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = 7  # user_id
+        session.execute = AsyncMock(return_value=result)
+        session.add = MagicMock()
+        session.commit = AsyncMock()
+
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=session)
+        ctx.__aexit__ = AsyncMock(return_value=None)
+        with patch("services.speaker_vocabulary_service.AsyncSessionLocal", return_value=ctx):
+            await capture_transcript(
+                speaker_id=42, text="Schalte das Licht ein", language="de", is_new_speaker=False
+            )
+
+        session.add.assert_called_once()
+        session.commit.assert_called_once()
+        added = session.add.call_args[0][0]
+        assert added.user_id == 7
+        assert added.text == "Schalte das Licht ein"
+        assert added.language == "de"
+        assert added.circle_tier == 0
+
+    @pytest.mark.asyncio
+    async def test_swallows_db_errors(self):
+        """capture_transcript must not raise — it's fire-and-forget."""
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(side_effect=RuntimeError("DB exploded"))
+        ctx.__aexit__ = AsyncMock(return_value=None)
+        with patch("services.speaker_vocabulary_service.AsyncSessionLocal", return_value=ctx):
+            # Must not raise
+            await capture_transcript(
+                speaker_id=42, text="hello", language="de", is_new_speaker=False
+            )
+
+
+@pytest.mark.unit
+class TestVocabInitialPromptHandler:
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_user_id_is_none(self):
+        result = await vocab_initial_prompt_handler(
+            user_id=None, room_id=10, language="de"
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_cold_start(self):
+        """No vocab rows yet → None, platform default takes over."""
+        session = MagicMock()
+        empty_result = MagicMock()
+        empty_result.all.return_value = []
+        session.execute = AsyncMock(return_value=empty_result)
+
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=session)
+        ctx.__aexit__ = AsyncMock(return_value=None)
+        with patch("services.speaker_vocabulary_service.AsyncSessionLocal", return_value=ctx):
+            result = await vocab_initial_prompt_handler(
+                user_id=1, room_id=None, language="de"
+            )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_builds_prompt_with_user_name_and_terms(self):
+        session = MagicMock()
+        terms_result = MagicMock()
+        terms_result.all.return_value = [("frigate",), ("paperless",), ("wohnzimmer",)]
+        user_result = MagicMock()
+        user_result.first.return_value = ("Eduard", "evdb")
+        session.execute = AsyncMock(side_effect=[terms_result, user_result])
+
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=session)
+        ctx.__aexit__ = AsyncMock(return_value=None)
+        with patch("services.speaker_vocabulary_service.AsyncSessionLocal", return_value=ctx):
+            result = await vocab_initial_prompt_handler(
+                user_id=1, room_id=None, language="de"
+            )
+        assert result is not None
+        assert "Sprecher: Eduard" in result
+        assert "Häufige Begriffe: frigate, paperless, wohnzimmer" in result
+
+    @pytest.mark.asyncio
+    async def test_builds_english_prompt(self):
+        session = MagicMock()
+        terms_result = MagicMock()
+        terms_result.all.return_value = [("docker",), ("cluster",)]
+        user_result = MagicMock()
+        user_result.first.return_value = ("Eduard", "evdb")
+        session.execute = AsyncMock(side_effect=[terms_result, user_result])
+
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=session)
+        ctx.__aexit__ = AsyncMock(return_value=None)
+        with patch("services.speaker_vocabulary_service.AsyncSessionLocal", return_value=ctx):
+            result = await vocab_initial_prompt_handler(
+                user_id=1, room_id=None, language="en"
+            )
+        assert result is not None
+        assert "Speaker: Eduard" in result
+        assert "Frequent terms: docker, cluster" in result
+
+    @pytest.mark.asyncio
+    async def test_truncates_long_prompt(self):
+        session = MagicMock()
+        terms_result = MagicMock()
+        # 30 long terms → easily > 220 chars
+        long_terms = [(f"langeswort{i}",) for i in range(30)]
+        terms_result.all.return_value = long_terms
+        user_result = MagicMock()
+        user_result.first.return_value = ("Eduard", "evdb")
+        session.execute = AsyncMock(side_effect=[terms_result, user_result])
+
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=session)
+        ctx.__aexit__ = AsyncMock(return_value=None)
+        with patch("services.speaker_vocabulary_service.AsyncSessionLocal", return_value=ctx):
+            result = await vocab_initial_prompt_handler(
+                user_id=1, room_id=None, language="de"
+            )
+        assert result is not None
+        assert len(result) <= 220
+
+    @pytest.mark.asyncio
+    async def test_swallows_db_errors_returns_none(self):
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(side_effect=RuntimeError("DB exploded"))
+        ctx.__aexit__ = AsyncMock(return_value=None)
+        with patch("services.speaker_vocabulary_service.AsyncSessionLocal", return_value=ctx):
+            result = await vocab_initial_prompt_handler(
+                user_id=1, room_id=None, language="de"
+            )
+        assert result is None

--- a/tests/backend/test_whisper_prompt_builder.py
+++ b/tests/backend/test_whisper_prompt_builder.py
@@ -265,6 +265,31 @@ class TestPromptLength:
 
 
 @pytest.mark.unit
+class TestHouseholdGraphChangedHook:
+
+    @pytest.mark.asyncio
+    async def test_invalidate_handler_clears_cache(self):
+        """The handler that ships with the module clears the singleton's cache."""
+        from services.whisper_prompt_builder import whisper_prompt_household_changed
+
+        builder = get_whisper_prompt_builder()
+        # Seed the cache so we have something to clear.
+        with patch("services.whisper_prompt_builder.run_hooks", AsyncMock(return_value=["seed"])):
+            await builder.build(user_id=1, room_id=10, language="de", db_session=None)
+        assert builder.stats()["size"] == 1
+
+        await whisper_prompt_household_changed(kind="user", mutation="created")
+        assert builder.stats()["size"] == 0
+
+    @pytest.mark.asyncio
+    async def test_handler_returns_none_for_fire_and_forget_contract(self):
+        """Hook returns None so run_hooks() doesn't accumulate it as a result."""
+        from services.whisper_prompt_builder import whisper_prompt_household_changed
+        result = await whisper_prompt_household_changed(kind="room", mutation="updated")
+        assert result is None
+
+
+@pytest.mark.unit
 class TestSingletonAccessor:
 
     def test_get_whisper_prompt_builder_returns_singleton(self):


### PR DESCRIPTION
## Summary

The two B-3 follow-ups discussed in the architecture doc.

### 1. Hook-broadcast cache invalidation

The 5-min TTL on \`WhisperPromptBuilder\` was a v1 contract. Renamed rooms or new household members lingered in cached prompts for up to 5 minutes.

- New broadcast event \`household_graph_changed\` (kwargs: \`kind\`, \`mutation\`)
- Fired by user/room mutation routes (POST/PATCH/DELETE on \`/api/users\`, \`/api/rooms\`, plus the HA-area import paths)
- \`WhisperPromptBuilder\` registers a fire-and-forget handler that drops its cache on receipt
- Future caches (frequency-vocab, intent-context entity list) plug in here without amendments to mutation sites

### 2. Per-user frequency-ranked STT vocabulary

Mines confirmed-speaker transcripts to build a per-user vocab frequency table that the prompt builder folds into \`initial_prompt\`.

**Pipeline:**
1. **Capture** — after \`transcribe_with_speaker\` confirms a real (not auto-enrolled) speaker, the linked \`User.id\` is resolved via \`User.speaker_id\` and the transcript is appended to \`speaker_vocabulary_corpus\` (fire-and-forget).
2. **Tokenize** — daily lifecycle loop runs a regex tokenizer (lowercase, drop short/numeric/de+en stopwords), counts per \`(user_id, language)\`, writes top-200 to \`speaker_vocabulary\`. Idempotent rebuild.
3. **Bias** — \`vocab_initial_prompt_handler\` registers on \`build_whisper_initial_prompt\`. Queries top-30 terms, formats as \`Sprecher: X. Häufige Begriffe: a, b, c, ...\`. Returns None on cold start → platform default takes over.

**Privacy:** Both tables carry \`circle_tier\` defaulting to 0 (self). Lookup is per-user_id; vocab never crosses speakers by design at v1. Tier filter becomes load-bearing if we ever expose vocab across users (household-common terms).

## Files

- \`alembic/versions/a0b1c2d3e4f5_add_speaker_vocabulary.py\` — new migration
- \`models/database.py\` — \`SpeakerVocabularyCorpus\`, \`SpeakerVocabulary\` ORM
- \`services/speaker_vocabulary_service.py\` — tokenizer, capture, batch rebuild, hook handler
- \`services/whisper_prompt_builder.py\` — invalidate hook handler, kept module exports stable
- \`api/lifecycle.py\` — register both hooks at startup, schedule daily vocab rebuild
- \`api/routes/users.py\` — fire \`household_graph_changed\` on mutations
- \`ha_glue/api/routes/rooms.py\` — same for room mutations + HA-area import
- \`utils/hooks.py\` — declare \`household_graph_changed\`
- \`utils/config.py\` — \`speaker_vocab_capture_enabled\` (default true) + rebuild interval
- \`services/whisper_service.py\` — fire-and-forget capture call in Case 1 (identified speaker)

## Tests

- 18 new vocab tests (tokenizer, capture, handler)
- 1 new cache-invalidation test (handler clears the cache)
- Total: 105/106 pass on .159 staging — same pre-existing flake as main, no new failures

## Out of scope

- B-4 (audio-preprocessing offload) — soft-blocked on Opus encoding, hard-blocked on the XVF3800 vs software-only architecture decision

## Test plan

- [ ] Migration runs cleanly on the cluster: \`alembic upgrade head\`
- [ ] Vocab corpus accumulates rows after a few confirmed-speaker turns
- [ ] After 24h, the rebuild loop produces non-empty \`speaker_vocabulary\` rows
- [ ] On the next STT call, log shows the vocab handler returning a "Sprecher: X. Häufige Begriffe: ..." prompt instead of the platform default
- [ ] Renaming a room takes effect on the very next STT call (cache invalidated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)