### PR TITLE
fix(brain): KG chat-extraction prompt hardening + clean 5 active garbage rels

### DIFF
--- a/src/backend/prompts/knowledge_graph.yaml
+++ b/src/backend/prompts/knowledge_graph.yaml
@@ -3,10 +3,16 @@
 # entities and relations from conversation exchanges.
 
 de:
-  extraction_system: "Du extrahierst Entitaeten und Relationen aus Dialogen. Antworte NUR mit einem JSON-Objekt. Keine Nummern, IDs, URLs oder OCR-Artefakte als Entitaeten. Nur Entitaeten mit konkretem Eigennamen."
+  extraction_system: "Du extrahierst Entitaeten und Relationen aus Dialogen. Antworte NUR mit einem JSON-Objekt. Keine Nummern, IDs, URLs oder OCR-Artefakte als Entitaeten. Nur Entitaeten mit konkretem Eigennamen. Du erfindest niemals Fakten — du extrahierst ausschliesslich, was im Dialog steht."
 
   extraction_prompt: |
     Analysiere den folgenden Dialog und extrahiere benannte Entitaeten und ihre Beziehungen.
+
+    GRUNDREGELN — IMMER BEFOLGEN:
+    1. Sowohl Subject als auch Object jeder Relation MUESSEN woertlich im Dialog (User- ODER Assistent-Nachricht) vorkommen. Wenn auch nur einer der beiden Namen nicht im Text steht: KEINE Relation.
+    2. NIEMALS eine Relation ausgeben, bei der Subject und Object dieselbe Entitaet sind (kein Self-Loop wie "Anna ist_verheiratet_mit Anna").
+    3. NIEMALS Weltwissen ausserhalb des Dialogs nutzen, um Lücken zu fuellen. Wenn der Dialog nichts ueber den Ehepartner einer Person sagt, gibt es KEINE ist_verheiratet_mit-Relation — auch dann nicht, wenn du den Ehepartner aus Trainingsdaten zu kennen glaubst.
+    4. Pronomen sorgfaeltig aufloesen: "Du", "ich", "meine Frau", "meine Mutter" beziehen sich auf VERSCHIEDENE Personen. Fakten ueber "ich" gehoeren nicht zu "meine Mutter", auch wenn beide im selben Dialog vorkommen.
 
     Nur KONKRETE, BENANNTE Entitaeten extrahieren — mit echtem Namen oder Titel:
     - Personen (vollstaendiger Name oder Spitzname, NICHT generische Rollen)
@@ -17,8 +23,9 @@ de:
     - Konzepte: NUR persoenliche Hobbys, Studienfaecher, Berufsbezeichnungen — NICHT Dokumentfelder oder juristische Begriffe
 
     RELATIONEN extrahieren:
-    - Beziehungen zwischen Entitaeten ("wohnt_in", "arbeitet_bei", "mag", "besitzt", "kennt", "ist_verheiratet_mit")
+    - Beziehungen zwischen Entitaeten ("wohnt_in", "arbeitet_bei", "mag", "besitzt", "kennt", "ist_verheiratet_mit", "hat_kind", "ist_mutter_von", "ist_vater_von")
     - Nur Relationen die EXPLIZIT im Dialog erwaehnt werden
+    - Praedikat-Objekt-Typ muss passen: "wohnt_in" / "befindet_sich_in" / "hat_sitz_in" → Ort; "ist_verheiratet_mit" / "hat_kind" / "ist_mutter_von" → Person. Verwende KEIN Personen-Praedikat mit einem Ort als Object.
     - confidence: 0.5-1.0 (wie sicher ist die Relation)
 
     IGNORIERE (NIEMALS als Entitaet extrahieren):
