### PR TITLE
feat(llm): migrate text-LLM tier to llama-server (Qwen3.6-35B-A3B MoE)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,7 +60,34 @@ POSTGRES_DB=renfield
 REDIS_URL=redis://redis:6379
 
 # -----------------------------------------------------------------------------
-# Ollama (local LLM inference)
+# OpenAI-compatible LLM (e.g. llama-server with Qwen3.6-35B-A3B MoE)
+# -----------------------------------------------------------------------------
+# When LLM_OPENAI_BASE_URL is set, the agent + chat + RAG + intent + KG +
+# memory tiers route through this endpoint instead of Ollama. Embeddings
+# and vision stay on Ollama (separate models the llama-server doesn't host).
+#
+# Per-tier override: set LLM_OPENAI_FOR_<TIER>=false to keep that one tier
+# on Ollama (e.g. LLM_OPENAI_FOR_INTENT=false to run intent classification
+# on a small Ollama model).
+# LLM_OPENAI_BASE_URL=http://llama-server-agent:8080/v1
+# LLM_OPENAI_API_KEY=no-key
+# LLM_OPENAI_MODEL=qwen3.6
+# LLM_OPENAI_FOR_AGENT=true             # Default when BASE_URL is set
+# LLM_OPENAI_FOR_CHAT=true
+# LLM_OPENAI_FOR_RAG=true
+# LLM_OPENAI_FOR_INTENT=true
+# LLM_OPENAI_FOR_KG=true
+# LLM_OPENAI_FOR_MEMORY=true
+
+# Separate OpenAI-compatible embedding endpoint (a llama-server pod with
+# `--embedding`, hosting an embedding-specific GGUF). When set, embeddings
+# bypass Ollama. Dimension must match EMBEDDING_DIMENSION (2560 for
+# Qwen3-Embedding-4B).
+# LLM_OPENAI_EMBED_BASE_URL=http://llama-server-embed:8080/v1
+# LLM_OPENAI_EMBED_MODEL=qwen3-embedding
+
+# -----------------------------------------------------------------------------
+# Ollama (legacy fallback; only used when no LLM_OPENAI_* endpoints are set)
 # -----------------------------------------------------------------------------
 # Single Ollama host for all models by default. Set OLLAMA_FALLBACK_URL when
 # primary points at an external GPU (e.g. cuda.local) that may go offline —

--- a/k8s/backend.yaml
+++ b/k8s/backend.yaml
@@ -51,10 +51,14 @@ spec:
               until nc -z postgres 5432; do sleep 1; done
               echo "waiting for redis..."
               until nc -z redis 6379; do sleep 1; done
-              echo "waiting for llama-server-agent..."
-              until nc -z llama-server-agent 8080; do sleep 1; done
-              echo "waiting for llama-server-embed..."
-              until nc -z llama-server-embed 8080; do sleep 1; done
+              # /health on llama-server returns {"status":"ok"} only once the
+              # GGUF model is fully loaded (~60-90s cold start). A plain TCP
+              # check would pass too early, the backend would start serving,
+              # and the first LLM call would 503 until the model warmed up.
+              echo "waiting for llama-server-agent /health..."
+              until wget -q -O- http://llama-server-agent:8080/health 2>/dev/null | grep -q '"ok"'; do sleep 2; done
+              echo "waiting for llama-server-embed /health..."
+              until wget -q -O- http://llama-server-embed:8080/health 2>/dev/null | grep -q '"ok"'; do sleep 2; done
               echo "deps ready"
               # Ensure the persistent HOME exists so Python libs can create
               # their cache dirs there on first run (EasyOCR, HF, torch, whisper).
@@ -107,6 +111,15 @@ spec:
                 secretKeyRef:
                   name: renfield-secrets
                   key: openweather-api-key
+            # llama-server accepts any non-empty key today, but route the
+            # value through a Secret so future swap-in of a real bearer
+            # (vLLM, OpenAI, etc.) doesn't require a ConfigMap rewrite.
+            - name: LLM_OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: renfield-secrets
+                  key: llm-openai-api-key
+                  optional: true
             - name: NEWSAPI_KEY
               valueFrom:
                 secretKeyRef:

--- a/k8s/backend.yaml
+++ b/k8s/backend.yaml
@@ -51,8 +51,10 @@ spec:
               until nc -z postgres 5432; do sleep 1; done
               echo "waiting for redis..."
               until nc -z redis 6379; do sleep 1; done
-              echo "waiting for ollama..."
-              until nc -z ollama 11434; do sleep 1; done
+              echo "waiting for llama-server-agent..."
+              until nc -z llama-server-agent 8080; do sleep 1; done
+              echo "waiting for llama-server-embed..."
+              until nc -z llama-server-embed 8080; do sleep 1; done
               echo "deps ready"
               # Ensure the persistent HOME exists so Python libs can create
               # their cache dirs there on first run (EasyOCR, HF, torch, whisper).

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -29,13 +29,29 @@ data:
   # on the cluster subnet.
   PAPERLESS_API_URL: "http://192.168.1.162:8000"
 
-  # Models (auto-pulled by Ollama on first use if missing from NFS)
+  # OpenAI-compatible LLM endpoints (llama-server pods on the cluster).
+  #   - Chat/Agent/RAG/Intent/KG/Memory → llama-server-agent (Qwen3.6-35B-A3B
+  #     MoE Q4_K_XL on k8s-gpu-1 with tensor-split across both GPUs).
+  #   - Embeddings → llama-server-embed (Qwen3-Embedding-4B Q4_K_M on
+  #     k8s-gpu-2 CPU-only, with --embedding --pooling last).
+  # Vision is currently disabled (OLLAMA_VISION_MODEL=""); a third
+  # llama-server-vision pod can be added in a follow-up step.
+  LLM_OPENAI_BASE_URL: "http://llama-server-agent:8080/v1"
+  LLM_OPENAI_API_KEY: "no-key"
+  LLM_OPENAI_MODEL: "qwen3.6"
+  LLM_OPENAI_EMBED_BASE_URL: "http://llama-server-embed:8080/v1"
+  LLM_OPENAI_EMBED_MODEL: "qwen3-embedding"
+
+  # Legacy Ollama model names kept for back-compat with config code paths
+  # that read them as defaults. They're NOT used while the LLM_OPENAI_*
+  # endpoints are set, except OLLAMA_VISION_MODEL which gates the vision
+  # tier (empty = disabled).
   OLLAMA_MODEL: "qwen3:14b"
   OLLAMA_CHAT_MODEL: "qwen3:14b"
   OLLAMA_RAG_MODEL: "qwen3:14b"
   OLLAMA_INTENT_MODEL: "qwen3:8b"
   OLLAMA_EMBED_MODEL: "qwen3-embedding:4b"
