### PR TITLE
fix(pro): drop compliance footer from LoginPage

### DIFF
--- a/src/frontend/src/i18n/locales/de.pro.json
+++ b/src/frontend/src/i18n/locales/de.pro.json
@@ -2,8 +2,7 @@
   "_comment": "Edition='pro' overlay applied on top of de.json when VITE_APP_EDITION=pro. Replaces household-flavored Circles vocabulary with enterprise/banking-friendly equivalents (Sichtbarkeit / Team / Organisation / Vertraulich). Keys not listed here fall through to de.json. See src/i18n/index.ts merge logic.",
   "auth": {
     "personalAssistant": "KI-Assistent für Release Management",
-    "tenantPrefix": "Anmeldung bei",
-    "complianceFooter": "DSGVO-konform · BaFin-kompatibel · Auf .de gehostet"
+    "tenantPrefix": "Anmeldung bei"
   },
   "nav": {
     "brain": "Wissensbasis",

--- a/src/frontend/src/i18n/locales/en.pro.json
+++ b/src/frontend/src/i18n/locales/en.pro.json
@@ -2,8 +2,7 @@
   "_comment": "Edition='pro' overlay applied on top of en.json when VITE_APP_EDITION=pro. Replaces household-flavored Circles vocabulary with enterprise/banking-friendly equivalents (visibility / team / organization / confidential). Keys not listed here fall through to en.json. See src/i18n/index.ts merge logic.",
   "auth": {
     "personalAssistant": "AI for Release Management",
-    "tenantPrefix": "Sign in to",
-    "complianceFooter": "GDPR-compliant · BaFin-conformant · Hosted on .de"
+    "tenantPrefix": "Sign in to"
   },
   "nav": {
     "brain": "Knowledge",

--- a/src/frontend/src/pages/LoginPage.tsx
+++ b/src/frontend/src/pages/LoginPage.tsx
@@ -246,17 +246,9 @@ export default function LoginPage() {
           )}
         </div>
 
-        {/* Footer — pro edition adds compliance trust markers below the
-            product line. Banking customers look for these as legitimacy
-            signals on the auth surface. */}
         <p className="text-center text-gray-500 text-sm mt-8">
           {appName} · {t('auth.personalAssistant')}
         </p>
-        {isPro && (
-          <p className="text-center text-gray-600 text-xs mt-2 tracking-wide">
-            {t('auth.complianceFooter')}
-          </p>
-        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Removes 'DSGVO-konform · BaFin-kompatibel · Auf .de gehostet' line + the matching i18n overlay keys. Per user request — reads as marketing copy in this position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)