### PR TITLE
fix(satellite): close enviro pHAT provisioning drift + inventory naming gap

### DIFF
--- a/src/satellite/provisioning/inventory.example.yml
+++ b/src/satellite/provisioning/inventory.example.yml
@@ -5,6 +5,15 @@
 # never end up in the repository.
 #
 # Default SSH user on Raspberry Pi OS is `pi`. Change to match your image.
+#
+# IMPORTANT: the inventory hostname MUST match the host_vars/<name>.yml
+# filename — Ansible auto-loads host_vars by inventory_hostname. If they
+# differ, per-host settings (hat_type, camera_enabled, enviro_phat_enabled,
+# …) silently do NOT load and the device is provisioned with defaults
+# (e.g. envirophat never installed → no environment telemetry).
+#
+# hat_type selects the audio driver / asound path. Supported values:
+#   2mic | 4mic | xvf3800-usb | whisplay
 
 all:
   children:
@@ -13,9 +22,15 @@ all:
         satellite-livingroom:
           ansible_host: satellite-livingroom.local
           ansible_user: pi
+          hat_type: 2mic
         satellite-kitchen:
           ansible_host: satellite-kitchen.local
           ansible_user: pi
+          hat_type: 4mic
+        # ReSpeaker XVF3800 USB + Enviro pHAT + Pi Camera. Per-host extras
+        # (enviro_phat_enabled, camera_enabled) live in
+        # host_vars/satellite-bedroom.yml — keyed by THIS hostname.
         # satellite-bedroom:
         #   ansible_host: 192.168.1.50
         #   ansible_user: pi
+        #   hat_type: xvf3800-usb

--- a/src/satellite/provisioning/provision.yml
+++ b/src/satellite/provisioning/provision.yml
@@ -312,8 +312,14 @@
         virtualenv: "{{ satellite_venv }}"
         extra_args: "--no-deps"
 
+    # Also tagged `app`: this is a host-conditional venv dependency, and the
+    # safety-recommended code-only deploy (`--tags app`, avoids driver/service
+    # restart brick-risk on Pi Zero 2 W) would otherwise skip it forever — a
+    # device enabling enviro_phat would silently never get the lib (the
+    # sat-benszimmer drift, 2026-05). This pip task notifies no restart/reboot
+    # handler, so running it on `app` deploys stays restart-free.
     - name: Install envirophat package
-      tags: [python]
+      tags: [python, app]
       when: enviro_phat_enabled | default(false)
       become_user: "{{ ansible_user }}"
       ansible.builtin.pip:

--- a/src/satellite/provisioning/provision.yml
+++ b/src/satellite/provisioning/provision.yml
@@ -326,6 +326,56 @@
         name: envirophat
         virtualenv: "{{ satellite_venv }}"
 
+    # envirophat hard-imports the C extension `smbus`, provided ONLY by the
+    # apt package python3-smbus (no working pip equivalent on Raspbian). The
+    # venv is created WITHOUT --system-site-packages, so apt alone is not
+    # enough — the .so must be linked into the venv. Recreating the venv with
+    # system-site-packages would change dependency resolution for every
+    # satellite, so we link just this one ABI-matching module (system python
+    # and venv python are the same 3.11.x on Pi OS). Without these two tasks
+    # the envirophat install above imports-fails and enviro telemetry is
+    # silently dead (the sat-benszimmer drift, 2026-05).
+    - name: Install python3-smbus (envirophat C-extension dependency)
+      tags: [python, app]
+      when: enviro_phat_enabled | default(false)
+      ansible.builtin.apt:
+        name: python3-smbus
+        state: present
+
+    - name: Discover system smbus extension module
+      tags: [python, app]
+      when: enviro_phat_enabled | default(false)
+      ansible.builtin.shell: >-
+        set -o pipefail;
+        dpkg -L python3-smbus | grep -E '/smbus\.cpython-.*\.so$' | head -1
+      args:
+        executable: /bin/bash
+      register: smbus_so
+      changed_when: false
+
+    - name: Find venv site-packages directory
+      tags: [python, app]
+      when: enviro_phat_enabled | default(false)
+      ansible.builtin.find:
+        paths: "{{ satellite_venv }}/lib"
+        patterns: "site-packages"
+        file_type: directory
+        recurse: true
+      register: venv_site_packages
+
+    - name: Link system smbus module into the venv
+      tags: [python, app]
+      when:
+        - enviro_phat_enabled | default(false)
+        - smbus_so.stdout | length > 0
+        - venv_site_packages.files | length > 0
+      become_user: "{{ ansible_user }}"
+      ansible.builtin.file:
+        src: "{{ smbus_so.stdout }}"
+        dest: "{{ venv_site_packages.files[0].path }}/{{ smbus_so.stdout | basename }}"
+        state: link
+        force: true
+
     # =========================================================================
     # APP — Deploy application code
     # =========================================================================


