### PR TITLE
fix(brain): mirror OCR-garbage filter on BM25 path + refresh stale threshold comment

### DIFF
--- a/src/backend/services/rag_retrieval.py
+++ b/src/backend/services/rag_retrieval.py
@@ -323,9 +323,14 @@ class RAGRetrieval:
         if knowledge_base_id:
             params["kb_id"] = knowledge_base_id
 
+        from utils.content_quality import is_low_quality_text
+
         result = await self.db.execute(sql, params)
         rows = result.fetchall()
 
+        # Mirror the OCR-garbage filter in _search_dense — BM25 results
+        # flow into the same RRF and can otherwise still surface failed
+        # Paperless OCR chunks. Same fix at the symmetric retrieval path.
         return [
             {
                 "chunk": {
@@ -348,6 +353,7 @@ class RAGRetrieval:
                 "similarity": round(float(row.rank), 6),
             }
             for row in rows
+            if not is_low_quality_text(row.content)
         ]
 
     # ==========================================================================

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -329,11 +329,13 @@ class Settings(BaseSettings):
     memory_extraction_v2_shadow: bool = False                                # Phase A: run v2 in shadow mode alongside v1
     memory_extraction_v2_authoritative: bool = False                         # Phase B: v2 is primary; v1 becomes legacy fallback
     # Lane D — separate retrieval threshold for the v2 extract pipeline.
-    # Chat retrieval uses `memory_retrieval_threshold=0.7` for high
-    # precision (don't surface tangential memories to the user). Extract
-    # is a different surface: high recall is what matters, and the LLM
-    # plus the drift check together replace the score gate. Defaulting
-    # to 0.0 means the LLM sees top-K candidates regardless of similarity.
+    # Chat retrieval uses ``memory_retrieval_threshold`` (currently 0.5
+    # after the 2026-05-26 brain-quality tune, dropped from 0.7 because
+    # natural German question queries embed below 0.7 against fact
+    # memories). Extract is a different surface: high recall is what
+    # matters, and the LLM plus the drift check together replace the
+    # score gate. Defaulting to 0.0 means the LLM sees top-K candidates
+    # regardless of similarity.
     #
     # Empirical basis: the 0.7 default produced cross_session_update
     # detection of 0.143; setting this to 0.0 raised it to 0.929 with no


### PR DESCRIPTION
Two findings from `/review adecbcf` post-merge. Both auto-fixable.

1. `_search_bm25` was returning unfiltered chunks — the OCR-garbage filter shipped in #621 only covered the dense path. BM25 results flow into the same RRF merge and can still surface garbage. Now gated on both retrievers symmetrically.
2. The Lane D docstring still said "Chat retrieval uses memory_retrieval_threshold=0.7" after the value was dropped to 0.5 in the same PR. Refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)