### PR TITLE
fix(k8s): repoint init dep-gates off scaled-to-0 llama-server-*

### DIFF
--- a/k8s/backend.yaml
+++ b/k8s/backend.yaml
@@ -62,8 +62,13 @@ spec:
               # you flip back to that endpoint, re-enable its health check too.
               echo "waiting for cuda.local llama-server /health..."
               until wget -q -O- http://cuda.local:8081/health 2>/dev/null | grep -q '"ok"'; do sleep 2; done
-              echo "waiting for llama-server-embed /health..."
-              until wget -q -O- http://llama-server-embed:8080/health 2>/dev/null | grep -q '"ok"'; do sleep 2; done
+              # Embeddings moved to the in-cluster ollama service on
+              # 2026-05-13 (configmap OLLAMA_EMBED_URL=http://ollama:11434);
+              # llama-server-embed is scaled to 0. /api/version confirms the
+              # server is up — ollama lazy-loads the embed model on first
+              # request and the backend has retry/fallback for the warm-up.
+              echo "waiting for ollama embed endpoint..."
+              until wget -q -O- http://ollama:11434/api/version 2>/dev/null | grep -q '"version"'; do sleep 2; done
               echo "deps ready"
               # Ensure the persistent HOME exists so Python libs can create
               # their cache dirs there on first run (EasyOCR, HF, torch, whisper).

--- a/k8s/document-worker.yaml
+++ b/k8s/document-worker.yaml
@@ -55,8 +55,11 @@ spec:
               echo "waiting for redis...";    until nc -z redis 6379;    do sleep 1; done
               # /health on llama-server returns {"status":"ok"} only once the GGUF
               # model is fully loaded; TCP-only would pass before warmup.
-              echo "waiting for llama-server-agent /health..."; until wget -q -O- http://llama-server-agent:8080/health 2>/dev/null | grep -q '"ok"'; do sleep 2; done
-              echo "waiting for llama-server-embed /health..."; until wget -q -O- http://llama-server-embed:8080/health 2>/dev/null | grep -q '"ok"'; do sleep 2; done
+              # Agent endpoint moved to cuda.local, embeddings to in-cluster
+              # ollama on 2026-05-13; both in-cluster llama-server-* are
+              # scaled to 0. See k8s/backend.yaml init container for rationale.
+              echo "waiting for cuda.local llama-server /health..."; until wget -q -O- http://cuda.local:8081/health 2>/dev/null | grep -q '"ok"'; do sleep 2; done
+              echo "waiting for ollama embed endpoint...";           until wget -q -O- http://ollama:11434/api/version 2>/dev/null | grep -q '"version"'; do sleep 2; done
               echo "deps ready"
               mkdir -p /app/data/cache-home/.cache /app/data/cache-home/.EasyOCR
           resources:


### PR DESCRIPTION
## Problem

Production `backend` was wedged in `Init:0/1` for **2 days 18 hours**. Root cause: the 2026-05-13 migration (#572) moved the agent endpoint to `cuda.local:8081` and embeddings to the in-cluster `ollama` service (`configmap OLLAMA_EMBED_URL=http://ollama:11434`), scaling both in-cluster `llama-server-{agent,embed}` to **0 replicas**.

#572 only fixed the *agent* wait in `backend.yaml`. Left pointing at the now-dead in-cluster services:
- `backend.yaml` — the *embed* `wait-for-deps` gate (`llama-server-embed:8080`) → backend could never finish init.
- `document-worker.yaml` — *both* the agent and embed gates → would wedge on its next restart (its running pod is 26d old and predates the migration).

A `rollout restart` could not recover backend because the init gate could never pass.

## Fix

- Embed gates → `http://ollama:11434/api/version` (grep `"version"`). ollama lazy-loads the embed model on first request and the backend has retry/fallback, so server-readiness is the right gate. `qwen3-embedding:4b` is confirmed present in ollama.
- `document-worker.yaml` agent gate → `cuda.local:8081`, matching `backend.yaml`.

## Verification

Applied live to `renfield-private` during the v2.6.1 deploy on 2026-05-16:
- `backend`, `document-worker` rolled out successfully (init gate now passes).
- Backend pod on new image digest `sha256:fde5cf…260e6f3c`; `/health` OK in-pod and via `https://renfield.local` ingress.
- Browser E2E: app renders, WebSocket connected, chat history works.

Without this in git, the next clean-checkout redeploy reintroduces the outage gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)