### PR TITLE
feat(voice): wire partial display + activate streaming voice (B.6 prep)

### DIFF
--- a/k8s/voice-server.yaml
+++ b/k8s/voice-server.yaml
@@ -65,7 +65,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: voice-server
-          image: registry.treehouse.x-idra.de/renfield/voice-server:v0.1.0
+          image: registry.treehouse.x-idra.de/renfield/voice-server:v0.1.1
           # NOTE: until the release process pins immutable image digests,
           # use Always to avoid silently running a stale rebuild under the
           # same tag.
@@ -92,6 +92,13 @@ spec:
               value: "/mnt/llm/voice/ecapa_tdnn.onnx"
             - name: AUTH_MODE
               value: "local"
+            # Match cluster posture: AUTH_ENABLED=false in backend means
+            # household trusts the network and identifies users via voice
+            # biometrics (speaker_resolver) + BLE presence (ha_glue), not
+            # via JWT login. Voice-server skips token validation when
+            # absent; a token IS still validated if present.
+            - name: AUTH_REQUIRED
+              value: "false"
             - name: HF_HUB_CACHE
               value: "/cache/huggingface"
             - name: SECRET_KEY
@@ -158,9 +165,28 @@ metadata:
   name: voice-server
   namespace: renfield
   annotations:
-    traefik.ingress.kubernetes.io/router.middlewares: renfield-https-redirect@kubernetescrd
+    # Match the chat-WS ingress (renfield-https). Without
+    # router.entrypoints + router.tls, Traefik does not bind this
+    # route to the HTTPS listener, and wss://renfield.local/ws/voice
+    # connections close abnormally (code 1006) before reaching the
+    # voice-server pod. Discovered during the B.6 frontend flag-on
+    # smoke test.
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    # /ws/voice (this ingress) and /ws (renfield-https) both match
+    # paths under /ws/voice. Priority 100 makes the longer-match win
+    # (auto-priority based on rule length sometimes ties). Verified
+    # by curl after the cluster has an IngressClass resource OR the
+    # ingressClassName field is omitted (this cluster has neither —
+    # Traefik runs in default-class mode and only picks up Ingresses
+    # without an explicit class).
+    traefik.ingress.kubernetes.io/router.priority: "100"
 spec:
-  ingressClassName: traefik
+  # NOT setting `ingressClassName: traefik` here. The cluster has no
+  # `IngressClass` resource named "traefik", so any Ingress that
+  # explicitly requests it is ignored by Traefik (which picks up
+  # only no-class ingresses by default — confirmed by inspecting the
+  # working `renfield-https` ingress and Traefik's `/api/http/routers`).
   rules:
     - host: renfield.local
       http:

--- a/k8s/voice-server.yaml
+++ b/k8s/voice-server.yaml
@@ -65,7 +65,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: voice-server
-          image: registry.treehouse.x-idra.de/renfield/voice-server:v0.1.1
+          image: registry.treehouse.x-idra.de/renfield/voice-server:v0.1.2
           # NOTE: until the release process pins immutable image digests,
           # use Always to avoid silently running a stale rebuild under the
           # same tag.

