### PR TITLE
chore(k8s): AGENT_MODEL → qwen3.6 (log cosmetic)

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -63,7 +63,7 @@ data:
   OLLAMA_INTENT_MODEL: "qwen3:8b"
   OLLAMA_EMBED_MODEL: "qwen3-embedding:4b"
   OLLAMA_VISION_MODEL: ""
-  AGENT_MODEL: "qwen3:14b"
+  AGENT_MODEL: "qwen3.6"
   EMBEDDING_DIMENSION: "2560"
   # B.4.d: WHISPER_MODEL, PIPER_VOICES, PIPER_DEFAULT_VOICE removed.
   # The voice tier runs in voice-server (k8s-gpu-3) since B.1; backend


### PR DESCRIPTION
Per `tasks/todo.md` §4. Functionally a no-op; just makes the agent-tier logs match the model name llama-server actually serves (`--alias qwen3.6`).

`is_thinking_model('qwen3.6')` still matches the 'qwen3' prefix in `utils/llm_client.py:42-48` so thinking-model detection is unaffected.

After merge: `kubectl apply -f k8s/configmap.yaml && kubectl rollout restart deployment/backend -n renfield` (configmap-as-env values aren't auto-reloaded).

Other `OLLAMA_*_MODEL` keys left alone deliberately — they're separate routing concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)