### PR TITLE
fix(brain): migration backfill — WHERE NOT EXISTS instead of ON CONFLICT ON CONSTRAINT

### DIFF
--- a/src/backend/alembic/versions/pc20260530_document_processing_history.py
+++ b/src/backend/alembic/versions/pc20260530_document_processing_history.py
@@ -111,6 +111,13 @@ def upgrade() -> None:
     # Backfill: one initial_ingest row per existing Document. force_ocr=false
     # because initial_ingest by definition didn't pass a force flag.
     # ON CONFLICT keeps the migration safely re-runnable after a partial fail.
+    #
+    # Note: ``uq_dph_initial_ingest_per_doc`` is a partial unique INDEX, not a
+    # named CONSTRAINT (Postgres doesn't support partial UNIQUE constraints,
+    # only partial unique INDEXES). ``ON CONFLICT ON CONSTRAINT`` requires a
+    # real constraint, so use the index-inference form ``ON CONFLICT (col)
+    # WHERE <predicate>`` — Postgres matches the partial unique index by
+    # column tuple + predicate.
     op.execute(
         """
         INSERT INTO document_processing_history
@@ -123,7 +130,10 @@ def upgrade() -> None:
             false,
             'initial_ingest'
         FROM documents
-        ON CONFLICT ON CONSTRAINT uq_dph_initial_ingest_per_doc DO NOTHING
+        WHERE NOT EXISTS (
+            SELECT 1 FROM document_processing_history h
+            WHERE h.document_id = documents.id AND h.trigger = 'initial_ingest'
+        )
         """
     )
 


### PR DESCRIPTION
## Hotfix for v2.10.7 production deploy

The migration shipped in #629 (\`pc20260530_dph\`) failed during the v2.10.7 prod deploy with:

\`\`\`
sqlalchemy.exc.ProgrammingError: constraint
\"uq_dph_initial_ingest_per_doc\" for table
\"document_processing_history\" does not exist
\`\`\`

\`ON CONFLICT ON CONSTRAINT\` requires a real CONSTRAINT, but \`uq_dph_initial_ingest_per_doc\` is a partial unique INDEX. Postgres forbids partial UNIQUE constraints — only partial unique indexes are allowed — so the constraint name doesn't exist.

## Fix

Replaced \`ON CONFLICT ON CONSTRAINT ... DO NOTHING\` with \`WHERE NOT EXISTS (...)\`. Same idempotence guarantee, no dependency on index-inference syntax.

## Migration state

\`transaction_per_migration=True\` rolled back the failed migration cleanly on prod. \`alembic current\` is back at \`pc20260529_dc_multilingual_fts\`. The table was never created — no schema state to undo.

## Test plan

- [ ] Re-apply the migration job in prod after this lands and the new image is pushed as v2.10.8 (v2.10.7 is being retracted since it never successfully deployed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)