### PR TITLE
feat(pro): app-polish (Tier 1 + compact TierPicker)

### DIFF
--- a/src/frontend/src/components/Layout.tsx
+++ b/src/frontend/src/components/Layout.tsx
@@ -84,6 +84,13 @@ interface LayoutProps {
   children: ReactNode;
 }
 
+// Pro-edition deploys (e.g. Reva for X-IDRA) put 12+ nav items in a
+// release-management workflow where icon-only rails create constant
+// "what was that one again?" friction. Expand the sidebar by default
+// at lg+. Community deploys keep the collapsed-rail-with-hover pattern
+// — appropriate for a household assistant with fewer destinations.
+const IS_PRO_EDITION = import.meta.env.VITE_APP_EDITION === 'pro';
+
 export default function Layout({ children }: LayoutProps) {
   const { t } = useTranslation();
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -218,7 +225,7 @@ export default function Layout({ children }: LayoutProps) {
           <span className="absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-5 bg-accent-400 rounded-r" />
         )}
         <Icon className="w-5 h-5 shrink-0" aria-hidden="true" />
-        <span className="lg:opacity-0 lg:group-hover/sidebar:opacity-100 transition-opacity duration-200 overflow-hidden whitespace-nowrap">{item.name}</span>
+        <span className={`${IS_PRO_EDITION ? '' : 'lg:opacity-0 lg:group-hover/sidebar:opacity-100'} transition-opacity duration-200 overflow-hidden whitespace-nowrap`}>{item.name}</span>
       </Link>
     );
   };
