### PR TITLE
feat(wissensbasis): A4 search-driven direct-entry for /wissensbasis

### DIFF
--- a/src/frontend/src/api/resources/wissensbasis.ts
+++ b/src/frontend/src/api/resources/wissensbasis.ts
@@ -98,6 +98,18 @@ export interface RoleMix {
   role: string | null;
 }
 
+export interface SearchHit {
+  entity_id: string;
+  display_name: string;
+  entity_type: string;
+  mention_count: number;
+}
+
+export interface SearchResults {
+  items: SearchHit[];
+  total: number;
+}
+
 // Query key factories. Keep keys local to this resource — `keys.ts` is
 // shared and would couple the platform to a Reva-only feature flag.
 const wbKeys = {
@@ -106,6 +118,7 @@ const wbKeys = {
   focus: (entityId: string, hops: number, maxPerHop: number | null) =>
     ['wissensbasis', 'focus', entityId, { hops, maxPerHop }] as const,
   mix: (role: string | null) => ['wissensbasis', 'mix', role] as const,
+  search: (q: string) => ['wissensbasis', 'search', q] as const,
 };
 
 async function fetchTrace(sessionId: string): Promise<TracePeek> {
@@ -166,6 +179,36 @@ export function useFocusQuery(
       enabled: enabled && !!entityId,
     },
     'wissensbasis.focus.couldNotLoad',
+  );
+}
+
+async function fetchSearch(q: string): Promise<SearchResults> {
+  const { data } = await apiClient.get<SearchResults>('/api/wissensbasis/search', {
+    params: { q },
+  });
+  return data;
+}
+
+/**
+ * A4 direct-entry search. Live suggestions over KGEntity.name.
+ *
+ * Use case: user lands on /wissensbasis with a specific entity in
+ * mind. Empty query short-circuits to no results — the direct-entry
+ * premise is "I know what I'm looking for," not "show me everything."
+ *
+ * STALE.LIVE keeps the suggestion list fresh during typing without
+ * spamming the backend across debounce ticks.
+ */
+export function useSearchQuery(q: string, enabled = true) {
+  const trimmed = q.trim();
+  return useApiQuery(
+    {
+      queryKey: wbKeys.search(trimmed),
+      queryFn: () => fetchSearch(trimmed),
+      staleTime: STALE.LIVE,
+      enabled: enabled && trimmed.length > 0,
+    },
+    'wissensbasis.search.couldNotLoad',
   );
 }
 

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -1244,6 +1244,14 @@
       "altListToggle": "Als Liste anzeigen ({{count}} Entitäten)",
       "canvasLabel": "Visualisierung des Argumentationsgraphen"
     },
+    "search": {
+      "label": "Entität nach Name suchen — Releases, Tickets, Personen, Dokumente",
+      "placeholder": "z. B. PRODUCT-A 1.3.5 oder REVA-100",
+      "hint": "Direkteinstieg. Tippe den Namen dessen, was du fokussieren möchtest.",
+      "noResults": "Nichts gefunden zu \"{{q}}\". Anderen Namen versuchen oder eine ID einfügen.",
+      "mentions": "{{count}} Erwähnungen",
+      "couldNotLoad": "Suche fehlgeschlagen"
+    },
     "focus": {
       "empty": "Klicke auf einen Zitations-Chip in der Antwort, um eine Entität zu fokussieren.",
       "directNeighbors": "Direkte Nachbarn",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -1244,6 +1244,14 @@
       "altListToggle": "Show as list ({{count}} entities)",
       "canvasLabel": "Reasoning graph visualization"
     },
