### PR TITLE
fix(memory): retrieve() should flush, not commit — was breaking shadow savepoint

### DIFF
--- a/src/backend/services/memory_retrieval.py
+++ b/src/backend/services/memory_retrieval.py
@@ -171,7 +171,16 @@ class MemoryRetrieval:
                 })
                 memory_ids.append(row.id)
 
-        # Update access tracking
+        # Update access tracking. flush() not commit() — the caller's
+        # outer transaction decides when to persist. Previously this
+        # committed unconditionally, which broke the v2-shadow savepoint
+        # (the commit closed the savepoint's enclosing transaction,
+        # causing the rollback at the end of `_extract_v2_shadow_only`
+        # to fail with `ResourceClosedError: This transaction is
+        # closed`). Real callers (chat_handler, agent loop) commit at
+        # the end of their own scope anyway, so this preserves access
+        # tracking durability while letting shadow mode properly roll
+        # back.
         if memory_ids:
             await self.db.execute(
                 update(ConversationMemory)
@@ -181,7 +190,7 @@ class MemoryRetrieval:
                     last_accessed_at=datetime.now(UTC).replace(tzinfo=None),
                 )
             )
-            await self.db.commit()
+            await self.db.flush()
 
         return memories
 


### PR DESCRIPTION
## Summary

Root cause of the v2-shadow savepoint rollback failure surfaced after PR #579 made the exception name visible: `ResourceClosedError: This transaction is closed`.

`MemoryRetrieval.retrieve()` committed access-tracking unconditionally. Called from inside the v2 shadow savepoint, that commit closed the savepoint's enclosing transaction. The next `sp.rollback()` then failed and the shadow log row never landed — Phase A measurement stayed dark even after PR #578 (lock leak) + PR #579 (KG NotNull).

## Fix

`db.commit()` → `db.flush()`. Access tracking persists when the outer caller commits — chat_handler, agent loop, etc. all commit at the end of their scope. Shadow mode now rolls back access tracking alongside the v2 ops.

## Test plan
- [x] py_compile clean
- [ ] After rollout: `memory_v2_shadow_log` populates with `v2_outcome != fallback`
- [ ] After rollout: no "savepoint rollback failed" warnings
- [ ] After rollout: access-tracking still works for chat retrieval (unit test on retrieve is unchanged — caller's transaction commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)