### PR TITLE
feat(auth): OIDC SSO frontend — login button + URL-fragment hand-off

### DIFF
--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -76,6 +76,11 @@ ARG VITE_APP_EDITION=community
 # this to the customer organization name (e.g. "X-IDRA Systems"). See
 # pages/LoginPage.tsx for the render logic.
 ARG VITE_APP_TENANT_NAME=
+# OIDC SSO ("Sign in with Microsoft" button on LoginPage). Set to "true"
+# when the backend's REVA_OIDC_ENABLED is also true. The frontend gates
+# the button + the URL-fragment hand-off parser on this flag. Default
+# false — community deploys don't ship OIDC and the button stays hidden.
+ARG VITE_OIDC_ENABLED=false
 
 # Set environment variables for build
 ENV VITE_API_URL=${VITE_API_URL}
@@ -86,6 +91,7 @@ ENV VITE_CHAT_STARTERS=${VITE_CHAT_STARTERS}
 ENV VITE_FEATURE_VOICE_STREAM=${VITE_FEATURE_VOICE_STREAM}
 ENV VITE_APP_EDITION=${VITE_APP_EDITION}
 ENV VITE_APP_TENANT_NAME=${VITE_APP_TENANT_NAME}
+ENV VITE_OIDC_ENABLED=${VITE_OIDC_ENABLED}
 
 # App Code kopieren
 COPY . .

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -95,7 +95,19 @@
     "emailPlaceholder": "deine@email.de",
     "optional": "optional",
     "alreadyHaveAccount": "Bereits ein Konto?",