+    "search": {
+      "label": "Search an entity by name — releases, tickets, people, documents",
+      "placeholder": "e.g. PRODUCT-A 1.3.5 or REVA-100",
+      "hint": "Direct entry. Start typing the name of the thing you want to focus on.",
+      "noResults": "Nothing found for \"{{q}}\". Try a different name or paste an ID.",
+      "mentions": "{{count}} mentions",
+      "couldNotLoad": "Search failed"
+    },
     "focus": {
       "empty": "Click a citation chip in the answer to focus an entity here.",
       "directNeighbors": "Direct neighbors",

--- a/src/frontend/src/pages/WissensbasisPage.tsx
+++ b/src/frontend/src/pages/WissensbasisPage.tsx
@@ -1,26 +1,32 @@
 /**
  * WissensbasisPage — standalone /wissensbasis route.
  *
- * Reuses the same A2 + A4 components as the chat-page side panel.
- * Vertical stack on mobile, side-by-side on desktop. URL-encoded
- * `?focus=<atom_id>` deep-link is read by WissensbasisProvider.
+ * Composed A2 + A4 panel (the approved A-LANDING design). Use case
+ * per the user: "When I use the wissensbasis directly, I know exactly
+ * what I'm looking for as entry point." Chat is the open-ended query
+ * surface; this page is the direct-entry surface.
  *
- * Use case: power-user browse mode — open the page, paste an entity
- * link from elsewhere, get the full focus neighborhood without going
- * through the chat.
- *
- * No search input in v1; v2 may add one. Today the page expects to be
- * navigated to with a `?focus=` param (from CitationChip overflow links,
- * shared URLs, or bookmarks).
+ * Therefore:
+ *   - When ?focus= is set (e.g. from a citation chip click), the A4
+ *     card fills with that entity's focus neighborhood.
+ *   - When ?focus= is NOT set, A4 renders a search input with live
+ *     suggestions (the A4 mock's "search-driven" pattern). Pick a
+ *     suggestion → ?focus=<id> → focus card.
+ *   - The A2 card fills only when ?session= is supplied (chat-driven
+ *     flow). On direct entry without a session, A2 shows its empty
+ *     placeholder by design.
  */
 
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSearchParams } from 'react-router';
-import { Layers } from 'lucide-react';
+import { useNavigate, useSearchParams } from 'react-router';
+import { Layers, Search } from 'lucide-react';
 
 import {
   useFocusQuery,
+  useSearchQuery,
   useTraceQuery,
+  type SearchHit,
 } from '../api/resources/wissensbasis';
 import { WissensbasisProvider, useWissensbasis } from '../context/WissensbasisContext';
 import { FocusNeighborhood } from '../components/wissensbasis/FocusNeighborhood';
