### PR TITLE
feat(wissensbasis): render observed_fields[] + source_priority in A4 panel

### DIFF
--- a/src/frontend/src/api/resources/wissensbasis.ts
+++ b/src/frontend/src/api/resources/wissensbasis.ts
@@ -60,6 +60,24 @@ export interface FocusEdge {
   relation: string;
 }
 
+/**
+ * A value observed for an entity at a specific time. Sourced from the
+ * sprint-2 wb_field_provenance substrate. Backend pins the JSON value
+ * the source returned at ``fetched_at`` so audit replay reconstructs
+ * "what did we know about X at time Y" even after the upstream value
+ * changes or the upstream record is deleted.
+ *
+ * source_type is the coarse DB CHECK enum (release / jira / confluence /
+ * itsm / memory / derived). The fine-grained source (release_phase,
+ * jira_issue, …) is recoverable from the row's field_path.
+ */
+export interface ObservedField {
+  field_path: string;
+  value: unknown;
+  fetched_at: string; // ISO 8601 UTC
+  source_type: string;
+}
+
 export interface FocusNeighborhood {
   focus: FocusEntity;
   hop1: FocusEntity[];
@@ -67,6 +85,10 @@ export interface FocusNeighborhood {
   edges: FocusEdge[];
   overflow_hop1: number;
   overflow_hop2: number;
+  // Sprint 2 additions — default to empty / null so older API responses
+  // (which omit them) still deserialize cleanly.
+  observed_fields?: ObservedField[];
+  source_priority?: 1 | 2 | 3 | null;
 }
 
 export interface RoleMix {

--- a/src/frontend/src/components/wissensbasis/FocusNeighborhood.tsx
+++ b/src/frontend/src/components/wissensbasis/FocusNeighborhood.tsx
@@ -13,12 +13,17 @@
  * a citation chip in the answer.
  */
 
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
-import { Eye, MoreHorizontal } from 'lucide-react';
+import { Clock, Eye, MoreHorizontal } from 'lucide-react';
 
 import { CitationChip } from './CitationChip';
-import type { FocusEntity, FocusNeighborhood as FocusNeighborhoodData } from '../../api/resources/wissensbasis';
+import type {
+  FocusEntity,
+  FocusNeighborhood as FocusNeighborhoodData,
+  ObservedField,
+} from '../../api/resources/wissensbasis';
 
 export interface FocusNeighborhoodProps {
   data: FocusNeighborhoodData | null;
@@ -58,7 +63,8 @@ export function FocusNeighborhood({ data, isLoading, errorMessage }: FocusNeighb
 
   return (
     <div className="space-y-3 px-3 py-2">
-      <FocusCard focus={data.focus} />
+      <FocusCard focus={data.focus} sourcePriority={data.source_priority ?? null} />
+      <ObservedFieldsSection observed={data.observed_fields ?? []} />
       <NeighborSection
         title={t('wissensbasis.focus.directNeighbors', 'Direct neighbors')}
         entities={data.hop1}
@@ -95,9 +101,23 @@ function NeighborhoodSkeleton() {
   );
 }
 
-function FocusCard({ focus }: { focus: FocusEntity }) {
+function FocusCard({
+  focus,
+  sourcePriority,
+}: {
+  focus: FocusEntity;
+  sourcePriority: 1 | 2 | 3 | null;
+}) {
   const { t } = useTranslation();
   const importancePct = Math.round(focus.importance * 100);
+  const sourceLabelKey =
+    sourcePriority === 1
+      ? 'wissensbasis.focus.sourcePriority1'
+      : sourcePriority === 2
+        ? 'wissensbasis.focus.sourcePriority2'
+        : sourcePriority === 3
+          ? 'wissensbasis.focus.sourcePriority3'
+          : null;
   return (
     <div className="rounded-md border border-accent-300 dark:border-accent-700 bg-accent-50 dark:bg-accent-900/20 px-3 py-2">
       <p className="font-semibold text-sm text-accent-900 dark:text-accent-100 break-words">
@@ -113,9 +133,123 @@ function FocusCard({ focus }: { focus: FocusEntity }) {
             </span>
           </>
         )}
+        {sourceLabelKey && (
+          <>
+            <span className="mx-1.5 opacity-50">·</span>
+            <span className="italic">{t(sourceLabelKey)}</span>
+          </>
+        )}
       </p>
     </div>
   );
+}
+
+/**
+ * Observed values section — renders the sprint-2 wb_field_provenance
+ * snapshots returned in `FocusNeighborhood.observed_fields[]`. Each
+ * entry is a (field_path, value, fetched_at) triple. Source priority
+ * 1 = cached provenance, 2 = KG only, 3 = trace fallback. Observed
+ * fields only appear when priority is 1 (P2/P3 don't contribute).
+ *
+ * Backend coarsening keeps values JSON-serializable; for display the
+ * component stringifies them — leaves dicts/lists readable rather
+ * than blank.
+ */
+function ObservedFieldsSection({ observed }: { observed: ObservedField[] }) {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+  if (observed.length === 0) return null;
+
+  // Show 5 most-recent by default; expand reveals the full list.
+  const sorted = [...observed].sort(
+    (a, b) => new Date(b.fetched_at).getTime() - new Date(a.fetched_at).getTime(),
+  );
+  const VISIBLE = 5;
+  const visible = expanded ? sorted : sorted.slice(0, VISIBLE);
+  const hidden = sorted.length - visible.length;
+
+  return (
+    <div>
+      <p
+        className="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1.5 flex items-center gap-1"
+        title={t(
+          'wissensbasis.focus.observedFieldsTooltip',
+          'Field values pinned at observation time — source for audit replay',
+        )}
+      >
+        <Clock className="h-3 w-3" aria-hidden="true" />
+        {t('wissensbasis.focus.observedFields', 'Observed values')}
+      </p>
+      <ul className="space-y-1">
+        {visible.map((f, idx) => (
+          <ObservedFieldRow key={`${f.source_type}:${f.field_path}:${idx}`} field={f} />
+        ))}
+      </ul>
+      {hidden > 0 && !expanded && (
+        <button
+          type="button"
+          onClick={() => setExpanded(true)}
+          className="mt-1.5 text-xs text-accent-700 dark:text-accent-400 hover:underline"
+        >
+          {t('wissensbasis.focus.observedFieldsMore', '+{{count}} more values', { count: hidden })}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function ObservedFieldRow({ field }: { field: ObservedField }) {
+  const { t, i18n } = useTranslation();
+  const when = formatTimestamp(field.fetched_at, i18n.language);
+  const valueText = stringifyValue(field.value);
+  return (
+    <li className="text-xs">
+      <span className="font-mono text-gray-500 dark:text-gray-400">{field.field_path}</span>
+      <span className="mx-1.5 opacity-50">=</span>
+      <span className="text-gray-900 dark:text-gray-100 break-all">{valueText}</span>
+      <span className="ml-1.5 text-gray-400 dark:text-gray-500 italic">
+        {t('wissensbasis.focus.observedAt', 'as of {{when}}', { when })}
+      </span>
+    </li>
+  );
+}
+
+function stringifyValue(value: unknown): string {
+  if (value === null || value === undefined) return '∅';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function formatTimestamp(iso: string, locale: string): string {
+  // Show as relative when recent (< 24h) — "5m ago", "3h ago" — and
+  // an absolute short-date otherwise. Avoids "2026-05-12T06:24:11.689175"
+  // dominating the row while staying precise enough for audit context.
+  try {
+    const t = new Date(iso).getTime();
+    if (!Number.isFinite(t)) return iso;
+    const deltaMin = (Date.now() - t) / 60000;
+    if (deltaMin < 1) return locale.startsWith('de') ? 'gerade eben' : 'just now';
+    if (deltaMin < 60) {
+      const mins = Math.floor(deltaMin);
+      return locale.startsWith('de') ? `vor ${mins} Min` : `${mins}m ago`;
+    }
+    if (deltaMin < 60 * 24) {
+      const hrs = Math.floor(deltaMin / 60);
+      return locale.startsWith('de') ? `vor ${hrs} Std` : `${hrs}h ago`;
+    }
+    return new Date(iso).toLocaleDateString(locale, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  } catch {
+    return iso;
+  }
 }
 
 interface NeighborSectionProps {

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -1252,7 +1252,14 @@
       "overflowTooltip": "Standalone-Ansicht öffnen, um alle Nachbarn zu durchsuchen",
       "importance": "Wichtigkeit {{pct}}%",
       "importanceTooltip": "Konnektivitäts-Score",
-      "couldNotLoad": "Fokus-Nachbarschaft konnte nicht geladen werden"
+      "couldNotLoad": "Fokus-Nachbarschaft konnte nicht geladen werden",
+      "observedFields": "Beobachtete Werte",
+      "observedFieldsTooltip": "Feldwerte, die zum Beobachtungszeitpunkt festgehalten wurden — Quelle für Audit-Replay",
+      "observedAt": "Stand: {{when}}",
+      "observedFieldsMore": "+{{count}} weitere Werte",
+      "sourcePriority1": "Aus zwischengespeicherten Snapshots",
+      "sourcePriority2": "Aus dem Wissensgraph",
+      "sourcePriority3": "Aus aktueller Session-Spur"
     },
     "chip": {
       "ariaLabel": "Fokus auf {{label}}",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -1252,7 +1252,14 @@
       "overflowTooltip": "Open the standalone view to browse all neighbors",
       "importance": "importance {{pct}}%",
       "importanceTooltip": "Connectivity score",
-      "couldNotLoad": "Could not load focus neighborhood"
+      "couldNotLoad": "Could not load focus neighborhood",
+      "observedFields": "Observed values",
+      "observedFieldsTooltip": "Field values pinned at observation time — source for audit replay",
+      "observedAt": "as of {{when}}",
+      "observedFieldsMore": "+{{count}} more values",
+      "sourcePriority1": "From cached snapshots",
+      "sourcePriority2": "From knowledge graph",
+      "sourcePriority3": "From recent session trace"
     },
     "chip": {
       "ariaLabel": "Focus on {{label}}",

--- a/tests/frontend/react/components/wissensbasis/FocusNeighborhood.test.tsx
+++ b/tests/frontend/react/components/wissensbasis/FocusNeighborhood.test.tsx
@@ -1,9 +1,23 @@
 import { describe, it, expect } from 'vitest';
-import { screen } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/react';
 
 import { FocusNeighborhood } from '../../../../../src/frontend/src/components/wissensbasis/FocusNeighborhood';
 import { WissensbasisProvider } from '../../../../../src/frontend/src/context/WissensbasisContext';
 import { renderWithRouter } from '../../test-utils';
+
+const baseData = {
+  focus: {
+    entity_id: 'r1',
+    display_name: 'REL-100',
+    entity_type: 'release',
+    importance: 0.5,
+  },
+  hop1: [],
+  hop2: [],
+  edges: [],
+  overflow_hop1: 0,
+  overflow_hop2: 0,
+};
 
 describe('FocusNeighborhood', () => {
   it('renders empty placeholder when no data', () => {
@@ -54,5 +68,104 @@ describe('FocusNeighborhood', () => {
       </WissensbasisProvider>,
     );
     expect(screen.getByRole('alert')).toHaveTextContent('Backend down');
+  });
+
+  // Sprint 2 — observed_fields + source_priority rendering.
+
+  it('renders observed values when API includes them', () => {
+    renderWithRouter(
+      <WissensbasisProvider>
+        <FocusNeighborhood
+          data={{
+            ...baseData,
+            source_priority: 1,
+            observed_fields: [
+              {
+                field_path: 'status',
+                value: 'IN_PROGRESS',
+                fetched_at: new Date().toISOString(),
+                source_type: 'release',
+              },
+              {
+                field_path: 'owner',
+                value: 'alice',
+                fetched_at: new Date().toISOString(),
+                source_type: 'release',
+              },
+            ],
+          }}
+        />
+      </WissensbasisProvider>,
+    );
+    expect(screen.getByText('status')).toBeInTheDocument();
+    expect(screen.getByText('IN_PROGRESS')).toBeInTheDocument();
+    expect(screen.getByText('owner')).toBeInTheDocument();
+    expect(screen.getByText('alice')).toBeInTheDocument();
+  });
+
+  it('caps observed values at 5 and reveals more via the expand button', () => {
+    const now = new Date().toISOString();
+    const fields = Array.from({ length: 8 }, (_, i) => ({
+      field_path: `field_${i}`,
+      value: `value_${i}`,
+      fetched_at: now,
+      source_type: 'release',
+    }));
+    renderWithRouter(
+      <WissensbasisProvider>
+        <FocusNeighborhood data={{ ...baseData, observed_fields: fields }} />
+      </WissensbasisProvider>,
+    );
+    // 5 visible by default — fields 0..4 should be rendered.
+    expect(screen.getByText('field_0')).toBeInTheDocument();
+    expect(screen.getByText('field_4')).toBeInTheDocument();
+    // field_5+ are hidden until expand.
+    expect(screen.queryByText('field_5')).not.toBeInTheDocument();
+    // "+3 weitere Werte" button.
+    const more = screen.getByRole('button', { name: /\+3 weitere/ });
+    fireEvent.click(more);
+    expect(screen.getByText('field_5')).toBeInTheDocument();
+    expect(screen.getByText('field_7')).toBeInTheDocument();
+  });
+
+  it('renders source priority label when present', () => {
+    renderWithRouter(
+      <WissensbasisProvider>
+        <FocusNeighborhood data={{ ...baseData, source_priority: 1 }} />
+      </WissensbasisProvider>,
+    );
+    // German default — sourcePriority1 = "Aus zwischengespeicherten Snapshots".
+    expect(screen.getByText(/Aus zwischengespeicherten Snapshots/)).toBeInTheDocument();
+  });
+
+  it('omits observed-values section when array is empty', () => {
+    renderWithRouter(
+      <WissensbasisProvider>
+        <FocusNeighborhood data={{ ...baseData, observed_fields: [] }} />
+      </WissensbasisProvider>,
+    );
+    // The "Beobachtete Werte" heading should not appear when the array is empty.
+    expect(screen.queryByText(/Beobachtete Werte/)).not.toBeInTheDocument();
+  });
+
+  it('stringifies non-scalar observed values without crashing', () => {
+    renderWithRouter(
+      <WissensbasisProvider>
+        <FocusNeighborhood
+          data={{
+            ...baseData,
+            observed_fields: [
+              {
+                field_path: 'status',
+                value: { name: 'To Do', category: 'To Do' }, // nested object (jira shape)
+                fetched_at: new Date().toISOString(),
+                source_type: 'jira',
+              },
+            ],
+          }}
+        />
+      </WissensbasisProvider>,
+    );
+    expect(screen.getByText(/"name":"To Do"/)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Sprint 2 of Wissensbasis Longitudinal shipped a Reva-side backend that serves `wb_field_provenance` snapshots on every `/api/wissensbasis/focus` response — but the panel ignored them. This PR finally renders the audit-replay data the BaFin substrate was built to capture.

A-LANDING (the approved variant from the 2026-05-09 design exploration) lands A4 = the FocusNeighborhood as the entity-driven panel. `observed_fields` belongs in A4 by that spec; this is the implementation.

## What lands

| File | Change |
|------|--------|
| `src/frontend/src/api/resources/wissensbasis.ts` | New `ObservedField` interface; `FocusNeighborhood` gains optional `observed_fields` + `source_priority`. Both default to undefined so older API responses still deserialize. |
| `src/frontend/src/components/wissensbasis/FocusNeighborhood.tsx` | New `ObservedFieldsSection` between focus card and hop1 neighbors. 5 rows visible by default + "+N more" expand. Relative timestamps ("vor 5 Min" / "5m ago") with fall-through to short-date. Nested-object values JSON-stringified safely. |
| Same file, `FocusCard` | Appends source-priority label (italic): "Aus zwischengespeicherten Snapshots" / "Aus dem Wissensgraph" / "Aus aktueller Session-Spur" |
| `src/frontend/src/i18n/locales/{de,en}.json` | 7 new entries under `wissensbasis.focus` |
| `tests/frontend/react/components/wissensbasis/FocusNeighborhood.test.tsx` | 5 new vitest cases |

## Test plan

- [x] `npm test -- FocusNeighborhood` — 8 cases pass (3 existing + 5 new)
- [x] `npm run build` — clean, no new chunks
- [x] `npx tsc --noEmit` — clean
- [ ] On merge: bump Reva's renfield submodule, redeploy, navigate to `chat.reva.aktivities.ai/wissensbasis?focus=<release-id>` — verify a non-empty observed-values section renders with the actual `wb_field_provenance` data already in prod (200+ rows from the substrate validation turns earlier today)

## Designs reference

`~/.gstack/projects/X-idra-Systems-GmbH-reva/designs/wissensgraph-20260509/`
- `approved.json` — A-LANDING approved (A2 60% / A4 40% composed)
- `variant-A4-focus.html` — the A4 mock this implements
- `variant-A3-temporal.html` — the next variant ("what changed"), still unbuilt; will pair with this in a follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)