### PR TITLE
fix(users): unlink-speaker hits wrong URL — 404 swallowed silently

### DIFF
--- a/src/frontend/src/api/resources/users.ts
+++ b/src/frontend/src/api/resources/users.ts
@@ -103,7 +103,10 @@ async function linkSpeakerRequest(args: { userId: number; speakerId: number }): 
 }
 
 async function unlinkSpeakerRequest(userId: number): Promise<void> {
-  await apiClient.delete(`/api/users/${userId}/unlink-speaker`);
+  // Backend uses REST verb-on-noun: POST /link-speaker creates the link,
+  // DELETE /link-speaker removes it. There is no `/unlink-speaker` route
+  // — it returned 404 silently and the unlink button looked broken.
+  await apiClient.delete(`/api/users/${userId}/link-speaker`);
 }
 
 export function useUsersQuery() {

--- a/tests/frontend/react/pages/UsersPage.test.tsx
+++ b/tests/frontend/react/pages/UsersPage.test.tsx
@@ -261,6 +261,71 @@ describe('UsersPage', () => {
         expect(deleteUserId).not.toBeNull();
       });
     });
+
+    it('unlinks speaker via DELETE /api/users/:id/link-speaker', async () => {
+      // Regression: previous code called DELETE /unlink-speaker (typo); the
+      // backend route is DELETE /link-speaker (REST verb-on-noun).
+      // The 404 was swallowed silently and the unlink button looked broken.
+      const user = userEvent.setup();
+      let unlinkUrl: string | null = null;
+
+      server.use(
+        http.delete(`${BASE_URL}/api/users/:id/link-speaker`, ({ request, params }) => {
+          unlinkUrl = new URL(request.url).pathname;
+          return HttpResponse.json({ id: parseInt(params.id as string, 10), speaker_id: null });
+        }),
+      );
+
+      renderWithProviders(<UsersPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('user1')).toBeInTheDocument();
+      });
+
+      // user1 (id=2) has speaker_id=1, so its row shows the unlink button.
+      const unlinkButtons = screen.getAllByTitle('Sprecher trennen');
+      await user.click(unlinkButtons[0]);
+
+      await waitFor(() => {
+        expect(unlinkUrl).toBe('/api/users/2/link-speaker');
+      });
+    });
+
+    it('links speaker via POST /api/users/:id/link-speaker', async () => {
+      const user = userEvent.setup();
+      let linkPostBody: { speaker_id?: number } | null = null;
+      let linkUrl: string | null = null;
+
+      server.use(
+        http.post<{ id: string }>(`${BASE_URL}/api/users/:id/link-speaker`, async ({ request, params }) => {
+          linkUrl = new URL(request.url).pathname;
+          linkPostBody = (await request.json()) as { speaker_id?: number };
+          return HttpResponse.json({ id: parseInt(params.id, 10), speaker_id: linkPostBody.speaker_id });
+        }),
+      );
+
+      renderWithProviders(<UsersPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('admin')).toBeInTheDocument();
+      });
+
+      // admin (id=1) has speaker_id=null — its row shows the link button.
+      // Speaker 2 in the mock is the only unlinked one (Speaker 1 is on user1).
+      const linkButtons = screen.getAllByTitle('Sprecher verknüpfen');
+      await user.click(linkButtons[0]);
+
+      // Modal opens with available speakers; click Speaker 2.
+      await waitFor(() => {
+        expect(screen.getByText('Speaker 2')).toBeInTheDocument();
+      });
+      await user.click(screen.getByText('Speaker 2'));
+
+      await waitFor(() => {
+        expect(linkUrl).toBe('/api/users/1/link-speaker');
+        expect(linkPostBody).toEqual({ speaker_id: 2 });
+      });
+    });
   });
 
   describe('Error Handling', () => {


### PR DESCRIPTION
## Summary

Bug: clicking 'Sprecher trennen' (Unlink speaker) on the Users admin page does nothing visible. The user reasonably interpreted this as 'cannot link/unlink speakers any longer' — the link flow looks broken too because there are no available speakers to link when nobody can be unlinked.

## Root cause

| | URL |
|---|---|
| Frontend (`api/resources/users.ts:106`) | `DELETE /api/users/${userId}/unlink-speaker` |
| Backend (`routes/users.py:567`) | `DELETE /api/users/${user_id}/link-speaker` |

REST verb-on-noun: backend uses POST `/link-speaker` (create the link) and DELETE `/link-speaker` (remove it). Frontend had a typo: `/unlink-speaker`.

The 404 was caught, surfaced as a generic error toast that was easy to miss, and the speaker stayed linked.

## Reproduction (verified via Playwright on prod)

```
Click "Sprecher trennen" on user1 (linked) → confirm dialog → "Trennen"
DEVTOOLS:
  DELETE https://renfield.local/api/users/2/unlink-speaker → 404
  Console: "API Error: Ne"
```

## Fix

One-line in `src/frontend/src/api/resources/users.ts:106`: change `/unlink-speaker` → `/link-speaker`.

## Test plan

- [x] Two new MSW-backed tests in `tests/frontend/react/pages/UsersPage.test.tsx`:
  - `unlinks speaker via DELETE /api/users/:id/link-speaker`
  - `links speaker via POST /api/users/:id/link-speaker`
  - Both pin the URL contract; reverting to the typo would fail the unlink test
- [x] Existing UsersPage tests still pass (17/17)
- [x] No new typecheck errors (one pre-existing tail error in `test-chat-mock.ts` is from the W10 TypeScript migration, unrelated)

## Out of scope (follow-ups)

- The iOS Capacitor bundle (`src/frontend/ios/`) has the same buggy URL but is a frozen 2026-03-31 snapshot. It'll be picked up automatically when the iOS app is next rebuilt; not blocking.
- The error toast for `users.failedToUnlink` could be more prominent — current wording shown briefly was easy for the user to miss. Defer to a UX pass.

## Deployment

This is a frontend-only fix. Production rollout: Docker rebuild + Harbor push + `kubectl rollout restart deployment frontend` after merge. Voice + audio paths unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)