### PR TITLE
fix(voice): /api/voice/stt rejected browser webm uploads

### DIFF
--- a/k8s/voice-server.yaml
+++ b/k8s/voice-server.yaml
@@ -65,7 +65,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: voice-server
-          image: registry.treehouse.x-idra.de/renfield/voice-server:v0.1.2
+          image: registry.treehouse.x-idra.de/renfield/voice-server:v0.1.3
           # NOTE: until the release process pins immutable image digests,
           # use Always to avoid silently running a stale rebuild under the
           # same tag.

--- a/voice-server/voice_server/api/rest_voice.py
+++ b/voice-server/voice_server/api/rest_voice.py
@@ -26,7 +26,7 @@ from fastapi.responses import Response
 from pydantic import BaseModel
 
 from voice_server.auth import AuthError, authenticate
-from voice_server.services.audio_decoder import AudioDecoder
+from voice_server.services.audio_oneshot import OneshotDecodeError, decode_audio_to_pcm
 from voice_server.services.speaker_service import SpeakerService
 from voice_server.services.stt_service import STTService
 from voice_server.services.tts_service import TTSService
@@ -69,25 +69,20 @@ async def stt_endpoint(
     if not audio_bytes:
         raise HTTPException(status_code=400, detail="empty audio")
 
-    content_type = (audio.content_type or "").lower()
-    codec = (
-        "audio/wav"
-        if "wav" in content_type or audio.filename and audio.filename.lower().endswith(".wav")
-        else "audio/webm;codecs=opus" if "webm" in content_type
-        else "audio/ogg;codecs=opus" if "ogg" in content_type
-        else "audio/wav"
-    )
-
-    decoder = AudioDecoder(codec)
+    # REST gives us a complete file — let ffmpeg auto-detect the container
+    # and codec. The streaming AudioDecoder pins -f to a codec hint
+    # because chunks can't be auto-detected, but that hint over-constrains
+    # full-file uploads (e.g. browser MediaRecorder webm/opus rejected by
+    # `-f webm`). The one-shot decoder also captures stderr so failures
+    # produce a real error message instead of silent 0 PCM.
     try:
-        await decoder.start()
-        await decoder.push(audio_bytes)
-        pcm = await decoder.flush()
-    finally:
-        await decoder.close()
+        pcm = await decode_audio_to_pcm(audio_bytes)
+    except OneshotDecodeError as e:
+        logger.warning("STT decode failed: %s", e)
+        raise HTTPException(status_code=400, detail=f"audio decode failed: {e}") from e
 
     if pcm.size == 0:
-        raise HTTPException(status_code=400, detail="ffmpeg produced no PCM")
+        raise HTTPException(status_code=400, detail="empty PCM after decode")
 
     stt: STTService = request.app.state.stt
     speaker: SpeakerService = request.app.state.speaker

--- a/voice-server/voice_server/services/audio_oneshot.py
+++ b/voice-server/voice_server/services/audio_oneshot.py
@@ -1,0 +1,70 @@
+"""One-shot audio decoder for REST file uploads.
+
+Distinct from AudioDecoder (streaming path) — REST gives us a complete
+file, so we let ffmpeg auto-detect the format instead of pinning `-f`
+to a codec hint. Browsers' MediaRecorder webm output sometimes fails
+the strict `-f webm` demuxer when the explicit codec hint doesn't
+match the Matroska track-codec inside; auto-detect handles webm/opus,
+ogg/opus, wav, mp3, flac, m4a transparently.
+
+Stderr captured (not DEVNULL) so failures surface in logs instead of
+the silent "0 PCM bytes" mystery the streaming path produces.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+class OneshotDecodeError(Exception):
+    pass
+
+
+async def decode_audio_to_pcm(audio_bytes: bytes, *, timeout_s: float = 30.0) -> np.ndarray:
+    """Decode any common audio container to mono 16 kHz float32 PCM.
+
+    Fixed argv (no shell). ffmpeg auto-detects the input format from
+    the byte stream — works for the full set browsers / satellites
+    actually send (webm/opus, ogg/opus, wav, mp3, flac, m4a).
+    """
+    if not audio_bytes:
+        raise OneshotDecodeError("empty input")
+
+    argv = [
+        "ffmpeg",
+        "-loglevel", "error",
+        "-i", "pipe:0",
+        "-ac", "1",
+        "-ar", "16000",
+        "-f", "f32le",
+        "pipe:1",
+    ]
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(
+            proc.communicate(audio_bytes), timeout=timeout_s
+        )
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+        raise OneshotDecodeError(f"ffmpeg timeout after {timeout_s}s") from None
+
+    if proc.returncode != 0:
+        msg = stderr.decode("utf-8", errors="replace").strip()[:400]
+        raise OneshotDecodeError(f"ffmpeg exit {proc.returncode}: {msg}")
+
+    if not stdout:
+        msg = stderr.decode("utf-8", errors="replace").strip()[:400]
+        raise OneshotDecodeError(f"ffmpeg produced no PCM (stderr: {msg})")
+
+    return np.frombuffer(stdout, dtype=np.float32).copy()


### PR DESCRIPTION
## Summary

Real-Mac browser test of the legacy `useAudioRecording` REST path hit a 500 on `/api/voice/stt`. Console error chain:

```
ort-wasm-simd-threaded.mjs:44:343  Lb (wakeword detector)
Failed to load resource: 500 (stt, line 0)
API Error: Ee
Voice input error: Ee
```

Backend logs revealed:
```
voice-server STT returned 400: ffmpeg produced no PCM
HTTPException: 400: Transkription fehlgeschlagen → 500 to browser
```

## Root cause

Voice-server's REST endpoint was reusing the streaming `AudioDecoder` which pins ffmpeg's `-f` codec hint. That's correct for streaming chunks (RISK-2: partial data can't auto-detect format), but over-constraining for one-shot file uploads. Browser MediaRecorder webm/opus output sometimes fails the strict `-f webm` demuxer.

`AudioDecoder` also routes ffmpeg's stderr to `DEVNULL`, so the failure surfaced as the silent 0-PCM mystery instead of a real error.

## Fix

New `voice_server/services/audio_oneshot.py` — fixed-argv ffmpeg invocation without `-f`, lets ffmpeg auto-detect from bytes. Captures stderr for diagnostics. 30 s timeout guard.

`rest_voice.py` STT endpoint switches to the one-shot helper. WS path keeps `AudioDecoder` (correct for streaming chunks).

K8s manifest bumped to `:v0.1.3`.

## Verified live

Backend → voice-server STT now returns 200 with correct German transcript for both:
- Piper-generated WAV (the path that always worked)
- Converted webm/opus file mimicking what MediaRecorder produces

Both paths through the same `/api/voice/stt` REST endpoint.

## Why this surfaces now

PR #532 made `whisper_service.transcribe_bytes` delegate to voice-server via HTTP when `VOICE_SERVER_URL` is set. The cluster has had `VOICE_SERVER_URL=http://voice-server:8080` since #533. Pre-#532, `whisper_service` wrote bytes to a tempfile and called `faster-whisper` directly, which has its own permissive audio loader. Post-#532, the bytes flow through voice-server's `AudioDecoder` whose strict `-f` rejected webms that faster-whisper would have happily decoded.

## Test plan

- [x] py_compile clean
- [x] Backend → voice-server STT works for WAV (regression check)
- [x] Backend → voice-server STT works for webm/opus (the actual bug)
- [ ] Real-Mac browser test: speak into the mic, transcript appears, chat responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)