### PR TITLE
feat: pluggable auth provider registry + post_authenticate hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,36 @@ Dispatch for both is a special case in `services/action_executor.py` that inject
 
 Failed tool turns are persisted with `action_success: False` in message metadata. The `conv_context` builder in `services/agent_service.py` prepends `[VORHERIGE_FEHLGESCHLAGENE_AKTION]` to those assistant messages when re-injecting history into the next agent turn. The `conv_context_template` in `prompts/agent.yaml` carries a hint telling the LLM to treat marker lines as historical, not as current state — so a repeated user request retries the tool instead of echoing the old error.
 
+### Pluggable auth provider registry (ebongard/renfield#591)
+
+`/auth/login` no longer hard-codes "an `authenticate` hook then bcrypt". It
+delegates to `auth/login_flow.py::resolve_login`, which: (1) still honors the
+legacy `authenticate` hook first (a plugin returning a `User` is authoritative
+— unchanged backward-compat seam), then (2) runs the **provider registry**
+credential walk (`auth/registry.py`): providers ordered by ascending
+`priority`, multi-active, per-provider `enabled` gate, **first non-None wins**.
+A provider that raises or exceeds `auth_provider_timeout_seconds` is
+**skipped fail-open** — WARNING log + `auth_provider_unreachable_total{provider_id}`
+counter + continue the walk. (3) On a `ProviderResult`, the **single
+`post_authenticate` hook** fires exactly once *before* the JWT is minted.
+
+The cross-repo contract is `auth/provider_contract.py` (`ProviderResult` frozen
+dataclass + `AuthProvider` Protocol + `PROVIDER_RESULT_CONTRACT_VERSION`).
+Renfield owns authn; the Reva consumer (a `post_authenticate` handler) owns
+identity resolution and returns the renfield user id. **Standalone fallback:**
+0 handlers registered → JWT minted from the `db` provider's subject (legacy
+behavior, keeps the renfield test suite green); ≥1 handler registered but none
+resolve → login denied (no half-bound token). JWT `sub` unchanged; the cosmetic
+`username` claim now carries `display_name` (no consumer reads it).
+
+Built-ins (`auth/providers/`): `db` (priority 100, always on, wraps bcrypt),
+`ldap` (priority 50, authn-only — no local-user create; that is the
+identity consumer's job; config-gated), `google`/`github`/`apple` (redirect
+providers, **`enabled=False` by default**, enabling is config-only). The
+group→role **authz seam is defined in docstrings only**, not implemented this
+delivery (`extras["ldap_member_of"]` is carried but unused). New config:
+`ldap_auth_*`, `oauth_{google,github,apple}_*`, `auth_provider_timeout_seconds`.
+
 ### Circles v1 (access tiers)
 
 Detailed user-facing and architectural documentation: [`docs/CIRCLES.md`](docs/CIRCLES.md). Narrative of the broader knowledge system (the four subsystems circles protect): [`docs/SECOND_BRAIN.md`](docs/SECOND_BRAIN.md). Code-level summary below.

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -665,6 +665,39 @@ DEFAULT_ADMIN_PASSWORD=changeme
 # Voice Authentication
 VOICE_AUTH_ENABLED=false
 VOICE_AUTH_MIN_CONFIDENCE=0.7
+
+# === Pluggable auth provider registry (ebongard/renfield#591) ===
+# Per-provider credential-walk timeout; a provider exceeding this is
+# skipped fail-open (WARNING + auth_provider_unreachable_total counter).
+AUTH_PROVIDER_TIMEOUT_SECONDS=10.0
+
+# LDAP credential provider (authn only — no group→role mapping yet).
+# Default off → DB-only behavior unchanged.
+LDAP_AUTH_ENABLED=false
+LDAP_URL=                              # ldaps://host:636 or ldap://host:389
+LDAP_BIND_DN=                          # service account DN for the user search
+LDAP_BIND_PASSWORD=
+LDAP_AUTH_USER_BASE_DN=                # subtree searched for the user
+LDAP_AUTH_USER_FILTER=(uid={username}) # {username} is substituted (RFC4515-escaped)
+LDAP_CONNECT_TIMEOUT=5
+LDAP_RECEIVE_TIMEOUT=10
+
+# Social redirect providers — all ship disabled; enabling is config-only
+# (no redeploy), off the credential critical path.
+OAUTH_GOOGLE_ENABLED=false
+OAUTH_GOOGLE_CLIENT_ID=
+OAUTH_GOOGLE_CLIENT_SECRET=
+OAUTH_GOOGLE_REDIRECT_URI=
+OAUTH_GITHUB_ENABLED=false
+OAUTH_GITHUB_CLIENT_ID=
+OAUTH_GITHUB_CLIENT_SECRET=
+OAUTH_GITHUB_REDIRECT_URI=
+OAUTH_APPLE_ENABLED=false
+OAUTH_APPLE_CLIENT_ID=                 # Apple Services ID
+OAUTH_APPLE_TEAM_ID=
+OAUTH_APPLE_KEY_ID=
+OAUTH_APPLE_PRIVATE_KEY=
+OAUTH_APPLE_REDIRECT_URI=
 ```
 
 **Defaults:**
@@ -677,6 +710,9 @@ VOICE_AUTH_MIN_CONFIDENCE=0.7
 - `DEFAULT_ADMIN_PASSWORD`: `changeme`
 - `VOICE_AUTH_ENABLED`: `false`
 - `VOICE_AUTH_MIN_CONFIDENCE`: `0.7`
+- `AUTH_PROVIDER_TIMEOUT_SECONDS`: `10.0`
+- `LDAP_AUTH_ENABLED`: `false` · `LDAP_AUTH_USER_FILTER`: `(uid={username})` · `LDAP_CONNECT_TIMEOUT`: `5` · `LDAP_RECEIVE_TIMEOUT`: `10`
+- `OAUTH_{GOOGLE,GITHUB,APPLE}_ENABLED`: `false` (all social providers disabled by default — enabling is a config-only change)
 
 **Produktion:**
 ```bash

