### PR TITLE
feat(vision): enable the vision tier (qwen3-vl:8b)

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -39,8 +39,11 @@ data:
   #     /v1/embeddings. Same qwen3-embedding:4b model, just GPU-served
   #     (10-20x faster than the previous CPU path on k8s-gpu-2).
   #     llama-server-embed deployment is scaled to 0 (replicas=0).
-  # Vision still disabled (OLLAMA_VISION_MODEL=""); add llama-server-vision
-  # pod if/when vision tier is wanted.
+  # Vision tier ENABLED — OLLAMA_VISION_MODEL=qwen3-vl:8b (see below),
+  # served by the existing in-cluster `ollama` pod on k8s-gpu-1 (idle
+  # 16 GB RTX 5060 Ti). OLLAMA_VISION_URL already routes there, so no
+  # separate llama-server-vision pod is needed. Rollback: set the model
+  # back to "".
   LLM_OPENAI_BASE_URL: "http://cuda.local:8081/v1"
   # LLM_OPENAI_API_KEY is sourced from the `renfield-secrets`/`llm-openai-api-key`
   # Secret in backend.yaml. llama-server accepts any non-empty value today;
@@ -75,7 +78,7 @@ data:
   OLLAMA_RAG_MODEL: "qwen3:14b"
   OLLAMA_INTENT_MODEL: "qwen3:8b"
   OLLAMA_EMBED_MODEL: "qwen3-embedding:4b"
-  OLLAMA_VISION_MODEL: ""
+  OLLAMA_VISION_MODEL: "qwen3-vl:8b"
   AGENT_MODEL: "qwen3.6"
   EMBEDDING_DIMENSION: "2560"
   # B.4.d: WHISPER_MODEL, PIPER_VOICES, PIPER_DEFAULT_VOICE removed.


### PR DESCRIPTION
Re-enables the vision tier — todo.md §3.

`OLLAMA_VISION_MODEL` was `""`, gating vision off. Turns out the work was already done: `qwen3-vl:8b` is pulled into the in-cluster `ollama` pod on **k8s-gpu-1** (2 GPUs, one fully-idle 16 GB RTX 5060 Ti), and `OLLAMA_VISION_URL` already routes there. One-line gate flip.

**Verified before flipping:**
- `qwen3-vl:8b` loads + runs on the cluster Ollama.
- Image round-trip: POST `/api/generate` with the Renfield app icon → accurate description ("cartoon-style red bat with glowing green eyes") in ~960 ms, HTTP 200.
- Backend vision codepath is live — consumers: `ollama_service.py`, `satellite_handler.py` (satellite camera), `paperless_metadata_extractor.py` (OCR metadata fallback).

The todo's "new CPU-only llama-server-vision pod on k8s-gpu-2" plan is moot — k8s-gpu-2 has no usable GPU; this path is GPU-accelerated, sub-second.

**Deploy:** `kubectl apply -f k8s/configmap.yaml` + `rollout restart deploy/backend deploy/document-worker` (both consume the vision env). No image rebuild, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)