### PR TITLE
feat(satellites): report & display real per-device hardware

### DIFF
--- a/docs/SATELLITE_MONITORING.md
+++ b/docs/SATELLITE_MONITORING.md
@@ -132,8 +132,13 @@ GET /api/satellites
       "capabilities": {
         "local_wakeword": true,
         "speaker": true,
-        "led_count": 3,
-        "button": true
+        "led_count": 12,
+        "button": true,
+        "led_type": "xvf3800",
+        "mic_channels": 4,
+        "has_camera": true,
+        "has_display": false,
+        "has_enviro": true
       },
       "metrics": {
         "audio_rms": 1234.5,

--- a/src/backend/ha_glue/api/routes/satellites.py
+++ b/src/backend/ha_glue/api/routes/satellites.py
@@ -26,11 +26,17 @@ router = APIRouter()
 # =============================================================================
 
 class SatelliteCapabilitiesResponse(BaseModel):
-    """Satellite hardware capabilities"""
+    """Satellite hardware capabilities (as reported by the device on
+    register; conservative defaults for older clients)."""
     local_wakeword: bool = True
     speaker: bool = True
     led_count: int = 3
     button: bool = True
+    led_type: str | None = None
+    mic_channels: int = 1
+    has_camera: bool = False
+    has_display: bool = False
+    has_enviro: bool = False
 
 
 class SatelliteMetricsResponse(BaseModel):

--- a/src/backend/ha_glue/services/satellite_manager.py
+++ b/src/backend/ha_glue/services/satellite_manager.py
@@ -37,11 +37,22 @@ class SatelliteState(str, Enum):
 
 @dataclass
 class SatelliteCapabilities:
-    """Hardware capabilities of a satellite"""
+    """Hardware capabilities of a satellite.
+
+    Defaults are conservative: a satellite running an older client that
+    does not report the richer fields keeps working and simply shows the
+    base badges. ``led_type`` is None / ``mic_channels`` 1 / has_* False
+    until the device reports its real config.
+    """
     local_wakeword: bool = True
     speaker: bool = True
     led_count: int = 3
     button: bool = True
+    led_type: str | None = None
+    mic_channels: int = 1
+    has_camera: bool = False
+    has_display: bool = False
+    has_enviro: bool = False
 
 
 @dataclass
@@ -170,7 +181,12 @@ class SatelliteManager:
                 local_wakeword=capabilities.get("local_wakeword", True),
                 speaker=capabilities.get("speaker", True),
                 led_count=capabilities.get("led_count", 3),
-                button=capabilities.get("button", True)
+                button=capabilities.get("button", True),
+                led_type=capabilities.get("led_type"),
+                mic_channels=capabilities.get("mic_channels", 1),
+                has_camera=capabilities.get("has_camera", False),
+                has_display=capabilities.get("has_display", False),
+                has_enviro=capabilities.get("has_enviro", False),
             )
 
             # Register satellite
@@ -611,7 +627,12 @@ class SatelliteManager:
                 "capabilities": {
                     "local_wakeword": sat.capabilities.local_wakeword,
                     "speaker": sat.capabilities.speaker,
-                    "led_count": sat.capabilities.led_count
+                    "led_count": sat.capabilities.led_count,
+                    "led_type": sat.capabilities.led_type,
+                    "mic_channels": sat.capabilities.mic_channels,
+                    "has_camera": sat.capabilities.has_camera,
+                    "has_display": sat.capabilities.has_display,
+                    "has_enviro": sat.capabilities.has_enviro,
                 },
                 # Version and update info
                 "version": sat.version,

