### PR TITLE
fix(brain): retrieval quality — threshold tune + OCR-garbage filter + lexical retriever

### DIFF
--- a/src/backend/alembic/versions/pc20260526b_document_chunks_search_vector_gin.py
+++ b/src/backend/alembic/versions/pc20260526b_document_chunks_search_vector_gin.py
@@ -1,0 +1,52 @@
+"""GIN index on document_chunks.search_vector — brain-quality fix.
+
+Revision ID: pc20260526b_dc_search_gin
+Revises: pc20260527_skill_approval_status
+Create Date: 2026-05-26 19:00:00.000000
+
+``document_chunks.search_vector`` has been populated since the BM25
+retriever shipped, but the table never had a GIN index on it. Every
+lexical retrieval issued a sequential scan with per-row
+``websearch_to_tsquery @@`` evaluation. Fine on the 159-row production
+corpus today; will become the dominant cost the moment Paperless
+ingestion picks up.
+
+GIN is the right index for tsvector by every Postgres-side benchmark;
+``CREATE INDEX CONCURRENTLY`` so the index build doesn't lock the
+table on production deploy. Cannot run inside a transaction — Alembic
+detects the ``with_concurrency`` op below and runs it outside the
+implicit migration transaction.
+"""
+from alembic import op
+
+
+revision = "pc20260526b_dc_search_gin"
+down_revision = "pc20260527_skill_approval_status"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name if bind is not None else "postgresql"
+    if dialect != "postgresql":
+        return
+
+    # CONCURRENTLY must run outside a transaction. Alembic wraps
+    # upgrade() in a transaction by default; the safe pattern is
+    # autocommit_block.
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            "idx_document_chunks_search_vector_gin "
+            "ON document_chunks USING gin (search_vector)"
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name if bind is not None else "postgresql"
+    if dialect != "postgresql":
+        return
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS idx_document_chunks_search_vector_gin")

