### PR TITLE
feat(wissensbasis): browse-everything catalog when no deep-link params

### DIFF
--- a/src/frontend/src/api/resources/wissensbasis.ts
+++ b/src/frontend/src/api/resources/wissensbasis.ts
@@ -98,6 +98,30 @@ export interface RoleMix {
   role: string | null;
 }
 
+export interface SessionListItem {
+  session_id: string;
+  preview: string;
+  updated_at: string;
+  message_count: number;
+}
+
+export interface SessionList {
+  items: SessionListItem[];
+  total: number;
+}
+
+export interface EntityListItem {
+  entity_id: string;
+  display_name: string;
+  entity_type: string;
+  mention_count: number;
+}
+
+export interface EntityList {
+  items: EntityListItem[];
+  total: number;
+}
+
 // Query key factories. Keep keys local to this resource — `keys.ts` is
 // shared and would couple the platform to a Reva-only feature flag.
 const wbKeys = {
@@ -106,6 +130,8 @@ const wbKeys = {
   focus: (entityId: string, hops: number, maxPerHop: number | null) =>
     ['wissensbasis', 'focus', entityId, { hops, maxPerHop }] as const,
   mix: (role: string | null) => ['wissensbasis', 'mix', role] as const,
+  sessions: (limit: number) => ['wissensbasis', 'sessions', limit] as const,
+  entities: (limit: number) => ['wissensbasis', 'entities', limit] as const,
 };
 
 async function fetchTrace(sessionId: string): Promise<TracePeek> {
@@ -166,6 +192,55 @@ export function useFocusQuery(
       enabled: enabled && !!entityId,
     },
     'wissensbasis.focus.couldNotLoad',
+  );
+}
+
+async function fetchSessions(limit: number): Promise<SessionList> {
+  const { data } = await apiClient.get<SessionList>('/api/wissensbasis/sessions', {
+    params: { limit },
+  });
+  return data;
+}
+
+async function fetchEntities(limit: number): Promise<EntityList> {
+  const { data } = await apiClient.get<EntityList>('/api/wissensbasis/entities', {
+    params: { limit },
+  });
+  return data;
+}
+
+/**
+ * Recent sessions for the wissensbasis A2 picker.
+ *
+ * Used when the user lands on /wissensbasis without ?session= in the URL —
+ * surfaces all the chats they've had so they can pick one to inspect
+ * instead of staring at an empty card.
+ */
+export function useRecentSessionsQuery(limit = 50, enabled = true) {
+  return useApiQuery(
+    {
+      queryKey: wbKeys.sessions(limit),
+      queryFn: () => fetchSessions(limit),
+      staleTime: STALE.LIVE, // session list churns whenever a chat happens
+      enabled,
+    },
+    'wissensbasis.sessions.couldNotLoad',
+  );
+}
+
+/**
+ * Top entities for the wissensbasis A4 picker. Mention-count ordered,
+ * mirrors what the user is most likely to want to focus on.
+ */
+export function useRecentEntitiesQuery(limit = 60, enabled = true) {
+  return useApiQuery(
+    {
+      queryKey: wbKeys.entities(limit),
+      queryFn: () => fetchEntities(limit),
+      staleTime: STALE.DEFAULT,
+      enabled,
+    },
+    'wissensbasis.entities.couldNotLoad',
   );
 }
 

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -1223,8 +1223,21 @@
       "description": "Zusammengesetzte Ansicht aktueller Argumentation und der Nachbarschaft fokussierter Entitäten.",
       "reasoningSection": "Argumentations-Subgraph",
       "reasoningHeading": "Aktuelle Argumentation",
+      "recentSessionsHeading": "Letzte Unterhaltungen",
       "focusSection": "Fokus-Nachbarschaft",