--- a/src/backend/api/routes/auth.py
+++ b/src/backend/api/routes/auth.py
@@ -20,7 +20,6 @@ from models.database import Role, User
 from models.permissions import get_all_permissions
 from services.api_rate_limiter import limiter
 from services.auth_service import (
-    authenticate_user,
     create_access_token,
     create_refresh_token,
     create_user,
@@ -116,24 +115,40 @@ async def login(
     Uses OAuth2 password flow (username + password in form data).
     Returns access token (short-lived) and refresh token (long-lived).
     """
-    # Pluggable auth: check hooks first (e.g. LDAP, SAML, OAuth).
-    # If a hook returns a User object, skip the default DB-based auth.
-    # If all hooks return None, fall through to the default.
-    from utils.hooks import run_hooks
+    # Pluggable auth provider registry (ebongard/renfield#591). This
+    # generalizes the pre-registry "authenticate hook → bcrypt fallback"
+    # two-step without breaking it: the legacy `authenticate` hook is still
+    # honored first; the DB/LDAP/social providers run the credential walk;
+    # `post_authenticate` is fired exactly once before the JWT is minted.
+    # See auth/login_flow.py for the full resolution + standalone-fallback
+    # contract.
+    from auth.login_flow import resolve_login
 
-    hook_results = await run_hooks(
-        "authenticate",
+    outcome = await resolve_login(
+        db=db,
         username=form_data.username,
         password=form_data.password,
-        db=db,
+        channel="web",
     )
-    user = next((r for r in hook_results if r is not None), None)
 
-    # Default: DB-based bcrypt authentication
-    if user is None:
-        user = await authenticate_user(db, form_data.username, form_data.password)
+    if outcome is None:
+        # Bad credentials OR a registered post_authenticate consumer declined
+        # to resolve — both are an opaque 401 (do not leak which).
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
-    if not user:
+    # Re-load on the request session to mint tokens / update last_login, and
+    # enforce is_active uniformly. NOTE: pre-registry, a legacy `authenticate`
+    # hook returning a *disabled* User would still get tokens (only the bcrypt
+    # path checked is_active). The registry path now rejects inactive users on
+    # every path (intended hardening). The response is the SAME opaque 401 as
+    # bad credentials — never a distinct 403 — so login does not leak whether a
+    # disabled account exists (no user-enumeration oracle).
+    user = await get_user_by_id(db, outcome.user_id)
+    if not user or not user.is_active:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect username or password",
@@ -144,13 +159,18 @@ async def login(
     user.last_login = datetime.now(UTC).replace(tzinfo=None)
     await db.commit()
 
-    # Create tokens
+    # Create tokens. `sub` (= renfield user id) is the only consumed identity
+    # claim; the cosmetic `username` claim now carries display_name (no
+    # consumer reads it — verified design decision #6).
     access_token = create_access_token(
-        data={"sub": str(user.id), "username": user.username}
+        data={"sub": str(user.id), "username": outcome.display_name}
     )
     refresh_token = create_refresh_token(user.id)
 
-    logger.info(f"User logged in: {user.username}")
+    logger.info(
+        f"User logged in: {user.username} "
+        f"(provider={outcome.provider_id})"
+    )
 
     return TokenResponse(
         access_token=access_token,

--- a/src/backend/auth/__init__.py
+++ b/src/backend/auth/__init__.py
@@ -1,0 +1,36 @@
+"""Renfield pluggable authentication: provider contract + registry.
+
+Public surface:
+    ProviderResult, AuthProvider, PROVIDER_RESULT_CONTRACT_VERSION
+        — the cross-repo contract (ebongard/renfield#591).
+    ProviderRegistry, get_registry, build_default_registry
+        — priority-ordered, multi-active provider registry.
+    resolve_login
+        — runs the credential walk, fires ``post_authenticate`` once, and
+          returns the resolution outcome for ``/auth/login``.
+"""
+
+from auth.provider_contract import (
+    PROVIDER_RESULT_CONTRACT_VERSION,
+    AuthProvider,
+    ProviderResult,
+)
+from auth.login_flow import LoginOutcome, resolve_login
+from auth.registry import (
+    ProviderRegistry,
+    build_default_registry,
+    get_registry,
+    set_registry,
+)
+
+__all__ = [
+    "PROVIDER_RESULT_CONTRACT_VERSION",
+    "AuthProvider",
+    "ProviderResult",
+    "ProviderRegistry",
+    "build_default_registry",
+    "get_registry",
+    "set_registry",
+    "LoginOutcome",
+    "resolve_login",
+]

--- a/src/backend/auth/login_flow.py
+++ b/src/backend/auth/login_flow.py
@@ -1,0 +1,111 @@
+"""`/auth/login` resolution: registry walk + the single ``post_authenticate``.
+
+This generalizes the pre-registry two-step (``authenticate`` hook → bcrypt
+fallback) WITHOUT breaking it:
+
+  1. **Legacy ``authenticate`` hook** (unchanged): if a plugin's hook returns
+     a Renfield ``User``, that is authoritative — exactly today's behavior,
+     bit-for-bit. (No ``post_authenticate`` is fired here: the legacy hook has
+     already resolved identity to a concrete User row. This is the
+     backward-compat seam acceptance criterion #6 protects.)
+  2. Else the **provider registry credential walk** runs. Its built-in
+     ``DBProvider`` replaces the old inline bcrypt fallback; ``LDAPProvider``
+     and any plugin-registered providers participate by priority.
+  3. On a registry ``ProviderResult``, ``post_authenticate`` is fired **exactly
+     once, before any JWT is minted**:
+       * a consumer is registered and resolves → its renfield user id is used;
+       * a consumer is registered but none resolve → **deny** (return None);
+       * **no** consumer registered (standalone Renfield) → legacy fallback:
+         the ``db`` provider's subject IS the renfield user id; any other
+         provider cannot be resolved without an identity layer → deny.
+
+Returns a :class:`LoginOutcome` (the route loads the ``User`` by id to update
+``last_login`` and mint tokens) or ``None`` (→ 401; the route does not
+distinguish "bad credentials" from "unresolved" — both are 401).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from loguru import logger
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.registry import get_registry
+from utils.hooks import has_hook, run_hooks
+
+
+@dataclass(frozen=True)
+class LoginOutcome:
+    """What `/auth/login` needs to mint a token. ``provider_id`` is for audit
+    logging only (``legacy_hook`` for the backward-compat path)."""
+
+    user_id: int
+    display_name: str
+    provider_id: str
+
+
+def _display_name_from_user(user) -> str:
+    parts = [p for p in (getattr(user, "first_name", None),
+                          getattr(user, "last_name", None)) if p]
+    return " ".join(parts) if parts else user.username
+
+
+async def resolve_login(
+    *,
+    db: AsyncSession,
+    username: str,
+    password: str,
+    channel: str = "web",
+) -> LoginOutcome | None:
+    # --- Step 1: legacy `authenticate` hook (unchanged existing seam) -------
+    legacy_results = await run_hooks(
+        "authenticate", username=username, password=password, db=db
+    )
+    legacy_user = next((r for r in legacy_results if r is not None), None)
+    if legacy_user is not None:
+        return LoginOutcome(
+            user_id=int(legacy_user.id),
+            display_name=_display_name_from_user(legacy_user),
+            provider_id="legacy_hook",
+        )
+
+    # --- Step 2: provider registry credential walk -------------------------
+    result = await get_registry().authenticate(
+        username=username, password=password, channel=channel
+    )
+    if result is None:
+        return None  # every provider declined → 401 (bad credentials)
+
+    # --- Step 3: fire post_authenticate exactly once, before JWT mint ------
+    if has_hook("post_authenticate"):
+        resolutions = await run_hooks("post_authenticate", result=result)
+        resolved = next((r for r in resolutions if r is not None), None)
+        if resolved is None:
+            # Consumer present but unresolved (no signal / version mismatch /
+            # consumer crashed → run_hooks swallowed it). Deny — never mint a
+            # half-bound token.
+            logger.warning(
+                f"post_authenticate did not resolve provider "
+                f"{result.provider_id!r} result — login denied"
+            )
+            return None
+        return LoginOutcome(
+            user_id=int(resolved),
+            display_name=result.display_name,
+            provider_id=result.provider_id,
+        )
+
+    # No consumer registered → standalone legacy fallback.
+    if result.provider_id == "db":
+        return LoginOutcome(
+            user_id=int(result.subject),
+            display_name=result.display_name,
+            provider_id=result.provider_id,
+        )
+    logger.warning(
+        f"Provider {result.provider_id!r} authenticated but no "
+        f"post_authenticate consumer is registered to resolve a non-DB "
+        f"identity — login denied (standalone Renfield)"
+    )
+    return None

--- a/src/backend/auth/provider_contract.py
+++ b/src/backend/auth/provider_contract.py
@@ -1,0 +1,211 @@
+"""Renfield pluggable-auth provider contract, v1.
+
+The cross-repo seam between Renfield (owns authentication) and Reva (owns
+identity). The ONLY thing crossing the repo boundary is one value object
+(``ProviderResult``) emitted through one hook (``post_authenticate``). Keeping
+that surface tiny and versioned is what lets the two repos move on independent
+release cadences.
+
+  RENFIELD                                   REVA
+  AuthProvider.authenticate()        \\
+  (DB, LDAP) — credential walk        \\
+                                        >--> post_authenticate(ProviderResult)
+  redirect callback (Google, GitHub,  /        |
+  Apple; Reva adds Entra/SAML)       /         v
+                                        adapt → ProviderLookupResult
+                                        → IdentityService canonical join
+                                        → one renfield_user_id
+
+Verified consumer shape (so the adapter is real, not guessed):
+``reva.identity.types.ProviderLookupResult`` (src/reva/identity/types.py:108-134):
+    subject: str
+    display_name: str
+    primary_email: str | None = None
+    system_projections: dict[str, str] = {}
+    extras: dict[str, str] = {}
+
+This contract is pinned by ``ebongard/renfield#591``. Any breaking change to
+``ProviderResult`` bumps ``PROVIDER_RESULT_CONTRACT_VERSION`` and is coordinated
+across both repos in one push.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+# Bump on ANY breaking change to ProviderResult. Renfield and the Reva submodule
+# bump together in one push. The Reva hook consumer rejects a ProviderResult
+# whose `v` it does not understand (logged + counter) rather than mis-adapting it.
+PROVIDER_RESULT_CONTRACT_VERSION = 1
+
+
+@dataclass(frozen=True)
+class ProviderResult:
+    """The single value object that crosses the Renfield→Reva boundary.
+
+    Emitted by Renfield once a provider has successfully authenticated a human,
+    via the ``post_authenticate`` hook. Frozen: a provider must not mutate a
+    result after returning it; the hook consumer treats it as read-only.
+
+    Field-by-field:
+
+    v:
+        Contract version. Always set to ``PROVIDER_RESULT_CONTRACT_VERSION`` by
+        the producing Renfield build. The Reva consumer compares and refuses
+        unknown majors (fail-closed on contract mismatch — distinct from the
+        fail-OPEN provider-down policy).
+
+    provider_id:
+        Stable provider key: ``db``, ``ldap``, ``google``, ``github``,
+        ``apple`` (Renfield built-ins) or ``entra``, ``saml`` (Reva edition
+        providers registered into the same registry). Lowercase, no spaces.
+        Used for the per-provider projection key and audit.
+
+    subject:
+        The provider-stable, opaque, immutable user id within that provider
+        (LDAP entryUUID, OIDC ``sub``/``oid``, GitHub numeric id, ...). This is
+        the STRONG per-method identity key. Never an email, never a username.
+        Maps to ProviderLookupResult.subject and ultimately
+        canonical_users.subject for same-provider re-login.
+
+    email:
+        Normalized email or None. Normalization rule (locked): lowercase + trim
+        ONLY. No Gmail dot/plus folding. Treat as opaque. None when the
+        provider exposes no email (common for Teams-derived flows).
+
+    email_verified:
+        True only if the provider asserts the email is verified. The
+        cross-provider email JOIN uses the email ONLY when this is True. An
+        unverified or absent email never links two identities.
+
+    display_name:
+        Human-readable, display-only. Never an identity key (mutable, not
+        unique). Maps to ProviderLookupResult.display_name.
+
+    system_projections:
+        Per-integration external IDs this provider can assert, as
+        ``{system: external_id}``. THIS is how Teams unifies with web: the
+        Entra provider emits ``{"entra": "<oid>"}`` and the Teams channel
+        adapter resolves the same ``entra:<oid>`` projection — so Teams (which
+        has no verified email) still joins the canonical human. Each entry
+        becomes a user_projection row. Values are opaque strings.
+
+    extras:
+        Opaque provider attributes for the DOWNSTREAM AUTHZ layer only. The
+        canonical identity layer never interprets these. Type is
+        ``dict[str, str]`` to match the existing consumer; structured values
+        (e.g. LDAP ``memberOf``, a list) MUST be serialized by the provider —
+        convention: JSON-encoded string under a documented key
+        (e.g. ``extras["ldap_member_of"] = '["cn=...","cn=..."]'``). The authz
+        provider layer (separate, not in this delivery) deserializes.
+
+    channel:
+        Originating channel: ``web``, ``teams_chat``, ``teams_tab`` (extensible).
+        The Reva channel adapter uses this to enforce the channel × provider
+        compatibility matrix (e.g. reject ``github`` on ``teams_tab``).
+    """
+
+    v: int
+    provider_id: str
+    subject: str
+    email_verified: bool
+    display_name: str
+    channel: str
+    email: str | None = None
+    system_projections: dict[str, str] = field(default_factory=dict)
+    extras: dict[str, str] = field(default_factory=dict)
+
+
+@runtime_checkable
+class AuthProvider(Protocol):
+    """What every provider plugs into the Renfield registry implements.
+
+    Two entry styles, one output:
+      * Credential providers (db, ldap): the registry calls ``authenticate``
+        in a PRIORITY WALK. First non-None wins. A provider that raises/timeouts
+        is SKIPPED (fail-open) — the registry logs WARNING + increments
+        ``auth_provider_unreachable_total{provider_id}`` and continues the walk.
+      * Federated/redirect providers (google, github, apple, entra, saml): NOT
+        in the credential walk. They are user-selected entry points; their
+        redirect callback constructs the ``ProviderResult`` directly.
+
+    Either way the result reaches Reva through the single ``post_authenticate``
+    hook — see the hook contract docstring below.
+
+    Authz seam (defined, NOT implemented this delivery): a future
+    authz-provider layer will consume ``ProviderResult.extras`` (e.g.
+    deserialize ``extras["ldap_member_of"]``) to map provider groups → Renfield
+    roles. Today's providers only carry the raw attributes in ``extras``; no
+    provider performs group→role mapping. See ``ebongard/renfield#591`` and the
+    approved design's "Authz seam" decision.
+    """
+
+    #: Stable lowercase key, matches ProviderResult.provider_id.
+    provider_id: str
+
+    #: Channels this provider supports, e.g. {"web"} or
+    #: {"web", "teams_chat", "teams_tab"} for Entra. The registry + Reva
+    #: channel adapter enforce the compatibility matrix from this.
+    supported_channels: frozenset[str]
+
+    #: Registry resolution order for credential providers (lower = earlier in
+    #: the priority walk). Ignored for redirect providers.
+    priority: int
+
+    #: Default-off gate. Social providers ship enabled=False; flipping it is a
+    #: config-only change (no redeploy, does not touch braid-deletion/rollback).
+    enabled: bool
+
+    async def authenticate(
+        self, *, username: str, password: str, channel: str
+    ) -> ProviderResult | None:
+        """Credential providers only. Return a ``ProviderResult`` on success,
+        ``None`` to fall through to the next provider in the walk. Raising or
+        timing out is treated as provider-unreachable → skipped (fail-open).
+        Redirect providers implement this as ``return None`` and produce their
+        ``ProviderResult`` in their OAuth/OIDC callback instead.
+        """
+        ...
+
+
+# ------------------------------------------------------------------------------
+# post_authenticate hook contract (the cross-repo seam)
+# ------------------------------------------------------------------------------
+#
+# Renfield fires exactly ONE hook after any provider (credential-walk winner OR
+# redirect-callback) authenticates a human, BEFORE minting the JWT:
+#
+#     await run_hooks("post_authenticate", result=<ProviderResult>)
+#
+#   * Fires once per successful authentication, regardless of entry style.
+#   * Reva's registered consumer adapts ProviderResult → ProviderLookupResult,
+#     runs the canonical join ((provider_id,subject) → shared projection →
+#     verified email), and returns the resolved renfield_user_id.
+#   * The JWT `sub` (= renfield_user_id) remains the only consumed identity
+#     claim (verified: auth_service.py:242, verify_route.py:76). The `username`
+#     claim is cosmetic and standardized to display_name; no consumer depends
+#     on it.
+#   * If a consumer is registered but cannot resolve (no signal,
+#     contract-version mismatch), Renfield denies the login rather than minting
+#     a half-bound token.
+#   * If NO consumer is registered at all (standalone Renfield, e.g. the
+#     renfield repo's own test suite or a renfield-without-reva deploy),
+#     Renfield falls back to legacy behavior: the JWT is minted from the
+#     authenticated Renfield User row directly. This preserves pre-registry
+#     behavior and is an implementation nuance — it does not alter this
+#     cross-repo surface.
+#
+# Adapter (lives in REVA, shown here so the contract is unambiguous):
+#
+#     ProviderResult                  →  ProviderLookupResult
+#     ------------------------------------------------------------
+#     subject                         →  subject
+#     display_name                    →  display_name
+#     email if email_verified else _  →  primary_email
+#     system_projections              →  system_projections
+#                                        (+ {provider_id: subject} added so
+#                                         same-provider re-login is a direct hit)
+#     extras                          →  extras   (authz layer only)
+#     v / channel / provider_id       →  consumed by the adapter itself
+#                                        (version gate, matrix enforce, key)

--- a/src/backend/auth/providers/__init__.py
+++ b/src/backend/auth/providers/__init__.py
@@ -1,0 +1,9 @@
+"""Built-in Renfield auth providers.
+
+Credential providers (in the priority walk): ``db`` (priority 100),
+``ldap`` (priority 50 — tried before DB, mirroring the pre-registry
+``authenticate``-hook-before-bcrypt order).
+
+Redirect providers (NOT in the walk; user-selected entry points):
+``google``, ``github``, ``apple`` — all ``enabled=False`` by default.
+"""

--- a/src/backend/auth/providers/apple.py
+++ b/src/backend/auth/providers/apple.py
@@ -1,0 +1,41 @@
+"""Sign in with Apple redirect provider. enabled=False by default.
+
+See google.py for why redirect providers expose only ``authorize_url`` here.
+Apple uses ``response_mode=form_post`` (scopes name/email are returned to the
+callback as a POST). client_id is the Services ID; the team_id/key_id/private
+key are only needed by the (Reva-side) client-secret-JWT mint at callback time.
+"""
+
+from __future__ import annotations
+
+import secrets
+from urllib.parse import urlencode
+
+from auth.providers.base import RedirectProvider
+from utils.config import settings
+
+_AUTHORIZE = "https://appleid.apple.com/auth/authorize"
+
+
+class AppleProvider(RedirectProvider):
+    provider_id = "apple"
+    supported_channels = frozenset({"web"})
+
+    @property
+    def enabled(self) -> bool:
+        return settings.oauth_apple_enabled
+
+    def authorize_url(self, channel: str) -> str | None:
+        if not settings.oauth_apple_enabled:
+            return None
+        if not settings.oauth_apple_client_id or not settings.oauth_apple_redirect_uri:
+            return None
+        params = {
+            "client_id": settings.oauth_apple_client_id,
+            "redirect_uri": settings.oauth_apple_redirect_uri,
+            "response_type": "code",
+            "scope": "name email",
+            "response_mode": "form_post",
+            "state": secrets.token_urlsafe(24),
+        }
+        return f"{_AUTHORIZE}?{urlencode(params)}"

--- a/src/backend/auth/providers/base.py
+++ b/src/backend/auth/providers/base.py
@@ -1,0 +1,80 @@
+"""Shared helpers + base classes for built-in providers.
+
+These do not extend the cross-repo contract (``provider_contract.py`` stays
+byte-faithful to ebongard/renfield#591). They are Renfield-internal
+conveniences so each provider is small and consistent.
+"""
+
+from __future__ import annotations
+
+from auth.provider_contract import (
+    PROVIDER_RESULT_CONTRACT_VERSION,
+    ProviderResult,
+)
+
+
+def normalize_email(email: str | None) -> str | None:
+    """Contract-locked normalization: lowercase + trim ONLY.
+
+    No Gmail dot/plus folding. Empty/whitespace-only → None. Treat the result
+    as opaque (see ProviderResult.email docstring).
+    """
+    if email is None:
+        return None
+    cleaned = email.strip().lower()
+    return cleaned or None
+
+
+def make_result(
+    *,
+    provider_id: str,
+    subject: str,
+    display_name: str,
+    channel: str,
+    email: str | None = None,
+    email_verified: bool = False,
+    system_projections: dict[str, str] | None = None,
+    extras: dict[str, str] | None = None,
+) -> ProviderResult:
+    """Build a ``ProviderResult`` with ``v`` pinned to the contract version and
+    the email normalized. Single construction point so every built-in provider
+    stamps ``v`` and normalizes identically."""
+    return ProviderResult(
+        v=PROVIDER_RESULT_CONTRACT_VERSION,
+        provider_id=provider_id,
+        subject=subject,
+        email=normalize_email(email),
+        email_verified=email_verified and normalize_email(email) is not None,
+        display_name=display_name,
+        channel=channel,
+        system_projections=dict(system_projections or {}),
+        extras=dict(extras or {}),
+    )
+
+
+class RedirectProvider:
+    """Base for federated/redirect providers (google, github, apple, …).
+
+    Not in the credential walk: ``authenticate`` always returns ``None``. The
+    OAuth/OIDC callback (Reva-side channel wiring, future) constructs the
+    ``ProviderResult`` and feeds it through ``post_authenticate``. Here we only
+    own the registry-facing metadata + the ``authorize_url`` entry point the
+    login UI renders, so each social provider is independently testable and off
+    the credential critical path.
+    """
+
+    provider_id: str = ""
+    supported_channels: frozenset[str] = frozenset({"web"})
+    # priority is ignored for redirect providers; kept high so an accidental
+    # appearance in a sorted view never precedes a real credential provider.
+    priority: int = 1000
+    enabled: bool = False
+
+    async def authenticate(
+        self, *, username: str, password: str, channel: str
+    ) -> ProviderResult | None:
+        return None
+
+    def authorize_url(self, channel: str) -> str | None:  # pragma: no cover -
+        """Override: return the IdP authorize URL for *channel*, or None."""
+        return None

--- a/src/backend/auth/providers/db.py
+++ b/src/backend/auth/providers/db.py
@@ -1,0 +1,53 @@
+"""DB credential provider — wraps Renfield's existing bcrypt auth.
+
+This is the always-on, lowest-precedence credential provider (priority 100):
+the registry walks higher-precedence providers (e.g. LDAP at 50) first, then
+falls back to local bcrypt — exactly the pre-registry
+``authenticate``-hook-then-``authenticate_user`` order.
+
+``subject`` is the Renfield user id as a string. In a standalone Renfield
+(no ``post_authenticate`` consumer) ``/auth/login`` uses this subject directly
+as the JWT ``sub`` — that is the legacy-fallback path.
+"""
+
+from __future__ import annotations
+
+from auth.provider_contract import ProviderResult
+from auth.providers.base import make_result
+from services.auth_service import authenticate_user
+from services.database import AsyncSessionLocal
+
+
+def _display_name(user) -> str:
+    parts = [p for p in (user.first_name, user.last_name) if p]
+    return " ".join(parts) if parts else user.username
+
+
+class DBProvider:
+    """Local username/password against the ``users`` table (bcrypt)."""
+
+    provider_id = "db"
+    supported_channels = frozenset({"web"})
+    priority = 100
+    enabled = True
+
+    async def authenticate(
+        self, *, username: str, password: str, channel: str
+    ) -> ProviderResult | None:
+        # Own short-lived session: the contract signature carries no db
+        # handle, and the credential walk must not borrow the request session
+        # (a failed bcrypt check should not touch request-scoped tx state).
+        async with AsyncSessionLocal() as session:
+            user = await authenticate_user(session, username, password)
+            if user is None:
+                return None
+            return make_result(
+                provider_id=self.provider_id,
+                subject=str(user.id),
+                display_name=_display_name(user),
+                channel=channel,
+                email=user.email,
+                # Local accounts are not email-verified by Renfield; the
+                # cross-provider email join must not link on this.
+                email_verified=False,
+            )

--- a/src/backend/auth/providers/github.py
+++ b/src/backend/auth/providers/github.py
@@ -1,0 +1,38 @@
+"""GitHub OAuth redirect provider. enabled=False by default.
+
+See google.py for why redirect providers expose only ``authorize_url`` here;
+the callback (code→token→user, then ``post_authenticate``) is Reva-side.
+"""
+
+from __future__ import annotations
+
+import secrets
+from urllib.parse import urlencode
+
+from auth.providers.base import RedirectProvider
+from utils.config import settings
+
+_AUTHORIZE = "https://github.com/login/oauth/authorize"
+
+
+class GitHubProvider(RedirectProvider):
+    provider_id = "github"
+    supported_channels = frozenset({"web"})
+
+    @property
+    def enabled(self) -> bool:
+        return settings.oauth_github_enabled
+
+    def authorize_url(self, channel: str) -> str | None:
+        if not settings.oauth_github_enabled:
+            return None
+        if not settings.oauth_github_client_id or not settings.oauth_github_redirect_uri:
+            return None
+        params = {
+            "client_id": settings.oauth_github_client_id,
+            "redirect_uri": settings.oauth_github_redirect_uri,
+            "scope": "read:user user:email",
+            "state": secrets.token_urlsafe(24),
+            "allow_signup": "false",
+        }
+        return f"{_AUTHORIZE}?{urlencode(params)}"

--- a/src/backend/auth/providers/google.py
+++ b/src/backend/auth/providers/google.py
@@ -1,0 +1,44 @@
+"""Google OAuth2 / OIDC redirect provider. enabled=False by default.
+
+Not in the credential walk. ``authorize_url`` is the only Renfield-side
+surface: it builds the consent URL the login UI links to. The OAuth callback
+(token exchange + id_token → ``ProviderResult`` + ``post_authenticate``) is
+Reva-side channel wiring and out of scope for this PR — enabling this provider
+without that wiring renders a button that has no callback yet, which is why it
+ships off by default.
+"""
+
+from __future__ import annotations
+
+import secrets
+from urllib.parse import urlencode
+
+from auth.providers.base import RedirectProvider
+from utils.config import settings
+
+_AUTHORIZE = "https://accounts.google.com/o/oauth2/v2/auth"
+
+
+class GoogleProvider(RedirectProvider):
+    provider_id = "google"
+    supported_channels = frozenset({"web"})
+
+    @property
+    def enabled(self) -> bool:
+        return settings.oauth_google_enabled
+
+    def authorize_url(self, channel: str) -> str | None:
+        if not settings.oauth_google_enabled:
+            return None
+        if not settings.oauth_google_client_id or not settings.oauth_google_redirect_uri:
+            return None
+        params = {
+            "client_id": settings.oauth_google_client_id,
+            "redirect_uri": settings.oauth_google_redirect_uri,
+            "response_type": "code",
+            "scope": "openid email profile",
+            "state": secrets.token_urlsafe(24),
+            "access_type": "online",
+            "prompt": "select_account",
+        }
+        return f"{_AUTHORIZE}?{urlencode(params)}"

--- a/src/backend/auth/providers/ldap.py
+++ b/src/backend/auth/providers/ldap.py
@@ -1,0 +1,203 @@
+"""LDAP credential provider — authn only.
+
+Ported from Reva's proven ``ldap_auth.py`` (RFC 4515 filter escaping,
+service-account search + user-bind verify, TLS via ``ldaps://``,
+connect/receive timeouts). What is intentionally NOT ported: local Renfield
+user creation/update. Under the registry, identity resolution
+(create-or-link a canonical user) is the ``post_authenticate`` consumer's job
+(Reva). This provider only proves "these credentials are valid for this
+directory subject" and emits a ``ProviderResult``.
+
+Fail semantics (so the registry's fail-open policy is correct):
+  * wrong password / user not found  → return ``None`` (decline, continue walk)
+  * directory unreachable / timeout  → **raise** (registry skips + increments
+    ``auth_provider_unreachable_total{ldap}`` + continues the walk)
+  * ldap3 missing / unconfigured     → log + return ``None`` (misconfig is not
+    an outage; do not pollute the unreachable counter)
+
+Authz seam (defined, NOT implemented here): ``memberOf`` is serialized into
+``extras["ldap_member_of"]`` as a JSON string per the contract convention. No
+group→role mapping happens in this delivery — a future authz-provider layer
+deserializes it. See provider_contract.py.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from loguru import logger
+
+from auth.provider_contract import ProviderResult
+from auth.providers.base import make_result
+from utils.config import settings
+
+_LDAP_ESCAPE_RE = re.compile(r"([\\*\(\)\x00/])")
+
+
+def _escape_ldap_filter(value: str) -> str:
+    """Escape special characters in an LDAP filter value per RFC 4515."""
+    return _LDAP_ESCAPE_RE.sub(lambda m: f"\\{ord(m.group(1)):02x}", value)
+
+
+def _attr(attrs: dict[str, Any], key: str, default: str = "") -> str:
+    val = attrs.get(key, default)
+    if isinstance(val, list):
+        return str(val[0]) if val else default
+    return str(val) if val else default
+
+
+class LDAPProvider:
+    """Directory bind verification. Priority 50 → walked before DB."""
+
+    provider_id = "ldap"
+    supported_channels = frozenset({"web"})
+    priority = 50
+
+    @property
+    def enabled(self) -> bool:
+        # Config-driven so enabling is a config-only change (no redeploy) and
+        # tests can flip it via settings.
+        return settings.ldap_auth_enabled
+
+    async def authenticate(
+        self, *, username: str, password: str, channel: str
+    ) -> ProviderResult | None:
+        if not settings.ldap_auth_enabled:
+            return None
+        if not username or not password:
+            return None
+
+        try:
+            import ldap3
+            from ldap3 import SAFE_SYNC, Connection, Server
+        except ImportError:
+            logger.error("ldap3 not installed — LDAP auth unavailable")
+            return None
+
+        user_base_dn = settings.ldap_auth_user_base_dn
+        if not user_base_dn or not settings.ldap_url:
+            logger.warning(
+                "LDAP auth enabled but LDAP_URL / LDAP_AUTH_USER_BASE_DN "
+                "not configured — declining"
+            )
+            return None
+
+        safe_username = _escape_ldap_filter(username)
+        user_filter = settings.ldap_auth_user_filter.format(
+            username=safe_username
+        )
+
+        use_ssl = settings.ldap_url.startswith("ldaps://")
+        server = Server(
+            settings.ldap_url,
+            use_ssl=use_ssl,
+            connect_timeout=settings.ldap_connect_timeout,
+        )
+
+        try:
+            # Step 1: service-account bind → locate the user entry.
+            with Connection(
+                server,
+                user=settings.ldap_bind_dn,
+                password=settings.ldap_bind_password.get_secret_value(),
+                auto_bind=True,
+                receive_timeout=settings.ldap_receive_timeout,
+                client_strategy=SAFE_SYNC,
+            ) as conn:
+                # SAFE_SYNC → entries live in `response`, not conn.entries.
+                _ok, _result, response, _request = conn.search(
+                    search_base=user_base_dn,
+                    search_filter=user_filter,
+                    attributes=[
+                        "entryUUID",
+                        "objectGUID",
+                        "displayName",
+                        "mail",
+                        "memberOf",
+                        "uid",
+                        "cn",
+                        "sn",
+                        "givenName",
+                        "sAMAccountName",
+                    ],
+                )
+                entries = [
+                    r
+                    for r in (response or [])
+                    if r.get("type") == "searchResEntry"
+                ]
+                if not entries:
+                    logger.debug(
+                        f"LDAP auth: user {username!r} not found in "
+                        f"{user_base_dn}"
+                    )
+                    return None
+                user_dn = entries[0]["dn"]
+                attrs = entries[0].get("attributes", {})
+
+            # Step 2: user-bind → verify the supplied password.
+            with Connection(
+                server,
+                user=user_dn,
+                password=password,
+                auto_bind=True,
+                receive_timeout=settings.ldap_receive_timeout,
+                client_strategy=SAFE_SYNC,
+            ):
+                pass  # bind ok ⇒ credentials valid
+
+        except ldap3.core.exceptions.LDAPBindError:
+            logger.debug(
+                f"LDAP auth: bind failed for {username!r} (wrong password "
+                f"or not found)"
+            )
+            return None
+        except ldap3.core.exceptions.LDAPSocketOpenError as e:
+            # Directory unreachable → let the registry treat this as
+            # provider-unreachable (fail-open skip + counter + continue walk).
+            logger.error(f"LDAP auth: server unreachable at {settings.ldap_url}: {e}")
+            raise
+        except ldap3.core.exceptions.LDAPException as e:
+            logger.error(f"LDAP auth: directory error for {username!r}: {e}")
+            raise
+
+        # Step 3: build the contract result. subject = strong directory id.
+        subject = (
+            _attr(attrs, "entryUUID")
+            or _attr(attrs, "objectGUID")
+            or user_dn  # stable-enough fallback; logged below if used
+        )
+        if subject == user_dn:
+            logger.warning(
+                f"LDAP auth: no entryUUID/objectGUID for {username!r}; "
+                f"falling back to DN as subject (less stable across moves)"
+            )
+
+        display_name = (
+            _attr(attrs, "displayName")
+            or _attr(attrs, "cn")
+            or _attr(attrs, "uid")
+            or username
+        )
+        mail = _attr(attrs, "mail") or None
+        member_of = attrs.get("memberOf") or []
+        if isinstance(member_of, str):
+            member_of = [member_of]
+
+        logger.info(
+            f"LDAP auth: {username!r} authenticated as {display_name!r} "
+            f"(subject={subject})"
+        )
+        return make_result(
+            provider_id=self.provider_id,
+            subject=str(subject),
+            display_name=display_name,
+            channel=channel,
+            email=mail,
+            # Directory mail is organization-asserted ⇒ treat as verified so
+            # the cross-provider email join may use it.
+            email_verified=mail is not None,
+            extras={"ldap_member_of": json.dumps([str(m) for m in member_of])},
+        )

--- a/src/backend/auth/registry.py
+++ b/src/backend/auth/registry.py
@@ -1,0 +1,195 @@
+"""Priority-ordered, multi-active auth provider registry.
+
+The registry generalizes Renfield's pre-existing ``authenticate`` hook seam
+(`api/routes/auth.py`): instead of one hook walk it owns an ordered set of
+providers and a single ``post_authenticate`` emission point.
+
+Resolution model
+----------------
+* **Credential providers** (db, ldap): the registry runs a PRIORITY WALK
+  (ascending ``priority``, lower first) over enabled providers whose
+  ``supported_channels`` include the request channel. **First non-None wins.**
+* A provider that raises, or exceeds ``settings.auth_provider_timeout_seconds``,
+  is **skipped (fail-open)**: WARNING log + ``auth_provider_unreachable_total
+  {provider_id}`` counter, then the walk continues to the next provider.
+* **Redirect providers** (google, github, apple, …) are NOT in the credential
+  walk — their ``authenticate`` returns None. They are user-selected entry
+  points; ``redirect_entries`` enumerates them for the login UI and their
+  OAuth/OIDC callback constructs the ``ProviderResult`` directly.
+
+The registry is identity-agnostic. It produces a ``ProviderResult`` and fires
+``post_authenticate`` exactly once; the Reva consumer (or the standalone
+legacy fallback in ``/auth/login``) turns that into a Renfield user id.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from loguru import logger
+
+from auth.provider_contract import AuthProvider, ProviderResult
+from utils.config import settings
+from utils.metrics import record_auth_provider_unreachable
+
+
+class ProviderRegistry:
+    """Ordered, multi-active provider set with a per-provider ``enabled`` gate."""
+
+    def __init__(self) -> None:
+        self._providers: list[AuthProvider] = []
+
+    # -- registration --------------------------------------------------------
+
+    def register(self, provider: AuthProvider) -> None:
+        """Add a provider. Duplicate ``provider_id`` replaces the prior one
+        (idempotent re-bootstrap; last registration wins)."""
+        self._providers = [
+            p for p in self._providers if p.provider_id != provider.provider_id
+        ]
+        self._providers.append(provider)
+        logger.debug(
+            f"Auth provider registered: {provider.provider_id} "
+            f"(priority={provider.priority}, enabled={provider.enabled})"
+        )
+
+    def clear(self) -> None:
+        """Drop all providers (test isolation / re-bootstrap)."""
+        self._providers = []
+
+    # -- introspection -------------------------------------------------------
+
+    def all(self) -> list[AuthProvider]:
+        """All registered providers, ascending ``priority``."""
+        return sorted(self._providers, key=lambda p: p.priority)
+
+    def get(self, provider_id: str) -> AuthProvider | None:
+        return next(
+            (p for p in self._providers if p.provider_id == provider_id), None
+        )
+
+    def credential_providers(self, channel: str) -> list[AuthProvider]:
+        """Enabled providers that participate in the credential walk for
+        *channel*, in priority order."""
+        return [
+            p
+            for p in self.all()
+            if p.enabled and channel in p.supported_channels
+        ]
+
+    def redirect_entries(self, channel: str) -> list[tuple[str, str]]:
+        """``(provider_id, authorize_url)`` for every enabled redirect provider
+        that exposes an ``authorize_url(channel)`` entry point for *channel*.
+
+        Credential-only providers (no ``authorize_url``) are excluded, so this
+        is the list the login UI renders as "Sign in with …" buttons.
+        """
+        entries: list[tuple[str, str]] = []
+        for p in self.all():
+            if not p.enabled or channel not in p.supported_channels:
+                continue
+            authorize_url = getattr(p, "authorize_url", None)
+            if authorize_url is None:
+                continue
+            url = authorize_url(channel)
+            if url:
+                entries.append((p.provider_id, url))
+        return entries
+
+    # -- credential walk -----------------------------------------------------
+
+    async def authenticate(
+        self, *, username: str, password: str, channel: str
+    ) -> ProviderResult | None:
+        """Run the priority walk. Return the first provider's non-None
+        ``ProviderResult``, or None if every provider declined.
+
+        Fail-open: a provider that raises or times out is skipped (logged +
+        counted) and the walk continues. This never raises.
+        """
+        timeout = settings.auth_provider_timeout_seconds
+        for provider in self.credential_providers(channel):
+            try:
+                result = await asyncio.wait_for(
+                    provider.authenticate(
+                        username=username, password=password, channel=channel
+                    ),
+                    timeout=timeout,
+                )
+            except TimeoutError:
+                logger.warning(
+                    f"Auth provider {provider.provider_id!r} timed out after "
+                    f"{timeout}s — skipped (fail-open), continuing walk"
+                )
+                record_auth_provider_unreachable(provider.provider_id)
+                continue
+            except Exception:
+                logger.opt(exception=True).warning(
+                    f"Auth provider {provider.provider_id!r} errored — "
+                    f"skipped (fail-open), continuing walk"
+                )
+                record_auth_provider_unreachable(provider.provider_id)
+                continue
+
+            if result is not None:
+                logger.debug(
+                    f"Auth provider {provider.provider_id!r} resolved "
+                    f"credential walk (channel={channel})"
+                )
+                return result
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Module-level default registry
+# ---------------------------------------------------------------------------
+
+_registry: ProviderRegistry | None = None
+
+
+def build_default_registry() -> ProviderRegistry:
+    """Construct the registry from config and install it as the singleton.
+
+    All built-ins are registered; the per-provider ``enabled`` gate (driven by
+    config) decides participation. Social providers ship ``enabled=False`` —
+    flipping them on is a config-only change, no redeploy.
+    """
+    # Imported here to avoid a circular import at module load
+    # (providers import the contract; the package __init__ imports the
+    # registry).
+    from auth.providers.apple import AppleProvider
+    from auth.providers.db import DBProvider
+    from auth.providers.github import GitHubProvider
+    from auth.providers.google import GoogleProvider
+    from auth.providers.ldap import LDAPProvider
+
+    registry = ProviderRegistry()
+    registry.register(DBProvider())
+    registry.register(LDAPProvider())
+    registry.register(GoogleProvider())
+    registry.register(GitHubProvider())
+    registry.register(AppleProvider())
+
+    global _registry
+    _registry = registry
+    logger.info(
+        "Auth provider registry built: "
+        + ", ".join(
+            f"{p.provider_id}({'on' if p.enabled else 'off'})"
+            for p in registry.all()
+        )
+    )
+    return registry
+
+
+def get_registry() -> ProviderRegistry:
+    """Return the process-wide registry, building the default lazily."""
+    if _registry is None:
+        return build_default_registry()
+    return _registry
+
+
+def set_registry(registry: ProviderRegistry | None) -> None:
+    """Override / reset the singleton (tests)."""
+    global _registry
+    _registry = registry

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -442,6 +442,41 @@ class Settings(BaseSettings):
     allow_registration: bool = True  # Allow self-registration
     require_email_verification: bool = False  # Not implemented yet
 
+    # === Pluggable auth provider registry (ebongard/renfield#591) ===
+    # Per-provider credential walk timeout. A provider exceeding this is
+    # skipped (fail-open) — see auth/registry.py.
+    auth_provider_timeout_seconds: float = 10.0
+
+    # --- LDAP credential provider (authn only; group→role authz is a
+    #     separate future layer). Default off → DB-only behavior unchanged. ---
+    ldap_auth_enabled: bool = False
+    ldap_url: str = ""  # ldaps://host:636 or ldap://host:389
+    ldap_bind_dn: str = ""  # service account DN for the user search
+    ldap_bind_password: SecretStr = ""
+    ldap_auth_user_base_dn: str = ""  # subtree to search for the user
+    ldap_auth_user_filter: str = "(uid={username})"  # {username} substituted
+    ldap_connect_timeout: int = 5
+    ldap_receive_timeout: int = 10
+
+    # --- Social redirect providers. All ship enabled=False; enabling is a
+    #     config-only change (no redeploy). Off the credential critical path. ---
+    oauth_google_enabled: bool = False
+    oauth_google_client_id: str = ""
+    oauth_google_client_secret: SecretStr = ""
+    oauth_google_redirect_uri: str = ""
+
+    oauth_github_enabled: bool = False
+    oauth_github_client_id: str = ""
+    oauth_github_client_secret: SecretStr = ""
+    oauth_github_redirect_uri: str = ""
+
+    oauth_apple_enabled: bool = False
+    oauth_apple_client_id: str = ""  # Services ID
+    oauth_apple_team_id: str = ""
+    oauth_apple_key_id: str = ""
+    oauth_apple_private_key: SecretStr = ""
+    oauth_apple_redirect_uri: str = ""
+
     # Voice authentication
     voice_auth_enabled: bool = False
     voice_auth_min_confidence: float = 0.7

--- a/src/backend/utils/hooks.py
+++ b/src/backend/utils/hooks.py
@@ -62,6 +62,18 @@ HOOK_EVENTS: frozenset[str] = frozenset({
     "presence_last_left",
     "compact_mcp_result",
     "authenticate",
+    # Pluggable-auth identity resolution — fired ONCE by /auth/login after
+    # any provider (credential-walk winner OR redirect callback) authenticates
+    # a human, BEFORE the JWT is minted. Kwarg: `result: ProviderResult`
+    # (auth/provider_contract.py — the ebongard/renfield#591 cross-repo seam).
+    # The Reva consumer adapts it, runs the canonical-identity join, and
+    # returns the resolved renfield user id (int or str-castable). First
+    # non-None result wins (registration order = precedence). If a consumer is
+    # registered but none resolve, the login is DENIED (no half-bound token).
+    # If NO consumer is registered at all (standalone Renfield), /auth/login
+    # falls back to legacy behavior (JWT from the authenticated User row) —
+    # see the post_authenticate contract docstring in provider_contract.py.
+    "post_authenticate",
     # Intent classification fallback — fired by the LLM intent dispatcher
     # when JSON parsing fails and a domain-specific consumer (e.g. HA via
     # ha_glue) might still recognize the user's intent from raw keywords.
@@ -382,6 +394,17 @@ async def run_hooks_with_errors(
                 f"Hook {getattr(fn, '__qualname__', repr(fn))} failed for {event}"
             )
     return results, errors
+
+
+def has_hook(event: str) -> bool:
+    """True if at least one handler is registered for *event*.
+
+    Lets a caller distinguish "no consumer registered" from "consumer
+    registered but returned nothing" — `run_hooks` collapses both to an empty
+    list. `/auth/login` uses this for the standalone legacy-fallback decision
+    (see the post_authenticate contract).
+    """
+    return bool(_hooks.get(event))
 
 
 def clear_hooks() -> None:

--- a/src/backend/utils/metrics.py
+++ b/src/backend/utils/metrics.py
@@ -39,6 +39,7 @@ _agent_outcome_total = None
 _injection_attempts_total = None
 _budget_reductions_total = None
 _output_guard_violations_total = None
+_auth_provider_unreachable_total = None
 
 
 def _init_metrics():
@@ -52,6 +53,7 @@ def _init_metrics():
     global _mcp_tool_duration_seconds, _mcp_tool_errors_total
     global _agent_outcome_total, _injection_attempts_total
     global _budget_reductions_total, _output_guard_violations_total
+    global _auth_provider_unreachable_total
 
     if _metrics_initialized:
         return
@@ -149,6 +151,18 @@ def _init_metrics():
             "renfield_output_guard_violations_total",
             "Output guard violations detected",
             ["violation"],
+        )
+
+        # Pluggable-auth fail-open observability. Name intentionally matches
+        # the cross-repo design contract (ebongard/renfield#591) verbatim —
+        # no `renfield_` prefix — so dashboards/alerts written against the
+        # approved design resolve without translation.
+        _auth_provider_unreachable_total = Counter(
+            "auth_provider_unreachable_total",
+            "Auth provider skipped during the credential walk because it "
+            "errored or timed out (fail-open). A non-zero rate means a "
+            "provider is silently down.",
+            ["provider_id"],
         )
 
         _metrics_initialized = True
@@ -256,6 +270,14 @@ def record_budget_reduction(pass_name: str):
     if not _metrics_initialized:
         return
     _budget_reductions_total.labels(pass_name=pass_name).inc()
+
+
+def record_auth_provider_unreachable(provider_id: str):
+    """Record that a credential provider was skipped (fail-open) because it
+    errored or timed out during the registry's priority walk."""
+    if not _metrics_initialized:
+        return
+    _auth_provider_unreachable_total.labels(provider_id=provider_id).inc()
 
 
 def record_output_guard_violation(violation: str):

--- a/tests/backend/test_auth_provider_registry.py
+++ b/tests/backend/test_auth_provider_registry.py
@@ -1,0 +1,592 @@
+"""Tests for the pluggable auth provider registry (ebongard/renfield#591).
+
+Covers the engineering-review test matrix:
+
+  registry priority walk (order) · fail-open skip (+ WARNING log + counter) ·
+  redirect-provider entry per provider · post_authenticate fires once /
+  contract shape / `v` · login-denied-when-unresolved · standalone
+  no-consumer legacy fallback · DB happy + wrong-password · LDAP bind
+  success/fail/server-down · social provider default-OFF · existing
+  `authenticate` hook regression · JWT `sub` unchanged + username=display_name
+  · UNIQUE(users.username) concurrency backstop present.
+
+These are unit tests: providers/hooks/sessions are mocked so the matrix runs
+without Postgres/LDAP. The DB-insert IntegrityError→re-SELECT retry itself is
+Reva-side (`ensure_renfield_user`, out of scope per the handover §5); the
+Renfield-side guarantee is the already-existing UNIQUE constraint, asserted
+here.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from auth.provider_contract import (
+    PROVIDER_RESULT_CONTRACT_VERSION,
+    AuthProvider,
+    ProviderResult,
+)
+from auth.providers.base import make_result, normalize_email
+from auth.registry import ProviderRegistry
+from utils.hooks import clear_hooks, register_hook
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+class _FakeProvider:
+    """Minimal AuthProvider for walk/ordering/fail-open tests."""
+
+    def __init__(self, pid, *, priority, enabled=True, result=None,
+                 raises=None, hang=False, channels=frozenset({"web"})):
+        self.provider_id = pid
+        self.priority = priority
+        self.enabled = enabled
+        self.supported_channels = channels
+        self._result = result
+        self._raises = raises
+        self._hang = hang
+        self.calls = 0
+
+    async def authenticate(self, *, username, password, channel):
+        self.calls += 1
+        if self._hang:
+            import asyncio
+            await asyncio.sleep(60)
+        if self._raises is not None:
+            raise self._raises
+        return self._result
+
+
+def _result(pid="db", subject="1", channel="web", **kw):
+    return make_result(
+        provider_id=pid, subject=subject, display_name=kw.get("dn", "Ada L"),
+        channel=channel, email=kw.get("email"),
+        email_verified=kw.get("email_verified", False),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_hooks():
+    clear_hooks()
+    yield
+    clear_hooks()
+
+
+# ---------------------------------------------------------------------------
+# Contract
+# ---------------------------------------------------------------------------
+
+class TestContract:
+    @pytest.mark.unit
+    def test_version_is_one(self):
+        assert PROVIDER_RESULT_CONTRACT_VERSION == 1
+
+    @pytest.mark.unit
+    def test_provider_result_frozen(self):
+        r = _result()
+        with pytest.raises(Exception):
+            r.subject = "mutated"  # frozen dataclass
+
+    @pytest.mark.unit
+    def test_make_result_stamps_v_and_normalizes_email(self):
+        r = make_result(provider_id="db", subject="7", display_name="X",
+                         channel="web", email="  Foo@Bar.COM ",
+                         email_verified=True)
+        assert r.v == PROVIDER_RESULT_CONTRACT_VERSION
+        assert r.email == "foo@bar.com"  # lowercase + trim only
+        assert r.email_verified is True
+
+    @pytest.mark.unit
+    def test_email_verified_false_when_no_email(self):
+        r = make_result(provider_id="db", subject="7", display_name="X",
+                         channel="web", email="   ", email_verified=True)
+        assert r.email is None
+        assert r.email_verified is False  # cannot be verified with no email
+
+    @pytest.mark.unit
+    def test_normalize_email_no_plus_or_dot_folding(self):
+        assert normalize_email("a.b+tag@gmail.com") == "a.b+tag@gmail.com"
+
+    @pytest.mark.unit
+    def test_fake_provider_satisfies_protocol(self):
+        assert isinstance(_FakeProvider("db", priority=1), AuthProvider)
+
+
+# ---------------------------------------------------------------------------
+# Registry: priority walk, multi-active, enabled gate, fail-open
+# ---------------------------------------------------------------------------
+
+class TestRegistryWalk:
+    @pytest.mark.unit
+    async def test_priority_walk_order_first_non_none_wins(self):
+        reg = ProviderRegistry()
+        low = _FakeProvider("ldap", priority=50, result=_result("ldap", "L"))
+        high = _FakeProvider("db", priority=100, result=_result("db", "D"))
+        reg.register(high)
+        reg.register(low)  # registered out of order on purpose
+        out = await reg.authenticate(username="u", password="p", channel="web")
+        assert out.provider_id == "ldap"  # lower priority walked first
+        assert low.calls == 1
+        assert high.calls == 0  # short-circuited
+
+    @pytest.mark.unit
+    async def test_decline_falls_through_to_next(self):
+        reg = ProviderRegistry()
+        reg.register(_FakeProvider("ldap", priority=50, result=None))
+        reg.register(_FakeProvider("db", priority=100,
+                                   result=_result("db", "9")))
+        out = await reg.authenticate(username="u", password="p", channel="web")
+        assert out.provider_id == "db"
+
+    @pytest.mark.unit
+    async def test_disabled_provider_skipped(self):
+        reg = ProviderRegistry()
+        dis = _FakeProvider("ldap", priority=50, enabled=False,
+                            result=_result("ldap"))
+        reg.register(dis)
+        reg.register(_FakeProvider("db", priority=100,
+                                   result=_result("db", "3")))
+        out = await reg.authenticate(username="u", password="p", channel="web")
+        assert out.provider_id == "db"
+        assert dis.calls == 0
+
+    @pytest.mark.unit
+    async def test_channel_filter(self):
+        reg = ProviderRegistry()
+        reg.register(_FakeProvider("db", priority=100,
+                                   result=_result("db"),
+                                   channels=frozenset({"teams_tab"})))
+        out = await reg.authenticate(username="u", password="p",
+                                     channel="web")
+        assert out is None  # provider does not support 'web'
+
+    @pytest.mark.unit
+    async def test_fail_open_on_error_skips_logs_counts_continues(
+        self, monkeypatch
+    ):
+        counted = []
+        monkeypatch.setattr(
+            "auth.registry.record_auth_provider_unreachable",
+            lambda pid: counted.append(pid),
+        )
+        reg = ProviderRegistry()
+        reg.register(_FakeProvider("ldap", priority=50,
+                                   raises=RuntimeError("boom")))
+        reg.register(_FakeProvider("db", priority=100,
+                                   result=_result("db", "5")))
+        out = await reg.authenticate(username="u", password="p",
+                                     channel="web")
+        assert out.provider_id == "db"          # walk continued
+        assert counted == ["ldap"]               # counter incremented
+
+    @pytest.mark.unit
+    async def test_fail_open_on_timeout(self, monkeypatch):
+        counted = []
+        monkeypatch.setattr(
+            "auth.registry.record_auth_provider_unreachable",
+            lambda pid: counted.append(pid),
+        )
+        monkeypatch.setattr(
+            "auth.registry.settings.auth_provider_timeout_seconds", 0.01
+        )
+        reg = ProviderRegistry()
+        reg.register(_FakeProvider("ldap", priority=50, hang=True))
+        reg.register(_FakeProvider("db", priority=100,
+                                   result=_result("db", "5")))
+        out = await reg.authenticate(username="u", password="p",
+                                     channel="web")
+        assert out.provider_id == "db"
+        assert counted == ["ldap"]
+
+    @pytest.mark.unit
+    async def test_all_decline_returns_none(self):
+        reg = ProviderRegistry()
+        reg.register(_FakeProvider("db", priority=100, result=None))
+        assert await reg.authenticate(
+            username="u", password="p", channel="web") is None
+
+    @pytest.mark.unit
+    def test_register_replaces_same_id(self):
+        reg = ProviderRegistry()
+        reg.register(_FakeProvider("db", priority=100))
+        reg.register(_FakeProvider("db", priority=10))
+        assert len(reg.all()) == 1
+        assert reg.get("db").priority == 10
+
+
+# ---------------------------------------------------------------------------
+# Redirect providers: default-OFF + entry per provider
+# ---------------------------------------------------------------------------
+
+class TestRedirectProviders:
+    @pytest.mark.unit
+    def test_social_disabled_by_default(self):
+        from auth.providers.apple import AppleProvider
+        from auth.providers.github import GitHubProvider
+        from auth.providers.google import GoogleProvider
+        assert GoogleProvider().enabled is False
+        assert GitHubProvider().enabled is False
+        assert AppleProvider().enabled is False
+
+    @pytest.mark.unit
+    async def test_redirect_provider_not_in_credential_walk(self):
+        from auth.providers.google import GoogleProvider
+        assert await GoogleProvider().authenticate(
+            username="u", password="p", channel="web") is None
+
+    @pytest.mark.unit
+    def test_authorize_url_per_provider_when_configured(self, monkeypatch):
+        from auth.providers.github import GitHubProvider
+        from auth.providers.google import GoogleProvider
+        for mod, prov in (("google", GoogleProvider()),
+                          ("github", GitHubProvider())):
+            monkeypatch.setattr(
+                f"auth.providers.{mod}.settings.oauth_{mod}_enabled", True)
+            monkeypatch.setattr(
+                f"auth.providers.{mod}.settings.oauth_{mod}_client_id", "cid")
+            monkeypatch.setattr(
+                f"auth.providers.{mod}.settings.oauth_{mod}_redirect_uri",
+                "https://r/cb")
+            url = prov.authorize_url("web")
+            assert url and "client_id=cid" in url and prov.provider_id in url
+
+    @pytest.mark.unit
+    def test_registry_redirect_entries_lists_enabled_only(self, monkeypatch):
+        from auth.providers.google import GoogleProvider
+        reg = ProviderRegistry()
+        reg.register(GoogleProvider())
+        assert reg.redirect_entries("web") == []  # default off
+        monkeypatch.setattr(
+            "auth.providers.google.settings.oauth_google_enabled", True)
+        monkeypatch.setattr(
+            "auth.providers.google.settings.oauth_google_client_id", "cid")
+        monkeypatch.setattr(
+            "auth.providers.google.settings.oauth_google_redirect_uri",
+            "https://r/cb")
+        entries = reg.redirect_entries("web")
+        assert [pid for pid, _ in entries] == ["google"]
+
+
+# ---------------------------------------------------------------------------
+# DB provider
+# ---------------------------------------------------------------------------
+
+class TestDBProvider:
+    @asynccontextmanager
+    async def _fake_session(self):
+        yield MagicMock()
+
+    @pytest.mark.unit
+    async def test_db_happy_path(self, monkeypatch):
+        from auth.providers import db as dbmod
+        user = MagicMock(id=42, email="Ada@Example.com",
+                         first_name="Ada", last_name="Lovelace",
+                         username="ada")
+        monkeypatch.setattr(dbmod, "AsyncSessionLocal", self._fake_session)
+        monkeypatch.setattr(dbmod, "authenticate_user",
+                            AsyncMock(return_value=user))
+        r = await dbmod.DBProvider().authenticate(
+            username="ada", password="pw", channel="web")
+        assert r.provider_id == "db"
+        assert r.subject == "42"
+        assert r.display_name == "Ada Lovelace"
+        assert r.email == "ada@example.com"
+        assert r.email_verified is False  # local accounts not verified
+        assert r.v == PROVIDER_RESULT_CONTRACT_VERSION
+
+    @pytest.mark.unit
+    async def test_db_wrong_password_returns_none(self, monkeypatch):
+        from auth.providers import db as dbmod
+        monkeypatch.setattr(dbmod, "AsyncSessionLocal", self._fake_session)
+        monkeypatch.setattr(dbmod, "authenticate_user",
+                            AsyncMock(return_value=None))
+        assert await dbmod.DBProvider().authenticate(
+            username="ada", password="bad", channel="web") is None
+
+    @pytest.mark.unit
+    def test_db_provider_always_enabled_priority_after_ldap(self):
+        from auth.providers.db import DBProvider
+        from auth.providers.ldap import LDAPProvider
+        assert DBProvider().enabled is True
+        assert LDAPProvider().priority < DBProvider().priority
+
+
+# ---------------------------------------------------------------------------
+# LDAP provider — bind ok / fail / server-down
+# ---------------------------------------------------------------------------
+
+class TestLDAPProvider:
+    def _cfg(self, monkeypatch, **over):
+        from auth.providers import ldap as lm
+        defaults = dict(ldap_auth_enabled=True, ldap_url="ldaps://d:636",
+                        ldap_auth_user_base_dn="ou=u,dc=x",
+                        ldap_auth_user_filter="(uid={username})",
+                        ldap_bind_dn="cn=svc", ldap_connect_timeout=1,
+                        ldap_receive_timeout=1)
+        defaults.update(over)
+        for k, v in defaults.items():
+            monkeypatch.setattr(f"auth.providers.ldap.settings.{k}", v)
+        monkeypatch.setattr(
+            "auth.providers.ldap.settings.ldap_bind_password",
+            MagicMock(get_secret_value=lambda: "svcpw"))
+        return lm
+
+    @pytest.mark.unit
+    async def test_ldap_disabled_returns_none(self, monkeypatch):
+        lm = self._cfg(monkeypatch, ldap_auth_enabled=False)
+        assert await lm.LDAPProvider().authenticate(
+            username="u", password="p", channel="web") is None
+
+    @pytest.mark.unit
+    async def test_ldap_bind_success(self, monkeypatch):
+        lm = self._cfg(monkeypatch)
+        fake_ldap3 = MagicMock()
+        entry = {"type": "searchResEntry", "dn": "uid=ada,ou=u,dc=x",
+                 "attributes": {"entryUUID": "uuid-1",
+                                "displayName": "Ada L", "mail": "ada@x.io",
+                                "memberOf": ["cn=eng", "cn=all"]}}
+
+        class _Conn:
+            def __init__(self, *a, **k): ...
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+            def search(self, **k): return (True, {}, [entry], {})
+
+        fake_ldap3.Connection = _Conn
+        fake_ldap3.Server = lambda *a, **k: MagicMock()
+        fake_ldap3.SAFE_SYNC = "SAFE_SYNC"
+        fake_ldap3.core.exceptions.LDAPBindError = type(
+            "LBE", (Exception,), {})
+        fake_ldap3.core.exceptions.LDAPSocketOpenError = type(
+            "LSO", (Exception,), {})
+        fake_ldap3.core.exceptions.LDAPException = type(
+            "LE", (Exception,), {})
+        monkeypatch.setitem(__import__("sys").modules, "ldap3", fake_ldap3)
+        monkeypatch.setitem(__import__("sys").modules,
+                            "ldap3.core", fake_ldap3.core)
+        monkeypatch.setitem(__import__("sys").modules,
+                            "ldap3.core.exceptions",
+                            fake_ldap3.core.exceptions)
+        r = await lm.LDAPProvider().authenticate(
+            username="ada", password="pw", channel="web")
+        assert r.provider_id == "ldap"
+        assert r.subject == "uuid-1"
+        assert r.email == "ada@x.io" and r.email_verified is True
+        import json
+        assert json.loads(r.extras["ldap_member_of"]) == ["cn=eng", "cn=all"]
+
+    @pytest.mark.unit
+    async def test_ldap_bind_fail_returns_none(self, monkeypatch):
+        lm = self._cfg(monkeypatch)
+        LBE = type("LBE", (Exception,), {})
+
+        class _Conn:
+            def __init__(self, *a, **k):
+                if k.get("user", "").startswith("uid="):
+                    raise LBE()  # user-bind fails = wrong password
+
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+            def search(self, **k):
+                return (True, {}, [{"type": "searchResEntry",
+                                    "dn": "uid=ada,ou=u,dc=x",
+                                    "attributes": {}}], {})
+
+        fake = MagicMock()
+        fake.Connection = _Conn
+        fake.Server = lambda *a, **k: MagicMock()
+        fake.SAFE_SYNC = "S"
+        fake.core.exceptions.LDAPBindError = LBE
+        fake.core.exceptions.LDAPSocketOpenError = type("LSO", (Exception,), {})
+        fake.core.exceptions.LDAPException = type("LE", (Exception,), {})
+        for m in ("ldap3", "ldap3.core", "ldap3.core.exceptions"):
+            monkeypatch.setitem(__import__("sys").modules, m,
+                                fake if m == "ldap3" else
+                                (fake.core if m == "ldap3.core"
+                                 else fake.core.exceptions))
+        assert await lm.LDAPProvider().authenticate(
+            username="ada", password="bad", channel="web") is None
+
+    @pytest.mark.unit
+    async def test_ldap_server_down_raises_for_fail_open(self, monkeypatch):
+        """Directory unreachable must RAISE so the registry counts it as
+        provider-unreachable (fail-open), not silently decline."""
+        lm = self._cfg(monkeypatch)
+        LSO = type("LSO", (Exception,), {})
+
+        class _Conn:
+            def __init__(self, *a, **k): raise LSO("no route")
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+
+        fake = MagicMock()
+        fake.Connection = _Conn
+        fake.Server = lambda *a, **k: MagicMock()
+        fake.SAFE_SYNC = "S"
+        fake.core.exceptions.LDAPBindError = type("LBE", (Exception,), {})
+        fake.core.exceptions.LDAPSocketOpenError = LSO
+        fake.core.exceptions.LDAPException = type("LE", (Exception,), {})
+        for m, obj in (("ldap3", fake), ("ldap3.core", fake.core),
+                       ("ldap3.core.exceptions", fake.core.exceptions)):
+            monkeypatch.setitem(__import__("sys").modules, m, obj)
+        with pytest.raises(LSO):
+            await lm.LDAPProvider().authenticate(
+                username="ada", password="pw", channel="web")
+
+    @pytest.mark.unit
+    async def test_registry_fail_open_wraps_ldap_server_down(
+        self, monkeypatch
+    ):
+        """End-to-end: an LDAP server-down inside the registry walk is a
+        counted skip, and the DB provider still resolves the login."""
+        counted = []
+        monkeypatch.setattr(
+            "auth.registry.record_auth_provider_unreachable",
+            lambda pid: counted.append(pid))
+        reg = ProviderRegistry()
+        reg.register(_FakeProvider("ldap", priority=50,
+                                   raises=ConnectionError("down")))
+        reg.register(_FakeProvider("db", priority=100,
+                                   result=_result("db", "1")))
+        out = await reg.authenticate(username="u", password="p",
+                                     channel="web")
+        assert out.provider_id == "db"
+        assert counted == ["ldap"]
+
+
+# ---------------------------------------------------------------------------
+# resolve_login: post_authenticate once / deny / standalone / legacy hook
+# ---------------------------------------------------------------------------
+
+class TestResolveLogin:
+    def _registry_with(self, monkeypatch, result):
+        reg = ProviderRegistry()
+        reg.register(_FakeProvider(
+            result.provider_id if result else "db",
+            priority=100, result=result))
+        monkeypatch.setattr("auth.login_flow.get_registry", lambda: reg)
+        return reg
+
+    @pytest.mark.unit
+    async def test_standalone_db_fallback_no_consumer(self, monkeypatch):
+        from auth.login_flow import resolve_login
+        self._registry_with(monkeypatch, _result("db", "77", dn="Ada"))
+        out = await resolve_login(db=MagicMock(), username="u",
+                                  password="p", channel="web")
+        assert out is not None
+        assert out.user_id == 77
+        assert out.display_name == "Ada"
+        assert out.provider_id == "db"
+
+    @pytest.mark.unit
+    async def test_standalone_denies_non_db_without_consumer(
+        self, monkeypatch
+    ):
+        from auth.login_flow import resolve_login
+        self._registry_with(monkeypatch, _result("ldap", "uuid"))
+        assert await resolve_login(
+            db=MagicMock(), username="u", password="p",
+            channel="web") is None
+
+    @pytest.mark.unit
+    async def test_post_authenticate_fires_once_with_contract_shape(
+        self, monkeypatch
+    ):
+        from auth.login_flow import resolve_login
+        seen = []
+
+        async def consumer(*, result):
+            seen.append(result)
+            return 999
+
+        register_hook("post_authenticate", consumer)
+        self._registry_with(monkeypatch, _result("ldap", "uuid-x",
+                                                  dn="Grace H"))
+        out = await resolve_login(db=MagicMock(), username="u",
+                                  password="p", channel="web")
+        assert out.user_id == 999
+        assert out.display_name == "Grace H"
+        assert len(seen) == 1                       # fired exactly once
+        assert isinstance(seen[0], ProviderResult)  # contract shape
+        assert seen[0].v == PROVIDER_RESULT_CONTRACT_VERSION
+
+    @pytest.mark.unit
+    async def test_login_denied_when_consumer_unresolved(self, monkeypatch):
+        from auth.login_flow import resolve_login
+
+        async def consumer(*, result):
+            return None  # consumer present but cannot resolve
+
+        register_hook("post_authenticate", consumer)
+        self._registry_with(monkeypatch, _result("db", "5"))
+        # Even a db result is denied if a consumer is registered and declines
+        assert await resolve_login(
+            db=MagicMock(), username="u", password="p",
+            channel="web") is None
+
+    @pytest.mark.unit
+    async def test_bad_credentials_returns_none(self, monkeypatch):
+        from auth.login_flow import resolve_login
+        self._registry_with(monkeypatch, None)
+        assert await resolve_login(
+            db=MagicMock(), username="u", password="bad",
+            channel="web") is None
+
+    @pytest.mark.unit
+    async def test_legacy_authenticate_hook_still_wins(self, monkeypatch):
+        """Backward-compat: a plugin's `authenticate` hook returning a User
+        is authoritative and short-circuits the registry (no
+        post_authenticate fired)."""
+        from auth.login_flow import resolve_login
+        fired = []
+
+        async def legacy(*, username, password, db):
+            return MagicMock(id=13, first_name="Leg", last_name="Acy",
+                             username="legacy")
+
+        async def pa(*, result):
+            fired.append(result)
+            return 1
+
+        register_hook("authenticate", legacy)
+        register_hook("post_authenticate", pa)
+        reg = ProviderRegistry()
+        walk = _FakeProvider("db", priority=100, result=_result("db", "999"))
+        reg.register(walk)
+        monkeypatch.setattr("auth.login_flow.get_registry", lambda: reg)
+        out = await resolve_login(db=MagicMock(), username="u",
+                                  password="p", channel="web")
+        assert out.user_id == 13                # legacy hook wins
+        assert out.provider_id == "legacy_hook"
+        assert walk.calls == 0                  # registry not consulted
+        assert fired == []                      # post_authenticate NOT fired
+
+
+# ---------------------------------------------------------------------------
+# JWT claim mapping + concurrency backstop
+# ---------------------------------------------------------------------------
+
+class TestJWTAndConcurrency:
+    @pytest.mark.unit
+    def test_jwt_sub_unchanged_username_is_display_name(self):
+        """The login route mints {sub: str(user.id), username: display_name}.
+        Assert that decoding yields sub=id and username=display_name."""
+        from services.auth_service import create_access_token, decode_token
+        token = create_access_token(
+            data={"sub": "42", "username": "Ada Lovelace"})
+        payload = decode_token(token)
+        assert payload["sub"] == "42"            # sub = renfield user id
+        assert payload["username"] == "Ada Lovelace"  # = display_name
+
+    @pytest.mark.unit
+    def test_users_username_unique_constraint_exists(self):
+        """Renfield-side concurrency backstop: UNIQUE(users.username) already
+        exists, so a concurrent same-subject insert (Reva-side
+        ensure_renfield_user) is a catchable IntegrityError, not a dup row."""
+        from models.database import User
+        assert User.__table__.c.username.unique is True


### PR DESCRIPTION
Renfield-side of "Approach B" — Renfield owns authentication via a priority-ordered, multi-active provider registry that emits one `post_authenticate(ProviderResult)` hook before minting the JWT. Identity resolution (the Reva consumer, `canonical_users` join, channel adapters, OIDC/Entra/SAML, the authz group→role layer) is intentionally **out of scope** per the handover §5.

Refs #591

## Acceptance checklist

- [x] `ProviderResult` v1 + `AuthProvider` Protocol + `PROVIDER_RESULT_CONTRACT_VERSION=1` at `src/backend/auth/provider_contract.py`, byte-faithful to the pinned v1 contract (only the module docstring rewritten for the landed location).
- [x] Registry: ascending-priority walk, multi-active, per-provider `enabled` gate, first non-None wins.
- [x] Fail-open: a provider that raises or exceeds `auth_provider_timeout_seconds` is skipped → WARNING log + `auth_provider_unreachable_total{provider_id}` counter + walk continues. Registry never re-raises.
- [x] `post_authenticate` fired exactly once on success, **before** JWT mint; login denied if a consumer is registered but none resolve (no half-bound token).
- [x] DB + LDAP + Google + GitHub + Apple providers; the social three `enabled=False` by default, enabling is config-only.
- [x] Existing `/auth/login` behavior preserved — the legacy `authenticate` hook is still authoritative and short-circuits the registry with no `post_authenticate` fired. Regression-tested.
- [x] Concurrency: `UNIQUE(users.username)` backstop asserted (the SELECT→INSERT IntegrityError→re-SELECT retry is Reva-side per §5; Renfield's contribution is the already-present unique constraint).
- [x] JWT `sub` unchanged; cosmetic `username` claim now carries `display_name`.
- [x] Full unit test matrix (`tests/backend/test_auth_provider_registry.py`, 34 tests). Renfield suite green, zero regressions.

## Standalone fallback (implementation nuance — not a contract change)

The contract says "deny if `post_authenticate` is unresolved", but standalone Renfield (this repo's own test suite / a renfield-without-reva deploy) registers **no** `post_authenticate` consumer. To preserve existing behavior:

- **0 handlers registered** → mint JWT from the `db` provider's subject (legacy behavior); non-`db` providers are denied (no identity layer to resolve them).
- **≥1 handler registered but none resolve** → deny login.

This does not alter the cross-repo `ProviderResult`/`post_authenticate` surface, so it does not re-open #591. Explicitly approved by the repo owner before implementation.

## Reviewer notes (dedicated code-review pass)

A `pr-review-toolkit:code-reviewer` pass returned **PR-ready, no blockers**. Two notes, both addressed/documented:

1. **(Fixed)** The new `is_active` enforcement initially returned a distinct `403` on the legacy-hook path — a user-enumeration oracle vs the opaque `401` of other login failures. Now returns the **same opaque 401** for "no user OR inactive", uniform with bad-credentials.
2. **(Behavior-change note)** Pre-registry, a legacy `authenticate` hook returning a *disabled* `User` would still receive tokens (only the bcrypt path checked `is_active`). The registry path now enforces `is_active` on **every** path including the legacy hook — intended security hardening. Also: legacy-hook users must now be loadable by id on the request session; no in-tree hook (ha_glue/Reva persist first) is affected, but it is a tightening of the legacy seam worth noting for plugin authors.

## New config

`AUTH_PROVIDER_TIMEOUT_SECONDS`, `LDAP_AUTH_*`, `OAUTH_{GOOGLE,GITHUB,APPLE}_*` — all documented in `docs/ENVIRONMENT_VARIABLES.md`; CLAUDE.md has a new subsystem note.

## Test verification

Run on the `.159` build box (CI is intentionally non-functional for this repo): new suite **34/34**; existing `test_auth.py` + `test_auth_user_or_default.py` **40/40**; broad `-k 'login or auth or hook'` sweep showed the **identical 16 pre-existing noise-floor failures** with and without these changes → **+34 net new passing, zero regressions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
