### PR TITLE
feat(chat): render citation chips per-message from persisted metadata

### DIFF
--- a/src/frontend/src/pages/ChatPage/ChatMessages.tsx
+++ b/src/frontend/src/pages/ChatPage/ChatMessages.tsx
@@ -303,7 +303,7 @@ export default function ChatMessages() {
               </ul>
             )}
 
-            {message.role === 'assistant' ? renderMessageContent(message.content, t('chat.albumArt'), chipEntities, `msg-${index}`) : <p className="whitespace-pre-wrap">{message.content}</p>}
+            {message.role === 'assistant' ? renderMessageContent(message.content, t('chat.albumArt'), message.entities ?? chipEntities, `msg-${index}`) : <p className="whitespace-pre-wrap">{message.content}</p>}
 
             {/* Adaptive Card (from WebSocket card message) */}
             {message.card && (

--- a/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
+++ b/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
@@ -37,6 +37,7 @@ import type {
 } from '../hooks/useChatWebSocket';
 import type { UploadStates, UploadedDocument } from '../hooks/useDocumentUpload';
 import type { Conversation } from '../../../types/chat';
+import type { TraceEntity } from '../../../api/resources/wissensbasis';
 import { useConfirmDialog } from '../../../components/ConfirmDialog';
 
 const SESSION_STORAGE_KEY = 'renfield_current_session';
@@ -86,6 +87,27 @@ export interface ChatUiMessage {
   federationProgress?: Record<string, FederationProgressEntry>;
   attachments?: MessageAttachment[];
   card?: Record<string, unknown>;
+  // Entities resolved during THIS turn, persisted per-message by Reva's
+  // on_pre_save_message. Lets the chip renderer wrap mentions per bubble
+  // instead of smearing the session-last reasoning trace across all of them.
+  entities?: TraceEntity[];
+}
+
+/** Map a persisted history message to the in-memory UI shape. */
+function historyToUiMessage(m: {
+  role: string;
+  content: string;
+  metadata?: unknown;
+}): ChatUiMessage {
+  const meta = m.metadata as
+    | { attachments?: MessageAttachment[]; wb_entities?: TraceEntity[] }
+    | undefined;
+  return {
+    role: m.role === 'system' ? 'assistant' : (m.role as 'user' | 'assistant'),
+    content: m.content,
+    ...(meta?.attachments && meta.attachments.length > 0 && { attachments: meta.attachments }),
+    ...(meta?.wb_entities && meta.wb_entities.length > 0 && { entities: meta.wb_entities }),
+  };
 }
 
 interface EmailDialogState {
@@ -1248,14 +1270,7 @@ export function ChatProvider({ children }: ChatProviderProps) {
         try {
           const history = await loadConversationHistory(sessionId);
           if (history.length > 0) {
-            setMessages(history.map((m) => {
-              const meta = m.metadata as { attachments?: MessageAttachment[] } | undefined;
-              return {
-                role: m.role === 'system' ? 'assistant' : m.role,
-                content: m.content,
-                ...(meta?.attachments && meta.attachments.length > 0 && { attachments: meta.attachments }),
-              };
-            }));
+            setMessages(history.map(historyToUiMessage));
           }
         } catch (err) {
           console.error('Failed to load conversation history:', err);
@@ -1278,14 +1293,7 @@ export function ChatProvider({ children }: ChatProviderProps) {
     setHistoryLoading(true);
     try {
       const history = await loadConversationHistory(newSessionId);
-      setMessages(history.map((m) => {
-        const meta = m.metadata as { attachments?: MessageAttachment[] } | undefined;
-        return {
-          role: m.role === 'system' ? 'assistant' : m.role,
-          content: m.content,
-          ...(meta?.attachments && meta.attachments.length > 0 && { attachments: meta.attachments }),
-        };
-      }));
+      setMessages(history.map(historyToUiMessage));
       setSessionId(newSessionId);
       localStorage.setItem(SESSION_STORAGE_KEY, newSessionId);
       setSidebarOpen(false);


### PR DESCRIPTION
## Summary

Web-chat citation chips were sourced from a single session-wide reasoning trace (`/api/wissensbasis/trace` returns only the most-recent turn) and the frontend applied that one entity set to **every** assistant bubble — so in multi-turn conversations only the last turn ever showed chips.

This renders chips **per message** instead:

- `ChatUiMessage` gains optional `entities[]`, populated from `message.metadata.wb_entities` (persisted by Reva's `on_pre_save_message` — see the paired Reva PR).
- `ChatMessages` uses `message.entities ?? chipEntities` so the live streaming turn still falls back to the session trace until it reloads (no regression to the live path).
- The two duplicate inline history mappers in `ChatContext` are consolidated into a shared `historyToUiMessage` helper (behavior-preserving for `attachments` + `role` narrowing).

Pairs with Reva `feat/chip-per-message-entities` (backend persists `metadata["wb_entities"]`). Frontend is backward-compatible: messages without `wb_entities` fall back to existing behavior.

## Test plan

- [x] `tsc --noEmit` clean
- [x] eslint clean on changed files (only pre-existing unrelated warnings)
- [x] Reva-side unit suite verified against the prod image (67 passed, 4 new tests; 2 failures pre-existing baseline)
- [ ] Manual: multi-turn web-chat conversation — chips render on every assistant bubble on reload, not just the last
- [ ] Manual: live streaming turn still chips via session-trace fallback

## Known follow-up (not blocking)

The persisted path excludes `person` entities (GDPR/BetrVG) on the Reva side, but the live pre-reload session-trace fallback is still unfiltered (pre-existing). Tracked as a P1 follow-up (person-type filter at the trace chokepoint + broader person-focus policy audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)