### PR TITLE
feat(tests): add tsconfig.json to tests/frontend/react/ for compile-time type checking

### DIFF
--- a/tests/frontend/react/api/hooks.test.tsx
+++ b/tests/frontend/react/api/hooks.test.tsx
@@ -3,7 +3,7 @@ import { renderHook, waitFor, act } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { I18nextProvider } from 'react-i18next';
-import type { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import type { AxiosError } from 'axios';
 
 import { server } from '../mocks/server';
@@ -24,7 +24,7 @@ interface MutVars {
   x?: number;
 }
 
-function makeWrapper(): (props: { children: ReactNode }) => JSX.Element {
+function makeWrapper(): (props: { children: ReactNode }) => ReactElement {
   const client = new QueryClient({
     defaultOptions: {
       queries: { retry: false, gcTime: 0, staleTime: 0 },
@@ -287,7 +287,13 @@ describe('useApiMutation', () => {
     });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    const error: ApiError | null = result.current.error;
+    // Annotation omitted: the test-tree node_modules and src/frontend's
+    // node_modules each ship their own copy of axios, so the locally-declared
+    // `ApiError` (axios from test tree) is structurally identical but
+    // nominally distinct from the one inside `useApiMutation` (axios from
+    // src/frontend tree). Letting TS infer `result.current.error` keeps the
+    // two trees from colliding while preserving the runtime check.
+    const error = result.current.error;
     expect(error?.response?.status).toBe(418);
   });
 });

--- a/tests/frontend/react/api/invalidation.test.tsx
+++ b/tests/frontend/react/api/invalidation.test.tsx
@@ -3,7 +3,7 @@ import { renderHook, waitFor, act } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { I18nextProvider } from 'react-i18next';
-import type { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 import { server } from '../mocks/server';
 import { TEST_CONFIG } from '../config';
@@ -19,7 +19,7 @@ import type {
 
 const BASE = TEST_CONFIG.API_BASE_URL;
 
-function makeWrapper(client: QueryClient): (props: { children: ReactNode }) => JSX.Element {
+function makeWrapper(client: QueryClient): (props: { children: ReactNode }) => ReactElement {
   return function Wrapper({ children }: { children: ReactNode }) {
     return (
       <I18nextProvider i18n={i18n}>

--- a/tests/frontend/react/package-lock.json
+++ b/tests/frontend/react/package-lock.json
@@ -14,6 +14,9 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
+        "@types/node": "^22.10.0",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.2.1",
         "@vitest/coverage-v8": "^4.0.18",
         "axios": "^1.6.5",
@@ -26,6 +29,7 @@
         "react-dom": "^19.2.3",
         "react-i18next": "^14.1.3",
         "react-router": "^7.13.0",
+        "typescript": "^5.7.0",
         "vitest": "^4.0.18"
       }
     },
@@ -1731,6 +1735,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
     "node_modules/@types/statuses": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
@@ -2251,6 +2285,13 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/data-urls": {
       "version": "6.0.1",
@@ -3755,6 +3796,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/until-async": {
       "version": "3.0.2",

--- a/tests/frontend/react/package.json
+++ b/tests/frontend/react/package.json
@@ -7,12 +7,16 @@
   "scripts": {
     "test": "vitest",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/node": "^22.10.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.2.1",
     "@vitest/coverage-v8": "^4.0.18",
     "axios": "^1.6.5",
@@ -25,6 +29,7 @@
     "react-dom": "^19.2.3",
     "react-i18next": "^14.1.3",
     "react-router": "^7.13.0",
+    "typescript": "^5.7.0",
     "vitest": "^4.0.18"
   },
   "dependencies": {

--- a/tests/frontend/react/pages/RolesPage.test.tsx
+++ b/tests/frontend/react/pages/RolesPage.test.tsx
@@ -1,3 +1,4 @@
+import { createElement, Fragment } from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -27,7 +28,7 @@ vi.mock('../../../../src/frontend/src/context/AuthContext', async () => {
 vi.mock('../../../../src/frontend/src/components/ConfirmDialog', () => {
   const result: UseConfirmDialogResult = {
     confirm: () => Promise.resolve(true),
-    ConfirmDialogComponent: null,
+    ConfirmDialogComponent: createElement(Fragment),
   };
   return {
     useConfirmDialog: (): UseConfirmDialogResult => result,

--- a/tests/frontend/react/pages/RoomsPage.test.tsx
+++ b/tests/frontend/react/pages/RoomsPage.test.tsx
@@ -1,3 +1,4 @@
+import { createElement, Fragment } from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -50,7 +51,7 @@ const mockHAAreas: HAArea[] = [
 vi.mock('../../../../src/frontend/src/components/ConfirmDialog', () => {
   const result: UseConfirmDialogResult = {
     confirm: () => Promise.resolve(true),
-    ConfirmDialogComponent: null,
+    ConfirmDialogComponent: createElement(Fragment),
   };
   return {
     useConfirmDialog: (): UseConfirmDialogResult => result,

--- a/tests/frontend/react/pages/SpeakersPage.test.tsx
+++ b/tests/frontend/react/pages/SpeakersPage.test.tsx
@@ -1,3 +1,4 @@
+import { createElement, Fragment } from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -30,7 +31,7 @@ const mockServiceStatus: SpeakerServiceStatus = {
 vi.mock('../../../../src/frontend/src/components/ConfirmDialog', () => {
   const result: UseConfirmDialogResult = {
     confirm: () => Promise.resolve(true),
-    ConfirmDialogComponent: null,
+    ConfirmDialogComponent: createElement(Fragment),
   };
   return {
     useConfirmDialog: (): UseConfirmDialogResult => result,

--- a/tests/frontend/react/pages/UsersPage.test.tsx
+++ b/tests/frontend/react/pages/UsersPage.test.tsx
@@ -1,3 +1,4 @@
+import { createElement, Fragment } from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -27,7 +28,7 @@ vi.mock('../../../../src/frontend/src/context/AuthContext', async () => {
 vi.mock('../../../../src/frontend/src/components/ConfirmDialog', () => {
   const result: UseConfirmDialogResult = {
     confirm: () => Promise.resolve(true),
-    ConfirmDialogComponent: null,
+    ConfirmDialogComponent: createElement(Fragment),
   };
   return {
     useConfirmDialog: (): UseConfirmDialogResult => result,

--- a/tests/frontend/react/tsconfig.json
+++ b/tests/frontend/react/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    "strict": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+
+    "types": ["node", "@testing-library/jest-dom"],
+
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["../../../src/frontend/src/*"]
+    }
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.js",
+    "vitest.config.js",
+    "../../../src/frontend/src/types/**/*.d.ts"
+  ],
+  "exclude": ["node_modules", "coverage"]
+}


### PR DESCRIPTION
## Summary

Closes the follow-up from #520. The test directory was \`.tsx\` at runtime but had no \`tsconfig.json\` — vitest just transpiled via esbuild, so type errors didn't fail anything. Now \`npm run typecheck\` actually validates the migrated tests.

## What's in scope

- \`tests/frontend/react/tsconfig.json\` — strict, \`jsx: react-jsx\`, bundler resolution, \`@/*\` alias to \`src/frontend/src/*\`, includes ambient \`.d.ts\` files from the source types directory so \`openwakeword-wasm-browser\` and \`@capacitor/core\` declarations propagate.
- \`package.json\` — adds \`@types/node\`, \`@types/react\`, \`@types/react-dom\`, \`typescript\` as devDeps, plus \`npm run typecheck\` script.
- 4 page-test mocks corrected: \`ConfirmDialogComponent: null\` → \`createElement(Fragment)\`. Mock was violating the source's \`UseConfirmDialogResult\` contract (\`ReactElement\`, non-null).
- 2 api-test files: \`JSX.Element\` → \`ReactElement\` (React 19 dropped global \`JSX\` namespace).
- 1 explicit type inference fix: \`api/hooks.test.tsx\` annotation \`ApiError | null\` collided with the structurally-identical type from the hook because the test tree and src/frontend tree each ship their own copy of axios. Two distinct \`AxiosError\` symbols. Dropped the annotation; comment explains.

## Verification

- \`cd tests/frontend/react && npx tsc --noEmit\` → exit 0, no errors
- 4 touched page-test files: 69/69 pass when run alone
- 3 api-test files: 14/14 pass when run alone
- Full-suite variance unchanged from main (`isolate: false` flake documented in vitest config)

## Why this matters

Before this PR, all the typing work in #520 paid off only in the IDE — there was no compile-time gate. Now CI/local can run \`npm run typecheck\` and catch type drift before it lands. Already paid for itself: caught a real contract violation in 4 page mocks (returning \`null\` where the source declares \`ReactElement\`).

## No shortcuts

No \`as any\`, no \`// @ts-nocheck\`, no shim files. The one explicit inference is documented inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)