### PR TITLE
feat(chat): card_emit_inline flag + chat_handler build_assistant_card call site

### DIFF
--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -1604,6 +1604,55 @@ WICHTIG: Nutze die ECHTEN Daten aus dem Ergebnis! Gib NUR die Antwort, KEIN JSON
                     room_context, full_response, websocket
                 )
 
+            # Card-emit-inline: build + send the Adaptive Card BEFORE the
+            # `done` marker so it lands in the same logical event as the
+            # streamed prose (no "prose first, card overlays a second
+            # later" flip). The `build_assistant_card` hook is
+            # transport-pure by contract — it returns the payload; this
+            # call site owns the send + its own try/except. Gated on
+            # `card_emit_inline`; when off (default), the legacy
+            # fire-and-forget `post_message` hook still emits the card
+            # after `done`. `run_hooks` runs every handler and returns a
+            # list — we take the first well-shaped result (registration
+            # order is precedence, per the hook contract). The Reva
+            # handler sources `tool_summaries` from its own request-scoped
+            # ContextVar (it's Reva-internal agent-loop state, not
+            # available here), so the kwarg is left None — it exists as a
+            # test-injection override only.
+            if settings.card_emit_inline and session_id and full_response:
+                try:
+                    from utils.hooks import run_hooks
+                    _card_results = await run_hooks(
+                        "build_assistant_card",
+                        tool_summaries=None,
+                        assistant_msg=full_response,
+                        lang=ollama.default_lang,
+                        user_id=user_id,
+                        session_id=msg_session_id,
+                        rid=request_id_var.get("--------"),
+                    )
+                    _card_payload = next(
+                        (
+                            r for r in (_card_results or [])
+                            if isinstance(r, dict) and r.get("card")
+                        ),
+                        None,
+                    )
+                    if _card_payload:
+                        _ws_card: dict = {
+                            "type": "card",
+                            "card": _card_payload["card"],
+                        }
+                        if _card_payload.get("replace_text"):
+                            _ws_card["replace_text"] = _card_payload["replace_text"]
+                        await websocket.send_json(_ws_card)
+                except Exception as e:
+                    # Never block `done` on a card-build/send failure.
+                    logger.warning(
+                        f"[{request_id_var.get('--------')}] "
+                        f"card_emit_inline failed: {e}"
+                    )
+
             # Stream finished - tell frontend if TTS was handled server-side
             done_msg = {
                 "type": "done",

--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -1619,7 +1619,7 @@ WICHTIG: Nutze die ECHTEN Daten aus dem Ergebnis! Gib NUR die Antwort, KEIN JSON
             # ContextVar (it's Reva-internal agent-loop state, not
             # available here), so the kwarg is left None — it exists as a
             # test-injection override only.
-            if settings.card_emit_inline and session_id and full_response:
+            if settings.card_emit_inline and msg_session_id and full_response:
                 try:
                     from utils.hooks import run_hooks
                     _card_results = await run_hooks(
@@ -1631,14 +1631,13 @@ WICHTIG: Nutze die ECHTEN Daten aus dem Ergebnis! Gib NUR die Antwort, KEIN JSON
                         session_id=msg_session_id,
                         rid=request_id_var.get("--------"),
                     )
-                    _card_payload = next(
-                        (
-                            r for r in (_card_results or [])
-                            if isinstance(r, dict) and r.get("card")
-                        ),
-                        None,
-                    )
-                    if _card_payload:
+                    # run_hooks already filters None (the handler returns
+                    # None for no-card), so results[0] is the first
+                    # registered handler's card — strict registration-order
+                    # precedence per the hook contract. The .get("card")
+                    # check stays as a shape guard.
+                    _card_payload = (_card_results or [None])[0]
+                    if isinstance(_card_payload, dict) and _card_payload.get("card"):
                         _ws_card: dict = {
                             "type": "card",
                             "card": _card_payload["card"],

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -199,6 +199,24 @@ class Settings(BaseSettings):
     agent_router_model: str | None = None  # Dedicated router model (default: ollama_intent_model)
     agent_router_url: str | None = None    # Dedicated Ollama URL for router (default: agent_ollama_url)
     agent_orchestrator_enabled: bool = False  # Enable cross-MCP query orchestration (opt-in)
+    # Card-emit-inline (card-flip UX fix). When True, the WebSocket chat
+    # handler awaits the `build_assistant_card` hook AFTER the agent loop
+    # produces its final answer but BEFORE the `done` marker, and emits
+    # the card in the same logical event as the streamed prose. When
+    # False (default), the call site is dormant and cards are emitted by
+    # the fire-and-forget `post_message` hook after `done` (legacy
+    # behaviour — prose appears, card overlays it ~1s later).
+    #
+    # Default False on purpose: the renfield call site and the Reva-side
+    # `on_post_message` card-branch gate land as separate PRs with a
+    # submodule bump between. A deploy window with new-renfield +
+    # old-Reva would emit TWO cards (chat_handler inline AND the
+    # un-gated post_message hook) if this defaulted True. Ship both
+    # halves, deploy, verify both SHAs in /api/health, THEN flip to True
+    # via a ConfigMap patch (no rebuild) — and flip back the same way if
+    # `reva_cards_render_errors_total` spikes. See the Reva repo
+    # docs/plans/card-emit-inline.md "Rollout" section.
+    card_emit_inline: bool = False
     # W5 — previously hardcoded timeouts now configurable
     agent_preselect_timeout: float = Field(default=10.0, ge=1.0, le=60.0)
     """Timeout for tool pre-selection LLM call in agent_service.py:_preselect_tools.


### PR DESCRIPTION
## Summary

Step 3a of card-emit-inline (full plan: Reva repo `docs/plans/card-emit-inline.md`). The user-visible half — chat_handler builds + emits the Adaptive Card **before** the `done` marker so it lands with the streamed prose. Kills the "prose first, card overlays ~1s later" flip on web chat.

- Adds `card_emit_inline: bool = False` to `utils/config.py`.
- chat_handler, between TTS routing and the `done` send: when the flag is on, `await run_hooks("build_assistant_card", ...)`, take the first well-shaped result, wrap `{"type":"card",...}`, send before `done`. try/except so a failure never blocks `done`.

## Why default False (load-bearing)

This renfield call site and the Reva-side `on_post_message` card-branch gate ship as **separate PRs with a submodule bump between**. If this defaulted True, a deploy window with new-renfield + old-Reva would emit **two cards** (inline here AND the still-un-gated `post_message` hook). Default False keeps the call site dormant → behaviour identical to today. Rollout: ship both halves, deploy, verify both SHAs in `/api/health`, flip to True via ConfigMap (no rebuild). Flip back the same way if `reva_cards_render_errors_total` spikes.

## Inert until flipped

With `card_emit_inline=False` (default) the call site never fires; the legacy fire-and-forget `post_message` hook still emits the card after `done`. Zero behaviour change on merge or deploy. Safe to land independently.

## tool_summaries kwarg is None by design

The Reva `build_assistant_card` handler sources `tool_summaries` from its own request-scoped ContextVar (Reva-internal agent-loop state — not available in chat_handler). The kwarg exists as a test-injection override only. The call site runs in the request coroutine where that ContextVar is populated; the handler peeks it without draining (the drain stays in `on_post_message` for its non-card branches). Documented in the plan.

## Test plan

- [x] `py_compile` clean (config.py + chat_handler.py)
- [x] Flag present, gated call site present
- [ ] Independent reviewer sign-off
- [ ] End-to-end E2E lands with the Reva-side PR (Step 3b) where the gate makes the flip-fix observable; nothing to integration-test here while the call site is dormant by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)