### PR TITLE
chore: post-v2.10 quality sweep (auth eager-load, route guard, doc refresh, shadow-log retention)

### DIFF
--- a/docs/TECHNICAL_DEBT.md
+++ b/docs/TECHNICAL_DEBT.md
@@ -2,7 +2,7 @@
 
 Dieses Dokument enthält eine umfassende Analyse der technischen Schulden im gesamten Renfield-System.
 
-**Letzte Aktualisierung:** 2026-05-26
+**Letzte Aktualisierung:** 2026-05-26 (Frontend-Sweep: TypeScript-Migration als abgeschlossen markiert, alle Major-Dep-Updates als erledigt, Komponentengrößen mit aktuellen Zahlen)
 
 ---
 
@@ -11,10 +11,10 @@ Dieses Dokument enthält eine umfassende Analyse der technischen Schulden im ges
 | Bereich | Kritisch | Mittel | Niedrig | Gesamt | Behoben |
 |---------|----------|--------|---------|--------|---------|
 | Backend | 0 | 3 | 4 | 9 | 10 |
-| Frontend | 0 | 1 | 3 | 7 | 5 |
+| Frontend | 0 | 0 | 2 | 4 | 7 |
 | Satellite | 0 | 3 | 2 | 5 | 5 |
 | Infrastruktur | 0 | 3 | 2 | 6 | 6 |
-| **Gesamt** | **0** | **10** | **11** | **27** | **26** |
+| **Gesamt** | **0** | **9** | **10** | **24** | **28** |
 
 ---
 
@@ -280,43 +280,30 @@ pages/ChatPage/
 
 ---
 
-#### 3. TypeScript Migration (teilweise abgeschlossen)
+#### ~~3. TypeScript Migration~~ ✅ Abgeschlossen
 
-**Status:** ✅ Grundgerüst migriert (2026-01-26)
+**Status:** Vollständig migriert (Verifiziert 2026-05-26)
 
-**Migrierte Dateien:**
-- `tsconfig.json`, `tsconfig.node.json` - TypeScript Konfiguration
-- `vite.config.ts` - Vite Config mit Path Aliases
-- `src/types/` - Type Definitionen (device, chat, api)
-- `src/hooks/*.ts` - Alle Hooks (useDeviceConnection, useChatSessions, useWakeWord, useCapabilities)
-- `src/context/*.tsx` - Alle Contexts (Auth, Device, Theme)
-- `src/utils/*.ts` - Utilities (axios, debug)
-- `src/config/wakeword.ts` - Wake Word Konfiguration
+W10-Migration komplett: `src/frontend/src/` ist 100% TypeScript — **59 `.ts` + 86 `.tsx`, 0 `.jsx`/`.js`**. Strict mode aktiv (`strict: true`, kein `allowJs`), `npm run typecheck` ist Pflicht-Gate. Test-Suite (`tests/frontend/react/`) mitmigriert. PR-Kette: #487 + Folge-PRs (#519/#520/#521/#522).
 
-**Noch zu migrieren:**
-- `src/pages/*.jsx` - Seiten-Komponenten
-- `src/components/*.jsx` - UI-Komponenten
-- `src/main.jsx`, `src/App.jsx` - Entry Points
-
-**Konfiguration:** Permissive Settings (`strict: false`, `allowJs: true`) für schrittweise Migration.
+Verbleibender Hinweis: Faked `.tsx`-Shims (`as FC<any>`, `// @ts-nocheck`) sind verboten — siehe `memory/feedback_no_shortcuts_typescript.md`. Ehrliches `.jsx` wäre besser als ein gefakter `.tsx`.
 
 ---
 
-#### 4. Outdated Dependencies (teilweise behoben)
+#### ~~4. Outdated Dependencies (alle Majors)~~ ✅ Abgeschlossen
 
-| Package | Current | Latest | Breaking | Status |
-|---------|---------|--------|----------|--------|
-| react | 18.3.1 | 19.x | ⚠️ Major | ⏳ |
-| react-router-dom | 6.30.3 | 7.x | ⚠️ Major | ⏳ |
-| tailwindcss | 3.4.19 | 4.x | ⚠️ Major | ⏳ |
-| vite | 5.4.21 | 7.x | ⚠️ Major | ⏳ |
-| @headlessui/react | 1.7.19 | 2.x | ⚠️ Major | ⏳ |
-| lucide-react | 0.307.0 | 0.563.0 | ✅ Minor | ✅ |
+**Status:** Alle Major-Versionen aktualisiert (Verifiziert 2026-05-26)
 
