### PR TITLE
test(chat): unit-test historyToUiMessage (per-message chips mapper)

### DIFF
--- a/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
+++ b/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
@@ -94,7 +94,7 @@ export interface ChatUiMessage {
 }
 
 /** Map a persisted history message to the in-memory UI shape. */
-function historyToUiMessage(m: {
+export function historyToUiMessage(m: {
   role: string;
   content: string;
   metadata?: unknown;

--- a/tests/frontend/react/context/historyToUiMessage.test.ts
+++ b/tests/frontend/react/context/historyToUiMessage.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+
+import { historyToUiMessage } from '../../../../src/frontend/src/pages/ChatPage/context/ChatContext';
+
+/**
+ * historyToUiMessage maps a persisted conversation-history row to the
+ * in-memory ChatUiMessage shape. The load-bearing invariants:
+ *
+ *  - system → assistant role normalization (user/assistant pass through)
+ *  - attachments / entities are attached ONLY when present AND non-empty.
+ *    The empty-array omission matters: ChatMessages renders chips with
+ *    `message.entities ?? chipEntities`. An empty `entities: []` is a
+ *    non-null value, so it would suppress the session-trace fallback and
+ *    show NO chips on the live turn. Omitting the key keeps the fallback.
+ */
+describe('historyToUiMessage', () => {
+  it('passes through a user message', () => {
+    const r = historyToUiMessage({ role: 'user', content: 'hi' });
+    expect(r).toEqual({ role: 'user', content: 'hi' });
+  });
+
+  it('passes through an assistant message', () => {
+    const r = historyToUiMessage({ role: 'assistant', content: 'hello' });
+    expect(r).toEqual({ role: 'assistant', content: 'hello' });
+  });
+
+  it('normalizes a system message to assistant', () => {
+    const r = historyToUiMessage({ role: 'system', content: 'sys note' });
+    expect(r.role).toBe('assistant');
+    expect(r.content).toBe('sys note');
+  });
+
+  it('attaches wb_entities as entities when present and non-empty', () => {
+    const ents = [
+      { entity_id: 'Apps/F/R1', display_name: 'Product A - 1.2.3', entity_type: 'release' },
+    ];
+    const r = historyToUiMessage({
+      role: 'assistant',
+      content: 'Releases…',
+      metadata: { wb_entities: ents },
+    });
+    expect(r.entities).toEqual(ents);
+  });
+
+  it('does NOT attach entities for an empty wb_entities array (keeps the chipEntities fallback)', () => {
+    const r = historyToUiMessage({
+      role: 'assistant',
+      content: 'x',
+      metadata: { wb_entities: [] },
+    });
+    expect(r).not.toHaveProperty('entities');
+  });
+
+  it('attaches attachments when present and non-empty', () => {
+    const atts = [{ upload_id: 'u1', filename: 'a.pdf' }];
+    const r = historyToUiMessage({
+      role: 'assistant',
+      content: 'see file',
+      metadata: { attachments: atts },
+    });
+    expect(r.attachments).toEqual(atts);
+  });
+
+  it('does NOT attach attachments for an empty array', () => {
+    const r = historyToUiMessage({
+      role: 'assistant',
+      content: 'x',
+      metadata: { attachments: [] },
+    });
+    expect(r).not.toHaveProperty('attachments');
+  });
+
+  it('carries both attachments and entities when both are present', () => {
+    const atts = [{ upload_id: 'u1', filename: 'a.pdf' }];
+    const ents = [{ entity_id: 'R1', display_name: 'Rel', entity_type: 'release' }];
+    const r = historyToUiMessage({
+      role: 'assistant',
+      content: 'x',
+      metadata: { attachments: atts, wb_entities: ents },
+    });
+    expect(r.attachments).toEqual(atts);
+    expect(r.entities).toEqual(ents);
+  });
+
+  it('handles missing metadata without attachments/entities keys', () => {
+    const r = historyToUiMessage({ role: 'assistant', content: 'x' });
+    expect(r).not.toHaveProperty('attachments');
+    expect(r).not.toHaveProperty('entities');
+  });
+
+  it('ignores unrelated metadata keys', () => {
+    const r = historyToUiMessage({
+      role: 'user',
+      content: 'x',
+      metadata: { intent: 'release', action_success: true },
+    });
+    expect(r).toEqual({ role: 'user', content: 'x' });
+  });
+});


### PR DESCRIPTION
## Summary

Adds the missing Vitest coverage for `historyToUiMessage` (the per-message citation-chips history mapper introduced in #587). Exports the helper (was module-private) and adds `tests/frontend/react/context/historyToUiMessage.test.ts` — 10 cases.

Covers the load-bearing invariants:
- `system` → `assistant` role normalization; `user`/`assistant` pass through
- `attachments` / `entities` attached **only when present AND non-empty** — an empty `entities: []` is a non-null value that would suppress `ChatMessages`' `message.entities ?? chipEntities` fallback and hide chips on the live turn; omitting the key preserves the fallback
- missing/irrelevant metadata → no spurious keys

## Test plan

- [x] `npm run test:run -- context/historyToUiMessage.test.ts` → **10/10 pass**
- [x] Changed file typechecks clean; the single `npm run typecheck` error is **pre-existing & unrelated** — `tests/frontend/react/test-chat-mock.ts`'s `defaultChatContextValue` predates the required `partialText` field on `ChatContextValue` (`ChatContext.tsx:161`), not touched here. Worth a separate tiny mock-drift fix.

Runtime-inert: the only `src/` change is adding an `export` keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)