### PR TITLE
fix(self-learning): seed status default + curator test contract

### DIFF
--- a/src/backend/services/skill_service.py
+++ b/src/backend/services/skill_service.py
@@ -326,6 +326,12 @@ class SkillService:
             trigger_examples=trigger_examples or [],
             tool_sequence=tool_sequence or [],
             source=SKILL_SOURCE_SEED,
+            # System-shipped seeds bypass the draft-gate — they're
+            # repo-managed (seed_skills/*.md), not LLM-emitted, so the
+            # human-review threat model doesn't apply. Without this the
+            # column default 'draft' would keep every seed out of
+            # retrieval until an admin clicked Approve.
+            status=SKILL_STATUS_APPROVED,
             embedding=embedding,
             atom_id=None,
             circle_tier=TIER_PUBLIC,

--- a/tests/backend/test_skills_routes.py
+++ b/tests/backend/test_skills_routes.py
@@ -535,17 +535,21 @@ class TestCuratorRun:
     async def test_admin_can_trigger(
         self, async_client: AsyncClient, auth_as_admin, patched_embed,
     ):
-        """Happy path: admin can fire the curator run. With no skills in
-        DB the report has duplicates_found=0 + stale_archived=0."""
+        """Happy path: admin fires the curator run; v2.10 returns the
+        completed SkillCuratorRun audit row (single object, not a list)."""
         resp = await async_client.post(
             "/api/skills/curator/run",
             json={"user_id": auth_as_admin.id},
         )
-        # Either 200 with empty report list (the per-user code path) or
-        # a list with one zero'd report. Both are valid here.
         assert resp.status_code == 200
         body = resp.json()
-        assert isinstance(body, list)
+        assert isinstance(body, dict)
+        assert body["run_type"] == "manual"
+        assert body["triggered_by_user_id"] == auth_as_admin.id
+        assert body["status"] in ("success", "partial", "failed")
+        # Empty DB → nothing to merge or archive.
+        assert body["duplicate_pairs_merged"] == 0
+        assert body["stale_skills_archived"] == 0
 
     async def test_non_admin_blocked(
         self, async_client: AsyncClient, auth_as_owner,


### PR DESCRIPTION
## Summary

Two test failures surfaced on the `.159` build box after the v2.10 merge (#615). Both were real bugs.

1. **`SkillService.load_seed` left seeds in draft state.** The function constructed `ProceduralSkill(...)` without setting `status`, so seeds inherited the model default `'draft'` and never reached the agent's retrieval — `has_any_skills()` returned False even after a successful load. System seeds are repo-managed (`seed_skills/*.md`), not LLM-emitted, so the human-review gate doesn't apply. Fix: pass `status=SKILL_STATUS_APPROVED` explicitly. Caught by `test_skill_service.py::TestHasAnySkills::test_true_after_insert`.

2. **Pre-existing `test_admin_can_trigger` asserted the legacy curator contract** (list of per-user reports). The v2.10 route now returns a single `SkillCuratorRun` audit row per the design doc. Updated the assertions.

## Test plan

- [x] Verified on `.159`: `85 passed, 1 skipped (postgres-only), 0 failed`
- [ ] Re-run on `.159` post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)