### PR TITLE
fix(i18n): pluralise LED / mic capability badges

### DIFF
--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -720,8 +720,10 @@
     "caps": {
       "wakeWord": "Wake Word",
       "speaker": "Lautsprecher",
-      "leds": "{{count}} LEDs",
-      "mics": "{{count}} Mikrofone",
+      "leds_one": "1 LED",
+      "leds_other": "{{count}} LEDs",
+      "mics_one": "1 Mikrofon",
+      "mics_other": "{{count}} Mikrofone",
       "camera": "Kamera",
       "display": "Display",
       "enviro": "Umweltsensor"

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -720,8 +720,10 @@
     "caps": {
       "wakeWord": "Wake Word",
       "speaker": "Speaker",
-      "leds": "{{count}} LEDs",
-      "mics": "{{count}} Mics",
+      "leds_one": "1 LED",
+      "leds_other": "{{count}} LEDs",
+      "mics_one": "1 Mic",
+      "mics_other": "{{count}} Mics",
       "camera": "Camera",
       "display": "Display",
       "enviro": "Environment Sensor"

--- a/tests/frontend/react/pages/SatellitesPage.test.tsx
+++ b/tests/frontend/react/pages/SatellitesPage.test.tsx
@@ -93,4 +93,37 @@ describe('SatellitesPage capability badges', () => {
     expect(screen.queryByText('Kamera')).not.toBeInTheDocument();
     expect(screen.queryByText('Umweltsensor')).not.toBeInTheDocument();
   });
+
+  it('uses singular form when a satellite reports exactly one LED', async () => {
+    // sat-arbeitszimmer-style: whisplay HAT has 1 status RGB LED.
+    // i18next picks _one over _other for count=1 → "1 LED", not "1 LEDs".
+    mockSatellites({
+      ...base,
+      satellite_id: 'arbeitszimmer',
+      room: 'Arbeitszimmer',
+      capabilities: {
+        local_wakeword: true,
+        speaker: true,
+        led_count: 1,
+        led_type: 'gpio_rgb',
+        mic_count: 2,
+        has_camera: true,
+        has_display: true,
+        has_enviro: false,
+      },
+    });
+
+    renderWithProviders(<SatellitesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Arbeitszimmer')).toBeInTheDocument();
+    });
+    await userEvent.click(screen.getByText('Arbeitszimmer'));
+
+    expect(await screen.findByText('1 LED')).toBeInTheDocument();
+    expect(screen.queryByText('1 LEDs')).not.toBeInTheDocument();
+    expect(screen.getByText('2 Mikrofone')).toBeInTheDocument();
+    expect(screen.getByText('Kamera')).toBeInTheDocument();
+    expect(screen.getByText('Display')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
The capability badges added in #594 / #595 are gated on `count`-interpolated i18n keys, but only the plural form was defined — so a satellite reporting exactly one device reads as **"1 LEDs"** / **"1 Mikrofone"**. `sat-arbeitszimmer` (whisplay HAT, 1 status RGB LED) is the trigger; any future single-mic device would hit the same.

Use i18next's count-based `_one` / `_other` plural keys.

- `de.json` / `en.json`: `leds` → `leds_one` + `leds_other`; `mics` → `mics_one` + `mics_other`.
- `SatellitesPage.tsx` unchanged — the `t()` call already passes `count`, so i18next resolves the plural form automatically once the keys exist.
- `SatellitesPage.test.tsx`: new singular-case test (`led_count: 1` → `'1 LED'` present, `'1 LEDs'` not present). All 3 tests pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
