### PR TITLE
docs: correct stale backend test count → 3,400+

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ For memory-retrieval callers: pass `user_id=asker_id`. For RAG search: pass `use
 
 ## Testing
 
-Tests in `tests/` at project root. Backend: 1,300+ tests.
+Tests in `tests/` at project root. Backend: 3,400+ tests.
 
 **Markers:** `@pytest.mark.unit`, `@pytest.mark.database`, `@pytest.mark.integration`, `@pytest.mark.e2e`, `@pytest.mark.backend`, `@pytest.mark.frontend`, `@pytest.mark.satellite`
 

--- a/README.de.md
+++ b/README.de.md
@@ -298,7 +298,7 @@ METRICS_ENABLED=false             # Prometheus /metrics (opt-in)
 make lint                    # Lint all code (ruff + eslint)
 make format-backend          # Format + auto-fix mit ruff
 make test                    # Alle Tests
-make test-backend            # Backend-Tests (2.100+)
+make test-backend            # Backend-Tests (3.400+)
 make test-frontend-react     # React-Tests (Vitest + RTL)
 make test-coverage           # Tests mit Coverage-Report (fail-under=50%)
 ```

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ METRICS_ENABLED=false             # Prometheus /metrics (opt-in)
 ```bash
 make lint                    # lint all code (ruff + eslint)
 make test                    # all tests
-make test-backend            # backend tests (2,100+)
+make test-backend            # backend tests (3,400+)
 make test-frontend-react     # React tests (Vitest + RTL)
 make test-coverage           # tests with coverage report
 ```


### PR DESCRIPTION
The backend test count was stale and inconsistent across three files:

| File | Was | Now |
|---|---|---|
| `CLAUDE.md` | `1,300+` | `3,400+` |
| `README.md` | `2,100+` | `3,400+` |
| `README.de.md` | `2.100+` | `3.400+` |

**Measurement:** 3,453 `def test_` functions across 149 files in `tests/backend/`. Only 7 `@pytest.mark.parametrize` decorators exist, so the pytest-collected count sits within a few percent of the function count. `3,400+` is a conservative floor.

Follow-up to the test-count discrepancy flagged in #606.

🤖 Generated with [Claude Code](https://claude.com/claude-code)