### PR TITLE
docs: backfill CHANGELOG for v2.6.1 / v2.7.0 / v2.7.1

### DIFF
--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -22,6 +22,52 @@ Voice barge-in: the user can interrupt the assistant's speech by simply talking 
 
 - A client-cancelled TTS request previously raised an error bubble in chat because the voice-server did not distinguish a client cancel from a genuine failure.
 
+## [v2.7.1] — 2026-05-20
+
+### Fixed
+
+- LED and microphone capability badges are now pluralised correctly ([#596](https://github.com/ebongard/renfield/pull/596)).
+
+## [v2.7.0] — 2026-05-19
+
+Pluggable auth-provider registry plus truthful satellite hardware reporting.
+
+### Added
+
+- **Pluggable auth-provider registry + `post_authenticate` hook** — `/auth/login` is no longer hard-wired to "the `authenticate` hook, then bcrypt"; it delegates to a priority-ordered, multi-active provider registry. Built-ins: `db` (bcrypt), `ldap`, and the `google`/`github`/`apple` redirect providers (disabled by default) ([#592](https://github.com/ebongard/renfield/pull/592)).
+- **Real per-device satellite hardware reporting** — satellites report and display their actual hardware instead of static assumptions ([#594](https://github.com/ebongard/renfield/pull/594)).
+
+### Fixed
+
+- Closed the enviro pHAT provisioning drift; `python3-smbus` is provisioned and linked into the non-system-site venv ([#593](https://github.com/ebongard/renfield/pull/593)).
+- Fixed the `num_leds` template gap; the physical microphone count is now counted truthfully ([#595](https://github.com/ebongard/renfield/pull/595)).
+
+## [v2.6.1] — 2026-05-18
+
+Stabilises the Mem0-v2 memory architecture landed in v2.6.0, plus several chat-UI features.
+
+### Added
+
+- **`build_assistant_card` hook** — new synchronous hook event, the `card_emit_inline` flag, and the `chat_handler` call site for it ([#584](https://github.com/ebongard/renfield/pull/584), [#585](https://github.com/ebongard/renfield/pull/585)).
+- **Per-message citation chips** — rendered from each message's persisted metadata ([#587](https://github.com/ebongard/renfield/pull/587)).
+- **Wissensbasis panel** — mirrors the left-nav hamburger menu for the Wissensbasis panel ([#588](https://github.com/ebongard/renfield/pull/588)).
+- **Lane C — two-stage retrieval** (WIP) with a recency-aware rerank ([#582](https://github.com/ebongard/renfield/pull/582)).
+
+### Changed
+
+- The v2-extract retrieval threshold is now separate from the chat threshold; `MEMORY_EXTRACT_RETRIEVAL_MODE` is deprecated and warns ([#583](https://github.com/ebongard/renfield/pull/583)).
+
+### Fixed
+
+- Leaked advisory locks are released at pool check-in; KG entity/atom creation is atomic ([#578](https://github.com/ebongard/renfield/pull/578)).
+- Corrected KG entity/atom ordering and a log-format bug ([#579](https://github.com/ebongard/renfield/pull/579)).
+- `retrieve()` now flushes instead of committing — committing broke the shadow savepoint ([#580](https://github.com/ebongard/renfield/pull/580)); the shadow-log row is persisted with an explicit `db.commit()` ([#581](https://github.com/ebongard/renfield/pull/581)).
+- Decoupled the k8s init dependency-gates from the scaled-to-0 `llama-server-*` deployments ([#586](https://github.com/ebongard/renfield/pull/586)).
+
+### For contributors
+
+- Unit test for `historyToUiMessage` (the per-message chips mapper) ([#589](https://github.com/ebongard/renfield/pull/589)); added the missing `partialText` to the `defaultChatContextValue` mock ([#590](https://github.com/ebongard/renfield/pull/590)).
+
 ## [v2.6.0] — 2026-05-14
 
 Phase 0 baseline-measurement substrate plus Lane B/2 of the Mem0 memory architecture: replaces v1's per-turn LLM loop (which produced a ~91% duplicate rate) with a batched ADD/UPDATE/DELETE/NOOP extractor gated by optimistic concurrency. Architecture is landed and flag-gated. Phase A shadow rollout collects v1/v2 comparison data in `memory_v2_shadow_log` before the `memory_extraction_v2_authoritative=True` flip ([#577](https://github.com/ebongard/renfield/pull/577)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,52 @@ Voice-Barge-in: Der Nutzer kann die Sprachausgabe des Assistenten unterbrechen, 
 
 - Eine vom Client stornierte TTS-Anfrage löste zuvor eine Fehler-Blase im Chat aus, weil der voice-server nicht zwischen Client-Abbruch und echtem Fehler unterschied.
 
+## [v2.7.1] — 2026-05-20
+
+### Behoben
+
+- LED- und Mikrofon-Capability-Badges werden nun korrekt pluralisiert ([#596](https://github.com/ebongard/renfield/pull/596)).
+
+## [v2.7.0] — 2026-05-19
+
+Pluggable Auth-Provider-Registry plus wahrheitsgetreue Hardware-Meldung der Satelliten.
+
+### Hinzugefügt
+
+- **Pluggable Auth-Provider-Registry + `post_authenticate`-Hook** — `/auth/login` ist nicht länger auf "`authenticate`-Hook, dann bcrypt" festverdrahtet, sondern delegiert an eine nach Priorität geordnete, mehrfach aktive Provider-Registry. Built-ins: `db` (bcrypt), `ldap` sowie die Redirect-Provider `google`/`github`/`apple` (standardmäßig deaktiviert) ([#592](https://github.com/ebongard/renfield/pull/592)).
+- **Echte Per-Device-Hardware-Meldung der Satelliten** — Satelliten melden und zeigen ihre tatsächliche Hardware-Ausstattung statt statischer Annahmen ([#594](https://github.com/ebongard/renfield/pull/594)).
+
+### Behoben
+
+- Provisioning-Drift des enviro pHAT geschlossen; `python3-smbus` wird bereitgestellt und in das Nicht-System-Site-venv verlinkt ([#593](https://github.com/ebongard/renfield/pull/593)).
+- `num_leds`-Template-Lücke behoben; die physische Mikrofon-Anzahl wird wahrheitsgetreu gezählt ([#595](https://github.com/ebongard/renfield/pull/595)).
+
+## [v2.6.1] — 2026-05-18
+
+Stabilisierung der in v2.6.0 gelandeten Mem0-v2-Memory-Architektur, dazu mehrere Chat-UI-Funktionen.
+
+### Hinzugefügt
+
+- **`build_assistant_card`-Hook** — neues synchrones Hook-Event, das `card_emit_inline`-Flag und die zugehörige Aufrufstelle im `chat_handler` ([#584](https://github.com/ebongard/renfield/pull/584), [#585](https://github.com/ebongard/renfield/pull/585)).
+- **Citation-Chips pro Nachricht** — aus den persistierten Metadaten je Nachricht gerendert ([#587](https://github.com/ebongard/renfield/pull/587)).
+- **Wissensbasis-Panel** — das Hamburger-Menü der linken Navigation für das Wissensbasis-Panel gespiegelt ([#588](https://github.com/ebongard/renfield/pull/588)).
+- **Lane C — Two-Stage-Retrieval** (WIP) mit recency-bewusstem Rerank ([#582](https://github.com/ebongard/renfield/pull/582)).
+
+### Geändert
+
+- Der v2-Extract-Retrieval-Schwellwert ist nun vom Chat-Schwellwert getrennt; `MEMORY_EXTRACT_RETRIEVAL_MODE` ist deprecated und löst eine Warnung aus ([#583](https://github.com/ebongard/renfield/pull/583)).
+
+### Behoben
+
+- Geleakte Advisory-Locks werden beim Pool-Checkin freigegeben; die KG-Entity/Atom-Erzeugung erfolgt atomar ([#578](https://github.com/ebongard/renfield/pull/578)).
+- KG-Entity/Atom-Reihenfolge und ein Log-Format-Fehler korrigiert ([#579](https://github.com/ebongard/renfield/pull/579)).
+- `retrieve()` flusht nun statt zu committen — das Committen brach zuvor das Shadow-Savepoint ([#580](https://github.com/ebongard/renfield/pull/580)); die Shadow-Log-Zeile wird mit explizitem `db.commit()` persistiert ([#581](https://github.com/ebongard/renfield/pull/581)).
+- k8s-Init-Dependency-Gates von den auf 0 skalierten `llama-server-*`-Deployments entkoppelt ([#586](https://github.com/ebongard/renfield/pull/586)).
+
+### Für Mitwirkende
+
+- Unit-Test für `historyToUiMessage` (Per-Message-Chips-Mapper) ([#589](https://github.com/ebongard/renfield/pull/589)); fehlendes `partialText` im `defaultChatContextValue`-Mock ergänzt ([#590](https://github.com/ebongard/renfield/pull/590)).
+
 ## [v2.6.0] — 2026-05-14
 
 Phase 0 baseline-measurement substrate plus Lane B/2 der Mem0-Memory-Architecture: vom Per-Turn-LLM-Loop mit ~91 % Duplikat-Rate zu einem batched ADD/UPDATE/DELETE/NOOP-Extractor mit Optimistic Concurrency. Architektur ist gelandet und schalter-gegated — Phase A Shadow-Rollout sammelt v1/v2-Vergleichsdaten in `memory_v2_shadow_log` bevor `memory_extraction_v2_authoritative=True` geflippt wird ([#577](https://github.com/ebongard/renfield/pull/577)).


### PR DESCRIPTION
Backfills the three released versions the CHANGELOG skipped (it jumped v2.6.0 → v2.8.0). Reconstructed from the git history between tags:

- **v2.6.1** (2026-05-18) — Mem0-v2 memory-architecture stabilisation + chat-UI features (`build_assistant_card` hook, per-message citation chips, Wissensbasis panel, Lane C retrieval WIP). PRs #578–#590.
- **v2.7.0** (2026-05-19) — pluggable auth-provider registry + `post_authenticate` hook; real satellite hardware reporting. PRs #592–#595.
- **v2.7.1** (2026-05-20) — pluralised LED/mic capability badges. PR #596.

Both `CHANGELOG.md` (DE) and `CHANGELOG.en.md` (EN). Entries summarised from PR titles + commit messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)