### PR TITLE
fix(circles): alias circle_memberships as 'cm' to prevent outer-alias shadow

### DIFF
--- a/src/backend/services/circle_sql.py
+++ b/src/backend/services/circle_sql.py
@@ -124,13 +124,22 @@ def circles_filter_clause(
     # parses cleanly here. SQLite is permissive about the direct cast which
     # is why the string-shape tests (run on SQLite) didn't catch this — the
     # production bug surfaced as 500 on /knowledge-graph against asyncpg.
+    #
+    # Alias for circle_memberships is "cm", NOT "m". A previous version used
+    # "m", which silently shadowed the OUTER alias when callers pass
+    # table_alias="m" (the default for conversation_memories_circles_filter).
+    # In that case {owner_alias}.{owner_col} expands to "m.user_id" — and
+    # inside this EXISTS scope, "m" resolves to circle_memberships, which
+    # has no user_id column. The query fails with
+    # "column m.user_id does not exist". Caught in prod 2026-05-12 in
+    # the chat_handler memory-retrieval path.
     parts.append(
         f"EXISTS ("
-        f"  SELECT 1 FROM circle_memberships m "
-        f"  WHERE m.circle_owner_id = {owner_alias}.{owner_col} "
-        f"  AND m.member_user_id = :{asker_param} "
-        f"  AND m.dimension = 'tier' "
-        f"  AND (m.value::text)::int <= {table_alias}.{tier_col}"
+        f"  SELECT 1 FROM circle_memberships cm "
+        f"  WHERE cm.circle_owner_id = {owner_alias}.{owner_col} "
+        f"  AND cm.member_user_id = :{asker_param} "
+        f"  AND cm.dimension = 'tier' "
+        f"  AND (cm.value::text)::int <= {table_alias}.{tier_col}"
         f")"
     )
 

--- a/tests/backend/test_circle_sql.py
+++ b/tests/backend/test_circle_sql.py
@@ -43,10 +43,12 @@ class TestCirclesFilterClause:
 
     def test_membership_subquery_uses_owner_alias(self):
         clause = circles_filter_clause(table_alias="e")
-        assert "circle_memberships m" in clause
-        assert "m.circle_owner_id = e.user_id" in clause
-        assert "m.dimension = 'tier'" in clause
-        assert "(m.value::text)::int <= e.circle_tier" in clause
+        # circle_memberships uses inner alias 'cm' (not 'm') to avoid
+        # shadowing outer table aliases — see the rename commit message.
+        assert "circle_memberships cm" in clause
+        assert "cm.circle_owner_id = e.user_id" in clause
+        assert "cm.dimension = 'tier'" in clause
+        assert "(cm.value::text)::int <= e.circle_tier" in clause
 
     def test_owner_table_alias_overrides_only_owner_col(self):
         # When owner is on a JOINed table (kb), tier should still come from
@@ -60,8 +62,8 @@ class TestCirclesFilterClause:
         )
         assert "kb.owner_id = :asker_id" in clause
         assert "dc.circle_tier = :asker_id_pub" in clause
-        assert "m.circle_owner_id = kb.owner_id" in clause
-        assert "(m.value::text)::int <= dc.circle_tier" in clause
+        assert "cm.circle_owner_id = kb.owner_id" in clause
+        assert "(cm.value::text)::int <= dc.circle_tier" in clause
 
     def test_source_id_expr_overrides_default(self):
         clause = circles_filter_clause(

--- a/tests/backend/test_circle_sql.py
+++ b/tests/backend/test_circle_sql.py
@@ -125,6 +125,27 @@ class TestConversationMemoriesWrapper:
             "asker_id": 42, "asker_id_pub": TIER_PUBLIC, "asker_id_src": "conversation_memories",
         }
 
+    def test_circle_memberships_alias_does_not_shadow_outer(self):
+        """Regression: circle_memberships must NOT use alias 'm'.
+
+        The default alias for conversation_memories is also 'm'. When the
+        EXISTS subquery used 'circle_memberships m', the inner 'm'
+        shadowed the outer wherever the clause referenced
+        ``{owner_alias}.{owner_col}`` (which expands to 'm.user_id'). The
+        production query then failed with "column m.user_id does not exist"
+        because the resolution happened inside the subquery where 'm'
+        means circle_memberships (no user_id column).
+
+        Caught in prod 2026-05-12 in the chat_handler memory-retrieval
+        path. Fix: alias circle_memberships as 'cm'.
+        """
+        clause, _ = conversation_memories_circles_filter(asker_id=42)
+        assert "circle_memberships m " not in clause, (
+            "circle_memberships must NOT use alias 'm' — would shadow "
+            "the outer conversation_memories alias"
+        )
+        assert "circle_memberships cm " in clause
+
 
 class TestDocumentChunksWrapper:
     def test_owner_from_kb_tier_from_chunk(self):


### PR DESCRIPTION
## Summary

`circles_filter_clause` aliased `circle_memberships` as `m` inside its EXISTS subquery. When callers pass `table_alias="m"` (the default for `conversation_memories_circles_filter`), the inner `m` shadowed the outer wherever the clause referenced `{owner_alias}.{owner_col}` — which expands to `m.user_id`. Inside the EXISTS scope `m` means `circle_memberships`, which has no `user_id` column.

## Production symptom (2026-05-12)

Discovered while investigating wissensbasis sprint-2 deploy in Reva:

```
WARNING | api.websocket.chat_handler:_retrieve_memory_context:419
Memory retrieval failed: UndefinedColumnError: column m.user_id does not exist
```

`_retrieve_memory_context` catches the exception and falls back to "no memories injected" — so every agent turn since this bug landed has been silently operating WITHOUT conversation-memory context. The `WARNING` log level (vs. `DEBUG`) is what surfaced it post-deploy.

## Fix

Rename the EXISTS subquery's alias from `m` to `cm`. Other callers (`document_chunks_circles_filter` → `dc`, `kg_entities_circles_filter` → `e`, etc.) already pass distinct `table_alias` values so they were never affected by the shadow — only the conversation_memories path was reachable.

## Regression test

`test_circle_memberships_alias_does_not_shadow_outer` asserts that `'circle_memberships m '` never appears in the generated clause. Guards against future drift back to the shadowing alias.

## Test plan

- [x] `tests/backend/test_circle_sql.py::TestConversationMemoriesWrapper` — both tests pass (the pre-existing `m.user_id = :asker_id` assertion still holds; the new shadow-guard assertion is added)
- [ ] On merge: bump Reva's renfield submodule, redeploy, confirm `Memory retrieval failed` warnings disappear from `_retrieve_memory_context` log path

🤖 Generated with [Claude Code](https://claude.com/claude-code)