### PR TITLE
docs: post-v2.8.0 — voice-server deploy coverage + changelog

### DIFF
--- a/.claude/skills/deploy-production/SKILL.md
+++ b/.claude/skills/deploy-production/SKILL.md
@@ -12,13 +12,14 @@ disable-model-invocation: true
 - **Never force-push to main** and never bypass branch protection; main merges go through a PR (see `git-workflow` skill).
 - **CI is intentionally non-functional for this project** — run tests on the .159 build box, not in CI.
 - **ConfigMap-provided files are NOT in the image.** `mcp_servers.yaml`, `agent_roles.yaml`, `kg_scopes.yaml`, `mail_accounts.yaml` live only in the `renfield-mcp-config` ConfigMap. If the build-box working copy ever grows these as untracked files or directories at `src/backend/config/*`, the resulting image breaks the pod's subPath mount with `not a directory`. Keep `src/backend/.dockerignore` carving these paths out, and clean them on .159 if you see root-owned leftovers from kubelet bind-mount artefacts.
+- **`voice-server` is a separate image and a GPU deploy.** Changes under `voice-server/` need their own image build (see "Voice-server image" below) — the backend/frontend steps do NOT cover it. It runs on a GPU node; a NVIDIA driver/library mismatch there CrashLoops new pods. See that section.
 
 ## Topology at a glance
 
 | Role | Where | Notes |
 |---|---|---|
 | Build box | `192.168.1.159` (`renfield.local` mDNS often flaky — use the IP) | Docker Compose up for dev/test only. Used for `docker build` + `docker push`. Runs the full backend/test stack so pytest is executed here. **Not production.** |
-| Container registry | `https://registry.treehouse.x-idra.de` | Harbor. Namespace paths used: `renfield/backend`, `renfield/frontend`. `harbor-pull-secret` already exists in the `renfield` k8s namespace. |
+| Container registry | `https://registry.treehouse.x-idra.de` | Harbor. Namespace paths used: `renfield/backend`, `renfield/frontend`, `renfield/voice-server`. `harbor-pull-secret` already exists in the `renfield` k8s namespace. |
 | Production | Private k8s cluster (kubectl context **`renfield-private`**) | GPU-accelerated LLM, Traefik ingress, Longhorn storage, MetalLB LB at `192.168.1.230`. Canonical doc: `docs/KUBERNETES_DEPLOYMENT.md`. |
 
 Single-VM `renfield.local` deployment on `/opt/renfield` is legacy / build-box only. Anything calling itself a "prod rsync" is referring to the build box, not production.
@@ -127,6 +128,37 @@ Always build + push a pinned tag (`:vX.Y.Z`) alongside `:latest` — gives you a
 
 **Why the image stays ~3.5 GB:** `src/backend/constraints.txt` pins `torch`/`torchaudio`/`torchvision` to the `+cpu` wheels so transitive deps (docling, easyocr, transformers) can't drag in the 2.7 GB CUDA runtime + 641 MB triton. Don't lift that constraint unless you've thought through the Harbor push timeout.
 