--- a/src/backend/services/lexical_retrieval.py
+++ b/src/backend/services/lexical_retrieval.py
@@ -1,0 +1,258 @@
+"""Lexical (keyword / name) retrieval for the polymorphic atom store.
+
+Vector search is great for paraphrase queries ("what does the user
+prefer to drink?" → "user likes tea") but bad for name and short-token
+queries ("Jutta" → ...). Embedding similarity between a single token
+and the corpus depends on the embedding model's behaviour at that
+extreme; for qwen3-embedding:4b on the production corpus we measured
+cosine ~0.0-0.5 between "jutta" and the literal sentence "Jutta mag
+Maracujas und Ananas". Below `memory_retrieval_threshold` either way —
+the user sees nothing.
+
+This module adds a deterministic lexical retriever that complements
+the vector path. It feeds into `polymorphic_atom_store` as an extra
+source for the RRF merge. When the same atom appears in both lists
+the RRF score doubles up, which is exactly the boost we want for
+"this is both a semantic AND keyword match" cases.
+
+Two methods, each returning results in the shape the existing
+`_wrap_*` helpers in polymorphic_atom_store already understand:
+
+  - ``search_chunks_lexical(query, asker_id, top_k)``     → RAG shape
+  - ``search_memories_lexical(query, asker_id, top_k)``   → memory shape
+
+Chunks use the existing ``document_chunks.search_vector`` tsvector
+(populated at ingestion). Memories use ILIKE — `conversation_memories`
+has no tsvector column today, and a per-user corpus rarely exceeds
+~1000 rows, so the seq-scan cost is negligible. A future migration
+could add tsvector here too, but it's not on the critical path.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from loguru import logger
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from services.circle_sql import (
+    conversation_memories_circles_filter,
+    document_chunks_circles_filter,
+)
+from utils.config import settings
+from utils.content_quality import is_low_quality_text
+
+
+# Drop short tokens (≤2 chars) and a bare-minimum German+English stop list.
+# Lexical retrieval on "the" or "und" produces matches with no signal;
+# this is just enough to keep the LIKE/tsquery patterns sharp without
+# pulling in a heavyweight tokenizer.
+_STOP_TOKENS = {
+    "der", "die", "das", "und", "oder", "aber", "ist", "wer", "was",
+    "wie", "wo", "wann", "warum", "mag", "den", "dem", "des",
+    "the", "and", "or", "but", "is", "are", "who", "what",
+    "how", "where", "when", "why", "of", "for", "in", "on", "at",
+}
+
+
+def _significant_tokens(query: str) -> list[str]:
+    """Split ``query`` into tokens worth a lexical lookup.
+
+    Strips short tokens and a small stop-word set. Returns an empty
+    list when the cleaned query is too thin to be useful — caller is
+    expected to short-circuit to [] in that case.
+    """
+    raw = re.findall(r"[A-Za-zÄÖÜäöüß0-9]{2,}", query or "")
+    out = [t for t in raw if len(t) >= 3 and t.lower() not in _STOP_TOKENS]
+    return out
+
+
+class LexicalRetrieval:
+    """Keyword/name retrieval for chunks (tsvector) and memories (ILIKE)."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def search_chunks_lexical(
+        self,
+        query: str,
+        *,
+        asker_id: int | None,
+        top_k: int,
+    ) -> list[dict[str, Any]]:
+        """tsvector OR-match across `document_chunks.search_vector`.
+
+        Returns results in the same shape as ``RAGRetrieval.search``
+        so the existing ``_wrap_rag_results`` in polymorphic_atom_store
+        can consume the output directly.
+
+        Skips silently when the query has no significant tokens, when
+        the asker isn't identified (caller will scope to the right
+        user upstream), or when the backing dialect isn't Postgres
+        (test harness sqlite).
+        """
+        tokens = _significant_tokens(query)
+        if not tokens or asker_id is None:
+            return []
+        if self.db.bind is None or self.db.bind.dialect.name != "postgresql":
+            return []
+
+        fts_config = settings.rag_hybrid_fts_config
+        circles_clause, circles_params = document_chunks_circles_filter(asker_id)
+        or_query = " OR ".join(tokens)
+
+        sql = text(f"""
+            SELECT
+                dc.id, dc.document_id, dc.content, dc.chunk_index,
+                dc.page_number, dc.section_title, dc.chunk_type,
+                dc.parent_chunk_id, dc.circle_tier,
+                d.filename, d.title AS doc_title,
+                d.atom_id AS doc_atom_id, d.circle_tier AS doc_circle_tier,
+                ts_rank_cd(dc.search_vector, websearch_to_tsquery(:fts_config, :or_query)) AS rank
+            FROM document_chunks dc
+            JOIN documents d ON dc.document_id = d.id
+            LEFT JOIN knowledge_bases kb ON d.knowledge_base_id = kb.id
+            WHERE d.status = 'completed'
+              AND dc.search_vector IS NOT NULL
+              AND dc.search_vector @@ websearch_to_tsquery(:fts_config, :or_query)
+              AND {circles_clause}
+            ORDER BY rank DESC
+            LIMIT :limit
+        """)
+        params: dict[str, Any] = {
+            "or_query": or_query,
+            "fts_config": fts_config,
+            "limit": top_k,
+            **circles_params,
+        }
+        try:
+            rows = (await self.db.execute(sql, params)).fetchall()
+        except Exception as e:  # noqa: BLE001
+            # Don't let a malformed query take the brain page down — we
+            # have a vector retriever as the primary path.
+            logger.warning(f"🔍 Lexical chunk search failed (ignored): {e}")
+            return []
+
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            if is_low_quality_text(row.content):
+                continue
+            out.append({
+                "chunk": {
+                    "id": row.id,
+                    "content": row.content,
+                    "chunk_index": row.chunk_index,
+                    "page_number": row.page_number,
+                    "section_title": row.section_title,
+                    "chunk_type": row.chunk_type,
+                    "parent_chunk_id": row.parent_chunk_id,
+                    "circle_tier": row.circle_tier or 0,
+                },
+                "document": {
+                    "id": row.document_id,
+                    "filename": row.filename,
+                    "title": row.doc_title or row.filename,
+                    "atom_id": row.doc_atom_id,
+                    "circle_tier": row.doc_circle_tier or 0,
+                },
+                # ts_rank_cd output is unbounded; expose it as "similarity"
+                # for shape compatibility but it's an unrelated scale —
+                # only used as the snippet-tiebreaker in the wrappers.
+                "similarity": round(float(row.rank), 6),
+            })
+        return out
+
+    async def search_memories_lexical(
+        self,
+        query: str,
+        *,
+        asker_id: int | None,
+        top_k: int,
+    ) -> list[dict[str, Any]]:
+        """ILIKE OR-match across ``conversation_memories.content``.
+
+        Returns results in the same shape as
+        ``MemoryRetrieval.retrieve`` so ``_wrap_memory_results`` in
+        polymorphic_atom_store can consume the output directly.
+
+        Each token must appear (case-insensitive) for the row to match.
+        That's a tighter recall than tsvector's OR but matches user
+        intent for name queries: typing "Jutta Geburtstag" should
+        prefer rows that mention BOTH.
+        """
+        tokens = _significant_tokens(query)
+        if not tokens or asker_id is None:
+            return []
+
+        is_postgres = (
+            self.db.bind is not None
+            and self.db.bind.dialect.name == "postgresql"
+        )
+
+        # ILIKE is Postgres-only — sqlite test harness needs plain LIKE
+        # (sqlite's LIKE is case-insensitive by default for ASCII).
+        like_op = "ILIKE" if is_postgres else "LIKE"
+        clauses = []
+        params: dict[str, Any] = {"limit": top_k}
+        for i, token in enumerate(tokens):
+            param_name = f"tok_{i}"
+            clauses.append(f"m.content {like_op} :{param_name}")
+            params[param_name] = f"%{token}%"
+        token_filter = " AND ".join(clauses)
+
+        if is_postgres:
+            circles_clause, circles_params = conversation_memories_circles_filter(asker_id)
+            params.update(circles_params)
+            sql = text(f"""
+                SELECT
+                    m.id, m.atom_id, m.user_id, m.content,
+                    m.category, m.importance, m.confidence,
+                    m.circle_tier, m.created_at, m.last_accessed_at
+                FROM conversation_memories m
+                WHERE m.is_active = TRUE
+                  AND {token_filter}
+                  AND {circles_clause}
+                ORDER BY m.importance DESC, m.created_at DESC
+                LIMIT :limit
+            """)
+        else:
+            # Sqlite test path: no circle_sql tier_clause helpers, no
+            # is_active assumption (some fixtures omit it). Owner-only
+            # filter is enough for unit-test parity.
+            params["asker_id"] = asker_id
+            sql = text(f"""
+                SELECT
+                    m.id, m.atom_id, m.user_id, m.content,
+                    m.category, m.importance, m.confidence,
+                    m.circle_tier, m.created_at, m.last_accessed_at
+                FROM conversation_memories m
+                WHERE m.user_id = :asker_id
+                  AND {token_filter}
+                ORDER BY m.importance DESC, m.created_at DESC
+                LIMIT :limit
+            """)
+
+        try:
+            rows = (await self.db.execute(sql, params)).fetchall()
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"🔍 Lexical memory search failed (ignored): {e}")
+            return []
+
+        return [
+            {
+                "id": row.id,
+                "atom_id": row.atom_id,
+                "user_id": row.user_id,
+                "content": row.content,
+                "category": row.category,
+                "importance": float(row.importance) if row.importance is not None else 0.5,
+                "confidence": float(row.confidence) if row.confidence is not None else 1.0,
+                "circle_tier": row.circle_tier or 0,
+                "created_at": row.created_at,
+                # similarity unused but kept for shape parity with
+                # MemoryRetrieval.retrieve.
+                "similarity": 1.0,
+            }
+            for row in rows
+        ]

