### PR TITLE
fix: conversation-handoff ordering bug + MCP arg-guard (PR 2)

### DIFF
--- a/src/backend/services/conversation_handoff.py
+++ b/src/backend/services/conversation_handoff.py
@@ -107,7 +107,7 @@ async def try_handoff_context(
             msg_result = await db.execute(
                 select(Message)
                 .where(Message.conversation_id == source.id)
-                .order_by(Message.created_at.desc())
+                .order_by(Message.timestamp.desc())
                 .limit(5)
             )
             seed_messages = list(reversed(msg_result.scalars().all()))

--- a/src/backend/services/mcp_client.py
+++ b/src/backend/services/mcp_client.py
@@ -359,7 +359,11 @@ async def _geocode_location_arguments(arguments: dict, input_schema: dict) -> di
     Returns:
         Arguments with location resolved to latitude/longitude if applicable.
     """
-    if not input_schema:
+    # Geocoding only applies to dict-shaped arguments against a schema that
+    # declares lat/lon. A non-dict payload (a malformed tool call) passes
+    # through untouched so the real validation error surfaces downstream
+    # instead of an AttributeError raised from inside geocoding.
+    if not input_schema or not isinstance(arguments, dict):
         return arguments
 
     properties = input_schema.get("properties", {})

--- a/tests/backend/test_conversation_handoff.py
+++ b/tests/backend/test_conversation_handoff.py
@@ -22,21 +22,6 @@ def clear_debounce():
     _last_handoff.clear()
 
 
-# services/conversation_handoff.py:110 orders the message-copy query by
-# ``Message.created_at`` — but the Message model's timestamp column is
-# named ``timestamp``, not ``created_at``. Any handoff whose source
-# conversation has a NULL summary hits that branch and raises
-# ``AttributeError: type object 'Message' has no attribute 'created_at'``,
-# which the broad except in try_handoff_context swallows into a False
-# return. This is a real source bug — the fix (Message.created_at ->
-# Message.timestamp) belongs in PR 2; these three tests correctly catch it.
-_HANDOFF_MESSAGE_COPY_SOURCE_BUG = pytest.mark.skip(
-    reason="services/conversation_handoff.py references Message.created_at "
-    "but the column is Message.timestamp — NULL-summary handoffs raise "
-    "AttributeError. Real source bug; fix belongs in PR 2."
-)
-
-
 def _make_conversation(session_id, speaker_id, user_id=None, context_vars=None, summary=None, minutes_ago=5):
     """Create a Conversation-like mock for testing."""
     conv = MagicMock(spec=Conversation)
@@ -145,7 +130,6 @@ async def test_handoff_idempotent(db_session):
     assert target.context_vars == {"new": True}
 
 
-@_HANDOFF_MESSAGE_COPY_SOURCE_BUG
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_handoff_debounce(db_session):
@@ -176,7 +160,6 @@ async def test_handoff_debounce(db_session):
     assert result2 is False
 
 
-@_HANDOFF_MESSAGE_COPY_SOURCE_BUG
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_handoff_null_summary_copies_messages(db_session):
@@ -264,7 +247,6 @@ async def test_handoff_expired_source(db_session):
     assert result is False
 
 
-@_HANDOFF_MESSAGE_COPY_SOURCE_BUG
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_handoff_auth_disabled_speaker_only(db_session):

--- a/tests/backend/test_mcp_streaming.py
+++ b/tests/backend/test_mcp_streaming.py
@@ -101,6 +101,7 @@ class TestExecuteToolStreamingYieldOnce:
             arguments={"x": 1},
             user_permissions=["a"],
             user_id=42,
+            progress_sink=None,
         )
         assert chunks == [sentinel]
 
@@ -145,18 +146,28 @@ class TestExecuteToolStreamingYieldOnce:
 
     @pytest.mark.asyncio
     @pytest.mark.unit
-    async def test_aclose_mid_call_cancels_background_task(self):
-        """If the consumer closes the iterator while execute_tool is still
-        running, the underlying await is cancelled. The result is discarded
-        (not yielded anywhere)."""
+    async def test_cancel_mid_call_cancels_underlying_tool(self):
+        """If the consumer's iteration is cancelled while execute_tool is
+        still running, the cancellation propagates into the generator and
+        the underlying tool await is cancelled — no orphaned work.
+
+        A consumer aborts mid-call by cancelling the task driving the
+        iterator. `aclose()` cannot serve here: calling it from another
+        task while an `__anext__()` is in flight raises RuntimeError at the
+        Python level — not a usage pattern real consumers have."""
         import asyncio
 
         manager = MCPManager()
         started = asyncio.Event()
+        tool_cancelled = asyncio.Event()
 
         async def slow_tool(*args, **kwargs):
             started.set()
-            await asyncio.sleep(10)  # would exceed test timeout if not cancelled
+            try:
+                await asyncio.sleep(10)  # exceeds test timeout if not cancelled
+            except asyncio.CancelledError:
+                tool_cancelled.set()
+                raise
             return {"success": True, "message": "", "data": None}
 
         with patch.object(manager, "execute_tool", new=AsyncMock(side_effect=slow_tool)):
@@ -167,11 +178,11 @@ class TestExecuteToolStreamingYieldOnce:
 
             task = asyncio.create_task(consume_first())
             await started.wait()  # execute_tool is now running
-            await it.aclose()     # close mid-await
-            # The consume task should fail because the generator closed
-            # before yielding anything.
-            with pytest.raises((StopAsyncIteration, asyncio.CancelledError, GeneratorExit)):
+            task.cancel()         # consumer aborts its iteration
+            with pytest.raises(asyncio.CancelledError):
                 await task
+            # the cancellation reached the underlying tool await
+            await asyncio.wait_for(tool_cancelled.wait(), timeout=1.0)
 
     @pytest.mark.asyncio
     @pytest.mark.unit
@@ -228,6 +239,24 @@ def _streaming_manager(session_call_tool):
     )
     manager._tool_index["mcp.peer1.query_brain"] = tool
     return manager
+
+
+class TestGeocodeArgumentGuard:
+    """`_geocode_location_arguments` must not choke on a non-dict payload."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_non_dict_arguments_pass_through(self):
+        """A malformed (non-dict) argument payload is returned untouched, so
+        the real validation error surfaces downstream instead of an
+        AttributeError raised from inside geocoding."""
+        from services.mcp_client import _geocode_location_arguments
+
+        schema = {
+            "type": "object",
+            "properties": {"latitude": {}, "longitude": {}},
+        }
+        assert await _geocode_location_arguments([], schema) == []
 
 
 class TestExecuteToolStreamingWire:
@@ -354,16 +383,19 @@ class TestExecuteToolStreamingWire:
     @pytest.mark.unit
     async def test_unrelated_typeerror_is_not_swallowed(self):
         """Narrow catch: only the 'unexpected keyword progress_callback'
-        TypeError triggers the fallback. Other TypeErrors (e.g. bad
-        arguments type) must propagate instead of silently retrying."""
+        TypeError triggers the fallback. Any other TypeError raised by the
+        tool call must propagate instead of silently retrying."""
         def bad_call_tool(name, arguments, progress_callback=None):
-            # Simulates a genuinely broken call (e.g. arguments type mismatch)
-            # that happens to raise TypeError without mentioning progress_callback.
-            raise TypeError("arguments must be a dict, got list")
+            # An unrelated TypeError from the tool call itself — its message
+            # does NOT mention progress_callback, so it must propagate rather
+            # than trigger the no-progress-callback fallback retry.
+            raise TypeError("tool exploded")
 
         manager = _streaming_manager(bad_call_tool)
-        with pytest.raises(TypeError, match="must be a dict"):
-            async for _ in manager.execute_tool_streaming("mcp.peer1.query_brain", []):
+        # Valid (dict) arguments so the call reaches call_tool — a non-dict
+        # payload would be rejected earlier by input-schema validation.
+        with pytest.raises(TypeError, match="tool exploded"):
+            async for _ in manager.execute_tool_streaming("mcp.peer1.query_brain", {}):
                 pass
 
     @pytest.mark.asyncio


### PR DESCRIPTION
PR 2 of the test-suite effort — the genuine source defects reserved while [#608](https://github.com/ebongard/renfield/pull/608) cleared the ~590 test-rot failures.

## Source fixes

- **`conversation_handoff.py`** — the NULL-summary "copy last 5 messages as seed context" query ordered by `Message.created_at`, but the column is `Message.timestamp`. The `AttributeError` was swallowed into a `False` return by the broad `except`, so every NULL-summary handoff silently lost its seed-context copy.
- **`mcp_client.py` `_geocode_location_arguments`** — added an `isinstance(arguments, dict)` guard. A non-dict payload previously raised an `AttributeError` from inside geocoding; it now passes through so input-schema validation rejects it cleanly downstream.

## Test changes (the 3 reserved `test_mcp_streaming.py` + 3 un-skipped handoff tests)

- **`test_aclose_mid_call`** — rewritten. The original called `aclose()` from a sibling task while an `__anext__()` was in flight, which raises `RuntimeError: aclose(): asynchronous generator is already running` at the Python level *regardless of source code*. **B-13 was a test bug, not a source bug.** Real consumers abort by cancelling the iterating task — the test now does that and asserts the underlying tool await is cancelled.
- **`test_unrelated_typeerror`** — used `[]` as arguments; with the geocode guard that now reaches schema validation (rejected as non-object) before `call_tool`. Switched to valid `{}` args so it actually exercises the narrow `except TypeError` around `call_tool`.
- **`test_delegates_to_execute_tool_once`** — added `progress_sink=None` to the delegation assertion (signature gained the kwarg).
- Added a unit test for the `_geocode_location_arguments` non-dict guard.
- Un-skipped the 3 `test_conversation_handoff.py` NULL-summary tests (the `conversation_handoff.py` fix makes them pass).

## Verification

Full backend suite on `.159`: **3455 passed, 0 failed, 30 skipped**. The suite is now completely green (the 30 skips are documented Postgres-only / root-in-container cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)