### PR TITLE
fix: release leaked advisory locks at pool checkin + atomic KG entity/atom creation

### DIFF
--- a/bin/cleanup_orphan_kg_atoms.sql
+++ b/bin/cleanup_orphan_kg_atoms.sql
@@ -1,0 +1,92 @@
+-- One-shot cleanup for orphan kg_node atoms blocking KG extraction.
+--
+-- Symptom (observed in prod 2026-05-14):
+--   Every chat turn fires kg_post_message_hook and fails with
+--   UniqueViolationError on uq_atoms_source. atoms table has 192 rows
+--   pointing at kg_entities IDs 1..220 (with gaps), but kg_entities
+--   has 0 rows — the sequence was reset and the underlying entity
+--   rows were deleted without cleaning up their backing atoms.
+--
+-- Root cause:  resolve_entity (knowledge_graph_service.py) inserted
+-- the atom BEFORE the kg_entity, then UPDATEd the atom's source_id
+-- after the entity flushed. If anything between failed AND the atom
+-- write had already been committed by upsert_atom-style code paths
+-- elsewhere, an orphan atom committed without its entity. The schema
+-- has no FK on atoms.source_id (it's a string, not a real FK), so
+-- nothing prevents the drift.
+--
+-- Fix is in resolve_entity (insert entity first in a savepoint, then
+-- atom with real source_id). This script removes the pre-existing
+-- damage so the next attempt succeeds.
+--
+-- Usage:
+--   kubectl -n reva exec postgres-0 -- psql -U postgres -d reva \
+--     < bin/cleanup_orphan_kg_atoms.sql
+--
+-- Idempotent: re-running is a no-op once the orphans are cleared.
+
+BEGIN;
+
+-- 1. Show what we're about to delete (for the human running it).
+\echo 'Orphan kg_node atoms (atom_id -> source_id) — to be removed:'
+SELECT atom_id, source_table, source_id
+FROM atoms
+WHERE atom_type = 'kg_node'
+  AND source_table = 'kg_entities'
+  AND NOT EXISTS (
+      SELECT 1 FROM kg_entities e
+      WHERE e.id::text = atoms.source_id
+  )
+ORDER BY source_id::int
+LIMIT 10;
+
+\echo 'Orphan kg_edge atoms (atom_id -> source_id) — to be removed:'
+SELECT atom_id, source_table, source_id
+FROM atoms
+WHERE atom_type = 'kg_edge'
+  AND source_table = 'kg_relations'
+  AND NOT EXISTS (
+      SELECT 1 FROM kg_relations r
+      WHERE r.id::text = atoms.source_id
+  )
+ORDER BY source_id::int
+LIMIT 10;
+
+-- 2. Delete them.
+DELETE FROM atoms
+WHERE atom_type = 'kg_node'
+  AND source_table = 'kg_entities'
+  AND NOT EXISTS (
+      SELECT 1 FROM kg_entities e
+      WHERE e.id::text = atoms.source_id
+  );
+
+\echo 'kg_node orphans deleted.'
+
+DELETE FROM atoms
+WHERE atom_type = 'kg_edge'
+  AND source_table = 'kg_relations'
+  AND NOT EXISTS (
+      SELECT 1 FROM kg_relations r
+      WHERE r.id::text = atoms.source_id
+  );
+
+\echo 'kg_edge orphans deleted.'
+
+-- 3. Reset the kg_entities + kg_relations sequences to MAX(id)+1 so the
+--    next inserts don't collide with whatever the application thinks is
+--    "free". If the tables are empty, this resets to 1.
+SELECT setval(
+    pg_get_serial_sequence('kg_entities', 'id'),
+    COALESCE((SELECT MAX(id) FROM kg_entities), 0) + 1,
+    false
+);
+SELECT setval(
+    pg_get_serial_sequence('kg_relations', 'id'),
+    COALESCE((SELECT MAX(id) FROM kg_relations), 0) + 1,
+    false
+);
+
+\echo 'Sequences reset.'
+
+COMMIT;

--- a/src/backend/services/atom_service.py
+++ b/src/backend/services/atom_service.py
@@ -175,6 +175,7 @@ class AtomService:
         atom_type: str,
         owner_user_id: int,
         tier: int,
+        source_id: int | str | None = None,
     ) -> str:
         """Pre-create an atoms row before the source row exists.
 
@@ -185,6 +186,13 @@ class AtomService:
         method seeds the atoms row with a unique placeholder ``source_id``;
         the caller invokes :meth:`finalize_source_id` after flushing the
         source row to patch the real PK.
+
+        If the caller can supply the real ``source_id`` upfront (e.g. the
+        source row's ``atom_id`` FK is nullable, so the source row was
+        already flushed and its PK is known), pass it here to skip the
+        placeholder dance entirely — eliminates one UPDATE statement and
+        prevents the orphan-atom failure mode where a placeholder atom
+        commits but the source row's later flush is rolled back.
 
         Returns the minted atom_id. Intended call pattern:
 
@@ -204,13 +212,15 @@ class AtomService:
         """
         atom_id = str(uuid.uuid4())
         source_table = _table_for_atom_type(atom_type)