+### Voice-server image (build ONLY when `voice-server/` changed)
+
+`voice-server/` is a third image in the monorepo — the backend/frontend steps above do **not** cover it. Build it only when something under `voice-server/` changed. It has its own `v0.1.x` versioning, independent of the repo's `vX.Y.Z` (bump the patch digit: `v0.1.5` → `v0.1.6`).
+
+```bash
+# Rsync the voice-server build context — its own directory IS the context
+ssh evdb@192.168.1.159 "mkdir -p /tmp/renfield-build-vX.Y.Z/voice-server"
+rsync -avz --delete \
+  --exclude='__pycache__' --exclude='*.pyc' --exclude='.pytest_cache' --exclude='.env' \
+  voice-server/ evdb@192.168.1.159:/tmp/renfield-build-vX.Y.Z/voice-server/
+
+# Build + push on .159. Dockerfile is FROM nvidia/cuda:...-runtime but builds
+# fine on the CPU build box (no GPU needed to BUILD). Layers usually cache, so
+# only the changed app layer pushes — fast.
+ssh evdb@192.168.1.159
+R=registry.treehouse.x-idra.de/renfield/voice-server
+cd /tmp/renfield-build-vX.Y.Z/voice-server
+docker build -t $R:v0.1.N -t $R:latest -f Dockerfile .
+docker push $R:v0.1.N
+docker push $R:latest
+```
+
+Run its tests against the freshly built image — CI doesn't, and the .159 backend container can't import the voice-server deps:
+
+```bash
+docker run --rm -v /tmp/renfield-build-vX.Y.Z/voice-server:/work -w /work \
+  $R:v0.1.N sh -c 'python3 -m pip install -q pytest pytest-asyncio && python3 -m pytest tests/ -q'
+```
+
+**GPU-node driver drift (verified painful, v2.8.0 deploy 2026-05-22).** The `voice-server` Deployment runs on the `k8s-gpu-3` GPU node. If `apt` upgraded that node's NVIDIA driver libraries without a reboot, a *new* voice-server pod CrashLoops with `failed to initialize NVML: Driver/library version mismatch` — the *old* pod keeps running, only new pods fail, so it stays latent until the next voice-server rollout. Fix is a **node reboot**, not an image rollback (a fresh pod on the old image crashes identically). A live `modprobe -r nvidia*` reload fails — `nvidia_uvm` stays held even when `lsof /dev/nvidia*` is empty. Procedure: `kubectl cordon k8s-gpu-3` → delete the `frontend` pod so it reschedules off the node (keeps the UI up) → `ssh ... sudo reboot` → wait for `Ready` → `kubectl uncordon` → `kubectl rollout restart deploy/voice-server`. Confirm `dkms status` has the nvidia module built for the kernel the node will boot into first (a pending kernel update can switch it).
+
 ### Harbor 504 / "Client Closed Request" on the 2.66 GB pip-install layer
 
 When `requirements.txt` changes (so the deps layer cache misses), Docker tries to upload a single 2.66 GB layer to Harbor. The ingress proxy in front of Harbor has been observed timing out on this with `received unexpected HTTP status: 504 Gateway Timeout` or `unknown: Client Closed Request`. The error reproduces on the same layer ID across multiple retries (verified during the v2.3.0 deploy 2026-05-01 — 4 attempts, same `ed85...` layer, same error).
@@ -158,7 +190,21 @@ kubectl -n renfield rollout status deploy/backend --timeout=600s
 kubectl -n renfield rollout status deploy/dlna-mcp --timeout=600s
 kubectl -n renfield rollout status deploy/document-worker --timeout=600s
 kubectl -n renfield rollout status deploy/frontend --timeout=600s