-  OLLAMA_VISION_MODEL: "qwen3-vl:8b"
+  OLLAMA_VISION_MODEL: ""
   AGENT_MODEL: "qwen3:14b"
   EMBEDDING_DIMENSION: "2560"
   WHISPER_MODEL: "small"

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -37,7 +37,10 @@ data:
   # Vision is currently disabled (OLLAMA_VISION_MODEL=""); a third
   # llama-server-vision pod can be added in a follow-up step.
   LLM_OPENAI_BASE_URL: "http://llama-server-agent:8080/v1"
-  LLM_OPENAI_API_KEY: "no-key"
+  # LLM_OPENAI_API_KEY is sourced from the `renfield-secrets`/`llm-openai-api-key`
+  # Secret in backend.yaml. llama-server accepts any non-empty value today;
+  # the Secret indirection lets us swap to a real bearer (vLLM, OpenAI…)
+  # without re-applying this ConfigMap.
   LLM_OPENAI_MODEL: "qwen3.6"
   LLM_OPENAI_EMBED_BASE_URL: "http://llama-server-embed:8080/v1"
   LLM_OPENAI_EMBED_MODEL: "qwen3-embedding"

--- a/k8s/document-worker.yaml
+++ b/k8s/document-worker.yaml
@@ -53,8 +53,10 @@ spec:
             - |
               echo "waiting for postgres..."; until nc -z postgres 5432; do sleep 1; done
               echo "waiting for redis...";    until nc -z redis 6379;    do sleep 1; done
-              echo "waiting for llama-server-agent..."; until nc -z llama-server-agent 8080; do sleep 1; done
-              echo "waiting for llama-server-embed..."; until nc -z llama-server-embed 8080; do sleep 1; done
+              # /health on llama-server returns {"status":"ok"} only once the GGUF
+              # model is fully loaded; TCP-only would pass before warmup.
+              echo "waiting for llama-server-agent /health..."; until wget -q -O- http://llama-server-agent:8080/health 2>/dev/null | grep -q '"ok"'; do sleep 2; done
+              echo "waiting for llama-server-embed /health..."; until wget -q -O- http://llama-server-embed:8080/health 2>/dev/null | grep -q '"ok"'; do sleep 2; done
               echo "deps ready"
               mkdir -p /app/data/cache-home/.cache /app/data/cache-home/.EasyOCR
           resources:

--- a/k8s/document-worker.yaml
+++ b/k8s/document-worker.yaml
@@ -53,7 +53,8 @@ spec:
             - |
               echo "waiting for postgres..."; until nc -z postgres 5432; do sleep 1; done
               echo "waiting for redis...";    until nc -z redis 6379;    do sleep 1; done
-              echo "waiting for ollama...";   until nc -z ollama 11434;  do sleep 1; done
+              echo "waiting for llama-server-agent..."; until nc -z llama-server-agent 8080; do sleep 1; done
+              echo "waiting for llama-server-embed..."; until nc -z llama-server-embed 8080; do sleep 1; done
               echo "deps ready"
               mkdir -p /app/data/cache-home/.cache /app/data/cache-home/.EasyOCR
           resources:

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -8,7 +8,8 @@ resources:
   - configmap.yaml
   - postgres.yaml
   - redis.yaml
-  - ollama.yaml
+  - llama-server.yaml
+  - llama-server-embed.yaml
   - searxng.yaml
   - dlna-mcp.yaml
   - mdns-responder.yaml

--- a/k8s/llama-server-embed.yaml
+++ b/k8s/llama-server-embed.yaml
@@ -1,0 +1,102 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: llama-server-embed
+  namespace: renfield
+  labels:
+    app.kubernetes.io/name: llama-server-embed
+    app.kubernetes.io/part-of: renfield
+spec:
+  selector:
+    app.kubernetes.io/name: llama-server-embed
+  ports:
+    - port: 8080
+      targetPort: 8080
+      name: http
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llama-server-embed
+  namespace: renfield
+  labels:
+    app.kubernetes.io/name: llama-server-embed
+    app.kubernetes.io/part-of: renfield
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: llama-server-embed
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: llama-server-embed
+        app.kubernetes.io/part-of: renfield
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: k8s-gpu-2
+      containers:
+        - name: llama-server
+          image: ghcr.io/ggml-org/llama.cpp:server
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-m"
+            - "/models/qwen3-embedding-4b-q4km.gguf"
+            - "--host"
+            - "0.0.0.0"
+            - "--port"
+            - "8080"
+            - "--embedding"
+            - "--pooling"
+            - "last"
+            - "-c"
+            - "8192"
+            - "--parallel"
+            - "4"
+            - "--alias"
+            - "qwen3-embedding"
+            - "--metrics"
+            - "-t"
+            - "6"
+          ports:
+            - containerPort: 8080
+              name: http
+          resources:
+            requests:
+              cpu: "1"
+              memory: 4Gi
+            limits:
+              cpu: "6"
+              memory: 12Gi
+          volumeMounts:
+            - name: models
+              mountPath: /models
+              readOnly: true
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 24
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 120
+            periodSeconds: 30
+            failureThreshold: 5
+      volumes:
+        - name: models
+          hostPath:
+            path: /mnt/llm
+            type: Directory

--- a/k8s/llama-server.yaml
+++ b/k8s/llama-server.yaml
@@ -1,0 +1,120 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: llama-server-agent
+  namespace: renfield
+  labels:
+    app.kubernetes.io/name: llama-server-agent
+    app.kubernetes.io/part-of: renfield
+spec:
+  selector:
+    app.kubernetes.io/name: llama-server-agent
+  ports:
+    - port: 8080
+      targetPort: 8080
+      name: http
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llama-server-agent
+  namespace: renfield
+  labels:
+    app.kubernetes.io/name: llama-server-agent
+    app.kubernetes.io/part-of: renfield
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: llama-server-agent
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: llama-server-agent
+        app.kubernetes.io/part-of: renfield
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: k8s-gpu-1
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: llama-server
+          image: ghcr.io/ggml-org/llama.cpp:server-cuda
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-m"
+            - "/models/qwen3.6-35b-a3b-q4kxl.gguf"
+            - "--host"
+            - "0.0.0.0"
+            - "--port"
+            - "8080"
+            - "-ngl"
+            - "99"
+            - "--tensor-split"
+            - "16,16"
+            - "-c"
+            - "65536"
+            - "--parallel"
+            - "4"
+            - "-fa"
+            - "on"
+            - "-ctk"
+            - "q8_0"
+            - "-ctv"
+            - "q8_0"
+            - "--temp"
+            - "0.6"
+            - "--top-p"
+            - "0.95"
+            - "--alias"
+            - "qwen3.6"
+            - "--metrics"
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: LLAMA_ARG_N_GPU_LAYERS
+              value: "99"
+          resources:
+            requests:
+              cpu: "2"
+              memory: 8Gi
+              nvidia.com/gpu: 2
+            limits:
+              cpu: "8"
+              memory: 24Gi
+              nvidia.com/gpu: 2
+          volumeMounts:
+            - name: models
+              mountPath: /models
+              readOnly: true
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 36
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 600
+            periodSeconds: 30
+            failureThreshold: 5
+      volumes:
+        - name: models
+          hostPath:
+            path: /mnt/llm
+            type: Directory

