### PR TITLE
fix(auth): LDAPProvider retries without AD-only attrs on strict OpenLDAP

### DIFF
--- a/src/backend/auth/providers/ldap.py
+++ b/src/backend/auth/providers/ldap.py
@@ -96,6 +96,21 @@ class LDAPProvider:
             connect_timeout=settings.ldap_connect_timeout,
         )
 
+        # OpenLDAP (entryUUID/uid) vs AD (objectGUID/sAMAccountName) split the
+        # subject + username attrs. Strict OpenLDAP rejects the WHOLE search
+        # with LDAPAttributeError "invalid attribute type objectGUID" when an
+        # unknown attr is in the explicit list — fail-open then swallows it
+        # and the walk falls through to db, returning 401. Try the AD-aware
+        # superset first; on LDAPAttributeError, retry without the AD-only
+        # names. entryUUID/uid alone still gives a stable subject + username
+        # for OpenLDAP; AD continues to get objectGUID/sAMAccountName.
+        _attrs_full = [
+            "entryUUID", "objectGUID", "displayName", "mail", "memberOf",
+            "uid", "cn", "sn", "givenName", "sAMAccountName",
+        ]
+        _attrs_openldap = [
+            a for a in _attrs_full if a not in ("objectGUID", "sAMAccountName")
+        ]
         try:
             # Step 1: service-account bind → locate the user entry.
             with Connection(
@@ -107,22 +122,22 @@ class LDAPProvider:
                 client_strategy=SAFE_SYNC,
             ) as conn:
                 # SAFE_SYNC → entries live in `response`, not conn.entries.
-                _ok, _result, response, _request = conn.search(
-                    search_base=user_base_dn,
-                    search_filter=user_filter,
-                    attributes=[
-                        "entryUUID",
-                        "objectGUID",
-                        "displayName",
-                        "mail",
-                        "memberOf",
-                        "uid",
-                        "cn",
-                        "sn",
-                        "givenName",
-                        "sAMAccountName",
-                    ],
-                )
+                try:
+                    _ok, _result, response, _request = conn.search(
+                        search_base=user_base_dn,
+                        search_filter=user_filter,
+                        attributes=_attrs_full,
+                    )
+                except ldap3.core.exceptions.LDAPAttributeError:
+                    logger.debug(
+                        "LDAP auth: directory rejected AD-only attrs — "
+                        "retrying as OpenLDAP (entryUUID/uid only)"
+                    )
+                    _ok, _result, response, _request = conn.search(
+                        search_base=user_base_dn,
+                        search_filter=user_filter,
+                        attributes=_attrs_openldap,
+                    )
                 entries = [
                     r
                     for r in (response or [])


### PR DESCRIPTION
## Summary
`LDAPProvider.authenticate()` issues `conn.search(..., attributes=[…])` with both the OpenLDAP-only (`entryUUID`, `uid`) and AD-only (`objectGUID`, `sAMAccountName`) attribute names in a single explicit list. Strict OpenLDAP rejects the **whole search** with `LDAPAttributeError: invalid attribute type objectGUID` rather than silently returning `null` for the unknown attrs.

The provider's outer `except LDAPException` catches that as a directory error and `raise`s — which the registry treats as provider-unreachable, fail-open-skips it, and the walk falls through to `db`. Since the LDAP-only user has no DB row, the user gets a 401 "Incorrect username or password" despite valid LDAP credentials.

curl-reproducible against any strict OpenLDAP (e.g. `osixia/openldap`):

```
ldap3.core.exceptions.LDAPAttributeError: invalid attribute type objectGUID
```

## Fix
Try the AD-aware superset first; on `LDAPAttributeError`, retry without `objectGUID` and `sAMAccountName`. `entryUUID` + `uid` stay in the list so OpenLDAP gets a stable subject + username for the `ProviderResult`; AD continues to use `objectGUID`/`sAMAccountName` from the first attempt — no regression.

## Verification (downstream X-idra-Systems-GmbH/reva)
- Pre-fix: `POST /api/auth/login testuser/test123` against `osixia/openldap` → 401. Pod log: `auth.providers.ldap:authenticate:163 - LDAP auth: directory error for 'testuser': invalid attribute type objectGUID` then `auth.registry:authenticate:127 - Auth provider 'ldap' errored — skipped (fail-open), continuing walk`.
- Post-fix: same request → 200 + JWT. Pod log: `LDAP auth: directory rejected AD-only attrs — retrying as OpenLDAP (entryUUID/uid only)` (DEBUG), then `LDAP auth: 'testuser' authenticated as 'Test User' (subject=<entryUUID>)`.

## Scope
- Only affects OpenLDAP (or any directory that rejects unknown attributes); AD path is identical to before.
- One additional round-trip in the OpenLDAP case (the retry). Acceptable for an interactive login.