### PR TITLE
feat(chat): auto-extract Paperless metadata + parallel chat-attachment uploads

### DIFF
--- a/src/backend/api/routes/chat_upload.py
+++ b/src/backend/api/routes/chat_upload.py
@@ -279,15 +279,70 @@ async def forward_to_paperless(
         file_bytes = await f.read()
     file_content_base64 = base64.b64encode(file_bytes).decode("ascii")
 
-    # Execute MCP tool
+    # Build the upload-tool params. Default is filename-only — same as the
+    # pre-auto-extraction behaviour, kept as the safe fallback if the
+    # extractor errors. The metadata-extraction block below populates
+    # additional fields (correspondent, document_type, tags, etc.) when
+    # they resolve cleanly against the live Paperless taxonomy.
+    upload_params: dict = {
+        "title": upload.filename,
+        "filename": upload.filename,
+        "file_content_base64": file_content_base64,
+    }
+    extracted_fields: list[str] = []  # for the response message
+
+    # Auto-extract metadata. Same pipeline the audit flow uses, just with
+    # the ambiguity-resolution step skipped — only EXACT/strong-fuzzy
+    # resolutions on the live taxonomy go into upload_params. Anything
+    # the extractor flagged as needing user decision is dropped silently
+    # so this stays a one-click action; users who want curation reach for
+    # the audit flow instead.
+    try:
+        from services.paperless_metadata_extractor import PaperlessMetadataExtractor
+
+        extractor = PaperlessMetadataExtractor(mcp_manager=manager)
+        extraction = await extractor.extract(
+            attachment_id=upload_id,
+            session_id=upload.session_id,
+            lang="de",
+        )
+        if extraction.error:
+            logger.info(
+                f"Paperless metadata extraction returned an error; "
+                f"falling back to filename-only: {extraction.error}"
+            )
+        else:
+            meta = extraction.metadata
+            if meta.title:
+                upload_params["title"] = meta.title
+                extracted_fields.append("title")
+            if meta.correspondent:
+                upload_params["correspondent"] = meta.correspondent
+                extracted_fields.append("correspondent")
+            if meta.document_type:
+                upload_params["document_type"] = meta.document_type
+                extracted_fields.append("type")
+            if meta.tags:
+                upload_params["tags"] = meta.tags
+                extracted_fields.append(f"{len(meta.tags)} tags")
+            if meta.storage_path:
+                upload_params["storage_path"] = meta.storage_path
+                extracted_fields.append("path")
+            if meta.created_date:
+                upload_params["created_date"] = meta.created_date.isoformat()
+                extracted_fields.append("date")
+    except Exception as e:
+        # The extractor is best-effort; never let it block the bare upload.
+        # OCR failures, taxonomy fetch errors, and LLM timeouts all funnel
+        # here. The user still gets the document into Paperless — just
+        # without auto-filled metadata.
+        logger.warning(f"Paperless metadata extraction failed; falling back to filename-only: {e}")
+
+    # Execute MCP tool with the (possibly metadata-enriched) params.
     try:
         mcp_result = await manager.execute_tool(
             "mcp.paperless.upload_document",
-            {
-                "title": upload.filename,
-                "filename": upload.filename,
-                "file_content_base64": file_content_base64,
-            },
+            upload_params,
         )
     except Exception as e:
         logger.error(f"Paperless forward failed: {e}")
@@ -306,10 +361,15 @@ async def forward_to_paperless(
     if not mcp_result or not mcp_result.get("success"):
         raise HTTPException(status_code=502, detail="Paperless forwarding failed")
 
+    if extracted_fields:
+        message = f"Sent to Paperless with auto-extracted: {', '.join(extracted_fields)}"
+    else:
+        message = "Sent to Paperless"
+
     return PaperlessResponse(
         success=True,
         paperless_task_id=str(task_id) if task_id else None,
-        message="Sent to Paperless",
+        message=message,
     )
 
 

--- a/src/frontend/src/pages/ChatPage/hooks/useDocumentUpload.ts
+++ b/src/frontend/src/pages/ChatPage/hooks/useDocumentUpload.ts
@@ -73,12 +73,13 @@ export function useDocumentUpload() {
   }, []);
 
   const uploadDocuments = useCallback(async (files: File[], sessionId: string): Promise<Array<UploadedDocument | null>> => {
-    const results: Array<UploadedDocument | null> = [];
-    for (const file of files) {
-      const result = await uploadDocument(file, sessionId);
-      results.push(result);
-    }
-    return results;
+    // Parallel uploads. Each upload has its own progress slot via
+    // `fileKey` (counter-based, see uploadDocument), so the concurrent
+    // progress bars don't collide. The earlier sequential `for-await`
+    // implementation cost ~N × single-upload time when picking N files
+    // at once — for a typical 3-5 doc batch this matters. Backend is
+    // async FastAPI on multipart, no concurrency issue.
+    return Promise.all(files.map((file) => uploadDocument(file, sessionId)));
   }, [uploadDocument]);
 
   const clearError = useCallback((fileKey?: string) => {

--- a/tests/backend/test_chat_upload.py
+++ b/tests/backend/test_chat_upload.py
@@ -622,6 +622,178 @@ class TestChatUploadPaperless:
         assert response.status_code == 404
 
     @pytest.mark.backend
+    async def test_paperless_uses_extracted_metadata(
+        self, async_client: AsyncClient, db_session: AsyncSession
+    ):
+        """Auto-extracted metadata flows into mcp.paperless.upload_document params.
+
+        When the metadata extractor returns a non-empty PaperlessMetadata
+        (correspondent, document_type, tags, etc.), the route must include
+        those fields in the MCP tool call — not just title/filename. This
+        is the scenario that turns a one-click forward into a fully-tagged
+        Paperless document.
+        """
+        from datetime import date as _date
+
+        from services.paperless_metadata_extractor import (
+            ExtractionResult,
+            PaperlessMetadata,
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            f.write(b"%PDF-1.4 test content")
+            tmp_path = f.name
+
+        try:
+            upload = ChatUpload(
+                session_id="paperless-meta-test",
+                filename="rechnung.pdf",
+                file_type="pdf",
+                file_size=500,
+                status="completed",
+                file_path=tmp_path,
+            )
+            db_session.add(upload)
+            await db_session.commit()
+            await db_session.refresh(upload)
+
+            import json
+            mcp_result = {
+                "success": True,
+                "message": json.dumps({
+                    "success": True,
+                    "data": {"task_id": "meta-456"},
+                }),
+            }
+
+            mock_manager = AsyncMock()
+            mock_manager.execute_tool = AsyncMock(return_value=mcp_result)
+
+            # Mock the extractor to return resolved metadata. We patch the
+            # class on the import path the route uses (lazy import inside
+            # the handler) so ``PaperlessMetadataExtractor(mcp_manager=...)``
+            # returns our mock instance.
+            extracted = ExtractionResult(
+                metadata=PaperlessMetadata(
+                    title="Rechnung Wehrmann 2026-04",
+                    correspondent="Wehrmann GmbH",
+                    document_type="Rechnung",
+                    tags=["steuer", "2026"],
+                    storage_path="Belege/2026",
+                    created_date=_date(2026, 4, 15),
+                ),
+                doc_text="dummy",
+                error=None,
+            )
+            mock_extractor = AsyncMock()
+            mock_extractor.extract = AsyncMock(return_value=extracted)
+
+            from main import app
+            app.state.mcp_manager = mock_manager
+
+            try:
+                with patch(
+                    "services.paperless_metadata_extractor.PaperlessMetadataExtractor",
+                    return_value=mock_extractor,
+                ):
+                    response = await async_client.post(
+                        f"/api/chat/upload/{upload.id}/paperless"
+                    )
+            finally:
+                app.state.mcp_manager = None
+
+            assert response.status_code == 200
+            body = response.json()
+            assert body["success"] is True
+            assert body["paperless_task_id"] == "meta-456"
+            # Response message names which fields were auto-filled — UI uses
+            # this to show the user what got attached. Empty fields stay out.
+            assert "title" in body["message"]
+            assert "correspondent" in body["message"]
+
+            # The actual MCP call must carry every resolved field. A
+            # regression here means metadata was extracted but lost on the
+            # way to Paperless — silent and hard to spot in the UI.
+            sent_params = mock_manager.execute_tool.call_args[0][1]
+            assert sent_params["title"] == "Rechnung Wehrmann 2026-04"
+            assert sent_params["correspondent"] == "Wehrmann GmbH"
+            assert sent_params["document_type"] == "Rechnung"
+            assert sent_params["tags"] == ["steuer", "2026"]
+            assert sent_params["storage_path"] == "Belege/2026"
+            assert sent_params["created_date"] == "2026-04-15"
+            assert sent_params["filename"] == "rechnung.pdf"
+            assert "file_content_base64" in sent_params
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
+
+    @pytest.mark.backend
+    async def test_paperless_falls_back_when_extractor_errors(
+        self, async_client: AsyncClient, db_session: AsyncSession
+    ):
+        """Extractor failure must NOT block the bare upload.
+
+        OCR errors, taxonomy fetch failures, and LLM timeouts all funnel
+        into the same fallback path. The user still gets the document into
+        Paperless — just without auto-extracted metadata.
+        """
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            f.write(b"%PDF-1.4 unreadable")
+            tmp_path = f.name
+
+        try:
+            upload = ChatUpload(
+                session_id="paperless-fallback-test",
+                filename="scan.pdf",
+                file_type="pdf",
+                file_size=500,
+                status="completed",
+                file_path=tmp_path,
+            )
+            db_session.add(upload)
+            await db_session.commit()
+            await db_session.refresh(upload)
+
+            import json
+            mcp_result = {
+                "success": True,
+                "message": json.dumps({"success": True, "data": {"task_id": "fb-789"}}),
+            }
+
+            mock_manager = AsyncMock()
+            mock_manager.execute_tool = AsyncMock(return_value=mcp_result)
+
+            mock_extractor = AsyncMock()
+            mock_extractor.extract = AsyncMock(side_effect=RuntimeError("Docling crashed"))
+
+            from main import app
+            app.state.mcp_manager = mock_manager
+            try:
+                with patch(
+                    "services.paperless_metadata_extractor.PaperlessMetadataExtractor",
+                    return_value=mock_extractor,
+                ):
+                    response = await async_client.post(
+                        f"/api/chat/upload/{upload.id}/paperless"
+                    )
+            finally:
+                app.state.mcp_manager = None
+
+            assert response.status_code == 200
+            body = response.json()
+            assert body["success"] is True
+            assert body["paperless_task_id"] == "fb-789"
+
+            # Filename-only fallback — no metadata fields in the MCP call.
+            sent_params = mock_manager.execute_tool.call_args[0][1]
+            assert sent_params["title"] == "scan.pdf"
+            assert "correspondent" not in sent_params
+            assert "document_type" not in sent_params
+            assert "tags" not in sent_params
+            assert "created_date" not in sent_params
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
+
+    @pytest.mark.backend
     async def test_paperless_mcp_not_available(self, async_client: AsyncClient, db_session: AsyncSession):
         """No MCP manager returns 503"""
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:


### PR DESCRIPTION
## Summary

Two related improvements to the chat-attachment flow.

### Auto-extract metadata for Paperless

`POST /api/chat/upload/{id}/paperless` now runs `PaperlessMetadataExtractor` (the same Docling+LLM pipeline the audit flow uses) before forwarding, and populates Paperless with whatever resolved cleanly:

- ✅ Title, correspondent, document_type, tags, storage_path, created_date — exact / strong-fuzzy matches only
- 🤐 Ambiguous fields silently dropped (one-click action; for curation, use the agent's audit flow)
- 🛟 Extractor failure → falls back to filename-only behaviour (the existing pre-PR behaviour). The bare upload always happens.
- 📝 Response message names which fields auto-filled (e.g. `"Sent to Paperless with auto-extracted: title, correspondent, type, 2 tags"`).

### Parallel chat-attachment uploads

`useDocumentUpload.uploadDocuments` was a sequential `for-await` loop. Picking 5 files in the picker meant waiting ~5× single-upload time. Switched to `Promise.all` — uploads run concurrently. Per-file progress bars still isolated via the existing `fileKey` counter.

The file input has had `multiple` since the original implementation; this just makes multi-select actually feel multi-uploaded.

## Files

| File | Change |
|---|---|
| `src/backend/api/routes/chat_upload.py` | Extract before forwarding; merge resolved fields into `upload_document` params; fall back gracefully on extractor failure |
| `src/frontend/src/pages/ChatPage/hooks/useDocumentUpload.ts` | `for-await` → `Promise.all` |
| `tests/backend/test_chat_upload.py` | Two new tests: metadata flowed through to MCP; extractor failure fallback |

## Test plan

- [x] `test_paperless_uses_extracted_metadata` — mocks extractor returning a populated `PaperlessMetadata`, asserts every resolved field lands in `mcp.paperless.upload_document` call args
- [x] `test_paperless_falls_back_when_extractor_errors` — extractor raises, route still uploads bare (200), no metadata fields in MCP params
- [x] Existing `TestChatUploadPaperless` tests continue to pass (their malformed-PDF fixtures trigger the extractor's "could not read document" error path → same fallback)
- [ ] Browser smoke: attach 3 files → see all 3 progress bars in flight at once → click "Send to Paperless" on one → toast shows extracted summary → check Paperless; doc has correspondent/type/tags filled

## Out of scope

- Auto-creating missing Paperless taxonomy entries. Risky (extraction typos → junk taxonomy); audit flow handles it with explicit approval.
- Showing the extracted-fields summary in the toast (currently in the server message, not the localised toast). UX polish for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)