### PR TITLE
docs: fix vision-tier accuracy + broken model-guide links

### DIFF
--- a/.claude/agents/architecture-guide.md
+++ b/.claude/agents/architecture-guide.md
@@ -95,7 +95,6 @@ Important env vars: `MCP_ENABLED`, `AGENT_ENABLED`, `AUTH_ENABLED`, `PRESENCE_EN
 ## Documentation Index
 
 - `docs/ENVIRONMENT_VARIABLES.md` — All env vars
-- `docs/LLM_MODEL_GUIDE.md` — Model recommendations
 - `docs/ACCESS_CONTROL.md` — Auth & permissions
 - `docs/SECRETS_MANAGEMENT.md` — Production secrets
 - `docs/MULTILANGUAGE.md` — i18n guide

--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -8,6 +8,12 @@ For earlier history (v1.2.0 - v2.5.0), see [CHANGELOG.md](CHANGELOG.md) (German 
 
 ---
 
+## [v2.8.1] — 2026-05-22
+
+### Changed
+
+- **Vision tier enabled** — `OLLAMA_VISION_MODEL` is now set to `qwen3-vl:8b` (previously empty = disabled). Image queries from satellite cameras are answered again. The model runs on the in-cluster `ollama` pod (k8s-gpu-1, RTX 5060 Ti); a config-only change with no new image. PR [#604](https://github.com/ebongard/renfield/pull/604).
+
 ## [v2.8.0] — 2026-05-22
 
 Voice barge-in: the user can interrupt the assistant's speech by simply talking over it (Fork A — acoustic). A Phase 0 measurement confirmed up front that the browser's echo cancellation reliably separates the assistant's own TTS from the user speaking (6.8× margin on laptop speakers). PR [#601](https://github.com/ebongard/renfield/pull/601).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Alle markanten Änderungen an Renfield, seit Release `v1.2.0`. Format lehnt sich
 
 ---
 
+## [v2.8.1] — 2026-05-22
+
+### Geändert
+
+- **Vision-Tier aktiviert** — `OLLAMA_VISION_MODEL` ist nun auf `qwen3-vl:8b` gesetzt (zuvor leer = deaktiviert). Bild-Anfragen von Satelliten-Kameras werden wieder beantwortet. Das Modell läuft auf dem cluster-internen `ollama`-Pod (k8s-gpu-1, RTX 5060 Ti); reine Konfigurationsänderung ohne neues Image. PR [#604](https://github.com/ebongard/renfield/pull/604).
+
 ## [v2.8.0] — 2026-05-22
 
 Voice-Barge-in: Der Nutzer kann die Sprachausgabe des Assistenten unterbrechen, indem er einfach weiterspricht (Fork A — akustisch). Eine Phase-0-Messung bestätigte vorab, dass die Echo-Unterdrückung des Browsers die eigene TTS-Ausgabe zuverlässig vom Sprechen des Nutzers trennt (6,8-facher Abstand auf Laptop-Lautsprechern). PR [#601](https://github.com/ebongard/renfield/pull/601).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Renfield is a fully offline-capable, self-hosted **digital assistant** — a per
 
 **Tech Stack:** Python 3.11 + FastAPI + SQLAlchemy | React 18 + TypeScript + Vite + Tailwind CSS + PWA | Docker Compose, PostgreSQL 16, Redis 7, Ollama | Satellites: Pi Zero 2 W + ReSpeaker + OpenWakeWord
 
-**LLM:** Local models via Ollama (multi-model: chat, intent, RAG, agent, vision, embeddings). See `docs/LLM_MODEL_GUIDE.md`.
+**LLM:** Local models via Ollama (multi-model: chat, intent, RAG, agent, vision, embeddings).
 
 **Integrations:** Home Assistant, Frigate, n8n, SearXNG, Jellyfin, DLNA, Paperless, Email, Calendar — all via MCP servers.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Renfield is a fully offline-capable, self-hosted **digital assistant** — a per
 
 **Tech Stack:** Python 3.11 + FastAPI + SQLAlchemy | React 18 + TypeScript + Vite + Tailwind CSS + PWA | Docker Compose, PostgreSQL 16, Redis 7, Ollama | Satellites: Pi Zero 2 W + ReSpeaker + OpenWakeWord
 
-**LLM:** Local models via Ollama (multi-model: chat, intent, RAG, agent, embeddings). See `docs/LLM_MODEL_GUIDE.md`.
+**LLM:** Local models via Ollama (multi-model: chat, intent, RAG, agent, vision, embeddings). See `docs/LLM_MODEL_GUIDE.md`.
 
 **Integrations:** Home Assistant, Frigate, n8n, SearXNG, Jellyfin, DLNA, Paperless, Email, Calendar — all via MCP servers.
 

--- a/README.de.md
+++ b/README.de.md
@@ -241,8 +241,6 @@ AGENT_MODEL=                      # Optional: Agent-Modell
 AGENT_OLLAMA_URL=                 # Optional: Separate Ollama-Instanz
 ```
 
