### PR TITLE
feat(ws): forward replace_text through orchestrator + sub-intent paths

### DIFF
--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -1049,6 +1049,7 @@ async def websocket_endpoint(
                             sub_intent_handled = True
                             full_response = si_result.get("answer", "") or ""
                             card = si_result.get("card")
+                            replace_text = si_result.get("replace_text")
                             intent = {
                                 "intent": f"sub_intent.{role.sub_intent}",
                                 "confidence": 1.0,
@@ -1070,10 +1071,14 @@ async def websocket_endpoint(
                                     "content": full_response,
                                 })
                             if card:
-                                await websocket.send_json({
-                                    "type": "card",
-                                    "card": card,
-                                })
+                                card_msg: dict = {"type": "card", "card": card}
+                                if replace_text:
+                                    # Frontend overwrites the streamed
+                                    # bubble's content with this lede so
+                                    # the prose doesn't duplicate the
+                                    # card's contents.
+                                    card_msg["replace_text"] = replace_text
+                                await websocket.send_json(card_msg)
                             logger.info(
                                 f"Sub-intent '{role.name}/{role.sub_intent}' "
                                 f"handled by plugin (answer_chars={len(full_response)}, "
@@ -1173,6 +1178,7 @@ async def websocket_endpoint(
                         # Tool steps still stream live for in-progress UX.
                         deferred_final_answer: str | None = None
                         deferred_card: dict | None = None
+                        deferred_replace_text: str | None = None
 
                         async def _typing_callback() -> None:
                             await websocket.send_json({"type": "typing"})
@@ -1201,6 +1207,10 @@ async def websocket_endpoint(
                                 # is on the wire — frontend attaches the
                                 # card to the latest assistant message.
                                 deferred_card = (step.data or {}).get("card")
+                                # post_orchestration may also supply a
+                                # 1-line lede via ``replace_text`` to
+                                # collapse the streamed synthesis bubble.
+                                deferred_replace_text = (step.data or {}).get("replace_text")
                             else:
                                 await websocket.send_json(step_to_ws_message(step))
                             if step.step_type == "tool_result" and step.success and step.data:
@@ -1273,10 +1283,10 @@ async def websocket_endpoint(
                             })
 
                         if deferred_card:
-                            await websocket.send_json({
-                                "type": "card",
-                                "card": deferred_card,
-                            })
+                            card_msg: dict = {"type": "card", "card": deferred_card}
+                            if deferred_replace_text:
+                                card_msg["replace_text"] = deferred_replace_text
+                            await websocket.send_json(card_msg)
 
                         if agent_tool_results:
                             action_result = _build_agent_action_result(agent_tool_results)

--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -1958,11 +1958,15 @@ def step_to_ws_message(step: AgentStep) -> dict:
     elif step.step_type == "card":
         # Adaptive Card payload from a post_orchestration hook handler.
         # Frontend renders via AdaptiveCardRenderer attached to the latest
-        # assistant message.
-        return {
-            "type": "card",
-            "card": (step.data or {}).get("card"),
-        }
+        # assistant message. When the hook also returned a 1-line lede
+        # via ``replace_text``, the frontend overwrites the assistant
+        # bubble's prose so the card isn't doubled by the streamed
+        # synthesis.
+        data = step.data or {}
+        msg: dict = {"type": "card", "card": data.get("card")}
+        if data.get("replace_text"):
+            msg["replace_text"] = data["replace_text"]
+        return msg
     else:
         return {
             "type": "agent_thinking",

--- a/src/backend/services/orchestrator.py
+++ b/src/backend/services/orchestrator.py
@@ -328,11 +328,19 @@ class QueryOrchestrator:
         )
         for hr in hook_results:
             if isinstance(hr, dict) and hr.get("card"):
+                # Pass through replace_text alongside the card so the
+                # frontend can collapse the streamed synthesis bubble
+                # into a 1-line caption above the card. Empty / missing
+                # replace_text = preserve previous behaviour (keep the
+                # streamed prose).
+                step_data: dict = {"card": hr["card"]}
+                if hr.get("replace_text"):
+                    step_data["replace_text"] = hr["replace_text"]
                 yield AgentStep(
                     step_number=100,
                     step_type="card",
                     content="",
-                    data={"card": hr["card"]},
+                    data=step_data,
                 )
                 break
 


### PR DESCRIPTION
## Summary

Plumbs the new `replace_text` field (introduced in #567) end-to-end through the orchestrator + sub-intent dispatch paths. Until now only the `post_message` hook path emitted it; orchestrator/sub-intent paths sent cards directly without the lede, so users still saw the streamed synthesis prose AND the card.

- `orchestrator.py` — pass `replace_text` from the `post_orchestration` hook return into `AgentStep.data`.
- `agent_service.py::step_to_ws_message` — include `replace_text` in the WS message for `step_type='card'`.
- `chat_handler.py` (sub-intent) — read `replace_text` from the `dispatch_sub_intent` hook result and forward.
- `chat_handler.py` (orchestrator) — also defer `replace_text` alongside the card.

Backwards compatible: hook results that don't return `replace_text` keep the old behaviour.

## Test plan

- [x] Reva-side unit tests (75/75) — `tests/test_teams_cards.py` + `tests/test_wissensbasis_graph.py`.
- [ ] Live verification with an orchestrator query and a `my_dashboard` sub-intent query in `chat.reva.aktivities.ai` after the corresponding Reva change ([X-idra-Systems-GmbH/reva@<follow-up>]) lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)