### PR TITLE
feat(voice): barge-in — interrupt the assistant by speaking

### DIFF
--- a/docs/VOICE_PIPELINE_DESIGN.md
+++ b/docs/VOICE_PIPELINE_DESIGN.md
@@ -117,7 +117,7 @@ Endpoint: `wss://renfield.local/ws/voice`. One bidirectional connection per voic
 | binary frame | audio chunk in the codec announced by `session_start` | every ~100 ms while recording |
 | `{type: "stt_flush"}` | — | client-side VAD or "stop" button — commits the STT pipeline. Renamed from `audio_end` (see R3) to disambiguate from the server-side TTS-done message. |
 | `{type: "tts_request", request_id, text, language?, voice?}` | full assistant answer to synthesize | after chat response received from backend. `request_id` correlates downstream events. |
-| `{type: "cancel", request_id}` | — | reserved for Phase B.next (barge-in). Cancels the matching `tts_request`. |
+| `{type: "cancel", request_id}` | — | barge-in — cancels the matching in-flight `tts_request`. The frontend's `cancelAllPlayback()` sends one per pending request when the user interrupts. |
 | `{type: "ping"}` | — | keepalive, server replies with `pong` |
 
 #### Server → Client
@@ -128,6 +128,7 @@ Endpoint: `wss://renfield.local/ws/voice`. One bidirectional connection per voic
 | `{type: "final_transcript", text, language, speaker_embedding: float32[192], audio_duration_s}` | committed result on VAD silence | `speaker_embedding` is the raw ECAPA-TDNN output (192 floats, ~2 KB JSON) — the frontend forwards it on the chat WebSocket; backend's `services/speaker_service.py` does the cosine match + auto-enrolment. `audio_duration_s` lets the backend tag the SpeakerEmbedding row with what was sampled. |
 | binary frame | WAV chunk (22 kHz PCM, with WAV header) | one frame per synthesized sentence. **Self-describing format (review-cycle 3 GAP-3 fix):** the binary payload begins with a fixed 24-byte header — `magic` (4 bytes, ASCII `RFWA`), `request_id` (16 bytes, UUID), `sequence` (4 bytes, big-endian uint32). The remaining bytes are the standard WAV file. This removes the JSON-meta-frame ordering trap from v1.2 — the frontend can route every binary frame to the right playback queue without maintaining a "last-seen meta" cursor. The `audio_chunk_meta` JSON message is dropped from the protocol entirely. |
 | `{type: "tts_done", request_id}` | — | TTS finished for this `request_id`. Renamed from `audio_end` (R3). |
+| `{type: "cancelled", request_id}` | — | the server honoured a client `cancel` for this `request_id` (barge-in). A clean, expected stop — kept distinct from `error` so the frontend suppresses the failure bubble. A teardown/internal cancellation still emits `error`/`tts_failed`. |
 | `{type: "error", code, message, request_id?}` | typed: `stt_failed`, `tts_failed`, `model_unavailable`, `invalid_audio`, `speaker_extract_failed` | typed errors so the frontend can recover, not bubble up as generic 500. `speaker_extract_failed` does **not** abort the transcript — backend still gets `final_transcript` without `speaker_embedding`, treats the speaker as unknown for that turn. |
 
 ### Latency budget (target, post-R4 review)

--- a/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
+++ b/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
@@ -13,6 +13,7 @@ import {
   useQuickActions,
   useVoiceStream,
   type FinalTranscript,
+  type TtsOutcome,
 } from '../hooks';
 
 // Phase B streaming voice pipeline. When `VITE_FEATURE_VOICE_STREAM=true`,
