### PR TITLE
fix(test): add missing partialText to defaultChatContextValue mock

### DIFF
--- a/tests/frontend/react/test-chat-mock.ts
+++ b/tests/frontend/react/test-chat-mock.ts
@@ -58,6 +58,7 @@ export const defaultChatContextValue: ChatContextValue = {
   recording: false,
   audioLevel: 0,
   silenceTimeRemaining: 0,
+  partialText: '',
   toggleRecording: () => {},
 
   // RAG


### PR DESCRIPTION
## Summary

`partialText: string` is a required `ChatContextValue` field (`src/frontend/src/pages/ChatPage/context/ChatContext.tsx:161`), but `tests/frontend/react/test-chat-mock.ts`'s `defaultChatContextValue` predated it — so `npm run typecheck` failed with `test-chat-mock.ts(33,14): error TS2741: Property 'partialText' is missing`. Pre-existing drift, surfaced while adding the `historyToUiMessage` test (#589).

Adds `partialText: ''` (the runtime default when voice-stream is disabled, per `ChatContext.tsx:1020`) alongside the other audio fields.

## Test plan

- [x] `npm run typecheck` — now **clean** across the react test package (was 1 error)
- [x] `npm run test:run -- context/historyToUiMessage.test.ts` → 10/10 still pass

Test-infra only; no `src/` change, no runtime impact, no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)