### PR TITLE
chore(k8s): OLLAMA_KEEP_ALIVE=-1 + explicit MEMORY_EXTRACTION_MODEL

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -47,6 +47,14 @@ data:
   # the Secret indirection lets us swap to a real bearer (vLLM, OpenAI…)
   # without re-applying this ConfigMap.
   LLM_OPENAI_MODEL: "qwen3.6"
+  # Explicit: routes memory extraction through the chat tier (llama-server
+  # on cuda.local, Qwen3.6-35B-A3B). Without this, `_get_chat_client()`
+  # still resolves to llama-server because LLM_OPENAI_BASE_URL is set, but
+  # the model name passed to client.chat() falls back to OLLAMA_MODEL
+  # (qwen3:14b) — currently safe because llama-server overrides via
+  # --alias, but the configmap reads as misleading. See Agent B audit
+  # in reva/docs/architecture/memory-architecture-plan.md.
+  MEMORY_EXTRACTION_MODEL: "qwen3.6"
   LLM_OPENAI_EMBED_BASE_URL: "http://ollama:11434/v1"
   LLM_OPENAI_EMBED_MODEL: "qwen3-embedding:4b"
 

--- a/k8s/ollama.yaml
+++ b/k8s/ollama.yaml
@@ -69,8 +69,14 @@ spec:
               value: "0.0.0.0:11434"
             - name: OLLAMA_MODELS
               value: /root/.ollama/models
+            # Keep loaded models resident indefinitely. The hot-path
+            # small models (llama3.2:3b router, qwen3-embedding:4b)
+            # combined fit easily in the 32 GB combined VRAM (5070 Ti
+            # + 5060 Ti) so eviction has no upside. Previously 30m,
+            # which let Ollama unload between bursts of traffic and
+            # added ~12 s cold-load tail latency to router calls.
             - name: OLLAMA_KEEP_ALIVE
-              value: "30m"
+              value: "-1"
           volumeMounts:
             - name: models
               mountPath: /root/.ollama


### PR DESCRIPTION
Two follow-ups from the GPU + memory analysis in reva/docs/architecture/memory-architecture-plan.md:

1. **OLLAMA_KEEP_ALIVE: 30m → -1** — hot models stay resident, kills the ~12s cold-load tail latency on router calls.
2. **MEMORY_EXTRACTION_MODEL=qwen3.6** — make explicit what was safe-by-accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)