--- a/src/frontend/src/api/resources/satellites.ts
+++ b/src/frontend/src/api/resources/satellites.ts
@@ -28,6 +28,14 @@ export interface SatelliteCapabilities {
   local_wakeword?: boolean;
   speaker?: boolean;
   led_count?: number;
+  button?: boolean;
+  /** "apa102" | "gpio_rgb" | "xvf3800" | "none" — runtime LED/array hint
+   *  (true Ansible hat_type is not transmitted by the device). */
+  led_type?: string | null;
+  mic_channels?: number;
+  has_camera?: boolean;
+  has_display?: boolean;
+  has_enviro?: boolean;
 }
 
 export interface SatelliteSession {

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -717,6 +717,15 @@
     "english": "English"
   },
   "satellites": {
+    "caps": {
+      "wakeWord": "Wake Word",
+      "speaker": "Lautsprecher",
+      "leds": "{{count}} LEDs",
+      "mics": "{{count}} Mikrofone",
+      "camera": "Kamera",
+      "display": "Display",
+      "enviro": "Umweltsensor"
+    },
     "title": "Satelliten-Monitor",
     "subtitle": "Live-Status der verbundenen Satelliten",
     "loadError": "Satelliten konnten nicht geladen werden",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -717,6 +717,15 @@
     "english": "English"
   },
   "satellites": {
+    "caps": {
+      "wakeWord": "Wake Word",
+      "speaker": "Speaker",
+      "leds": "{{count}} LEDs",
+      "mics": "{{count}} Mics",
+      "camera": "Camera",
+      "display": "Display",
+      "enviro": "Environment Sensor"
+    },
     "title": "Satellite Monitor",
     "subtitle": "Live status of connected satellites",
     "loadError": "Failed to load satellites",

--- a/src/frontend/src/pages/SatellitesPage.tsx
+++ b/src/frontend/src/pages/SatellitesPage.tsx
@@ -304,16 +304,34 @@ function SatelliteCard({ satellite, expanded, onToggle, latestVersion, onUpdate 
             </div>
           )}
 
-          {/* Capabilities */}
+          {/* Capabilities — reported by the device on register; reflects
+              THIS satellite's real hardware (older clients fall back to the
+              base badges). */}
           <div className="flex flex-wrap gap-2">
             {satellite.capabilities?.local_wakeword && (
-              <Badge color="blue">Wake Word</Badge>
+              <Badge color="blue">{t('satellites.caps.wakeWord', 'Wake Word')}</Badge>
             )}
             {satellite.capabilities?.speaker && (
-              <Badge color="purple">Speaker</Badge>
+              <Badge color="purple">{t('satellites.caps.speaker', 'Speaker')}</Badge>
             )}
             {(satellite.capabilities?.led_count ?? 0) > 0 && (
-              <Badge color="amber">{satellite.capabilities?.led_count} LEDs</Badge>
+              <Badge color="amber">
+                {t('satellites.caps.leds', '{{count}} LEDs', { count: satellite.capabilities?.led_count })}
+              </Badge>
+            )}
+            {(satellite.capabilities?.mic_channels ?? 0) > 1 && (
+              <Badge color="teal">
+                {t('satellites.caps.mics', '{{count}} Mics', { count: satellite.capabilities?.mic_channels })}
+              </Badge>
+            )}
+            {satellite.capabilities?.has_camera && (
+              <Badge color="green">{t('satellites.caps.camera', 'Camera')}</Badge>
+            )}
+            {satellite.capabilities?.has_display && (
+              <Badge color="pink">{t('satellites.caps.display', 'Display')}</Badge>
+            )}
+            {satellite.capabilities?.has_enviro && (
+              <Badge color="accent">{t('satellites.caps.enviro', 'Environment Sensor')}</Badge>
             )}
           </div>
 

--- a/src/satellite/renfield_satellite/network/websocket_client.py
+++ b/src/satellite/renfield_satellite/network/websocket_client.py
@@ -68,6 +68,7 @@ class WebSocketClient:
         reconnect_interval: int = 5,
         heartbeat_interval: int = 30,
         language: str = "de",
+        capabilities: Optional[Dict[str, Any]] = None,
     ):
         """
         Initialize WebSocket client.
@@ -79,6 +80,11 @@ class WebSocketClient:
             reconnect_interval: Seconds between reconnect attempts
             heartbeat_interval: Seconds between heartbeats
             language: Language code for STT/TTS (e.g., 'de', 'en')
+            capabilities: Real hardware capabilities derived from this
+                satellite's config (led_count, mic_channels, has_camera,
+                has_display, led_type). Merged over conservative defaults in
+                the register payload; passing None keeps the safe defaults so
+                an older caller never breaks.
         """
         self.server_url = server_url
         self.satellite_id = satellite_id
@@ -86,6 +92,7 @@ class WebSocketClient:
         self.reconnect_interval = reconnect_interval
         self.heartbeat_interval = heartbeat_interval
         self.language = language
+        self._capabilities = capabilities or {}
 
         self._ws: Optional["WebSocketClientProtocol"] = None
         self._state = ConnectionState.DISCONNECTED
@@ -315,11 +322,14 @@ class WebSocketClient:
             "room": self.room,
             "language": self.language,
             "version": __version__,