-Siehe [docs/LLM_MODEL_GUIDE.md](docs/LLM_MODEL_GUIDE.md) für Modell-Empfehlungen.
-
 ### Integrationen (MCP)
 
 ```env
@@ -425,7 +423,6 @@ curl -X POST "http://localhost:8000/admin/reembed"
 |----------|--------|
 | [docs/FEATURES.md](docs/FEATURES.md) | Ausführliche Feature-Dokumentation |
 | [docs/ENVIRONMENT_VARIABLES.md](docs/ENVIRONMENT_VARIABLES.md) | Vollständige Konfigurationsreferenz |
-| [docs/LLM_MODEL_GUIDE.md](docs/LLM_MODEL_GUIDE.md) | Modell-Empfehlungen und Konfiguration |
 | [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) | Deployment-Anleitung |
 | [docs/SECRETS_MANAGEMENT.md](docs/SECRETS_MANAGEMENT.md) | Docker Secrets für Produktion |
 | [docs/SECURITY.md](docs/SECURITY.md) | Security Headers, CSP, Abhängigkeitssicherheit |

--- a/README.md
+++ b/README.md
@@ -167,8 +167,6 @@ OLLAMA_RAG_MODEL=qwen3:14b        # RAG answers
 OLLAMA_EMBED_MODEL=nomic-embed-text  # embeddings (768 dim)
 ```
 
-See [docs/LLM_MODEL_GUIDE.md](docs/LLM_MODEL_GUIDE.md) for model recommendations.
-
 ### Key Settings
 
 ```env
@@ -210,7 +208,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development guide.
 | [CONTRIBUTING.md](CONTRIBUTING.md) | How to contribute |
 | [docs/FEATURES.md](docs/FEATURES.md) | Detailed feature documentation |
 | [docs/ENVIRONMENT_VARIABLES.md](docs/ENVIRONMENT_VARIABLES.md) | Full configuration reference |
-| [docs/LLM_MODEL_GUIDE.md](docs/LLM_MODEL_GUIDE.md) | Model recommendations |
 | [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) | Deployment guide |
 | [docs/SECRETS_MANAGEMENT.md](docs/SECRETS_MANAGEMENT.md) | Docker secrets for production |
 | [docs/SECURITY.md](docs/SECURITY.md) | Security headers, CSP, dependency security |

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -106,8 +106,6 @@ OLLAMA_NUM_CTX=32768                  # Context Window für alle Ollama-Calls
 - `qwen3:8b` - Gute Alternative für weniger RAM
 - `qwen3-embedding:4b` - Embedding-Modell mit exzellentem Deutsch (2560 dim)
 
-Siehe `docs/LLM_MODEL_GUIDE.md` für eine vollständige Modell-Übersicht pro Rolle.
-
 ---
 
 ### Vision LLM (Satellite Camera)

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -104,7 +104,7 @@ OLLAMA_NUM_CTX=32768                  # Context Window für alle Ollama-Calls
 **Empfohlene Modelle:**
 - `qwen3:14b` - Chat, RAG, Intent (empfohlen mit GPU)
 - `qwen3:8b` - Gute Alternative für weniger RAM
-- `qwen3-embedding:4b` - Embedding-Modell mit exzellentem Deutsch (768 dim)
+- `qwen3-embedding:4b` - Embedding-Modell mit exzellentem Deutsch (2560 dim)
 
 Siehe `docs/LLM_MODEL_GUIDE.md` für eine vollständige Modell-Übersicht pro Rolle.
 
@@ -115,7 +115,7 @@ Siehe `docs/LLM_MODEL_GUIDE.md` für eine vollständige Modell-Übersicht pro Ro
 ```bash
 # Vision-fähiges Modell für Kamera-Snapshots von Satellites
 # Leer = Visual Queries deaktiviert (Bilder werden ignoriert)
-OLLAMA_VISION_MODEL=qwen3-vl
+OLLAMA_VISION_MODEL=qwen3-vl:8b
 
 # Optional: Separate Ollama-URL für das Vision-Modell
 # Nützlich wenn Vision auf einer anderen GPU läuft als Chat