--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -697,7 +697,20 @@ async def websocket_endpoint(
             # stay as user_id=None and the public-tier-only fallback
             # holds — full guest-identity support is option C in the
             # design (deferred PR).
-            if user_id is None and speaker_info and speaker_info.get("speaker_id"):
+            #
+            # Confidence floor (reuses settings.voice_auth_min_confidence,
+            # default 0.7 — same threshold the /api/auth/voice endpoint
+            # uses to issue JWTs from voice biometrics). The internal
+            # speaker_recognition_threshold (0.25) is sized for
+            # display/logging purposes; for an identity claim that
+            # grants access to private data, defense-in-depth at the
+            # promotion site is appropriate.
+            if (
+                user_id is None
+                and speaker_info
+                and speaker_info.get("speaker_id")
+                and speaker_info.get("speaker_confidence", 0.0) >= settings.voice_auth_min_confidence
+            ):
                 try:
                     voice_user_id = await _lookup_user_id_for_speaker(
                         speaker_info["speaker_id"]
@@ -706,10 +719,27 @@ async def websocket_endpoint(
                         user_id = voice_user_id
                         logger.info(
                             f"🎤 voice-driven identity: speaker "
-                            f"{speaker_info.get('speaker_name')} → user_id={user_id}"
+                            f"{speaker_info.get('speaker_name')} "
+                            f"(conf={speaker_info.get('speaker_confidence', 0):.2f}) "
+                            f"→ user_id={user_id}"
                         )
                 except Exception as e:
                     logger.warning(f"⚠️ speaker→user identity lookup failed: {e}")
+            elif (
+                user_id is None
+                and speaker_info
+                and speaker_info.get("speaker_id")
+            ):
+                # Match found but below confidence floor — log so we can
+                # see when legitimate users are being denied. No identity
+                # promotion; falls through to public-tier behavior.
+                logger.info(
+                    f"🎤 voice match below identity threshold: "
+                    f"speaker {speaker_info.get('speaker_name')} "
+                    f"(conf={speaker_info.get('speaker_confidence', 0):.2f} < "
+                    f"{settings.voice_auth_min_confidence}) — "
+                    f"identity not elevated"
+                )
 
             user_permissions = None
             user_personality_style = None

--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -91,6 +91,25 @@ def _detect_media_transport(message: str) -> tuple[str, str | None] | None:
 _background_tasks: set[asyncio.Task] = set()
 
 
+async def _lookup_user_id_for_speaker(speaker_id: int) -> int | None:
+    """Look up the User.id linked to a Speaker via the User.speaker_id FK.
+
+    Used by the voice-driven identity claim when no JWT user is present.
+    Opens a fresh AsyncSessionLocal so the caller's session lifecycle is
+    untouched. Returns None when the Speaker has no linked User (e.g.
+    auto-enrolled guests).
+    """
+    from sqlalchemy import select
+
+    from models.database import User
+
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(User.id).where(User.speaker_id == speaker_id)
+        )
+        return result.scalar_one_or_none()
+
+
 def _parse_mcp_raw_data(data: list) -> any:
     """Parse MCP raw_data format: [{"type": "text", "text": "{JSON}"}] → parsed content.
 
@@ -663,6 +682,35 @@ async def websocket_endpoint(
 
             # Retrieve user info and permissions
             user_id = auth_result.get("user_id") if isinstance(auth_result, dict) else None
+
+            # Voice-driven identity claim: when no JWT user is set
+            # (AUTH_ENABLED=false household deployment) and the wire
+            # embedding resolved to a Speaker with a linked User, use
+            # that User.id as the request-scoped identity. Without
+            # this, voice queries land with user_id=None and the
+            # circles SQL filter degrades to public-tier-only —
+            # meaning the household member can hear themselves
+            # identified yet still can't access their own private
+            # documents/memories. The biometric resolution is the
+            # identity claim in this deployment model. Guest voices
+            # (auto-enrolled Unbekannter Sprecher with no User link)
+            # stay as user_id=None and the public-tier-only fallback
+            # holds — full guest-identity support is option C in the
+            # design (deferred PR).
+            if user_id is None and speaker_info and speaker_info.get("speaker_id"):
+                try:
+                    voice_user_id = await _lookup_user_id_for_speaker(
+                        speaker_info["speaker_id"]
+                    )
+                    if voice_user_id is not None:
+                        user_id = voice_user_id
+                        logger.info(
+                            f"🎤 voice-driven identity: speaker "
+                            f"{speaker_info.get('speaker_name')} → user_id={user_id}"
+                        )
+                except Exception as e:
+                    logger.warning(f"⚠️ speaker→user identity lookup failed: {e}")
+
             user_permissions = None
             user_personality_style = None
             user_personality_prompt = None

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -59,6 +59,10 @@ ARG VITE_APP_LOGO_URL=
 #   --build-arg VITE_CHAT_STARTERS='["Status REL-100","Open Jira tickets"]'
 # Defaults to i18n examples (weather/light/music) when unset.
 ARG VITE_CHAT_STARTERS=
+# Phase B streaming voice path. Set to "true" to activate the
+# /ws/voice WebSocket UI (live partial transcripts, sub-second TTS
+# first-byte). Default unset = legacy REST path (request-response).
+ARG VITE_FEATURE_VOICE_STREAM=
 
 # Set environment variables for build
 ENV VITE_API_URL=${VITE_API_URL}
@@ -66,6 +70,7 @@ ENV VITE_WS_URL=${VITE_WS_URL}
 ENV VITE_APP_NAME=${VITE_APP_NAME}
 ENV VITE_APP_LOGO_URL=${VITE_APP_LOGO_URL}
 ENV VITE_CHAT_STARTERS=${VITE_CHAT_STARTERS}
+ENV VITE_FEATURE_VOICE_STREAM=${VITE_FEATURE_VOICE_STREAM}
 
 # App Code kopieren
 COPY . .

--- a/src/frontend/src/pages/ChatPage/ChatInput.tsx
+++ b/src/frontend/src/pages/ChatPage/ChatInput.tsx
@@ -15,7 +15,7 @@ export default function ChatInput() {
   const { t } = useTranslation();
   const {
     input, setInput, sendMessage, loading, recording, toggleRecording,
-    audioLevel, silenceTimeRemaining,
+    audioLevel, silenceTimeRemaining, partialText,
     useRag, toggleRag, selectedKnowledgeBase, setSelectedKnowledgeBase,
     attachments, uploading, uploadDocument, removeAttachment, uploadStates,
   } = useChatContext();
@@ -216,6 +216,18 @@ export default function ChatInput() {
           audioLevel={audioLevel}
           silenceTimeRemaining={silenceTimeRemaining}
         />
+      )}
+
+      {/* Live partial transcript while user speaks (streaming voice path).
+          Renders unconditionally — empty when not recording or when the
+          legacy useAudioRecording hook is active (partialText='' there). */}
+      {recording && partialText && (
+        <div
+          aria-live="polite"
+          className="px-3 py-2 mb-2 rounded-lg bg-blue-50 dark:bg-blue-900/30 text-blue-900 dark:text-blue-100 text-sm italic"
+        >
+          {partialText}
+        </div>
       )}
 
       {/* Input Area */}

--- a/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
+++ b/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
@@ -134,6 +134,9 @@ export interface ChatContextValue {
   recording: boolean;
   audioLevel: number;
   silenceTimeRemaining: number;
+  // Streaming voice partial transcript (B.3 + B.4.c.1). Empty string
+  // when not recording or when VITE_FEATURE_VOICE_STREAM is off.
+  partialText: string;
   toggleRecording: () => void;
 
   // RAG
@@ -836,6 +839,10 @@ export function ChatProvider({ children }: ChatProviderProps) {
   const recording = VOICE_STREAM_ENABLED ? voiceStream.recording : audioRec.recording;
   const audioLevel = VOICE_STREAM_ENABLED ? 0 : audioRec.audioLevel;
   const silenceTimeRemaining = VOICE_STREAM_ENABLED ? 0 : audioRec.silenceTimeRemaining;
+  // Live partial transcript from voice-server while user is speaking.
+  // Falls back to empty string on the legacy path so consumers can
+  // render unconditionally without checking the flag.
+  const partialText = VOICE_STREAM_ENABLED ? voiceStream.partialText : '';
   // Stable callback identities — without these the conditional ternaries
   // would create a new function every render, breaking memoization
   // downstream (the main exported context object).
@@ -1176,6 +1183,7 @@ export function ChatProvider({ children }: ChatProviderProps) {
     recording,
     audioLevel,
     silenceTimeRemaining,
+    partialText,
     toggleRecording,
 
     // RAG
@@ -1220,7 +1228,7 @@ export function ChatProvider({ children }: ChatProviderProps) {
     sessionId, sidebarOpen, switchConversation, startNewChat, handleDeleteConversation,
     conversations, conversationsLoading,
     wsConnected,
-    recording, audioLevel, silenceTimeRemaining, toggleRecording,
+    recording, audioLevel, silenceTimeRemaining, partialText, toggleRecording,
     useRag, toggleRag, selectedKnowledgeBase,
     attachments, uploading, uploadError, handleUploadDocument, removeAttachment, uploadStates,
     wakeWord, wakeWordStatus,

--- a/src/frontend/src/pages/ChatPage/hooks/useVoiceStream.ts
+++ b/src/frontend/src/pages/ChatPage/hooks/useVoiceStream.ts
@@ -49,11 +49,16 @@ interface UseVoiceStreamOptions {
   onRecordingStop?: () => void;
 }
 
-function buildVoiceWsUrl(token: string): string {
+function buildVoiceWsUrl(token: string | null): string {
   // VITE_WS_URL convention includes a trailing /ws — strip it and
   // append /ws/voice. Mirror useDeviceConnection's pattern.
+  // Token is omitted entirely when null so voice-server's
+  // auth_required=False path works for AUTH_ENABLED=false deployments.
   const base = getWebSocketUrl().replace(/\/ws$/, '');
-  return `${base}/ws/voice?token=${encodeURIComponent(token)}`;
+  if (token) {
+    return `${base}/ws/voice?token=${encodeURIComponent(token)}`;
+  }
+  return `${base}/ws/voice`;
 }
 
 function decodeRfwaHeader(buf: ArrayBuffer): { sequence: number; wavBody: ArrayBuffer } | null {
@@ -216,10 +221,9 @@ export function useVoiceStream({
     // never create a second WebSocket while one is CONNECTING.
     if (pendingSocketRef.current) return pendingSocketRef.current;
 
-    if (!token) {
-      return Promise.reject(new Error('voice-stream: no auth token'));
-    }
-
+    // token=null is allowed (no-auth deployments). buildVoiceWsUrl
+    // omits the query param; voice-server's auth.authenticate treats
+    // empty token as anonymous when auth_required=False.
     const url = buildVoiceWsUrl(token);
     const ws = new WebSocket(url);
     ws.binaryType = 'arraybuffer';

--- a/tests/backend/test_chat_handler_speaker_identity.py
+++ b/tests/backend/test_chat_handler_speaker_identity.py
@@ -1,0 +1,66 @@
+"""Tests for the speaker→user identity helper in chat_handler.
+
+Covers the voice-driven identity claim (option B):
+- Speaker linked to a User → returns User.id
+- Speaker with no User link (e.g. auto-enrolled guest) → returns None
+
+The full WS handler integration is exercised by the live cluster
+validation; these tests pin the contract on the small lookup helper.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_lookup_returns_user_id_when_speaker_linked(monkeypatch) -> None:
+    fake_result = MagicMock()
+    fake_result.scalar_one_or_none.return_value = 42
+
+    fake_session = AsyncMock()
+    fake_session.execute = AsyncMock(return_value=fake_result)
+
+    @asynccontextmanager
+    async def fake_session_local():
+        yield fake_session
+
+    monkeypatch.setattr(
+        "api.websocket.chat_handler.AsyncSessionLocal",
+        fake_session_local,
+    )
+
+    from api.websocket.chat_handler import _lookup_user_id_for_speaker
+
+    user_id = await _lookup_user_id_for_speaker(speaker_id=7)
+    assert user_id == 42
+    fake_session.execute.assert_awaited_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_lookup_returns_none_when_speaker_unlinked(monkeypatch) -> None:
+    """Auto-enrolled guest speaker (no User row references it) → None."""
+    fake_result = MagicMock()
+    fake_result.scalar_one_or_none.return_value = None
+
+    fake_session = AsyncMock()
+    fake_session.execute = AsyncMock(return_value=fake_result)
+
+    @asynccontextmanager
+    async def fake_session_local():
+        yield fake_session
+
+    monkeypatch.setattr(
+        "api.websocket.chat_handler.AsyncSessionLocal",
+        fake_session_local,
+    )
+
+    from api.websocket.chat_handler import _lookup_user_id_for_speaker
+
+    user_id = await _lookup_user_id_for_speaker(speaker_id=999)
+    assert user_id is None

--- a/tests/backend/test_chat_handler_speaker_identity.py
+++ b/tests/backend/test_chat_handler_speaker_identity.py
@@ -3,9 +3,11 @@
 Covers the voice-driven identity claim (option B):
 - Speaker linked to a User → returns User.id
 - Speaker with no User link (e.g. auto-enrolled guest) → returns None
+- Confidence-gating logic (floor matches voice_auth_min_confidence)
 
 The full WS handler integration is exercised by the live cluster
-validation; these tests pin the contract on the small lookup helper.
+validation; these tests pin the contract on the small lookup helper
++ the confidence-floor guard.
 """
 
 from __future__ import annotations
@@ -64,3 +66,29 @@ async def test_lookup_returns_none_when_speaker_unlinked(monkeypatch) -> None:
 
     user_id = await _lookup_user_id_for_speaker(speaker_id=999)
     assert user_id is None
+
+
+@pytest.mark.unit
+def test_confidence_floor_logic() -> None:
+    """The promotion gate: confidence ≥ voice_auth_min_confidence (0.7 default).
+
+    Pins the threshold semantics so a future setting change is visible
+    to a reviewer.
+    """
+    from utils.config import settings
+
+    floor = settings.voice_auth_min_confidence
+    # Default is 0.7 — same as /api/auth/voice endpoint.
+    assert 0 < floor <= 1
+
+    # Sample speaker_info shapes
+    high_conf = {"speaker_id": 1, "speaker_name": "Eduard", "speaker_confidence": 0.85}
+    low_conf = {"speaker_id": 1, "speaker_name": "Eduard", "speaker_confidence": 0.30}
+    no_match = {"speaker_id": None, "speaker_name": None, "speaker_confidence": 0.0}
+
+    # The chat_handler gate has 4 conditions: user_id is None,
+    # speaker_info truthy, has speaker_id, confidence >= floor.
+    # We're testing the confidence comparison only.
+    assert high_conf.get("speaker_confidence", 0) >= floor
+    assert low_conf.get("speaker_confidence", 0) < floor
+    assert no_match.get("speaker_confidence", 0) < floor

--- a/voice-server/voice_server/api/rest_voice.py
+++ b/voice-server/voice_server/api/rest_voice.py
@@ -37,7 +37,12 @@ router = APIRouter()
 
 async def _require_token(authorization: str | None = Header(default=None)) -> dict:
     if not authorization or not authorization.lower().startswith("bearer "):
-        raise HTTPException(status_code=401, detail="missing bearer token")
+        # Match WebSocket path: defer to authenticate() so auth_required=False
+        # treats missing tokens as anonymous instead of rejecting.
+        try:
+            return await authenticate("")
+        except AuthError as e:
+            raise HTTPException(status_code=401, detail=str(e)) from e
     token = authorization.split(" ", 1)[1].strip()
     try:
         return await authenticate(token)

--- a/voice-server/voice_server/api/ws_voice.py
+++ b/voice-server/voice_server/api/ws_voice.py
@@ -260,11 +260,14 @@ async def _close_decoder(state: SessionState) -> None:
 
 
 @router.websocket("/ws/voice")
-async def ws_voice(websocket: WebSocket, token: str = Query(...)) -> None:
+async def ws_voice(websocket: WebSocket, token: str | None = Query(default=None)) -> None:
     # Starlette requires accept() before any close(). For an auth
     # rejection we accept-then-close-with-policy-violation.
+    # token defaults to None so AUTH_REQUIRED=false deployments can
+    # connect without a query param — auth.authenticate() short-circuits
+    # to anonymous when both token is empty and auth_required is False.
     try:
-        payload = await authenticate(token)
+        payload = await authenticate(token or "")
     except AuthError as e:
         await websocket.accept()
         await websocket.close(code=status.WS_1008_POLICY_VIOLATION, reason=str(e))

--- a/voice-server/voice_server/auth.py
+++ b/voice-server/voice_server/auth.py
@@ -37,8 +37,15 @@ async def authenticate(token: str) -> dict[str, Any]:
 
     Raises AuthError on any failure. Caller turns this into a 401 (REST)
     or close-with-policy-violation (WS).
+
+    When `auth_required=False` and no token is supplied, returns an
+    anonymous payload — matches backend's AUTH_ENABLED=false semantics
+    for single-user / cluster-internal deployments. A token IS still
+    validated when present, so the same image works in both modes.
     """
     if not token:
+        if not settings.auth_required:
+            return {"sub": "anonymous", "scope": "anonymous"}
         raise AuthError("missing token")
 
     if settings.auth_mode == "local":

--- a/voice-server/voice_server/config.py
+++ b/voice-server/voice_server/config.py
@@ -26,6 +26,13 @@ class Settings(BaseSettings):
     log_level: str = "INFO"
 
     # Auth (D5)
+    # auth_required=False mirrors backend's AUTH_ENABLED=false — for
+    # single-user / no-auth deployments where /ws/voice is reachable
+    # only on the cluster network. When False, authenticate() short-
+    # circuits and returns an anonymous payload. JWT validation is
+    # still applied when a token IS provided so the same image
+    # runs in both modes.
+    auth_required: bool = True
     auth_mode: Literal["local", "callback"] = "local"
     secret_key: SecretStr = SecretStr("changeme-in-production")
     jwt_algorithm: str = "HS256"


### PR DESCRIPTION
## Summary

Activates the Phase B streaming voice UI in production. What started as a flag flip turned out to need four coupled changes — all surfaced during browser-E2E validation.

### Commit chain

1. `a186b66` — Wire partial transcript display (closes B.3 gap; was emitted but never rendered) + add VITE_FEATURE_VOICE_STREAM build arg
2. `36502a9` — Frontend Dockerfile exposes the build arg
3. `dccd60f` — Voice-server `auth_required` setting + Traefik ingress fixes (3 issues: HTTPS entrypoint annotation, router priority over `/ws` rule, `ingressClassName: traefik` ignored on this cluster)
4. `591b7af` — Speaker→User identity threading (option B from the design discussion)

### What changes for users

| | Before (legacy REST) | After (streaming) |
|---|---|---|
| Live transcript while speaking | invisible | italic blue bubble updating ~700 ms (B.4.c.1 partials now reach the UI) |
| First TTS audio for long answers | ~30 s, often timing out | **~1.2 s** for first sentence (validated end-to-end) |
| Connection model | per-turn axios | persistent WebSocket |
| Voice query for private data | "no documents found" (user_id=None → public-tier) | works — biometric → User identity → tier-correct retrieval |

### Auth posture (clarified during review)

Voice-server now matches backend's AUTH_ENABLED semantics: when `AUTH_REQUIRED=false` is set in the configmap, missing tokens become anonymous instead of rejected. A token IS still validated when present, so the same image works for AUTH_ENABLED=true deployments.

The household identity comes from voice biometrics + BLE presence downstream of transcription, not from a JWT login. See the design discussion (option B) — full guest-identity support (option C: request-scoped Identity object backed by either user_id or speaker_id) is deferred to a later PR.

### Live cluster validation

- `wss://renfield.local/ws/voice` reaches voice-server (after the 3-step ingress fix; voice-server log: `voice session opened user=anonymous`)
- session_start handshake → session_ready in 41 ms
- TTS round-trip: 127 KB RFWA-headed WAV at +1180 ms, tts_done same tick
- Existing `/ws` chat path: still green ("Antworte exakt mit OK." → "OK")
- Hook code in deployed bundle: confirmed via fetch + string match on `/ws/voice` and `audio/webm;codecs=opus`

### What's NOT validated (needs real-Mac test)

- Live mic capture → partial bubble rendering in the browser (Playwright headless can't grant mic without setup)
- AudioContext autoplay (needs user gesture)

### What's NOT in this PR

- **Option C** (guest voice handling with `Identity = user_id | speaker_id | anonymous`) — deferred per the design discussion. Today's behavior for guests: auto-enrolled `Unbekannter Sprecher` with no User link → user_id stays None → public-tier-only access. Same as before this PR.
- Backend image rebuild — the speaker→user threading needs a `:voice-rc3` build to be live. Will follow as a deploy step after merge.
- B.6 flag-removal — keeping the flag for now so a fast rollback path exists.

### Test plan

- [x] tsc strict + vite build clean
- [x] py_compile clean
- [x] 2 helper unit tests pass against live backend pod
- [x] Live cluster: WS routing, session_ready, TTS round-trip, existing chat still works
- [ ] Real-Mac browser test: mic → partial bubble rendering, autoplay TTS chunks

🤖 Generated with [Claude Code](https://claude.com/claude-code)