+            # Conservative defaults, overridden by real config-derived
+            # values passed in at construction (see __init__ `capabilities`).
             "capabilities": {
                 "local_wakeword": True,
                 "speaker": True,
                 "led_count": 3,
                 "button": True,
+                **self._capabilities,
             },
             "protocol_version": self._protocol_version
         }

--- a/src/satellite/renfield_satellite/satellite.py
+++ b/src/satellite/renfield_satellite/satellite.py
@@ -210,6 +210,19 @@ class Satellite:
             reconnect_interval=self.config.server.reconnect_interval,
             heartbeat_interval=self.config.server.heartbeat_interval,
             language=self.config.satellite.language,
+            # Real hardware capabilities so the fleet page reflects THIS
+            # device, not a hardcoded "3 LEDs" for every satellite.
+            # hat_type is an Ansible host_var, not in the runtime config;
+            # led_type ("apa102"/"gpio_rgb"/"xvf3800"/"none") + mic_channels
+            # are the truthful runtime hardware hints.
+            capabilities={
+                "led_count": self.config.led.num_leds,
+                "led_type": self.config.led.type,
+                "mic_channels": self.config.audio.channels,
+                "has_camera": self.config.camera.enabled,
+                "has_display": self.config.display.enabled,
+                "has_enviro": self.config.enviro.enabled,
+            },
         )
 
         # Service discovery for auto-finding server

--- a/tests/backend/test_satellites.py
+++ b/tests/backend/test_satellites.py
@@ -50,6 +50,69 @@ class TestSatelliteManager:
         assert manager.satellites["test-satellite"].language == "de"
 
     @pytest.mark.unit
+    async def test_register_reports_rich_hardware_capabilities(self, manager):
+        """A modern satellite reports its real hardware; the values must
+        survive into get_all_satellites() so the fleet page shows THIS
+        device (not the legacy hardcoded '3 LEDs' for everyone)."""
+        await manager.register(
+            satellite_id="benszimmer",
+            room="BensZimmer",
+            websocket=AsyncMock(),
+            capabilities={
+                "local_wakeword": True,
+                "speaker": True,
+                "led_count": 12,
+                "led_type": "xvf3800",
+                "mic_channels": 4,
+                "has_camera": True,
+                "has_display": False,
+                "has_enviro": True,
+            },
+            language="de",
+        )
+
+        caps = manager.satellites["benszimmer"].capabilities
+        assert caps.led_count == 12
+        assert caps.led_type == "xvf3800"
+        assert caps.mic_channels == 4
+        assert caps.has_camera is True
+        assert caps.has_display is False
+        assert caps.has_enviro is True
+
+        # Serialized payload the REST route forwards to the frontend
+        serialized = next(
+            s for s in manager.get_all_satellites()
+            if s["satellite_id"] == "benszimmer"
+        )["capabilities"]
+        assert serialized["led_count"] == 12
+        assert serialized["led_type"] == "xvf3800"
+        assert serialized["mic_channels"] == 4
+        assert serialized["has_camera"] is True
+        assert serialized["has_display"] is False
+        assert serialized["has_enviro"] is True
+
+    @pytest.mark.unit
+    async def test_register_legacy_client_falls_back_to_safe_defaults(self, manager):
+        """An older satellite that does not report the rich fields must
+        still register and yield conservative defaults (no crash, no
+        misleading hardware claims)."""
+        await manager.register(
+            satellite_id="old-sat",
+            room="Wohnzimmer",
+            websocket=AsyncMock(),
+            capabilities={"local_wakeword": True, "speaker": True},
+            language="de",
+        )
+
+        caps = manager.satellites["old-sat"].capabilities
+        assert caps.led_count == 3
+        assert caps.led_type is None
+        assert caps.mic_channels == 1
+        assert caps.has_camera is False
+        assert caps.has_display is False
+        assert caps.has_enviro is False
+
+    @pytest.mark.unit
     async def test_register_reconnect(self, manager):
         """Test reconnecting an existing satellite"""
         mock_ws1 = AsyncMock()