--- a/src/backend/services/polymorphic_atom_store.py
+++ b/src/backend/services/polymorphic_atom_store.py
@@ -83,6 +83,7 @@ class PolymorphicAtomStore:
         source (legacy behavior preserved).
         """
         from services.kg_retrieval import KGRetrieval
+        from services.lexical_retrieval import LexicalRetrieval
         from services.memory_retrieval import MemoryRetrieval
         from services.rag_retrieval import RAGRetrieval
         from services.skill_service import SkillService
@@ -92,6 +93,22 @@ class PolymorphicAtomStore:
         rag_task = RAGRetrieval(self.db).search(query_text, top_k=candidate_k)
         kg_task = KGRetrieval(self.db).get_relevant_context(query_text, user_id=asker_id)
         memory_task = MemoryRetrieval(self.db).retrieve(query_text, user_id=asker_id, limit=candidate_k)
+        # Lexical retrievers — keyword / name fallback for queries the
+        # vector path mis-ranks (single tokens like "Jutta", short
+        # German questions whose embedding sits below
+        # memory_retrieval_threshold). Returns RAG-shape and memory-shape
+        # dicts so the existing _wrap_rag_results / _wrap_memory_results
+        # helpers consume them unchanged. Duplicate atom_ids across
+        # vector + lexical lists get an RRF boost from both contributions
+        # — exactly the "this is both semantic AND keyword match"
+        # behaviour we want.
+        lex = LexicalRetrieval(self.db)
+        lexical_chunks_task = lex.search_chunks_lexical(
+            query_text, asker_id=asker_id, top_k=candidate_k,
+        )
+        lexical_memories_task = lex.search_memories_lexical(
+            query_text, asker_id=asker_id, top_k=candidate_k,
+        )
         # Self-learning Phase 1: procedural skills are atoms too — give
         # them a fourth source for the unified /brain search. Gated on
         # skills_enabled so the existing three-source RRF behavior is
@@ -110,18 +127,28 @@ class PolymorphicAtomStore:
         # programmer errors (e.g., import failure on the lazy-imported retrieval modules).
         # Removing the wrapper — exceptions in retrieval modules are converted to []
         # by the _wrap_* helpers, and any actual programmer error now bubbles to FastAPI.
-        rag_results, kg_context, memory_results, skill_results = await asyncio.gather(
-            rag_task, kg_task, memory_task, skill_task,
+        (
+            rag_results, kg_context, memory_results,
+            lexical_chunks, lexical_memories, skill_results,
+        ) = await asyncio.gather(
+            rag_task, kg_task, memory_task,
+            lexical_chunks_task, lexical_memories_task, skill_task,
             return_exceptions=True,
         )
 
         rag_matches = _wrap_rag_results(rag_results)
         kg_matches = _wrap_kg_context(kg_context)
         memory_matches = _wrap_memory_results(memory_results)
+        lexical_chunk_matches = _wrap_rag_results(lexical_chunks)
+        lexical_memory_matches = _wrap_memory_results(lexical_memories)
         skill_matches = _wrap_skill_results(skill_results)
 
         merged = _rrf_merge(
-            [rag_matches, kg_matches, memory_matches, skill_matches],
+            [
+                rag_matches, kg_matches, memory_matches,
+                lexical_chunk_matches, lexical_memory_matches,
+                skill_matches,
+            ],
             top_k=top_k,
             k=settings.rag_hybrid_rrf_k,
         )

--- a/src/backend/services/rag_retrieval.py
+++ b/src/backend/services/rag_retrieval.py
@@ -227,10 +227,23 @@ class RAGRetrieval:
         result = await self.db.execute(sql, params)
         rows = result.fetchall()
 
+        from utils.content_quality import is_low_quality_text
+
         results = []
         for row in rows:
             similarity = float(row.similarity) if row.similarity else 0
             if threshold and similarity < threshold:
+                continue
+            # Drop Paperless OCR-garbage chunks before they enter RRF
+            # downstream. The garbage rows match every query at a flat
+            # low score and snag rank=1 in the merge, drowning real
+            # answers. See utils.content_quality + the brain-search
+            # debug session that surfaced the Jutta queries.
+            if is_low_quality_text(row.content):
+                logger.debug(
+                    f"🗑️ Dropping low-quality chunk id={row.id} "
+                    f"doc={row.document_id} (OCR-garbage filter)"
+                )
                 continue
             results.append({
                 "chunk": {

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -305,7 +305,15 @@ class Settings(BaseSettings):
     # Conversation Memory (Long-term)
     memory_enabled: bool = False                                             # Opt-in
     memory_retrieval_limit: int = Field(default=3, ge=1, le=10)              # Max memories per query
-    memory_retrieval_threshold: float = Field(default=0.7, ge=0.0, le=1.0)  # Cosine-similarity threshold
+    # Cosine threshold for the chat-injection path. Dropped from 0.7 to
+    # 0.5 (2026-05-26) — the 0.7 gate was tuned for short paraphrase
+    # matches but suppressed natural German question queries against
+    # third-person fact memories (e.g. "Was mag Jutta gerne essen?"
+    # against "Jutta mag Maracujas und Ananas" embeds at ~0.55). The
+    # /brain page returned 0 hits even though the memory was a direct
+    # answer. 0.5 is calibrated for qwen3-embedding:4b's distribution;
+    # tune downward if cross-language false negatives still appear.
+    memory_retrieval_threshold: float = Field(default=0.5, ge=0.0, le=1.0)  # Cosine-similarity threshold
     memory_max_per_user: int = Field(default=500, ge=10, le=5000)           # Max active memories
     memory_context_decay_days: int = Field(default=30, ge=1, le=365)        # Days until context category expires
     memory_dedup_threshold: float = Field(default=0.9, ge=0.5, le=1.0)     # Deduplication threshold

--- a/src/backend/utils/content_quality.py
+++ b/src/backend/utils/content_quality.py
@@ -1,0 +1,86 @@
+"""Content-quality heuristics for retrieval-time filtering.
+
+Failed Paperless OCR runs produce chunks like::
+
+    - r . : ■ { - n ; ; : t » - , : : ' r ' ● r : ; '
+    ydl .'-Ti'
+
+These chunks embed into vector space with low information content and
+match *every* query at the same low cosine score. In the polymorphic
+atom store's RRF (Reciprocal Rank Fusion) merge they snag rank=1 in the
+RAG list and outrank actual answers — the user sees garbage at the top
+of the brain page even when a real memory contains the answer.
+
+This module provides a single heuristic, ``is_low_quality_text``,
+that retrieval modules call to suppress such chunks before they enter
+the merge.
+
+The heuristic intentionally tolerates short well-formed text: an empty
+string or a 5-char input is "low information" by length but is not OCR
+garbage. The garbage case is: medium-to-long text dominated by
+punctuation, glyphs, and 1-2 char runs with very few real words.
+"""
+from __future__ import annotations
+
+import re
+
+# A word-like token: ≥3 letters from a German-Latin alphabet. The bar is
+# deliberately language-aware (ä/ö/ü/ß) so German OCR with diacritics
+# isn't mis-classified as garbage. Anything outside this charset (digits,
+# punctuation, control glyphs from broken OCR) is NOT counted.
+_WORD_LIKE_RE = re.compile(r"^[A-Za-zÄÖÜäöüß]{3,}$")
+
+# Length floor: shorter inputs are dominated by noise statistics. A
+# 12-char chunk of valid text could trivially trip a ratio check that
+# works fine at 200 chars. We treat short inputs as ALWAYS high-quality
+# — the wins come on the medium-to-long garbage chunks.
+_MIN_LEN_FOR_QUALITY_CHECK = 40
+
+# Word-like-token ratio floor: below this, the text is dominated by
+# single-character runs / glyphs / punctuation. Calibrated empirically
+# against the production corpus: real text (German + technical English)
+# clears 0.4 by a wide margin; OCR garbage from Paperless lands 0.0-0.2.
+_MIN_WORDLIKE_RATIO = 0.30
+
+
+def is_low_quality_text(text: str | None) -> bool:
+    """True if the text reads as OCR garbage / glyph noise.
+
+    Returns False for None, empty, short (<40 char), or text that clears
+    the word-like-token ratio threshold. Only flags the medium-to-long
+    chunks dominated by single-char runs and punctuation glyphs that
+    failed Paperless OCR produces.
+    """
+    if not text:
+        return False
+    stripped = text.strip()
+    if len(stripped) < _MIN_LEN_FOR_QUALITY_CHECK:
+        return False
+
+    tokens = stripped.split()
+    if not tokens:
+        return False
+
+    wordlike = sum(1 for t in tokens if _WORD_LIKE_RE.fullmatch(t))
+    ratio = wordlike / len(tokens)
+    return ratio < _MIN_WORDLIKE_RATIO
+
+
+def filter_low_quality(items: list, *, text_key: str | None = None) -> list:
+    """Drop items whose text fails the quality check.
+
+    Pass dicts with ``text_key='content'`` (or whichever attribute
+    carries the body), or pass plain strings. The original list is not
+    mutated.
+    """
+    out = []
+    for item in items:
+        if text_key is None:
+            text = item if isinstance(item, str) else None
+        elif isinstance(item, dict):
+            text = item.get(text_key)
+        else:
+            text = getattr(item, text_key, None)
+        if not is_low_quality_text(text):
+            out.append(item)
+    return out

--- a/tests/backend/test_content_quality.py
+++ b/tests/backend/test_content_quality.py
@@ -1,0 +1,86 @@
+"""Unit tests for the OCR-garbage detection heuristic.
+
+Regression for the v2.10.2 brain-quality fix: the production corpus
+contained Paperless OCR chunks like
+``- r . : ■ { - n ; ; : t » - , : :' r ' ● r : ; '`` that were
+out-ranking real memories in the polymorphic atom store's RRF merge.
+"""
+from __future__ import annotations
+
+import pytest
+
+from utils.content_quality import filter_low_quality, is_low_quality_text
+
+
+# Real garbage chunks pulled from the production document_chunks table
+# (Paperless failed-OCR output) on 2026-05-26.
+# Note: the heuristic intentionally targets the truly-broken cases
+# (dominated by single-char runs and glyphs). Partially-corrupted text
+# like "qedQcht _gemocht klar mon, bei. Luohnnonn bouelemente ■ Im"
+# is allowed through — we'd rather a fuzzy chunk surface than a real
+# answer get dropped.
+GARBAGE_SAMPLES = [
+    "- r . : ■ { - n ; ; : t » - , : :' r ' ● r : ; '\nydl .'-Ti'",
+    ".\n;\n>\n■\nj J i\n-\n'\n●\n11-\n. <\nV,\n.\n▶\n■\n..C'j\n●\n●\n■■\n1\n.<\n,'r\n-",
+]
+
+# Realistic medium-to-long text that MUST NOT trip the heuristic.
+CLEAN_SAMPLES = [
+    "Jutta mag Maracujas und Ananas. Sie isst diese Früchte fast jeden Morgen zum Frühstück.",
+    "Invoice number 1SOGUR2D0010, Date of issue April 17, 2026, Amount due 142.50 EUR.",
+    "The agent loop dispatches MCP tools sequentially until either the budget exhausts or the model emits a final_answer step.",
+    "Der Benutzer und Jutta sind seit 26 Jahren verheiratet und feiern ihren Hochzeitstag am 27. Mai.",
+]
+
+
+@pytest.mark.parametrize("text", GARBAGE_SAMPLES)
+def test_garbage_flagged(text: str):
+    assert is_low_quality_text(text) is True, f"Should flag garbage: {text!r}"
+
+
+@pytest.mark.parametrize("text", CLEAN_SAMPLES)
+def test_clean_text_passes(text: str):
+    assert is_low_quality_text(text) is False, f"Should NOT flag clean text: {text!r}"
+
+
+def test_none_and_empty_pass():
+    assert is_low_quality_text(None) is False
+    assert is_low_quality_text("") is False
+    assert is_low_quality_text("   \n\t  ") is False
+
+
+def test_short_text_always_passes():
+    """Length floor: <40 char inputs are never flagged. A short fragment
+    might be all punctuation but isn't OCR garbage at the scale that
+    matters (single-token names, dates, etc.)."""
+    assert is_low_quality_text("Jutta") is False
+    assert is_low_quality_text("?!?!?!") is False
+    assert is_low_quality_text("$$$") is False
+
+
+def test_filter_low_quality_drops_garbage_dicts():
+    items = [
+        {"id": 1, "content": GARBAGE_SAMPLES[0]},
+        {"id": 2, "content": CLEAN_SAMPLES[0]},
+        {"id": 3, "content": GARBAGE_SAMPLES[1]},
+        {"id": 4, "content": CLEAN_SAMPLES[1]},
+    ]
+    kept = filter_low_quality(items, text_key="content")
+    assert [i["id"] for i in kept] == [2, 4]
+
+
+def test_filter_low_quality_keeps_missing_text_items():
+    """An item with no text under ``text_key`` is NOT garbage by the
+    heuristic's lights — None falls through ``is_low_quality_text``
+    as False (we can't judge what we can't read). This is intentional:
+    a missing snippet upstream is a different concern than OCR garbage,
+    and silently dropping rows here would mask the real upstream bug."""
+    items = [{"id": 1}, {"id": 2, "content": CLEAN_SAMPLES[0]}]
+    kept = filter_low_quality(items, text_key="content")
+    assert [i["id"] for i in kept] == [1, 2]
+
+
+def test_filter_low_quality_plain_strings():
+    items = [GARBAGE_SAMPLES[0], CLEAN_SAMPLES[0], GARBAGE_SAMPLES[1]]
+    kept = filter_low_quality(items)
+    assert kept == [CLEAN_SAMPLES[0]]

--- a/tests/backend/test_lexical_retrieval.py
+++ b/tests/backend/test_lexical_retrieval.py
@@ -1,0 +1,133 @@
+"""Unit tests for the lexical (keyword) retrieval path.
+
+Regression for the v2.10.3 brain-quality fix: ``/api/atoms?q=jutta``
+returned only 1 of 9 relevant memories because the polymorphic atom
+store had only vector retrievers and the user's third-person German
+queries embed below the 0.5 cosine threshold. The lexical retriever
+gives single-token name queries a deterministic recall floor.
+
+Sqlite test path: chunk lookups short-circuit to [] (no tsvector),
+memory lookups use a simplified owner-only ILIKE filter that still
+exercises the token-pattern, stop-word, and result-shape logic.
+"""
+from __future__ import annotations
+
+from datetime import datetime, UTC
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import ConversationMemory
+from services.lexical_retrieval import LexicalRetrieval, _significant_tokens
+
+
+# --------------------------------------------------------- token splitter
+class TestSignificantTokens:
+    def test_strips_short_tokens(self):
+        assert _significant_tokens("a is the of in on") == []
+
+    def test_keeps_name_tokens(self):
+        assert _significant_tokens("Jutta Geburtstag") == ["Jutta", "Geburtstag"]
+
+    def test_keeps_mixed_case_and_german_diacritics(self):
+        assert _significant_tokens("Maracujas und Ananas") == ["Maracujas", "Ananas"]
+
+    def test_handles_punctuation(self):
+        assert _significant_tokens("Was mag Jutta gerne essen?") == ["Jutta", "gerne", "essen"]
+
+    def test_empty_and_none(self):
+        assert _significant_tokens("") == []
+        assert _significant_tokens(None) == []
+
+
+# --------------------------------------------------------- memory ILIKE search
+async def _seed_memory(
+    db: AsyncSession,
+    *,
+    user_id: int,
+    content: str,
+    importance: float = 0.5,
+) -> int:
+    mem = ConversationMemory(
+        user_id=user_id,
+        content=content,
+        category="fact",
+        importance=importance,
+        confidence=1.0,
+        circle_tier=0,
+        created_at=datetime.now(UTC).replace(tzinfo=None),
+    )
+    db.add(mem)
+    await db.commit()
+    await db.refresh(mem)
+    return mem.id
+
+
+@pytest.mark.asyncio
+class TestSearchMemoriesLexical:
+    async def test_finds_single_token_name(self, db_session: AsyncSession):
+        await _seed_memory(db_session, user_id=1, content="Jutta mag Maracujas und Ananas")
+        await _seed_memory(db_session, user_id=1, content="Anna kocht gerne Pasta am Wochenende")
+        retr = LexicalRetrieval(db_session)
+        hits = await retr.search_memories_lexical("Jutta", asker_id=1, top_k=10)
+        contents = [h["content"] for h in hits]
+        assert "Jutta mag Maracujas und Ananas" in contents
+        assert "Anna kocht gerne Pasta am Wochenende" not in contents
+
+    async def test_requires_all_tokens(self, db_session: AsyncSession):
+        """Memory-side lexical uses AND across tokens — typing both
+        narrows correctly."""
+        await _seed_memory(db_session, user_id=1, content="Jutta mag Maracujas und Ananas")
+        await _seed_memory(db_session, user_id=1, content="Der Geburtstag des Kindes ist morgen")
+        retr = LexicalRetrieval(db_session)
+        hits = await retr.search_memories_lexical(
+            "Jutta Geburtstag", asker_id=1, top_k=10,
+        )
+        assert hits == []  # no row mentions both
+
+    async def test_returns_memory_shape(self, db_session: AsyncSession):
+        await _seed_memory(
+            db_session, user_id=1,
+            content="Jutta hat am 14.02.1969 Geburtstag",
+            importance=0.9,
+        )
+        retr = LexicalRetrieval(db_session)
+        hits = await retr.search_memories_lexical("Geburtstag", asker_id=1, top_k=5)
+        assert len(hits) == 1
+        h = hits[0]
+        for key in ("id", "atom_id", "user_id", "content", "category",
+                    "importance", "confidence", "circle_tier", "similarity"):
+            assert key in h, f"missing key {key} in memory shape"
+        assert h["importance"] == pytest.approx(0.9)
+
+    async def test_owner_scope_isolates_users(self, db_session: AsyncSession):
+        """In single-user-mode test harness we restrict to owner-only.
+        A memory owned by another user must not leak."""
+        await _seed_memory(db_session, user_id=2, content="Jutta mag Maracujas")
+        retr = LexicalRetrieval(db_session)
+        hits = await retr.search_memories_lexical("Jutta", asker_id=1, top_k=5)
+        assert hits == []
+
+    async def test_empty_query_returns_empty(self, db_session: AsyncSession):
+        retr = LexicalRetrieval(db_session)
+        assert await retr.search_memories_lexical("", asker_id=1, top_k=5) == []
+        assert await retr.search_memories_lexical("the of and", asker_id=1, top_k=5) == []
+
+    async def test_no_asker_returns_empty(self, db_session: AsyncSession):
+        """A retrieval call without a concrete asker can't be circles-
+        filtered safely. Refuse rather than leak."""
+        await _seed_memory(db_session, user_id=1, content="Jutta mag Maracujas")
+        retr = LexicalRetrieval(db_session)
+        assert await retr.search_memories_lexical("Jutta", asker_id=None, top_k=5) == []
+
+
+# --------------------------------------------------------- chunk path on sqlite
+@pytest.mark.asyncio
+class TestSearchChunksLexicalSqlite:
+    async def test_short_circuits_on_sqlite(self, db_session: AsyncSession):
+        """tsvector + websearch_to_tsquery don't exist in sqlite. The
+        retriever returns [] silently rather than raising — the
+        polymorphic store's RRF tolerates empty source lists."""
+        retr = LexicalRetrieval(db_session)
+        hits = await retr.search_chunks_lexical("Jutta", asker_id=1, top_k=5)
+        assert hits == []


### PR DESCRIPTION
## Summary

User reported the \`/brain\` search returning nothing for \"Jutta\" even though 9 memories about her exist in the corpus. Three structural problems compounded to make relevant rows invisible.

**1. \`memory_retrieval_threshold\` dropped 0.7 → 0.5.** The natural German question \"Was mag Jutta gerne essen?\" embeds at ~0.55 cosine against \"Jutta mag Maracujas und Ananas\" — above 0.5, under the old 0.7 gate. Query returned **0 hits** despite a direct answer being present.

**2. OCR-garbage chunks now drop out before RRF.** Production document chunks like \`- r . : ■ { - n ; ; : t » - , : :' r '\` (failed Paperless OCR) snag rank=1 on every query and drown real answers. New \`utils.content_quality.is_low_quality_text\` heuristic called from \`rag_retrieval._search_dense\` before results enter the fusion.

**3. Polymorphic atom store now runs a lexical retriever alongside the vector ones.** New \`services.lexical_retrieval.LexicalRetrieval\` — chunks via existing tsvector + \`websearch_to_tsquery\` (with circles filter), memories via \`ILIKE\`. Returns RAG-shape / memory-shape dicts so the existing \`_wrap_*\` helpers consume them unchanged. Duplicate atoms across vector + lexical sources get compounded RRF scores.

**Bonus:** \`pc20260526b\` migration adds a \`CONCURRENTLY\`-built GIN index on \`document_chunks.search_vector\`. Column has been populated since BM25 shipped but had no GIN index — every lexical query seq-scanned.

## Test plan

- [x] \`.159\` suite: **139 passed, 1 skipped, 0 failed**
- [x] Live experiments before/after on production data (Jutta queries)
- [ ] Verify post-deploy that \"Was mag Jutta gerne essen?\" actually returns the matching memory

🤖 Generated with [Claude Code](https://claude.com/claude-code)