--- a/k8s/ollama.yaml
+++ b/k8s/ollama.yaml
@@ -23,10 +23,19 @@ metadata:
     app.kubernetes.io/name: ollama
     app.kubernetes.io/part-of: renfield
 spec:
-  # k8s-gpu-1 hosts the llama-server (both GPUs via tensor-split). Ollama
-  # is now CPU-only on k8s-gpu-2 and serves only embeddings + vision
-  # (qwen3-embedding:4b, qwen3-vl:8b). Replicas: 1 — there is only one
-  # node without GPU contention to schedule on.
+  # ROLLBACK MANIFEST — NOT in kustomization.yaml.
+  #
+  # The text-LLM tier moved to the two `llama-server-*` pods. This Ollama
+  # deployment is kept as a fast rollback path: if the llama-server route
+  # ever needs to be reverted, `kubectl apply -f k8s/ollama.yaml` brings
+  # it back. Apply ONLY when also reverting the LLM_OPENAI_* settings in
+  # `configmap.yaml` so the backend doesn't end up with a half-migrated
+  # routing table (chat to llama-server, embed to Ollama, or vice versa).
+  #
+  # Targets k8s-gpu-2 explicitly because k8s-gpu-1 is now reserved for
+  # llama-server-agent's `nvidia.com/gpu: 2` claim. CPU-only runtime
+  # depends on k8s-gpu-2's containerd `default_runtime_name = runc`
+  # (see private_k8s/README.md).
   replicas: 1
   strategy:
     type: Recreate
@@ -115,6 +124,10 @@ spec:
           args:
             - |
               set -euo pipefail