@@ -21,6 +22,9 @@ import {
 // during the soak period so flag-off is the safety path.
 const VOICE_STREAM_ENABLED = import.meta.env.VITE_FEATURE_VOICE_STREAM === 'true';
 const ACCESS_TOKEN_KEY = 'renfield_access_token';
+// Stable no-op for the legacy (flag-off) path's cancelAllPlayback so the
+// context value's identity doesn't churn every render.
+const NOOP = (): void => {};
 import type {
   ActionWsMessage,
   AgentFederationProgressMessage,
@@ -160,6 +164,13 @@ export interface ChatContextValue {
   // when not recording or when VITE_FEATURE_VOICE_STREAM is off.
   partialText: string;
   toggleRecording: () => void;
+  // Barge-in (plan §5.3). `playbackActive` is true while a TTS reply is
+  // pending or playing; `cancelAllPlayback` stops it. Exposed for a
+  // future manual stop-speaking control — Fork A's acoustic listener
+  // triggers cancellation from inside useVoiceStream. NOOP / false on
+  // the legacy path.
+  playbackActive: boolean;
+  cancelAllPlayback: () => void;
 
   // RAG
   useRag: boolean;
@@ -959,12 +970,16 @@ export function ChatProvider({ children }: ChatProviderProps) {
     return () => window.removeEventListener('storage', handler);
   }, []);
 
-  // Sentence-streaming TTS bookkeeping — onTtsDone fires per dispatched
-  // sentence; when the stream is done AND no requests are in flight,
-  // resume wake word + clear the autoTTS-pending lock.
-  const handleStreamTtsDone = useCallback((requestId: string) => {
+  // Sentence-streaming TTS bookkeeping — onTtsSettled fires per
+  // dispatched sentence on EVERY terminal outcome (done / cancelled /
+  // error). Draining `pending` regardless of outcome is required: a
+  // barge-in cancels in-flight sentences, and if a `cancelled` frame
+  // did not drain the counter it would stay off-by-N and wake word
+  // would never resume (plan finding 8).
+  const handleStreamTtsSettled = useCallback((requestId: string, outcome: TtsOutcome) => {
     const stream = sentenceStreamRef.current;
     if (!stream.active) return;
+    debug.log('sentence-streaming TTS settled', requestId, outcome);
     stream.pending.delete(requestId);
     if (stream.streamDone && stream.pending.size === 0) {
       // Reset for the next utterance.
@@ -986,7 +1001,7 @@ export function ChatProvider({ children }: ChatProviderProps) {
     token: streamToken,
     onFinal: handleStreamFinal,
     onError: handleStreamError,
-    onTtsDone: handleStreamTtsDone,
+    onTtsSettled: handleStreamTtsSettled,
     // R7 fix from B.3 review: lastInputChannelRef + autoTTSPendingRef +
     // wake-word-pause are all set in handleRecordingStart; without these
     // hooks the streaming path silently bypasses auto-TTS for voice
@@ -1018,6 +1033,10 @@ export function ChatProvider({ children }: ChatProviderProps) {
   // Falls back to empty string on the legacy path so consumers can
   // render unconditionally without checking the flag.
   const partialText = VOICE_STREAM_ENABLED ? voiceStream.partialText : '';
+  // Barge-in surface (plan §5.3). Legacy path has no streaming TTS, so
+  // playback is never "active" and there is nothing to cancel.
+  const playbackActive = VOICE_STREAM_ENABLED ? voiceStream.playbackActive : false;
+  const cancelAllPlayback = VOICE_STREAM_ENABLED ? voiceStream.cancelAllPlayback : NOOP;
   // Stable callback identities — without these the conditional ternaries
   // would create a new function every render, breaking memoization
   // downstream (the main exported context object).
@@ -1364,6 +1383,8 @@ export function ChatProvider({ children }: ChatProviderProps) {
     silenceTimeRemaining,
     partialText,
     toggleRecording,
+    playbackActive,
+    cancelAllPlayback,
 
     // RAG
     useRag,
@@ -1409,6 +1430,7 @@ export function ChatProvider({ children }: ChatProviderProps) {
     conversations, conversationsLoading,
     wsConnected,
     recording, audioLevel, silenceTimeRemaining, partialText, toggleRecording,
+    playbackActive, cancelAllPlayback,
     useRag, toggleRag, selectedKnowledgeBase,
     attachments, uploading, uploadError, handleUploadDocument, removeAttachment, uploadStates,
     wakeWord, wakeWordStatus,

--- a/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
+++ b/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
@@ -43,6 +43,7 @@ import type { UploadStates, UploadedDocument } from '../hooks/useDocumentUpload'
 import type { Conversation } from '../../../types/chat';
 import type { TraceEntity } from '../../../api/resources/wissensbasis';
 import { useConfirmDialog } from '../../../components/ConfirmDialog';
+import { drainSentenceTts, type SentenceStreamState } from './sentenceStream';
 
 const SESSION_STORAGE_KEY = 'renfield_current_session';
 // How long sendMessageInternal waits for the WebSocket handshake before
@@ -424,13 +425,7 @@ export function ChatProvider({ children }: ChatProviderProps) {
   // when interleaved on the wire. Empirically saves ~22 s of
   // perceived latency on a typical Qwen3.6 German response (29.4 s
   // → 7.1 s end-to-end final-transcript-to-last-audio).
-  const sentenceStreamRef = useRef<{
-    accumulated: string;
-    dispatchedIdx: number;
-    active: boolean;
-    pending: Set<string>;
-    streamDone: boolean;
-  }>({
+  const sentenceStreamRef = useRef<SentenceStreamState>({
     accumulated: '',
     dispatchedIdx: 0,
     active: false,
@@ -980,8 +975,10 @@ export function ChatProvider({ children }: ChatProviderProps) {
     const stream = sentenceStreamRef.current;
     if (!stream.active) return;
     debug.log('sentence-streaming TTS settled', requestId, outcome);
-    stream.pending.delete(requestId);
-    if (stream.streamDone && stream.pending.size === 0) {
+    // drainSentenceTts drains on every outcome — done / cancelled /
+    // error alike (plan finding 8) — and reports when the turn is fully
+    // settled.
+    if (drainSentenceTts(stream, requestId)) {
       // Reset for the next utterance.
       stream.active = false;
       stream.accumulated = '';

--- a/src/frontend/src/pages/ChatPage/context/sentenceStream.ts
+++ b/src/frontend/src/pages/ChatPage/context/sentenceStream.ts
@@ -1,0 +1,44 @@
+/**
+ * Sentence-streaming TTS bookkeeping — the pure state-transition behind
+ * ChatContext's `handleStreamTtsSettled`.
+ *
+ * Extracted so the drain logic is unit-testable without a ChatProvider
+ * harness, and so the plan's "finding 8" property is enforced by the
+ * type signature itself (see `drainSentenceTts`).
+ */
+
+/** The mutable sentence-streaming state ChatContext threads per turn. */
+export interface SentenceStreamState {
+  /** Assistant text accumulated so far this turn. */
+  accumulated: string;
+  /** Index up to which `accumulated` has been dispatched to TTS. */
+  dispatchedIdx: number;
+  /** True once the first sentence of this turn has been dispatched. */
+  active: boolean;
+  /** request_ids of sentence TTS calls still in flight. */
+  pending: Set<string>;
+  /** True once the chat stream itself has finished (the `done` frame). */
+  streamDone: boolean;
+}
+
+/**
+ * Drain one settled TTS request from the pending set.
+ *
+ * Deliberately takes NO outcome argument: a request that finished, was
+ * cancelled (barge-in), or errored must all drain identically. If a
+ * `cancelled` frame failed to drain the set, the counter would sit
+ * off-by-N and wake word would never resume (plan finding 8). Omitting
+ * the parameter makes that regression structurally impossible — there
+ * is no outcome here to branch on.
+ *
+ * Returns true when the turn is fully settled (the stream is done AND
+ * nothing is left in flight); the caller then resets state + resumes
+ * wake word.
+ */
+export function drainSentenceTts(
+  stream: Pick<SentenceStreamState, 'pending' | 'streamDone'>,
+  requestId: string,
+): boolean {
+  stream.pending.delete(requestId);
+  return stream.streamDone && stream.pending.size === 0;
+}

--- a/src/frontend/src/pages/ChatPage/hooks/index.ts
+++ b/src/frontend/src/pages/ChatPage/hooks/index.ts
@@ -2,4 +2,4 @@ export { useChatWebSocket } from './useChatWebSocket';
 export { useAudioRecording } from './useAudioRecording';
 export { useDocumentUpload } from './useDocumentUpload';
 export { useQuickActions } from './useQuickActions';
-export { useVoiceStream, type FinalTranscript } from './useVoiceStream';
+export { useVoiceStream, type FinalTranscript, type TtsOutcome } from './useVoiceStream';

--- a/src/frontend/src/pages/ChatPage/hooks/useVoiceStream.ts
+++ b/src/frontend/src/pages/ChatPage/hooks/useVoiceStream.ts
@@ -823,7 +823,10 @@ export function useVoiceStream({
   // Phase 0 measured browser AEC keeps the assistant's own TTS well
   // below BARGE_IN_RMS_THRESHOLD on laptop speakers.
   useEffect(() => {
-    if (!playbackActive) return undefined;
+    // Also gate on !recording: the listener and an active recording are
+    // mutually exclusive. A manual mic-button press during TTS would
+    // otherwise leave a second mic stream open alongside the recorder.
+    if (!playbackActive || recording) return undefined;
     let cancelled = false;
 
     const open = async (): Promise<void> => {
@@ -904,7 +907,7 @@ export function useVoiceStream({
         bargeInStreamRef.current = null;
       }
     };
-  }, [playbackActive, ensureAudioContext]);
+  }, [playbackActive, recording, ensureAudioContext]);
 
   // Cleanup on unmount.
   useEffect(() => {

--- a/src/frontend/src/pages/ChatPage/hooks/useVoiceStream.ts
+++ b/src/frontend/src/pages/ChatPage/hooks/useVoiceStream.ts
@@ -31,6 +31,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { getWebSocketUrl } from '../../../utils/env';
 import { debug } from '../../../utils/debug';
+import { computeRms } from './voiceAudioUtils';
 
 const RFWA_MAGIC = new Uint8Array([0x52, 0x46, 0x57, 0x41]); // "RFWA"
 const HEADER_LEN = 24; // 4 magic + 16 uuid + 4 sequence
@@ -571,10 +572,7 @@ export function useVoiceStream({
           vadFrameRef.current = null;
           return;
         }
-        a.getByteFrequencyData(dataArray);
-        let sum = 0;
-        for (let i = 0; i < dataArray.length; i += 1) sum += dataArray[i] * dataArray[i];
-        const rms = Math.sqrt(sum / dataArray.length);
+        const rms = computeRms(a, dataArray);
         const now = Date.now();
         const recordingTime = now - recordingStart;
 

--- a/src/frontend/src/pages/ChatPage/hooks/useVoiceStream.ts
+++ b/src/frontend/src/pages/ChatPage/hooks/useVoiceStream.ts
@@ -14,6 +14,12 @@
  *   ws.onmessage(binary) → strip 24-byte RFWA header → decode WAV →
  *     bounded playback queue (decoded buffers played sequentially)
  *
+ * Cancellation / barge-in plumbing (plan §5.2):
+ *   A monotonic generation token + a pending-request map let
+ *   `cancelAllPlayback()` stop in-flight TTS cleanly — see the refs
+ *   block below. The acoustic barge-in listener that drives it lives
+ *   in Fork A (T4); this hook ships the shared mechanism.
+ *
  * Gated by `VITE_FEATURE_VOICE_STREAM=true`; consumers pick this hook
  * vs `useAudioRecording` based on the flag. The hook does NOT do its
  * own feature-flag check — caller responsibility.
@@ -31,6 +37,17 @@ const HEADER_LEN = 24; // 4 magic + 16 uuid + 4 sequence
 
 const VOICE_CODEC = 'audio/webm;codecs=opus';
 const CHUNK_INTERVAL_MS = 100;
+
+// A TTS request whose terminal frame (tts_done / cancelled / error)
+// never arrives — server crash, dropped frame, WS death — would pin
+// `playbackActive` true forever and (in Fork A) hold the barge-in mic
+// open. This watchdog force-drops such a rid as a last-resort backstop.
+const PENDING_TTS_WATCHDOG_MS = 60000;
+// Grace window for the `playbackActive` false-edge. TTS is sentence-
+// streamed (one request per sentence), so the raw signal flickers in
+// the gaps between sentences; holding it true through the gap makes it
+// one clean edge per reply instead of one per sentence.
+const PLAYBACK_IDLE_GRACE_MS = 600;
 
 // Timing diagnostics for voice pipeline. Toggle in browser console:
 //   localStorage.setItem('renfield_voice_timing', '1') → enable
@@ -58,6 +75,8 @@ const VAD = {
   SMOOTHING: 0.3,
 };
 
+type TtsOutcome = 'done' | 'cancelled' | 'error';
+
 interface FinalTranscript {
   text: string;
   language: string;
@@ -70,7 +89,11 @@ interface UseVoiceStreamOptions {
   onPartial?: (text: string, confidence: number) => void;
   onFinal?: (result: FinalTranscript) => void;
   onError?: (code: string, message: string, requestId?: string) => void;
-  onTtsDone?: (requestId: string) => void;
+  // Fires once per TTS request when it reaches a terminal frame:
+  // 'done' (finished), 'cancelled' (client barge-in), or 'error'.
+  // Consumers that count in-flight TTS MUST drain on every outcome —
+  // a missed 'cancelled' leaves the counter off-by-N (plan finding 8).
+  onTtsSettled?: (requestId: string, outcome: TtsOutcome) => void;
   onRecordingStart?: () => void | Promise<void>;
   onRecordingStop?: () => void;
 }
@@ -87,15 +110,30 @@ function buildVoiceWsUrl(token: string | null): string {
   return `${base}/ws/voice`;
 }
 
-function decodeRfwaHeader(buf: ArrayBuffer): { sequence: number; wavBody: ArrayBuffer } | null {
+function bytesToUuid(bytes: Uint8Array): string {
+  const hex: string[] = [];
+  for (let i = 0; i < 16; i += 1) hex.push(bytes[i].toString(16).padStart(2, '0'));
+  return (
+    `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-`
+    + `${hex.slice(6, 8).join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10, 16).join('')}`
+  );
+}
+
+function decodeRfwaHeader(
+  buf: ArrayBuffer,
+): { requestId: string; sequence: number; wavBody: ArrayBuffer } | null {
   if (buf.byteLength <= HEADER_LEN) return null;
   const view = new Uint8Array(buf, 0, 4);
   for (let i = 0; i < 4; i += 1) {
     if (view[i] !== RFWA_MAGIC[i]) return null;
   }
+  // Bytes 4..19 are the request_id (Python uuid.UUID.bytes — standard
+  // RFC 4122 order, so this reconstructs the crypto.randomUUID() string
+  // the client sent in the matching tts_request).
+  const requestId = bytesToUuid(new Uint8Array(buf, 4, 16));
   const dv = new DataView(buf, 20, 4);
   const sequence = dv.getUint32(0, false); // big-endian per protocol
-  return { sequence, wavBody: buf.slice(HEADER_LEN) };
+  return { requestId, sequence, wavBody: buf.slice(HEADER_LEN) };
 }
 
 function generateRequestId(): string {
@@ -115,7 +153,7 @@ export function useVoiceStream({
   onPartial,
   onFinal,
   onError,
-  onTtsDone,
+  onTtsSettled,
   onRecordingStart,
   onRecordingStop,
 }: UseVoiceStreamOptions) {
@@ -135,6 +173,23 @@ export function useVoiceStream({
   const chunkQueueRef = useRef<ArrayBuffer[]>([]);
   const drainingRef = useRef(false);
 
+  // --- Barge-in / cancellation plumbing (plan §5.2) ----------------
+  // Monotonic token. cancelAllPlayback() bumps it; speakText and
+  // drainQueue capture it across awaits and bail if it moved, so TTS
+  // the agent produced before the user interrupted never reaches the
+  // speaker. A monotonic counter is self-correcting — each new request
+  // captures the current value — so it never needs resetting.
+  const bargeInGenerationRef = useRef(0);
+  // request_id → its watchdog timer. A Map (not a Set) so a rid that
+  // settles normally clears its own timer; `.size` / `.has` still give
+  // the set-membership the rest of the code needs.
+  const pendingTtsRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  // The BufferSource currently playing — hoisted out of drainQueue so
+  // cancelAllPlayback can hard-stop it mid-sentence.
+  const currentSourceRef = useRef<AudioBufferSourceNode | null>(null);
+  // Debounce timer for the playbackActive false-edge (hysteresis).
+  const playbackIdleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const [recording, setRecording] = useState(false);
   const [partialText, setPartialText] = useState<string>('');
   const [connected, setConnected] = useState(false);
@@ -142,6 +197,10 @@ export function useVoiceStream({
   // indicator as the legacy hook (RMS bar + countdown).
   const [audioLevel, setAudioLevel] = useState(0);
   const [silenceTimeRemaining, setSilenceTimeRemaining] = useState(0);
+  // True while a TTS reply is pending or playing, held through the gaps
+  // between sentence-streamed chunks. Fork A's barge-in listener gates
+  // on this; ChatContext re-exports it for a future manual-stop button.
+  const [playbackActive, setPlaybackActive] = useState(false);
 
   // 'closed' is a valid AudioContextState at runtime but the TS DOM
   // lib version this project ships with omits it from the union.
@@ -155,6 +214,46 @@ export function useVoiceStream({
     return audioContextRef.current;
   }, []);
 
+  // --- playbackActive derivation (hysteresis) ----------------------
+  const isPlaybackIdle = useCallback((): boolean => (
+    pendingTtsRef.current.size === 0
+    && chunkQueueRef.current.length === 0
+    && !drainingRef.current
+  ), []);
+
+  const markPlaybackActive = useCallback((): void => {
+    if (playbackIdleTimerRef.current !== null) {
+      clearTimeout(playbackIdleTimerRef.current);
+      playbackIdleTimerRef.current = null;
+    }
+    setPlaybackActive(true);
+  }, []);
+
+  // Schedule the false-edge behind a grace window so the signal does
+  // not flap in the gap between two sentence-streamed TTS requests.
+  const maybeEndPlayback = useCallback((): void => {
+    if (!isPlaybackIdle()) return;
+    if (playbackIdleTimerRef.current !== null) return; // grace already pending
+    playbackIdleTimerRef.current = setTimeout(() => {
+      playbackIdleTimerRef.current = null;
+      if (isPlaybackIdle()) setPlaybackActive(false);
+    }, PLAYBACK_IDLE_GRACE_MS);
+  }, [isPlaybackIdle]);
+
+  // --- pending-TTS bookkeeping -------------------------------------
+  const removePendingTts = useCallback((requestId: string): void => {
+    const timer = pendingTtsRef.current.get(requestId);
+    if (timer === undefined) return;
+    clearTimeout(timer);
+    pendingTtsRef.current.delete(requestId);
+    maybeEndPlayback();
+  }, [maybeEndPlayback]);
+
+  const clearAllPendingTts = useCallback((): void => {
+    pendingTtsRef.current.forEach((timer) => clearTimeout(timer));
+    pendingTtsRef.current.clear();
+  }, []);
+
   const drainQueue = useCallback(async () => {
     if (drainingRef.current) return;
     drainingRef.current = true;
@@ -163,6 +262,11 @@ export function useVoiceStream({
         if (unmountedRef.current) return;
         const wavBuf = chunkQueueRef.current.shift();
         if (!wavBuf) continue;
+        // Capture the barge-in generation for this chunk. If the user
+        // interrupts while decodeAudioData is awaiting below, the token
+        // moves and we drop the decoded buffer rather than play audio
+        // the user already cancelled.
+        const gen = bargeInGenerationRef.current;
         try {
           const ctx = ensureAudioContext();
           if ((ctx.state as string) === 'closed') return;
@@ -171,11 +275,16 @@ export function useVoiceStream({
           }
           const audioBuffer = await ctx.decodeAudioData(wavBuf);
           if (unmountedRef.current || (ctx.state as string) === 'closed') return;
+          if (gen !== bargeInGenerationRef.current) break; // barge-in during decode
           const source = ctx.createBufferSource();
           source.buffer = audioBuffer;
           source.connect(ctx.destination);
+          currentSourceRef.current = source;
           await new Promise<void>((resolve) => {
-            source.onended = () => resolve();
+            source.onended = () => {
+              if (currentSourceRef.current === source) currentSourceRef.current = null;
+              resolve();
+            };
             source.start();
           });
         } catch (err) {
@@ -186,14 +295,28 @@ export function useVoiceStream({
       }
     } finally {
       drainingRef.current = false;
+      // No source is ever playing at a drainQueue exit — every exit is
+      // past an onended or before a start. Null the ref so a stale
+      // handle can't linger between a barge-in and the next reply.
+      currentSourceRef.current = null;
+      maybeEndPlayback();
     }
-  }, [ensureAudioContext]);
+  }, [ensureAudioContext, maybeEndPlayback]);
 
-  const enqueuePlayback = useCallback((wavBuf: ArrayBuffer) => {
+  const enqueuePlayback = useCallback((requestId: string, wavBuf: ArrayBuffer) => {
     if (unmountedRef.current) return;
+    // Rid gate: only play a frame whose request is still in flight. A
+    // binary frame already on the wire for a request the user just
+    // cancelled (cancelAllPlayback dropped it from pendingTtsRef) is
+    // discarded here instead of playing one stray sentence.
+    if (!pendingTtsRef.current.has(requestId)) {
+      debug.log('voice: dropping frame for settled/cancelled request', requestId);
+      return;
+    }
     chunkQueueRef.current.push(wavBuf);
+    markPlaybackActive();
     void drainQueue();
-  }, [drainQueue]);
+  }, [drainQueue, markPlaybackActive]);
 
   const handleTextMessage = useCallback((raw: string) => {
     let msg: Record<string, unknown>;
@@ -238,23 +361,43 @@ export function useVoiceStream({
         onFinal?.(result);
         break;
       }
-      case 'tts_done':
-        vlog('tts_done', { rid: msg.request_id });
-        onTtsDone?.((msg.request_id as string) ?? '');
+      case 'tts_done': {
+        const rid = (msg.request_id as string) ?? '';
+        vlog('tts_done', { rid });
+        removePendingTts(rid);
+        onTtsSettled?.(rid, 'done');
         break;
-      case 'error':
+      }
+      case 'cancelled': {
+        // Client barge-in honoured by the server (plan §5.1). A clean,
+        // expected stop — NOT an error; never surfaces to onError.
+        const rid = (msg.request_id as string) ?? '';
+        vlog('tts_cancelled', { rid });
+        removePendingTts(rid);
+        onTtsSettled?.(rid, 'cancelled');
+        break;
+      }
+      case 'error': {
+        // `error` is also a terminal frame for a TTS request — drain
+        // the pending entry so a failed rid can't pin playbackActive.
+        const rid = msg.request_id as string | undefined;
+        if (rid) {
+          removePendingTts(rid);
+          onTtsSettled?.(rid, 'error');
+        }
         onError?.(
           (msg.code as string) ?? 'unknown',
           (msg.message as string) ?? '',
-          msg.request_id as string | undefined,
+          rid,
         );
         break;
+      }
       case 'pong':
         break;
       default:
         debug.log('voice: unknown message type', t);
     }
-  }, [onPartial, onFinal, onError, onTtsDone]);
+  }, [onPartial, onFinal, onError, onTtsSettled, removePendingTts]);
 
   const ensureSocket = useCallback((): Promise<WebSocket> => {
     // Fast-path: already open and session_ready.
@@ -289,6 +432,16 @@ export function useVoiceStream({
         try { rec.stop(); } catch { /* ignore */ }
       }
       setRecording(false);
+      // No terminal frame will arrive for in-flight TTS once the socket
+      // is gone — drop the pending map (and its watchdog timers) and the
+      // undelivered queue so a leaked rid can't pin playbackActive true.
+      clearAllPendingTts();
+      chunkQueueRef.current = [];
+      if (playbackIdleTimerRef.current !== null) {
+        clearTimeout(playbackIdleTimerRef.current);
+        playbackIdleTimerRef.current = null;
+      }
+      setPlaybackActive(false);
     };
     ws.onerror = (ev) => {
       debug.log('voice: ws error', ev);
@@ -303,7 +456,7 @@ export function useVoiceStream({
         if (decoded) {
           vlog('binary_frame', { size: decoded.wavBody.byteLength, seq: decoded.sequence });
           // decoded.wavBody is a standalone WAV with its own header.
-          enqueuePlayback(decoded.wavBody);
+          enqueuePlayback(decoded.requestId, decoded.wavBody);
         } else {
           debug.log('voice: binary frame missing RFWA header, dropping');
         }
@@ -345,7 +498,7 @@ export function useVoiceStream({
       if (pendingSocketRef.current === handshake) pendingSocketRef.current = null;
     });
     return handshake;
-  }, [token, handleTextMessage, enqueuePlayback]);
+  }, [token, handleTextMessage, enqueuePlayback, clearAllPendingTts]);
 
   const startRecording = useCallback(async (): Promise<void> => {
     if (recording) return;
@@ -510,21 +663,72 @@ export function useVoiceStream({
     }
   }, []);
 
-  const speakText = useCallback(async (text: string, language?: string): Promise<string> => {
+  const speakText = useCallback(async (text: string, language?: string): Promise<string | null> => {
     vlog('speakText:start', { len: text.length, preview: text.slice(0, 40) });
-    const ws = await ensureSocket();
+    // Capture the barge-in generation before any await. If the user
+    // interrupts during the socket handshake below, the token moves and
+    // we drop this request rather than speak over their new turn.
+    const gen = bargeInGenerationRef.current;
+    let ws: WebSocket;
+    try {
+      ws = await ensureSocket();
+    } catch (e) {
+      debug.log('voice: speakText ensureSocket failed', e);
+      return null;
+    }
+    if (gen !== bargeInGenerationRef.current) {
+      vlog('speakText:gated', { reason: 'barge-in during handshake' });
+      return null;
+    }
     const requestId = generateRequestId();
+    // Watchdog backstop: if no terminal frame ever arrives, force-drop
+    // the rid so it can't pin playbackActive (and Fork A's mic) open.
+    const watchdog = setTimeout(() => {
+      if (pendingTtsRef.current.has(requestId)) {
+        debug.log('voice: tts watchdog force-dropped', requestId);
+        removePendingTts(requestId);
+      }
+    }, PENDING_TTS_WATCHDOG_MS);
+    pendingTtsRef.current.set(requestId, watchdog);
+    markPlaybackActive();
     ws.send(JSON.stringify({ type: 'tts_request', request_id: requestId, text, language }));
     vlog('tts_request_sent', { rid: requestId, len: text.length });
     return requestId;
-  }, [ensureSocket]);
+  }, [ensureSocket, markPlaybackActive, removePendingTts]);
 
+  // Send a cancel frame for one request. Private — cancelAllPlayback is
+  // the public operation; no caller wants per-request cancellation.
   const cancelTts = useCallback((requestId: string): void => {
     const ws = wsRef.current;
     if (ws && ws.readyState === WebSocket.OPEN) {
       ws.send(JSON.stringify({ type: 'cancel', request_id: requestId }));
     }
   }, []);
+
+  // Stop all TTS — the barge-in entry point. Drives the server-side
+  // cancel, the local queue flush, and the generation bump that gates
+  // any post-interrupt TTS the agent is still producing.
+  const cancelAllPlayback = useCallback((): void => {
+    // Bump the generation so TTS the agent generates for the
+    // interrupted turn no-ops in speakText / drainQueue.
+    bargeInGenerationRef.current += 1;
+    // Cancel every in-flight request server-side and drop it locally.
+    // Optimistic removal — a binary frame still on the wire for one of
+    // these rids is then dropped by enqueuePlayback's rid gate.
+    pendingTtsRef.current.forEach((timer, rid) => {
+      clearTimeout(timer);
+      cancelTts(rid);
+    });
+    pendingTtsRef.current.clear();
+    // Flush undelivered audio and hard-stop what is playing now.
+    chunkQueueRef.current = [];
+    if (currentSourceRef.current) {
+      try { currentSourceRef.current.stop(); } catch { /* already stopped */ }
+      currentSourceRef.current = null;
+    }
+    // Fork A wires synchronous barge-in-listener teardown in here (T4).
+    maybeEndPlayback();
+  }, [cancelTts, maybeEndPlayback]);
 
   // Cleanup on unmount.
   useEffect(() => {
@@ -546,6 +750,14 @@ export function useVoiceStream({
       }
       // Clear any queued chunks so the drain loop exits promptly.
       chunkQueueRef.current = [];
+      // Drop pending-TTS watchdog timers + the playback-idle timer so
+      // they can't fire into a destroyed component.
+      pendingTtsRef.current.forEach((timer) => clearTimeout(timer));
+      pendingTtsRef.current.clear();
+      if (playbackIdleTimerRef.current !== null) {
+        clearTimeout(playbackIdleTimerRef.current);
+        playbackIdleTimerRef.current = null;
+      }
       const ctx = audioContextRef.current;
       if (ctx && (ctx.state as string) !== 'closed') {
         try { void ctx.close(); } catch { /* ignore */ }
@@ -557,13 +769,14 @@ export function useVoiceStream({
     startRecording,
     stopRecording,
     speakText,
-    cancelTts,
+    cancelAllPlayback,
     recording,
     partialText,
     connected,
     audioLevel,
     silenceTimeRemaining,
+    playbackActive,
   };
 }
 
-export type { FinalTranscript };
+export type { FinalTranscript, TtsOutcome };

--- a/src/frontend/src/pages/ChatPage/hooks/useVoiceStream.ts
+++ b/src/frontend/src/pages/ChatPage/hooks/useVoiceStream.ts
@@ -31,7 +31,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { getWebSocketUrl } from '../../../utils/env';
 import { debug } from '../../../utils/debug';
-import { computeRms } from './voiceAudioUtils';
+import { computeRms, detectBargeIn } from './voiceAudioUtils';
 
 const RFWA_MAGIC = new Uint8Array([0x52, 0x46, 0x57, 0x41]); // "RFWA"
 const HEADER_LEN = 24; // 4 magic + 16 uuid + 4 sequence
@@ -49,6 +49,19 @@ const PENDING_TTS_WATCHDOG_MS = 60000;
 // the gaps between sentences; holding it true through the gap makes it
 // one clean edge per reply instead of one per sentence.
 const PLAYBACK_IDLE_GRACE_MS = 600;
+
+// --- Fork A barge-in listener (plan §6.2) ----------------------------
+// RMS threshold (0..255 scale) above which the mic counts as "voiced"
+// while TTS plays. The Phase 0 AEC spike measured TTS-only RMS p95 ≈ 8
+// vs human-speech median ≈ 54 on laptop speakers (6.8× margin); 20 sits
+// well clear of the TTS floor (geo-mean of the two was ≈ 20.7).
+const BARGE_IN_RMS_THRESHOLD = 20;
+// Voiced energy must hold this long continuously before it counts as a
+// barge-in — rejects transient clicks, coughs, and key taps.
+const BARGE_IN_SUSTAIN_MS = 150;
+// Suppress detection for this long after the listener opens, so browser
+// AEC has settled and playback has actually begun.
+const BARGE_IN_WARMUP_MS = 250;
 
 // Timing diagnostics for voice pipeline. Toggle in browser console:
 //   localStorage.setItem('renfield_voice_timing', '1') → enable
@@ -190,6 +203,22 @@ export function useVoiceStream({
   const currentSourceRef = useRef<AudioBufferSourceNode | null>(null);
   // Debounce timer for the playbackActive false-edge (hysteresis).
   const playbackIdleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // --- Fork A barge-in listener (plan §6.2/6.3) --------------------
+  // A dedicated analyser-only mic stream, opened for the duration of a
+  // TTS reply. On detection the SAME stream is promoted to the recorder
+  // (§6.3), so the user's interrupting utterance is captured, not lost.
+  const bargeInStreamRef = useRef<MediaStream | null>(null);
+  const bargeInAnalyserRef = useRef<AnalyserNode | null>(null);
+  const bargeInFrameRef = useRef<number | null>(null);
+  const bargeInVoicedSinceRef = useRef<number | null>(null);
+  const bargeInStartedAtRef = useRef<number>(0);
+  // Latched once a barge-in fires so the rAF loop cannot double-trigger
+  // between detection and teardown.
+  const bargeInFiredRef = useRef(false);
+  // Indirection so the listener effect never lists the handler as a
+  // dependency — the listener must open exactly once per reply.
+  const bargeInHandlerRef = useRef<() => void>(() => {});
 
   const [recording, setRecording] = useState(false);
   const [partialText, setPartialText] = useState<string>('');
@@ -501,42 +530,14 @@ export function useVoiceStream({
     return handshake;
   }, [token, handleTextMessage, enqueuePlayback, clearAllPendingTts]);
 
-  const startRecording = useCallback(async (): Promise<void> => {
-    if (recording) return;
-
-    if (!MediaRecorder.isTypeSupported(VOICE_CODEC)) {
-      onError?.('codec_unsupported', `browser does not support codec ${VOICE_CODEC}`);
-      return;
-    }
-
-    let ws: WebSocket;
-    try {
-      ws = await ensureSocket();
-    } catch (e) {
-      onError?.('ws_open_failed', e instanceof Error ? e.message : String(e));
-      return;
-    }
-
-    // Each utterance gets its own session_start so the server can
-    // spawn a fresh decoder. Without this, the first utterance works
-    // (decoder created on WS open), but every subsequent recording
-    // hits "decoder is None" on the server (finalize tore it down).
-    // Server's session_start handler is idempotent. WS message order
-    // is preserved end-to-end and the receive loop is sequential, so
-    // the session_start fully completes (decoder up) before the
-    // first MediaRecorder chunk arrives 100 ms later.
-    if (ws.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify({ type: 'session_start', codec: VOICE_CODEC }));
-    }
-
-    let stream: MediaStream;
-    try {
-      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-    } catch (e) {
-      onError?.('mic_denied', e instanceof Error ? e.message : String(e));
-      return;
-    }
-
+  // Build the MediaRecorder + VAD loop on an already-open mic stream
+  // and start streaming. Shared by startRecording (which gets a fresh
+  // getUserMedia stream) and the barge-in promotion (§6.3, which reuses
+  // the already-open listener stream — no second getUserMedia).
+  const beginRecordingWithStream = useCallback(async (
+    stream: MediaStream,
+    ws: WebSocket,
+  ): Promise<void> => {
     streamRef.current = stream;
     const recorder = new MediaRecorder(stream, { mimeType: VOICE_CODEC });
     recorderRef.current = recorder;
@@ -650,7 +651,43 @@ export function useVoiceStream({
 
     recorder.start(CHUNK_INTERVAL_MS);
     setRecording(true);
-  }, [recording, ensureSocket, ensureAudioContext, onError, onRecordingStart, onRecordingStop]);
+  }, [ensureAudioContext, onRecordingStart, onRecordingStop]);
+
+  const startRecording = useCallback(async (): Promise<void> => {
+    if (recording) return;
+
+    if (!MediaRecorder.isTypeSupported(VOICE_CODEC)) {
+      onError?.('codec_unsupported', `browser does not support codec ${VOICE_CODEC}`);
+      return;
+    }
+
+    let ws: WebSocket;
+    try {
+      ws = await ensureSocket();
+    } catch (e) {
+      onError?.('ws_open_failed', e instanceof Error ? e.message : String(e));
+      return;
+    }
+
+    // Each utterance gets its own session_start so the server spawns a
+    // fresh decoder (the first works off the WS-open decoder; later ones
+    // would hit "decoder is None" after finalize). Idempotent server-
+    // side; message order guarantees the decoder is up before the first
+    // chunk arrives ~100 ms later.
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: 'session_start', codec: VOICE_CODEC }));
+    }
+
+    let stream: MediaStream;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch (e) {
+      onError?.('mic_denied', e instanceof Error ? e.message : String(e));
+      return;
+    }
+
+    await beginRecordingWithStream(stream, ws);
+  }, [recording, ensureSocket, beginRecordingWithStream, onError]);
 
   const stopRecording = useCallback((): void => {
     const rec = recorderRef.current;
@@ -728,6 +765,147 @@ export function useVoiceStream({
     maybeEndPlayback();
   }, [cancelTts, maybeEndPlayback]);
 
+  // --- Fork A: barge-in detected → promote listener to recorder (§6.3)
+  const handleBargeInDetected = useCallback((): void => {
+    if (bargeInFiredRef.current) return;
+    bargeInFiredRef.current = true;
+    vlog('barge_in_detected');
+    // Stop the listening loop now; KEEP the stream — it is about to
+    // become the recording stream.
+    if (bargeInFrameRef.current !== null) {
+      cancelAnimationFrame(bargeInFrameRef.current);
+      bargeInFrameRef.current = null;
+    }
+    bargeInAnalyserRef.current = null;
+    const stream = bargeInStreamRef.current;
+    // Null the ref before the playbackActive effect's teardown can run,
+    // so teardown sees no listener stream to stop — ownership has moved.
+    bargeInStreamRef.current = null;
+
+    // Stop the assistant.
+    cancelAllPlayback();
+
+    if (!stream || recording) {
+      // No stream to promote, or a recording is somehow already live —
+      // the cancel above is all that was needed.
+      stream?.getTracks().forEach((tr) => tr.stop());
+      return;
+    }
+
+    // Promote the listener's stream straight into the recorder so the
+    // user's interrupting utterance becomes the next query — captured,
+    // not discarded (plan finding 6). No second getUserMedia.
+    void (async () => {
+      let ws: WebSocket;
+      try {
+        ws = await ensureSocket();
+      } catch (e) {
+        onError?.('ws_open_failed', e instanceof Error ? e.message : String(e));
+        stream.getTracks().forEach((tr) => tr.stop());
+        return;
+      }
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: 'session_start', codec: VOICE_CODEC }));
+      }
+      await beginRecordingWithStream(stream, ws);
+    })();
+  }, [cancelAllPlayback, ensureSocket, beginRecordingWithStream, onError, recording]);
+
+  // Keep the ref pointed at the latest handler so the listener effect
+  // below never depends on its identity — the listener opens exactly
+  // once per reply, not on every handler re-creation.
+  bargeInHandlerRef.current = handleBargeInDetected;
+
+  // The barge-in listener (plan §6.2): a dedicated analyser-only mic
+  // stream, open for the duration of a TTS reply, watching for the user
+  // to talk over the assistant. Gated on the hysteresis-debounced
+  // `playbackActive` so it is one open per reply, not one per sentence.
+  // Phase 0 measured browser AEC keeps the assistant's own TTS well
+  // below BARGE_IN_RMS_THRESHOLD on laptop speakers.
+  useEffect(() => {
+    if (!playbackActive) return undefined;
+    let cancelled = false;
+
+    const open = async (): Promise<void> => {
+      let stream: MediaStream;
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: false },
+        });
+      } catch (e) {
+        // Mic permission revoked between turns — degrade silently to
+        // no-barge-in for this reply (finding 3B). Mic button + wake
+        // word still work; the reply just plays uninterruptibly.
+        debug.log('voice: barge-in listener mic unavailable — barge-in off this reply', e);
+        return;
+      }
+      if (cancelled || unmountedRef.current) {
+        stream.getTracks().forEach((tr) => tr.stop());
+        return;
+      }
+      bargeInStreamRef.current = stream;
+      bargeInFiredRef.current = false;
+      bargeInVoicedSinceRef.current = null;
+      bargeInStartedAtRef.current = performance.now();
+      try {
+        const ctx = ensureAudioContext();
+        const source = ctx.createMediaStreamSource(stream);
+        const analyser = ctx.createAnalyser();
+        analyser.fftSize = VAD.FFT_SIZE;
+        analyser.smoothingTimeConstant = VAD.SMOOTHING;
+        source.connect(analyser);
+        bargeInAnalyserRef.current = analyser;
+        const scratch = new Uint8Array(analyser.frequencyBinCount);
+
+        const tick = (): void => {
+          const a = bargeInAnalyserRef.current;
+          if (!a || bargeInFiredRef.current) {
+            bargeInFrameRef.current = null;
+            return;
+          }
+          const now = performance.now();
+          if (now - bargeInStartedAtRef.current >= BARGE_IN_WARMUP_MS) {
+            const rms = computeRms(a, scratch);
+            const r = detectBargeIn(
+              rms, bargeInVoicedSinceRef.current, now,
+              BARGE_IN_RMS_THRESHOLD, BARGE_IN_SUSTAIN_MS,
+            );
+            bargeInVoicedSinceRef.current = r.voicedSince;
+            if (r.bargeIn) {
+              bargeInFrameRef.current = null;
+              bargeInHandlerRef.current();
+              return;
+            }
+          }
+          bargeInFrameRef.current = requestAnimationFrame(tick);
+        };
+        bargeInFrameRef.current = requestAnimationFrame(tick);
+      } catch (e) {
+        debug.log('voice: barge-in analyser setup failed', e);
+        stream.getTracks().forEach((tr) => tr.stop());
+        bargeInStreamRef.current = null;
+      }
+    };
+    void open();
+
+    return () => {
+      cancelled = true;
+      if (bargeInFrameRef.current !== null) {
+        cancelAnimationFrame(bargeInFrameRef.current);
+        bargeInFrameRef.current = null;
+      }
+      bargeInAnalyserRef.current = null;
+      // Stop the stream ONLY if it is still the listener's. If a
+      // barge-in fired, the handler nulled this ref and handed the
+      // stream to the recorder — leave that one running.
+      const s = bargeInStreamRef.current;
+      if (s) {
+        s.getTracks().forEach((tr) => tr.stop());
+        bargeInStreamRef.current = null;
+      }
+    };
+  }, [playbackActive, ensureAudioContext]);
+
   // Cleanup on unmount.
   useEffect(() => {
     return () => {
@@ -746,6 +924,14 @@ export function useVoiceStream({
       if (ws && ws.readyState !== WebSocket.CLOSED) {
         try { ws.close(); } catch { /* ignore */ }
       }
+      // Tear down the barge-in listener if one is still open.
+      if (bargeInFrameRef.current !== null) {
+        cancelAnimationFrame(bargeInFrameRef.current);
+        bargeInFrameRef.current = null;
+      }
+      bargeInAnalyserRef.current = null;
+      bargeInStreamRef.current?.getTracks().forEach((tr) => tr.stop());
+      bargeInStreamRef.current = null;
       // Clear any queued chunks so the drain loop exits promptly.
       chunkQueueRef.current = [];
       // Drop pending-TTS watchdog timers + the playback-idle timer so

--- a/src/frontend/src/pages/ChatPage/hooks/voiceAudioUtils.ts
+++ b/src/frontend/src/pages/ChatPage/hooks/voiceAudioUtils.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure audio helpers shared by useVoiceStream's two analyser loops: the
+ * end-of-utterance VAD (`checkSilence`) and Fork A's barge-in listener.
+ *
+ * Dependency-free and side-effect-free — they unit-test with nothing
+ * more than a stub `AnalyserNode`. Keeping one RMS implementation here
+ * means the two loops can never drift on how "loud" is measured.
+ */
+
+/**
+ * RMS of the analyser's current frequency-domain frame, on the 0..255
+ * byte scale.
+ *
+ * `scratch` is a caller-owned `Uint8Array` sized to
+ * `analyser.frequencyBinCount`, reused across frames so the rAF loop
+ * does not allocate.
+ */
+export function computeRms(analyser: AnalyserNode, scratch: Uint8Array<ArrayBuffer>): number {
+  analyser.getByteFrequencyData(scratch);
+  let sumSquares = 0;
+  for (let i = 0; i < scratch.length; i += 1) {
+    sumSquares += scratch[i] * scratch[i];
+  }
+  return scratch.length > 0 ? Math.sqrt(sumSquares / scratch.length) : 0;
+}
+
+/**
+ * Barge-in decision — pure and O(1).
+ *
+ * The caller threads `voicedSince`: the timestamp when RMS first rose
+ * to/above `threshold` in the current unbroken run of voiced frames, or
+ * `null` while below. Barge-in fires once voiced energy has been
+ * sustained for `sustainMs` — a brief dip below `threshold` resets the
+ * run, so transient noise spikes do not trigger.
+ *
+ * Returns the next `voicedSince` (thread it straight back in) and
+ * whether the sustain window is now met.
+ *
+ * Note: this is a deliberate, workable refinement of the plan §6.1
+ * sketch `detectBargeIn(belowSince, now, threshold, sustainMs)` — that
+ * 4-arg form had no RMS input, so `threshold` could not actually be
+ * applied. This form takes `rms` and owns the threshold comparison.
+ */
+export function detectBargeIn(
+  rms: number,
+  voicedSince: number | null,
+  now: number,
+  threshold: number,
+  sustainMs: number,
+): { voicedSince: number | null; bargeIn: boolean } {
+  if (rms < threshold) {
+    return { voicedSince: null, bargeIn: false };
+  }
+  const since = voicedSince ?? now;
+  return { voicedSince: since, bargeIn: now - since >= sustainMs };
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,145 +1,61 @@
-# Open Follow-Ups — post llama-server migration
+# Open Follow-Ups — refreshed 2026-05-21
 
-The Dual-GPU-VM plan that originally lived here has shipped — see PR #527 (text-LLM tier on `llama-server-agent` + `llama-server-embed`, `:llama-rc5` in production).
+Shipped / superseded items from the old voice-pipeline plan:
 
-Remaining open items:
+| Item | Reality |
+|---|---|
+| Phase A — streaming-first pipeline | Shipped: PR #509 (`faster-whisper` streaming + in-process Piper + singleton dedup), PR #534 (partial text + activation) |
+| Phase C — voice tier on GPU | Shipped: PR #531 (`voice-server` pod live on `k8s-gpu-3`); PR #532 wired `whisper_service` + `piper_service` thin-client delegation via `voice_server_url` |
+| Phase B.5 — XTTS-v2 evaluation | Shipped: PR #539 (decision: stay on Piper) |
+| End-of-utterance robustness | Shipped: PRs #535, #536 ("5 compounded design flaws") |
+| Voice-originated tool-call guard | Shipped: PR #542 (`verify_tool_call` hook + `voice_originated` ContextVar) |
+| **Voice barge-in (Fork A acoustic)** | **In review: PR #601** — interrupt the assistant by speaking. T1–T5 done; AEC spike passed 6.77×; two independent reviews. Plan: `tasks/voice-barge-in-plan.md`. Post-merge: run the PR's manual-test checklist on staging. |
+| Cosmetic `AGENT_MODEL=qwen3.6` | Done in `k8s/configmap.yaml` |
+| `:llama-rc5` re-tag to versioned | Moot — backend is on `:latest` with `imagePullPolicy: Always` |
+| Reva submodule bump (Stage 1) | Moot — submodule pointer is current (`v2.6.1-21-g856ae13`) |
 
----
-
-## 0. Voice-Pipeline Streaming + GPU (top priority)
-
-The current STT→LLM→TTS pipeline is request-response with three sequential blocking stages, all on CPU for the voice ends. Symptom: long answers TTS-timeout in the browser at 30 s, long recordings STT-timeout at 30 s. Architecturally we want:
-
-> **Streaming-first voice pipeline with VAD-driven barge-in, and GPU-resident voice models when hardware allows. Speech-to-Speech as the long-term endgame.**
-
-### Phase A — Streaming-First-Pipeline (2-3 days, no new hardware)
-
-Decided as the next concrete step. User already pushed back on patches (timeout bumps, frontend sentence-chunking) — we go straight to the structural fix.
-
-**Goals:**
-- First word audible within 1-2 s regardless of total answer length
-- No artificial axios timeouts; the connection stays open for as long as data flows
-- STT partial-transcript visibility while user is still speaking
-
-**Backend:**
-- New WebSocket `/ws/voice` (bidirectional). Frontend pushes audio chunks; backend pushes partial-transcript events + audio chunks.
-- STT: switch from `whisper.transcribe(file)` to `faster-whisper` streaming mode with `vad_filter=True`. Emit `{type: "partial", text: ...}` events as they arrive, then `{type: "final", text: ...}` on end-of-utterance.
-- TTS: split incoming text on sentence boundaries, run Piper per-sentence, write each WAV chunk to the WS as `{type: "audio_chunk", bytes: ...}`. End with `{type: "audio_end"}`.
-- Same backend pod, same Piper instance, same Whisper instance — no GPU change yet.
-
-**Frontend:**
-- New `useVoiceStream` hook to replace the request-response of `useAudioRecording` + the `speakText` REST call.
-- Capture: `MediaRecorder` chunked output to the WS.
-- Playback: `MediaSource` API with audio chunks appended to a SourceBuffer. Or continuous `AudioContext` BufferSource queue (simpler, slightly higher latency).
-- Drop the `_ttsErrorShown` window flag, drop the long-message console.warn — both gone with the new path.
-
-**Out of scope for Phase A:** barge-in (cancelling TTS when user starts speaking again). Mark for Phase B.
-
-### Phase B — Edge STT (offload to client device)
-
-Reduces backend STT load and latency by ~70 % for the macOS browser. Frontend uses `window.SpeechRecognition` (Web Speech API on Chrome/Safari) to do STT in-browser, sends only the final text. Satellites (Pi Zero) keep on-device VOSK or Whisper-tiny.
-
-Decision point: do we trust browser-side STT enough to skip Whisper for that path? For accessibility / multi-language, probably yes for the chat UI on a Mac. Satellites stay backend-driven.
-
-### Phase C — Voice-Tier auf GPU (medium-term, **needs the spare GPU**)
-
-User mentioned an unused GPU. Three places it could land:
-
-1. **As a third k8s node** (`k8s-gpu-3`) dedicated to voice: Piper-CUDA + faster-whisper-GPU + (later) Coqui XTTS-v2. ~150 ms TTS per sentence, <2 s STT for 10 s audio. Cleanest separation; LLM tier untouched. Needs k8s join + driver setup like the existing GPU nodes.
-2. **In the existing dual-GPU VM (`k8s-gpu-1`)** — but that node already has both GPUs claimed exclusively by `llama-server-agent`. Adding a third GPU to the same VM and reserving it for voice via taints/tolerations. Cleaner k8s-wise.
-3. **Separate dedicated host** outside k8s, accessed via OpenAI-compatible HTTP. Skips k8s overhead but adds an external dependency.
-
-**Action item for evdb: identify which physical machine the spare GPU fits into and how it slots into the k8s topology / VM layout.** Once that's known, write the manifest (`k8s/voice-server.yaml`) similar to `llama-server-embed.yaml`.
-
-### Phase D — Speech-to-Speech-Modell (long-term, watching)
-
-Replace STT+LLM+TTS pipeline with one multi-modal model. Candidates:
-- **Moshi** (Kyutai, open-source, ~7 B): full-duplex, on-device-capable, ~300 ms total round-trip, barge-in built in.
-- Future Llama-Voice / Qwen-Voice variants if they ship as open weights.
-
-Not actionable today — track upstream releases. When a stable open-weights model fits in 16-32 GB VRAM with acceptable quality, plan migration.
-
-### What we are explicitly NOT doing
-
-- **Bumping axios timeout to 180 s.** Hides the symptom, doesn't fix the architecture. Reverted.
-- **Frontend sentence-chunking with N parallel REST calls.** Half-streaming, leaves the pipeline shape unchanged. Reverted.
+Voice runs through `/ws/voice` on the `voice-server` pod with the frontend `useVoiceStream` hook, gated by `VITE_FEATURE_VOICE_STREAM=true`. Frames use the `RFWA` binary header (4-byte magic + 16-byte UUID + 4-byte sequence).
 
 ---
 
-## 1. Reva-Cross-Migration (3-stage convergence)
+## 1. Voice — edge STT (Phase B-original) — re-evaluate
 
-Reva (`/Users/evdb/projects.ai/reva`) consumes Renfield as a git submodule pinned at `48e493e` (3 commits behind main, pre-#527). Reva also has its own parallel adapter at `src/reva/llm/openai_client.py` (173 lines) — same Protocol pattern as Renfield's new `OpenAICompatibleClient`, but richer (Anthropic + vLLM backends, file trace logging). Done independently, before the Renfield migration landed.
+Original idea: `window.SpeechRecognition` in-browser, send only final text. Since the voice-server is now GPU-fast (<2 s STT for 10 s audio per the original Phase C estimate), this may no longer be worth the multi-engine complexity. Action: park unless someone measures a concrete win.
 
-**Goal:** Converge the two adapters without losing Reva's extra features. Three stages, each its own Reva-side PR. None of these are urgent — Reva works as-is today.
+## 2. Voice — Speech-to-Speech (Phase D) — tracking only
 
-### Stage 1 — submodule bump (5 min)
-
-```bash
-cd /Users/evdb/projects.ai/reva
-git submodule update --remote renfield
-cd renfield && git checkout origin/main
-cd .. && git add renfield
-git commit -m "chore(renfield): bump submodule to post-llama-server migration"
-```
-
-Then run Reva's test suite. Expected breakage: none of substance — Reva's per-role `ollama_url: "http://cuda.local:8081/v1"` workarounds in `config/agent_roles.yaml` still work because Renfield's old code path is unchanged when `LLM_OPENAI_BASE_URL` is unset.
-
-### Stage 2 — fold Reva's `OpenAIClient` into a subclass (1-2 h)
-
-Make `reva.llm.openai_client.OpenAIClient` extend `renfield.utils.llm_client.OpenAICompatibleClient`. Inherits:
-
-- `_OllamaShapedMessage` / `_OllamaShapedResponse` wrappers (no more drift)
-- `_options_to_openai`, `_think_extra_body`, `_convert_messages` (so Qwen3 thinking-mode workaround applies to Reva too)
-- Tool-call passthrough, embedding `.embedding`-shape
-
-Reva keeps as overrides:
-
-- `_log_llm_exchange` trace logging (file-based observability — not a Renfield platform feature today)
-- Multi-backend dispatch (Anthropic via `anthropic_client.py`, vLLM via `vllm_client.py`)
-
-### Stage 3 — drop Reva's per-role `ollama_url` workaround (1 h + Prod-Validierung)
-
-Replace `config/agent_roles.yaml` per-role `ollama_url: "http://cuda.local:8081/v1"` lines with the platform-level `LLM_OPENAI_BASE_URL` env var (same value), and the per-tier `LLM_OPENAI_FOR_*` flags where roles need to opt out individually. Cleaner config model, single point of truth.
-
-Validate against Reva's production cuda.local llama-server before merging.
+Not actionable. Watch upstream releases of Moshi (Kyutai), Llama-Voice, Qwen-Voice. Migrate when a stable open-weights model fits in 16-32 GB VRAM at acceptable quality with built-in barge-in.
 
 ---
 
-## 2. Vision-Tier (`Qwen3-VL`) wieder aktivieren
+## 3. Vision tier (`Qwen3-VL`) reactivation
 
-`OLLAMA_VISION_MODEL=""` ist im aktuellen Configmap deaktiviert. Drei mögliche Wege:
+Still off in production: `k8s/configmap.yaml` → `OLLAMA_VISION_MODEL: ""`. Plan unchanged from old file:
 
-a) **3. llama-server-Pod auf k8s-gpu-2** (CPU-only) mit `Qwen3-VL` GGUF + mmproj. Vision-Latenz auf CPU: 30-60 s/Bild — nutzbar für sporadische Use-Cases (Satellite-Camera, Paperless-Vision-Fallback).
+a) **Third llama-server pod on `k8s-gpu-2`** (CPU-only) with `Qwen3-VL-4B-Q4_K_M`. 30-60 s/Bild on CPU is acceptable for sporadic use (satellite-camera, Paperless OCR fallback). **Recommended.**
 
-b) **Reva-Modell auf cuda.local mitverwenden.** Reva hat Qwen3-VL bereits konfiguriert (`config/agent_roles.yaml`). Renfield könnte einen externen Vision-Endpoint via neuer ENV-Variable `LLM_OPENAI_VISION_BASE_URL` ansprechen. Cross-Project-Coupling — sollte mit dem Reva-Eigentümer abgestimmt werden.
+b) Reva's existing cuda.local Qwen3-VL via new `LLM_OPENAI_VISION_BASE_URL` env. Cross-project coupling — would need Reva-owner sign-off.
 
-c) **Vision streichen** wenn die Use-Cases den CPU-Aufwand nicht rechtfertigen. Satellite-Camera-Roundtrip, Paperless-Audit-OCR-Fallback — beides selten.
-
-Empfehlung: (a) mit kleinem Quant (`Qwen3-VL-4B-Q4_K_M`), separater Pod, eigener PR.
+c) Drop vision entirely if the use-cases don't justify the effort.
 
 ---
 
-## 3. Image-Versionierung
+## 4. Reva cross-migration — Stages 2 + 3 still open
 
-`:llama-rc5` ist ein Release-Candidate-Tag. Sobald das System ein paar Tage stabil läuft:
+Stage 1 (submodule bump) is moot; current pointer tracks main. Open:
 
-- `make release` für Versions-Tag (z.B. `v2.5.0`)
-- Auf `.159`: das Image als `:v2.5.0` und `:latest` re-taggen + pushen (siehe `deploy-production` Skill)
-- `k8s/backend.yaml` von hartcodiertem `:llama-rc5` auf `:latest` mit `imagePullPolicy: Always` zurück, oder auf den Versions-Tag pinnen
+- **Stage 2 (1-2 h)** — make `reva.llm.openai_client.OpenAIClient` extend `renfield.utils.llm_client.OpenAICompatibleClient` so Reva inherits the `_OllamaShapedMessage`/`_OllamaShapedResponse` wrappers, `_options_to_openai`, `_think_extra_body`, `_convert_messages` (incl. Qwen3 thinking-mode workaround). Reva keeps `_log_llm_exchange` trace logging and multi-backend dispatch (Anthropic, vLLM) as overrides.
+- **Stage 3 (1 h + prod-validation)** — drop per-role `ollama_url: "http://cuda.local:8081/v1"` in `reva/config/agent_roles.yaml`; switch to platform-level `LLM_OPENAI_BASE_URL` + per-tier `LLM_OPENAI_FOR_*` flags for opt-outs.
 
----
-
-## 4. Kosmetik: `AGENT_MODEL=qwen3.6` für saubere Logs
-
-llama-server akzeptiert beliebige Tag-Namen, aktuell loggen wir aber `qwen3:14b` als angefordertes Modell — irreführend. `k8s/configmap.yaml` `AGENT_MODEL: "qwen3:14b"` → `"qwen3.6"`. Funktional egal, aber Log-Lesbarkeit besser.
+Neither urgent; Reva works as-is.
 
 ---
 
-## 5. Lokales Repo-Cleanup
+## 5. Local repo cleanup
 
-- Lokale Branches gone-prune nach Merge: `git fetch -p && git branch -vv | awk '/: gone]/ {print $1}' | xargs -r git branch -D`
-- Stash from `fix/frontend-same-origin-default` ist obsolet (das war nur die WIP von der Migration, ist alles gemerged) — entfernen falls noch da: `git stash list | head -3`
+- `git fetch -p && git branch -vv | awk '/: gone]/ {print $1}' | xargs -r git branch -D`
+- `git stash list` — check for stale WIP stashes and drop if obsolete
 
 ---
 
-*Letzte Aktualisierung: 2026-05-04, nach Merge von #526 (frontend-same-origin), #527 (llama-server migration). PR #528 (LLM-client tests) noch offen.*
+*Last refreshed 2026-05-21 after voice barge-in (T1–T5) shipped to PR #601.*

--- a/tests/frontend/react/context/sentenceStream.test.ts
+++ b/tests/frontend/react/context/sentenceStream.test.ts
@@ -1,0 +1,53 @@
+/**
+ * drainSentenceTts — sentence-streaming TTS drain logic (plan finding 8).
+ *
+ * ChatContext's handleStreamTtsSettled fires for every terminal TTS
+ * outcome (done / cancelled / error). If a `cancelled` frame failed to
+ * drain the pending counter, it would sit off-by-N and wake word would
+ * never resume. drainSentenceTts has NO outcome parameter, so that
+ * regression is structurally impossible — these tests lock the drain +
+ * fully-settled reporting.
+ */
+import { describe, it, expect } from 'vitest';
+import { drainSentenceTts } from '../../../../src/frontend/src/pages/ChatPage/context/sentenceStream';
+
+describe('drainSentenceTts', () => {
+  it('removes the settled request id from the pending set', () => {
+    const stream = { pending: new Set(['a', 'b']), streamDone: false };
+    drainSentenceTts(stream, 'a');
+    expect([...stream.pending]).toEqual(['b']);
+  });
+
+  it('reports not-fully-settled while other requests are still in flight', () => {
+    const stream = { pending: new Set(['a', 'b']), streamDone: true };
+    expect(drainSentenceTts(stream, 'a')).toBe(false); // 'b' still pending
+  });
+
+  it('reports not-fully-settled when pending empties but the stream is not done', () => {
+    const stream = { pending: new Set(['a']), streamDone: false };
+    expect(drainSentenceTts(stream, 'a')).toBe(false); // chat stream still open
+  });
+
+  it('reports fully-settled once the stream is done and pending is empty', () => {
+    const stream = { pending: new Set(['a']), streamDone: true };
+    expect(drainSentenceTts(stream, 'a')).toBe(true);
+  });
+
+  it('drains identically regardless of a request\'s outcome (finding 8)', () => {
+    // The function takes no outcome — a cancelled or errored request
+    // drains exactly like a finished one. A 3-sentence turn whose
+    // sentences settle one by one (any mix of done/cancelled/error)
+    // fully drains, and the last settle reports the turn complete.
+    const stream = { pending: new Set(['s1', 's2', 's3']), streamDone: true };
+    expect(drainSentenceTts(stream, 's2')).toBe(false); // cancelled
+    expect(drainSentenceTts(stream, 's1')).toBe(false); // errored
+    expect(drainSentenceTts(stream, 's3')).toBe(true); // done — turn settled
+    expect(stream.pending.size).toBe(0);
+  });
+
+  it('is a harmless no-op for a request id not in the set', () => {
+    const stream = { pending: new Set(['a']), streamDone: false };
+    expect(drainSentenceTts(stream, 'unknown')).toBe(false);
+    expect([...stream.pending]).toEqual(['a']);
+  });
+});

--- a/tests/frontend/react/hooks/useVoiceStream.bargein.test.ts
+++ b/tests/frontend/react/hooks/useVoiceStream.bargein.test.ts
@@ -135,6 +135,10 @@ class MockAudioContext {
   // When false, decodeAudioData returns a promise the test resolves by
   // hand — lets a barge-in land while a decode is mid-flight.
   static autoDecode = true;
+  // Frequency-domain frame served by every analyser this context makes.
+  // Default [] → all zero → RMS 0 (silence). Tests set it loud to
+  // simulate the user speaking over the assistant.
+  static frequencyFrame: number[] = [];
 
   state = 'running';
   destination = {};
@@ -161,7 +165,11 @@ class MockAudioContext {
       fftSize: 0,
       smoothingTimeConstant: 0,
       frequencyBinCount: 16,
-      getByteFrequencyData: () => {},
+      getByteFrequencyData: (arr: Uint8Array): void => {
+        for (let i = 0; i < arr.length; i += 1) {
+          arr[i] = MockAudioContext.frequencyFrame[i] ?? 0;
+        }
+      },
       connect: () => {},
     };
   }
@@ -191,6 +199,45 @@ function lastCtx(): MockAudioContext {
 async function flushMicrotasks(): Promise<void> {
   for (let i = 0; i < 8; i += 1) await Promise.resolve();
 }
+
+// --- MediaRecorder + getUserMedia mocks (recording + barge-in paths) -
+class MockMediaRecorder {
+  static instances: MockMediaRecorder[] = [];
+  static isTypeSupported = (): boolean => true;
+
+  state: 'inactive' | 'recording' | 'paused' = 'inactive';
+  stream: MediaStream;
+  mimeType: string;
+  ondataavailable: ((e: unknown) => void) | null = null;
+  onstop: (() => void) | null = null;
+  start = vi.fn((): void => { this.state = 'recording'; });
+  stop = vi.fn((): void => {
+    this.state = 'inactive';
+    this.onstop?.();
+  });
+
+  constructor(stream: MediaStream, opts?: { mimeType?: string }) {
+    this.stream = stream;
+    this.mimeType = opts?.mimeType ?? '';
+    MockMediaRecorder.instances.push(this);
+  }
+}
+
+function makeFakeStream(): MediaStream {
+  const track = { stop: vi.fn(), kind: 'audio' as const };
+  return {
+    getTracks: () => [track],
+    getAudioTracks: () => [track],
+  } as unknown as MediaStream;
+}
+
+// getUserMedia mock. Flip `getUserMediaShouldReject` to exercise the
+// barge-in listener's silent-degrade path (finding 3B).
+let getUserMediaShouldReject = false;
+const getUserMediaMock = vi.fn(async (): Promise<MediaStream> => {
+  if (getUserMediaShouldReject) throw new DOMException('denied', 'NotAllowedError');
+  return makeFakeStream();
+});
 
 type VoiceHook = ReturnType<typeof useVoiceStream>;
 
@@ -235,9 +282,26 @@ beforeEach(() => {
   MockVoiceWebSocket.instances = [];
   MockAudioContext.instances = [];
   MockAudioContext.autoDecode = true;
+  MockAudioContext.frequencyFrame = [];
+  MockMediaRecorder.instances = [];
+  getUserMediaShouldReject = false;
+  getUserMediaMock.mockClear();
   vi.stubGlobal('WebSocket', MockVoiceWebSocket);
   vi.stubGlobal('AudioContext', MockAudioContext);
-  vi.useFakeTimers();
+  vi.stubGlobal('MediaRecorder', MockMediaRecorder);
+  Object.defineProperty(navigator, 'mediaDevices', {
+    value: { getUserMedia: getUserMediaMock },
+    configurable: true,
+  });
+  // Fake rAF + performance too: the barge-in listener's
+  // requestAnimationFrame loop and its performance.now() warmup/sustain
+  // clock must both advance under vi.advanceTimersByTime.
+  vi.useFakeTimers({
+    toFake: [
+      'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'Date',
+      'performance', 'requestAnimationFrame', 'cancelAnimationFrame',
+    ],
+  });
 });
 
 afterEach(() => {
@@ -414,7 +478,11 @@ describe('useVoiceStream — barge-in plumbing', () => {
       ws.emitMessage(makeRfwaFrame('00000000-0000-4000-8000-000000000000'));
     });
     expect(result.current.playbackActive).toBe(false);
-    expect(MockAudioContext.instances).toHaveLength(0); // never reached playback
+    // The barge-in listener may have built an AudioContext, but a dropped
+    // frame must never reach drainQueue — so no buffer source is created.
+    const sourcesPlayed = MockAudioContext.instances
+      .reduce((n, c) => n + c.createdSources.length, 0);
+    expect(sourcesPlayed).toBe(0);
   });
 
   it('a binary frame for an in-flight request passes the rid gate and reaches playback', async () => {
@@ -462,5 +530,96 @@ describe('useVoiceStream — barge-in plumbing', () => {
       await flushMicrotasks();
     });
     expect(ctx.createdSources).toHaveLength(0);
+  });
+
+  it('the barge-in listener does not fire while the mic is silent', async () => {
+    MockAudioContext.frequencyFrame = []; // silence
+    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    const { ws } = await speakAndConnect(result);
+    await act(async () => { await flushMicrotasks(); }); // listener open() settles
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+      await flushMicrotasks();
+    });
+    expect(sentOfType(ws, 'cancel')).toHaveLength(0);
+    expect(MockMediaRecorder.instances).toHaveLength(0);
+  });
+
+  it('voiced energy within the warmup window does not fire a barge-in', async () => {
+    MockAudioContext.frequencyFrame = new Array(16).fill(200); // loud
+    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    const { ws } = await speakAndConnect(result);
+    await act(async () => { await flushMicrotasks(); });
+    // Only 200ms elapse — short of the 250ms warmup, so detection is
+    // suppressed even though the mic is loud.
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+      await flushMicrotasks();
+    });
+    expect(sentOfType(ws, 'cancel')).toHaveLength(0);
+    expect(MockMediaRecorder.instances).toHaveLength(0);
+  });
+
+  it('sustained voiced energy fires a barge-in: cancels TTS and promotes to recording', async () => {
+    MockAudioContext.frequencyFrame = new Array(16).fill(200); // user speaking
+    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    const { ws } = await speakAndConnect(result);
+    await act(async () => { await flushMicrotasks(); });
+
+    // Past warmup (250ms) + sustain (150ms) — the rAF loop detects it.
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+      await flushMicrotasks(); // let the promotion's async IIFE settle
+    });
+
+    expect(sentOfType(ws, 'cancel').length).toBeGreaterThan(0); // TTS cancelled
+    expect(MockMediaRecorder.instances.length).toBeGreaterThan(0); // promoted
+    expect(MockMediaRecorder.instances[0].start).toHaveBeenCalled();
+  });
+
+  it('a denied mic disables barge-in for the reply without surfacing an error', async () => {
+    getUserMediaShouldReject = true;
+    MockAudioContext.frequencyFrame = new Array(16).fill(200);
+    const onError = vi.fn();
+    const { result } = renderHook(() => useVoiceStream({ token: null, onError }));
+    const { ws } = await speakAndConnect(result);
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+      await flushMicrotasks();
+    });
+    // Listener never opened → no barge-in, and the degradation is silent.
+    expect(sentOfType(ws, 'cancel')).toHaveLength(0);
+    expect(MockMediaRecorder.instances).toHaveLength(0);
+    expect(onError).not.toHaveBeenCalled();
+  });
+});
+
+describe('useVoiceStream — checkSilence regression (plan §8.3)', () => {
+  // IRON RULE: the computeRms extraction (T4a) refactored checkSilence.
+  // This proves end-of-utterance auto-stop still fires.
+  it('still auto-stops the recorder after trailing silence', async () => {
+    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    let startP!: Promise<void>;
+    act(() => { startP = result.current.startRecording(); });
+    const ws = lastWs();
+    await act(async () => {
+      ws.fireOpen();
+      ws.emitJson({ type: 'session_ready' });
+      await startP;
+      await flushMicrotasks();
+    });
+    const recorder = MockMediaRecorder.instances[0];
+    expect(recorder).toBeDefined();
+    expect(recorder.start).toHaveBeenCalled();
+
+    // Speak for a bit — sets speechSeen and clears the min-recording gate.
+    MockAudioContext.frequencyFrame = new Array(16).fill(200);
+    act(() => { vi.advanceTimersByTime(900); });
+    expect(recorder.stop).not.toHaveBeenCalled();
+
+    // Fall silent past SILENCE_DURATION_MS (1500ms) — VAD must auto-stop.
+    MockAudioContext.frequencyFrame = [];
+    act(() => { vi.advanceTimersByTime(1700); });
+    expect(recorder.stop).toHaveBeenCalled();
   });
 });

--- a/tests/frontend/react/hooks/useVoiceStream.bargein.test.ts
+++ b/tests/frontend/react/hooks/useVoiceStream.bargein.test.ts
@@ -1,0 +1,466 @@
+/**
+ * useVoiceStream — barge-in / cancellation plumbing (plan §5.2, task T3).
+ *
+ * Covers the shared cancellation mechanism: the generation token that
+ * gates post-interrupt TTS, the pending-request lifecycle across every
+ * terminal frame (tts_done / cancelled / error), the WS-close and 60s
+ * watchdog cleanup paths, cancelAllPlayback's fan-out, and the rid gate
+ * that drops stray frames.
+ *
+ * Fork A's acoustic listener + AudioContext playback path are covered
+ * by the T4 test pass (voiceAudioUtils.test.ts + the fork cases) — these
+ * tests deliberately need only a mock WebSocket.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useVoiceStream } from '../../../../src/frontend/src/pages/ChatPage/hooks/useVoiceStream';
+
+type WsListener = (event: unknown) => void;
+
+// Mock WebSocket with addEventListener support — useVoiceStream's
+// session_ready handshake registers via addEventListener, not just the
+// on* properties, so the mock must drive both.
+class MockVoiceWebSocket {
+  static instances: MockVoiceWebSocket[] = [];
+  static OPEN = 1;
+  static CONNECTING = 0;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  url: string;
+  binaryType = 'blob';
+  readyState: number = MockVoiceWebSocket.CONNECTING;
+  sent: string[] = [];
+  onopen: WsListener | null = null;
+  onclose: WsListener | null = null;
+  onmessage: WsListener | null = null;
+  onerror: WsListener | null = null;
+  private listeners: Record<string, WsListener[]> = {};
+
+  constructor(url: string) {
+    this.url = url;
+    MockVoiceWebSocket.instances.push(this);
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.fireClose();
+  }
+
+  addEventListener(type: string, cb: WsListener): void {
+    (this.listeners[type] ||= []).push(cb);
+  }
+
+  removeEventListener(type: string, cb: WsListener): void {
+    this.listeners[type] = (this.listeners[type] || []).filter((f) => f !== cb);
+  }
+
+  private emit(type: string, ev: unknown): void {
+    [...(this.listeners[type] || [])].forEach((f) => f(ev));
+  }
+
+  // --- test drivers --------------------------------------------------
+  fireOpen(): void {
+    this.readyState = MockVoiceWebSocket.OPEN;
+    this.onopen?.(new Event('open'));
+    this.emit('open', new Event('open'));
+  }
+
+  fireClose(): void {
+    this.readyState = MockVoiceWebSocket.CLOSED;
+    const ev = { type: 'close' };
+    this.onclose?.(ev);
+    this.emit('close', ev);
+  }
+
+  emitMessage(data: string | ArrayBuffer): void {
+    const ev = { data };
+    this.onmessage?.(ev);
+    this.emit('message', ev);
+  }
+
+  /** Convenience for server→client JSON frames. */
+  emitJson(payload: object): void {
+    this.emitMessage(JSON.stringify(payload));
+  }
+}
+
+function lastWs(): MockVoiceWebSocket {
+  const ws = MockVoiceWebSocket.instances.at(-1);
+  if (!ws) throw new Error('no MockVoiceWebSocket created');
+  return ws;
+}
+
+function sentOfType(ws: MockVoiceWebSocket, type: string): Array<Record<string, unknown>> {
+  return ws.sent
+    .map((s) => JSON.parse(s) as Record<string, unknown>)
+    .filter((m) => m.type === type);
+}
+
+// Build a 24-byte-RFWA-headed binary frame for a given request id.
+function uuidToBytes(uuid: string): Uint8Array {
+  const hex = uuid.replace(/-/g, '');
+  const out = new Uint8Array(16);
+  for (let i = 0; i < 16; i += 1) out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  return out;
+}
+function makeRfwaFrame(requestId: string, sequence = 0): ArrayBuffer {
+  const buf = new Uint8Array(24 + 8); // 8-byte dummy WAV body
+  buf.set([0x52, 0x46, 0x57, 0x41], 0); // "RFWA"
+  buf.set(uuidToBytes(requestId), 4);
+  new DataView(buf.buffer).setUint32(20, sequence, false);
+  return buf.buffer;
+}
+
+// Minimal AudioContext mock for the playback-path tests. drainQueue
+// touches: state, resume, decodeAudioData, createBufferSource,
+// destination. A real source fires onended when playback ends.
+class MockAudioBufferSource {
+  buffer: unknown = null;
+  onended: (() => void) | null = null;
+  connect = vi.fn();
+  start = vi.fn(() => {
+    // drainQueue assigns onended before calling start(), so resolving
+    // its await synchronously here mirrors a finished playback.
+    this.onended?.();
+  });
+  stop = vi.fn(() => { this.onended?.(); });
+}
+
+class MockAudioContext {
+  static instances: MockAudioContext[] = [];
+  // When false, decodeAudioData returns a promise the test resolves by
+  // hand — lets a barge-in land while a decode is mid-flight.
+  static autoDecode = true;
+
+  state = 'running';
+  destination = {};
+  pendingDecodes: Array<(buf: unknown) => void> = [];
+  createdSources: MockAudioBufferSource[] = [];
+
+  constructor() {
+    MockAudioContext.instances.push(this);
+  }
+
+  decodeAudioData(_buf: ArrayBuffer): Promise<unknown> {
+    if (MockAudioContext.autoDecode) return Promise.resolve({ duration: 1 });
+    return new Promise((resolve) => { this.pendingDecodes.push(resolve); });
+  }
+
+  createBufferSource(): MockAudioBufferSource {
+    const source = new MockAudioBufferSource();
+    this.createdSources.push(source);
+    return source;
+  }
+
+  createAnalyser() {
+    return {
+      fftSize: 0,
+      smoothingTimeConstant: 0,
+      frequencyBinCount: 16,
+      getByteFrequencyData: () => {},
+      connect: () => {},
+    };
+  }
+
+  createMediaStreamSource() {
+    return { connect: () => {} };
+  }
+
+  resume(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  close(): Promise<void> {
+    this.state = 'closed';
+    return Promise.resolve();
+  }
+}
+
+function lastCtx(): MockAudioContext {
+  const ctx = MockAudioContext.instances.at(-1);
+  if (!ctx) throw new Error('no MockAudioContext created');
+  return ctx;
+}
+
+// Playback uses resolved promises, not timers — a few microtask hops
+// drain the whole drainQueue coroutine.
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 8; i += 1) await Promise.resolve();
+}
+
+type VoiceHook = ReturnType<typeof useVoiceStream>;
+
+// Render the hook, then run speakText() to first-connect: drive the
+// socket open + session_ready so the handshake resolves and the
+// tts_request goes out. Returns the resolved request id.
+async function speakAndConnect(
+  result: { current: VoiceHook },
+  text = 'hallo welt',
+): Promise<{ ws: MockVoiceWebSocket; rid: string }> {
+  let ridP!: Promise<string | null>;
+  act(() => {
+    ridP = result.current.speakText(text);
+  });
+  const ws = lastWs();
+  await act(async () => {
+    ws.fireOpen();
+    ws.emitJson({ type: 'session_ready' });
+    await ridP;
+  });
+  const rid = await ridP;
+  if (typeof rid !== 'string') {
+    throw new Error('speakAndConnect: speakText did not resolve to a request id');
+  }
+  return { ws, rid };
+}
+
+// speakText() on an already-connected hook (ensureSocket fast-path).
+async function speakAgain(
+  result: { current: VoiceHook },
+  text: string,
+): Promise<string | null> {
+  let ridP!: Promise<string | null>;
+  await act(async () => {
+    ridP = result.current.speakText(text);
+    await ridP;
+  });
+  return ridP;
+}
+
+beforeEach(() => {
+  MockVoiceWebSocket.instances = [];
+  MockAudioContext.instances = [];
+  MockAudioContext.autoDecode = true;
+  vi.stubGlobal('WebSocket', MockVoiceWebSocket);
+  vi.stubGlobal('AudioContext', MockAudioContext);
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('useVoiceStream — barge-in plumbing', () => {
+  it('speakText dispatches a tts_request and resolves to its request id', async () => {
+    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    const { ws, rid } = await speakAndConnect(result);
+
+    expect(typeof rid).toBe('string');
+    const ttsRequests = sentOfType(ws, 'tts_request');
+    expect(ttsRequests).toHaveLength(1);
+    expect(ttsRequests[0].request_id).toBe(rid);
+    expect(result.current.playbackActive).toBe(true);
+  });
+
+  it('speakText is gated (returns null) when cancelAllPlayback fires during the handshake', async () => {
+    // Headline 1A: TTS the agent produced before the user interrupted
+    // must not reach the speaker.
+    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    let ridP!: Promise<string | null>;
+    act(() => {
+      ridP = result.current.speakText('soll nicht gesprochen werden');
+    });
+    const ws = lastWs();
+    // Barge-in lands while the socket handshake is still in flight.
+    act(() => {
+      result.current.cancelAllPlayback();
+    });
+    await act(async () => {
+      ws.fireOpen();
+      ws.emitJson({ type: 'session_ready' });
+      await ridP;
+    });
+
+    expect(await ridP).toBeNull();
+    expect(sentOfType(ws, 'tts_request')).toHaveLength(0);
+  });
+
+  it('tts_done drains the request and ends playback after the grace window', async () => {
+    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    const { ws, rid } = await speakAndConnect(result);
+    expect(result.current.playbackActive).toBe(true);
+
+    act(() => {
+      ws.emitJson({ type: 'tts_done', request_id: rid });
+    });
+    // Held true through the inter-sentence grace window...
+    expect(result.current.playbackActive).toBe(true);
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(result.current.playbackActive).toBe(false);
+  });
+
+  it('a cancelled frame drains the request without surfacing an error', async () => {
+    const onError = vi.fn();
+    const onTtsSettled = vi.fn();
+    const { result } = renderHook(() =>
+      useVoiceStream({ token: null, onError, onTtsSettled }),
+    );
+    const { ws, rid } = await speakAndConnect(result);
+
+    act(() => {
+      ws.emitJson({ type: 'cancelled', request_id: rid });
+    });
+
+    expect(onTtsSettled).toHaveBeenCalledWith(rid, 'cancelled');
+    expect(onError).not.toHaveBeenCalled(); // cancel is not a failure
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(result.current.playbackActive).toBe(false);
+  });
+
+  it('an error frame with a request_id drains the request and surfaces onError', async () => {
+    const onError = vi.fn();
+    const onTtsSettled = vi.fn();
+    const { result } = renderHook(() =>
+      useVoiceStream({ token: null, onError, onTtsSettled }),
+    );
+    const { ws, rid } = await speakAndConnect(result);
+
+    act(() => {
+      ws.emitJson({ type: 'error', code: 'tts_failed', message: 'boom', request_id: rid });
+    });
+
+    expect(onTtsSettled).toHaveBeenCalledWith(rid, 'error');
+    expect(onError).toHaveBeenCalledWith('tts_failed', 'boom', rid);
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(result.current.playbackActive).toBe(false);
+  });
+
+  it('WS close clears pending TTS and ends playback immediately', async () => {
+    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    const { ws } = await speakAndConnect(result);
+    expect(result.current.playbackActive).toBe(true);
+
+    act(() => {
+      ws.fireClose();
+    });
+    // No grace window on a socket death — the terminal frame is never coming.
+    expect(result.current.playbackActive).toBe(false);
+  });
+
+  it('the 60s watchdog force-drops a request whose terminal frame never arrives', async () => {
+    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    await speakAndConnect(result);
+    expect(result.current.playbackActive).toBe(true);
+
+    // No tts_done / cancelled / error ever arrives.
+    act(() => {
+      vi.advanceTimersByTime(60000); // watchdog fires
+    });
+    act(() => {
+      vi.advanceTimersByTime(600); // playback-idle grace
+    });
+    expect(result.current.playbackActive).toBe(false);
+  });
+
+  it('cancelAllPlayback sends one cancel frame per in-flight request', async () => {
+    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    const { ws, rid } = await speakAndConnect(result, 'satz eins');
+    const rid2 = await speakAgain(result, 'satz zwei');
+    const rid3 = await speakAgain(result, 'satz drei');
+
+    act(() => {
+      result.current.cancelAllPlayback();
+    });
+
+    const cancels = sentOfType(ws, 'cancel');
+    expect(cancels).toHaveLength(3);
+    expect(cancels.map((c) => c.request_id).sort()).toEqual([rid, rid2, rid3].sort());
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(result.current.playbackActive).toBe(false);
+  });
+
+  it('cancelAllPlayback after the socket closed does not throw', async () => {
+    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    const { ws } = await speakAndConnect(result);
+    act(() => {
+      ws.fireClose();
+    });
+    expect(() => {
+      act(() => {
+        result.current.cancelAllPlayback();
+      });
+    }).not.toThrow();
+  });
+
+  it('a binary frame for an unknown request id is dropped (rid gate)', async () => {
+    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    const { ws, rid } = await speakAndConnect(result);
+
+    // Settle the real request so playback is idle.
+    act(() => {
+      ws.emitJson({ type: 'tts_done', request_id: rid });
+      vi.advanceTimersByTime(600);
+    });
+    expect(result.current.playbackActive).toBe(false);
+
+    // A stray frame for a request that is no longer pending must be
+    // dropped — if it were enqueued it would reach drainQueue, build an
+    // AudioContext, and flip playbackActive back to true.
+    act(() => {
+      ws.emitMessage(makeRfwaFrame('00000000-0000-4000-8000-000000000000'));
+    });
+    expect(result.current.playbackActive).toBe(false);
+    expect(MockAudioContext.instances).toHaveLength(0); // never reached playback
+  });
+
+  it('a binary frame for an in-flight request passes the rid gate and reaches playback', async () => {
+    // Positive counterpart to the drop test. Without this, an inverted
+    // gate condition (drop the pending ones) would silently discard ALL
+    // TTS audio and the suite would still pass.
+    MockAudioContext.autoDecode = true;
+    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    const { ws, rid } = await speakAndConnect(result);
+
+    await act(async () => {
+      ws.emitMessage(makeRfwaFrame(rid));
+      await flushMicrotasks();
+    });
+
+    const ctx = lastCtx();
+    expect(ctx.createdSources.length).toBeGreaterThan(0); // frame was played
+    expect(ctx.createdSources[0].start).toHaveBeenCalled();
+  });
+
+  it('drainQueue discards a chunk that finishes decoding after a barge-in', async () => {
+    // The core 1C race: a frame is mid-decode when the user interrupts.
+    // The generation re-check after decodeAudioData must drop the buffer
+    // instead of starting a source.
+    MockAudioContext.autoDecode = false;
+    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    const { ws, rid } = await speakAndConnect(result);
+
+    await act(async () => {
+      ws.emitMessage(makeRfwaFrame(rid));
+      await flushMicrotasks();
+    });
+    const ctx = lastCtx();
+    expect(ctx.pendingDecodes).toHaveLength(1); // drainQueue parked on decode
+
+    // Barge-in lands while the decode is still in flight.
+    act(() => {
+      result.current.cancelAllPlayback();
+    });
+
+    // The decode resolves now — but the generation moved, so drainQueue
+    // must break before creating a source.
+    await act(async () => {
+      ctx.pendingDecodes[0]({ duration: 1 });
+      await flushMicrotasks();
+    });
+    expect(ctx.createdSources).toHaveLength(0);
+  });
+});

--- a/tests/frontend/react/hooks/useVoiceStream.bargein.test.ts
+++ b/tests/frontend/react/hooks/useVoiceStream.bargein.test.ts
@@ -231,11 +231,24 @@ function makeFakeStream(): MediaStream {
   } as unknown as MediaStream;
 }
 
-// getUserMedia mock. Flip `getUserMediaShouldReject` to exercise the
-// barge-in listener's silent-degrade path (finding 3B).
+// getUserMedia mock. `getUserMediaShouldReject` exercises the listener's
+// silent-degrade path (finding 3B); `getUserMediaDeferred` holds the
+// promise open so a test can resolve it after the reply has already
+// ended (the open()-vs-cleanup race).
 let getUserMediaShouldReject = false;
+let getUserMediaDeferred = false;
+let getUserMediaResolvers: Array<() => void> = [];
+let lastDeferredStream: MediaStream | null = null;
 const getUserMediaMock = vi.fn(async (): Promise<MediaStream> => {
   if (getUserMediaShouldReject) throw new DOMException('denied', 'NotAllowedError');
+  if (getUserMediaDeferred) {
+    return new Promise<MediaStream>((resolve) => {
+      getUserMediaResolvers.push(() => {
+        lastDeferredStream = makeFakeStream();
+        resolve(lastDeferredStream);
+      });
+    });
+  }
   return makeFakeStream();
 });
 
@@ -285,6 +298,9 @@ beforeEach(() => {
   MockAudioContext.frequencyFrame = [];
   MockMediaRecorder.instances = [];
   getUserMediaShouldReject = false;
+  getUserMediaDeferred = false;
+  getUserMediaResolvers = [];
+  lastDeferredStream = null;
   getUserMediaMock.mockClear();
   vi.stubGlobal('WebSocket', MockVoiceWebSocket);
   vi.stubGlobal('AudioContext', MockAudioContext);
@@ -575,6 +591,9 @@ describe('useVoiceStream — barge-in plumbing', () => {
     expect(sentOfType(ws, 'cancel').length).toBeGreaterThan(0); // TTS cancelled
     expect(MockMediaRecorder.instances.length).toBeGreaterThan(0); // promoted
     expect(MockMediaRecorder.instances[0].start).toHaveBeenCalled();
+    // The promotion reuses the listener's stream — NO second getUserMedia
+    // (plan §6.3). The one call is the listener opening.
+    expect(getUserMediaMock).toHaveBeenCalledTimes(1);
   });
 
   it('a denied mic disables barge-in for the reply without surfacing an error', async () => {
@@ -591,6 +610,30 @@ describe('useVoiceStream — barge-in plumbing', () => {
     expect(sentOfType(ws, 'cancel')).toHaveLength(0);
     expect(MockMediaRecorder.instances).toHaveLength(0);
     expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('a listener mic that resolves after the reply ended is stopped, not leaked', async () => {
+    // open()-vs-cleanup race: getUserMedia is still in flight when the
+    // reply finishes. The cancelled-flag guard must stop the late stream.
+    getUserMediaDeferred = true;
+    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    const { ws, rid } = await speakAndConnect(result);
+    await act(async () => { await flushMicrotasks(); }); // listener parked on getUserMedia
+    expect(getUserMediaResolvers).toHaveLength(1);
+
+    // The reply ends before the mic resolves → playbackActive falls →
+    // the listener effect cleanup runs (cancelled = true).
+    act(() => { ws.emitJson({ type: 'tts_done', request_id: rid }); });
+    act(() => { vi.advanceTimersByTime(600); }); // playback-idle grace
+
+    // The mic resolves only now — open() must see cancelled and stop it.
+    await act(async () => {
+      getUserMediaResolvers[0]();
+      await flushMicrotasks();
+    });
+    expect(lastDeferredStream).not.toBeNull();
+    const track = lastDeferredStream!.getTracks()[0];
+    expect(track.stop).toHaveBeenCalled(); // late stream stopped — no leak
   });
 });
 

--- a/tests/frontend/react/hooks/voiceAudioUtils.test.ts
+++ b/tests/frontend/react/hooks/voiceAudioUtils.test.ts
@@ -1,0 +1,95 @@
+/**
+ * voiceAudioUtils — pure audio helpers (plan §6.1, task T4).
+ *
+ * `computeRms` and `detectBargeIn` carry the barge-in decision logic;
+ * being pure they test exhaustively with no WebAudio mock beyond a
+ * one-method stub AnalyserNode.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  computeRms,
+  detectBargeIn,
+} from '../../../../src/frontend/src/pages/ChatPage/hooks/voiceAudioUtils';
+
+// Stub AnalyserNode — computeRms only calls getByteFrequencyData, which
+// fills the caller's array. `as unknown as AnalyserNode` matches the
+// partial-stub pattern already used in ChatPage.test.tsx.
+function stubAnalyser(frame: number[]): AnalyserNode {
+  return {
+    getByteFrequencyData: (arr: Uint8Array): void => {
+      for (let i = 0; i < arr.length; i += 1) arr[i] = frame[i] ?? 0;
+    },
+  } as unknown as AnalyserNode;
+}
+
+describe('computeRms', () => {
+  it('returns 0 for a silent (all-zero) frame', () => {
+    const scratch = new Uint8Array(8);
+    expect(computeRms(stubAnalyser([0, 0, 0, 0, 0, 0, 0, 0]), scratch)).toBe(0);
+  });
+
+  it('returns the max (255) for a fully-saturated frame', () => {
+    const scratch = new Uint8Array(4);
+    expect(computeRms(stubAnalyser([255, 255, 255, 255]), scratch)).toBe(255);
+  });
+
+  it('computes the root-mean-square of a mixed frame', () => {
+    // RMS of [30,40,0,0] = sqrt((900+1600)/4) = sqrt(625) = 25.
+    const scratch = new Uint8Array(4);
+    expect(computeRms(stubAnalyser([30, 40, 0, 0]), scratch)).toBe(25);
+  });
+
+  it('returns 0 for an empty scratch buffer instead of NaN', () => {
+    expect(computeRms(stubAnalyser([]), new Uint8Array(0))).toBe(0);
+  });
+});
+
+describe('detectBargeIn', () => {
+  const THRESHOLD = 20;
+  const SUSTAIN = 150;
+
+  it('reports no barge-in and clears the run while RMS is below threshold', () => {
+    const r = detectBargeIn(5, 1000, 2000, THRESHOLD, SUSTAIN);
+    expect(r).toEqual({ voicedSince: null, bargeIn: false });
+  });
+
+  it('starts the run on the first voiced frame but does not fire yet', () => {
+    const r = detectBargeIn(50, null, 1000, THRESHOLD, SUSTAIN);
+    expect(r.voicedSince).toBe(1000); // run anchored at `now`
+    expect(r.bargeIn).toBe(false); // sustain window not met
+  });
+
+  it('does not fire before the sustain window elapses', () => {
+    // voiced since t=1000, now t=1100 → only 100ms < 150ms.
+    const r = detectBargeIn(50, 1000, 1100, THRESHOLD, SUSTAIN);
+    expect(r).toEqual({ voicedSince: 1000, bargeIn: false });
+  });
+
+  it('fires once voiced energy is sustained past the window', () => {
+    // voiced since t=1000, now t=1200 → 200ms >= 150ms.
+    const r = detectBargeIn(50, 1000, 1200, THRESHOLD, SUSTAIN);
+    expect(r).toEqual({ voicedSince: 1000, bargeIn: true });
+  });
+
+  it('fires exactly at the sustain boundary (>= is inclusive)', () => {
+    const r = detectBargeIn(50, 1000, 1150, THRESHOLD, SUSTAIN);
+    expect(r.bargeIn).toBe(true);
+  });
+
+  it('treats RMS exactly at the threshold as voiced', () => {
+    const r = detectBargeIn(THRESHOLD, null, 1000, THRESHOLD, SUSTAIN);
+    expect(r.voicedSince).toBe(1000);
+  });
+
+  it('resets the run when RMS dips below threshold mid-window', () => {
+    // A run was building (voicedSince=1000) but this frame dipped —
+    // the run is cancelled, so transient noise cannot accumulate.
+    const r = detectBargeIn(8, 1000, 1120, THRESHOLD, SUSTAIN);
+    expect(r).toEqual({ voicedSince: null, bargeIn: false });
+
+    // ...and the next voiced frame restarts the clock from scratch.
+    const restart = detectBargeIn(50, r.voicedSince, 1130, THRESHOLD, SUSTAIN);
+    expect(restart.voicedSince).toBe(1130);
+    expect(restart.bargeIn).toBe(false);
+  });
+});

--- a/tests/frontend/react/test-chat-mock.ts
+++ b/tests/frontend/react/test-chat-mock.ts
@@ -60,6 +60,8 @@ export const defaultChatContextValue: ChatContextValue = {
   silenceTimeRemaining: 0,
   partialText: '',
   toggleRecording: () => {},
+  playbackActive: false,
+  cancelAllPlayback: () => {},
 
   // RAG
   useRag: false,

--- a/voice-server/pytest.ini
+++ b/voice-server/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+# asyncio_mode=auto lets plain `async def test_*` run without a marker.
+asyncio_mode = auto
+# Make the `voice_server` package importable when pytest runs from the
+# voice-server/ directory.
+pythonpath = .
+testpaths = tests

--- a/voice-server/requirements-dev.txt
+++ b/voice-server/requirements-dev.txt
@@ -1,0 +1,8 @@
+# Test-only dependencies for the voice-server. Install alongside
+# requirements.txt to run `pytest`. Kept separate so the runtime
+# image stays lean.
+#
+#   pip install -r requirements.txt -r requirements-dev.txt
+#
+pytest>=8.0
+pytest-asyncio>=0.24

--- a/voice-server/tests/test_cancel_ack.py
+++ b/voice-server/tests/test_cancel_ack.py
@@ -1,0 +1,186 @@
+"""Tests for client-initiated TTS cancellation acknowledgement.
+
+Covers the barge-in cancel contract on `/ws/voice`:
+
+  - a client `cancel` while synthesis is in flight  -> `cancelled` frame
+  - an internal / session-teardown cancellation     -> legacy `error` frame
+  - a `cancel` for an already-finished request      -> no-op, no marker leak
+  - a normal completion                             -> `tts_done`, no marker
+  - a synthesis failure                             -> `error` with the cause
+
+Environment: importing `voice_server.api.ws_voice` pulls in the STT /
+speaker / decoder service modules, so this runs where the voice-server
+runtime deps are installed (the .159 build box or the voice-server
+image), not on a bare dev machine. Synthesis itself is faked, so no
+Piper / Whisper / GPU is exercised.
+
+    cd voice-server && pip install -r requirements.txt -r requirements-dev.txt
+    pytest tests/test_cancel_ack.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+
+from voice_server.api.ws_voice import (
+    SessionState,
+    _cancel_tts,
+    _spawn_tts,
+)
+
+
+class FakeWebSocket:
+    """Records every frame sent, so tests can assert on the wire output."""
+
+    def __init__(self) -> None:
+        self.text_frames: list[dict] = []
+        self.bytes_frames: list[bytes] = []
+
+    async def send_text(self, text: str) -> None:
+        self.text_frames.append(json.loads(text))
+
+    async def send_bytes(self, data: bytes) -> None:
+        self.bytes_frames.append(data)
+
+    def frames_of_type(self, frame_type: str) -> list[dict]:
+        return [f for f in self.text_frames if f.get("type") == frame_type]
+
+
+class ControllableTTS:
+    """Fake TTSService whose `stream_sentences` is test-driven.
+
+    Yields one frame, then parks on `released` until the test lets it
+    finish — giving every test a deterministic in-flight window to fire
+    a cancel into. Set `fail` to raise instead of parking.
+    """
+
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.released = asyncio.Event()
+        self.fail: Exception | None = None
+
+    async def stream_sentences(self, text, request_id, language=None):
+        self.started.set()
+        yield b"frame-0"
+        if self.fail is not None:
+            raise self.fail
+        await self.released.wait()
+        yield b"frame-1"
+
+
+def _new_rid() -> str:
+    return str(uuid.uuid4())
+
+
+async def test_client_cancel_emits_cancelled_frame() -> None:
+    """A client `cancel` mid-synthesis -> `cancelled` frame, no `error`."""
+    ws = FakeWebSocket()
+    state = SessionState(user_id="u1")
+    tts = ControllableTTS()
+    rid = _new_rid()
+
+    await _spawn_tts(ws, state, {"request_id": rid, "text": "hallo welt"}, tts)
+    task = state.tts_tasks[rid]
+    # Once `started` is set the task has run uninterrupted to its park
+    # point — frame-0 is already sent and the generator is suspended.
+    await tts.started.wait()
+    assert ws.bytes_frames == [b"frame-0"]
+
+    await _cancel_tts(state, rid)
+    assert rid in state.client_cancelled  # marker set while the task is live
+
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass  # _run_tts re-raises after sending the ack — expected
+
+    assert ws.frames_of_type("cancelled") == [{"type": "cancelled", "request_id": rid}]
+    assert ws.frames_of_type("error") == []
+    assert ws.frames_of_type("tts_done") == []
+    assert rid not in state.client_cancelled  # marker discarded by _wrapped finally
+    assert rid not in state.tts_tasks
+
+
+async def test_internal_cancel_emits_error_frame() -> None:
+    """A teardown-style cancel (direct task.cancel, no `cancel` message)
+    keeps the legacy `error` frame — it is not a client barge-in."""
+    ws = FakeWebSocket()
+    state = SessionState(user_id="u1")
+    tts = ControllableTTS()
+    rid = _new_rid()
+
+    await _spawn_tts(ws, state, {"request_id": rid, "text": "irgendwas"}, tts)
+    task = state.tts_tasks[rid]
+    await tts.started.wait()
+
+    # Bypass _cancel_tts — this is how ws_voice's finally tears tasks down.
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    errors = ws.frames_of_type("error")
+    assert len(errors) == 1
+    assert errors[0]["code"] == "tts_failed"
+    assert errors[0]["request_id"] == rid
+    assert ws.frames_of_type("cancelled") == []
+    assert state.client_cancelled == set()
+
+
+async def test_cancel_after_done_is_noop() -> None:
+    """A `cancel` for a request that already finished is a no-op and
+    must not leave a marker behind (the leak _cancel_tts guards against)."""
+    ws = FakeWebSocket()
+    state = SessionState(user_id="u1")
+    tts = ControllableTTS()
+    tts.released.set()  # let synthesis run straight through
+    rid = _new_rid()
+
+    await _spawn_tts(ws, state, {"request_id": rid, "text": "fertig"}, tts)
+    await state.tts_tasks[rid]
+    assert ws.frames_of_type("tts_done") == [{"type": "tts_done", "request_id": rid}]
+
+    await _cancel_tts(state, rid)  # task already done / popped -> early return
+
+    assert state.client_cancelled == set()  # no marker added -> no leak
+    assert ws.frames_of_type("cancelled") == []
+
+
+async def test_normal_completion_leaves_no_marker() -> None:
+    """An uninterrupted request ends with `tts_done` and a clean set."""
+    ws = FakeWebSocket()
+    state = SessionState(user_id="u1")
+    tts = ControllableTTS()
+    tts.released.set()
+    rid = _new_rid()
+
+    await _spawn_tts(ws, state, {"request_id": rid, "text": "alles gut"}, tts)
+    await state.tts_tasks[rid]
+
+    assert ws.frames_of_type("tts_done") == [{"type": "tts_done", "request_id": rid}]
+    assert ws.frames_of_type("cancelled") == []
+    assert ws.frames_of_type("error") == []
+    assert state.client_cancelled == set()
+
+
+async def test_synthesis_failure_emits_error_not_cancelled() -> None:
+    """A genuine synthesis error surfaces as `error` with the real cause,
+    and never touches the cancel marker set."""
+    ws = FakeWebSocket()
+    state = SessionState(user_id="u1")
+    tts = ControllableTTS()
+    tts.fail = FileNotFoundError("piper voice missing")
+    rid = _new_rid()
+
+    await _spawn_tts(ws, state, {"request_id": rid, "text": "kaputt"}, tts)
+    await state.tts_tasks[rid]
+
+    errors = ws.frames_of_type("error")
+    assert len(errors) == 1
+    assert errors[0]["code"] == "model_unavailable"
+    assert "piper voice missing" in errors[0]["message"]
+    assert ws.frames_of_type("cancelled") == []
+    assert state.client_cancelled == set()

--- a/voice-server/voice_server/api/ws_voice.py
+++ b/voice-server/voice_server/api/ws_voice.py
@@ -13,7 +13,8 @@ Server→Client:
   - partial_transcript { text, confidence }
   - final_transcript { text, language, speaker_embedding[192], audio_duration_s }
   - <binary WAV with 24-byte RFWA header>              one frame per TTS sentence
-  - tts_done { request_id }
+  - tts_done { request_id }                            synthesis finished normally
+  - cancelled { request_id }                           client `cancel` honoured (barge-in)
   - error { code, message, request_id? }
   - pong
 
@@ -22,8 +23,10 @@ See VOICE_PIPELINE_DESIGN.md § "WebSocket protocol" for the full table.
 Concurrency model:
   TTS runs as an asyncio.Task so the receive loop keeps consuming audio
   chunks, ping, and cancel while synthesis is in flight. Per-request_id
-  task tracking lets `cancel` actually stop the audio stream
-  (Phase B.next barge-in arrives "for free" once the frontend wires it).
+  task tracking lets `cancel` actually stop the audio stream. A
+  client-initiated cancel emits a distinct `cancelled` frame (so the
+  frontend can suppress error UI on barge-in); a teardown/internal
+  cancel keeps the legacy `error` frame.
 """
 
 from __future__ import annotations
@@ -75,6 +78,13 @@ class SessionState:
     last_partial_text: str = ""
     started_at: float = 0.0
     tts_tasks: dict[str, asyncio.Task] = field(default_factory=dict)
+    # request_ids the client explicitly cancelled via a `cancel` message.
+    # _run_tts checks this on CancelledError to tell a client barge-in
+    # (emit a clean `cancelled` frame) apart from an internal or
+    # session-teardown cancellation (emit a genuine `error`). A marker is
+    # added only when a live task is actually cancelled, so the task's
+    # finally in _spawn_tts always runs and discards it — no leak.
+    client_cancelled: set[str] = field(default_factory=set)
     # During _finalize the decoder is closed and a fresh one is
     # spawned. Browser recorder buffers ~100 ms of chunks ahead, so
     # several arrive after the close. They previously hit
@@ -240,26 +250,39 @@ async def _finalize(
 
 async def _run_tts(
     ws: WebSocket,
+    state: SessionState,
     request_id: uuid.UUID,
     text: str,
     language: str | None,
     tts: TTSService,
 ) -> None:
     """Stream TTS frames for one request. Runs as a Task so the receive loop is unblocked."""
+    rid = str(request_id)
     try:
         async for frame in tts.stream_sentences(text, request_id, language=language):
             await ws.send_bytes(frame)
-        await _send_json(ws, {"type": "tts_done", "request_id": str(request_id)})
+        await _send_json(ws, {"type": "tts_done", "request_id": rid})
     except asyncio.CancelledError:
-        # Barge-in: client sent `cancel` for this request_id. Best-effort
-        # tts_done so the frontend cleans up its playback queue.
-        await _send_error(ws, "tts_failed", "cancelled by client", str(request_id))
+        # CancelledError reaches here from two sources: a client `cancel`
+        # message (barge-in) or the WS handler's finally cancelling
+        # in-flight tasks at session teardown. Only a client cancel is a
+        # clean, expected stop — emit a dedicated `cancelled` frame so
+        # the frontend distinguishes it from a real failure instead of
+        # surfacing a chat error bubble. Teardown keeps the legacy
+        # `error` frame (the WS is closing; delivery is best-effort).
+        if rid in state.client_cancelled:
+            try:
+                await _send_json(ws, {"type": "cancelled", "request_id": rid})
+            except Exception:
+                pass
+        else:
+            await _send_error(ws, "tts_failed", "cancelled internally", rid)
         raise
     except FileNotFoundError as e:
-        await _send_error(ws, "model_unavailable", str(e), str(request_id))
+        await _send_error(ws, "model_unavailable", str(e), rid)
     except Exception as e:
         logger.exception("tts failed for %s", request_id)
-        await _send_error(ws, "tts_failed", str(e), str(request_id))
+        await _send_error(ws, "tts_failed", str(e), rid)
 
 
 async def _spawn_tts(
@@ -288,9 +311,14 @@ async def _spawn_tts(
 
     async def _wrapped() -> None:
         try:
-            await _run_tts(ws, request_id, text, language, tts)
+            await _run_tts(ws, state, request_id, text, language, tts)
         finally:
             state.tts_tasks.pop(rid_key, None)
+            # Single discard site for the cancel marker. _cancel_tts only
+            # marks a rid whose task is live, so this finally is the one
+            # place that always runs afterwards — covers both the
+            # barge-in path and a never-cancelled normal completion.
+            state.client_cancelled.discard(rid_key)
 
     state.tts_tasks[rid_key] = asyncio.create_task(_wrapped())
 
@@ -298,9 +326,18 @@ async def _spawn_tts(
 async def _cancel_tts(state: SessionState, request_id_raw: str | None) -> None:
     if not request_id_raw:
         return
-    task = state.tts_tasks.get(str(request_id_raw))
-    if task is not None and not task.done():
-        task.cancel()
+    rid = str(request_id_raw)
+    task = state.tts_tasks.get(rid)
+    if task is None or task.done():
+        # Nothing live to cancel — the task already finished (the client
+        # raced its own tts_done) or never existed. Adding a marker here
+        # would leak: no _wrapped finally remains to discard it.
+        return
+    # Mark before cancelling so _run_tts's CancelledError handler reads
+    # it as a client barge-in. The task is live, so its finally will run
+    # and discard the marker.
+    state.client_cancelled.add(rid)
+    task.cancel()
 
 
 async def _close_decoder(state: SessionState) -> None:


### PR DESCRIPTION
## Voice barge-in — interrupt the assistant by speaking

Lets a user talk over the assistant's text-to-speech to redirect it. The streaming voice pipeline (`/ws/voice`, `useVoiceStream`) had no interrupt path — a long reply played to the end.

Gated by `VITE_FEATURE_VOICE_STREAM=true` (the streaming voice path); behaviourally inert when the flag is off.

### Why "Fork A acoustic" — the Phase 0 spike

The plan was restructured after a `/plan-eng-review` outside voice warned that browser AEC likely would not suppress the assistant's own TTS, making an open-mic listener self-interrupt. Rather than build on faith, **Phase 0 was a measurement spike** (`tasks/voice-barge-in-spike.html`). Result on Chrome 147 / macOS, laptop speakers, against a real 14.5s Piper WAV:

| Condition | RMS p95 | RMS median |
|---|---|---|
| TTS only (no human) | 8.0 | — |
| Human speech | — | 54.0 |

**6.77× separation** — browser AEC *does* suppress `AudioContext`-rendered TTS. Acoustic barge-in is viable; threshold set to 20.

### What's in it

| Commit | Layer |
|---|---|
| `810d7c7` | **voice-server** — `cancel` now emits a distinct `cancelled` ack frame for client-initiated cancellation (vs the legacy `error` for teardown/internal). |
| `a6531dd` | **Shared plumbing** — generation token, `pendingTtsRef` + 60s watchdog, `cancelAllPlayback`, RFWA request-id frame gate, `playbackActive` (600ms hysteresis), `onTtsSettled`. |
| `42972b1` | **Refactor** — `computeRms` + `detectBargeIn` extracted to `voiceAudioUtils.ts`; `checkSilence` rebased onto it. |
| `c664281` | **Fork A** — acoustic barge-in listener (one per reply, AEC mic, 250ms warmup + 150ms sustain), listener→recorder promotion (the interrupting utterance becomes the next query — same stream, no second `getUserMedia`), `drainSentenceTts` extraction. |
| `0b1d156` | T4 review fixes — listener gated on `!recording`; two test gaps closed. |
| `88c3931` | docs — `/ws/voice` protocol table. |

### Reviews

Two independent reviews (`pr-review-toolkit` code-reviewer). Both traced the concurrency-heavy paths (generation-token races, stream-ownership transfer on promotion, teardown races) and found **the production code correct**. Every finding was a test-coverage gap or a defensive-invariant nit; all are closed in-branch. Outside-voice cross-model challenge from the eng-review is folded into the plan.

### Verification

- `tsc --noEmit` clean (frontend src + test dir).
- 35 voice unit/integration tests green (`voiceAudioUtils` 11, `sentenceStream` 6, `useVoiceStream.bargein` 18).
- 108 changed-surface tests green.
- voice-server: `voice-server/tests/test_cancel_ack.py` (5 cases) — runs on `.159` / the voice-server image (needs `faster-whisper` etc.).

### Manual-test checklist (run post-deploy on staging)

Browser-based E2E is mandatory after a k8s rollout (curl smoke is not enough). **Two images** in this PR — voice-server (`810d7c7`) and frontend — both must deploy. Requires `VITE_FEATURE_VOICE_STREAM=true`.

| # | Step | Expected | Pass |
|---|---|---|---|
| 1 | Ask a question that yields a long (5+ sentence) spoken reply. | Assistant starts speaking; first audio within ~1-2s. | ☐ |
| 2 | At roughly sentence 2, speak a short interruption ("stop", "warte"). | TTS audio stops within ~300ms. **No** red error bubble in chat. | ☐ |
| 3 | After the interrupt, observe what the mic does. | Recording starts automatically; the interrupting utterance is transcribed and sent as the next query (it is *captured*, not discarded). | ☐ |
| 4 | During a long reply, make ambient noise *below* speech level (typing, low traffic) — do not speak. | No barge-in fires; the reply plays through. | ☐ |
| 5 | During a long reply, barge in twice in quick succession. | Each handled cleanly; no stuck "speaking" state, no console errors. | ☐ |
| 6 | Revoke mic permission in the browser, then trigger a spoken reply. | Reply plays uninterruptibly (barge-in silently disabled). Mic button + wake word still work. No crash, no error bubble. | ☐ |
| 7 | Let a long reply finish *without* interrupting. | Plays to the end; the listener tears down (browser mic indicator goes off). | ☐ |
| 8 | Headphones: repeat step 2. | Same as step 2 — cleaner (no echo path at all). | ☐ |

Audio behaviour, so no automated browser E2E (faking mic input in CI is brittle; CI is non-functional for this project regardless). This checklist is the verification of record.

### Out of scope

- **Software AEC** — not needed; the spike confirmed browser AEC suffices on Chrome/macOS. Safari's AEC differs and was not measured — re-run the spike if Safari becomes a target client.
- **Aborting the upstream LLM on barge-in** — only the audio stops; the agent keeps thinking. The generation token makes post-interrupt sentences inaudible. True abort needs an agent-loop cancel path — separate work.
- **Truncating the assistant transcript at the spoken boundary** — the interrupted message stays whole (matches Siri / ChatGPT voice mode).
- **A manual on-screen "stop speaking" button** — `cancelAllPlayback` is exposed on `ChatContextValue` for it; the UI is a follow-up.

### Note for review

`detectBargeIn`'s signature is `(rms, voicedSince, now, threshold, sustainMs)`, a deliberate refinement of the plan §6.1 sketch `(belowSince, now, threshold, sustainMs)` — the 4-arg form had no RMS input, so its `threshold` argument was dead. Documented in-code; flagging here for explicit sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
