### PR TITLE
chore(voice): B.4.d — drop legacy WHISPER_*/PIPER_* env vars

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -65,9 +65,13 @@ data:
   OLLAMA_VISION_MODEL: ""
   AGENT_MODEL: "qwen3:14b"
   EMBEDDING_DIMENSION: "2560"
-  WHISPER_MODEL: "small"
-  PIPER_VOICES: "de:de_DE-thorsten-high,en:en_US-amy-medium"
-  PIPER_DEFAULT_VOICE: "de_DE-thorsten-high"
+  # B.4.d: WHISPER_MODEL, PIPER_VOICES, PIPER_DEFAULT_VOICE removed.
+  # The voice tier runs in voice-server (k8s-gpu-3) since B.1; backend
+  # services only consume STT/TTS via voice_server_client. The
+  # in-process Whisper/Piper code paths are gated on
+  # `VOICE_SERVER_URL` being unset and exist for local dev only.
+  # Pydantic Settings keeps reasonable defaults if anything reads
+  # these — the env vars themselves are no longer authoritative.
 
   # RAG
   RAG_ENABLED: "true"


### PR DESCRIPTION
## Summary

Final step of the Phase B voice migration: drop `WHISPER_MODEL`, `PIPER_VOICES`, `PIPER_DEFAULT_VOICE` from the configmap. The backend has been routing voice through voice-server since #531, and #532 made the in-process Whisper/Piper code paths a dev-only fallback gated on `VOICE_SERVER_URL` being unset.

## Strict ordering (per design § Migration plan)

Already done in this order (no risk of crashing a running pod):
1. ✅ #531 — voice-server stands up; backend optionally delegates `/api/voice/voice-chat`
2. ✅ #532 — backend's `whisper_service` + `piper_service` delegate when `VOICE_SERVER_URL` is set
3. ✅ Backend rolled to `:voice-rc2` with the new code
4. ✅ Voice-server rolled with the partial-VAD fix
5. ✅ E2E validation green (voice-chat orchestrator + browser smoke + partial transcripts under continuous speech)
6. ⬅ **THIS PR** — drop the env vars now that no running pod relies on them

## Live state

- Backend: `:voice-rc2` running, `VOICE_SERVER_URL=http://voice-server:8080` set
- Voice-server: live on k8s-gpu-3, ECAPA on CUDAExecutionProvider
- Speaches deployment: scaled to 0 (parked, will be removed in a follow-up after a week of soak)

## Test plan

- [x] Configmap applied without backend restart (was already applied as a no-op safety pass during validation; this PR captures it in the repo)
- [x] Backend `/health` still ok
- [x] Voice-chat E2E still works post-configmap-update
- [ ] Watch for ~1 week of stable voice traffic before considering Speaches removal + `VITE_FEATURE_VOICE_STREAM` flag drop (B.6)

## Phase B is now done

The migration described in `docs/VOICE_PIPELINE_DESIGN.md` § "Phase B" is complete:
- Voice tier moved off backend pod onto k8s-gpu-3 voice-server
- Streaming WebSocket protocol live (frontend behind feature flag)
- Speaker recognition preserved end-to-end (D4)
- Phase B promise of partial transcripts during continuous speech now actually delivered (was empirically broken in #531 due to vad_filter; fixed in B.4.c.1)
- Same response shape preserved for satellite firmware (`/api/voice/{stt,tts,voice-chat}`)

Next milestones from the design: B.5 (XTTS-v2 spike, separate work), B.6 (flag drop after soak), Phase C (speech-to-speech endgame).

🤖 Generated with [Claude Code](https://claude.com/claude-code)