--- a/tests/frontend/react/pages/SatellitesPage.test.tsx
+++ b/tests/frontend/react/pages/SatellitesPage.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { server } from '../mocks/server';
+import { BASE_URL } from '../mocks/handlers';
+import SatellitesPage from '../../../../src/frontend/src/pages/SatellitesPage';
+import { renderWithProviders } from '../test-utils';
+import type { SatelliteData } from '../../../../src/frontend/src/api/resources/satellites';
+
+/**
+ * Capability badges must reflect the satellite's REAL reported hardware,
+ * not the legacy hardcoded "3 LEDs" for every device. i18n test language
+ * is German (test-utils sets 'de'), so assertions use the de.json strings.
+ */
+
+function mockSatellites(sat: SatelliteData) {
+  server.use(
+    http.get(`${BASE_URL}/api/satellites`, () =>
+      HttpResponse.json({ satellites: [sat], latest_version: '1.0.0' }),
+    ),
+  );
+}
+
+const base = {
+  state: 'idle' as const,
+  uptime_seconds: 120,
+  heartbeat_ago_seconds: 2,
+};
+
+describe('SatellitesPage capability badges', () => {
+  it('renders the real hardware of a fully-equipped satellite', async () => {
+    mockSatellites({
+      ...base,
+      satellite_id: 'benszimmer',
+      room: 'BensZimmer',
+      capabilities: {
+        local_wakeword: true,
+        speaker: true,
+        led_count: 12,
+        led_type: 'xvf3800',
+        mic_channels: 4,
+        has_camera: true,
+        has_display: true,
+        has_enviro: true,
+      },
+    });
+
+    renderWithProviders(<SatellitesPage />);
+
+    // Cards render collapsed; capability badges live in the expanded body.
+    await waitFor(() => {
+      expect(screen.getByText('BensZimmer')).toBeInTheDocument();
+    });
+    await userEvent.click(screen.getByText('BensZimmer'));
+
+    // Data-driven, not the hardcoded 3
+    expect(await screen.findByText('12 LEDs')).toBeInTheDocument();
+    expect(screen.getByText('4 Mikrofone')).toBeInTheDocument();
+    expect(screen.getByText('Kamera')).toBeInTheDocument();
+    expect(screen.getByText('Umweltsensor')).toBeInTheDocument();
+    expect(screen.getByText('Wake Word')).toBeInTheDocument();
+    expect(screen.getByText('Lautsprecher')).toBeInTheDocument();
+    expect(screen.queryByText('3 LEDs')).not.toBeInTheDocument();
+  });
+
+  it('shows conservative badges for a legacy/minimal satellite', async () => {
+    mockSatellites({
+      ...base,
+      satellite_id: 'old-sat',
+      room: 'Wohnzimmer',
+      capabilities: {
+        local_wakeword: true,
+        speaker: true,
+        led_count: 3,
+        mic_channels: 1,
+        has_camera: false,
+        has_display: false,
+        has_enviro: false,
+      },
+    });
+
+    renderWithProviders(<SatellitesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Wohnzimmer')).toBeInTheDocument();
+    });
+    await userEvent.click(screen.getByText('Wohnzimmer'));
+
+    expect(await screen.findByText('3 LEDs')).toBeInTheDocument();
+    // Single-mic → no Mics badge; absent optional hardware → no badges
+    expect(screen.queryByText('1 Mikrofone')).not.toBeInTheDocument();
+    expect(screen.queryByText('Kamera')).not.toBeInTheDocument();
+    expect(screen.queryByText('Umweltsensor')).not.toBeInTheDocument();
+  });
+});

--- a/tests/satellite/test_satellite.py
+++ b/tests/satellite/test_satellite.py
@@ -351,3 +351,70 @@ class TestZeroconfDiscovery:
         props = mock_zeroconf_discovery["properties"]
         assert "ws_path" in props
         assert props["ws_path"] == "/ws/satellite"