-**Änderungen (2026-01-25):**
-- lucide-react 0.307.0 → 0.563.0 aktualisiert
+| Package | Damals | Heute | Notes |
+|---------|--------|-------|-------|
+| react | 18.3.1 | **19.2.3** | ✅ Major |
+| react-router | 6.30.3 (dom) | **7.13.0** | ✅ Major + Package umgezogen auf `react-router` |
+| tailwindcss | 3.4.19 | **4.1.18** | ✅ Major |
+| vite | 5.4.21 | **7.3.1** | ✅ Major |
+| @headlessui/react | 1.7.19 | — | ✅ Entfernt (durch eigene Komponenten ersetzt) |
+| lucide-react | 0.307.0 | 0.563.0 | ✅ |
 
-**Empfehlung:** Major-Updates einzeln planen und testen.
+Frontend hängt jetzt am aktuellen React-Major; nächste Wartungsrunde betrifft nur noch Minor-/Patch-Bumps.
 
 ---
 
@@ -332,15 +319,19 @@ Kommentar wurde erweitert um die Begründung zu dokumentieren.
 
 ### 🟢 Niedrig
 
-#### 6. Große Komponenten
+#### 6. Große Komponenten (überwacht — alle in TypeScript)
 
-- `SpeakersPage.jsx` (1027 Zeilen)
-- `RoomsPage.jsx` (762 Zeilen)
-- `useDeviceConnection.js` (616 Zeilen)
+Stand 2026-05-26 (nach W10-Migration, Endungen jetzt `.tsx`/`.ts`):
+
+- `pages/SpeakersPage.tsx` (929 Zeilen — leicht geschrumpft seit dem Audit)
+- `pages/RoomsPage.tsx` (721 Zeilen — leicht geschrumpft)
+- `hooks/useDeviceConnection.ts` (637 Zeilen — leicht **gewachsen**; nächste Wartungsrunde aufteilen)
+
+**Empfehlung:** Sub-Hook-Extraktion bei `useDeviceConnection.ts` priorisieren (Reconnect-Logik, Health-Probe, Capability-Sync sind drei unabhängige Verantwortlichkeiten in einer Datei).
 
 #### 7. Fehlende Error Boundaries
 
-Nur eine zentrale ErrorBoundary, keine Feature-spezifischen.
+Nur eine zentrale ErrorBoundary (in `App.tsx`); keine Feature-spezifischen. Eine fehlgeschlagene Komponente — z.B. ein Payload-Parse-Bug auf `/admin/curator` — nimmt das gesamte SPA mit, statt nur den betroffenen Bereich. Vorschlag: pro Top-Level-Route eine eigene Boundary (Render-Fallback `<RouteErrorFallback />` + automatischer Logout-Reset-Pfad).
 
 #### ~~8. Keine Unit Tests für Hooks~~ ✅ Behoben
 

--- a/src/backend/api/lifecycle.py
+++ b/src/backend/api/lifecycle.py
@@ -370,6 +370,56 @@ def _schedule_skill_curator():
     )
 
 
