### PR TITLE
fix(kg+memory): correct KG entity/atom ordering + log-format bug

### DIFF
--- a/src/backend/services/conversation_memory_service.py
+++ b/src/backend/services/conversation_memory_service.py
@@ -441,8 +441,7 @@ class ConversationMemoryService:
                     # outer caller's transaction will eventually decide
                     # whether to commit (v1 writes will persist regardless).
                     logger.warning(
-                        "v2 shadow: savepoint rollback failed (swallowed): %s",
-                        type(e_rb).__name__,
+                        f"v2 shadow: savepoint rollback failed (swallowed): {type(e_rb).__name__}: {e_rb}"
                     )
 
         # Write the shadow log row in its OWN savepoint so a log-table

--- a/src/backend/services/knowledge_graph_service.py
+++ b/src/backend/services/knowledge_graph_service.py
@@ -425,45 +425,53 @@ class KnowledgeGraphService:
         # atom_id=None (the source-row ORM column is nullable). Production
         # always has the bootstrap admin, so the atom-backed path is the one
         # that actually runs.
-        # Order-of-operations fix (2026-05-14): previously this created the
-        # atom row FIRST with a "__pending__" source_id, then inserted the
-        # kg_entity, then UPDATEd the atom's source_id with the entity's
-        # real PK. If anything between those steps failed (validation,
-        # embedding flush, dedup query) AND the atom's flush had already
-        # been committed by another code path (e.g. atom_service.upsert_atom
-        # internal commit), production ended up with orphan atoms pointing
-        # at kg_entities IDs that never existed — every subsequent attempt
-        # to create a kg_entity then hit `uq_atoms_source` and failed,
-        # blocking the entire KG-extraction pipeline indefinitely.
+        # Atomicity fix (2026-05-14): the entity/atom creation must be
+        # all-or-nothing. The original code flushed the atom row (with
+        # __pending__ source_id) and then flushed the entity row in
+        # separate db.flush() calls, relying on the outer transaction to
+        # commit both together. But upsert_atom-style internal commits
+        # elsewhere — or a partial-failure path that committed the atom
+        # before the entity flush — left 192 orphan kg_node atoms in
+        # prod, blocking every subsequent kg_entity insert on
+        # uq_atoms_source. Wrapping the entire dance in begin_nested()
+        # makes the savepoint roll back atomically on ANY failure inside.
         #
-        # Insert the entity first (in a savepoint so a rollback doesn't
-        # poison the outer transaction), get its real PK, then create the
-        # atom with that PK — no placeholder, no later UPDATE step. The
-        # savepoint also guarantees that if the atom insert fails the
-        # entity insert is rolled back atomically.
-        entity = KGEntity(
-            user_id=owner_id,
-            name=name,
-            entity_type=entity_type if entity_type in KG_ENTITY_TYPES else "thing",
-            description=description,
-            embedding=embedding,
-            atom_id=None,
-            circle_tier=default_tier,
-        )
+        # Ordering stays atom-first because kg_entities.atom_id is
+        # NOT NULL at the DB level (alembic migration pc20260420 sets the
+        # FK as NOT NULL non-deferrable — the ORM column nullable=True
+        # comment in models/database.py is misleading drift). The
+        # placeholder-then-finalize pattern is preserved; the atomicity
+        # comes from the savepoint.
         atom_id: str | None = None
         if owner_id is not None:
             async with self.db.begin_nested():
-                self.db.add(entity)
-                await self.db.flush()  # assigns entity.id
                 atom_id = await self._atom_service().create_with_source(
                     atom_type="kg_node",
                     owner_user_id=owner_id,
                     tier=default_tier,
-                    source_id=entity.id,
                 )
-                entity.atom_id = atom_id
-                await self.db.flush()
+                entity = KGEntity(
+                    user_id=owner_id,
+                    name=name,
+                    entity_type=entity_type if entity_type in KG_ENTITY_TYPES else "thing",
+                    description=description,
+                    embedding=embedding,
+                    atom_id=atom_id,
+                    circle_tier=default_tier,
+                )
+                self.db.add(entity)
+                await self.db.flush()  # entity.id assigned
+                await self._atom_service().finalize_source_id(atom_id, entity.id)
         else:
+            entity = KGEntity(
+                user_id=owner_id,
+                name=name,
+                entity_type=entity_type if entity_type in KG_ENTITY_TYPES else "thing",
+                description=description,
+                embedding=embedding,
+                atom_id=None,
+                circle_tier=default_tier,
+            )
             self.db.add(entity)
             await self.db.flush()
         logger.debug(f"KG: New entity '{name}' ({entity_type}) id={entity.id} atom_id={atom_id}")


### PR DESCRIPTION
## Summary

Follow-up to #578. Prod verification surfaced two correctness regressions:

1. **KG NotNull regression** — #578's `resolve_entity` rewrite inserted the entity first with `atom_id=NULL`, banking on the ORM column being `nullable=True`. But the alembic migration `pc20260420` sets the DB column NOT NULL — schema drift the ORM comment didn't capture. Every KG entity insert now hits `NotNullViolationError`. Correct fix: keep the original order (atom first with placeholder, entity second, finalize atom source_id third) BUT wrap in `begin_nested()` for atomicity. That was the actual goal — atomicity, not reordering.

2. **Log format bug** — the v2 shadow savepoint rollback warning used `"%s"` placeholder but loguru uses `{}`, so the actual exception was never visible. Switched to f-string. Will need this when investigating the still-failing savepoint rollback.

## Test plan
- [x] py_compile clean
- [ ] After rollout: no `NotNullViolationError` in `kg_post_message_hook` logs
- [ ] After rollout: when v2 shadow savepoint fails, the log line shows the actual exception type + message

🤖 Generated with [Claude Code](https://claude.com/claude-code)