### PR TITLE
feat(k8s): point LLM_OPENAI_BASE_URL at cuda.local (RTX 5090)

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -29,14 +29,19 @@ data:
   # on the cluster subnet.
   PAPERLESS_API_URL: "http://192.168.1.162:8000"
 
-  # OpenAI-compatible LLM endpoints (llama-server pods on the cluster).
-  #   - Chat/Agent/RAG/Intent/KG/Memory → llama-server-agent (Qwen3.6-35B-A3B
-  #     MoE Q4_K_XL on k8s-gpu-1 with tensor-split across both GPUs).
-  #   - Embeddings → llama-server-embed (Qwen3-Embedding-4B Q4_K_M on
-  #     k8s-gpu-2 CPU-only, with --embedding --pooling last).
-  # Vision is currently disabled (OLLAMA_VISION_MODEL=""); a third
-  # llama-server-vision pod can be added in a follow-up step.
-  LLM_OPENAI_BASE_URL: "http://llama-server-agent:8080/v1"
+  # OpenAI-compatible LLM endpoints — moved to cuda.local (RTX 5090) on
+  # 2026-05-13 per reva/docs/architecture/gpu-allocation.md.
+  #   - Chat/Agent/RAG/Intent/KG/Memory → cuda.local:8081 (llama-server with
+  #     full Qwen3.6-35B-A3B MoE, shared with Reva). Previous in-cluster
+  #     llama-server-agent (Q4 on k8s-gpu-1) is now scaled to 0 — kept as
+  #     a fast failover via `kubectl scale --replicas=1`.
+  #   - Embeddings → still llama-server-embed (Qwen3-Embedding-4B Q4_K_M on
+  #     k8s-gpu-2 CPU). Switching to Ollama's qwen3-embedding:4b on
+  #     k8s-gpu-1 GPU is faster but the quant levels differ — would
+  #     require re-embedding the stored corpus. Tracked separately.
+  # Vision still disabled (OLLAMA_VISION_MODEL=""); add llama-server-vision
+  # pod if/when vision tier is wanted.
+  LLM_OPENAI_BASE_URL: "http://cuda.local:8081/v1"
   # LLM_OPENAI_API_KEY is sourced from the `renfield-secrets`/`llm-openai-api-key`
   # Secret in backend.yaml. llama-server accepts any non-empty value today;
   # the Secret indirection lets us swap to a real bearer (vLLM, OpenAI…)


### PR DESCRIPTION
## Summary

llama-server-agent was scaled to `replicas=0` in #570 as part of the GPU reallocation — its endpoint at `http://llama-server-agent:8080/v1` is now unreachable. This PR flips Renfield to use the 5090's llama-server directly (shared with Reva, **full Qwen3.6-35B-A3B not the Q4 tensor-split we ran on k8s-gpu-1**).

**Quality upgrade**: 35B MoE full precision vs Q4_K_XL on the previous two-GPU tensor split.

Embeddings stay on `llama-server-embed` for this rollout — Ollama's `qwen3-embedding:4b` on k8s-gpu-1 GPU is the eventual home, but quant levels differ and the stored corpus would need re-embedding. Tracked as a separate follow-up.

**Failover**: `kubectl scale deploy/llama-server-agent -n renfield --replicas=1` boots the Q4 backup in ~30-45s. Then patch `LLM_OPENAI_BASE_URL` back.

## Co-rolling with

- #569 (external Ingress) — merged
- #570 (Ollama tier on k8s-gpu-1, idle Q4) — merged
- X-idra-Systems-GmbH/reva@d11d4d2 (alias qwen3.6, URL flips) — live and verified

## Test plan

- [ ] After merge + apply: \`kubectl -n renfield rollout restart deployment/backend\`
- [ ] Backend logs show LLM calls going to cuda.local:8081/v1
- [ ] Browser test in \`renfield.local\`: send a chat message, expect coherent response (Qwen3.6 vs the previous Q4 — usually noticeably better reasoning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)