### PR TITLE
fix(k8s): point backend init wait at cuda.local llama-server

### DIFF
--- a/k8s/backend.yaml
+++ b/k8s/backend.yaml
@@ -55,8 +55,13 @@ spec:
               # GGUF model is fully loaded (~60-90s cold start). A plain TCP
               # check would pass too early, the backend would start serving,
               # and the first LLM call would 503 until the model warmed up.
-              echo "waiting for llama-server-agent /health..."
-              until wget -q -O- http://llama-server-agent:8080/health 2>/dev/null | grep -q '"ok"'; do sleep 2; done
+              #
+              # Agent endpoint moved to cuda.local (RTX 5090) on 2026-05-13 —
+              # see reva/docs/architecture/gpu-allocation.md. The in-cluster
+              # llama-server-agent is now idle (replicas=0) as failover; if
+              # you flip back to that endpoint, re-enable its health check too.
+              echo "waiting for cuda.local llama-server /health..."
+              until wget -q -O- http://cuda.local:8081/health 2>/dev/null | grep -q '"ok"'; do sleep 2; done
               echo "waiting for llama-server-embed /health..."
               until wget -q -O- http://llama-server-embed:8080/health 2>/dev/null | grep -q '"ok"'; do sleep 2; done
               echo "deps ready"


### PR DESCRIPTION
Follow-up to #571. Backend init container blocked on llama-server-agent /health which never returns (replicas=0 in #570). Re-point at cuda.local so init can complete.

Without this, backend rollout-restart stalls in Init:0/1 indefinitely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)