@@ -32,6 +39,15 @@ de:
     - KEINE einzelnen deutschen Substantive die Dokumentfelder beschreiben: z.B. "Inkasso", "Flatrate", "Messstellenbetrieb", "Mahngebuehren", "Zahlungsbedingungen"
     - KEINE Geldbetraege oder Waehrungsangaben ("100 EUR", "0,04 Euro")
     - KEINE generischen Geschaeftsbegriffe ("Leistungserbringer", "Zahlungsdienstleister", "Vertragsnummer", "Abrechnungszeitraum")
+
+    BEISPIEL fuer korrekte Ablehnung — Dialog: "Anna ist meine Mutter."
+    RICHTIG:
+      entities: [{{"name": "Anna", "type": "person"}}]
+      relations: [{{"subject": "Anna", "predicate": "ist_mutter_von", "object": "<Sprecher-Name falls im Dialog genannt, sonst nichts>", "confidence": 0.9}}]
+    FALSCH (Self-Loop):
+      relations: [{{"subject": "Anna", "predicate": "ist_mutter_von", "object": "Anna"}}]
+    FALSCH (Halluzination — Ehemann nicht im Dialog):
+      relations: [{{"subject": "Anna", "predicate": "ist_verheiratet_mit", "object": "Hans Filbinger"}}]
 
     Dialog:
     User: {user_message}
@@ -99,10 +115,16 @@ de:
     }}
 
 en:
-  extraction_system: "You extract entities and relations from dialogs. Reply ONLY with a JSON object. No numbers, IDs, URLs, or OCR artifacts as entities. Only entities with concrete proper names."
+  extraction_system: "You extract entities and relations from dialogs. Reply ONLY with a JSON object. No numbers, IDs, URLs, or OCR artifacts as entities. Only entities with concrete proper names. You never invent facts — you only extract what is actually in the dialog."
 
   extraction_prompt: |
     Analyze the following dialog and extract named entities and their relationships.
+
+    GROUND RULES — ALWAYS FOLLOW:
+    1. Both the subject and the object of every relation MUST appear verbatim in the dialog (user OR assistant turn). If either name is not in the text: NO relation.
+    2. NEVER emit a relation where subject and object are the same entity (no self-loops like "Anna married_to Anna").
+    3. NEVER use world knowledge from outside the dialog to fill in facts. If the dialog says nothing about a person's spouse, there is NO married_to relation — even if you believe you know the spouse from training data.
+    4. Resolve pronouns carefully: "you", "I", "my wife", "my mother" refer to DIFFERENT people. Facts about "I" do not belong to "my mother", even when both appear in the same dialog.
 
     Only extract CONCRETE, NAMED entities — with real names or titles:
     - People (full names or nicknames, NOT generic roles)
@@ -113,8 +135,9 @@ en:
     - Concepts: ONLY personal hobbies, fields of study, job titles — NOT document fields or legal terms
 
     EXTRACT relations:
-    - Relationships between entities ("lives_in", "works_at", "likes", "owns", "knows", "married_to")
+    - Relationships between entities ("lives_in", "works_at", "likes", "owns", "knows", "married_to", "has_child", "is_mother_of", "is_father_of")
     - Only relations EXPLICITLY mentioned in the dialog
+    - Predicate/object-type must match: "lives_in" / "located_in" / "headquartered_in" → place; "married_to" / "has_child" / "is_mother_of" → person. NEVER use a person-relation predicate with a place as the object.
     - confidence: 0.5-1.0 (how certain is the relation)
 
     IGNORE (NEVER extract as entity):
@@ -128,6 +151,15 @@ en:
     - NO single nouns describing document fields: e.g. "collection", "flatrate", "meter operation", "late fees", "payment terms"
     - NO monetary amounts or currency references ("100 EUR", "0.04 Euro")
     - NO generic business terms ("service provider", "payment processor", "contract number", "billing period")
