### PR TITLE
fix(alembic): drop NOW()-based partial predicate from idx_wb_fp_recent

### DIFF
--- a/src/backend/alembic/versions/pc20260511_wissensbasis_longitudinal.py
+++ b/src/backend/alembic/versions/pc20260511_wissensbasis_longitudinal.py
@@ -130,13 +130,15 @@ def upgrade() -> None:
     if not _has_idx(inspector, "wb_field_provenance", "idx_wb_fp_atom_id"):
         op.create_index("idx_wb_fp_atom_id", "wb_field_provenance", ["atom_id"])
 
-    # Partial index for freshness/staleness queries (postgres only — sqlite
-    # ignores the WHERE clause but creates a full index, harmless for tests).
-    if dialect == "postgresql" and not _has_idx(inspector, "wb_field_provenance", "idx_wb_fp_recent"):
-        op.execute(
-            "CREATE INDEX idx_wb_fp_recent ON wb_field_provenance (fetched_at) "
-            "WHERE fetched_at > NOW() - INTERVAL '90 days'"
-        )
+    # Index for freshness/staleness queries on fetched_at. Originally written
+    # as a partial index with `WHERE fetched_at > NOW() - INTERVAL '90 days'`,
+    # but postgres rejects that — partial-index predicates must be IMMUTABLE
+    # and NOW() is STABLE. The rolling-window intent was also moot: NOW() is
+    # evaluated once at CREATE INDEX time, so the cutoff would have been a
+    # static deploy-time snapshot, not a rolling window. A full B-tree on
+    # fetched_at serves the same freshness queries and the table ships empty.
+    if not _has_idx(inspector, "wb_field_provenance", "idx_wb_fp_recent"):
+        op.create_index("idx_wb_fp_recent", "wb_field_provenance", ["fetched_at"])
 
     # =========================================================================
     # wb_field_provenance_archive — destination for legal_hold rows that


### PR DESCRIPTION
## Summary

Surfaced as a deploy blocker for v2.9.0. Migration \`pc20260511_wissensbasis_longitudinal.py\` (Reva-compat work, 2026-05-11) created a partial index whose predicate uses \`NOW()\`:

\`\`\`sql
CREATE INDEX idx_wb_fp_recent ON wb_field_provenance (fetched_at)
  WHERE fetched_at > NOW() - INTERVAL '90 days'
\`\`\`

Postgres rejects this with:

> \`InvalidObjectDefinitionError: functions in index predicate must be marked IMMUTABLE\`

\`NOW()\` is \`STABLE\`, and partial-index predicates require \`IMMUTABLE\` functions. The migration has been broken on postgres since it was written; it only surfaced now because nothing has run \`alembic upgrade\` against the production DB since this migration landed (live DB still at \`a0b1c2d3e4f5\`).

The rolling-window intent was also moot: \`NOW()\` is evaluated once at CREATE INDEX time, so the cutoff would have been a static deploy-time snapshot, not a "last 90 days" window.

## Fix

Drop the partial predicate; create a full B-tree on \`fetched_at\`. The freshness queries the index was meant to serve are equally well served by a full index, and the table ships empty in current deployments so size is not a concern.

## Test plan

- [ ] Fresh-DB alembic upgrade head — confirm the index is created without error
- [ ] Verify \`\\d+ wb_field_provenance\` shows \`idx_wb_fp_recent btree (fetched_at)\` (no WHERE)
- [ ] After this lands, re-cut v2.9.1 release tag and re-run the v2.9.0 deploy flow against the fixed chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)