@@ -234,7 +241,7 @@ export default function Layout({ children }: LayoutProps) {
       </a>
 
       {/* Fixed Header */}
-      <header className="fixed top-0 left-0 right-0 h-16 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 z-40 transition-colors lg:pl-16">
+      <header className={`fixed top-0 left-0 right-0 h-16 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 z-40 transition-colors ${IS_PRO_EDITION ? 'lg:pl-72' : 'lg:pl-16'}`}>
         <div className="h-full px-4 flex items-center justify-between">
           {/* Left: Hamburger + Logo */}
           <div className="flex items-center space-x-2">
@@ -253,11 +260,16 @@ export default function Layout({ children }: LayoutProps) {
             </Link>
           </div>
 
-          {/* Right: Language + Theme Toggle + Device Status + User */}
+          {/* Right: Language + Theme Toggle + Device Status + User.
+              DeviceStatus is the voice-satellite/device-setup pill — only
+              meaningful for community deploys (households with multi-room
+              voice hardware). For pro edition deploys (e.g. Reva for
+              X-IDRA), users have no satellites; the "Set up device" button
+              links to a flow that doesn't apply. Hide it. */}
           <div className="flex items-center space-x-2 sm:space-x-3">
             <LanguageSwitcher compact />
             <ThemeToggle />
-            <DeviceStatus compact />
+            {import.meta.env.VITE_APP_EDITION !== 'pro' && <DeviceStatus compact />}
 
             {/* User/Auth in Header */}
             {authEnabled && (
@@ -300,7 +312,7 @@ export default function Layout({ children }: LayoutProps) {
         ref={sidebarRef}
         id="sidebar"
         className={`group/sidebar fixed top-0 left-0 h-full flex flex-col bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 z-50 transform transition-all duration-300 ease-out
-          w-72 lg:w-16 lg:hover:w-72 lg:translate-x-0
+          w-72 ${IS_PRO_EDITION ? 'lg:w-72' : 'lg:w-16 lg:hover:w-72'} lg:translate-x-0
           ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'}
         `}
         aria-label={t('nav.mainNavigation')}
@@ -444,7 +456,7 @@ export default function Layout({ children }: LayoutProps) {
       {/* Main Content */}
       <main
         id="main-content"
-        className="pt-16 min-h-screen lg:pl-16"
+        className={`pt-16 min-h-screen ${IS_PRO_EDITION ? 'lg:pl-72' : 'lg:pl-16'}`}
         tabIndex={-1}
       >
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">

--- a/src/frontend/src/components/TierPicker.tsx
+++ b/src/frontend/src/components/TierPicker.tsx
@@ -13,13 +13,41 @@ interface TierPickerProps {
   onChange: (tier: CircleTier) => void;
   disabled?: boolean;
   className?: string;
+  /**
+   * Render as a compact native <select> instead of a 5-pill radiogroup.
+   * Used in dense list contexts (e.g. the review queue) where the 5-pill
+   * row wraps onto two lines per atom and inflates the row height. The
+   * pill version stays the default for the settings page where one
+   * picker per page reads clearly.
+   */
+  variant?: 'pills' | 'compact';
 }
 
 const ALL_TIERS: CircleTier[] = [0, 1, 2, 3, 4];
 
-export default function TierPicker({ value, onChange, disabled = false, className = '' }: TierPickerProps) {
+export default function TierPicker({ value, onChange, disabled = false, className = '', variant = 'pills' }: TierPickerProps) {
   const { t } = useTranslation();
   const buttonRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  if (variant === 'compact') {
+    const current: CircleTier = (value != null ? (value as CircleTier) : 0);
+    return (
+      <select
+        aria-label={t('circles.tierPickerLabel')}
+        value={current}
+        disabled={disabled}
+        onChange={(e) => onChange(Number(e.target.value) as CircleTier)}
+        className={`text-xs font-medium px-2 py-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-hidden focus:ring-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
+      >
+        {ALL_TIERS.map((tier) => (
+          <option key={tier} value={tier}>
+            {TIER_SYMBOLS[tier]} {t(`circles.tier.${tier}`)}
+          </option>
+        ))}
+      </select>
+    );
+  }
+
   // Track which tier *we* just moved to via keyboard so we can restore focus
   // after React re-renders with the new selection. Without this, roving-tabindex
   // leaves focus on the previously-selected (now tabindex=-1) button and the

--- a/src/frontend/src/i18n/locales/de.pro.json
+++ b/src/frontend/src/i18n/locales/de.pro.json
@@ -6,7 +6,14 @@
     "complianceFooter": "DSGVO-konform · BaFin-kompatibel · Auf .de gehostet"
   },
   "nav": {
+    "brain": "Wissensbasis",
+    "memory": "Notizen",
+    "brainReview": "Prüf-Eingang",
     "circles": "Sichtbarkeit"
+  },
+  "memory": {
+    "title": "Notizen",
+    "subtitle": "Langfristiger Kontext zu Releases, Tickets und Entscheidungen"
   },
   "circles": {
     "tier": {
@@ -19,6 +26,11 @@
       "2": "Für mein Team sichtbar.",
       "3": "Für die gesamte Organisation sichtbar."
     },
+    "brainTitle": "Wissensbasis",
+    "brainSubtitle": "Suche in Dokumenten, Tickets, Releases und erfasstem Kontext.",
+    "brainSearchPlaceholder": "Versuche „offene Releases\" oder „PROJ-1234\"…",
+    "brainEmpty": "Stelle eine Suchanfrage. Versuche „offene Releases\", „meine Tickets\" oder „Sprint 23 Retro\".",
+    "brainNoMatches": "Keine Wissens-Einträge gefunden. Versuche eine allgemeinere Anfrage.",
     "tierAriaLabel": "Sichtbarkeitsstufe {{tier}}: {{label}}",
     "tierPickerLabel": "Sichtbarkeitsstufe wählen",
     "settingsTitle": "Sichtbarkeit & Mitglieder",

--- a/src/frontend/src/i18n/locales/en.pro.json
+++ b/src/frontend/src/i18n/locales/en.pro.json
@@ -5,6 +5,16 @@
     "tenantPrefix": "Sign in to",
     "complianceFooter": "GDPR-compliant · BaFin-conformant · Hosted on .de"
   },
+  "nav": {
+    "brain": "Knowledge",
+    "memory": "Notes",
+    "brainReview": "Review queue",
+    "circles": "Visibility"
+  },
+  "memory": {
+    "title": "Notes",
+    "subtitle": "Long-term context for releases, tickets, and decisions"
+  },
   "circles": {
     "tier": {
       "0": "Personal",
@@ -18,6 +28,11 @@
       "2": "Visible to my team.",
       "3": "Visible to the entire organization."
     },
+    "brainTitle": "Knowledge base",
+    "brainSubtitle": "Search across documents, tickets, releases, and captured context.",
+    "brainSearchPlaceholder": "Try \"open releases\" or \"PROJ-1234\"...",
+    "brainEmpty": "Type a query above to search. Try \"open releases\", \"my tickets\", or \"Sprint 23 retro\".",
+    "brainNoMatches": "No knowledge entries matched. Try a broader query or different wording.",
     "tierAriaLabel": "Visibility {{tier}}: {{label}}",
     "tierPickerLabel": "Choose visibility",
     "settingsTitle": "Visibility & Members",

--- a/src/frontend/src/pages/BrainReviewPage.tsx
+++ b/src/frontend/src/pages/BrainReviewPage.tsx
@@ -162,6 +162,7 @@ export default function BrainReviewPage() {
                 </div>
                 <div className="sm:ml-4 sm:flex-shrink-0">
                   <TierPicker
+                    variant="compact"
                     value={tier}
                     onChange={(t2) => handleTierChange(atom, t2)}
                     disabled={saving}


### PR DESCRIPTION
## Summary

Tier-1 enterprise polish for `VITE_APP_EDITION=pro` deploys (Reva for X-IDRA) plus one Tier-3 follow-through:

- **Sidebar:** expanded by default at `lg:` (`lg:w-72`) with always-visible labels. Header + main padding follows. Community deploys keep the slim icon-rail-with-hover-expand.
- **DeviceStatus pill:** hidden in pro — links to a voice-satellite flow that doesn't apply to enterprise.
- **i18n overlays:** `nav.brain` → "Knowledge / Wissensbasis", `nav.memory` → "Notes / Notizen", `nav.brainReview` → "Review queue / Prüf-Eingang". Brain page hero + actionable empty-state ("open releases", "PROJ-1234", "Sprint 23 retro").
- **TierPicker:** new `variant="compact"` renders native `<select>` styled inline. Wired into `BrainReviewPage` so the per-row 5-pill picker no longer wraps onto two lines on dense atom lists. Settings page keeps the radiogroup pills.

## Test plan

- [ ] Build community frontend → sidebar still icon-rail-with-hover, DeviceStatus visible
- [ ] Build pro frontend (Reva) → sidebar wide with labels, no DeviceStatus
- [ ] `/brain` (pro) → "Knowledge base" + actionable empty-state copy
- [ ] `/brain/review` → tier picker is one compact dropdown per row
- [ ] `/settings/circles` → tier picker still pill radiogroup

🤖 Generated with [Claude Code](https://claude.com/claude-code)