+
+    EXAMPLE of correct rejection — dialog: "Anna is my mother."
+    CORRECT:
+      entities: [{{"name": "Anna", "type": "person"}}]
+      relations: [{{"subject": "Anna", "predicate": "is_mother_of", "object": "<speaker name if mentioned in dialog, otherwise nothing>", "confidence": 0.9}}]
+    WRONG (self-loop):
+      relations: [{{"subject": "Anna", "predicate": "is_mother_of", "object": "Anna"}}]
+    WRONG (hallucination — husband not in dialog):
+      relations: [{{"subject": "Anna", "predicate": "married_to", "object": "Hans Filbinger"}}]
 
     Dialog:
     User: {user_message}

--- a/tests/backend/test_kg_extraction_prompt.py
+++ b/tests/backend/test_kg_extraction_prompt.py
@@ -1,0 +1,91 @@
+"""
+Regression tests for the KG extraction prompt hardening clauses.
+
+The 2026-05-26 incident in production produced 11 garbage relations from two
+adjacent chat sessions: self-loops (Anna ist_verheiratet_mit Anna),
+training-data hallucinations (Hans Filbinger), and predicate/object-type
+mismatches (Anna heißt_auch Kleinenbroich — Kleinenbroich is a place, not a
+name). The prompt was tightened with four ground rules + a worked example.
+
+These tests lock the clauses in. They do not exercise the LLM — they assert
+that the rendered prompt contains the guidance the model needs to see.
+"""
+import pytest
+
+
+class TestKGExtractionPromptHardening:
+    """The extraction prompt must carry the anti-hallucination rules."""
+
+    @pytest.fixture(autouse=True)
+    def reload_prompts(self):
+        from services.prompt_manager import prompt_manager
+        prompt_manager.reload()
+
+    @pytest.mark.unit
+    def test_german_prompt_carries_ground_rules(self):
+        from services.prompt_manager import prompt_manager
+
+        rendered = prompt_manager.get(
+            "knowledge_graph", "extraction_prompt", lang="de",
+            user_message="Eduard ist verheiratet mit Jutta.",
+            assistant_response="Notiert.",
+        )
+
+        assert "GRUNDREGELN" in rendered
+        # Rule 1 — verbatim grounding
+        assert "woertlich im Dialog" in rendered
+        # Rule 2 — no self-loops
+        assert "Self-Loop" in rendered or "Subject und Object dieselbe Entitaet" in rendered
+        # Rule 3 — no world-knowledge hallucination
+        assert "Weltwissen" in rendered
+        # Rule 4 — pronoun discipline
+        assert "Pronomen" in rendered
+        # Predicate/object-type contract
+        assert "Praedikat-Objekt-Typ" in rendered
+        # Worked rejection example mentions the specific failure shapes
+        assert "Hans Filbinger" in rendered  # hallucination example
+        # Original template hooks still present
+        assert "Eduard ist verheiratet mit Jutta." in rendered
+        assert "Notiert." in rendered
+
+    @pytest.mark.unit
+    def test_english_prompt_carries_ground_rules(self):
+        from services.prompt_manager import prompt_manager
+
+        rendered = prompt_manager.get(
+            "knowledge_graph", "extraction_prompt", lang="en",
+            user_message="Eduard is married to Jutta.",
+            assistant_response="Noted.",
+        )
+
+        assert "GROUND RULES" in rendered
+        # Rule 1
+        assert "verbatim in the dialog" in rendered
+        # Rule 2
+        assert "self-loop" in rendered or "subject and object are the same" in rendered
+        # Rule 3
+        assert "world knowledge" in rendered
+        # Rule 4
+        assert "Pronouns" in rendered or "pronouns" in rendered
+        # Type contract
+        assert "Predicate/object-type" in rendered or "predicate/object" in rendered.lower()
+        # Worked example
+        assert "Hans Filbinger" in rendered
+        # Template hooks
+        assert "Eduard is married to Jutta." in rendered
+        assert "Noted." in rendered
+
+    @pytest.mark.unit
+    def test_system_prompts_reject_invention(self):
+        """The system message in both languages must forbid fact invention."""
+        from services.prompt_manager import prompt_manager
+
+        de_system = prompt_manager.get(
+            "knowledge_graph", "extraction_system", lang="de"
+        )
+        en_system = prompt_manager.get(
+            "knowledge_graph", "extraction_system", lang="en"
+        )
+
+        assert "erfindest niemals" in de_system
+        assert "never invent" in en_system