+
+
+# ============================================================================
+# WebSocket register payload — real hardware capabilities
+# ============================================================================
+
+class TestWebSocketClientCapabilities:
+    """The satellite must report its REAL hardware in the register payload
+    so the fleet page reflects this device, not a hardcoded '3 LEDs'.
+    The contract is decoupled: satellite.py builds the dict from Config and
+    passes it in; websocket_client merges it over conservative defaults."""
+
+    def _client(self, **kw):
+        from renfield_satellite.network.websocket_client import WebSocketClient
+        return WebSocketClient(satellite_id="sat-x", room="Room", **kw)
+
+    def test_no_capabilities_keeps_safe_defaults(self):
+        """Backward compat: an old caller that passes nothing must not
+        crash and must carry an empty override set."""
+        client = self._client()
+        assert client._capabilities == {}
+
+    def test_capabilities_stored(self):
+        caps = {"led_count": 12, "mic_channels": 4, "has_camera": True}
+        client = self._client(capabilities=caps)
+        assert client._capabilities == caps
+
+    async def test_register_payload_merges_device_caps_over_defaults(self):
+        """The register message must contain the device's real values,
+        with conservative defaults filling anything not reported."""
+        import json
+
+        client = self._client(capabilities={
+            "led_count": 12,
+            "led_type": "xvf3800",
+            "mic_channels": 4,
+            "has_camera": True,
+            "has_display": False,
+            "has_enviro": True,
+        })
+
+        sent = {}
+
+        async def _capture(message):
+            sent.update(message)
+
+        client._send = _capture
+        client._ws = AsyncMock()
+        client._ws.recv = AsyncMock(return_value=json.dumps({
+            "type": "register_ack", "success": True,
+            "config": {}, "protocol_version": "1.0",
+        }))
+
+        await client._register()
+
+        caps = sent["capabilities"]
+        # Defaults still present
+        assert caps["local_wakeword"] is True
+        assert caps["speaker"] is True
+        assert caps["button"] is True
+        # Device-reported values win
+        assert caps["led_count"] == 12
+        assert caps["led_type"] == "xvf3800"
+        assert caps["mic_channels"] == 4
+        assert caps["has_camera"] is True
+        assert caps["has_display"] is False
+        assert caps["has_enviro"] is True


### PR DESCRIPTION
## Problem

The satellite fleet page showed a hardcoded **"Wake Word / Speaker / 3 LEDs"** for *every* satellite. The satellite client literally sent a fixed `capabilities` dict on register and never read its own config, so e.g. BensZimmer/Fitnessraum (12 LEDs), Arbeitszimmer (display + camera, 0 LEDs) all wrongly showed "3 LEDs" and nothing about their real hardware. This corrects misleading data, not just adds badges.

## Changes

- **Satellite client**: build capabilities from `Config` (`led_count`, `led_type`, `mic_channels`, `has_camera`, `has_display`, `has_enviro`) and pass them into `WebSocketClient`, merged over conservative defaults in the register payload. Decoupled — `satellite.py` owns the `Config`→dict mapping; an older caller passing nothing keeps the safe defaults (no crash).
- **Backend**: `SatelliteCapabilities` dataclass + `register()` mapping + `get_all_satellites()` serialization + `SatelliteCapabilitiesResponse` carry the new fields. Pure pass-through, conservative defaults, **no DB migration** (ephemeral in-memory model unchanged by design).
- **Frontend**: render Mics / Camera / Display / Environment-Sensor badges; LED count is now data-driven. i18n'd **all** capability badges in `de` + `en` (the pre-existing Wake Word/Speaker/LEDs were hardcoded English — a CLAUDE.md violation in that block).
- `docs/SATELLITE_MONITORING.md` example updated.

## Scope / honest notes

- True Ansible `hat_type` is **not** in the satellite's runtime config, so it is not transmitted; `led_type` (`xvf3800`/`apa102`/`gpio_rgb`/`none`) + `mic_channels` are surfaced as the truthful runtime hardware hints instead of fabricating a HAT string.
- Offline display was deliberately scoped out (chosen "ephemeral only"): capabilities stay in-memory; an offline / not-yet-reconnected satellite falls back to default badges.
- **Rollout caveat:** a satellite keeps sending the old hardcoded values until its client is updated **and its service restarted** — the Pi Zero 2 W brick-risk class. Backend + frontend are backward compatible, so a mixed fleet renders correctly (defaults for not-yet-updated devices). Staged per-device rollout is a separate operation.

## Tests / verification

- **Backend (.159):** new `TestSatelliteManager` rich + legacy-fallback capability-flow tests pass; the 5 pre-existing `TestSatelliteAPI` route-not-mounted failures are unchanged vs a stashed pristine baseline → **+2 net, zero regressions**.
- **Frontend:** `tsc --noEmit` clean (only unrelated pre-existing `three` errors); new `SatellitesPage.test.tsx` (rich vs minimal satellite, expand-card, data-driven LED count) — **2/2 pass**; test-dir `npm run typecheck` clean.
- **Satellite client:** register-payload merge + backward-compat test added and `py_compile`-clean, but **not executed** — the `tests/satellite` suite has no runner in the validation environment (mock-based, compile-verified only). Should be run wherever that suite normally runs before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
