### PR TITLE
fix(memory): persist shadow log row with explicit db.commit()

### DIFF
--- a/src/backend/services/conversation_memory_service.py
+++ b/src/backend/services/conversation_memory_service.py
@@ -465,10 +465,19 @@ class ConversationMemoryService:
                 v2_error=v2_error,
             ))
             await self.db.flush()
-            # Release the savepoint. Without this, asyncpg treats the nested
-            # transaction as unresolved on outer commit and the row write is
-            # not durable.
+            # Release the savepoint into the outer transaction.
             await log_sp.commit()
+            # Persist the outer transaction. Without this, callers that
+            # don't commit explicitly (e.g. chat_handler's
+            # `async with AsyncSessionLocal()` which closes WITHOUT
+            # committing the autobegun outer transaction) silently lose
+            # the shadow log row on session close — verified empirically
+            # in prod 2026-05-14 where 4 chat turns produced 0 shadow
+            # log rows despite extract_and_save_v2 running cleanly. The
+            # log row is the WHOLE POINT of shadow mode; persist it
+            # ourselves rather than depending on the caller's commit
+            # discipline.
+            await self.db.commit()
         except Exception as e:
             if log_sp is not None:
                 try:
@@ -476,7 +485,7 @@ class ConversationMemoryService:
                 except Exception:
                     pass
             logger.warning(
-                "v2 shadow: log-row write failed (swallowed): %s", type(e).__name__
+                f"v2 shadow: log-row write failed (swallowed): {type(e).__name__}: {e}"
             )
 
     async def _extract_and_save_v1_impl(


### PR DESCRIPTION
## Summary

The fifth and (hopefully) final iteration on the v2-shadow Phase A bug surfaced this afternoon.

Direct in-pod probe of `extract_and_save` wrapped with `await db.commit()` writes the shadow log row correctly. The same call via `chat_handler._extract_memories_background` does NOT — even after PR #580 fixed the savepoint rollback issue, 4 chat turns still produced 0 shadow log rows.

Root cause: `chat_handler` wraps the call in `async with AsyncSessionLocal() as db:` with no explicit `db.commit()`. SQLAlchemy AsyncSession's `__aexit__` closes the session **without** committing. The savepoint commit in `_extract_v2_shadow_only` releases the log row into the outer transaction, but the outer transaction silently rolls back on session close. The row is lost.

Fix: explicit `await self.db.commit()` at the end of `_extract_v2_shadow_only`. The shadow row is the whole point of shadow mode — persist it ourselves.

Also fixed the lingering `%s` format string in the log-row-write exception handler (PR #579 fixed the same bug in the savepoint-rollback warning; this one was overlooked).

## Test plan
- [x] py_compile clean
- [x] In-pod probe (this PR's call path mirrors what the probe did) — direct call already writes the row
- [ ] After rollout: `memory_v2_shadow_log` populates with `v2_outcome IN ('saved','noop')` and `v2_ops_json` non-NULL

🤖 Generated with [Claude Code](https://claude.com/claude-code)