### PR TITLE
fix(frontend): SW must not swallow /auth and /api navigations

### DIFF
--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -59,6 +59,15 @@ export default defineConfig({
         ]
       },
       workbox: {
+        // The SPA navigateFallback (index.html) must NOT swallow
+        // server-handled routes. Without this denylist the Workbox
+        // service worker returns the cached app shell for /auth/*
+        // navigations, so OIDC/SAML redirect logins AND their IdP
+        // callbacks never reach the backend — the auth dance is
+        // invisible to every returning visitor (the SW is installed).
+        // curl works (no SW); real browsers don't. RegExps are
+        // evaluated on every navigation, so keep them minimal.
+        navigateFallbackDenylist: [/^\/auth\//, /^\/api\//],
         // Exclude large WASM files from precaching (ONNX Runtime)
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff,woff2}'],
         // Skip large files silently instead of erroring

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -67,7 +67,14 @@ export default defineConfig({
         // invisible to every returning visitor (the SW is installed).
         // curl works (no SW); real browsers don't. RegExps are
         // evaluated on every navigation, so keep them minimal.
-        navigateFallbackDenylist: [/^\/auth\//, /^\/api\//],
+        navigateFallbackDenylist: [
+          /^\/auth\//,         // OIDC / social redirect login + callback
+          /^\/oauth2\//,       // OAuth2 redirect paths some IdPs mount
+          /^\/saml\//,         // SAML ACS / SLO callbacks
+          /^\/api\//,          // backend JSON API (same-origin)
+          /^\/ws\//,           // WebSocket upgrade paths
+          /^\/\.well-known\//, // OIDC discovery, ACME, etc.
+        ],
         // Exclude large WASM files from precaching (ONNX Runtime)
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff,woff2}'],
         // Skip large files silently instead of erroring


### PR DESCRIPTION
## Summary
The PWA service worker silently breaks redirect-based auth: `vite.config.ts`'s VitePWA config omits `navigateFallbackDenylist`, so Workbox's default `navigateFallback: index.html` serves the cached SPA shell for **every** same-origin navigation — including `/auth/oidc/login` AND the IdP's redirect back to `/auth/oidc/callback`. The auth dance never reaches the backend; the browser just renders the SPA. `curl` works (no SW), real browsers don't.

## Fix
Add `navigateFallbackDenylist: [/^\/auth\//, /^\/api\//]` to the workbox block. Workbox evaluates these RegExps on every navigation, so they're kept minimal. The existing `runtimeCaching` rule with `urlPattern: /^https:\/\/api\./` only matches a separate-origin shape and doesn't cover same-origin `/api/*`.

## Verification (downstream consumer X-idra-Systems-GmbH/reva)
- **Pre-fix** (any returning visitor with the SW installed): `GET /auth/oidc/login` → 200 with cached `index.html`; Microsoft never reached; OIDC dance silently invisible. The bug surfaced as "user sees no login screen" while `curl` of the same URL correctly 302s.
- **Post-fix**: the SW skips the cached shell on `/auth/*`, request hits the backend, server returns the 302 to the IdP. Same for `/auth/oidc/callback` so the IdP redirect-back actually mints the session.

## Scope
- Affects every redirect-based auth flow (OIDC, SAML, social) on this PWA.
- No behavior change for non-`/auth`, non-`/api` SPA routes.
- After merge, downstream needs to rebuild the frontend image so `sw.js` ships the new denylist.