@@ -29,8 +35,6 @@ import PageHeader from '../components/PageHeader';
 
 export default function WissensbasisPage() {
   return (
-    // syncWithUrl=true lets the page hydrate from `?focus=` and write
-    // it back when the user clicks chips inside the page.
     <WissensbasisProvider syncWithUrl>
       <WissensbasisPageInner />
     </WissensbasisProvider>
@@ -41,9 +45,6 @@ function WissensbasisPageInner() {
   const { t } = useTranslation();
   const { focusEntityId } = useWissensbasis();
   const [searchParams] = useSearchParams();
-  // Optional `?session=` param to preview an existing trace alongside
-  // the focus neighborhood. Without it the A2 panel renders the empty
-  // state — that's fine for the deep-browse use case.
   const sessionId = searchParams.get('session');
 
   const traceQ = useTraceQuery(sessionId);
@@ -81,13 +82,187 @@ function WissensbasisPageInner() {
           <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">
             {t('wissensbasis.page.focusHeading', 'Entity neighborhood')}
           </h2>
-          <FocusNeighborhood
-            data={focusQ.data ?? null}
-            isLoading={focusQ.isLoading}
-            errorMessage={focusQ.errorMessage}
-          />
+          {focusEntityId ? (
+            <FocusNeighborhood
+              data={focusQ.data ?? null}
+              isLoading={focusQ.isLoading}
+              errorMessage={focusQ.errorMessage}
+            />
+          ) : (
+            <DirectEntrySearch />
+          )}
         </section>
       </div>
+    </div>
+  );
+}
+
+/**
+ * A4 direct-entry search input + live suggestions.
+ *
+ * Renders when the page is reached without a ?focus= deep-link. The
+ * premise (per the design): the user types the entity name they have
+ * in mind, picks a suggestion, the focus card fills. Different code
+ * path from chip-click navigation, same destination.
+ *
+ * Debounce: 180ms — fast enough to feel live, slow enough to avoid
+ * one request per keystroke. The hook itself is gated on q.length>0
+ * so empty input does no network work.
+ */
+function DirectEntrySearch() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [rawQ, setRawQ] = useState('');
+  const [debouncedQ, setDebouncedQ] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedQ(rawQ), 180);
+    return () => clearTimeout(id);
+  }, [rawQ]);
+
+  const searchQ = useSearchQuery(debouncedQ);
+  const hits: SearchHit[] = searchQ.data?.items ?? [];
+
+  useEffect(() => {
+    // Reset highlight whenever the result set changes so the visible
+    // top item is always selectable via Enter.
+    setActiveIndex(0);
+  }, [hits.length]);
+
+  function pick(hit: SearchHit) {
+    navigate(`/wissensbasis?focus=${encodeURIComponent(hit.entity_id)}`);
+  }
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'ArrowDown' && hits.length > 0) {
+      e.preventDefault();
+      setActiveIndex((i) => Math.min(i + 1, hits.length - 1));
+    } else if (e.key === 'ArrowUp' && hits.length > 0) {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter' && hits.length > 0) {
+      e.preventDefault();
+      pick(hits[activeIndex]);
+    } else if (e.key === 'Escape') {
+      setRawQ('');
+    }
+  }
+
+  return (
+    <div className="px-1 py-2">
+      <label
+        htmlFor="wb-search"
+        className="block text-xs text-gray-500 dark:text-gray-400 mb-1.5"
+      >
+        {t(
+          'wissensbasis.search.label',
+          'Search an entity by name — releases, tickets, people, documents',
+        )}
+      </label>
+      <div className="relative">
+        <Search
+          className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400"
+          aria-hidden="true"
+        />
+        <input
+          ref={inputRef}
+          id="wb-search"
+          type="text"
+          value={rawQ}
+          onChange={(e) => setRawQ(e.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder={t(
+            'wissensbasis.search.placeholder',
+            'e.g. PRODUCT-A 1.3.5 or REVA-100',
+          )}
+          className="input w-full pl-9 pr-3 py-2 text-sm"
+          autoComplete="off"
+          spellCheck={false}
+          aria-controls="wb-search-suggestions"
+          aria-expanded={hits.length > 0}
+          aria-activedescendant={
+            hits.length > 0 ? `wb-search-hit-${activeIndex}` : undefined
+          }
+        />
+      </div>
+
+      {searchQ.isLoading && debouncedQ ? (
+        <div className="mt-2 space-y-1">
+          {[...Array(3)].map((_, i) => (
+            <div
+              key={i}
+              className="h-8 rounded bg-gray-100 dark:bg-gray-800 animate-pulse"
+            />
+          ))}
+        </div>
+      ) : null}
+
+      {debouncedQ && !searchQ.isLoading && hits.length === 0 ? (
+        <p className="mt-3 text-xs text-gray-500 dark:text-gray-400 italic px-1">
+          {t(
+            'wissensbasis.search.noResults',
+            'Nothing found for "{{q}}". Try a different name or paste an ID.',
+            { q: debouncedQ },
+          )}
+        </p>
+      ) : null}
+
+      {hits.length > 0 ? (
+        <ul
+          id="wb-search-suggestions"
+          role="listbox"
+          className="mt-2 space-y-0.5 max-h-[50vh] overflow-y-auto"
+        >
+          {hits.map((hit, i) => (
+            <li
+              key={hit.entity_id}
+              id={`wb-search-hit-${i}`}
+              role="option"
+              aria-selected={i === activeIndex}
+            >
+              <button
+                type="button"
+                onClick={() => pick(hit)}
+                onMouseEnter={() => setActiveIndex(i)}
+                className={`w-full text-left rounded-md px-2.5 py-1.5 transition-colors
+                  ${i === activeIndex
+                    ? 'bg-accent-100 dark:bg-accent-900/30'
+                    : 'hover:bg-gray-100 dark:hover:bg-gray-800/60'}`}
+              >
+                <p className="text-xs text-gray-800 dark:text-gray-100 truncate">
+                  {hit.display_name}
+                </p>
+                <p className="text-[10px] text-gray-500 dark:text-gray-400 mt-0.5">
+                  {hit.entity_type}
+                  {hit.mention_count > 0 && (
+                    <>
+                      <span className="mx-1 opacity-50">·</span>
+                      {t('wissensbasis.search.mentions', '{{count}} mentions', {
+                        count: hit.mention_count,
+                      })}
+                    </>
+                  )}
+                </p>
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {!debouncedQ ? (
+        <p className="mt-4 text-xs text-gray-500 dark:text-gray-400 italic px-1">
+          {t(
+            'wissensbasis.search.hint',
+            'Direct entry. Start typing the name of the thing you want to focus on.',
+          )}
+        </p>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
Per the A-LANDING design + user's stated framing: Chat is the open-ended query surface, /wissensbasis is the direct-entry surface ('I know what I'm looking for'). The A4 mock shows a large search input with live suggestions — implementing that.

Empty state (no ?focus=) now renders DirectEntrySearch: autofocused input, 180ms debounce, live suggestions, keyboard nav, aria-listbox. Click or Enter → ?focus=<id> → existing focus path.

Replaces PR #563's catalog mode (reverted in #564) with the design-aligned pattern.

Backend pair: /api/wissensbasis/search?q= on the Reva main branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)