### PR TITLE
feat(k8s): Ollama tier on k8s-gpu-1 for shared small models; idle Q4 backup

### DIFF
--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - redis.yaml
   - llama-server.yaml
   - llama-server-embed.yaml
+  - ollama.yaml
   - searxng.yaml
   - dlna-mcp.yaml
   - mdns-responder.yaml

--- a/k8s/llama-server.yaml
+++ b/k8s/llama-server.yaml
@@ -24,7 +24,13 @@ metadata:
     app.kubernetes.io/name: llama-server-agent
     app.kubernetes.io/part-of: renfield
 spec:
-  replicas: 1
+  # Idle in steady state — primary chat/agent moved to cuda.local (RTX 5090)
+  # for both Reva and Renfield (see reva/docs/architecture/gpu-allocation.md).
+  # This Q4 deployment stays as a fast failover: `kubectl scale deploy/llama-server-agent
+  # -n renfield --replicas=1` boots the model in ~30-45s. While idle, the
+  # 5070 Ti + 5060 Ti on k8s-gpu-1 are free for the Ollama small-models tier
+  # (one GPU claimed by Ollama; the other available for failover or future workloads).
+  replicas: 0
   strategy:
     type: Recreate
   selector:

--- a/k8s/ollama.yaml
+++ b/k8s/ollama.yaml
@@ -23,19 +23,23 @@ metadata:
     app.kubernetes.io/name: ollama
     app.kubernetes.io/part-of: renfield
 spec:
-  # ROLLBACK MANIFEST — NOT in kustomization.yaml.
+  # Shared small-models tier for Reva + Renfield (2026-05-13).
   #
-  # The text-LLM tier moved to the two `llama-server-*` pods. This Ollama
-  # deployment is kept as a fast rollback path: if the llama-server route
-  # ever needs to be reverted, `kubectl apply -f k8s/ollama.yaml` brings
-  # it back. Apply ONLY when also reverting the LLM_OPENAI_* settings in
-  # `configmap.yaml` so the backend doesn't end up with a half-migrated
-  # routing table (chat to llama-server, embed to Ollama, or vice versa).
+  # Hosts four small models that don't justify llama-server's per-model
+  # process overhead but benefit from GPU inference:
+  #   - llama3.2:3b           ~2 GB  — Reva router, Renfield intent fallback
+  #   - qwen3:8b              ~5 GB  — Renfield intent
+  #   - qwen3-embedding:4b    ~3 GB  — Renfield embeddings (shared with
+  #                                    legacy llama-server-embed until that's
+  #                                    retired; see follow-up note)
+  #   - nomic-embed-text     ~0.5 GB — Reva embeddings
+  # Total resident: ~10 GB.
   #
-  # Targets k8s-gpu-2 explicitly because k8s-gpu-1 is now reserved for
-  # llama-server-agent's `nvidia.com/gpu: 2` claim. CPU-only runtime
-  # depends on k8s-gpu-2's containerd `default_runtime_name = runc`
-  # (see private_k8s/README.md).
+  # Pinned to k8s-gpu-1 (5070 Ti + 5060 Ti, 32 GB combined). Claims one
+  # GPU; the other stays free for the idle llama-server-agent Q4 model
+  # (replicas=0 in steady state) when failover is needed.
+  #
+  # See reva/docs/architecture/gpu-allocation.md for the cluster layout.
   replicas: 1
   strategy:
     type: Recreate
@@ -49,7 +53,11 @@ spec:
         app.kubernetes.io/part-of: renfield
     spec:
       nodeSelector:
-        kubernetes.io/hostname: k8s-gpu-2
+        kubernetes.io/hostname: k8s-gpu-1
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
       containers:
         - name: ollama
           image: ollama/ollama:latest
@@ -82,9 +90,11 @@ spec:
             requests:
               cpu: "2"
               memory: 4Gi
+              nvidia.com/gpu: 1
             limits:
               cpu: "6"
               memory: 16Gi
+              nvidia.com/gpu: 1
       volumes:
         - name: models
           hostPath:
@@ -124,11 +134,9 @@ spec:
           args:
             - |
               set -euo pipefail
-              # Rollback prepull: only models the llama-server path doesn't
-              # provide today. Embeddings live on llama-server-embed in the
-              # current architecture, so prepulling qwen3-embedding here is
-              # only needed when you actually flip the rollback switch.
-              for m in qwen3-embedding:4b qwen3-vl:8b; do
+              # Pre-pull the four small models hosted on this Ollama:
+              # router (Reva), intent (Renfield), embeddings for both.
+              for m in llama3.2:3b qwen3:8b qwen3-embedding:4b nomic-embed-text; do
                 echo "Pulling $m ..."
                 code=$(curl -sS -o /tmp/out -w '%{http_code}' -X POST http://ollama:11434/api/pull \
                   -H 'Content-Type: application/json' \


### PR DESCRIPTION
## Summary

Implements the GPU allocation plan in [reva/docs/architecture/gpu-allocation.md](../reva/blob/main/docs/architecture/gpu-allocation.md).

- Activates the previously rollback-only \`k8s/ollama.yaml\` and pins it to **k8s-gpu-1** with one \`nvidia.com/gpu: 1\` claim. Hosts four small models (~10 GB total):
  - \`llama3.2:3b\` — Reva router, Renfield intent fallback
  - \`qwen3:8b\` — Renfield intent
  - \`qwen3-embedding:4b\` — Renfield embeddings (eventual replacement for \`llama-server-embed\`)
  - \`nomic-embed-text\` — Reva embeddings
- **Idles \`llama-server-agent\`** (\`replicas: 0\`). Primary chat/agent for both apps moves to cuda.local (RTX 5090, full-quality Qwen3.6-35B-A3B). Manifest stays so failover is one \`kubectl scale\` away.
- Pre-pull job updated to grab the new four-model set.

The 5070 Ti (16 GB) hosts the Ollama tier; the 5060 Ti (16 GB) stays free for failover or future workloads.

## Co-rolling with

- ebongard/renfield#569 — external Ingress (merged)
- X-idra-Systems-GmbH/reva@\<pending\> — alias rename \`qwen3.5:27b\` → \`qwen3.6\` + URL flips

## Test plan

- [ ] After merge + apply: \`kubectl -n renfield get pods -l app.kubernetes.io/name=ollama\` shows 1/1 Running on k8s-gpu-1
- [ ] \`kubectl -n renfield get pods -l app.kubernetes.io/name=llama-server-agent\` shows 0 pods (scaled to 0)
- [ ] Pre-pull Job completes; \`kubectl -n renfield exec deploy/ollama -- ollama list\` shows the four models
- [ ] From a Reva pod: \`curl -H 'Host: ollama.test.local' http://192.168.1.230/api/tags\` returns the four models
- [ ] Reva router (llama3.2:3b) classification still works after the URL flip

🤖 Generated with [Claude Code](https://claude.com/claude-code)