### PR TITLE
fix(alembic): re-chain speaker_vocabulary to current head

### DIFF
--- a/src/backend/alembic/versions/a0b1c2d3e4f5_add_speaker_vocabulary.py
+++ b/src/backend/alembic/versions/a0b1c2d3e4f5_add_speaker_vocabulary.py
@@ -7,7 +7,7 @@ Phase B-3 follow-up: per-user frequency-ranked vocabulary for STT bias.
   by the batch tokenizer.
 
 Revision ID: a0b1c2d3e4f5
-Revises: z9a0b1c2d3e4
+Revises: pc20260426_paperless_upload_tracking
 Create Date: 2026-05-02
 """
 import sqlalchemy as sa
@@ -15,7 +15,7 @@ from alembic import op
 
 # revision identifiers
 revision = "a0b1c2d3e4f5"
-down_revision = "z9a0b1c2d3e4"
+down_revision = "pc20260426_paperless_upload_tracking"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
v2.4.2 deploy was blocked: the speaker_vocabulary migration's \`down_revision = "z9a0b1c2d3e4"\` collided with \`pc20260331_add_parent_chunk_id\`, which already chains off \`z9a0b1c2d3e4\`. Two children of one parent → alembic 'Multiple head revisions' error.

Re-chain off \`pc20260426_paperless_upload_tracking\` (the actual single head per \`alembic current\` against the live cluster). Schema unchanged — just the pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)