### PR TITLE
feat(hooks): verify_tool_call gate + voice_originated ContextVar

### DIFF
--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -22,6 +22,7 @@ from services.input_guard import detect_injection
 from services.websocket_auth import WSAuthError, authenticate_websocket
 from services.websocket_rate_limiter import get_rate_limiter
 from utils.config import settings
+from utils.voice_context import voice_originated
 
 from .shared import (
     ConversationSessionState,
@@ -598,6 +599,14 @@ async def websocket_endpoint(
                 await send_ws_error(websocket, WSErrorCode.RATE_LIMITED, reason)
                 continue
 
+            # Voice-origin signal: clear FIRST, then set after validation.
+            # Two-step so we can't leak the previous message's value if a
+            # future refactor adds an early-return path before the post-
+            # validation .set(). Child tasks spawned via
+            # ``asyncio.create_task`` / ``asyncio.gather`` inherit the
+            # value automatically (Python 3.7+ context propagation).
+            voice_originated.set(False)
+
             # Validate message
             try:
                 msg = WSChatMessage(**data)
@@ -613,15 +622,7 @@ async def websocket_endpoint(
                 await send_ws_error(websocket, WSErrorCode.INVALID_MESSAGE, str(e))
                 continue
 
-            # Voice-origin signal for downstream gates (plugin hooks like
-            # Reva's voice-2FA destructive-tool gate). Truthy embedding =
-            # came from the voice path; null/empty = text. Set per-message
-            # via ContextVar; child tasks spawned with ``asyncio.create_task``
-            # / ``asyncio.gather`` inherit the value automatically (Python
-            # 3.7+ context propagation). Each iteration of the WS loop
-            # overwrites the previous value, so a voice message followed
-            # by a text message correctly clears the flag.
-            from utils.voice_context import voice_originated
+            # Truthy embedding = came from the voice path; null/empty = text.
             voice_originated.set(bool(msg_speaker_embedding))
 
             # Phase B (B.4.a): resolve voice-server-supplied speaker

--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -613,6 +613,17 @@ async def websocket_endpoint(
                 await send_ws_error(websocket, WSErrorCode.INVALID_MESSAGE, str(e))
                 continue
 
+            # Voice-origin signal for downstream gates (plugin hooks like
+            # Reva's voice-2FA destructive-tool gate). Truthy embedding =
+            # came from the voice path; null/empty = text. Set per-message
+            # via ContextVar; child tasks spawned with ``asyncio.create_task``
+            # / ``asyncio.gather`` inherit the value automatically (Python
+            # 3.7+ context propagation). Each iteration of the WS loop
+            # overwrites the previous value, so a voice message followed
+            # by a text message correctly clears the flag.
+            from utils.voice_context import voice_originated
+            voice_originated.set(bool(msg_speaker_embedding))
+
             # Phase B (B.4.a): resolve voice-server-supplied speaker
             # embedding. When present, this came in via the streaming
             # voice path (voice-server /ws/voice → frontend → chat-WS).

--- a/src/backend/services/action_executor.py
+++ b/src/backend/services/action_executor.py
@@ -131,11 +131,45 @@ class ActionExecutor:
         # MCP tool intents (mcp.* prefix — handles HA, n8n, weather, search, etc.)
         if self.mcp_manager and intent.startswith("mcp."):
             logger.info(f"🔌 Executing MCP tool: {intent}")
+            from utils.hooks import run_hooks
+            from utils.voice_context import voice_originated
+
+            # Plugin gate: ``verify_tool_call`` runs BEFORE ``pre_mcp_call``.
+            # Plugins (e.g. Reva's voice-2FA destructive-tool gate) may
+            # short-circuit the MCP call by returning an abort sentinel.
+            # Param repair via ``pre_mcp_call`` is wasted work if the call
+            # is going to be aborted, and the audit row should log what
+            # the LLM intended (pre-rewrite), not the corrected version.
+            voice_flag = voice_originated.get()
+            verify_results = await run_hooks(
+                "verify_tool_call",
+                intent=intent,
+                parameters=parameters,
+                user_id=user_id,
+                voice_originated=voice_flag,
+            )
+            for verdict in verify_results:
+                if isinstance(verdict, dict) and verdict.get("abort") is True:
+                    logger.info(
+                        f"🛑 verify_tool_call aborted {intent} "
+                        f"(voice_originated={voice_flag})"
+                    )
+                    user_response = verdict.get("user_response", "")
+                    # Adaptive Card dict OR plain string. Both flow back
+                    # into the agent loop as if they were the tool result;
+                    # downstream rendering is the chat handler's job.
+                    return {
+                        "success": True,
+                        "message": user_response if isinstance(user_response, str) else "",
+                        "data": user_response if isinstance(user_response, dict) else None,
+                        "action_taken": False,
+                        "verify_aborted": True,
+                    }
+
             # Plugin pre-call rewrite. Plugins may repair malformed LLM
             # tool calls here (e.g. substitute a release id when the LLM
             # passed a title). First well-shaped non-None dict replaces
             # parameters; everything else is ignored.
-            from utils.hooks import run_hooks
             pre_call_results = await run_hooks(
                 "pre_mcp_call",
                 intent=intent,

--- a/src/backend/services/action_executor.py
+++ b/src/backend/services/action_executor.py
@@ -156,10 +156,17 @@ class ActionExecutor:
                     )
                     user_response = verdict.get("user_response", "")
                     # Adaptive Card dict OR plain string. Both flow back
-                    # into the agent loop as if they were the tool result;
-                    # downstream rendering is the chat handler's job.
+                    # into the agent loop as the tool result; downstream
+                    # rendering is the chat handler's job.
+                    #
+                    # success=False is intentional: the agent loop must
+                    # NOT chain another tool call thinking the original
+                    # succeeded. The user response IS the operation's
+                    # outcome — a confirmation prompt — not a delivered
+                    # action. action_taken=False reinforces this for the
+                    # legacy execution-state signal.
                     return {
-                        "success": True,
+                        "success": False,
                         "message": user_response if isinstance(user_response, str) else "",
                         "data": user_response if isinstance(user_response, dict) else None,
                         "action_taken": False,

--- a/src/backend/utils/hooks.py
+++ b/src/backend/utils/hooks.py
@@ -250,6 +250,45 @@ HOOK_EVENTS: frozenset[str] = frozenset({
     # title to its API id when the LLM passed the wrong parameter
     # shape). Platform default (no handler) is a no-op.
     "pre_mcp_call",
+    # Pre-MCP tool call gate — fired by ActionExecutor BEFORE
+    # ``pre_mcp_call`` for any ``mcp.*`` intent. Handlers receive
+    # ``intent: str, parameters: dict, user_id: int | None,
+    # voice_originated: bool`` and return:
+    #
+    #   * ``None`` — defer to other handlers / platform (proceed normally)
+    #   * ``{"abort": True, "user_response": <str | dict>, "audit": {...}}``
+    #     — skip the tool call. ``user_response`` is returned to the agent
+    #     loop as if it were the tool result (string for plain text,
+    #     Adaptive Card dict for rich UI). ``audit`` is a free-form dict
+    #     surfaced to other registered handlers via the same hook return
+    #     channel — platform itself doesn't persist it.
+    #   * ``{"abort": False}`` — explicit allow (currently equivalent to None;
+    #     reserved for future "force-allow over a later abort" semantics).
+    #
+    # Ordering: ``verify_tool_call`` runs BEFORE ``pre_mcp_call``. Rationale:
+    # the gate decides whether to execute at all; param repair is wasted
+    # work if the call is going to be aborted, and the audit row should
+    # log what the LLM intended (pre-rewrite), not the platform-corrected
+    # version.
+    #
+    # Forward-compat note for new ``pre_mcp_call`` handlers: if your
+    # handler normalizes a field that a ``verify_tool_call`` handler's
+    # policy reads (e.g. case-folding ``transition_issue.status``), the
+    # gate will see the pre-normalized value. Either move the rewrite
+    # to a different hook or update the policy to match the post-rewrite
+    # shape.
+    #
+    # First abort-sentinel result wins (registration order). Handler
+    # exceptions are caught and logged via ``run_hooks``; a crashed
+    # handler returns no opinion (proceeds to next handler / tool call).
+    # Plugins that need fail-closed semantics (BaFin / regulated tenants
+    # where a crashed gate must not silently allow voice-destructive
+    # calls through) should register a sibling watchdog handler that
+    # observes their primary handler's heartbeat.
+    #
+    # Platform default (no handler) is a no-op — proceeds to
+    # ``pre_mcp_call`` and the MCP call as before.
+    "verify_tool_call",
 })
 
 HookFn = Callable[..., Coroutine[Any, Any, Any]]

--- a/src/backend/utils/hooks.py
+++ b/src/backend/utils/hooks.py
@@ -256,35 +256,40 @@ HOOK_EVENTS: frozenset[str] = frozenset({
     # voice_originated: bool`` and return:
     #
     #   * ``None`` — defer to other handlers / platform (proceed normally)
-    #   * ``{"abort": True, "user_response": <str | dict>, "audit": {...}}``
-    #     — skip the tool call. ``user_response`` is returned to the agent
-    #     loop as if it were the tool result (string for plain text,
-    #     Adaptive Card dict for rich UI). ``audit`` is a free-form dict
-    #     surfaced to other registered handlers via the same hook return
-    #     channel — platform itself doesn't persist it.
-    #   * ``{"abort": False}`` — explicit allow (currently equivalent to None;
-    #     reserved for future "force-allow over a later abort" semantics).
+    #   * ``{"abort": True, "user_response": <str | dict>}`` — skip the
+    #     tool call. ``user_response`` is returned to the agent loop in
+    #     the synthesized result (string in ``message`` for plain text,
+    #     Adaptive Card dict in ``data`` for rich UI). The synthesized
+    #     result has ``success=False, action_taken=False`` so the agent
+    #     loop does NOT chain a follow-up tool call.
+    #   * ``{"abort": False}`` — explicit allow (currently equivalent to
+    #     None; reserved for future "force-allow over a later abort"
+    #     semantics).
     #
-    # Ordering: ``verify_tool_call`` runs BEFORE ``pre_mcp_call``. Rationale:
-    # the gate decides whether to execute at all; param repair is wasted
-    # work if the call is going to be aborted, and the audit row should
-    # log what the LLM intended (pre-rewrite), not the platform-corrected
-    # version.
+    # Multi-handler resolution: ``run_hooks`` filters None and returns
+    # all non-None contributions in registration order. ActionExecutor
+    # iterates and short-circuits on the FIRST ``{"abort": True}`` —
+    # later handlers' aborts are discarded silently. If you need to
+    # observe later handlers' opinions even after an abort, do that
+    # plumbing in your handler, not on the platform side.
     #
-    # Forward-compat note for new ``pre_mcp_call`` handlers: if your
-    # handler normalizes a field that a ``verify_tool_call`` handler's
-    # policy reads (e.g. case-folding ``transition_issue.status``), the
-    # gate will see the pre-normalized value. Either move the rewrite
-    # to a different hook or update the policy to match the post-rewrite
-    # shape.
+    # Ordering vs ``pre_mcp_call``: ``verify_tool_call`` runs FIRST.
+    # The gate decides whether to execute at all; param repair is
+    # wasted work if the call is going to be aborted, and an audit log
+    # should record what the LLM intended (pre-rewrite), not the
+    # platform-corrected version. If your ``pre_mcp_call`` handler
+    # normalizes a field a ``verify_tool_call`` policy reads (e.g.
+    # case-folding ``transition_issue.status``), the gate sees the
+    # pre-normalized value. Plugin authors: either move the rewrite to
+    # a different hook or write the policy against the LLM-shaped value.
     #
-    # First abort-sentinel result wins (registration order). Handler
-    # exceptions are caught and logged via ``run_hooks``; a crashed
-    # handler returns no opinion (proceeds to next handler / tool call).
-    # Plugins that need fail-closed semantics (BaFin / regulated tenants
-    # where a crashed gate must not silently allow voice-destructive
-    # calls through) should register a sibling watchdog handler that
-    # observes their primary handler's heartbeat.
+    # Failure semantics: handler exceptions are caught and logged via
+    # ``run_hooks`` — a crashed handler returns no opinion and the call
+    # proceeds. This is fail-OPEN at the platform layer. Plugins that
+    # need fail-CLOSED semantics (e.g. BaFin/regulated tenants where a
+    # crashed gate must not silently allow voice-destructive calls)
+    # MUST add their own outer try/except inside the handler that
+    # converts any exception to an abort sentinel.
     #
     # Platform default (no handler) is a no-op — proceeds to
     # ``pre_mcp_call`` and the MCP call as before.

--- a/src/backend/utils/voice_context.py
+++ b/src/backend/utils/voice_context.py
@@ -1,0 +1,50 @@
+"""Per-request voice-origin signal for the chat pipeline.
+
+When a chat message arrives via the voice path (frontend recorded audio →
+voice-server STT → ``WSChatMessage.speaker_embedding`` populated), this
+flag is set ``True`` for the duration of the request. Downstream code
+(plugin hooks, tool-execution gates, audit logging) reads it without
+threading the signal through every method signature.
+
+Why a ContextVar and not a kwarg:
+
+The chat-pipeline boundary is the WS handler; downstream paths fan out
+through agent loop → MCP execute → orchestrator sub-agents. Plumbing a
+``voice_originated`` kwarg through every layer (and every plugin's
+``pre_mcp_call`` / ``execute_tool`` handler) would be invasive and
+incomplete — plugin-defined tools aren't required to accept new kwargs.
+``contextvars`` propagates naturally to ``asyncio.create_task`` / ``gather``
+children (Python 3.7+) and stays request-scoped.
+
+Example::
+
+    from utils.voice_context import voice_originated
+
+    # WS handler, after parsing the inbound message:
+    voice_originated.set(bool(msg.speaker_embedding))
+
+    # Anywhere downstream:
+    if voice_originated.get():
+        ...
+
+Plugins (e.g. Reva's voice-2FA gate) may also set their own ContextVars
+for related signals (``voice_confirmed`` for re-issued tool calls after
+user confirmation). Those live in the plugin module; only the platform
+signal lives here.
+
+Audit note (2026-05-08, voice-2FA Phase 2):
+
+The chat path uses ``asyncio.create_task`` and ``asyncio.gather`` in
+several places (chat_handler, agent_service, orchestrator). Both
+APIs propagate the calling task's context to children by default —
+no explicit ``contextvars.copy_context()`` needed. The risk surface
+is non-default executors (``loop.run_in_executor``) and synchronous
+threadpool dispatch. Audit results are documented in the Phase 2 PR.
+"""
+from contextvars import ContextVar
+
+# True iff the current request originated from the voice path.
+# Default False: text channel, internal callers, background workers.
+voice_originated: ContextVar[bool] = ContextVar(
+    "voice_originated", default=False,
+)

--- a/tests/backend/test_action_executor.py
+++ b/tests/backend/test_action_executor.py
@@ -367,6 +367,11 @@ class TestActionExecutorVerifyToolCall:
         action_executor.mcp_manager.execute_tool.assert_not_called()
         assert result["verify_aborted"] is True
         assert result["action_taken"] is False
+        # success=False is intentional: agent loop must NOT chain another
+        # tool call thinking the original succeeded. The user response IS
+        # the operation's outcome (a confirmation prompt), not a delivered
+        # action.
+        assert result["success"] is False
         assert result["message"] == "Bitte bestätige diese Aktion."
 
     @pytest.mark.unit
@@ -393,6 +398,7 @@ class TestActionExecutorVerifyToolCall:
 
         action_executor.mcp_manager.execute_tool.assert_not_called()
         assert result["verify_aborted"] is True
+        assert result["success"] is False
         assert result["data"] == card
 
     @pytest.mark.unit
@@ -528,6 +534,95 @@ class TestActionExecutorVerifyToolCall:
             _hooks["verify_tool_call"].remove(crashing)
 
         # Handler crashed → run_hooks logged + skipped → MCP call proceeds.
+        action_executor.mcp_manager.execute_tool.assert_called_once()
+
+    @pytest.mark.unit
+    async def test_multiple_handlers_first_returns_none_second_aborts(self, action_executor):
+        """When multiple handlers register: None defers to next; first abort wins.
+
+        Pins the multi-handler resolution that the contract docstring
+        documents — without this test, a future refactor that breaks
+        ordering wouldn't be caught.
+        """
+        from utils.hooks import _hooks, register_hook
+
+        async def handler_a_none(intent, parameters, **kwargs):
+            return None
+
+        async def handler_b_aborts(intent, parameters, **kwargs):
+            return {"abort": True, "user_response": "blocked by B"}
+
+        register_hook("verify_tool_call", handler_a_none)
+        register_hook("verify_tool_call", handler_b_aborts)
+        try:
+            result = await action_executor.execute({
+                "intent": "mcp.release.delete_release",
+                "parameters": {"id": "REL-1"},
+                "confidence": 0.9,
+            })
+        finally:
+            _hooks["verify_tool_call"].remove(handler_a_none)
+            _hooks["verify_tool_call"].remove(handler_b_aborts)
+
+        action_executor.mcp_manager.execute_tool.assert_not_called()
+        assert result["verify_aborted"] is True
+        assert result["message"] == "blocked by B"
+
+    @pytest.mark.unit
+    async def test_multiple_abort_handlers_first_wins(self, action_executor):
+        """First abort sentinel wins, later abort discarded silently.
+
+        Pins the contract: registration order determines precedence.
+        Plugin authors who register a verify_tool_call handler need to
+        know that a later handler can never override an earlier abort.
+        """
+        from utils.hooks import _hooks, register_hook
+
+        async def handler_a_aborts(intent, parameters, **kwargs):
+            return {"abort": True, "user_response": "first abort"}
+
+        async def handler_b_aborts(intent, parameters, **kwargs):
+            return {"abort": True, "user_response": "second abort"}
+
+        register_hook("verify_tool_call", handler_a_aborts)
+        register_hook("verify_tool_call", handler_b_aborts)
+        try:
+            result = await action_executor.execute({
+                "intent": "mcp.release.delete_release",
+                "parameters": {"id": "REL-1"},
+                "confidence": 0.9,
+            })
+        finally:
+            _hooks["verify_tool_call"].remove(handler_a_aborts)
+            _hooks["verify_tool_call"].remove(handler_b_aborts)
+
+        action_executor.mcp_manager.execute_tool.assert_not_called()
+        assert result["message"] == "first abort"
+
+    @pytest.mark.unit
+    async def test_malformed_sentinel_proceeds(self, action_executor):
+        """Truthy non-bool 'abort' values do NOT trigger an abort.
+
+        Strict interpretation of the contract: only ``abort is True`` aborts.
+        Strings, numbers, dicts in the abort field are treated as no-opinion
+        — caller bug, fail-OPEN to MCP. Plugins must use the literal True.
+        """
+        from utils.hooks import _hooks, register_hook
+
+        async def malformed(intent, parameters, **kwargs):
+            return {"abort": "yes", "user_response": "blocked?"}  # truthy non-bool
+
+        register_hook("verify_tool_call", malformed)
+        try:
+            await action_executor.execute({
+                "intent": "mcp.release.list_releases",
+                "parameters": {},
+                "confidence": 0.9,
+            })
+        finally:
+            _hooks["verify_tool_call"].remove(malformed)
+
+        # Malformed sentinel ignored → MCP call proceeds normally.
         action_executor.mcp_manager.execute_tool.assert_called_once()
 
 

--- a/tests/backend/test_action_executor.py
+++ b/tests/backend/test_action_executor.py
@@ -300,6 +300,238 @@ class TestActionExecutorPreMCPCall:
 
 
 # ============================================================================
+# verify_tool_call hook Tests
+# ============================================================================
+
+class TestActionExecutorVerifyToolCall:
+    """Tests for the verify_tool_call gate hook.
+
+    The hook fires BEFORE pre_mcp_call. Plugins (e.g. Reva voice-2FA)
+    return an abort sentinel to short-circuit the MCP call and surface
+    a confirmation card to the user instead.
+    """
+
+    @pytest.mark.unit
+    async def test_no_handler_falls_through_to_pre_mcp_call(self, action_executor):
+        """No verify_tool_call handler registered: MCP execute proceeds normally."""
+        await action_executor.execute({
+            "intent": "mcp.release.list_releases",
+            "parameters": {"status": "active"},
+            "confidence": 0.9,
+        })
+        action_executor.mcp_manager.execute_tool.assert_called_once()
+
+    @pytest.mark.unit
+    async def test_none_return_proceeds(self, action_executor):
+        """Handler returning None defers — MCP call proceeds."""
+        from utils.hooks import _hooks, register_hook
+
+        async def noop(intent, parameters, user_id=None, voice_originated=False, **_):
+            return None
+
+        register_hook("verify_tool_call", noop)
+        try:
+            await action_executor.execute({
+                "intent": "mcp.release.list_releases",
+                "parameters": {},
+                "confidence": 0.9,
+            })
+        finally:
+            _hooks["verify_tool_call"].remove(noop)
+
+        action_executor.mcp_manager.execute_tool.assert_called_once()
+
+    @pytest.mark.unit
+    async def test_abort_true_skips_mcp_and_returns_user_response(self, action_executor):
+        """Handler returning {abort: True, user_response: str} skips the MCP call."""
+        from utils.hooks import _hooks, register_hook
+
+        async def abort_handler(
+            intent, parameters, user_id=None, voice_originated=False, **_,
+        ):
+            return {
+                "abort": True,
+                "user_response": "Bitte bestätige diese Aktion.",
+            }
+
+        register_hook("verify_tool_call", abort_handler)
+        try:
+            result = await action_executor.execute({
+                "intent": "mcp.release.delete_release",
+                "parameters": {"id": "REL-4711"},
+                "confidence": 0.9,
+            })
+        finally:
+            _hooks["verify_tool_call"].remove(abort_handler)
+
+        action_executor.mcp_manager.execute_tool.assert_not_called()
+        assert result["verify_aborted"] is True
+        assert result["action_taken"] is False
+        assert result["message"] == "Bitte bestätige diese Aktion."
+
+    @pytest.mark.unit
+    async def test_abort_with_dict_user_response_returns_in_data(self, action_executor):
+        """Adaptive Card dict in user_response lands in result['data']."""
+        from utils.hooks import _hooks, register_hook
+
+        card = {"type": "AdaptiveCard", "body": [{"type": "TextBlock", "text": "Confirm?"}]}
+
+        async def abort_handler(
+            intent, parameters, user_id=None, voice_originated=False, **_,
+        ):
+            return {"abort": True, "user_response": card}
+
+        register_hook("verify_tool_call", abort_handler)
+        try:
+            result = await action_executor.execute({
+                "intent": "mcp.release.delete_release",
+                "parameters": {"id": "REL-4711"},
+                "confidence": 0.9,
+            })
+        finally:
+            _hooks["verify_tool_call"].remove(abort_handler)
+
+        action_executor.mcp_manager.execute_tool.assert_not_called()
+        assert result["verify_aborted"] is True
+        assert result["data"] == card
+
+    @pytest.mark.unit
+    async def test_abort_false_proceeds(self, action_executor):
+        """Handler returning {abort: False} is treated as no-opinion / proceed."""
+        from utils.hooks import _hooks, register_hook
+
+        async def explicit_allow(
+            intent, parameters, user_id=None, voice_originated=False, **_,
+        ):
+            return {"abort": False}
+
+        register_hook("verify_tool_call", explicit_allow)
+        try:
+            await action_executor.execute({
+                "intent": "mcp.release.list_releases",
+                "parameters": {},
+                "confidence": 0.9,
+            })
+        finally:
+            _hooks["verify_tool_call"].remove(explicit_allow)
+
+        action_executor.mcp_manager.execute_tool.assert_called_once()
+
+    @pytest.mark.unit
+    async def test_runs_before_pre_mcp_call(self, action_executor):
+        """verify_tool_call fires before pre_mcp_call. If gate aborts,
+        pre_mcp_call's parameter-rewrite never happens.
+        """
+        from utils.hooks import _hooks, register_hook
+
+        rewrite_called = []
+
+        async def gate(intent, parameters, user_id=None, voice_originated=False, **_):
+            return {"abort": True, "user_response": "blocked"}
+
+        async def rewrite(intent, parameters, user_id=None, **_):
+            rewrite_called.append(True)
+            return {"id": "rewritten"}
+
+        register_hook("verify_tool_call", gate)
+        register_hook("pre_mcp_call", rewrite)
+        try:
+            await action_executor.execute({
+                "intent": "mcp.release.delete_release",
+                "parameters": {"title": "REL-4711"},
+                "confidence": 0.9,
+            })
+        finally:
+            _hooks["verify_tool_call"].remove(gate)
+            _hooks["pre_mcp_call"].remove(rewrite)
+
+        assert rewrite_called == [], (
+            "pre_mcp_call must NOT run when verify_tool_call returns abort=True"
+        )
+        action_executor.mcp_manager.execute_tool.assert_not_called()
+
+    @pytest.mark.unit
+    async def test_voice_originated_kwarg_threaded_from_contextvar(self, action_executor):
+        """The handler receives voice_originated=True when the ContextVar is set."""
+        from utils.hooks import _hooks, register_hook
+        from utils.voice_context import voice_originated as voice_originated_var
+
+        captured_kwargs = {}
+
+        async def capture_handler(intent, parameters, **kwargs):
+            captured_kwargs.update(kwargs)
+            return None
+
+        register_hook("verify_tool_call", capture_handler)
+        try:
+            voice_originated_var.set(True)
+            await action_executor.execute({
+                "intent": "mcp.release.start_release",
+                "parameters": {"id": "REL-4711"},
+                "confidence": 0.9,
+            })
+        finally:
+            _hooks["verify_tool_call"].remove(capture_handler)
+            # Reset for any subsequent test in the same task context.
+            voice_originated_var.set(False)
+
+        assert captured_kwargs.get("voice_originated") is True
+        assert captured_kwargs.get("user_id") is None  # default from fixture
+        action_executor.mcp_manager.execute_tool.assert_called_once()
+
+    @pytest.mark.unit
+    async def test_voice_originated_default_false(self, action_executor):
+        """When ContextVar is unset (text channel), handler receives False."""
+        from utils.hooks import _hooks, register_hook
+
+        captured = {}
+
+        async def capture_handler(intent, parameters, **kwargs):
+            captured["voice"] = kwargs.get("voice_originated")
+            return None
+
+        register_hook("verify_tool_call", capture_handler)
+        try:
+            # Do NOT set voice_originated. Default False applies.
+            await action_executor.execute({
+                "intent": "mcp.release.list_releases",
+                "parameters": {},
+                "confidence": 0.9,
+            })
+        finally:
+            _hooks["verify_tool_call"].remove(capture_handler)
+
+        assert captured["voice"] is False
+
+    @pytest.mark.unit
+    async def test_handler_exception_does_not_abort(self, action_executor):
+        """Handler crash is caught by run_hooks; MCP call proceeds.
+
+        Fail-open behavior at this layer is intentional — fail-closed
+        semantics are the responsibility of the registering plugin
+        (which should pair the gate with a watchdog handler if its
+        regulatory posture requires it).
+        """
+        from utils.hooks import _hooks, register_hook
+
+        async def crashing(intent, parameters, **kwargs):
+            raise RuntimeError("simulated handler crash")
+
+        register_hook("verify_tool_call", crashing)
+        try:
+            await action_executor.execute({
+                "intent": "mcp.release.list_releases",
+                "parameters": {},
+                "confidence": 0.9,
+            })
+        finally:
+            _hooks["verify_tool_call"].remove(crashing)
+
+        # Handler crashed → run_hooks logged + skipped → MCP call proceeds.
+        action_executor.mcp_manager.execute_tool.assert_called_once()
+
+
+# ============================================================================
 # ActionExecutor Edge Cases Tests
 # ============================================================================
 

--- a/tests/backend/test_voice_context.py
+++ b/tests/backend/test_voice_context.py
@@ -1,0 +1,134 @@
+"""Tests for the ``voice_originated`` ContextVar.
+
+The flag is set at WS message receipt by ``api/websocket/chat_handler.py``
+based on whether the inbound ``WSChatMessage.speaker_embedding`` is
+truthy. Downstream plugin hooks (notably Reva's voice-2FA destructive-tool
+gate) read it without threading the signal through every method signature.
+
+Critical properties tested here:
+
+1. **Default is False** — text-channel callers and background workers
+   that haven't crossed a voice WS message see ``False``.
+2. **Set propagates to ``asyncio.create_task`` children** — Python 3.7+
+   context propagation; we don't need explicit ``copy_context``.
+3. **Set propagates to ``asyncio.gather`` children** — same mechanism.
+4. **Set is request-scoped, not process-scoped** — concurrent requests
+   with different voice-origin values don't bleed into each other.
+"""
+from __future__ import annotations
+
+import asyncio
+from contextvars import copy_context
+
+import pytest
+
+from utils.voice_context import voice_originated
+
+
+@pytest.mark.unit
+def test_default_is_false():
+    """Fresh context: voice_originated.get() returns False."""
+    # Use a fresh context to avoid leakage from earlier tests in the same
+    # process. ``copy_context().run`` gives us isolation.
+    ctx = copy_context()
+
+    def _read() -> bool:
+        return voice_originated.get()
+
+    assert ctx.run(_read) is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_set_visible_in_same_task():
+    """set(True) in a task is visible to subsequent reads in the same task."""
+
+    async def _reader_after_set() -> bool:
+        voice_originated.set(True)
+        return voice_originated.get()
+
+    result = await _reader_after_set()
+    assert result is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_set_propagates_to_create_task_child():
+    """asyncio.create_task inherits the parent's ContextVar value.
+
+    This is Python 3.7+ default behavior; the test pins it as a contract
+    so a future regression (e.g. someone wrapping create_task in a
+    non-propagating helper) is caught immediately.
+    """
+
+    async def _child() -> bool:
+        return voice_originated.get()
+
+    voice_originated.set(True)
+    task = asyncio.create_task(_child())
+    result = await task
+    assert result is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_set_propagates_to_gather_children():
+    """asyncio.gather with bare coroutines: each child sees parent value.
+
+    Renfield's orchestrator uses ``asyncio.gather`` for parallel sub-agent
+    fan-out. Each sub-agent must see voice_originated=True if the parent
+    was a voice message.
+    """
+
+    async def _child() -> bool:
+        return voice_originated.get()
+
+    voice_originated.set(True)
+    results = await asyncio.gather(_child(), _child(), _child())
+    assert results == [True, True, True]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_isolation_between_independent_tasks():
+    """Two independently-spawned tasks have independent ContextVar values.
+
+    This pins the per-task isolation property: setting voice_originated=True
+    in one task does NOT bleed into a sibling task that started from a
+    different parent context.
+    """
+
+    async def _set_true_and_yield() -> bool:
+        voice_originated.set(True)
+        await asyncio.sleep(0)  # yield so the other task can interleave
+        return voice_originated.get()
+
+    async def _read_default() -> bool:
+        await asyncio.sleep(0)  # yield to let the other task run first
+        return voice_originated.get()
+
+    # Two top-level tasks via gather. Each starts from the parent context
+    # (default False). One sets True, one reads. The reader must see False.
+    result_true_setter, result_reader = await asyncio.gather(
+        copy_context().run(asyncio.ensure_future, _set_true_and_yield()),
+        copy_context().run(asyncio.ensure_future, _read_default()),
+    )
+    assert result_true_setter is True
+    assert result_reader is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_set_does_not_leak_back_to_parent():
+    """A child task setting True does NOT mutate the parent's value.
+
+    contextvars semantics: child sees a snapshot of parent context;
+    child's own .set() does not propagate back. This pins the property.
+    """
+
+    async def _child_sets_true() -> None:
+        voice_originated.set(True)
+
+    voice_originated.set(False)  # parent baseline
+    await asyncio.create_task(_child_sets_true())
+    assert voice_originated.get() is False


### PR DESCRIPTION
## Summary

New `verify_tool_call` hook fires before `pre_mcp_call` for any `mcp.*` intent. Plugins return `{abort: True, user_response: <str|dict>}` to short-circuit the MCP call and surface a confirmation card to the user. None / `{abort: False}` defers and proceeds normally.

Companion `utils/voice_context.py` ContextVar carries the voice-origin signal from the WS handler down to the hook without threading kwargs through every layer. Set at WS message receipt based on whether `WSChatMessage.speaker_embedding` is truthy. `asyncio.create_task` and `asyncio.gather` propagate the value to children automatically.

Used by Reva's voice-2FA destructive-tool gate (separate Reva PR), shipping as v1 of the voice-server-migration follow-up #5. Platform default with no handler is a no-op — `pre_mcp_call` and the MCP call run as before.

## Audit of existing task spawn sites in the chat path

| Site | API | Propagation |
|---|---|---|
| `chat_handler.py:933, 1619, 1646` | `asyncio.create_task` | OK (Python 3.7+ default) |
| `agent_service.py:1436` | `asyncio.gather` | OK |
| `orchestrator.py:523/529/536` | `create_task` + `gather` | OK |
| `loop.run_in_executor` anywhere in chat path | (none found) | n/a |

No explicit `contextvars.copy_context()` needed — Python 3.7+ default propagation covers every site. Any future thread-pool dispatch in this path will need explicit `copy_context()` to keep the flag visible.

## Test plan

- [x] Unit: `tests/backend/test_voice_context.py` — 6 tests pin ContextVar default-False, same-task visibility, `create_task`/`gather` propagation, sibling-task isolation, child-doesn't-leak-to-parent
- [x] Unit: `tests/backend/test_action_executor.py::TestActionExecutorVerifyToolCall` — 9 tests pin no-handler fall-through, None defers, abort-True skips MCP, dict `user_response` lands in `result['data']`, abort-False proceeds, runs-before-`pre_mcp_call` ordering, `voice_originated` kwarg threaded from ContextVar, default False when unset, handler exception fail-OPEN
- [x] Existing `_rewrite_mcp_call` (release-id title→id repair) verified to still run after `verify_tool_call` returns None

## Hook contract documented inline

Plugins requiring fail-CLOSED semantics (e.g. Reva's BaFin-regulated voice gate) must wrap their handler body in try/except and return abort sentinel on internal error. Renfield's `run_hooks` is fail-OPEN by design — crashed handler skipped, MCP call proceeds. The contract is explicit in `utils/hooks.py` so plugin authors aren't surprised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)