### PR TITLE
feat(auth): show human name in /auth/me + Layout, not the raw username

### DIFF
--- a/src/backend/api/routes/auth.py
+++ b/src/backend/api/routes/auth.py
@@ -421,6 +421,8 @@ async def get_auth_status(
         user_response = UserResponse(
             id=user.id,
             username=user.username,
+            first_name=user.first_name,
+            last_name=user.last_name,
             email=user.email,
             role=user.role.name,
             role_id=user.role_id,

--- a/src/backend/api/routes/auth.py
+++ b/src/backend/api/routes/auth.py
@@ -294,6 +294,8 @@ async def register(
     return UserResponse(
         id=user.id,
         username=user.username,
+        first_name=user.first_name,
+        last_name=user.last_name,
         email=user.email,
         role=user.role.name,
         role_id=user.role_id,
@@ -319,6 +321,8 @@ async def get_current_user_info(
     return UserResponse(
         id=user.id,
         username=user.username,
+        first_name=user.first_name,
+        last_name=user.last_name,
         email=user.email,
         role=user.role.name,
         role_id=user.role_id,

--- a/src/frontend/src/components/Layout.tsx
+++ b/src/frontend/src/components/Layout.tsx
@@ -113,6 +113,16 @@ export default function Layout({ children }: LayoutProps) {
 
   const { user, isAuthenticated, authEnabled, logout, hasAnyPermission, isFeatureEnabled } = useAuth();
 
+  // Display name fallback chain. Post auth-provider-registry, usernames are
+  // keyed on `<provider_id>:<subject>` (e.g. `entra:62d9da60-…`, `ldap:<uuid>`)
+  // — raw they look ugly. Prefer the human first+last, then first alone,
+  // then username.
+  const userDisplayName = user
+    ? ([user.first_name, user.last_name].filter(Boolean).join(' ').trim()
+        || user.first_name
+        || user.username)
+    : '';
+
   // Backend-gated Reva features that aren't in Renfield's feature dict.
   // wissensbasisAvailable: true when /api/wissensbasis/me/mix is reachable
   // (route mounted), undefined while the probe is in flight (don't flash
@@ -294,12 +304,12 @@ export default function Layout({ children }: LayoutProps) {
                 <button
                   onClick={handleLogout}
                   className="flex items-center space-x-2 px-3 py-1.5 rounded-lg text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-                  title={`${t('auth.loggedInAs')} ${user?.username}`}
+                  title={`${t('auth.loggedInAs')} ${userDisplayName}`}
                 >
                   <div className="w-7 h-7 rounded-full bg-primary-600/30 flex items-center justify-center">
                     <User className="w-4 h-4 text-primary-600 dark:text-primary-400" />
                   </div>
-                  <span className="hidden sm:block text-sm">{user?.username}</span>
+                  <span className="hidden sm:block text-sm">{userDisplayName}</span>
                 </button>
               ) : (
                 <Link
@@ -432,7 +442,7 @@ export default function Layout({ children }: LayoutProps) {
                         <User className="w-4 h-4 text-primary-600 dark:text-primary-400" />
                       </div>
                       <div className="flex-1 min-w-0 lg:opacity-0 lg:group-hover/sidebar:opacity-100 transition-opacity duration-200">
-                        <p className="text-sm font-medium text-gray-900 dark:text-white truncate">{user?.username}</p>
+                        <p className="text-sm font-medium text-gray-900 dark:text-white truncate">{userDisplayName}</p>
                         <p className="text-xs text-gray-500 dark:text-gray-400 truncate">{user?.role?.name}</p>
                       </div>
                     </div>

--- a/src/frontend/src/types/api.ts
+++ b/src/frontend/src/types/api.ts
@@ -133,6 +133,8 @@ export interface ApiError {
 export interface User {
   id: number;
   username: string;
+  first_name?: string | null;
+  last_name?: string | null;
   email?: string;
   is_active: boolean;
   role_id: number;


### PR DESCRIPTION
## Summary
`UserResponse` already declares `first_name` / `last_name` (`routes/auth.py:69-70`), but the two response constructors in the same file (register + /me) silently omit them when building the response — so the API returns them as `null` even when the DB has values. The frontend `User` interface (`types/api.ts`) is missing the fields entirely, and `Layout.tsx` renders `user?.username` directly in three places (header tooltip, header chip, sidebar identity card).

When `username` is a short human handle (`admin`, `evdb`, `releaseadmin`) the raw value reads fine. With the new pluggable auth provider registry (#591/#592), it's common for downstream consumers (e.g. X-idra-Systems-GmbH/reva) to mint Renfield rows keyed on `<provider_id>:<subject>` — e.g. `entra:62d9da60-…`, `ldap:f7b87212-bbc9-…`. Those keys are stable + correct but ugly in the UI.

## Changes
- **Backend** (`src/backend/api/routes/auth.py`): pass `first_name=user.first_name, last_name=user.last_name` to both `UserResponse(...)` constructions (register endpoint + `/me` endpoint).
- **Frontend type** (`src/frontend/src/types/api.ts`): add `first_name?: string | null; last_name?: string | null;` to the `User` interface — already correctly populated by the backend, just not in the type.
- **Frontend Layout** (`src/frontend/src/components/Layout.tsx`): add a `userDisplayName = first+last || first || username` derivation and use it in the three render sites. Fallback chain preserves the existing render for users with empty first/last.

## Verification (downstream X-idra-Systems-GmbH/reva, against this patched build)
- `GET /api/auth/me` returns `{"first_name": "Test", "last_name": "User", "username": "ldap:f7b87212-…", …}` (was `first_name: null` before this patch).
- Header chip + sidebar identity card render `Test User` instead of `ldap:f7b87212-…`.
- A user whose `first_name`/`last_name` are NULL still renders `username` bare → **no regression** for the pre-registry default render.

## Scope
- No new fields, no DB change, no migration — `users.first_name` and `users.last_name` already exist (`UsersPage.tsx:37-38` already shows them in the admin grid).
- Pure response-shape backfill + a frontend type/render polish.