### PR TITLE
feat(hooks): add build_assistant_card synchronous hook event

### DIFF
--- a/src/backend/utils/hooks.py
+++ b/src/backend/utils/hooks.py
@@ -40,11 +40,17 @@ HOOK_EVENTS: frozenset[str] = frozenset({
     # `session_id: str`, `rid: str`. Handlers return a dict
     # `{"card": <adaptive-card>, "replace_text": <1-line lede>}` (the
     # `replace_text` key is optional) or None to contribute nothing.
-    # First well-shaped non-None result wins — registration order is
-    # precedence. Handlers MUST be pure with respect to transport (no
-    # WebSocket send, no DB write); the caller owns emission. Handler
-    # exceptions are caught by `run_hooks` and logged — a card-build
-    # failure degrades to no-card, never blocks the response.
+    #
+    # `run_hooks` does NOT short-circuit — it runs every registered
+    # handler and returns a list of all non-None results. The caller is
+    # responsible for picking `results[0]` (registration order is
+    # precedence) and emitting exactly one card. Handlers MUST be pure
+    # with respect to transport: no WebSocket send, no DB write. The
+    # caller owns emission — a handler that sends a card itself will
+    # double-send (the caller emits results[0] AND the handler already
+    # sent), producing two cards with no warning. Handler exceptions are
+    # caught by `run_hooks` and logged — a card-build failure degrades
+    # to no-card, never blocks the response.
     "build_assistant_card",
     "post_document_ingest",
     "retrieve_context",

--- a/src/backend/utils/hooks.py
+++ b/src/backend/utils/hooks.py
@@ -27,6 +27,25 @@ HOOK_EVENTS: frozenset[str] = frozenset({
     "register_tools",
     "execute_tool",
     "post_message",
+    # Synchronous Adaptive-Card build — fired by the WebSocket chat
+    # handler AFTER the agent loop produces its final answer but BEFORE
+    # the `done` marker is sent. Unlike `post_message` (fire-and-forget,
+    # runs after `done`), this hook is awaited inline so the card lands
+    # in the same logical event as the streamed prose — eliminates the
+    # "prose first, card overlays a second later" flip web-chat users
+    # see on release-list and similar card-able responses.
+    #
+    # Kwargs: `tool_summaries: list[tuple[str,str]] | None`,
+    # `assistant_msg: str`, `lang: str`, `user_id: int | None`,
+    # `session_id: str`, `rid: str`. Handlers return a dict
+    # `{"card": <adaptive-card>, "replace_text": <1-line lede>}` (the
+    # `replace_text` key is optional) or None to contribute nothing.
+    # First well-shaped non-None result wins — registration order is
+    # precedence. Handlers MUST be pure with respect to transport (no
+    # WebSocket send, no DB write); the caller owns emission. Handler
+    # exceptions are caught by `run_hooks` and logged — a card-build
+    # failure degrades to no-card, never blocks the response.
+    "build_assistant_card",
     "post_document_ingest",
     "retrieve_context",
     "pre_agent_context",


### PR DESCRIPTION
## Summary

Adds `build_assistant_card` to the `HOOK_EVENTS` frozenset so plugins can register a synchronous Adaptive-Card builder. **Event name + contract docstring only — no call site in this PR.**

This is Step 2 of the card-emit-inline work (full plan lives in the Reva repo, `docs/plans/card-emit-inline.md`). The goal: let the WebSocket chat handler build the card *inline, awaited before the `done` marker*, instead of in the fire-and-forget `post_message` hook that runs *after* `done`. The post-`done` timing is what makes web-chat users see the prose first and the card overlay it a second later.

## Why this is safe to land alone

`register_hook` rejects unknown event names with `ValueError`, so the Reva-side handler can't be registered until this name exists in `HOOK_EVENTS`. But a registered handler for an event with **no call site** is completely inert — `run_hooks("build_assistant_card", ...)` is never invoked, so nothing changes at runtime. Landing the event name first lets the Reva handler register cleanly; the chat_handler call site lands in Step 3.

## Contract (documented inline in the frozenset)

- **Synchronous**: caller `await`s it before emitting `done`.
- **Kwargs**: `tool_summaries`, `assistant_msg`, `lang`, `user_id`, `session_id`, `rid`.
- **Returns**: `{"card": <adaptive-card>, "replace_text": <1-line lede>}` (replace_text optional) or `None`.
- **First non-None wins** — registration order is precedence.
- **Transport-pure**: handlers must not send WebSocket / write DB; the caller owns emission.
- Handler exceptions are caught by `run_hooks` and logged — a build failure degrades to no-card, never blocks the response.

## Test plan

- [x] `py_compile` + AST parse clean
- [x] Event name present in `HOOK_EVENTS`
- [ ] Independent reviewer sign-off
- [ ] Step 3 (chat_handler call site) will carry the integration + E2E tests — there's nothing to integration-test here since the event has no call site yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)