### PR TITLE
feat(reva-compat): bridge — prompt_hashes on /health + Token budget log line

### DIFF
--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -274,8 +274,19 @@ async def wakeword_websocket(websocket: WebSocket):
 # Health Check Endpoints
 @app.get("/health")
 async def health_check():
-    """Quick health check for load balancers."""
-    return {"status": "ok"}
+    """Quick health check for load balancers.
+
+    Includes `prompt_hashes` (12-char SHA-256 prefixes per loaded YAML file)
+    so deploy verification can confirm a release actually changed the prompts.
+    Used by Reva's audit trail and the deployment-verification check.
+    """
+    try:
+        from services.prompt_manager import prompt_manager
+        prompt_hashes = prompt_manager.prompt_hashes
+    except Exception:
+        # Health endpoint must never fail — if PromptManager isn't ready, omit the field.
+        prompt_hashes = {}
+    return {"status": "ok", "prompt_hashes": prompt_hashes}
 
 
 _health_redis_client = None

--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -816,9 +816,10 @@ class AgentService:
         # Canonical entry-log line. Stable format consumed by Reva's
         # `test_token_budget_logged` E2E assertion and any future grafana
         # log-based dashboard. Subsequent "Budget pass N (...)" lines remain
-        # for per-reduction observability.
+        # for per-reduction observability. `:.1%` retains one decimal so a
+        # 0.8% load doesn't truncate to a misleading `(0%)`.
         logger.info(
-            f"Token budget: {prompt_tokens + reserved}/{max_tokens} ({utilization:.0%})"
+            f"Token budget: {prompt_tokens + reserved}/{max_tokens} ({utilization:.1%})"
         )
 
         try:

--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -813,6 +813,14 @@ class AgentService:
         utilization = (prompt_tokens + reserved) / max_tokens
         passes_run: list[str] = []
 
+        # Canonical entry-log line. Stable format consumed by Reva's
+        # `test_token_budget_logged` E2E assertion and any future grafana
+        # log-based dashboard. Subsequent "Budget pass N (...)" lines remain
+        # for per-reduction observability.
+        logger.info(
+            f"Token budget: {prompt_tokens + reserved}/{max_tokens} ({utilization:.0%})"
+        )
+
         try:
             if utilization <= threshold:
                 return prompt, memory_context, document_context, conversation_history

--- a/tests/backend/test_health_endpoint.py
+++ b/tests/backend/test_health_endpoint.py
@@ -40,16 +40,21 @@ class TestHealthEndpoint:
 
     @pytest.mark.asyncio
     async def test_health_tolerates_prompt_manager_failure(self):
-        """If PromptManager raises during access, /health still returns 'ok'."""
+        """If PromptManager raises during access, /health still returns 'ok'.
+
+        The mutating-the-MagicMock-class trick (`type(mock).prop = property(...)`)
+        leaks across tests because unittest.mock.patch does NOT restore class-
+        level descriptor additions. Subclass `MagicMock` instead so the
+        descriptor is scoped to one instance type and is GC'd with the test.
+        """
         from main import health_check
 
-        broken_pm = MagicMock()
-        # Reading the property must raise — use a property descriptor on the class
-        type(broken_pm).prompt_hashes = property(
-            lambda self: (_ for _ in ()).throw(RuntimeError("PM not ready"))
-        )
+        class _BrokenPM(MagicMock):
+            @property
+            def prompt_hashes(self):
+                raise RuntimeError("PM not ready")
 
-        with patch("services.prompt_manager.prompt_manager", broken_pm):
+        with patch("services.prompt_manager.prompt_manager", _BrokenPM()):
             result = await health_check()
 
         assert result["status"] == "ok"