+
+# voice-server is a SEPARATE, fifth deploy — roll it ONLY when its image
+# changed (see "Voice-server image"). It runs a pinned tag, so set image:
+kubectl -n renfield set image deploy/voice-server \
+  voice-server=registry.treehouse.x-idra.de/renfield/voice-server:v0.1.N
+kubectl -n renfield rollout status deploy/voice-server --timeout=600s
 ```
+
+> **Pinned deploys — `rollout restart` is a no-op for them.** In the live
+> cluster `frontend` and `voice-server` often run pinned tags (`:vX.Y.Z` /
+> `:v0.1.N`) even though the committed `k8s/*.yaml` manifests say `:latest`.
+> For a pinned deploy, `rollout restart` re-pulls the *same* tag — it does
+> NOT pick up new code. Always `kubectl set image` for those two. Check live
+> state first: `kubectl -n renfield get deploy -o
+> custom-columns=D:.metadata.name,IMG:.spec.template.spec.containers[0].image`.
 
 > **Image-pull timing.** First pull of a 3.5 GB backend image takes 2-5 minutes per node.
 > Subsequent rollouts on the same node hit the local cache and start in seconds.
@@ -234,11 +280,11 @@ curl -sI http://renfield.local/          # 308 → https
 2. ✅ Tag `vX.Y.Z` locally + push tag + create GitHub release.
 3. ✅ rsync `src/backend`, `src/frontend`, `data/wakeword-models` to `/tmp/renfield-build-vX.Y.Z` on .159 (the model dir lands INSIDE the backend build context as `wakeword-models/`).
 4. ✅ Verify staging — `Dockerfile`, `.dockerignore`, `wakeword-models/` (~9 files) all present; `config/mcp_servers.yaml` etc. NOT present (else the configmap mount breaks).
-5. ✅ Build backend (long if requirements.txt changed) and frontend (fast).
-6. ✅ Push `:latest` and `:vX.Y.Z` for both — verify each `digest:` line in the push output.
-7. ✅ `kubectl rollout restart` on backend, dlna-mcp, document-worker, frontend (all four).
-8. ✅ `kubectl rollout status` per deploy with 600s timeout.
-9. ✅ Verify image digests across all 4 deploys match what was pushed.
+5. ✅ Build backend (long if requirements.txt changed) and frontend (fast); build voice-server ONLY if `voice-server/` changed (its own `v0.1.x` tag).
+6. ✅ Push `:latest` + the pinned tag for each image built — verify each `digest:` line in the push output.
+7. ✅ Roll out: `rollout restart` backend, dlna-mcp, document-worker; `kubectl set image` for frontend (and voice-server if rebuilt) — both run pinned tags, so `rollout restart` is a no-op for them.
+8. ✅ `kubectl rollout status` per rolled deploy with 600s timeout.
+9. ✅ Verify image digests across the rolled deploys match what was pushed.
 10. ✅ Backend health smoke (`curl -sS http://localhost:8000/health` inside the pod).
 11. ✅ Browser smoke for migrated pages / new features.
 12. ✅ Cleanup `/tmp/renfield-build-vX.Y.Z` on .159.

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -8,6 +8,20 @@ For earlier history (v1.2.0 - v2.5.0), see [CHANGELOG.md](CHANGELOG.md) (German 
 
 ---
 
+## [v2.8.0] — 2026-05-22
+
+Voice barge-in: the user can interrupt the assistant's speech by simply talking over it (Fork A — acoustic). A Phase 0 measurement confirmed up front that the browser's echo cancellation reliably separates the assistant's own TTS from the user speaking (6.8× margin on laptop speakers). PR [#601](https://github.com/ebongard/renfield/pull/601).
+
+### Added
+
+- **Acoustic barge-in listener** (`useVoiceStream`) — during TTS playback the browser opens an analyser-only mic stream. Sustained voiced energy above threshold cancels playback; the same audio track is promoted to the recorder, so the interrupting utterance is captured as the next query — no second `getUserMedia` call ([#601](https://github.com/ebongard/renfield/pull/601)).
+- **`cancelled` acknowledgement frame** in the voice-server `/ws/voice` protocol — a client-initiated cancellation is acknowledged cleanly instead of surfacing as a chat error bubble; an internal cancellation keeps the `error` frame ([#601](https://github.com/ebongard/renfield/pull/601)).
+- **`computeRms` / `detectBargeIn`** as pure, tested helpers in `voiceAudioUtils.ts`; the existing end-of-utterance VAD now shares the same RMS implementation.
+
+### Fixed
+
+- A client-cancelled TTS request previously raised an error bubble in chat because the voice-server did not distinguish a client cancel from a genuine failure.
+
 ## [v2.6.0] — 2026-05-14
 
 Phase 0 baseline-measurement substrate plus Lane B/2 of the Mem0 memory architecture: replaces v1's per-turn LLM loop (which produced a ~91% duplicate rate) with a batched ADD/UPDATE/DELETE/NOOP extractor gated by optimistic concurrency. Architecture is landed and flag-gated. Phase A shadow rollout collects v1/v2 comparison data in `memory_v2_shadow_log` before the `memory_extraction_v2_authoritative=True` flip ([#577](https://github.com/ebongard/renfield/pull/577)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Alle markanten Änderungen an Renfield, seit Release `v1.2.0`. Format lehnt sich
 
 ---
 
+## [v2.8.0] — 2026-05-22
+
+Voice-Barge-in: Der Nutzer kann die Sprachausgabe des Assistenten unterbrechen, indem er einfach weiterspricht (Fork A — akustisch). Eine Phase-0-Messung bestätigte vorab, dass die Echo-Unterdrückung des Browsers die eigene TTS-Ausgabe zuverlässig vom Sprechen des Nutzers trennt (6,8-facher Abstand auf Laptop-Lautsprechern). PR [#601](https://github.com/ebongard/renfield/pull/601).
+
+### Hinzugefügt
+
+- **Akustischer Barge-in-Listener** (`useVoiceStream`) — Während der TTS-Wiedergabe öffnet der Browser einen reinen Analyser-Mic-Stream. Anhaltende Sprachenergie über dem Schwellwert bricht die Wiedergabe ab; dieselbe Audiospur wird zum Aufnahme-Stream befördert, sodass die unterbrechende Äußerung als nächste Anfrage erfasst wird — ohne zweiten `getUserMedia`-Aufruf ([#601](https://github.com/ebongard/renfield/pull/601)).
+- **`cancelled`-Quittungsframe** im `/ws/voice`-Protokoll des voice-server — eine vom Client ausgelöste Stornierung wird sauber bestätigt statt als Fehler-Blase im Chat dargestellt; eine interne Stornierung behält den `error`-Frame ([#601](https://github.com/ebongard/renfield/pull/601)).
+- **`computeRms` / `detectBargeIn`** als reine, getestete Hilfsfunktionen in `voiceAudioUtils.ts`; die bestehende End-of-Utterance-VAD nutzt nun dieselbe RMS-Implementierung.
+
+### Behoben
+
+- Eine vom Client stornierte TTS-Anfrage löste zuvor eine Fehler-Blase im Chat aus, weil der voice-server nicht zwischen Client-Abbruch und echtem Fehler unterschied.
+
 ## [v2.6.0] — 2026-05-14
 
 Phase 0 baseline-measurement substrate plus Lane B/2 der Mem0-Memory-Architecture: vom Per-Turn-LLM-Loop mit ~91 % Duplikat-Rate zu einem batched ADD/UPDATE/DELETE/NOOP-Extractor mit Optimistic Concurrency. Architektur ist gelandet und schalter-gegated — Phase A Shadow-Rollout sammelt v1/v2-Vergleichsdaten in `memory_v2_shadow_log` bevor `memory_extraction_v2_authoritative=True` geflippt wird ([#577](https://github.com/ebongard/renfield/pull/577)).

--- a/docs/VOICE_PIPELINE_DESIGN.md
+++ b/docs/VOICE_PIPELINE_DESIGN.md
@@ -43,7 +43,7 @@ User direction: **no patches**. Phase B is the structural fix. Phase C is the ar
 
 ### Non-goals (explicitly deferred)
 
-- **Barge-in / interrupt-while-speaking.** Needs full-duplex with echo cancellation and is its own design problem. Phase B.next.
+- ~~**Barge-in / interrupt-while-speaking.**~~ **Shipped in v2.8.0** (Fork A — acoustic, PR #601). A Phase 0 spike measured browser AEC sufficient on laptop speakers (6.8× TTS-vs-speech separation), so no software echo cancellation was needed. The browser opens an analyser-only mic during TTS playback and promotes that stream to the recorder on detection.
 - **Multi-language voice cloning.** Stays on `de_DE-thorsten-high` and `en_US-amy-medium`. XTTS-v2 evaluated separately.
 - **Wake-word on the server.** Frontend already runs `openwakeword` in-browser via WASM; server doesn't need to listen for hot-words.
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -9,7 +9,7 @@ Shipped / superseded items from the old voice-pipeline plan:
 | Phase B.5 — XTTS-v2 evaluation | Shipped: PR #539 (decision: stay on Piper) |
 | End-of-utterance robustness | Shipped: PRs #535, #536 ("5 compounded design flaws") |
 | Voice-originated tool-call guard | Shipped: PR #542 (`verify_tool_call` hook + `voice_originated` ContextVar) |
-| **Voice barge-in (Fork A acoustic)** | **In review: PR #601** — interrupt the assistant by speaking. T1–T5 done; AEC spike passed 6.77×; two independent reviews. Plan: `tasks/voice-barge-in-plan.md`. Post-merge: run the PR's manual-test checklist on staging. |
+| **Voice barge-in (Fork A acoustic)** | **Shipped — v2.8.0** (PR #601, deployed 2026-05-22): interrupt the assistant by speaking. AEC spike passed 6.77×; two independent reviews. Plan: `tasks/voice-barge-in-plan.md`. **Open:** run the PR's 8-step manual barge-in checklist live (needs a human + mic). |
 | Cosmetic `AGENT_MODEL=qwen3.6` | Done in `k8s/configmap.yaml` |
 | `:llama-rc5` re-tag to versioned | Moot — backend is on `:latest` with `imagePullPolicy: Always` |
 | Reva submodule bump (Stage 1) | Moot — submodule pointer is current (`v2.6.1-21-g856ae13`) |


### PR DESCRIPTION
Post-v2.8.0 documentation sweep.

- **deploy-production skill**: adds the voice-server image (separate monorepo image, own `v0.1.x` versioning, CUDA build, test-in-image). Documents that `frontend` + `voice-server` run **pinned tags** in the live cluster — `rollout restart` is a no-op, `kubectl set image` required. Adds the GPU-node NVIDIA driver-mismatch gotcha (new GPU pod CrashLoops on `NVML Driver/library version mismatch` → node reboot) hit during the v2.8.0 deploy.
- **CHANGELOG.md / CHANGELOG.en.md**: v2.8.0 entry (voice barge-in).
- **VOICE_PIPELINE_DESIGN.md**: barge-in moved out of Non-goals — shipped.
- **tasks/todo.md**: barge-in marked shipped + deployed.

Note: the CHANGELOGs have a pre-existing gap (no v2.6.1 / v2.7.0 / v2.7.1 entries) — not backfilled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)