@@ -123,10 +123,10 @@ OLLAMA_VISION_URL=http://host.docker.internal:11434
 ```
 
 **Defaults:**
-- `OLLAMA_VISION_MODEL`: `""` (deaktiviert)
+- `OLLAMA_VISION_MODEL`: `""` (deaktiviert) — Code-Default. **Produktion setzt `qwen3-vl:8b`** (siehe `k8s/configmap.yaml`); der Vision-Tier ist seit 2026-05-22 aktiv und läuft auf dem cluster-internen `ollama`-Pod (k8s-gpu-1).
 - `OLLAMA_VISION_URL`: `None` (verwendet Standard-OLLAMA_URL)
 
-**Empfohlenes Modell:** `qwen3-vl` (~12 GB VRAM, passt auf 16 GB Karten, gutes Deutsch).
+**Empfohlenes Modell:** `qwen3-vl:8b` (~12 GB VRAM, passt auf 16 GB Karten, gutes Deutsch).
 
 Siehe [SATELLITE_CAMERA.md](SATELLITE_CAMERA.md) für Setup und Modellvergleich.
 
@@ -638,7 +638,7 @@ CB_AGENT_RECOVERY_TIMEOUT=60.0
 EMBEDDING_DIMENSION=768
 ```
 
-**Default:** `768` (passend für `nomic-embed-text` und `qwen3-embedding:4b`)
+**Default:** `768` (Code-Default, passend für `nomic-embed-text`). Produktion nutzt `2560` für `qwen3-embedding:4b` — siehe `k8s/configmap.yaml`. Bei Modellwechsel muss der Vektor-Index neu angelegt werden.
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -719,8 +719,6 @@ Ollama kann auf einem separaten GPU-Server laufen:
 OLLAMA_URL=http://cuda.local:11434
 ```
 
-Siehe [LLM_MODEL_GUIDE.md](LLM_MODEL_GUIDE.md) für Modell-Empfehlungen und Benchmarks.
-
 ### LLM Client Factory
 
 Alle Services nutzen eine zentrale Factory (`utils/llm_client.py`) mit URL-basiertem Caching (gleiche URL → gleiche Client-Instanz) und einem `LLMClient` Protocol.

--- a/docs/SATELLITE_CAMERA.md
+++ b/docs/SATELLITE_CAMERA.md
@@ -9,7 +9,7 @@ and send it alongside the transcribed speech to a Vision-LLM for image-aware res
 
 1. Wakeword detected -> camera snapshot captured in background
 2. User finishes speaking -> audio transcribed, snapshot attached to `audio_end` message
-3. Backend receives image + text -> routes to Vision-LLM (e.g. `minicpm-v`)
+3. Backend receives image + text -> routes to Vision-LLM (`qwen3-vl:8b`)
 4. Vision-LLM describes what it sees -> TTS response spoken back
 
 ## Architecture
@@ -55,7 +55,7 @@ Set in `.env`:
 
 ```bash
 # Vision model (must support Ollama's images parameter)
-OLLAMA_VISION_MODEL=qwen3-vl
+OLLAMA_VISION_MODEL=qwen3-vl:8b
 
 # Optional: dedicated Ollama instance for vision (e.g. GPU server)
 OLLAMA_VISION_URL=http://host.docker.internal:11434
@@ -64,7 +64,7 @@ OLLAMA_VISION_URL=http://host.docker.internal:11434
 Then pull the model:
 
 ```bash
-ollama pull qwen3-vl
+ollama pull qwen3-vl:8b
 ```
 
 If `OLLAMA_VISION_MODEL` is empty (default), visual queries are disabled and the
@@ -120,19 +120,21 @@ No new message types are introduced. Satellites without cameras simply omit the 
 
 ## Vision Models
 
-Tested models:
+Candidate models:
 
-| Model | Size | VRAM | Speed (GPU) | Quality |
-|-------|------|------|-------------|---------|
-| **`qwen3-vl`** | 6.0GB | ~12GB | ~30s | Excellent scene description, good German |
-| `qwen2.5vl` | 5.0GB | ~10GB | ~25s | Good vision, slightly older |
-| `minicpm-v` | 5.5GB | ~19GB | ~50s (partial offload on 16GB) | Good for text reading |
-| `llava:7b` | 4.7GB | ~6GB | ~8s | Good general vision |
-| `llava:13b` | 8.0GB | ~12GB | ~15s | Better quality, slower |
+| Model | Size | VRAM | Quality |
+|-------|------|------|---------|
+| **`qwen3-vl:8b`** | ~6GB | ~12GB | Excellent scene description, good German |
+| `qwen2.5vl` | ~5GB | ~10GB | Good vision, slightly older |
+| `minicpm-v` | ~5.5GB | ~19GB | Good for text reading |
+| `llava:7b` | ~4.7GB | ~6GB | Good general vision |
+| `llava:13b` | ~8GB | ~12GB | Better quality, slower |
 