-      "focusHeading": "Entitäts-Nachbarschaft"
+      "focusHeading": "Entitäts-Nachbarschaft",
+      "recentEntitiesHeading": "Entitäten durchstöbern"
+    },
+    "sessions": {
+      "empty": "Noch keine Unterhaltungen. Starte eine, um die Wissensbasis zu füllen.",
+      "noPreview": "(keine Vorschau)",
+      "meta": "{{count}} Nachr · {{when}}",
+      "couldNotLoad": "Letzte Unterhaltungen konnten nicht geladen werden"
+    },
+    "entities": {
+      "empty": "Noch keine Entitäten. Sprich mit Reva, dann erscheinen sie hier.",
+      "mentionCount": "{{count}} Erwähnungen",
+      "couldNotLoad": "Entitäten konnten nicht geladen werden"
     },
     "panel": {
       "ariaLabel": "Wissensbasis-Komposition",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -1223,8 +1223,21 @@
       "description": "Composed view of recent reasoning and focused entity neighborhood.",
       "reasoningSection": "Reasoning subgraph",
       "reasoningHeading": "Recent reasoning",
+      "recentSessionsHeading": "Recent conversations",
       "focusSection": "Focus neighborhood",
-      "focusHeading": "Entity neighborhood"
+      "focusHeading": "Entity neighborhood",
+      "recentEntitiesHeading": "Browse entities"
+    },
+    "sessions": {
+      "empty": "No conversations yet. Start one to populate the knowledge base.",
+      "noPreview": "(no preview)",
+      "meta": "{{count}} msg · {{when}}",
+      "couldNotLoad": "Could not load recent conversations"
+    },
+    "entities": {
+      "empty": "No entities yet. Talk to Reva and they will appear here.",
+      "mentionCount": "{{count}} mentions",
+      "couldNotLoad": "Could not load entities"
     },
     "panel": {
       "ariaLabel": "Wissensbasis composed view",

--- a/src/frontend/src/pages/WissensbasisPage.tsx
+++ b/src/frontend/src/pages/WissensbasisPage.tsx
@@ -1,25 +1,22 @@
 /**
  * WissensbasisPage — standalone /wissensbasis route.
  *
- * Reuses the same A2 + A4 components as the chat-page side panel.
- * Vertical stack on mobile, side-by-side on desktop. URL-encoded
- * `?focus=<atom_id>` deep-link is read by WissensbasisProvider.
- *
- * Use case: power-user browse mode — open the page, paste an entity
- * link from elsewhere, get the full focus neighborhood without going
- * through the chat.
- *
- * No search input in v1; v2 may add one. Today the page expects to be
- * navigated to with a `?focus=` param (from CitationChip overflow links,
- * shared URLs, or bookmarks).
+ * Composed A2 + A4 panel (the approved A-LANDING design). When the
+ * page is reached with no URL params, the cards become browse-everything
+ * pickers — recent sessions on the A2 side, top entities on the A4
+ * side — so the user lands on actual content instead of placeholders.
+ * URL deep-links (`?focus=`, `?session=`) take precedence and fill
+ * the respective card directly.
  */
 
 import { useTranslation } from 'react-i18next';
-import { useSearchParams } from 'react-router';
-import { Layers } from 'lucide-react';
+import { Link, useSearchParams } from 'react-router';
+import { Layers, MessageSquare, MessageSquareText, Sparkles } from 'lucide-react';
 
 import {
   useFocusQuery,
+  useRecentEntitiesQuery,
+  useRecentSessionsQuery,
   useTraceQuery,
 } from '../api/resources/wissensbasis';
 import { WissensbasisProvider, useWissensbasis } from '../context/WissensbasisContext';
@@ -41,13 +38,15 @@ function WissensbasisPageInner() {
   const { t } = useTranslation();
   const { focusEntityId } = useWissensbasis();
   const [searchParams] = useSearchParams();
-  // Optional `?session=` param to preview an existing trace alongside
-  // the focus neighborhood. Without it the A2 panel renders the empty
-  // state — that's fine for the deep-browse use case.
   const sessionId = searchParams.get('session');
 
   const traceQ = useTraceQuery(sessionId);
   const focusQ = useFocusQuery(focusEntityId);
+
+  // Catalog queries fire only when the corresponding deep-link is
+  // absent — keeps the request load minimal for the chip-driven flow.
+  const sessionsQ = useRecentSessionsQuery(50, !sessionId);
+  const entitiesQ = useRecentEntitiesQuery(60, !focusEntityId);
 
   return (
     <div className="space-y-4">
@@ -66,12 +65,21 @@ function WissensbasisPageInner() {
           aria-label={t('wissensbasis.page.reasoningSection', 'Reasoning subgraph')}
         >
           <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">
-            {t('wissensbasis.page.reasoningHeading', 'Recent reasoning')}
+            {sessionId
+              ? t('wissensbasis.page.reasoningHeading', 'Recent reasoning')
+              : t('wissensbasis.page.recentSessionsHeading', 'Recent conversations')}
           </h2>
-          <ReasoningSubgraph
-            trace={traceQ.data?.trace ?? { entities: [], edges: [] }}
-            isLoading={traceQ.isLoading}
-          />
+          {sessionId ? (
+            <ReasoningSubgraph
+              trace={traceQ.data?.trace ?? { entities: [], edges: [] }}
+              isLoading={traceQ.isLoading}
+            />
+          ) : (
+            <SessionsCatalog
+              items={sessionsQ.data?.items ?? []}
+              isLoading={sessionsQ.isLoading}
+            />
+          )}
         </section>
 
         <section
@@ -79,15 +87,173 @@ function WissensbasisPageInner() {
           aria-label={t('wissensbasis.page.focusSection', 'Focus neighborhood')}
         >
           <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">
-            {t('wissensbasis.page.focusHeading', 'Entity neighborhood')}
+            {focusEntityId
+              ? t('wissensbasis.page.focusHeading', 'Entity neighborhood')
+              : t('wissensbasis.page.recentEntitiesHeading', 'Browse entities')}
           </h2>
-          <FocusNeighborhood
-            data={focusQ.data ?? null}
-            isLoading={focusQ.isLoading}
-            errorMessage={focusQ.errorMessage}
-          />
+          {focusEntityId ? (
+            <FocusNeighborhood
+              data={focusQ.data ?? null}
+              isLoading={focusQ.isLoading}
+              errorMessage={focusQ.errorMessage}
+            />
+          ) : (
+            <EntitiesCatalog
+              items={entitiesQ.data?.items ?? []}
+              isLoading={entitiesQ.isLoading}
+            />
+          )}
         </section>
       </div>
     </div>
   );
+}
+
+/**
+ * Browse-everything: recent sessions list.
+ *
+ * Shows the user's chats newest-first with the opening question as
+ * preview text. Clicking navigates to /wissensbasis?session=<id>,
+ * which fills the A2 panel with that conversation's reasoning trace.
+ */
+function SessionsCatalog({
+  items,
+  isLoading,
+}: {
+  items: Array<{
+    session_id: string;
+    preview: string;
+    updated_at: string;
+    message_count: number;
+  }>;
+  isLoading: boolean;
+}) {
+  const { t } = useTranslation();
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2 px-1 py-2">
+        {[...Array(5)].map((_, i) => (
+          <div key={i} className="h-10 rounded bg-gray-100 dark:bg-gray-800 animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="text-xs text-gray-500 dark:text-gray-400 italic px-3 py-6 text-center">
+        <MessageSquare className="h-4 w-4 inline-block mr-1" aria-hidden="true" />
+        {t(
+          'wissensbasis.sessions.empty',
+          'No conversations yet. Start one to populate the knowledge base.',
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <ul className="space-y-1 max-h-[60vh] overflow-y-auto pr-1">
+      {items.map((s) => (
+        <li key={s.session_id}>
+          <Link
+            to={`/wissensbasis?session=${encodeURIComponent(s.session_id)}`}
+            className="block rounded-md px-2.5 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+          >
+            <p className="text-xs text-gray-800 dark:text-gray-100 truncate">
+              {s.preview || (
+                <span className="italic text-gray-400 dark:text-gray-500">
+                  {t('wissensbasis.sessions.noPreview', '(no preview)')}
+                </span>
+              )}
+            </p>
+            <p className="text-[10px] text-gray-500 dark:text-gray-400 mt-0.5">
+              {t('wissensbasis.sessions.meta', '{{count}} msg · {{when}}', {
+                count: s.message_count,
+                when: formatRelativeOrDate(s.updated_at),
+              })}
+            </p>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * Browse-everything: top entities list.
+ *
+ * Mention-count ordered, clickable. Clicking sets ?focus= which the
+ * existing FocusNeighborhood path picks up.
+ */
+function EntitiesCatalog({
+  items,
+  isLoading,
+}: {
+  items: Array<{
+    entity_id: string;
+    display_name: string;
+    entity_type: string;
+    mention_count: number;
+  }>;
+  isLoading: boolean;
+}) {
+  const { t } = useTranslation();
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-wrap gap-1.5 px-1 py-2">
+        {[...Array(8)].map((_, i) => (
+          <div key={i} className="h-6 w-20 rounded bg-gray-100 dark:bg-gray-800 animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="text-xs text-gray-500 dark:text-gray-400 italic px-3 py-6 text-center">
+        <Sparkles className="h-4 w-4 inline-block mr-1" aria-hidden="true" />
+        {t(
+          'wissensbasis.entities.empty',
+          'No entities yet. Talk to Reva and they will appear here.',
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-h-[60vh] overflow-y-auto pr-1">
+      <div className="flex flex-wrap gap-1.5">
+        {items.map((e) => (
+          <Link
+            key={e.entity_id}
+            to={`/wissensbasis?focus=${encodeURIComponent(e.entity_id)}`}
+            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs
+              bg-gray-100 dark:bg-gray-800/60 text-gray-800 dark:text-gray-100
+              hover:bg-accent-100 dark:hover:bg-accent-900/30 transition-colors"
+            title={t('wissensbasis.entities.mentionCount', '{{count}} mentions', {
+              count: e.mention_count,
+            })}
+          >
+            <MessageSquareText className="h-3 w-3 opacity-50" aria-hidden="true" />
+            <span className="truncate max-w-[14ch]">{e.display_name}</span>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function formatRelativeOrDate(iso: string): string {
+  try {
+    const t = new Date(iso).getTime();
+    if (!Number.isFinite(t)) return '';
+    const deltaMin = (Date.now() - t) / 60000;
+    if (deltaMin < 60) return `${Math.max(1, Math.floor(deltaMin))}m`;
+    if (deltaMin < 60 * 24) return `${Math.floor(deltaMin / 60)}h`;
+    return new Date(iso).toLocaleDateString();
+  } catch {
+    return '';
+  }
 }


### PR DESCRIPTION
User reported the page showed empty placeholders on naked /wissensbasis navigation. They want to see all saved content, not just default to the last session. This PR makes the A2 card a session picker + A4 card an entity picker when no ?session= / ?focus= is present. Click an item → existing URL-driven flow fills the card.

Pairs with Reva's new /api/wissensbasis/{sessions,entities} endpoints (separate commit on the Reva main branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)