### PR TITLE
fix(frontend): default to same-origin in production builds

### DIFF
--- a/.claude/skills/deploy-production/SKILL.md
+++ b/.claude/skills/deploy-production/SKILL.md
@@ -100,6 +100,13 @@ docker push registry.treehouse.x-idra.de/renfield/frontend:latest
 docker push registry.treehouse.x-idra.de/renfield/frontend:vX.Y.Z
 ```
 
+> **No `--build-arg VITE_API_URL` required.** Since v2.4.4 the frontend defaults
+> to relative URLs in production builds (axios `baseURL=""` → same-origin). As
+> long as Traefik routes `/api/*` and `/ws` on the same host as the frontend
+> (which the `renfield-private` ingress does), the bundle works out of the
+> box. Pass `--build-arg VITE_API_URL=https://other.host` only for cross-origin
+> deployments. See `src/frontend/src/utils/env.ts`.
+
 ### Step 3 — Cleanup
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Alle markanten Änderungen an Renfield, seit Release `v1.2.0`. Format lehnt sich
 
 ---
 
+## [v2.4.4] — 2026-05-04
+
+Hotfix für das deployte k8s-Frontend-Bundle: ohne explizites `VITE_API_URL`-Build-Arg fiel der Production-Build auf `http://localhost:8000` zurück, was im Browser zu Mixed-Content-Blocking auf `https://renfield.local` führte (`/admin/satellites` zeigte "Satelliten konnten nicht geladen werden", DevTools-Console zeigte `XMLHttpRequest cannot load http://localhost:8000/api/satellites due to access control checks`). Backend war unverändert erreichbar; das Bundle zeigte nur auf den falschen Host.
+
+### Behoben
+
+- **Frontend Same-Origin-Default** — `getApiBaseUrl()` in `src/frontend/src/utils/env.ts` liefert in Production-Builds (`import.meta.env.PROD`) bei fehlendem oder leerem `VITE_API_URL` jetzt einen leeren String. axios verwendet dadurch relative URLs, die im Same-Origin-Reverse-Proxy-Setup (Traefik routet `/api/*` und `/ws` auf demselben Host wie `/`) automatisch korrekt aufgelöst werden — ohne dass der Build-Schritt einen `--build-arg VITE_API_URL=...` setzen muss. Das frühere Verhalten — Fallback auf `http://localhost:8000` mit Console-Warning — bleibt im Dev-Modus (`npm run dev`) erhalten. `deploy-production`-Skill um die Erläuterung ergänzt, dass der Build-Arg jetzt nur noch für echte Cross-Origin-Deployments nötig ist.
+
+---
+
 ## [v2.4.3] — 2026-05-02
 
 Brücke zur Reva-Kompatibilität. Schließt die letzten zwei kosmetischen Lücken aus dem Reva-Compat-Audit (`reva/docs/architecture/renfield-compatibility-requirements.md`); die anderen neun von elf Items waren in vorigen Sprints bereits restauriert. Nach diesem Release kann Reva sein Renfield-Submodul auf `main` bumpen und seine 75 E2E-Tests gegen die hier liegende Codebasis fahren.

--- a/src/frontend/src/utils/env.ts
+++ b/src/frontend/src/utils/env.ts
@@ -36,12 +36,19 @@ function warnFallback(varName: string, fallbackValue: string): void {
 }
 
 /**
- * REST API base URL for the Renfield backend. Falls back to localhost:8000
- * when `VITE_API_URL` is unset, with a console warning.
+ * REST API base URL for the Renfield backend.
+ *
+ * - DEV (`npm run dev`): falls back to `http://localhost:8000` with a console warning.
+ * - PROD (built bundle) without `VITE_API_URL`: returns `""` so axios uses
+ *   relative URLs against the same origin. Standard same-origin reverse-proxy
+ *   deployment (Traefik routes `/api/*` to backend, `/` to frontend) just works
+ *   without any build-arg. Set `VITE_API_URL` only if the API is hosted on a
+ *   different origin.
  */
 export function getApiBaseUrl(): string {
   const value = import.meta.env.VITE_API_URL as string | undefined;
   if (value && value.length > 0) return value;
+  if (import.meta.env.PROD) return '';
   warnFallback('VITE_API_URL', FALLBACK_API_URL);
   return FALLBACK_API_URL;
 }


### PR DESCRIPTION
## Summary

- **Root cause:** Frontend Production-Builds ohne `--build-arg VITE_API_URL=...` fielen auf `http://localhost:8000` zurück. Auf `https://renfield.local/admin/satellites` führte das zu Mixed-Content-Blocking (`XMLHttpRequest cannot load http://localhost:8000/api/satellites due to access control checks`) und dem User-sichtbaren "Satelliten konnten nicht geladen werden".
- **Fix:** `getApiBaseUrl()` in `src/frontend/src/utils/env.ts` gibt in PROD bei fehlender `VITE_API_URL` jetzt `""` zurück → axios nutzt relative URLs → Same-Origin via Traefik. Dev-Verhalten unverändert (Fallback + Console-Warning).
- **Doku:** `CHANGELOG.md` (v2.4.4), `deploy-production`-Skill um Erläuterung ergänzt — Build-Arg ist nur noch für echte Cross-Origin-Deployments nötig.

## Test plan

- [x] Static-Bundle-Verifikation: `function Xk(){return""}` — minified `getApiBaseUrl` gibt leeren String zurück; vite hat den Localhost-Fallback im PROD-Bundle tree-shaken.
- [x] Image `frontend:v2.4.4` gebaut auf `192.168.1.159`, gepusht zu Harbor, ausgerollt auf `renfield-private`.
- [x] User-Bestätigung im Browser: `/admin/satellites` lädt, kein Mixed-Content-Error mehr.
- [ ] Reviewer: bei Bedarf Same-Origin-Verhalten lokal mit `npm run build && npm run preview` gegenchecken.

## Notes for reviewer

- Keine Änderung am WS-Pfad (`getWebSocketUrl`) — der Dockerfile-Default `VITE_WS_URL=/ws` produziert bereits eine relative URL.
- Auswirkung auf Dev-Workflow: keine. Wer `npm run dev` ausführt, bekommt weiterhin den Localhost-Fallback mit Warning.
- Image ist bereits in Production live (v2.4.4); das hier ist die nachgelagerte Code+Doku-Synchronisation auf `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)