### PR TITLE
fix(circles): cast m.value through text for asyncpg json→int compat

### DIFF
--- a/src/backend/services/circle_sql.py
+++ b/src/backend/services/circle_sql.py
@@ -115,13 +115,22 @@ def circles_filter_clause(
     # Tier-membership check: asker is in owner's circles AND their tier
     # value is at-or-below the atom's tier (deeper-placed members can
     # reach atoms at their depth or wider).
+    #
+    # ``circle_memberships.value`` is JSON (int for dimension='tier', str for
+    # dimension='tenant'/'project' — see CircleMembership model). PostgreSQL
+    # cannot cast `json` directly to `integer` (raises CannotCoerceError);
+    # the canonical idiom is to go through `text`. Filter on dimension='tier'
+    # already guarantees the JSON value is a number, so `::text::int` always
+    # parses cleanly here. SQLite is permissive about the direct cast which
+    # is why the string-shape tests (run on SQLite) didn't catch this — the
+    # production bug surfaced as 500 on /knowledge-graph against asyncpg.
     parts.append(
         f"EXISTS ("
         f"  SELECT 1 FROM circle_memberships m "
         f"  WHERE m.circle_owner_id = {owner_alias}.{owner_col} "
         f"  AND m.member_user_id = :{asker_param} "
         f"  AND m.dimension = 'tier' "
-        f"  AND (m.value)::int <= {table_alias}.{tier_col}"
+        f"  AND (m.value::text)::int <= {table_alias}.{tier_col}"
         f")"
     )
 

--- a/tests/backend/test_circle_sql.py
+++ b/tests/backend/test_circle_sql.py
@@ -46,7 +46,7 @@ class TestCirclesFilterClause:
         assert "circle_memberships m" in clause
         assert "m.circle_owner_id = e.user_id" in clause
         assert "m.dimension = 'tier'" in clause
-        assert "(m.value)::int <= e.circle_tier" in clause
+        assert "(m.value::text)::int <= e.circle_tier" in clause
 
     def test_owner_table_alias_overrides_only_owner_col(self):
         # When owner is on a JOINed table (kb), tier should still come from
@@ -61,7 +61,7 @@ class TestCirclesFilterClause:
         assert "kb.owner_id = :asker_id" in clause
         assert "dc.circle_tier = :asker_id_pub" in clause
         assert "m.circle_owner_id = kb.owner_id" in clause
-        assert "(m.value)::int <= dc.circle_tier" in clause
+        assert "(m.value::text)::int <= dc.circle_tier" in clause
 
     def test_source_id_expr_overrides_default(self):
         clause = circles_filter_clause(


### PR DESCRIPTION
## Summary

PostgreSQL cannot cast `json` directly to `integer` — `asyncpg.exceptions.CannotCoerceError: cannot cast type json to integer`. The `circles_filter_clause` SQL builder emits `(m.value)::int` which fails the moment any user has a row in `circle_memberships`.

## Reproduction

A user (id=8) hitting `chat.reva.aktivities.ai/knowledge-graph`:

```
asyncpg.exceptions.CannotCoerceError: cannot cast type json to integer
[SQL: SELECT count(kg_entities.id) ... AND (m.value)::int <= kg_entities.circle_tier]
[parameters: (8, 4, 'kg_entities')]
```

The page can't load — `SELECT count(*) FROM kg_entities` is the first query and the circles filter is applied to every kg_entities query (memory access control).

## Fix

`circle_memberships.value` is `Column(JSON)` to generalize across dimensions (`tier` = int, `tenant`/`project` = str). The cast site is gated by `m.dimension = 'tier'` so we know the JSON value is a number, but Postgres still has no direct `json → int` cast operator. The canonical idiom is to go through `text`:

```diff
-    AND (m.value)::int <= ...
+    AND (m.value::text)::int <= ...
```

`m.value::text` produces the JSON serialization (`'2'` for the number `2`), which casts cleanly to int.

## Why undetected

`tests/backend/test_circle_sql.py` is SQLite + string-shape — it asserts the literal SQL string content, never executes the query. SQLite is permissive about json→int and silently coerces. asyncpg / Postgres is strict.

## Validation

Verified against the production database on the kubeadm cluster (12 rows returned cleanly):

```
$ psql -d reva -c "SELECT count(*) FROM kg_entities e WHERE ... AND (m.value::text)::int <= e.circle_tier"
count: 12
```

Test assertions in `test_circle_sql.py` updated to match the new SQL.

## Affected pages

Every page that queries entities through the polymorphic atom store with circle filtering — `knowledge-graph`, `brain`, `brain/review`, anything calling `rag.search()` with circle reach. All were 500-broken for any user with at least one membership row in another user's circles.

## Follow-up worth doing (not in this PR)

Add a real-Postgres integration test that exercises the clause. SQLite-only string-shape testing missed this for as long as the column has been JSON. Out of scope here — requires switching the test fixture to Postgres for the affected tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)