### PR TITLE
fix(routing): word-boundary keyword match in SemanticRouter

### DIFF
--- a/src/backend/services/semantic_router.py
+++ b/src/backend/services/semantic_router.py
@@ -7,6 +7,7 @@ via cosine similarity. Falls back to None if no role exceeds the threshold.
 """
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -184,13 +185,17 @@ class SemanticRouter:
         # Keyword boost operates on role-level only (sub_intents rely on
         # their explicit utterances rather than keyword hints).
         if _KEYWORD_BOOST:
-            msg_lower = message.lower()
+            # Tokenize into lowercase word set so substring traps like
+            # `'board' in 'dashboard'` cannot fire a boost. `\w+` with
+            # default UNICODE flag handles ö/ä/ü/ß, so keywords like
+            # 'störung' still match.
+            msg_words = set(re.findall(r"\w+", message.lower()))
             boosted_role = None
             boosted_sim = 0.0
             for role_name, keywords in _KEYWORD_BOOST.items():
                 if role_name not in self._role_embeddings:
                     continue
-                if any(kw in msg_lower for kw in keywords):
+                if any(kw in msg_words for kw in keywords):
                     sim = _best_of(self._role_embeddings[role_name], 0.0) + _KEYWORD_BOOST_AMOUNT
                     if sim > boosted_sim:
                         boosted_sim = sim

--- a/tests/backend/test_agent_router.py
+++ b/tests/backend/test_agent_router.py
@@ -1279,6 +1279,99 @@ class TestSetSemanticRouter:
 
 
 # ---------------------------------------------------------------------------
+# SemanticRouter keyword-boost: word-boundary matching
+# Regression: substring matching let `'board'` (jira keyword) trigger on
+# `'dashboard'` and steal release/my_dashboard routing for "Mein Dashboard".
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticRouterKeywordBoostBoundary:
+    """Keyword boost must match whole words, not arbitrary substrings."""
+
+    def _build_router(self, keyword_boost_map):
+        """Build a SemanticRouter with one embedding per role and a module-
+        level _KEYWORD_BOOST set to ``keyword_boost_map``.
+
+        Each role gets the same embedding vector so semantic similarity
+        does not preselect one role over another — the boost is the only
+        differentiator.
+        """
+        from services import semantic_router as sr_module
+
+        sr = sr_module.SemanticRouter(threshold=0.75)
+        same_vec = [1.0, 0.0, 0.0]
+        sr._role_embeddings = {role: [same_vec] for role in keyword_boost_map}
+        sr._initialized = True
+
+        embed_response = MagicMock()
+        embed_response.embedding = same_vec
+        client = AsyncMock()
+        client.embeddings = AsyncMock(return_value=embed_response)
+        sr._ollama_client = client
+
+        sr_module._KEYWORD_BOOST.clear()
+        sr_module._KEYWORD_BOOST.update(
+            {role: [k.lower() for k in kws] for role, kws in keyword_boost_map.items()}
+        )
+        return sr
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_dashboard_does_not_match_board_keyword(self):
+        """`'board'` is a jira keyword — must not fire on `'dashboard'`."""
+        from services import semantic_router as sr_module
+
+        sr = self._build_router({
+            "release": ["release", "releases"],
+            "jira": ["jira", "ticket", "board", "epic"],
+        })
+        try:
+            role, _sub, _sim = await sr.classify("Mein Dashboard")
+        finally:
+            sr_module._KEYWORD_BOOST.clear()
+
+        # No keyword in {"mein", "dashboard"} matches release or jira → no
+        # boost → caller falls back to LLM (returns None at threshold).
+        # The crucial assertion: jira boost must NOT have fired.
+        assert role != "jira"
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_explicit_board_keyword_still_boosts(self):
+        """Whole-word `'board'` must still trigger the jira boost."""
+        from services import semantic_router as sr_module
+
+        sr = self._build_router({
+            "release": ["release"],
+            "jira": ["board"],
+        })
+        try:
+            role, _sub, sim = await sr.classify("Show me the board")
+        finally:
+            sr_module._KEYWORD_BOOST.clear()
+
+        assert role == "jira"
+        assert sim >= 0.75
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_german_umlaut_keyword_matches_word(self):
+        """`'störung'` must match as a word in German messages."""
+        from services import semantic_router as sr_module
+
+        sr = self._build_router({
+            "jira": ["ticket"],
+            "itsm": ["störung"],
+        })
+        try:
+            role, _sub, _sim = await sr.classify("Ich habe eine Störung gemeldet")
+        finally:
+            sr_module._KEYWORD_BOOST.clear()
+
+        assert role == "itsm"
+
+
+# ---------------------------------------------------------------------------
 # Anti-dashboard guard + sub_intent inference on fast paths
 # (follow-up to PR #384 review findings)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The SemanticRouter's keyword-boost path used substring matching, which caused `'board' in 'dashboard'` to fire the jira keyword boost on the message "Mein Dashboard". This stole `release/my_dashboard` sub-intent routing and silently misrouted to jira.

Visible in pod logs as `keyword boost: 'release' (1.000) → 'jira' (1.150)`.

## Fix

Tokenize the message into `\w+` words and assert keyword membership against that set. Default Python regex `\w+` handles ö/ä/ü/ß correctly, so umlaut-bearing keywords like `störung` still match.

```python
# Before
msg_lower = message.lower()
if any(kw in msg_lower for kw in keywords):  # substring → trips on 'dashboard' ⊃ 'board'
    ...

# After
msg_words = set(re.findall(r"\w+", message.lower()))
if any(kw in msg_words for kw in keywords):  # set membership over whole tokens
    ...
```

## How it was caught

Downstream in Reva's E2E suite. `scenarios/release/test_dashboard_chain.py::TestDashboardChain::test_01_dashboard` flipped PASS → FAIL when the agent model was upgraded from Qwen3.5-27B to Qwen3.6-27B. Investigation showed both models actually routed the same way (to jira) — the test had been passing under Qwen3.5 only by coincidence: the chattier Qwen3.5 prose happened to include one of the test's asserted German keywords (`Aufgabe`/`Status`/`Release`), so the assertion passed even though the routing was wrong. Qwen3.6's terser response stopped including those keywords by accident, exposing the long-standing bug.

After the fix, "Mein Dashboard" routes to `role=release, sub_intent=my_dashboard, confidence=1.00` deterministically. Verified 3/3 in isolation, and in full E2E (107/118 pass on the v2.4.3 baseline, all 11 failures unrelated to this routing path).

## Tests added

Three new tests under `TestSemanticRouterKeywordBoostBoundary` in `tests/backend/test_agent_router.py`:

1. `test_dashboard_does_not_match_board_keyword` — the regression case
2. `test_explicit_board_keyword_still_boosts` — positive case (whole-word `board` in `"Show me the board"` still triggers jira boost as designed)
3. `test_german_umlaut_keyword_matches_word` — `störung` matches in `"Ich habe eine Störung gemeldet"`

## Test plan

- [x] Three new unit tests in `tests/backend/test_agent_router.py::TestSemanticRouterKeywordBoostBoundary`
- [x] Manual fuzz against 7 cases including hyphenated identifiers (`metadata-rfc-7234`), inner substring (`rfcabc`), umlauts, multi-keyword
- [x] Reva-side E2E verified `test_01_dashboard` PASS 3/3 in isolation post-fix
- [x] Reva-side full E2E on v2.4.3 + this fix confirmed routing trace `role=release, layer=semantic, confidence=1.00, sub_intent=my_dashboard` for `"Mein Dashboard"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)