### PR TITLE
fix(auth): /auth/status UserResponse missing personality_style/personality_prompt

### DIFF
--- a/src/backend/api/routes/auth.py
+++ b/src/backend/api/routes/auth.py
@@ -428,6 +428,8 @@ async def get_auth_status(
             role_id=user.role_id,
             permissions=user.get_permissions(),
             is_active=user.is_active,
+            personality_style=user.personality_style,
+            personality_prompt=user.personality_prompt,
             created_at=user.created_at,
             last_login=user.last_login,
             speaker_id=user.speaker_id


### PR DESCRIPTION
## Summary
`/auth/status`'s `UserResponse(...)` constructor omits `personality_style` and `personality_prompt`. The `/me` (line 321) and `/register` (line 294) constructors include them. UserResponse's Pydantic defaults (`"freundlich"` + `None`) keep the response shape valid — no crash — but a returning user whose personality is non-default sees a stale value on the app-shell bootstrap until the frontend hydrates from a subsequent `/me` call.

Pre-existing — predates #599 (which closed the same shape of bug for `first_name`/`last_name`). Surfaced during an independent review pass of the #599 follow-up.

## Fix
Two lines: thread `personality_style=user.personality_style, personality_prompt=user.personality_prompt` into the third UserResponse constructor.

## Follow-up worth considering
This is the third "one of three UserResponse constructors got forgotten" bug in this file (`first_name`/`last_name` initially missed `/me` and `/status` in #599; now this). A `_user_response(user: User) -> UserResponse` helper would close the trap permanently — future fields land in one place. Not in this PR (keeping the fix minimal and the diff small enough to backport), but flagging.

## Scope
- No schema change, no migration, no test impact (no `/auth/status` test pins these fields today).
- No behavior regression for default-personality users (defaults were already filled in by Pydantic).