-        placeholder = f"__pending__{atom_id}"
+        seed_source_id: str = (
+            str(source_id) if source_id is not None else f"__pending__{atom_id}"
+        )
         now = datetime.now(UTC).replace(tzinfo=None)
         atom_row = AtomModel(
             atom_id=atom_id,
             atom_type=atom_type,
             source_table=source_table,
-            source_id=placeholder,
+            source_id=seed_source_id,
             owner_user_id=int(owner_user_id),
             policy={"tier": int(tier)},
             created_at=now,

--- a/src/backend/services/conversation_memory_service.py
+++ b/src/backend/services/conversation_memory_service.py
@@ -696,8 +696,17 @@ class ConversationMemoryService:
                 {"k": self._user_lock_key(user_id)},
             )
         except Exception as e:
-            # Don't propagate — if the session is already in error state
-            # the lock releases when the session disconnects anyway.
+            # Don't propagate — the connection pool's `before_checkin`
+            # event handler in services/database.py runs
+            # pg_advisory_unlock_all() as a defensive sweep before the
+            # connection returns to the pool, so a release-here failure
+            # does NOT leak the lock to the next caller. The earlier
+            # comment claiming "the lock releases when the session
+            # disconnects anyway" was wrong: pg_advisory_lock is
+            # session-level (= per-connection), and a pool checkin does
+            # NOT disconnect the underlying connection. Without the
+            # before_checkin handler this release failure would block
+            # all subsequent v2 calls for the same user_id indefinitely.
             logger.warning(f"v2 extract: pg_advisory_unlock failed: {e}")
 
     async def _call_extract_v2_llm(

--- a/src/backend/services/database.py
+++ b/src/backend/services/database.py
@@ -4,7 +4,7 @@ Datenbank Service
 from pathlib import Path
 
 from loguru import logger
-from sqlalchemy import inspect, text
+from sqlalchemy import event, inspect, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from models.database import Base
@@ -20,6 +20,35 @@ engine = create_async_engine(
     pool_recycle=settings.db_pool_recycle,
     pool_pre_ping=True,
 )
+
+
+# Defensive cleanup: pg_advisory_lock is session-level (per-connection),
+# not transaction-level. ROLLBACK does NOT release it. If application code
+# fails to call pg_advisory_unlock before the connection returns to the
+# pool, the lock leaks and every subsequent caller for the same key
+# blocks forever on pg_advisory_lock waiting for nobody. This was
+# observed in prod on 2026-05-14 — three sessions queued on user_id=8
+# for 20+ minutes after a single v2-shadow-mode path failed mid-flight,
+# stalling all memory extraction for that user.
+#
+# Fix: release every advisory lock at connection checkin. Safe because
+# this codebase uses advisory locks for exactly one purpose
+# (ConversationMemoryService._user_lock_key — the v2 per-user extraction
+# serialisation). If a future feature wires another advisory lock, this
+# hook must be revisited.
+@event.listens_for(engine.sync_engine, "checkin")
+def _release_leaked_advisory_locks_on_checkin(dbapi_connection, connection_record):
+    """Release any held advisory locks when a connection returns to the pool."""
+    cursor = dbapi_connection.cursor()
+    try:
+        cursor.execute("SELECT pg_advisory_unlock_all();")
+    except Exception as e:
+        # Best-effort: never block checkin on cleanup failure. Worst case
+        # is the original leak symptom comes back, which we'll see in logs.
+        logger.warning(f"checkin: pg_advisory_unlock_all failed (swallowed): {type(e).__name__}: {e}")
+    finally:
+        cursor.close()
+
 
 # Session Factory
 AsyncSessionLocal = async_sessionmaker(

--- a/src/backend/services/knowledge_graph_service.py
+++ b/src/backend/services/knowledge_graph_service.py
@@ -425,26 +425,47 @@ class KnowledgeGraphService:
         # atom_id=None (the source-row ORM column is nullable). Production
         # always has the bootstrap admin, so the atom-backed path is the one
         # that actually runs.
-        atom_id: str | None = None
-        if owner_id is not None:
-            atom_id = await self._atom_service().create_with_source(
-                atom_type="kg_node",
-                owner_user_id=owner_id,
-                tier=default_tier,
-            )
+        # Order-of-operations fix (2026-05-14): previously this created the
+        # atom row FIRST with a "__pending__" source_id, then inserted the
+        # kg_entity, then UPDATEd the atom's source_id with the entity's
+        # real PK. If anything between those steps failed (validation,
+        # embedding flush, dedup query) AND the atom's flush had already
+        # been committed by another code path (e.g. atom_service.upsert_atom
+        # internal commit), production ended up with orphan atoms pointing
+        # at kg_entities IDs that never existed — every subsequent attempt
+        # to create a kg_entity then hit `uq_atoms_source` and failed,
+        # blocking the entire KG-extraction pipeline indefinitely.
+        #
+        # Insert the entity first (in a savepoint so a rollback doesn't
+        # poison the outer transaction), get its real PK, then create the
+        # atom with that PK — no placeholder, no later UPDATE step. The
+        # savepoint also guarantees that if the atom insert fails the
+        # entity insert is rolled back atomically.
         entity = KGEntity(
             user_id=owner_id,
             name=name,
             entity_type=entity_type if entity_type in KG_ENTITY_TYPES else "thing",
             description=description,
             embedding=embedding,
-            atom_id=atom_id,
+            atom_id=None,
             circle_tier=default_tier,
         )
-        self.db.add(entity)
-        await self.db.flush()
-        if atom_id is not None:
-            await self._atom_service().finalize_source_id(atom_id, entity.id)
+        atom_id: str | None = None
+        if owner_id is not None:
+            async with self.db.begin_nested():
+                self.db.add(entity)
+                await self.db.flush()  # assigns entity.id
+                atom_id = await self._atom_service().create_with_source(
+                    atom_type="kg_node",
+                    owner_user_id=owner_id,
+                    tier=default_tier,
+                    source_id=entity.id,
+                )
+                entity.atom_id = atom_id
+                await self.db.flush()
+        else:
+            self.db.add(entity)
+            await self.db.flush()
         logger.debug(f"KG: New entity '{name}' ({entity_type}) id={entity.id} atom_id={atom_id}")
         return entity
 


### PR DESCRIPTION
## Summary

Two cross-cutting prod bugs surfaced during browser-based QA of `chat.reva.aktivities.ai` on 2026-05-14 after the Lane B/2 v2-shadow rollout went live.

### Bug 1 — v2 shadow-mode silently hangs after one failure (P0 for Phase A)

`pg_advisory_lock` is **session-scoped** (= per connection), not transaction-scoped. The v2 path's `try/finally` release call CAN fail (network blip, mid-transaction error). When SQLAlchemy returns a connection to the pool with a lock still held, the next user of that connection inherits the lock and `pg_advisory_lock` blocks indefinitely on a release that will never come.

Observed in prod: three sessions queued on `user_id=8` for 20+ min after a single failed extraction, stalling **all** memory extraction for that user. PID 3378685 was `state=idle`, last query=`ROLLBACK`, but still holding the lock — only manual `pg_terminate_backend` unblocked the queue.

**Fix:** `before_checkin` event handler in `services/database.py` runs `pg_advisory_unlock_all()` before every connection returns to the pool. Defense-in-depth at the connection-pool layer where it belongs — the application code's release call still tries first (happy-path fast release), and the pool guarantees cleanup on the failure path. Safe because this codebase uses advisory locks for exactly one purpose (the v2 user-extraction lock); any future advisory-lock user must revisit this hook.

### Bug 2 — KG extraction blocked forever by orphan atoms (P1)

`resolve_entity` inserted the atom row FIRST with a `__pending__` placeholder `source_id`, then inserted the `kg_entity`, then UPDATEd the atom's `source_id` with the real entity PK. The two writes are not atomic at the SQL level. If anything between fails AND the atom write commits via a parallel code path (`upsert_atom` internal commit), the atom persists with a real `source_id` pointing at a `kg_entities` row that no longer exists. Every retry then hits `uq_atoms_source` on the orphan and the entire KG hook crashes.

Observed in prod: **192 orphan atoms** with `source_table='kg_entities'` but `kg_entities` had **0 rows**. Every chat turn since:
```
WARNING knowledge_graph_service:kg_post_message_hook:1347 -
UniqueViolationError on uq_atoms_source — key (kg_node, kg_entities, 4) already exists
```

**Fix:** `KGEntity.atom_id` is nullable. Insert the entity first inside `begin_nested()` (gets real PK), then create the atom with real `source_id` (no placeholder dance), patch `entity.atom_id`, flush. Savepoint rolls back atomically on any failure — no orphan rows possible.

`AtomService.create_with_source` gains an optional `source_id` param to skip the placeholder when the caller already knows the real PK. Backward compatible — omitting it preserves the existing flow used by every other consumer.

`bin/cleanup_orphan_kg_atoms.sql` is a one-shot script for the pre-existing 192-row damage. Idempotent.

## Test plan

- [x] py_compile clean on all 4 changed files
- [ ] Sync to .159, restart pod, send 2 chat turns:
  - [ ] `memory_v2_shadow_log` gets rows with `v2_outcome != fallback`
  - [ ] No `pg_advisory_lock` queue buildup in `pg_stat_activity`
  - [ ] `kg_entities` gets rows and the count matches `(SELECT COUNT(*) FROM atoms WHERE source_table='kg_entities')`
- [ ] Run cleanup script on prod once and confirm queue stays clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)