### PR TITLE
fix(self-learning): admin check honors auth_enabled=false; reorder trajectories routes

### DIFF
--- a/src/backend/api/routes/skills.py
+++ b/src/backend/api/routes/skills.py
@@ -65,12 +65,19 @@ _MAX_TOOL_NAME_CHARS = 128
 def _user_is_admin(user: User | None) -> bool:
     """Has the caller got the ADMIN permission?
 
-    Uses ``User.has_permission`` (delegates to the eagerly-loaded role).
-    The auth dependencies ``get_user_or_default`` / ``get_current_user``
-    both `selectinload(User.role)` so the lazy traversal here is safe.
-    Defaults to False on a None caller (auth-disabled single-user mode
-    where the inbox isn't surfaced anyway).
+    Mirrors the contract of ``services.auth_service.require_permission``:
+    when ``auth_enabled`` is False the whole permission system is bypassed
+    and the (single-user-mode) default user is treated as admin. Without
+    this branch the Skills Inbox + admin-view list filter + global
+    draft-count return 403 in every home deployment that hasn't opted
+    into auth.
+
+    Auth-enabled path: ``User.has_permission`` delegates to the eagerly-
+    loaded role. ``get_user_or_default`` / ``get_current_user`` both
+    ``selectinload(User.role)`` so the lazy traversal here is safe.
     """
+    if not settings.auth_enabled:
+        return True
     if user is None:
         return False
     try:

--- a/src/backend/api/routes/trajectories.py
+++ b/src/backend/api/routes/trajectories.py
@@ -220,34 +220,11 @@ async def export_jsonl(
     )
 
 
-# ------------------------------------------------------------------ get
-class TrajectoryDetailResponse(TrajectoryResponse):
-    raw_payload: dict[str, Any]
-    redacted_payload: dict[str, Any] | None
-
-
-@router.get("/{trajectory_id}", response_model=TrajectoryDetailResponse)
-@limiter.limit(settings.api_rate_limit_admin)
-async def get_trajectory(
-    request: Request,
-    trajectory_id: int,
-    db: AsyncSession = Depends(get_db),
-    _: User = Depends(require_permission(Permission.ADMIN)),
-):
-    """Single-row detail for the AdminTrajectoriesPage StepTimeline. Returns
-    the full raw_payload (and redacted_payload when available) so the
-    front-end can render the per-step tool call / result trace."""
-    row = (await db.execute(
-        select(AgentTrajectory).where(AgentTrajectory.id == trajectory_id)
-    )).scalar_one_or_none()
-    if row is None:
-        raise HTTPException(status_code=404, detail="Trajectory not found")
-    base = _to_summary(row)
-    return TrajectoryDetailResponse(
-        **base.model_dump(),
-        raw_payload=row.raw_payload or {},
-        redacted_payload=row.redacted_payload,
-    )
+# Single-row TrajectoryDetailResponse + GET /{trajectory_id} live at the
+# BOTTOM of this module — FastAPI matches in declaration order, so the
+# `/{trajectory_id}` route MUST come after every static-path route
+# (`/stats`, `/export.jsonl`) and after `/{trajectory_id}/flag`. Putting
+# it earlier would coerce `/stats` to `int("stats")` and 422.
 
 
 # ------------------------------------------------------------------ flag
@@ -308,4 +285,37 @@ async def trajectory_stats(
         flagged_total=flagged,
         capture_enabled=settings.trajectory_capture_enabled,
         retention_days=settings.trajectory_retention_days,
+    )
+
+
+# -------------------------------------------------------- get (single row)
+# MUST stay at the bottom — see the warning at the top of the flag/stats
+# region. FastAPI matches in declaration order; `/{trajectory_id}` would
+# otherwise eat `/stats` and `/export.jsonl`.
+class TrajectoryDetailResponse(TrajectoryResponse):
+    raw_payload: dict[str, Any]
+    redacted_payload: dict[str, Any] | None
+
+
+@router.get("/{trajectory_id}", response_model=TrajectoryDetailResponse)
+@limiter.limit(settings.api_rate_limit_admin)
+async def get_trajectory(
+    request: Request,
+    trajectory_id: int,
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(require_permission(Permission.ADMIN)),
+):
+    """Single-row detail for the AdminTrajectoriesPage StepTimeline. Returns
+    the full raw_payload (and redacted_payload when available) so the
+    front-end can render the per-step tool call / result trace."""
+    row = (await db.execute(
+        select(AgentTrajectory).where(AgentTrajectory.id == trajectory_id)
+    )).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Trajectory not found")
+    base = _to_summary(row)
+    return TrajectoryDetailResponse(
+        **base.model_dump(),
+        raw_payload=row.raw_payload or {},
+        redacted_payload=row.redacted_payload,
     )


### PR DESCRIPTION
## Summary

Post-deploy browser smoke against the live v2.10 cluster (run via Playwright on `.159`) surfaced two real bugs:

1. **`_user_is_admin` always returns False in single-user mode.** The helper called `user.has_permission(\"admin\")` unconditionally; the default user in `auth_enabled=false` deployments has no role grants, so the check fails. Net effect: `/api/skills?admin_view=true` returned 403, the Skills Inbox couldn't load drafts. Fixed by mirroring the contract of `services.auth_service.require_permission` — when `auth_enabled=false`, short-circuit to allow.

2. **`GET /api/trajectories/{trajectory_id}` was declared before `GET /api/trajectories/stats`.** FastAPI matches in declaration order, so `/stats` was coerced to `int(\"stats\")` → 422. The AdminTrajectoriesPage stats panel never rendered. Moved the `{trajectory_id}` route to the bottom of the file, with a comment that explains why.

## Test plan

- [x] Backend test suite on `.159`: 40 passed, 1 skipped (postgres-only)
- [x] Browser smoke on `.159` against the live cluster: all 5 v2.10 pages render their page markers; xhr table only shows the expected 404 from the Reva-only wissensbasis probe
- [ ] Redeploy and re-run the browser smoke post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)