+              # Rollback prepull: only models the llama-server path doesn't
+              # provide today. Embeddings live on llama-server-embed in the
+              # current architecture, so prepulling qwen3-embedding here is
+              # only needed when you actually flip the rollback switch.
               for m in qwen3-embedding:4b qwen3-vl:8b; do
                 echo "Pulling $m ..."
                 code=$(curl -sS -o /tmp/out -w '%{http_code}' -X POST http://ollama:11434/api/pull \

--- a/k8s/ollama.yaml
+++ b/k8s/ollama.yaml
@@ -23,9 +23,13 @@ metadata:
     app.kubernetes.io/name: ollama
     app.kubernetes.io/part-of: renfield
 spec:
-  replicas: 2
+  # k8s-gpu-1 hosts the llama-server (both GPUs via tensor-split). Ollama
+  # is now CPU-only on k8s-gpu-2 and serves only embeddings + vision
+  # (qwen3-embedding:4b, qwen3-vl:8b). Replicas: 1 — there is only one
+  # node without GPU contention to schedule on.
+  replicas: 1
   strategy:
-    type: RollingUpdate
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: ollama
@@ -35,20 +39,8 @@ spec:
         app.kubernetes.io/name: ollama
         app.kubernetes.io/part-of: renfield
     spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/hostname
-                    operator: In
-                    values: [k8s-gpu-1, k8s-gpu-2]
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  app.kubernetes.io/name: ollama
-              topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        kubernetes.io/hostname: k8s-gpu-2
       containers:
         - name: ollama
           image: ollama/ollama:latest
@@ -79,22 +71,16 @@ spec:
             periodSeconds: 30
           resources:
             requests:
-              cpu: "1"
+              cpu: "2"
               memory: 4Gi
-              nvidia.com/gpu: 1
             limits:
-              cpu: "4"
+              cpu: "6"
               memory: 16Gi
-              nvidia.com/gpu: 1
       volumes:
         - name: models
           hostPath:
             path: /mnt/llm/.ollama
             type: Directory
-      tolerations:
-        - key: nvidia.com/gpu
-          operator: Exists
-          effect: NoSchedule
 
 ---
 # One-shot Job: pre-pull models missing from NFS so first backend requests don't stall.
@@ -129,7 +115,7 @@ spec:
           args:
             - |
               set -euo pipefail
-              for m in qwen3:14b qwen3-embedding:4b qwen3-vl:8b; do
+              for m in qwen3-embedding:4b qwen3-vl:8b; do
                 echo "Pulling $m ..."
                 code=$(curl -sS -o /tmp/out -w '%{http_code}' -X POST http://ollama:11434/api/pull \
                   -H 'Content-Type: application/json' \

--- a/k8s/secrets.yaml.example
+++ b/k8s/secrets.yaml.example
@@ -31,6 +31,10 @@ stringData:
   n8n-api-key: ""
   paperless-api-token: ""
   mail-regfish-password: ""
+  # OpenAI-compatible LLM endpoint API key (llama-server / vLLM / OpenAI).
+  # llama-server accepts any non-empty string; leave blank to fall through
+  # to the "no-key" placeholder.
+  llm-openai-api-key: ""
 
 ---
 # Pull secret for Harbor (registry.treehouse.x-idra.de)

--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -248,7 +248,17 @@ async def _extract_memories_background(
     session_id: str | None,
     lang: str,
 ) -> None:
-    """Background task: extract and save memories from a conversation exchange."""
+    """Background task: extract and save memories from a conversation exchange.
+
+    Always logs the extraction outcome (including 0 memories) so silent
+    failures of the LLM extractor or guard short-circuits are visible in
+    production logs. Without this, missing memories look identical to a
+    bug-skipped trigger.
+    """
+    logger.info(
+        f"📝 Memory extraction starting (session={session_id}, user_id={user_id}, "
+        f"user_msg_len={len(user_message)}, assistant_msg_len={len(assistant_response)})"
+    )
     try:
         async with AsyncSessionLocal() as db:
             from services.conversation_memory_service import ConversationMemoryService
@@ -260,10 +270,12 @@ async def _extract_memories_background(
                 session_id=session_id,
                 lang=lang,
             )
-            if memories:
-                logger.info(f"Extracted {len(memories)} memories from conversation")
+            logger.info(
+                f"📝 Memory extraction done: extracted={len(memories)} "
+                f"(session={session_id})"
+            )
     except Exception as e:
-        logger.warning(f"Memory extraction failed: {e}")
+        logger.warning(f"Memory extraction failed: {e}", exc_info=True)
 
 
 def _format_file_size(size_bytes: int | None) -> str:
@@ -410,6 +422,7 @@ async def _stream_rag_response(
     document_context: str = "",
     personality_style: str | None = None,
     personality_prompt: str | None = None,
+    user_id: int | None = None,
 ) -> str:
     """Stream a RAG-enhanced or plain conversation response.
 
@@ -1131,6 +1144,7 @@ async def websocket_endpoint(
                             document_context=document_context,
                             personality_style=user_personality_style,
                             personality_prompt=user_personality_prompt,
+                            user_id=user_id,
                         )
                     else:
                         async for chunk in ollama.chat_stream(content, history=session_state.conversation_history, memory_context=memory_context, document_context=document_context, personality_style=user_personality_style, personality_prompt=user_personality_prompt):
@@ -1147,6 +1161,7 @@ async def websocket_endpoint(
                         document_context=document_context,
                         personality_style=user_personality_style,
                         personality_prompt=user_personality_prompt,
+                        user_id=user_id,
                     )
 
                 else:
@@ -1331,6 +1346,7 @@ WICHTIG: Nutze die ECHTEN Daten aus dem Ergebnis! Gib NUR die Antwort, KEIN JSON
                                 document_context=document_context,
                                 personality_style=user_personality_style,
                                 personality_prompt=user_personality_prompt,
+                                user_id=user_id,
                             )
                         else:
                             async for chunk in ollama.chat_stream(content, history=session_state.conversation_history, memory_context=memory_context, document_context=document_context, personality_style=user_personality_style, personality_prompt=user_personality_prompt):
@@ -1459,10 +1475,16 @@ WICHTIG: Nutze die ECHTEN Daten aus dem Ergebnis! Gib NUR die Antwort, KEIN JSON
             # memories from error-response text would otherwise re-inject the
             # error string into long-term memory as if it were a stable fact.
             _action_success = assistant_metadata.get("action_success")
-            if (settings.memory_enabled
-                    and settings.memory_extraction_enabled
-                    and full_response
-                    and _action_success is not False):
+            _mem_should_run = (
+                settings.memory_enabled
+                and settings.memory_extraction_enabled
+                and full_response
+                and _action_success is not False
+            )
+            if _mem_should_run:
+                logger.debug(
+                    f"📝 Scheduling memory extraction (session={msg_session_id})"
+                )
                 task = asyncio.create_task(
                     _extract_memories_background(
                         user_message=content,
@@ -1474,6 +1496,19 @@ WICHTIG: Nutze die ECHTEN Daten aus dem Ergebnis! Gib NUR die Antwort, KEIN JSON
                 )
                 _background_tasks.add(task)
                 task.add_done_callback(_background_tasks.discard)
+            else:
+                # WARN-level so the absence of extraction is auditable.
+                # The conversation/knowledge route can silently bypass this
+                # block today (e.g. when full_response is empty after a RAG
+                # fallback), and silent skips were previously indistinguishable
+                # from extractor success on an unmemorable turn.
+                logger.warning(
+                    f"📝 Memory extraction skipped: memory_enabled="
+                    f"{settings.memory_enabled} extraction_enabled="
+                    f"{settings.memory_extraction_enabled} "
+                    f"has_response={bool(full_response)} "
+                    f"action_success={_action_success}"
+                )
 
             # Hook: post_message (fire-and-forget for plugins like renfield-twin)
             from utils.hooks import run_hooks

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -16,6 +16,7 @@ celery>=5.3.6
 
 # LLM & AI
 ollama>=0.4.0                 # Ollama Python client (async support)
+openai>=1.55.0                # OpenAI-compatible client for llama-server / vLLM endpoints
 
 # RAG & Document Processing
 docling>=2.0.0                # IBM Docling for document parsing (includes docling-ibm-models)

--- a/src/backend/services/conversation_memory_service.py
+++ b/src/backend/services/conversation_memory_service.py
@@ -30,7 +30,7 @@ from models.database import (
     MemoryHistory,
 )
 from utils.config import settings
-from utils.llm_client import get_embed_client
+from utils.llm_client import get_default_client, get_embed_client
 
 # ---------------------------------------------------------------------------
 # Memory Poisoning Defense — pattern lists for extraction gating
@@ -71,7 +71,8 @@ class ConversationMemoryService:
 
     def __init__(self, db: AsyncSession):
         self.db = db
-        self._ollama_client = None
+        self._embed_client = None
+        self._chat_client = None
         # Cached fallback admin id for atoms registration when save() is
         # called without an authenticated user_id (single-user mode). See
         # _resolve_owner_user_id.
@@ -103,15 +104,31 @@ class ConversationMemoryService:
         from services.atom_service import AtomService
         return AtomService(self.db)
 
+    async def _get_embed_client(self):
+        """Lazy initialization of LLM client for embeddings (Qwen3-Embedding via llama-server-embed)."""
+        if self._embed_client is None:
+            self._embed_client = get_embed_client()
+        return self._embed_client
+
+    async def _get_chat_client(self):
+        """Lazy initialization of LLM client for chat/extraction (Qwen3.6 via llama-server-agent)."""
+        if self._chat_client is None:
+            self._chat_client = get_default_client()
+        return self._chat_client
+
     async def _get_ollama_client(self):
-        """Lazy initialization of Ollama client for embeddings."""
-        if self._ollama_client is None:
-            self._ollama_client = get_embed_client()
-        return self._ollama_client
+        """Deprecated alias kept for any external callers; returns the embed client.
+
+        Internal call-sites must use ``_get_embed_client`` (for embeddings) or
+        ``_get_chat_client`` (for chat/extraction) explicitly. Mixing the two
+        sends chat traffic to the CPU-only embed pod and adds 1-2 minutes per
+        request.
+        """
+        return await self._get_embed_client()
 
     async def _get_embedding(self, text_input: str) -> list[float]:
-        """Generate embedding using Ollama (nomic-embed-text, 768 dims)."""
-        client = await self._get_ollama_client()
+        """Generate embedding via the embed-tier LLM client."""
+        client = await self._get_embed_client()
         response = await client.embeddings(
             model=settings.ollama_embed_model,
             prompt=text_input
@@ -308,9 +325,15 @@ class ConversationMemoryService:
         )
         llm_options = prompt_manager.get_config("memory", "llm_options") or {}
 
-        # LLM call
+        # LLM call. Extraction expects strict JSON, so we disable thinking
+        # mode for thinking-capable models (Qwen3, Qwen3.6, deepseek-r1, …);
+        # otherwise the JSON ends up in `reasoning_content` and `content` is
+        # empty, returning an "extracted=0" silent miss. Same fix pattern as
+        # the KG and intent paths (see utils/llm_client.py).
+        from utils.llm_client import extract_response_content, get_classification_chat_kwargs
+
         try:
-            client = await self._get_ollama_client()
+            client = await self._get_chat_client()
             extraction_model = settings.memory_extraction_model or settings.ollama_model
             response = await client.chat(
                 model=extraction_model,
@@ -319,8 +342,9 @@ class ConversationMemoryService:
                     {"role": "user", "content": prompt},
                 ],
                 options=llm_options,
+                **get_classification_chat_kwargs(extraction_model),
             )
-            raw_text = response.message.content
+            raw_text = extract_response_content(response)
         except Exception as e:
             logger.warning(f"Memory extraction LLM call failed: {e}")
             return []
@@ -937,8 +961,10 @@ class ConversationMemoryService:
         )
         llm_options = prompt_manager.get_config("memory", "contradiction_llm_options") or {}
 
+        from utils.llm_client import extract_response_content, get_classification_chat_kwargs
+
         try:
-            client = await self._get_ollama_client()
+            client = await self._get_chat_client()
             extraction_model = settings.memory_extraction_model or settings.ollama_model
             response = await client.chat(
                 model=extraction_model,
@@ -947,8 +973,9 @@ class ConversationMemoryService:
                     {"role": "user", "content": prompt},
                 ],
                 options=llm_options,
+                **get_classification_chat_kwargs(extraction_model),
             )
-            raw_text = response.message.content
+            raw_text = extract_response_content(response)
         except Exception as e:
             logger.warning(f"Contradiction resolution LLM call failed: {e}")
             return None

--- a/src/backend/services/conversation_memory_service.py
+++ b/src/backend/services/conversation_memory_service.py
@@ -116,16 +116,6 @@ class ConversationMemoryService:
             self._chat_client = get_default_client()
         return self._chat_client
 
-    async def _get_ollama_client(self):
-        """Deprecated alias kept for any external callers; returns the embed client.
-
-        Internal call-sites must use ``_get_embed_client`` (for embeddings) or
-        ``_get_chat_client`` (for chat/extraction) explicitly. Mixing the two
-        sends chat traffic to the CPU-only embed pod and adds 1-2 minutes per
-        request.
-        """
-        return await self._get_embed_client()
-
     async def _get_embedding(self, text_input: str) -> list[float]:
         """Generate embedding via the embed-tier LLM client."""
         client = await self._get_embed_client()

--- a/src/backend/services/kg_retrieval.py
+++ b/src/backend/services/kg_retrieval.py
@@ -62,7 +62,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.database import KGEntity, KGRelation
 from utils.config import settings
-from utils.llm_client import get_embed_client
+from utils.llm_client import get_default_client, get_embed_client
 
 
 class KGRetrieval:
@@ -81,17 +81,24 @@ class KGRetrieval:
 
     def __init__(self, db: AsyncSession):
         self.db = db
-        self._ollama_client = None
+        self._embed_client = None
+        self._chat_client = None
 
-    async def _get_ollama_client(self):
-        """Lazy init of the embedding/extraction Ollama client."""
-        if self._ollama_client is None:
-            self._ollama_client = get_embed_client()
-        return self._ollama_client
+    async def _get_embed_client(self):
+        """Embed-tier LLM client (Qwen3-Embedding via llama-server-embed)."""
+        if self._embed_client is None:
+            self._embed_client = get_embed_client()
+        return self._embed_client
+
+    async def _get_chat_client(self):
+        """Chat-tier LLM client (Qwen3.6 via llama-server-agent) for entity-name extraction."""
+        if self._chat_client is None:
+            self._chat_client = get_default_client()
+        return self._chat_client
 
     async def _get_embedding(self, text_input: str) -> list[float]:
         """Generate embedding for query/entity text."""
-        client = await self._get_ollama_client()
+        client = await self._get_embed_client()
         response = await client.embeddings(
             model=settings.ollama_embed_model,
             prompt=text_input,
@@ -120,7 +127,7 @@ class KGRetrieval:
             llm_options = prompt_manager.get_config("knowledge_graph", "llm_options") or {}
             model = settings.kg_extraction_model or settings.ollama_model
 
-            client = await self._get_ollama_client()
+            client = await self._get_chat_client()
             response = await client.chat(
                 model=model,
                 messages=[

--- a/src/backend/services/knowledge_graph_service.py
+++ b/src/backend/services/knowledge_graph_service.py
@@ -18,7 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.database import KG_ENTITY_TYPES, TIER_PUBLIC, KGEntity, KGRelation
 from utils.config import settings
-from utils.llm_client import get_embed_client
+from utils.llm_client import get_default_client, get_embed_client
 
 # =============================================================================
 # Compiled regex patterns for entity validation (module-level for performance)
@@ -108,7 +108,8 @@ class KnowledgeGraphService:
 
     def __init__(self, db: AsyncSession):
         self.db = db
-        self._ollama_client = None
+        self._embed_client = None
+        self._chat_client = None
         # Cached fallback owner id — resolved lazily via _resolve_owner_user_id
         # when a writer doesn't carry an authenticated user (auth disabled, or
         # background jobs extracted from anonymous context). Matches the
@@ -147,14 +148,21 @@ class KnowledgeGraphService:
         from services.atom_service import AtomService
         return AtomService(self.db)
 
-    async def _get_ollama_client(self):
-        if self._ollama_client is None:
-            self._ollama_client = get_embed_client()
-        return self._ollama_client
+    async def _get_embed_client(self):
+        """Embed-tier LLM client (Qwen3-Embedding via llama-server-embed)."""
+        if self._embed_client is None:
+            self._embed_client = get_embed_client()
+        return self._embed_client
+
+    async def _get_chat_client(self):
+        """Chat-tier LLM client (Qwen3.6 via llama-server-agent) for KG extraction."""
+        if self._chat_client is None:
+            self._chat_client = get_default_client()
+        return self._chat_client
 
     async def _get_embedding(self, text_input: str) -> list[float]:
-        """Generate embedding using Ollama."""
-        client = await self._get_ollama_client()
+        """Generate embedding via the embed-tier LLM client."""
+        client = await self._get_embed_client()
         response = await client.embeddings(
             model=settings.ollama_embed_model,
             prompt=text_input,
@@ -183,7 +191,7 @@ class KnowledgeGraphService:
             llm_options = prompt_manager.get_config("knowledge_graph", "llm_options") or {}
             model = settings.kg_extraction_model or settings.ollama_model
 
-            client = await self._get_ollama_client()
+            client = await self._get_chat_client()
             response = await client.chat(
                 model=model,
                 messages=[
@@ -615,7 +623,7 @@ class KnowledgeGraphService:
         try:
             from utils.llm_client import extract_response_content, get_classification_chat_kwargs
 
-            client = await self._get_ollama_client()
+            client = await self._get_chat_client()
             response = await client.chat(
                 model=model,
                 messages=[
@@ -766,7 +774,7 @@ class KnowledgeGraphService:
         try:
             from utils.llm_client import extract_response_content, get_classification_chat_kwargs
 
-            client = await self._get_ollama_client()
+            client = await self._get_chat_client()
             response = await client.chat(
                 model=model,
                 messages=[

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -161,6 +161,29 @@ class Settings(BaseSettings):
     agent_total_timeout: float = Field(default=120.0, ge=5.0, le=600.0)
     agent_model: str | None = None     # Optional: separate model for agent (default: ollama_model)
     agent_ollama_url: str | None = None # Optional: separate Ollama instance for agent (default: ollama_url)
+
+    # OpenAI-compatible LLM endpoint (e.g. llama-server). When set, the agent
+    # tier (and optionally chat/RAG/intent via per-tier overrides below) routes
+    # through this endpoint instead of Ollama. The URL must include the
+    # OpenAI-compatible path prefix, typically `…/v1`.
+    llm_openai_base_url: str | None = None
+    llm_openai_api_key: SecretStr | None = None    # Any non-empty string is accepted by llama-server
+    llm_openai_model: str = "qwen3.6"               # Logical model name exposed by the server (`--alias`)
+    # Per-tier opt-in: when True, that tier uses llm_openai_base_url instead of Ollama.
+    # `agent` defaults to True if llm_openai_base_url is set; chat/rag/intent default
+    # to following the agent setting unless explicitly overridden.
+    llm_openai_for_agent: bool | None = None
+    llm_openai_for_chat: bool | None = None
+    llm_openai_for_rag: bool | None = None
+    llm_openai_for_intent: bool | None = None
+    llm_openai_for_kg: bool | None = None
+    llm_openai_for_memory: bool | None = None
+
+    # Separate OpenAI-compatible endpoint for embeddings (a llama-server pod
+    # configured with `--embedding`, hosting an embedding-specific GGUF like
+    # Qwen3-Embedding-4B). When set, embeddings route here instead of Ollama.
+    llm_openai_embed_base_url: str | None = None
+    llm_openai_embed_model: str = "qwen3-embedding"
     agent_conv_context_messages: int = 12  # Number of conversation history messages in agent loop
     conversation_summary_threshold: int = 10  # Trigger LLM summary when message count exceeds this
     agent_roles_path: str = "config/agent_roles.yaml"  # Path to agent role definitions

--- a/src/backend/utils/llm_client.py
+++ b/src/backend/utils/llm_client.py
@@ -165,32 +165,54 @@ def _make_client_with_fallback(primary_url: str) -> LLMClient:
 
 
 def get_default_client() -> LLMClient:
-    """Return the client for ``settings.ollama_url`` (with fallback if configured)."""
+    """Return the client for the default chat tier.
+
+    When ``LLM_OPENAI_BASE_URL`` is set and the chat tier opts in (default: yes),
+    routes through the OpenAI-compatible endpoint (llama-server). Otherwise
+    falls back to the Ollama URL with transparent OLLAMA_FALLBACK_URL retry.
+    """
+    if use_openai_for_tier("chat"):
+        client = get_openai_compat_client()
+        if client is not None:
+            return client  # type: ignore[return-value]
     return _make_client_with_fallback(settings.ollama_url)
 
 
 def get_embed_client() -> LLMClient:
     """Return the client for embedding calls.
 
-    Uses ``settings.ollama_embed_url`` when configured (separate Ollama instance
-    dedicated to embeddings), otherwise falls back to ``get_default_client()``.
-    Both paths include transparent fallback via ``OLLAMA_FALLBACK_URL``.
+    Priority:
+      1. ``LLM_OPENAI_EMBED_BASE_URL`` set → OpenAI-compatible embed client
+         (a llama-server pod with --embedding hosting Qwen3-Embedding etc).
+      2. ``OLLAMA_EMBED_URL`` set → dedicated Ollama embed instance.
+      3. Fall back to ``settings.ollama_url`` (NOT get_default_client, which
+         may itself have been swapped to a chat-only llama-server).
     """
+    embed_oa = get_openai_compat_embed_client()
+    if embed_oa is not None:
+        return embed_oa  # type: ignore[return-value]
     if settings.ollama_embed_url:
         return _make_client_with_fallback(settings.ollama_embed_url)
-    return get_default_client()
+    return _make_client_with_fallback(settings.ollama_url)
 
 
 def get_agent_client(
     role_url: str | None = None,
     fallback_url: str | None = None,
 ) -> tuple[LLMClient, str]:
-    """Resolve agent URL with priority: *role_url* → *fallback_url* → default.
+    """Resolve agent client with OpenAI-compatible priority:
+
+      1. If ``LLM_OPENAI_BASE_URL`` is set and the agent tier opts in (default
+         when configured): return the OpenAI-compatible client.
+      2. Otherwise: ``role_url`` → ``fallback_url`` → ``settings.ollama_url``
+         with transparent fallback wrapping.
 
     Returns ``(client, resolved_url)`` so callers can log which URL won.
-    The resolved client includes transparent fallback if ``OLLAMA_FALLBACK_URL``
-    is configured.
     """
+    if use_openai_for_tier("agent"):
+        client = get_openai_compat_client()
+        if client is not None:
+            return client, settings.llm_openai_base_url or ""  # type: ignore[return-value]
     resolved = role_url or fallback_url or settings.ollama_url
     return _make_client_with_fallback(resolved), resolved
 
@@ -198,6 +220,291 @@ def get_agent_client(
 def clear_client_cache() -> None:
     """Clear the client cache (useful in tests)."""
     _client_cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-compatible client adapter (for llama-server / vLLM / etc.)
+# ---------------------------------------------------------------------------
+#
+# llama-server exposes an OpenAI-compatible REST API at /v1. To plug it in
+# without touching every call-site, we wrap openai.AsyncOpenAI in an adapter
+# that satisfies the LLMClient Protocol AND returns response objects with
+# the same attribute shape as ollama.AsyncClient (`response.message.content`,
+# `response.message.tool_calls`, etc). Renfield's response handling already
+# tolerates dict-style and attribute-style access, so a SimpleNamespace
+# wrapper is enough.
+
+
+class _OllamaShapedMessage:
+    """Mimics ollama.ChatResponse.message — attribute access for content,
+    tool_calls, role, thinking. Renfield reads via getattr/dict mixed."""
+
+    __slots__ = ("role", "content", "tool_calls", "thinking")
+
+    def __init__(self, role: str, content: str, tool_calls: list[Any] | None, thinking: str | None) -> None:
+        self.role = role
+        self.content = content
+        self.tool_calls = tool_calls
+        self.thinking = thinking
+
+
+class _OllamaShapedResponse:
+    """Mimics ollama.ChatResponse with .message attribute."""
+
+    __slots__ = ("message", "model", "done")
+
+    def __init__(self, message: _OllamaShapedMessage, model: str) -> None:
+        self.message = message
+        self.model = model
+        self.done = True
+
+
+class OpenAICompatibleClient:
+    """Adapter that satisfies the LLMClient Protocol against an OpenAI-style API.
+
+    Translates Renfield's Ollama-shaped chat() invocation into an OpenAI
+    chat.completions request, then wraps the response so existing call-sites
+    that read ``response.message.content`` / ``.tool_calls`` / ``.thinking``
+    keep working unchanged.
+
+    Streaming is supported via async iterators that yield Ollama-shaped
+    chunks (``chunk.message.content``).
+
+    Embeddings: not supported by every llama-server build; raises
+    NotImplementedError so the caller falls through to the Ollama embed path.
+    """
+
+    def __init__(self, base_url: str, api_key: str, default_model: str) -> None:
+        import openai
+
+        self._client = openai.AsyncOpenAI(base_url=base_url.rstrip("/"), api_key=api_key or "no-key")
+        self._default_model = default_model
+        self._base_url = base_url
+
+    @staticmethod
+    def _convert_messages(messages: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+        """Pass Renfield's chat-message list through with minor normalization.
+
+        Ollama and OpenAI use the same {role, content} shape; tool messages
+        and tool_calls also match. Only difference: Ollama allows `images`
+        on user messages — we strip those (vision goes to a separate tier).
+        """
+        if not messages:
+            return []
+        out: list[dict[str, Any]] = []
+        for m in messages:
+            mm = {k: v for k, v in m.items() if k != "images"}
+            out.append(mm)
+        return out
+
+    @staticmethod
+    def _options_to_openai(options: dict[str, Any] | None, kwargs: dict[str, Any]) -> dict[str, Any]:
+        """Map Ollama `options` (temperature/top_p/num_predict/...) to OpenAI kwargs.
+
+        Only the fields Renfield actually sets are mapped — anything else is
+        dropped silently (ollama accepts a wide pile of options that have no
+        OpenAI counterpart, like `mirostat`).
+        """
+        oa: dict[str, Any] = {}
+        opts = options or {}
+        if "temperature" in opts:
+            oa["temperature"] = opts["temperature"]
+        if "top_p" in opts:
+            oa["top_p"] = opts["top_p"]
+        if "num_predict" in opts:
+            oa["max_tokens"] = opts["num_predict"]
+        if "seed" in opts:
+            oa["seed"] = opts["seed"]
+        if "stop" in opts:
+            oa["stop"] = opts["stop"]
+        if kwargs.get("format") == "json":
+            oa["response_format"] = {"type": "json_object"}
+        return oa
+
+    @staticmethod
+    def _think_extra_body(kwargs: dict[str, Any]) -> dict[str, Any]:
+        """Translate Ollama's `think=False` flag into a llama-server
+        chat-template kwarg so Qwen3-family thinking mode is suppressed."""
+        if kwargs.get("think") is False:
+            return {"chat_template_kwargs": {"enable_thinking": False}}
+        return {}
+
+    async def chat(
+        self,
+        model: str = "",
+        messages: list[dict[str, Any]] | None = None,
+        *,
+        stream: bool = False,
+        options: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        oa_messages = self._convert_messages(messages)
+        oa_kwargs = self._options_to_openai(options, kwargs)
+        extra_body = self._think_extra_body(kwargs)
+
+        # Tools: Ollama accepts a `tools` list with the OpenAI function schema
+        # already, so pass through. tool_choice maps directly.
+        if "tools" in kwargs:
+            oa_kwargs["tools"] = kwargs["tools"]
+        if "tool_choice" in kwargs:
+            oa_kwargs["tool_choice"] = kwargs["tool_choice"]
+
+        request_model = model or self._default_model
+
+        if stream:
+            return self._chat_stream(request_model, oa_messages, oa_kwargs, extra_body)
+
+        response = await self._client.chat.completions.create(
+            model=request_model,
+            messages=oa_messages,
+            stream=False,
+            extra_body=extra_body or None,
+            **oa_kwargs,
+        )
+        return self._wrap_response(response, request_model)
+
+    async def _chat_stream(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        oa_kwargs: dict[str, Any],
+        extra_body: dict[str, Any],
+    ) -> Any:
+        stream = await self._client.chat.completions.create(
+            model=model,
+            messages=messages,
+            stream=True,
+            extra_body=extra_body or None,
+            **oa_kwargs,
+        )
+        async for chunk in stream:
+            choice = chunk.choices[0] if chunk.choices else None
+            if not choice:
+                continue
+            delta = choice.delta
+            content = (delta.content or "") if delta else ""
+            tool_calls = getattr(delta, "tool_calls", None) if delta else None
+            yield _OllamaShapedResponse(
+                _OllamaShapedMessage(
+                    role="assistant",
+                    content=content,
+                    tool_calls=tool_calls,
+                    thinking=None,
+                ),
+                model,
+            )
+
+    @staticmethod
+    def _wrap_response(response: Any, model: str) -> _OllamaShapedResponse:
+        choice = response.choices[0] if response.choices else None
+        msg = choice.message if choice else None
+        content = (msg.content if msg else "") or ""
+        tool_calls = getattr(msg, "tool_calls", None) if msg else None
+        # llama-server with thinking-enabled exposes reasoning_content; harmless if absent.
+        thinking = getattr(msg, "reasoning_content", None) if msg else None
+        return _OllamaShapedResponse(
+            _OllamaShapedMessage(
+                role="assistant",
+                content=content,
+                tool_calls=tool_calls,
+                thinking=thinking,
+            ),
+            model,
+        )
+
+    async def embeddings(
+        self,
+        model: str = "",
+        prompt: str = "",
+        *,
+        options: dict[str, Any] | None = None,  # noqa: ARG002
+        **_kwargs: Any,
+    ) -> Any:
+        """Embed `prompt` and return an Ollama-shaped result with `.embedding`.
+
+        Renfield reads `response.embedding` (a flat list of floats); OpenAI
+        returns `response.data[0].embedding`. We wrap the OpenAI result in a
+        SimpleNamespace so existing call-sites need no change.
+        """
+        from types import SimpleNamespace
+
+        request_model = model or self._default_model
+        response = await self._client.embeddings.create(model=request_model, input=prompt)
+        first = response.data[0] if response.data else None
+        embedding = list(first.embedding) if first else []
+        return SimpleNamespace(embedding=embedding, model=request_model)
+
+    async def list(self) -> Any:  # noqa: D401
+        """Return a minimal Ollama-style model list. Used by health checks."""
+        from types import SimpleNamespace
+
+        oa_models = await self._client.models.list()
+        models = [SimpleNamespace(model=m.id, name=m.id) for m in oa_models.data]
+        return SimpleNamespace(models=models)
+
+
+def _make_openai_compat_client(*, base_url: str, default_model: str) -> OpenAICompatibleClient:
+    """Construct an OpenAI-compatible client for the given endpoint."""
+    api_key = settings.llm_openai_api_key.get_secret_value() if settings.llm_openai_api_key else "no-key"
+    return OpenAICompatibleClient(
+        base_url=base_url,
+        api_key=api_key,
+        default_model=default_model,
+    )
+
+
+def get_openai_compat_client() -> OpenAICompatibleClient | None:
+    """Cached chat/agent OpenAI-compatible client, or None if not configured."""
+    base_url = settings.llm_openai_base_url
+    if not base_url:
+        return None
+    cache_key = f"__openai_compat_chat__:{_normalize_url(base_url)}"
+    if cache_key not in _client_cache:
+        _client_cache[cache_key] = _make_openai_compat_client(  # type: ignore[assignment]
+            base_url=base_url,
+            default_model=settings.llm_openai_model,
+        )
+    return _client_cache.get(cache_key)  # type: ignore[return-value]
+
+
+def get_openai_compat_embed_client() -> OpenAICompatibleClient | None:
+    """Cached embed OpenAI-compatible client, or None if not configured.
+
+    Distinct from get_openai_compat_client() because embeddings live on a
+    separate llama-server pod (with --embedding flag and a different model).
+    """
+    base_url = settings.llm_openai_embed_base_url
+    if not base_url:
+        return None
+    cache_key = f"__openai_compat_embed__:{_normalize_url(base_url)}"
+    if cache_key not in _client_cache:
+        _client_cache[cache_key] = _make_openai_compat_client(  # type: ignore[assignment]
+            base_url=base_url,
+            default_model=settings.llm_openai_embed_model,
+        )
+    return _client_cache.get(cache_key)  # type: ignore[return-value]
+
+
+def use_openai_for_tier(tier: str) -> bool:
+    """Return True iff the given tier should route through the OpenAI-compatible
+    endpoint instead of Ollama.
+
+    Resolution order:
+      1. If `llm_openai_base_url` is unset → always False.
+      2. If a per-tier override is set explicitly → use it.
+      3. Otherwise, follow the agent setting (which defaults to True when the
+         endpoint is configured).
+    """
+    if not settings.llm_openai_base_url:
+        return False
+    per_tier_attr = f"llm_openai_for_{tier}"
+    per_tier = getattr(settings, per_tier_attr, None)
+    if per_tier is not None:
+        return bool(per_tier)
+    agent = settings.llm_openai_for_agent
+    if agent is None:
+        return True  # default: route everything through llama-server when configured
+    return bool(agent)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **New:** Two llama.cpp pods replace the Ollama deployment for the text-LLM tiers. `llama-server-agent` runs Qwen3.6-35B-A3B-UD-Q4_K_XL (~22 GB) on `k8s-gpu-1` with tensor-split across both GPUs (32 GB combined VRAM). `llama-server-embed` runs Qwen3-Embedding-4B (~2.4 GB) on `k8s-gpu-2` CPU-only. Embedding dimension stays at 2560 — no DB schema change.
- **Backend integration:** new `OpenAICompatibleClient` wraps `openai.AsyncClient` and returns Ollama-shaped responses (`response.message.content` / `tool_calls` / `thinking`), so existing call sites work unchanged. Routing logic in `utils/llm_client.py` picks per-tier (`agent`, `chat`, `embed`, …).
- **Three bugs uncovered + fixed during e2e validation** (details below).

## Hardware / k8s topology change

After the recent rewire, `k8s-gpu-1` (VM 201) gets both GPUs via Proxmox passthrough (`hostpci0` + `hostpci1`), `k8s-gpu-2` (VM 202) is CPU-only. Both VMs upgraded to 8 cores / 32 GB RAM. README in the `private_k8s` repo updated separately.

`llama-server-agent` requests `nvidia.com/gpu: 2` (exclusive on `k8s-gpu-1`). `llama-server-embed` runs CPU-only on `k8s-gpu-2`. Ollama deployment retargeted to `k8s-gpu-2` (CPU-only) and removed from `kustomization.yaml` — manifest kept in-tree as a fast-rollback option. Init-container `nc -z ollama 11434` swapped for waits on the two llama-server services in `backend.yaml` + `document-worker.yaml`.

## Bugs fixed during migration

1. **Chat-on-embed misrouting.** `conversation_memory_service`, `knowledge_graph_service`, and `kg_retrieval` all stored a single `_ollama_client = get_embed_client()` and used it for both `.embeddings()` and `.chat()`. Pre-split this worked because Ollama hosted both models on one URL; post-split the chat calls landed on the CPU embed pod (~5 tps), turning every WS turn into a 2 m+ pre-router stall. Split into `_get_chat_client` / `_get_embed_client` per service.

2. **`NameError: name 'user_id' is not defined`** in `api/websocket/chat_handler.py:_stream_rag_response`. Function signature was missing the parameter; every knowledge-route RAG call errored into the fallback path. Fixed signature + 3 call sites.

3. **Memory-extraction silent fail on Qwen3.6.** `extract_and_save` didn't pass `think=False`, so the JSON answer landed in `reasoning_content` while `content` came back empty — `extracted=0` with no warning. Same class of bug we landed for the KG path earlier. Fixed via the existing `get_classification_chat_kwargs(model)` + `extract_response_content(response)` pattern. Added INFO logs for memory extraction starting/done and a WARN for the trigger-skipped branch so silent skips are auditable.

## End-to-end timing (rc4, after both fixes)

| Path | Latency |
|---|---|
| HTTP plain conversation | 0.9 s |
| HTTP factual / math | 2.0 s |
| HTTP smart-home tool call | 2.1 s |
| HTTP web search (multi-step) | 7.0 s |
| WS pre-router (was 2 m 31 s) | 0.55 s |
| WS conversation + memory write | 1.1 s |
| WS conversation + memory recall | 3.5 s |
| WS smart-home (4 agent steps) | 9 s |

Reva-class throughput: 150 tok/s single-slot on the agent pod. Embed pod: ~50-200 ms per query on CPU.

## Test plan

- [x] llama-server-agent boots clean from `/mnt/llm/qwen3.6-35b-a3b-q4kxl.gguf` (NFS), tensor-split visible in `nvidia-smi`, both GPUs ~9-11 GB used.
- [x] llama-server-embed boots clean, dim=2560 verified via `/v1/embeddings`.
- [x] Backend health (`/health`) green; no `failed to initialize NVML` from k8s-gpu-2 (containerd `default_runtime_name` reverted to `runc`).
- [x] HTTP `/api/chat/send` battery (greeting / factual / smart-home / search / continuation) — all 0.9-7 s.
- [x] WebSocket `/ws/chat` smart-home tool-call (HassTurnOn) — 9 s for 4 agent steps with HA config issue (light-target mismatch in HA, not our concern).
- [x] WebSocket setup + cross-session recall via Memory ("Mein Lieblingsobst ist Ananas" → DB id=4 → recall in fresh session returns "Ananas").
- [x] Browser-E2E against `https://renfield.local` (Playwright with `--ignore-https-errors`).
- [ ] Vision tier (qwen3-vl) — disabled in this PR (`OLLAMA_VISION_MODEL=""`); 3rd llama-server pod with mmproj follows.
- [ ] Concurrency soak under realistic multi-user load (deferred).

Image rolled out as `registry.treehouse.x-idra.de/renfield/backend:llama-rc4` to all three image-consumers (backend, document-worker, dlna-mcp). No migrations needed (`alembic heads` unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)