--- a/tests/backend/test_health_endpoint.py
+++ b/tests/backend/test_health_endpoint.py
@@ -1,0 +1,56 @@
+"""Tests for the `/health` endpoint.
+
+Reva-compat: `/health` must expose `prompt_hashes` (12-char SHA-256 prefixes
+per loaded prompt YAML) so deploys can be verified to actually have changed
+the prompts. Used by Reva's audit trail.
+"""
+import sys
+from unittest.mock import MagicMock, patch
+
+# Pre-mock optional native deps
+_missing_stubs = [
+    "asyncpg", "faster_whisper", "speechbrain",
+    "speechbrain.inference", "speechbrain.inference.speaker",
+    "openwakeword", "openwakeword.model",
+    "piper", "piper.voice",
+]
+for _mod in _missing_stubs:
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+import pytest
+
+
+@pytest.mark.unit
+class TestHealthEndpoint:
+
+    @pytest.mark.asyncio
+    async def test_health_includes_prompt_hashes(self):
+        """The `/health` handler returns prompt_hashes from PromptManager."""
+        from main import health_check
+
+        fake_pm = MagicMock()
+        fake_pm.prompt_hashes = {"agent": "abc123def456", "intent": "deadbeefcafe"}
+
+        with patch("services.prompt_manager.prompt_manager", fake_pm):
+            result = await health_check()
+
+        assert result["status"] == "ok"
+        assert result["prompt_hashes"] == {"agent": "abc123def456", "intent": "deadbeefcafe"}
+
+    @pytest.mark.asyncio
+    async def test_health_tolerates_prompt_manager_failure(self):
+        """If PromptManager raises during access, /health still returns 'ok'."""
+        from main import health_check
+
+        broken_pm = MagicMock()
+        # Reading the property must raise — use a property descriptor on the class
+        type(broken_pm).prompt_hashes = property(
+            lambda self: (_ for _ in ()).throw(RuntimeError("PM not ready"))
+        )
+
+        with patch("services.prompt_manager.prompt_manager", broken_pm):
+            result = await health_check()
+
+        assert result["status"] == "ok"
+        assert result["prompt_hashes"] == {}

--- a/tests/backend/test_token_budget.py
+++ b/tests/backend/test_token_budget.py
@@ -159,3 +159,39 @@ class TestEnforceTokenBudget:
             # History should have been reduced to last 3
             assert returned_hist is not None
             assert len(returned_hist) <= 3
+
+
+class TestTokenBudgetLogLine:
+    """Reva-compat: `_enforce_token_budget` must emit a `Token budget: N/M (X%)`
+    log line on entry. Reva's `test_token_budget_logged` E2E asserts on this
+    substring; subsequent "Budget pass N (...)" lines are observability and
+    not part of the contract.
+    """
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_emits_canonical_log_line(self):
+        agent = _make_agent()
+        ctx = AgentContext(original_message="test")
+        prompt = "Hello " * 100
+
+        captured: list[str] = []
+        with patch("services.agent_service.settings") as s, \
+             patch("services.agent_service.logger") as log:
+            s.ollama_num_ctx = 32768
+            s.agent_default_num_predict = 2048
+            s.agent_budget_threshold = 0.85
+            log.info.side_effect = lambda msg, *a, **kw: captured.append(msg)
+
+            await agent._enforce_token_budget(
+                prompt, ctx, "test", None,
+                memory_context="", document_context="", lang="de",
+            )
+
+        # At least one log line must start with "Token budget:" — that's the
+        # contract Reva relies on. Format: "Token budget: <used>/<max> (<%>)".
+        canonical = [m for m in captured if m.startswith("Token budget:")]
+        assert canonical, f"No canonical log line found. Captured: {captured}"
+        # Sanity-check the format: should contain a slash, a percentage sign, parens.
+        assert "/" in canonical[0]
+        assert "%)" in canonical[0]


### PR DESCRIPTION
## Summary

Two cosmetic bridge fixes to close the last remaining gaps in Reva's compatibility audit. Reading the requirements doc against current \`main\` (audit summary in conversation transcript), 9 of the 11 items are already restored. These two were the only outstanding gaps.

### Gap 8 — \`/health\` exposes \`prompt_hashes\`

\`PromptManager.prompt_hashes\` already computes 12-char SHA-256 prefixes per loaded YAML; this PR plumbs them through the \`/health\` endpoint so deploy verification can confirm a release actually changed the prompts. The handler tolerates PromptManager failure with an empty dict — health endpoint must never break the load balancer.

\`\`\`json
{ "status": "ok", "prompt_hashes": {"agent": "abc123def456", "intent": "deadbeefcafe"} }
\`\`\`

### Gap 10 — \`_enforce_token_budget\` emits a canonical log line

Reva's \`test_token_budget_logged\` asserts the substring \`"Token budget:"\`. The current implementation logs \`"Budget pass N (...)"\` per reduction — informative but doesn't match Reva's contract. PR adds a single canonical line on entry: \`"Token budget: <used>/<max> (<%>)"\`. The per-pass lines remain for observability.

## Tests

3 new unit tests, all green on .159 staging:
- \`test_health_endpoint::test_health_includes_prompt_hashes\`
- \`test_health_endpoint::test_health_tolerates_prompt_manager_failure\`
- \`test_token_budget::TestTokenBudgetLogLine::test_emits_canonical_log_line\`

## After merge

Reva can bump the submodule to this commit and run its 75 E2E tests. Expectation: 0 failures from Renfield-side compatibility issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)