-**Recommendation:** `qwen3-vl` fits entirely in 16GB VRAM and delivers excellent results
-in German. `minicpm-v` requires 19GB and partially offloads to CPU on 16GB cards, causing
-~50s latency.
+**Recommendation:** `qwen3-vl:8b` fits entirely in 16 GB VRAM and delivers excellent
+results in German. `minicpm-v` requires ~19 GB and partially offloads to CPU on 16 GB
+cards.
 
-**Production (renfield.local):** `qwen3-vl` on RTX 5060 Ti (16GB), ~30s per query
-(including ~25s prompt evaluation for image tokens).
+**Production:** `qwen3-vl:8b` is served by the in-cluster `ollama` pod on `k8s-gpu-1`
+(RTX 5060 Ti, 16 GB) — `OLLAMA_VISION_URL` routes there, so no separate vision pod is
+needed. A single test-snapshot inference measured ~1 s end-to-end on the GPU; image-heavy
+scene descriptions with longer responses take proportionally longer.

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -68,7 +68,7 @@ class Settings(BaseSettings):
     ollama_model: str = "llama3.2:3b"  # Legacy fallback; recommended: qwen3:14b (see docs/LLM_MODEL_GUIDE.md)
     ollama_chat_model: str = "llama3.2:3b"      # Default for dev; recommended: qwen3:14b
     ollama_rag_model: str = "llama3.2:latest"   # Default for dev; recommended: qwen3:14b
-    ollama_embed_model: str = "nomic-embed-text" # Default for dev; recommended: qwen3-embedding:4b (768 dim)
+    ollama_embed_model: str = "nomic-embed-text" # Default for dev; recommended: qwen3-embedding:4b (2560 dim)
     ollama_intent_model: str = "llama3.2:3b"    # Default for dev; recommended: qwen3:8b
     ollama_num_ctx: int = 32768                   # Context window für alle Ollama-Calls
     ollama_connect_timeout: float = 10.0          # TCP connect timeout in seconds (fast-fail when host is down)

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -65,7 +65,7 @@ class Settings(BaseSettings):
 
     # Ollama - Multi-Modell Konfiguration
     ollama_url: str = "http://ollama:11434"
-    ollama_model: str = "llama3.2:3b"  # Legacy fallback; recommended: qwen3:14b (see docs/LLM_MODEL_GUIDE.md)
+    ollama_model: str = "llama3.2:3b"  # Legacy fallback; recommended: qwen3:14b
     ollama_chat_model: str = "llama3.2:3b"      # Default for dev; recommended: qwen3:14b
     ollama_rag_model: str = "llama3.2:latest"   # Default for dev; recommended: qwen3:14b
     ollama_embed_model: str = "nomic-embed-text" # Default for dev; recommended: qwen3-embedding:4b (2560 dim)


### PR DESCRIPTION
Audit of the reference docs against current code/config (`k8s/configmap.yaml`, `src/backend/utils/config.py`). All inaccuracies pre-dated the vision-tier reactivation (PR #604).

## Fixed

**Vision tier**
- `SATELLITE_CAMERA.md` / `ENVIRONMENT_VARIABLES.md`: model is `qwen3-vl:8b` (not `qwen3-vl` / `minicpm-v`).
- `SATELLITE_CAMERA.md`: "Production (renfield.local)" → in-cluster `ollama` pod on `k8s-gpu-1` — `renfield.local` is the build box, not production. Dropped the unvalidated per-model "Speed (GPU)" column; the only measured figure (~1 s for a test snapshot) now lives in the production note.
- `CLAUDE.md`: `vision` added to the multi-model list.

**Embedding dimension**
- `qwen3-embedding:4b` is 2560-dim, not 768 (`ENVIRONMENT_VARIABLES.md`, `config.py` comment). `EMBEDDING_DIMENSION` default `768` is the code default only — production uses `2560`.

**Broken links**
- `docs/LLM_MODEL_GUIDE.md` exists only at `docs/private/LLM_MODEL_GUIDE.md` (gitignored) — all 8 links to it were broken for anyone cloning. Removed from README.md, README.de.md, CLAUDE.md, FEATURES.md, ENVIRONMENT_VARIABLES.md, architecture-guide.md, and a config.py comment.

**Changelog**
- Added a v2.8.1 entry for the vision-tier reactivation (PR #604) — config-only, no new image.

## Not addressed
- `README.md` claims `2,100+` backend tests; `CLAUDE.md` says `1,300+`. One is stale — needs a `pytest --collect-only` on the `.159` build box to settle; not guessed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)