### PR TITLE
feat(wissensbasis): probe + hide nav/panel when backend gated off

### DIFF
--- a/src/frontend/src/api/resources/wissensbasis.ts
+++ b/src/frontend/src/api/resources/wissensbasis.ts
@@ -160,3 +160,32 @@ export function useRoleMixQuery(role: string | null, enabled = true) {
     'wissensbasis.mix.couldNotLoad',
   );
 }
+
+/**
+ * Check whether the Wissensbasis feature is enabled on the backend.
+ *
+ * The backend gates the entire `/api/wissensbasis/*` surface on the
+ * `REVA_WISSENSBASIS_ENABLED` env var: routes return 404 when off and
+ * authenticated 200/data when on. Frontend probes /me/mix once per
+ * session and treats 404 as "feature off".
+ *
+ * Use this to hide the nav entry + skip mounting the side panel when
+ * the backend is gated, avoiding empty-placeholder UX in flag-off
+ * environments. Returns:
+ *   - undefined while the probe is in flight (don't flash nav entry)
+ *   - true  when reachable (200) or auth-gated (401, meaning route is mounted)
+ *   - false on 404 (route gated off)
+ */
+export function useWissensbasisAvailable(): boolean | undefined {
+  // Reuses the role-mix query — it's the cheapest probe and operators
+  // already pay for it on first nav. CONFIG staleness keeps it cheap.
+  const q = useRoleMixQuery(null);
+  if (q.isLoading) return undefined;
+  // 404 = feature gated off → unavailable.
+  // Any other state (200 success, 401 unauth, 5xx server error) means
+  // the route is mounted on the backend, so the feature is "available"
+  // even if the user can't load data right now.
+  const status = (q.error as { response?: { status?: number } } | null)?.response?.status;
+  if (status === 404) return false;
+  return true;
+}

--- a/src/frontend/src/components/Layout.tsx
+++ b/src/frontend/src/components/Layout.tsx
@@ -38,6 +38,7 @@ import DeviceStatus from './DeviceStatus';
 import ThemeToggle from './ThemeToggle';
 import LanguageSwitcher from './LanguageSwitcher';
 import NotificationToast from './NotificationToast';
+import { useWissensbasisAvailable } from '../api/resources/wissensbasis';
 import { useAuth } from '../context/AuthContext';
 
 interface NavItemConfig {
@@ -110,6 +111,14 @@ export default function Layout({ children }: LayoutProps) {
 
   const { user, isAuthenticated, authEnabled, logout, hasAnyPermission, isFeatureEnabled } = useAuth();
 
+  // Backend-gated Reva features that aren't in Renfield's feature dict.
+  // wissensbasisAvailable: true when /api/wissensbasis/me/mix is reachable
+  // (route mounted), undefined while the probe is in flight (don't flash
+  // the entry), false on 404 (REVA_WISSENSBASIS_ENABLED=false). Hides the
+  // nav entry in flag-off environments so users don't click into a
+  // permanently empty page.
+  const wissensbasisAvailable = useWissensbasisAvailable();
+
   const mainNavigation: NavItem[] = mainNavigationConfig.map((item) => ({
     ...item,
     name: t(item.nameKey),
@@ -123,6 +132,10 @@ export default function Layout({ children }: LayoutProps) {
   const filterNavItems = (items: NavItem[]): NavItem[] => {
     return items.filter((item) => {
       if (item.feature && !isFeatureEnabled(item.feature)) return false;
+      // Reva-side: hide the wissensbasis entry when its backend gate is
+      // off. Treat `undefined` (probe in flight) as hidden too — better
+      // to be late-revealed than to flash and disappear.
+      if (item.href === '/wissensbasis' && wissensbasisAvailable !== true) return false;
       if (!authEnabled) return true;
       if (!item.permission) return true;
       return hasAnyPermission(item.permission);

--- a/src/frontend/src/pages/ChatPage/index.tsx
+++ b/src/frontend/src/pages/ChatPage/index.tsx
@@ -3,6 +3,7 @@ import { Menu } from 'lucide-react';
 import ChatSidebar from '../../components/ChatSidebar';
 import { WissensbasisSidePanel } from '../../components/wissensbasis/WissensbasisSidePanel';
 import { WissensbasisProvider } from '../../context/WissensbasisContext';
+import { useWissensbasisAvailable } from '../../api/resources/wissensbasis';
 
 import ChatHeader from './ChatHeader';
 import ChatMessages from './ChatMessages';
@@ -16,6 +17,13 @@ function ChatPageLayout() {
     conversations, conversationsLoading,
     sessionId, switchConversation, startNewChat, handleDeleteConversation,
   } = useChatContext();
+  // Hide the side panel + FAB when the Reva backend has
+  // REVA_WISSENSBASIS_ENABLED=false. Otherwise users see permanently
+  // empty placeholders. ChatMessages still imports the trace query,
+  // but useTraceQuery's `enabled` flag gates it on sessionId being
+  // present and the route returning a real result; when the route
+  // 404s, useTraceQuery falls through to empty data harmlessly.
+  const wissensbasisAvailable = useWissensbasisAvailable();
 
   return (
     <div className="h-[calc(100vh-8rem)] flex">
@@ -48,11 +56,13 @@ function ChatPageLayout() {
       </div>
 
       {/* Wissensbasis side panel — A-LANDING composed view (A2 reasoning + A4 focus).
-          Self-gates: backend routes return 404 when REVA_WISSENSBASIS_ENABLED=false,
-          which makes every query enabled=false and the panel renders empty placeholders.
-          Citation chips inside ChatMessages reach the same WissensbasisProvider via
-          context, so chip click → setFocus → side panel refocus works end-to-end. */}
-      <WissensbasisSidePanel sessionId={sessionId} role={null} />
+          Mounted only when the backend route is reachable (probed once via
+          useWissensbasisAvailable). When REVA_WISSENSBASIS_ENABLED=false in
+          prod, the routes 404 and the panel is omitted entirely — no empty
+          placeholders, no FAB clutter. */}
+      {wissensbasisAvailable === true && (
+        <WissensbasisSidePanel sessionId={sessionId} role={null} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
When REVA_WISSENSBASIS_ENABLED=false on the Reva backend, /api/wissensbasis/* returns 404. Frontend was still rendering the nav entry and chat-page side panel, leading to permanently empty UI. Add a one-shot probe (useWissensbasisAvailable, piggybacks on the existing role-mix query) and hide both surfaces when the route 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)