### PR TITLE
feat(theme): pro-edition slate dark mode via CSS attribute selector

### DIFF
--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -35,6 +35,41 @@
 }
 
 /*
+  Edition overlay: pro deploys (e.g. Reva white-label for X-IDRA) drift
+  the gray-* palette toward slate-* for a cooler, "serious enterprise
+  software" feel. Applied via `data-edition="pro"` on <html>, set in
+  main.tsx from VITE_APP_EDITION at boot time. Renfield community
+  deploys (the default) keep the warm-leaning gray-* untouched.
+
+  Why CSS variable override and not component edits: gray-* utility
+  classes (bg-gray-900, border-gray-700, text-gray-400) appear in 962
+  places across the codebase. Re-pointing the palette tokens at the
+  root flips every surface in one place; component code stays
+  identical. Slate-* has the same numeric scale (50..950) and is part
+  of Tailwind 4's default theme, so no new token namespace is added.
+
+  Decision rationale: see docs/design/reva-edition.md (Reva-side) and
+  the variant-comparison archive at
+  ~/.gstack/projects/X-idra-Systems-GmbH-reva/designs/dark-mode-tokens-20260508/
+
+  Crimson primary (--color-primary-*) and accent turquoise stay
+  identical — those are brand tokens, not surface tokens.
+*/
+[data-edition="pro"] {
+  --color-gray-50:  var(--color-slate-50);
+  --color-gray-100: var(--color-slate-100);
+  --color-gray-200: var(--color-slate-200);
+  --color-gray-300: var(--color-slate-300);
+  --color-gray-400: var(--color-slate-400);
+  --color-gray-500: var(--color-slate-500);
+  --color-gray-600: var(--color-slate-600);
+  --color-gray-700: var(--color-slate-700);
+  --color-gray-800: var(--color-slate-800);
+  --color-gray-900: var(--color-slate-900);
+  --color-gray-950: var(--color-slate-950);
+}
+
+/*
   The default border color has changed to `currentcolor` in Tailwind CSS v4,
   so we've added these compatibility styles to make sure everything still
   looks the same as it did with Tailwind CSS v3.

--- a/src/frontend/src/main.tsx
+++ b/src/frontend/src/main.tsx
@@ -7,6 +7,17 @@ import App from './App';
 import './index.css';
 import './i18n';
 
+// Edition selector for theme tokens. When VITE_APP_EDITION=pro, the
+// CSS attribute selector [data-edition="pro"] in index.css re-points
+// the gray-* palette to slate-* for a cooler enterprise feel —
+// covers every surface in the app via the existing utility classes
+// (962 gray-* usages remap automatically). Default Renfield
+// community: no attribute set, gray-* stays warm.
+const _edition = import.meta.env.VITE_APP_EDITION;
+if (_edition === 'pro') {
+  document.documentElement.dataset.edition = 'pro';
+}
+
 const rootElement = document.getElementById('root');
 if (!rootElement) {
   throw new Error('Root element #root not found in document');


### PR DESCRIPTION
## Summary

T13 from Reva's design backlog: re-point the gray-* palette to slate-* in `pro` edition deploys for a cooler "serious enterprise software" feel. Renfield community deploys are unchanged.

## Mechanism

```tsx
// src/main.tsx
if (import.meta.env.VITE_APP_EDITION === 'pro') {
  document.documentElement.dataset.edition = 'pro';
}
```

```css
/* src/index.css */
[data-edition="pro"] {
  --color-gray-50:  var(--color-slate-50);
  --color-gray-100: var(--color-slate-100);
  /* ...through --color-gray-950 */
  --color-gray-950: var(--color-slate-950);
}
```

That's it. Two files, ~16 LOC of real change.

## Why this approach

The gray-* utility classes (`bg-gray-900`, `border-gray-700`, `text-gray-400`, etc.) appear in **962 places** across the frontend. Re-pointing the palette tokens at `[data-edition="pro"]` flips every surface in one place; not a single component file changes. Slate-* has the same numeric scale (50..950) and is part of Tailwind 4's default theme, so no new token namespace is introduced — Tailwind already exposes `--color-slate-*`.

Brand tokens (`--color-primary-*` crimson, `--color-accent-*` turquoise, `--color-cream`) are unchanged. Crimson destructive CTA still pops, and arguably MORE against cooler slate backgrounds than against warm-current gray.

## Decision evidence

`/design-shotgun` produced four pixel-accurate variants (real CSS, not AI mockups) rendered against an identical Reva Releases dashboard:

- **A** Warm Current (baseline) — gray-*
- **B** Cool Slate — slate-* ← **picked**
- **C** Neutral Zinc — zinc-*
- **D** Steel Blue — custom blue-tinted

Comparison archive at Reva-side `~/.gstack/projects/X-idra-Systems-GmbH-reva/designs/dark-mode-tokens-20260508/`. Variant B chosen for: low risk (Tailwind family swap, same accessibility profile), conventional enterprise register (Linear/Stripe/Vercel territory), crimson primary contrast improves against cooler backgrounds.

## Renfield community impact

**Zero change.** The `data-edition` attribute is only set when `VITE_APP_EDITION=pro`. Without it, the `[data-edition="pro"]` CSS selector doesn't match and the gray-* palette stays warm.

## Test plan

- [x] Comparison archive shows all four variants side-by-side with palette swatches; B is the chosen direction
- [ ] Production verification post-deploy: visit https://chat.reva.aktivities.ai/ in dark mode, inspect `:root[data-edition="pro"]`, spot-check a card surface bg should resolve to `#1e293b` not `#1f2937`

🤖 Generated with [Claude Code](https://claude.com/claude-code)