### PR DESCRIPTION
## Problem

`sat-benszimmer` (ReSpeaker XVF3800 USB + Enviro pHAT + Pi Cam V3) ran for weeks with **zero environment telemetry**. Diagnosed read-only on the live device; three compounding upstream gaps, no code/hardware fault:

1. **Inventory naming:** Ansible auto-loads `host_vars/<inventory_hostname>.yml`. The device's `host_vars/satellite-benszimmer.yml` (`enviro_phat_enabled: true`, `hat_type`, camera) silently never loaded because the inventory key didn't match the filename → provisioned with defaults.
2. **Provisioning tag:** the `envirophat` venv install was `tags: [python]`-only; the safety-recommended code-only `--tags app` deploy (avoids the Pi Zero 2 W driver/restart brick-risk) skips it forever.
3. **Missing C-extension dep:** `envirophat` hard-imports the `smbus` C module (apt `python3-smbus` only — no working pip equivalent on Raspbian), and the venv is built **without** `--system-site-packages`, so even a correct full provision import-failed (`No module named 'smbus'`).

## Changes (provisioning made fully self-healing)

- **`provision.yml`**:
  - `envirophat` pip task → `tags: [python, app]`.
  - New gated tasks (`enviro_phat_enabled`, `[python, app]`): apt `python3-smbus`; discover the ABI-matching `smbus*.so` + venv site-packages dir; symlink the module into the venv. Chosen over recreating the venv with system-site-packages (which would alter dep resolution for **every** satellite). None of these notify a restart/reboot handler → safe on restart-free `app` deploys.
- **`inventory.example.yml`**: documents the hard rule that inventory hostname must match the `host_vars/<name>.yml` filename (the silent-default failure mode), adds `hat_type` to every example + an `xvf3800-usb` host shape.
- Local gitignored `inventory.yml` updated out-of-band to add `satellite-benszimmer` with the correct host_vars-matching name (not in this PR by design).

## Live retro-fix (done, risk explicitly accepted by repo owner)

Applied the exact sequence above to the running `sat-benszimmer` (Pi Zero 2 W), gating the restart on a verified in-venv import so a failed install never triggered a needless restart:

- venv install + `python3-smbus` + `.so` symlink → in-venv read OK **before** any service touch.
- Careful **clean stop (1 s, no SIGKILL) → `sync` → start** (unit has no SIGTERM trap, so SIGTERM exits promptly; SD flushed to minimise corruption window). **Device survived — not bricked.**
- New process logs `Enviro pHAT initialized`; live telemetry now reads temp/pressure/light/heading (light 0→832, heading 91.8→53.3 confirm sensors active). Audio/wakeword path regression-clean (XVF3800 capture + `hey_renfield` loaded; only the pre-existing benign asoundrc ALSA noise remains).

## Out of scope / noted

- Pre-existing, untouched: the local inventory's `sat-wohnzimmer` entry is mis-keyed the same way (flagged for a separate follow-up).

YAML of all changed files validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
