### PR TITLE
fix(chat): set request_id ContextVar at websocket message entry

### DIFF
--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -11,6 +11,7 @@ This module handles:
 
 import asyncio
 import re
+import uuid
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
 from loguru import logger
@@ -22,6 +23,7 @@ from services.input_guard import detect_injection
 from services.websocket_auth import WSAuthError, authenticate_websocket
 from services.websocket_rate_limiter import get_rate_limiter
 from utils.config import settings
+from utils.request_context import request_id as request_id_var
 from utils.voice_context import voice_originated
 
 from .shared import (
@@ -621,6 +623,18 @@ async def websocket_endpoint(
             except ValidationError as e:
                 await send_ws_error(websocket, WSErrorCode.INVALID_MESSAGE, str(e))
                 continue
+
+            # Per-message request id, set into the ContextVar so every
+            # downstream log line + every Reva observability counter +
+            # every wb_field_provenance row written in the async flush
+            # can be correlated back to this turn. Client-supplied
+            # request_id wins (up to 8 chars to fit the request_id
+            # ContextVar default's width); otherwise we mint a fresh
+            # 8-char UUID prefix. Without this set(), the ContextVar
+            # falls through to its default "--------" — every audit
+            # row gets the sentinel, defeating correlation.
+            rid = (msg_request_id or uuid.uuid4().hex)[:8]
+            request_id_var.set(rid)
 
             # Truthy embedding = came from the voice path; null/empty = text.
             voice_originated.set(bool(msg_speaker_embedding))

--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -595,6 +595,22 @@ async def websocket_endpoint(
             # Receive message
             data = await websocket.receive_json()
 
+            # Per-message request id, minted FIRST so every error path
+            # (rate-limit, validation) gets a fresh correlator instead of
+            # the "--------" sentinel or the previous turn's leftover.
+            # Mirrors the voice_originated.set(False) clear-before-validate
+            # pattern below. Client-supplied request_id (if any) overwrites
+            # this after validation.
+            #
+            # Without this set(), the ContextVar falls through to its
+            # default "--------" — every downstream log line, every Reva
+            # observability counter, and every wb_field_provenance row
+            # written in the async flush gets the sentinel, defeating
+            # correlation. Child tasks spawned via
+            # ``asyncio.create_task`` / ``asyncio.gather`` inherit the
+            # value automatically (Python 3.7+ context propagation).
+            request_id_var.set(uuid.uuid4().hex[:8])
+
             # Rate limiting check
             allowed, reason = rate_limiter.check(ip_address)
             if not allowed:
@@ -624,17 +640,12 @@ async def websocket_endpoint(
                 await send_ws_error(websocket, WSErrorCode.INVALID_MESSAGE, str(e))
                 continue
 
-            # Per-message request id, set into the ContextVar so every
-            # downstream log line + every Reva observability counter +
-            # every wb_field_provenance row written in the async flush
-            # can be correlated back to this turn. Client-supplied
-            # request_id wins (up to 8 chars to fit the request_id
-            # ContextVar default's width); otherwise we mint a fresh
-            # 8-char UUID prefix. Without this set(), the ContextVar
-            # falls through to its default "--------" — every audit
-            # row gets the sentinel, defeating correlation.
-            rid = (msg_request_id or uuid.uuid4().hex)[:8]
-            request_id_var.set(rid)
+            # Prefer the client-supplied request_id if present — lets the
+            # frontend correlate its own outbound id to backend traces.
+            # The fresh uuid set at loop-top stays if the client didn't
+            # send one.
+            if msg_request_id:
+                request_id_var.set(msg_request_id[:8])
 
             # Truthy embedding = came from the voice path; null/empty = text.
             voice_originated.set(bool(msg_speaker_embedding))


### PR DESCRIPTION
## Summary

`utils/request_context.request_id` is a `ContextVar[str]` with a default `"--------"` sentinel. It's read at ~30 call sites across the codebase via `.get()` for log correlation and observability. But it was never `.set()` anywhere in the websocket chat path — so every agent turn reads the sentinel default.

## Production impact

Discovered while validating Reva's wissensbasis sprint-2 substrate on 2026-05-12:

- All Reva log lines for ws turns prefix `[--------]` instead of a real correlator
- All `wb_field_provenance` audit-replay rows landed in sprint 2 carry `req_id="--------"` — useless for the BaFin-required "trace this turn through every observation" pattern
- Any `req_id`-labelled metrics counter sees all turns under one bucket

Sample of the substrate output before this fix:

```
 source_type | source_id | field_path     | snapshot_value_json | fetched_at                   | req_id
-------------+-----------+----------------+---------------------+------------------------------+----------
 jira        | REVA-1    | issues[44].sum | "Mein erstes ..."   | 2026-05-12 06:55:33.886+00   | --------
 jira        | REVA-12   | issues[0].stat | {"name":"To Do"...} | 2026-05-12 06:55:33.886+00   | --------
```

## Fix

In `chat_handler.websocket_endpoint`, after `msg = WSChatMessage(**data)` validation (line ~620, where `msg_request_id = msg.request_id` is already parsed), call:

```python
rid = (msg_request_id or uuid.uuid4().hex)[:8]
request_id_var.set(rid)
```

The ContextVar propagates automatically through `asyncio.create_task` / `gather` to all downstream agent + hook + async-flush tasks. No signature changes; no behavioral changes for code that doesn't read `request_id`.

Client-supplied `msg.request_id` wins (lets the frontend correlate its own request id to backend traces). Falls back to a fresh `uuid4().hex[:8]` per message. 8 chars matches the conventional width across both Renfield and Reva log formats.

## Test plan

- [x] Manual: deploy Renfield with this fix + Reva submodule bump + retry sprint-2 audit query → confirm `wb_field_provenance.req_id` is non-sentinel for the new rows
- [ ] On merge: bump Reva's renfield submodule, redeploy, watch `kubectl logs deployment/reva | head` for non-`[--------]` log prefixes on websocket turns
- [ ] Bonus: forward the same `rid` into the response message so the frontend can display + log it (not in scope here)

No regression test in this PR — `websocket_endpoint` requires the full FastAPI app + ws lifecycle + auth fixture, which is over-scope for the 2-line fix. The behavior is observable through any deploy + chat turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)