+def _schedule_skill_shadow_log_cleanup():
+    """Prune `skill_would_have_injected_log` rows older than the
+    configured retention.
+
+    The shadow log records every find_similar candidate the draft-gate
+    suppressed (v2.10 rollout instrumentation). It grows on every
+    matching query — a busy household can rack up tens of thousands
+    of rows / week. Without this sweep the table is unbounded until
+    ``skill_shadow_log_enabled`` is flipped off.
+
+    Gated on ``skills_enabled`` and ``skill_shadow_log_enabled`` so the
+    scheduler doesn't even start when the shadow log is off.
+    """
+    if not settings.skills_enabled or not settings.skill_shadow_log_enabled:
+        return
+
+    async def _tick():
+        from datetime import datetime, timedelta, UTC
+        from sqlalchemy import delete
+        from models.database import SkillWouldHaveInjectedLog
+
+        cutoff = datetime.now(UTC).replace(tzinfo=None) - timedelta(
+            days=settings.skill_shadow_log_retention_days
+        )
+        async with AsyncSessionLocal() as db_session:
+            result = await db_session.execute(
+                delete(SkillWouldHaveInjectedLog).where(
+                    SkillWouldHaveInjectedLog.created_at < cutoff
+                )
+            )
+            deleted = int(result.rowcount or 0)
+            if deleted:
+                await db_session.commit()
+                logger.info(
+                    f"🧹 Skill shadow log: pruned {deleted} row(s) "
+                    f"older than {settings.skill_shadow_log_retention_days}d"
+                )
+
+    _spawn_periodic_task(
+        name="Skill shadow-log cleanup",
+        interval=settings.skill_shadow_log_cleanup_interval,
+        work=_tick,
+        started_msg=(
+            f"Skill Shadow-Log Cleanup gestartet "
+            f"(interval={settings.skill_shadow_log_cleanup_interval}s, "
+            f"retention={settings.skill_shadow_log_retention_days}d)"
+        ),
+    )
+
+
 def _schedule_paperless_sweepers(app):
     """PR 4 — hourly sweepers for the Paperless learning loop.
 
@@ -715,6 +765,7 @@ async def lifespan(app: "FastAPI"):
     _schedule_federation_audit_cleanup()
     _schedule_trajectory_cleanup()
     _schedule_skill_curator()
+    _schedule_skill_shadow_log_cleanup()
     _schedule_paperless_sweepers(app)
 
     # Self-learning Phase 1: load bundled seed skills into the database.

--- a/src/backend/services/auth_service.py
+++ b/src/backend/services/auth_service.py
@@ -320,15 +320,23 @@ async def get_user_or_default(
     if current_user is not None:
         return current_user
 
-    # Auth-disabled: resolve to the admin user.
+    # Auth-disabled: resolve to the admin user. Eager-load `role` here
+    # — without it, downstream helpers that traverse `user.role.*`
+    # (`user.has_permission(...)`, `user.get_permissions()`) trip
+    # MissingGreenlet inside the async handler and silently return
+    # the wrong answer when wrapped in try/except. Class of bug: the
+    # `_user_is_admin` helper in api/routes/skills.py returned False
+    # in auth-disabled deploys until #617 worked around it.
     admin = (await db.execute(
-        select(User).where(User.username == "admin").limit(1)
+        select(User).where(User.username == "admin")
+        .options(selectinload(User.role))
+        .limit(1)
     )).scalar_one_or_none()
     if admin is not None:
         return admin
     # Admin was deleted/renamed — fall back to the first user by id.
     first = (await db.execute(
-        select(User).order_by(User.id).limit(1)
+        select(User).options(selectinload(User.role)).order_by(User.id).limit(1)
     )).scalar_one_or_none()
     if first is not None:
         return first

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -410,6 +410,8 @@ class Settings(BaseSettings):
     # window — the table can grow significantly under load.
     skill_shadow_log_enabled: bool = True
     skill_shadow_log_top_k: int = Field(default=10, ge=1, le=50)              # Cap shadow rows per query
+    skill_shadow_log_retention_days: int = Field(default=30, ge=1, le=365)    # Auto-delete shadow rows older than N days
+    skill_shadow_log_cleanup_interval: int = Field(default=86400, ge=300, le=604800)  # Cleanup tick (seconds)
 
     # Knowledge Graph (Entity-Relation triples from conversations)
     knowledge_graph_enabled: bool = False                                        # Opt-in

--- a/tests/backend/test_route_declaration_order.py
+++ b/tests/backend/test_route_declaration_order.py
@@ -1,0 +1,137 @@
+"""Repo-wide guard: a static-path route MUST NOT be declared after a
+parameterized route at the same prefix on the same HTTP method, unless
+the param is type-pinned (`{id:int}`, `{id:uuid}`, etc.).
+
+FastAPI walks routes in declaration order. `GET /things/{id}` declared
+before `GET /things/stats` makes the second route unreachable —
+`/things/stats` matches the first route with `id="stats"`, which then
+either 404s (after a DB lookup miss) or 422s (when the param type is
+``int``). The v2.10 admin console PR shipped one such bug
+(``GET /api/trajectories/{trajectory_id}`` declared before
+``GET /api/trajectories/stats``); #617 fixed it. This test prevents
+the class.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROUTE_RE = re.compile(r'^@router\.(get|post|put|patch|delete)\("([^"]+)"')
+
+
+def _route_dirs() -> list[Path]:
+    """Locate the route module dirs in both layouts we run under:
+    - Local: cwd is the repo root → ``src/backend/api/routes``.
+    - .159 container: cwd is /, code mounted at /app (= src/backend)
+      → ``/app/api/routes`` and ``/app/ha_glue/api/routes``.
+
+    Anchor off ``models.database``'s file path so we always find the
+    backend root regardless of cwd.
+    """
+    try:
+        import models.database as _db_mod
+        backend_root = Path(_db_mod.__file__).resolve().parent.parent
+    except Exception:
+        backend_root = Path("src/backend").resolve()
+    candidates = [
+        backend_root / "api" / "routes",
+        backend_root / "ha_glue" / "api" / "routes",
+    ]
+    return [c for c in candidates if c.is_dir()]
+
+
+# Resolved at import time so pytest parametrize sees the real list.
+ROUTE_DIRS = _route_dirs()
+
+
+def _has_param(path: str) -> bool:
+    return "{" in path
+
+
+def _shadows(static_path: str, param_path: str) -> bool:
+    """Does ``param_path`` swallow ``static_path`` during FastAPI's
+    declaration-order routing walk?
+
+    Same segment count + every param segment either un-typed or typed
+    with a converter that accepts the static segment's literal value.
+    """
+    s_parts = static_path.strip("/").split("/")
+    p_parts = param_path.strip("/").split("/")
+    if len(s_parts) != len(p_parts):
+        return False
+    for s_seg, p_seg in zip(s_parts, p_parts):
+        if p_seg.startswith("{"):
+            # ``{name}``  → matches anything → shadow risk
+            # ``{name:int}`` → only digits
+            # ``{name:uuid}`` → only UUIDs (static path almost never UUID)
+            converter = None
+            if ":" in p_seg:
+                converter = p_seg.split(":", 1)[1].rstrip("}").lower()
+            if converter == "int" and not s_seg.isdigit():
+                return False
+            if converter == "uuid":
+                return False
+            continue
+        if s_seg != p_seg:
+            return False
+    return True
+
+
+def _collect_routes(route_file: Path) -> list[tuple[int, str, str]]:
+    routes: list[tuple[int, str, str]] = []
+    for lineno, raw in enumerate(route_file.read_text().splitlines(), 1):
+        m = ROUTE_RE.match(raw.strip())
+        if m:
+            routes.append((lineno, m.group(1), m.group(2)))
+    return routes
+
+
+def _find_shadows(route_file: Path) -> list[str]:
+    routes = _collect_routes(route_file)
+    issues: list[str] = []
+    for i, (sn, sm, sp) in enumerate(routes):
+        if _has_param(sp):
+            continue
+        for pn, pm, pp in routes[:i]:
+            if _has_param(pp) and pm == sm and _shadows(sp, pp):
+                issues.append(
+                    f"{route_file}:{sn}  {sm.upper()} {sp}  shadowed by  "
+                    f"L{pn} {pm.upper()} {pp}"
+                )
+    return issues
+
+
+def _all_route_files() -> list[Path]:
+    out: list[Path] = []
+    for d in ROUTE_DIRS:
+        if d.is_dir():
+            out.extend(sorted(p for p in d.glob("*.py") if p.name != "__init__.py"))
+    return out
+
+
+def test_route_files_exist():
+    """Sanity check — if the route dirs vanish, the rest of this test
+    silently passes with zero files. Catch that immediately."""
+    files = _all_route_files()
+    assert len(files) > 5, f"Expected several route modules, found {files!r}"
+
+
+@pytest.mark.parametrize(
+    "route_file",
+    _all_route_files(),
+    ids=lambda p: str(p),
+)
+def test_no_static_shadowed_by_param(route_file: Path):
+    """A static-path route must not be declared after a same-method
+    untyped parameterized route at the same prefix.
+
+    If this fails:
+      - Move the static path ABOVE the parameterized one in the file
+        (FastAPI matches in declaration order, so static-first wins).
+      - OR pin the param to a converter: ``{thing_id:int}`` will
+        refuse to match ``"stats"`` and stop shadowing.
+    """
+    issues = _find_shadows(route_file)
+    assert not issues, "\n".join(["Route declaration shadow risk(s):", *issues])