### PR DESCRIPTION
## Summary

P0 from `tasks/kg-strategy.md`. Closes the immediate poisoning loop in the chat-extraction pipeline; sets up the validator and provenance work for P1/P2.

**The bug:** the 2026-05-26 incident produced 11 garbage relations from two adjacent chat sessions:
- Self-loops: `Anna ist_verheiratet_mit Anna`, `Anna hat_elternteil Anna`, `Anna ist_mutter_von Anna`
- Training-data hallucinations: `Anna ist_verheiratet_mit Hans Filbinger` (Filbinger was a German politician — pure model invention)
- Predicate/object-type mismatches: `Anna heißt_auch Kleinenbroich`, `Anna heiratet_vorheriger_name Kleinenbroich` (Kleinenbroich is a place, not a name)
- Entity-collapse: `Anna mag Mango` (Eduard's preference), `Anna hat_kind Ben` (Eduard & Jutta's son)

5 of those were still `is_active=true`, so `kg_retrieve_context_hook` was injecting them into every prompt that touched Anna/Jutta/Eduard. Not a UI artifact — a closed-loop poisoning failure.

## What this PR does

**1. Prompt hardening** (Option F in the strategy doc — soft guidance, not the structural fix). Adds four explicit ground rules to `extraction_prompt` in both DE and EN:

- Subject AND object must appear verbatim in the dialog text. If neither, no relation.
- Never emit `subject == object` (no self-loops).
- Never use world knowledge from outside the dialog to fill facts.
- Resolve pronouns carefully — "I" / "my mother" / "my wife" are different people.

Plus a predicate/object-type contract hint (kinship verbs target `person`, location verbs target `place`) and a worked rejection example showing the `Hans Filbinger` hallucination shape. `extraction_system` gets a "never invent facts" clause in both languages.

**2. Production data cleanup** (already applied via kubectl exec) — soft-deleted rels 88/89/90/92/97 on `renfield-private`:

```sql
UPDATE kg_relations SET is_active = false
WHERE id IN (88, 89, 90, 92, 97);
-- 5 rows updated, verified before/after, reversible
```

The poisoning loop is closed for those rows immediately; the prompt change closes the recurrence path once this PR lands and the backend reloads.

## What this PR does NOT do

The model can still hallucinate within the new prompt constraints. The structural fixes are coming in:

- **P1 (this week):** defensive validator inside `extract_and_save` — self-loop drop, source-grounding via verbatim-substring check, predicate→object_type heuristic, confidence floor. Catches what the prompt can't enforce structurally.
- **P2 (next week):** source-span provenance (new schema columns `source_message_id` + `source_span_start/end`). Makes grounding structural, not heuristic.
- **Investigation gate:** the entity-collapse mode (Eduard/Jutta facts attributed to Anna) survives source-grounding because Anna IS in the dialog. Root cause is either embedding-dedup threshold or LLM pronoun confusion — needs a half-day investigation either way.

Full option matrix + costed plan in `tasks/kg-strategy.md`.

## Test plan

- [x] `.159` ran: `tests/backend/test_kg_extraction_prompt.py` 3/3 pass (new file — locks the ground-rule clauses in)
- [x] `.159` ran: `tests/backend/test_kg_retrieval_extract.py` + `tests/backend/test_knowledge_graph_service.py` 120/120 sanity pass — existing tests don't depend on the old prompt strings
- [x] Production soft-delete verified before/after via kubectl exec
- [ ] After merge + deploy: query `/brain` UI for "Anna" — confirm the 5 garbage rels no longer render
- [ ] Watch a new chat session that mentions family members — confirm no new self-loops / hallucinations appear (informal; the validator in P1 is the real assurance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)