### PR TITLE
fix(voice): TTS regression on new piper-tts API + WS same-origin fallback

### DIFF
--- a/src/backend/services/piper_service.py
+++ b/src/backend/services/piper_service.py
@@ -117,9 +117,15 @@ class PiperService:
         served for the wrong speaker. Extend the cache key first if/when we
         adopt multi-speaker voices.
         """
+        # piper-tts API change: `synthesize()` now returns AudioChunk
+        # iterators and no longer writes to a wave file directly. Use the
+        # split `synthesize_wav()` method which preserves the prior contract
+        # (text in, populated WAV file out, sample format auto-set). Without
+        # this, `wave.close()` raises "# channels not specified" because the
+        # 2nd arg got interpreted as a SynthesisConfig and silently ignored.
         buffer = io.BytesIO()
         with wave.open(buffer, "wb") as wav_file:
-            voice.synthesize(text, wav_file)
+            voice.synthesize_wav(text, wav_file)
         return buffer.getvalue()
 
     async def _synthesize_async(self, voice: "PiperVoice", text: str) -> bytes:

--- a/src/frontend/src/utils/env.ts
+++ b/src/frontend/src/utils/env.ts
@@ -55,8 +55,13 @@ export function getApiBaseUrl(): string {
 
 /**
  * WebSocket URL for the Renfield backend (includes `/ws` path per convention).
- * Falls back to `ws://localhost:8000/ws` when `VITE_WS_URL` is unset, with a
- * console warning.
+ *
+ * - DEV (`npm run dev`): falls back to `ws://localhost:8000/ws` with a warning.
+ * - PROD (built bundle) without `VITE_WS_URL`: derives a same-origin WS URL
+ *   from `window.location` (e.g. `wss://renfield.local/ws`). Mirror of the
+ *   `getApiBaseUrl()` same-origin behaviour landed in PR #526. Without this,
+ *   a HTTPS-served bundle attempted `ws://localhost:8000/ws` from the
+ *   browser — mixed-content, blocked by Chrome.
  *
  * Consumers that need a different endpoint (e.g. `/ws/device`) should strip
  * the trailing `/ws` from the return value and append their own path —
@@ -65,6 +70,10 @@ export function getApiBaseUrl(): string {
 export function getWebSocketUrl(): string {
   const value = import.meta.env.VITE_WS_URL as string | undefined;
   if (value && value.length > 0) return value;
+  if (import.meta.env.PROD && typeof window !== 'undefined' && window.location) {
+    const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    return `${proto}//${window.location.host}/ws`;
+  }
   warnFallback('VITE_WS_URL', FALLBACK_WS_URL);
   return FALLBACK_WS_URL;
 }


### PR DESCRIPTION
## Summary

Two voice-pipeline fixes uncovered while testing on Chrome/macOS after #527 (llama-server migration). Both small, both already verified live in `:llama-rc6`.

### 1. TTS broken — piper-tts API breaking change

`services/piper_service.py:121-123`. piper-tts changed `voice.synthesize(text, wav_file)` into a generator returning `Iterable[AudioChunk]` and split the wave-writing variant off as `voice.synthesize_wav(text, wav_file)`. The old call signature silently re-interpreted `wav_file` as the new `syn_config` parameter, wrote nothing to the WAV buffer, and `wave.close()` raised `# channels not specified`.

Why now: the previous Docker image (v2.4.x) had a compatible piper-tts pinned via the deps layer cache; the rebuild for #527 pulled a newer wheel and tripped the latent incompatibility.

Fix: switch the one call to `synthesize_wav` — same external contract as before. No `requirements.txt` change.

**Backend log before:** `❌ TTS Fehler (de_DE-thorsten-high): # channels not specified`
**After:** `📥 Piper voice geladen: de_DE-thorsten-high` → `POST /api/voice/tts 200 OK` (~70 KB WAV)

### 2. `getWebSocketUrl()` same-origin fallback (mirror of #526)

PR #526 added a same-origin fallback to `getApiBaseUrl()`; the symmetric fix for `getWebSocketUrl()` wasn't landed at that time. Not the user-facing failure mode today because the Dockerfile defaults `VITE_WS_URL=/ws` (relative path already works), but a custom build that overrides `VITE_WS_URL=""` or removes the ARG would hit `ws://localhost:8000/ws` from a HTTPS page → mixed-content blocked.

## Test plan

- [x] `:llama-rc6` rolled to `backend`, `document-worker`, `dlna-mcp`
- [x] TTS smoke from inside backend pod: `POST /api/voice/tts` (24-char text) → 200 OK, 70 KB WAV
- [x] Chrome/macOS round-trip: STT (633-char transcript) → text chat → TTS playback all working after image rollout
- [x] No regression on the `getWebSocketUrl()` path with the default Dockerfile ARG

## Notes for future maintainers

If `requirements.txt` ever explicitly pins piper-tts to <`<the-version-with-new-API>`, this fix can be reverted — but the new API is cleaner anyway and the docs are consistent (`synthesize_wav` matches Whisper's `transcribe`-style APIs that produce a result type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)