--- a/tests/backend/test_skill_shadow_log_cleanup.py
+++ b/tests/backend/test_skill_shadow_log_cleanup.py
@@ -1,0 +1,76 @@
+"""Retention sweep for the v2.10 ``skill_would_have_injected_log`` table.
+
+The scheduler in ``api/lifecycle.py`` deletes rows older than
+``settings.skill_shadow_log_retention_days``. This test inlines the
+same DELETE so we don't need to spawn the periodic task in the test
+runner — what we care about is that the SQL is correct and bounded.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, UTC
+
+import pytest
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import SkillWouldHaveInjectedLog
+
+
+def _utcnow_naive() -> datetime:
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+async def _seed_row(db: AsyncSession, *, days_ago: float) -> int:
+    row = SkillWouldHaveInjectedLog(
+        skill_id=1,                              # FK relaxed for unit-test
+        user_id=None,
+        similarity_score=0.91,
+        status_at_query="draft",
+        created_at=_utcnow_naive() - timedelta(days=days_ago),
+    )
+    db.add(row)
+    await db.commit()
+    await db.refresh(row)
+    return row.id
+
+
+@pytest.mark.asyncio
+class TestShadowLogRetention:
+    async def test_prunes_rows_past_retention(self, db_session: AsyncSession):
+        old_id = await _seed_row(db_session, days_ago=45)
+        fresh_id = await _seed_row(db_session, days_ago=5)
+
+        cutoff = _utcnow_naive() - timedelta(days=30)
+        result = await db_session.execute(
+            delete(SkillWouldHaveInjectedLog).where(
+                SkillWouldHaveInjectedLog.created_at < cutoff
+            )
+        )
+        await db_session.commit()
+
+        # The exact rowcount semantics differ between dialects (sqlite
+        # reports actual deleted rows; some drivers report -1). The
+        # invariant we care about is the post-state, not the count.
+        remaining_ids = (
+            await db_session.execute(select(SkillWouldHaveInjectedLog.id))
+        ).scalars().all()
+        assert fresh_id in remaining_ids
+        assert old_id not in remaining_ids
+        # Sanity: rowcount when reported should match the one we deleted.
+        if result.rowcount is not None and result.rowcount >= 0:
+            assert result.rowcount == 1
+
+    async def test_noop_when_table_empty(self, db_session: AsyncSession):
+        cutoff = _utcnow_naive() - timedelta(days=30)
+        result = await db_session.execute(
+            delete(SkillWouldHaveInjectedLog).where(
+                SkillWouldHaveInjectedLog.created_at < cutoff
+            )
+        )
+        await db_session.commit()
+        # 0 rows in, 0 rows out — never call commit() in the production
+        # path if nothing was deleted (avoids log noise + an empty
+        # transaction). The scheduler in lifecycle.py guards on
+        # rowcount > 0; this asserts the guard is meaningful.
+        if result.rowcount is not None and result.rowcount >= 0:
+            assert result.rowcount == 0


### PR DESCRIPTION
## Summary

Four small follow-ups surfaced after the v2.10 ship. Each closes a real gap the deploy or /review exposed. None expand scope — all strengthen what's already there.

1. **`get_user_or_default` now eagerly loads `User.role`.** The MissingGreenlet from lazy-loading role inside helpers like `_user_is_admin` was the **root cause** behind #617 — admin checks silently returned False in auth-disabled deploys. The bypass in `skills.py` stays as defense-in-depth.

2. **New repo-wide regression test** (`test_route_declaration_order.py`) that scans every router and refuses static paths declared after a same-method untyped parameterized route at the same prefix. Catches the class behind #617 (`GET /{trajectory_id}` shadowing `GET /stats`). 0 issues across all routers today.

3. **Refreshed `docs/TECHNICAL_DEBT.md` frontend section.** TypeScript migration is fully complete (59 .ts + 86 .tsx, 0 .jsx) and every major dep update (React 19, react-router 7, Tailwind 4, Vite 7) has landed — the doc still listed them as ⏳. Big-file inventory refreshed; `useDeviceConnection.ts` grew to 637 lines and is now flagged as the next refactor target.

4. **Shadow-log retention sweep** — new scheduler in `api/lifecycle.py` prunes `skill_would_have_injected_log` rows past `skill_shadow_log_retention_days` (default 30). Without this the rollout instrumentation table grows unbounded.

## Test plan

- [x] `.159` backend test suite: **118 passed, 1 skipped, 0 failed** across the 6 touched suites
- [x] New `test_route_declaration_order.py` parametrizes over 13 routers, all green
- [x] New `test_skill_shadow_log_cleanup.py` confirms the DELETE bounds rows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)