-    "createAccount": "Konto erstellen"
+    "createAccount": "Konto erstellen",
+    "signInWithSso": "Mit SSO anmelden",
+    "ssoOrDivider": "oder",
+    "oidcError": {
+      "oidc_state_invalid": "Anmelde-Sitzung abgelaufen. Bitte erneut versuchen.",
+      "oidc_token_invalid": "Identität konnte nicht überprüft werden. Bitte erneut versuchen.",
+      "oidc_code_invalid": "Anmelde-Link abgelaufen. Bitte erneut versuchen.",
+      "oidc_disabled": "Ihr Konto wurde deaktiviert. Bitte wenden Sie sich an Ihren Administrator.",
+      "oidc_idp_unreachable": "Identitätsanbieter vorübergehend nicht erreichbar. Versuche es weiter unten mit Passwort-Login.",
+      "oidc_idp_error": "Identitätsanbieter hat einen Fehler zurückgegeben. Bitte erneut versuchen.",
+      "oidc_cancelled": "Anmeldung wurde abgebrochen.",
+      "oidc_internal": "Ein interner Fehler ist aufgetreten. Bitte erneut versuchen oder Support kontaktieren."
+    }
   },
   "chat": {
     "title": "Chat",

--- a/src/frontend/src/i18n/locales/de.pro.json
+++ b/src/frontend/src/i18n/locales/de.pro.json
@@ -2,7 +2,8 @@
   "_comment": "Edition='pro' overlay applied on top of de.json when VITE_APP_EDITION=pro. Replaces household-flavored Circles vocabulary with enterprise/banking-friendly equivalents (Sichtbarkeit / Team / Organisation / Vertraulich). Keys not listed here fall through to de.json. See src/i18n/index.ts merge logic.",
   "auth": {
     "personalAssistant": "KI-Assistent für Release Management",
-    "tenantPrefix": "Anmeldung bei"
+    "tenantPrefix": "Anmeldung bei",
+    "signInWithSso": "Mit Microsoft anmelden"
   },
   "nav": {
     "brain": "Wissensbasis",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -95,7 +95,19 @@
     "emailPlaceholder": "your@email.com",
     "optional": "optional",
     "alreadyHaveAccount": "Already have an account?",
-    "createAccount": "Create Account"
+    "createAccount": "Create Account",
+    "signInWithSso": "Sign in with SSO",
+    "ssoOrDivider": "or",
+    "oidcError": {
+      "oidc_state_invalid": "Login session expired. Try again.",
+      "oidc_token_invalid": "Could not verify identity. Try again.",
+      "oidc_code_invalid": "Login link expired. Try again.",
+      "oidc_disabled": "Your account has been disabled. Contact your administrator.",
+      "oidc_idp_unreachable": "Identity provider is temporarily unavailable. Try password login below.",
+      "oidc_idp_error": "Identity provider returned an error. Try again.",
+      "oidc_cancelled": "Login was cancelled.",
+      "oidc_internal": "An internal error occurred. Try again or contact support."
+    }
   },
   "chat": {
     "title": "Chat",

--- a/src/frontend/src/i18n/locales/en.pro.json
+++ b/src/frontend/src/i18n/locales/en.pro.json
@@ -2,7 +2,8 @@
   "_comment": "Edition='pro' overlay applied on top of en.json when VITE_APP_EDITION=pro. Replaces household-flavored Circles vocabulary with enterprise/banking-friendly equivalents (visibility / team / organization / confidential). Keys not listed here fall through to en.json. See src/i18n/index.ts merge logic.",
   "auth": {
     "personalAssistant": "AI for Release Management",
-    "tenantPrefix": "Sign in to"
+    "tenantPrefix": "Sign in to",
+    "signInWithSso": "Sign in with Microsoft"
   },
   "nav": {
     "brain": "Knowledge",

--- a/src/frontend/src/main.tsx
+++ b/src/frontend/src/main.tsx
@@ -18,6 +18,35 @@ if (_edition === 'pro') {
   document.documentElement.dataset.edition = 'pro';
 }
 
+// OIDC URL-fragment hand-off. After a successful OIDC dance the backend
+// redirects to /#access_token=<JWT>&expires_in=<seconds>&provider=entra.
+// We move those tokens into localStorage (the standard storage the rest
+// of the app reads from) and clear the fragment before React mounts —
+// otherwise AuthContext's mount-time fetchUser() would miss the token
+// and the user would briefly see the login page before the fetch retried.
+// Fragment is never sent to the server, so the JWT does NOT show up in
+// any HTTP request log even though it lands in the URL bar momentarily.
+function _consumeOidcHashHandoff(): void {
+  const hash = window.location.hash;
+  if (!hash || !hash.startsWith('#access_token=')) {
+    return;
+  }
+  const params = new URLSearchParams(hash.slice(1));
+  const accessToken = params.get('access_token');
+  if (!accessToken) return;
+
+  localStorage.setItem('renfield_access_token', accessToken);
+  // Clear the fragment from the URL bar without triggering a navigation.
+  // Replacing with `window.location.pathname + window.location.search` keeps
+  // any path/query the backend included (e.g. ?from=/brain).
+  history.replaceState(
+    null,
+    '',
+    window.location.pathname + window.location.search,
+  );
+}
+_consumeOidcHashHandoff();
+
 const rootElement = document.getElementById('root');
 if (!rootElement) {
   throw new Error('Root element #root not found in document');

--- a/src/frontend/src/pages/LoginPage.tsx
+++ b/src/frontend/src/pages/LoginPage.tsx
@@ -46,6 +46,24 @@ export default function LoginPage() {
   const fromState = (location.state as LocationStateWithFrom | null) ?? null;
   const from = fromState?.from?.pathname ?? '/';
 
+  // OIDC SSO flag — backend route mounting and frontend button visibility
+  // are independently gated. The frontend flag must match the backend's
+  // REVA_OIDC_ENABLED for the dance to actually work end-to-end. When the
+  // backend is on but the frontend flag is off, the button is hidden but
+  // direct navigation to /auth/oidc/login still works.
+  const oidcEnabled = import.meta.env.VITE_OIDC_ENABLED === 'true';
+
+  // Surface OIDC error redirects from the backend. After a failed dance
+  // /auth/oidc/callback redirects to /login?error=<code> where <code> is
+  // one of the documented values (oidc_state_invalid, oidc_token_invalid,
+  // oidc_code_invalid, oidc_disabled, oidc_idp_unreachable, oidc_idp_error,
+  // oidc_cancelled, oidc_internal). Render the localized message above
+  // the credentials form so the user knows what happened.
+  const oidcErrorCode = (() => {
+    const code = new URLSearchParams(location.search).get('error');
+    return code && code.startsWith('oidc_') ? code : null;
+  })();
+
   // Redirect if already authenticated or auth is disabled
   useEffect(() => {
     if (!authLoading && (isAuthenticated || !authEnabled)) {
@@ -148,6 +166,21 @@ export default function LoginPage() {
 
         {/* Login Card */}
         <div className="card-primary bg-gray-900 border-gray-700">
+          {/* OIDC error banner — shown when /auth/oidc/callback redirected
+              here with ?error=<code>. Distinct from the form `error` state
+              so a fresh form-submit error doesn't suppress the OIDC banner
+              the user just landed with. */}
+          {oidcErrorCode && (
+            <div className="bg-amber-900/20 border border-amber-700 rounded-lg p-4 mb-6">
+              <div className="flex items-center space-x-3">
+                <AlertCircle className="w-5 h-5 text-amber-500 shrink-0" />
+                <p className="text-amber-400">
+                  {t(`auth.oidcError.${oidcErrorCode}`, t('auth.oidcError.oidc_internal'))}
+                </p>
+              </div>
+            </div>
+          )}
+
           {/* Error Alert */}
           {error && (
             <div className="bg-red-900/20 border border-red-700 rounded-lg p-4 mb-6">
@@ -224,6 +257,48 @@ export default function LoginPage() {
               )}
             </button>
           </form>
+
+          {/* OIDC SSO button — full-page navigation (not Link/navigate)
+              because /auth/oidc/login responds 302 to the IdP, which is
+              outside our origin and can't be handled by react-router.
+              The backend's `_redirect_login_error` brings the user back
+              to /login?error=<code> on failure; the OIDC error banner
+              above renders the localized copy. */}
+          {oidcEnabled && (
+            <>
+              <div className="relative my-6" aria-hidden="true">
+                <div className="absolute inset-0 flex items-center">
+                  <div className="w-full border-t border-gray-700" />
+                </div>
+                <div className="relative flex justify-center text-xs">
+                  <span className="bg-gray-900 px-3 text-gray-500 uppercase tracking-wider">
+                    {t('auth.ssoOrDivider')}
+                  </span>
+                </div>
+              </div>
+              <a
+                href="/auth/oidc/login"
+                className="w-full btn bg-white text-gray-900 hover:bg-gray-100 py-3 flex items-center justify-center space-x-3 font-medium"
+              >
+                {/* Microsoft logo (4-square mark). Inline SVG keeps the
+                    button self-contained — no extra asset request, no
+                    icon-library dep. The 4 brand hex values are fixed by
+                    Microsoft's brand guidelines and not localized. */}
+                <svg
+                  className="w-5 h-5"
+                  viewBox="0 0 21 21"
+                  xmlns="http://www.w3.org/2000/svg"
+                  aria-hidden="true"
+                >
+                  <rect x="1" y="1" width="9" height="9" fill="#f25022" />
+                  <rect x="11" y="1" width="9" height="9" fill="#7fba00" />
+                  <rect x="1" y="11" width="9" height="9" fill="#00a4ef" />
+                  <rect x="11" y="11" width="9" height="9" fill="#ffb900" />
+                </svg>
+                <span>{t('auth.signInWithSso')}</span>
+              </a>
+            </>
+          )}
 
           {/* Registration Link — community edition only. Pro tenants
               provision users via LDAP / Microsoft Graph; surfacing


### PR DESCRIPTION
## Summary

Companion to Reva's OIDC backend PR (X-idra-Systems-GmbH/reva#191, merged + deployed dark on 2026-05-09). Without the frontend pieces, the backend's `/auth/oidc/callback` redirect to `/#access_token=<JWT>...` lands but nothing picks up the token.

Backend ships dormant (\`REVA_OIDC_ENABLED=false\` default). This frontend PR ships dormant the same way (\`VITE_OIDC_ENABLED=false\` default). When both flags flip together for a deploy, OIDC dance works end-to-end. Community Renfield deploys see zero change.

## What lands

### LoginPage button
- "Sign in with SSO" (community) / "Sign in with Microsoft" (pro overlay) button below the credentials form, separated by a localized "or" divider
- Inline SVG of Microsoft's 4-square brand mark — no asset request, no icon-library dep
- Full page navigation to \`/auth/oidc/login\` (\`<a href>\`, not react-router \`<Link>\`) because the IdP redirect crosses the origin
- Hidden by default — gated on \`VITE_OIDC_ENABLED\`

### URL-fragment hand-off parser (\`main.tsx\`)
- Runs **before** React mounts, so AuthContext's mount-time \`fetchUser()\` finds the token in localStorage on first render
- Reads \`#access_token=<JWT>&expires_in=<seconds>&provider=entra\`, writes to \`renfield_access_token\`, clears the fragment via \`history.replaceState\`
- Fragment is never sent in HTTP requests → the JWT doesn't appear in any backend access log even though it lands in the URL bar momentarily
- Conditional logic guarded by the prefix check (\`#access_token=\`); no flag needed because the fragment only ever appears after an OIDC dance completes

### OIDC error banner
- Surfaces \`/login?error=<code>\` redirects with localized copy
- Eight documented error codes match the backend's \`_redirect_login_error\` set: \`oidc_state_invalid\`, \`oidc_token_invalid\`, \`oidc_code_invalid\`, \`oidc_disabled\`, \`oidc_idp_unreachable\`, \`oidc_idp_error\`, \`oidc_cancelled\`, \`oidc_internal\`
- i18n falls back to \`oidc_internal\` copy for unknown codes — a future backend addition doesn't render bare keys

### Dockerfile
- \`VITE_OIDC_ENABLED\` build arg (default \`false\`). Plugins (Reva's \`bin/build-frontend.sh\`) pass \`--build-arg VITE_OIDC_ENABLED=true\` alongside the existing \`VITE_APP_EDITION=pro\` / \`VITE_APP_NAME=Reva\` args.

## Not in this PR

- **Silent reauth on JWT expiry** — frontend should hit \`/auth/oidc/login?prompt=none\` when the \`reva_login_provider=entra\` marker cookie is set. Needs apiClient 401-handler changes that warrant their own PR. Defer until OIDC has shipped for one customer and the basic dance is observed-stable.
- **Global logout helper** — backend supports \`?global=true\` (RP-Initiated Logout). Frontend wrapper for it lives in the same follow-up PR.

## Test plan

- [ ] Build community frontend → button hidden, no behavior change
- [ ] Build pro frontend with \`VITE_OIDC_ENABLED=true\` + Reva backend with \`REVA_OIDC_ENABLED=true\` → button shows on /login, click redirects to Entra, return-callback hands off JWT, lands logged in
- [ ] Hit \`/login?error=oidc_cancelled\` directly → localized "Login was cancelled" banner shows
- [ ] Hit \`/#access_token=fake-jwt-for-test\` directly → fragment cleared, "fake-jwt-for-test" in localStorage, AuthContext fails fetchUser cleanly (treats as expired token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)