### PR TITLE
feat(brain): KG relation validator — deterministic post-extraction filter

### DIFF
--- a/src/backend/prompts/knowledge_graph.yaml
+++ b/src/backend/prompts/knowledge_graph.yaml
@@ -232,3 +232,24 @@ llm_options:
   top_p: 0.2
   num_predict: 1024
   num_ctx: 4096
+
+# Deterministic post-extraction validation (services/kg_validator.py).
+# Applied to every relation candidate before it is persisted, in BOTH the
+# chat path (extract_and_save) and the document path (extract_from_text).
+# See tasks/kg-strategy.md (P1) for the rationale.
+relation_validation:
+  # Rule 4 — confidence floor. Defense-in-depth only; the 2026-05-26 incident
+  # relations were all emitted at confidence 1.0, so this does not catch them.
+  confidence_floor: 0.6
+
+  # Rule 3 — predicate/object-type contract. First matching pattern wins.
+  # A predicate matching NO pattern is allowed (open vocabulary is deliberate;
+  # this table must not become a back-door closed enum). object_type is one of
+  # person|place|organization|thing|event|concept.
+  predicate_object_type:
+    # Kinship / marriage predicates must target a person.
+    - pattern: "^(heiratet|ist_verheiratet|verheiratet_mit|hat_kind|ist_kind_von|ist_(mutter|vater|sohn|tochter|elternteil|eltern)|hat_elternteil|ist_eltern_mit|ist_geschwister|ist_verwandt|married_to|has_child|is_(mother|father|son|daughter|parent|sibling)_of)"
+      object_type: person
+    # Location predicates must target a place.
+    - pattern: "^(wohnt_in|lebt_in|befindet_sich_in|hat_sitz_in|ansaessig_in|sitzt_in|liegt_in|lives_in|located_in|based_in|headquartered_in|resides_in)"
+      object_type: place

--- a/src/backend/prompts/knowledge_graph.yaml
+++ b/src/backend/prompts/knowledge_graph.yaml
@@ -240,7 +240,10 @@ llm_options:
 relation_validation:
   # Rule 4 — confidence floor. Defense-in-depth only; the 2026-05-26 incident
   # relations were all emitted at confidence 1.0, so this does not catch them.
-  confidence_floor: 0.6
+  # MUST match the lower bound the extraction prompt advertises to the model
+  # ("confidence: 0.5-1.0") — a higher floor silently drops relations the LLM
+  # emitted exactly as instructed. Keep this and the prompt range in lockstep.
+  confidence_floor: 0.5
 
   # Rule 3 — predicate/object-type contract. First matching pattern wins.
   # A predicate matching NO pattern is allowed (open vocabulary is deliberate;

--- a/src/backend/services/kg_validator.py
+++ b/src/backend/services/kg_validator.py
@@ -19,11 +19,16 @@ Rules (in order):
 
 1. **No self-loop.** ``subject_id == object_id`` → reject. Primary catch for
    the 3 self-loop incidents (``Anna ist_verheiratet_mit Anna`` etc.).
-2. **Source grounding.** Both entity names must appear verbatim in the source
-   text (the dialog or document chunk the relation was extracted from). Token-
-   level, lowercased, contiguous-substring match. Catches hallucinations
-   (``Hans Filbinger``, ``Kleinenbroich``) that the model invented from world
-   knowledge — neither name is in the dialog.
+2. **Source grounding.** Both entity names must be anchored in the source text
+   (the dialog or document chunk the relation was extracted from): at least one
+   significant word (len>=3) of the name prefix-matches a source token in
+   either direction (so "Anna" ↔ "Annas" both hold — German inflection). Prefix
+   not substring, so "Ada" does not match "Kanada". Grounds on the
+   discriminating token rather than every word, because ``resolve_entity`` can
+   canonicalize a spoken "Eduard" into a stored "Eduard van den Bongard" — and
+   we must not drop that real chat-learned fact. Catches the hallucination class
+   (``Hans Filbinger``, ``Kleinenbroich``) which shares no token with a dialog
+   that never mentions them.
 3. **Predicate/object-type contract.** A regex-keyed heuristic table (loaded
    from ``prompts/knowledge_graph.yaml``) maps predicate-name patterns to a
    required object entity_type. ``heiratet_*`` / ``ist_mutter_von`` → ``person``;
@@ -34,7 +39,9 @@ Rules (in order):
 4. **Confidence floor.** ``confidence < floor`` → reject. Defense-in-depth
    only: all 11 incident relations were emitted at confidence 1.0, so this
    rule did not catch any of them. It guards a different failure class
-   (genuinely low-confidence model output).
+   (genuinely low-confidence model output). The floor (0.5) is pinned to the
+   lower bound the extraction prompt advertises ("confidence: 0.5-1.0") so it
+   never drops a relation the model emitted exactly as instructed.
 
 The validator is intentionally side-effect-free and takes plain values, not a
 DB session, so it unit-tests without a database. The caller resolves entities
@@ -48,8 +55,10 @@ from typing import Any, Protocol
 
 from loguru import logger
 
-# Default confidence floor if the yaml config is missing/unreadable.
-_DEFAULT_CONFIDENCE_FLOOR = 0.6
+# Default confidence floor if the yaml config is missing/unreadable. Matches
+# the lower bound the extraction prompt advertises to the model ("0.5-1.0") —
+# a higher default would silently drop relations the LLM emitted as instructed.
+_DEFAULT_CONFIDENCE_FLOOR = 0.5
 
 # Tokeniser for source grounding: split on whitespace + common punctuation so
 # "Annas," and "(Kleinenbroich)" reduce to "annas" / "kleinenbroich".
@@ -84,32 +93,53 @@ def _tokenise(text: str) -> set[str]:
     return {t for t in _RE_TOKEN_SPLIT.split(text.lower()) if t}
 
 
-def _name_is_grounded(name: str, source_tokens: set[str], source_lower: str) -> bool:
-    """True if ``name`` appears in the source text.
+def _name_is_grounded(name: str, source_tokens: set[str]) -> bool:
+    """True if ``name`` is anchored in the source text.
 
-    A multi-word name ("Hans Filbinger", "Anna Johanna von den Bongard") is
-    grounded if EVERY whitespace-separated word of the name appears as a
-    contiguous substring of some source token. Single-word names check the
-    one word. This tolerates German inflection ("Annas" contains "anna") and
-    surrounding punctuation, while still rejecting names whose words never
-    appear at all (the hallucination case).
+    The name we receive is the *resolved* entity's canonical name, which can be
+    longer than the surface form actually spoken — ``resolve_entity`` merges a
+    dialog mention "Eduard" into an existing entity stored as "Eduard van den
+    Bongard" via embedding similarity. If we required EVERY word of the
+    canonical name to appear, that legitimate relation would be dropped because
+    "van"/"den"/"bongard" aren't in the current short exchange. KG-from-chat is
+    a must-have, so we ground on the discriminating token instead:
+
+      A name is grounded if AT LEAST ONE of its significant words (length >= 3)
+      prefix-matches a source token (either direction, so "Anna" ↔ "Annas"
+      both hold — covers German inflection). Names whose words are all short
+      (<3 chars) are considered ungroundable (not grounded).
+
+    This still rejects the hallucination class: "Hans Filbinger" and
+    "Kleinenbroich" share NO token with a dialog that never mentions them, so
+    no word anchors and the relation is dropped. The deliberate trade-off is
+    mild over-acceptance (a partly-hallucinated name like "Anna Schmidt" grounds
+    on "Anna") — the safe direction when the alternative is silently losing real
+    chat-learned facts. Self-loop + predicate-type rules and the prompt's own
+    grounding instruction are the other layers; this rule is the net, not the
+    whole defense.
     """
     name_lower = name.strip().lower()
     if not name_lower:
         return False
 
-    # Fast path: the whole name appears verbatim as a substring.
-    if name_lower in source_lower:
-        return True
-
-    # Per-word: each word of the name must be a substring of some source token.
     words = [w for w in _RE_TOKEN_SPLIT.split(name_lower) if w]
     if not words:
         return False
-    for word in words:
-        if not any(word in tok for tok in source_tokens):
-            return False
-    return True
+
+    significant = [w for w in words if len(w) >= 3]
+    if not significant:
+        # All words are 1-2 chars (initials etc.): no significant token to
+        # anchor on → not grounded.
+        return False
+
+    # At least one significant word must prefix-match a source token in either
+    # direction. Prefix (not substring) avoids "ada" matching "kanada" while
+    # still accepting "anna" vs "annas".
+    for word in significant:
+        for tok in source_tokens:
+            if tok.startswith(word) or word.startswith(tok):
+                return True
+    return False
 
 
 def load_heuristics(prompt_manager: Any) -> dict[str, Any]:
@@ -175,11 +205,10 @@ def validate_relation(
         return ValidationResult(False, REASON_SELF_LOOP)
 
     # Rule 2 — source grounding. Both names must be in the source text.
-    source_lower = source_text.lower()
     source_tokens = _tokenise(source_text)
-    if not _name_is_grounded(subject.name, source_tokens, source_lower):
+    if not _name_is_grounded(subject.name, source_tokens):
         return ValidationResult(False, REASON_NOT_GROUNDED)
-    if not _name_is_grounded(obj.name, source_tokens, source_lower):
+    if not _name_is_grounded(obj.name, source_tokens):
         return ValidationResult(False, REASON_NOT_GROUNDED)
 
     # Rule 3 — predicate/object-type contract. First matching rule wins;

--- a/src/backend/services/kg_validator.py
+++ b/src/backend/services/kg_validator.py
@@ -1,0 +1,199 @@
+"""
+KG Relation Validator — defensive post-extraction filter.
+
+The LLM extraction step (``KnowledgeGraphService.extract_and_save`` and
+``extract_from_text``) emits relation candidates that occasionally violate
+basic invariants the model was *asked* to respect in the prompt but cannot be
+trusted to honour deterministically. This module is the deterministic backstop:
+it inspects each resolved relation candidate before it reaches
+``save_relation`` and drops the ones that fail a fixed rule set.
+
+Empirically (2026-05-26 incident, relations 88-98) this catches 10 of 11
+garbage relations. The 11th — ``Anna mag Mango`` where Eduard's preference is
+misattributed to Anna — is an *attribution* error the validator cannot see,
+because "Anna" genuinely appears in the dialog. That class is fixed at the
+prompt layer (speaker-identity binding), not here. See
+``tasks/kg-entity-collapse-investigation.md``.
+
+Rules (in order):
+
+1. **No self-loop.** ``subject_id == object_id`` → reject. Primary catch for
+   the 3 self-loop incidents (``Anna ist_verheiratet_mit Anna`` etc.).
+2. **Source grounding.** Both entity names must appear verbatim in the source
+   text (the dialog or document chunk the relation was extracted from). Token-
+   level, lowercased, contiguous-substring match. Catches hallucinations
+   (``Hans Filbinger``, ``Kleinenbroich``) that the model invented from world
+   knowledge — neither name is in the dialog.
+3. **Predicate/object-type contract.** A regex-keyed heuristic table (loaded
+   from ``prompts/knowledge_graph.yaml``) maps predicate-name patterns to a
+   required object entity_type. ``heiratet_*`` / ``ist_mutter_von`` → ``person``;
+   ``wohnt_in`` / ``hat_sitz_in`` → ``place``. A predicate that matches no
+   pattern is ALLOWED (open vocabulary is the strategic choice — the heuristic
+   must not become a back-door closed enum). Catches type mismatches like
+   ``Anna heißt_auch Kleinenbroich`` (person-predicate → place object).
+4. **Confidence floor.** ``confidence < floor`` → reject. Defense-in-depth
+   only: all 11 incident relations were emitted at confidence 1.0, so this
+   rule did not catch any of them. It guards a different failure class
+   (genuinely low-confidence model output).
+
+The validator is intentionally side-effect-free and takes plain values, not a
+DB session, so it unit-tests without a database. The caller resolves entities
+first, then asks the validator for a verdict.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from loguru import logger
+
+# Default confidence floor if the yaml config is missing/unreadable.
+_DEFAULT_CONFIDENCE_FLOOR = 0.6
+
+# Tokeniser for source grounding: split on whitespace + common punctuation so
+# "Annas," and "(Kleinenbroich)" reduce to "annas" / "kleinenbroich".
+_RE_TOKEN_SPLIT = re.compile(r"[\s.,;:!?()\[\]{}\"'„“”‚‘’/\\—–-]+")
+
+
+class _EntityLike(Protocol):
+    """Minimal shape the validator needs from a resolved KG entity."""
+
+    id: int
+    name: str
+    entity_type: str
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    """Outcome of validating a single relation candidate."""
+
+    ok: bool
+    reason: str | None = None  # rule name that rejected it; None if ok
+
+
+# Rule-name constants (stable strings for tests + metrics).
+REASON_SELF_LOOP = "self_loop"
+REASON_NOT_GROUNDED = "not_grounded"
+REASON_TYPE_MISMATCH = "predicate_object_type_mismatch"
+REASON_LOW_CONFIDENCE = "low_confidence"
+
+
+def _tokenise(text: str) -> set[str]:
+    """Lowercase + split source text into a set of bare tokens."""
+    return {t for t in _RE_TOKEN_SPLIT.split(text.lower()) if t}
+
+
+def _name_is_grounded(name: str, source_tokens: set[str], source_lower: str) -> bool:
+    """True if ``name`` appears in the source text.
+
+    A multi-word name ("Hans Filbinger", "Anna Johanna von den Bongard") is
+    grounded if EVERY whitespace-separated word of the name appears as a
+    contiguous substring of some source token. Single-word names check the
+    one word. This tolerates German inflection ("Annas" contains "anna") and
+    surrounding punctuation, while still rejecting names whose words never
+    appear at all (the hallucination case).
+    """
+    name_lower = name.strip().lower()
+    if not name_lower:
+        return False
+
+    # Fast path: the whole name appears verbatim as a substring.
+    if name_lower in source_lower:
+        return True
+
+    # Per-word: each word of the name must be a substring of some source token.
+    words = [w for w in _RE_TOKEN_SPLIT.split(name_lower) if w]
+    if not words:
+        return False
+    for word in words:
+        if not any(word in tok for tok in source_tokens):
+            return False
+    return True
+
+
+def load_heuristics(prompt_manager: Any) -> dict[str, Any]:
+    """Load the validation config block from prompts/knowledge_graph.yaml.
+
+    Shape:
+        relation_validation:
+          confidence_floor: 0.6
+          predicate_object_type:
+            - {pattern: "^(heiratet|ist_verheiratet|...)", object_type: person}
+            - {pattern: "^(wohnt_in|befindet_sich_in|...)", object_type: place}
+
+    Returns a normalised dict with compiled regexes. Missing/malformed config
+    degrades gracefully: confidence floor defaults, type rules become empty
+    (so rule 3 passes everything — fail-open, not fail-closed).
+    """
+    cfg = prompt_manager.get_config("knowledge_graph", "relation_validation") or {}
+
+    floor = cfg.get("confidence_floor", _DEFAULT_CONFIDENCE_FLOOR)
+    try:
+        floor = float(floor)
+    except (TypeError, ValueError):
+        floor = _DEFAULT_CONFIDENCE_FLOOR
+
+    rules: list[tuple[re.Pattern[str], str]] = []
+    for entry in cfg.get("predicate_object_type", []) or []:
+        pattern = entry.get("pattern")
+        object_type = entry.get("object_type")
+        if not pattern or not object_type:
+            continue
+        try:
+            rules.append((re.compile(pattern, re.IGNORECASE), object_type))
+        except re.error as e:
+            logger.warning(f"KG validator: bad predicate regex '{pattern}': {e}")
+
+    return {"confidence_floor": floor, "type_rules": rules}
+
+
+def validate_relation(
+    *,
+    subject: _EntityLike,
+    obj: _EntityLike,
+    predicate: str,
+    confidence: float,
+    source_text: str,
+    heuristics: dict[str, Any],
+) -> ValidationResult:
+    """Validate one resolved relation candidate. Pure, no I/O.
+
+    Args:
+        subject: resolved subject entity (needs .id, .name, .entity_type)
+        obj: resolved object entity
+        predicate: the relation predicate string
+        confidence: clamped confidence (caller already coerces to float)
+        source_text: the dialog/chunk the relation was extracted from
+        heuristics: output of ``load_heuristics``
+
+    Returns ValidationResult(ok=True) if the relation passes all rules, else
+    ok=False with ``reason`` set to the failing rule's constant.
+    """
+    # Rule 1 — no self-loop.
+    if subject.id == obj.id:
+        return ValidationResult(False, REASON_SELF_LOOP)
+
+    # Rule 2 — source grounding. Both names must be in the source text.
+    source_lower = source_text.lower()
+    source_tokens = _tokenise(source_text)
+    if not _name_is_grounded(subject.name, source_tokens, source_lower):
+        return ValidationResult(False, REASON_NOT_GROUNDED)
+    if not _name_is_grounded(obj.name, source_tokens, source_lower):
+        return ValidationResult(False, REASON_NOT_GROUNDED)
+
+    # Rule 3 — predicate/object-type contract. First matching rule wins;
+    # no match → allowed (open vocabulary).
+    pred_lower = predicate.strip().lower()
+    for pattern, required_type in heuristics.get("type_rules", []):
+        if pattern.search(pred_lower):
+            if obj.entity_type != required_type:
+                return ValidationResult(False, REASON_TYPE_MISMATCH)
+            break  # predicate matched a rule and the type is correct
+
+    # Rule 4 — confidence floor (defense-in-depth).
+    floor = heuristics.get("confidence_floor", _DEFAULT_CONFIDENCE_FLOOR)
+    if confidence < floor:
+        return ValidationResult(False, REASON_LOW_CONFIDENCE)
+
+    return ValidationResult(True)

--- a/src/backend/services/knowledge_graph_service.py
+++ b/src/backend/services/knowledge_graph_service.py
@@ -17,6 +17,8 @@ from sqlalchemy import func, or_, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.database import KG_ENTITY_TYPES, TIER_PUBLIC, KGEntity, KGRelation
+from services.kg_validator import load_heuristics as load_kg_heuristics
+from services.kg_validator import validate_relation as validate_kg_relation
 from utils.config import settings
 from utils.llm_client import get_default_client, get_embed_client
 
@@ -697,8 +699,12 @@ class KnowledgeGraphService:
         if rejected_count:
             logger.info(f"KG: Filtered out {rejected_count} invalid entities from conversation")
 
-        # Save relations
+        # Save relations (validated). Source text is the full exchange so the
+        # grounding rule can verify both entity names were actually spoken.
+        validation_source = f"{user_message}\n{assistant_response}"
+        heuristics = load_kg_heuristics(prompt_manager)
         saved_relations = []
+        rejected_relations = 0
         for rel in relations_data:
             subj_name = rel.get("subject", "").strip().lower()
             pred = rel.get("predicate", "").strip()
@@ -719,6 +725,22 @@ class KnowledgeGraphService:
             except (TypeError, ValueError):
                 conf = 0.8
 
+            verdict = validate_kg_relation(
+                subject=subject,
+                obj=obj,
+                predicate=pred,
+                confidence=conf,
+                source_text=validation_source,
+                heuristics=heuristics,
+            )
+            if not verdict.ok:
+                logger.info(
+                    f"KG: Rejected relation '{subject.name}' --{pred}--> "
+                    f"'{obj.name}' ({verdict.reason})"
+                )
+                rejected_relations += 1
+                continue
+
             relation = await self.save_relation(
                 subject_id=subject.id,
                 predicate=pred,
@@ -734,7 +756,8 @@ class KnowledgeGraphService:
         if saved_entities or saved_relations:
             logger.info(
                 f"KG: Extracted {len(saved_entities)} entities, "
-                f"{len(saved_relations)} relations (user_id={user_id})"
+                f"{len(saved_relations)} relations "
+                f"({rejected_relations} rejected by validator, user_id={user_id})"
             )
 
             # Broadcast to live KG graph viewers (fire-and-forget)
@@ -848,8 +871,11 @@ class KnowledgeGraphService:
         if rejected_count:
             logger.info(f"KG: Filtered out {rejected_count} invalid entities from document")
 
-        # Save relations
+        # Save relations (validated). Source text is the document chunk so the
+        # grounding rule can verify both entity names appear in the passage.
+        heuristics = load_kg_heuristics(prompt_manager)
         saved_relations = []
+        rejected_relations = 0
         for rel in relations_data:
             subj_name = rel.get("subject", "").strip().lower()
             pred = rel.get("predicate", "").strip()
@@ -870,6 +896,22 @@ class KnowledgeGraphService:
             except (TypeError, ValueError):
                 conf = 0.8
 
+            verdict = validate_kg_relation(
+                subject=subject,
+                obj=obj,
+                predicate=pred,
+                confidence=conf,
+                source_text=text,
+                heuristics=heuristics,
+            )
+            if not verdict.ok:
+                logger.info(
+                    f"KG: Rejected document relation '{subject.name}' --{pred}--> "
+                    f"'{obj.name}' ({verdict.reason})"
+                )
+                rejected_relations += 1
+                continue
+
             relation = await self.save_relation(
                 subject_id=subject.id,
                 predicate=pred,
@@ -886,7 +928,8 @@ class KnowledgeGraphService:
             logger.info(
                 f"KG: Extracted {len(saved_entities)} entities, "
                 f"{len(saved_relations)} relations from text "
-                f"(user_id={user_id}, source={source_ref})"
+                f"({rejected_relations} rejected by validator, "
+                f"user_id={user_id}, source={source_ref})"
             )
 
         return saved_entities, saved_relations

--- a/tests/backend/test_kg_validator.py
+++ b/tests/backend/test_kg_validator.py
@@ -1,0 +1,418 @@
+"""
+Unit tests for services/kg_validator.py — the deterministic post-extraction
+relation filter. No DB, no LLM: the validator is a pure function.
+
+Coverage:
+- Each of the 4 rules: happy + reject + boundary.
+- German inflection edge cases for source grounding.
+- Regression: the 11 known 2026-05-26 incident relations produce the right
+  reject reason (or pass, for the attribution case the validator can't see).
+- load_heuristics: yaml parsing, graceful degradation, regex compilation.
+"""
+import re
+
+import pytest
+
+from services.kg_validator import (
+    REASON_LOW_CONFIDENCE,
+    REASON_NOT_GROUNDED,
+    REASON_SELF_LOOP,
+    REASON_TYPE_MISMATCH,
+    load_heuristics,
+    validate_relation,
+)
+
+
+# --------------------------------------------------------------------------
+# Test doubles + fixtures
+# --------------------------------------------------------------------------
+
+class FakeEntity:
+    """Minimal stand-in for a resolved KGEntity (id, name, entity_type)."""
+
+    def __init__(self, id: int, name: str, entity_type: str):
+        self.id = id
+        self.name = name
+        self.entity_type = entity_type
+
+
+# Heuristics matching the production yaml (kept in sync by
+# test_yaml_heuristics_match_production below).
+HEURISTICS = {
+    "confidence_floor": 0.6,
+    "type_rules": [
+        (re.compile(
+            r"^(heiratet|ist_verheiratet|verheiratet_mit|hat_kind|ist_kind_von|"
+            r"ist_(mutter|vater|sohn|tochter|elternteil|eltern)|hat_elternteil|"
+            r"ist_eltern_mit|ist_geschwister|ist_verwandt|married_to|has_child|"
+            r"is_(mother|father|son|daughter|parent|sibling)_of)",
+            re.IGNORECASE), "person"),
+        (re.compile(
+            r"^(wohnt_in|lebt_in|befindet_sich_in|hat_sitz_in|ansaessig_in|"
+            r"sitzt_in|liegt_in|lives_in|located_in|based_in|headquartered_in|"
+            r"resides_in)",
+            re.IGNORECASE), "place"),
+    ],
+}
+
+
+def _validate(subject, obj, predicate, confidence, source_text, heuristics=HEURISTICS):
+    return validate_relation(
+        subject=subject,
+        obj=obj,
+        predicate=predicate,
+        confidence=confidence,
+        source_text=source_text,
+        heuristics=heuristics,
+    )
+
+
+# --------------------------------------------------------------------------
+# Rule 1 — no self-loop
+# --------------------------------------------------------------------------
+
+class TestSelfLoop:
+    @pytest.mark.unit
+    def test_self_loop_rejected(self):
+        anna = FakeEntity(11, "Anna", "person")
+        r = _validate(anna, anna, "ist_verheiratet_mit", 1.0, "Anna ist verheiratet.")
+        assert not r.ok
+        assert r.reason == REASON_SELF_LOOP
+
+    @pytest.mark.unit
+    def test_distinct_entities_same_name_not_a_loop(self):
+        # Different ids → not a self-loop even if names coincide.
+        a1 = FakeEntity(11, "Anna", "person")
+        a2 = FakeEntity(12, "Anna", "person")
+        r = _validate(a1, a2, "kennt", 0.9, "Anna kennt Anna.")
+        assert r.ok
+
+
+# --------------------------------------------------------------------------
+# Rule 2 — source grounding
+# --------------------------------------------------------------------------
+
+class TestSourceGrounding:
+    @pytest.mark.unit
+    def test_both_names_present_passes(self):
+        eduard = FakeEntity(1, "Eduard", "person")
+        jutta = FakeEntity(2, "Jutta", "person")
+        r = _validate(eduard, jutta, "ist_verheiratet_mit", 0.9,
+                      "Eduard ist mit Jutta verheiratet.")
+        assert r.ok
+
+    @pytest.mark.unit
+    def test_hallucinated_object_rejected(self):
+        # Hans Filbinger never appears in the dialog → reject.
+        anna = FakeEntity(11, "Anna", "person")
+        hans = FakeEntity(99, "Hans Filbinger", "person")
+        r = _validate(anna, hans, "ist_verheiratet_mit", 1.0,
+                      "Anna Johanna von den Bongard ist meine Mutter.")
+        assert not r.ok
+        assert r.reason == REASON_NOT_GROUNDED
+
+    @pytest.mark.unit
+    def test_german_inflection_genitive(self):
+        # "Annas" (genitive) contains "anna" → grounded.
+        anna = FakeEntity(11, "Anna", "person")
+        ben = FakeEntity(93, "Ben", "person")
+        r = _validate(anna, ben, "ist_mutter_von", 0.9,
+                      "Annas Sohn Ben kam zu Besuch.")
+        assert r.ok
+
+    @pytest.mark.unit
+    def test_multiword_name_all_words_present(self):
+        anna = FakeEntity(11, "Anna Johanna von den Bongard", "person")
+        ben = FakeEntity(93, "Ben", "person")
+        r = _validate(anna, ben, "ist_mutter_von", 0.9,
+                      "Anna Johanna von den Bongard ist Bens Mutter, und Ben ist hier.")
+        assert r.ok
+
+    @pytest.mark.unit
+    def test_multiword_name_one_word_missing_rejected(self):
+        # "Filbinger" present but "Hans" absent → not grounded.
+        anna = FakeEntity(11, "Anna", "person")
+        hans = FakeEntity(99, "Hans Filbinger", "person")
+        r = _validate(anna, hans, "kennt", 0.9,
+                      "Anna kennt einen Herrn Filbinger nicht.")
+        # "Hans" is absent → reject
+        assert not r.ok
+        assert r.reason == REASON_NOT_GROUNDED
+
+    @pytest.mark.unit
+    def test_punctuation_surrounding_name(self):
+        x = FakeEntity(1, "X-idra", "organization")
+        kb = FakeEntity(2, "Kleinenbroich", "place")
+        r = _validate(x, kb, "hat_sitz_in", 0.9,
+                      "Die Firma (X-idra) sitzt in Kleinenbroich.")
+        assert r.ok
+
+    @pytest.mark.unit
+    def test_punctuation_only_source_rejects_missing_entity(self):
+        a = FakeEntity(1, "Foo", "thing")
+        b = FakeEntity(2, "Bar", "thing")
+        # Neither Foo nor Bar appears → rejected (subject checked first).
+        r = _validate(a, b, "verknuepft_mit", 0.9, "Some unrelated text here.")
+        assert not r.ok
+        assert r.reason == REASON_NOT_GROUNDED
+
+
+# --------------------------------------------------------------------------
+# Rule 3 — predicate / object-type contract
+# --------------------------------------------------------------------------
+
+class TestPredicateObjectType:
+    @pytest.mark.unit
+    def test_kinship_predicate_with_place_object_rejected(self):
+        # "Anna heißt_auch Kleinenbroich" — wait, heißt_auch isn't in table.
+        # Use a kinship predicate to a place: ist_verheiratet_mit → place.
+        anna = FakeEntity(11, "Anna", "person")
+        kb = FakeEntity(2, "Kleinenbroich", "place")
+        r = _validate(anna, kb, "ist_verheiratet_mit", 1.0,
+                      "Anna und Kleinenbroich.")
+        assert not r.ok
+        assert r.reason == REASON_TYPE_MISMATCH
+
+    @pytest.mark.unit
+    def test_kinship_predicate_with_person_object_passes(self):
+        eduard = FakeEntity(1, "Eduard", "person")
+        jutta = FakeEntity(2, "Jutta", "person")
+        r = _validate(eduard, jutta, "ist_verheiratet_mit", 0.9,
+                      "Eduard und Jutta sind verheiratet.")
+        assert r.ok
+
+    @pytest.mark.unit
+    def test_location_predicate_with_org_object_rejected(self):
+        person = FakeEntity(1, "Eduard", "person")
+        org = FakeEntity(2, "X-idra", "organization")
+        r = _validate(person, org, "wohnt_in", 0.9, "Eduard wohnt in X-idra.")
+        assert not r.ok
+        assert r.reason == REASON_TYPE_MISMATCH
+
+    @pytest.mark.unit
+    def test_location_predicate_with_place_object_passes(self):
+        person = FakeEntity(1, "Eduard", "person")
+        place = FakeEntity(2, "Kleinenbroich", "place")
+        r = _validate(person, place, "wohnt_in", 0.9,
+                      "Eduard wohnt in Kleinenbroich.")
+        assert r.ok
+
+    @pytest.mark.unit
+    def test_unknown_predicate_allowed(self):
+        # Open vocabulary: a predicate matching no rule passes regardless of type.
+        a = FakeEntity(1, "Eduard", "person")
+        b = FakeEntity(2, "Mango", "thing")
+        r = _validate(a, b, "mag", 0.9, "Eduard mag Mango.")
+        assert r.ok
+
+    @pytest.mark.unit
+    def test_english_kinship_predicate_enforced(self):
+        anna = FakeEntity(11, "Anna", "person")
+        place = FakeEntity(2, "Berlin", "place")
+        r = _validate(anna, place, "married_to", 1.0, "Anna and Berlin.")
+        assert not r.ok
+        assert r.reason == REASON_TYPE_MISMATCH
+
+    @pytest.mark.unit
+    def test_case_insensitive_predicate_match(self):
+        anna = FakeEntity(11, "Anna", "person")
+        place = FakeEntity(2, "Berlin", "place")
+        r = _validate(anna, place, "IST_VERHEIRATET_MIT", 1.0, "Anna and Berlin.")
+        assert not r.ok
+        assert r.reason == REASON_TYPE_MISMATCH
+
+
+# --------------------------------------------------------------------------
+# Rule 4 — confidence floor (defense-in-depth)
+# --------------------------------------------------------------------------
+
+class TestConfidenceFloor:
+    @pytest.mark.unit
+    def test_below_floor_rejected(self):
+        a = FakeEntity(1, "Eduard", "person")
+        b = FakeEntity(2, "Mango", "thing")
+        r = _validate(a, b, "mag", 0.5, "Eduard mag Mango.")
+        assert not r.ok
+        assert r.reason == REASON_LOW_CONFIDENCE
+
+    @pytest.mark.unit
+    def test_at_floor_passes(self):
+        a = FakeEntity(1, "Eduard", "person")
+        b = FakeEntity(2, "Mango", "thing")
+        r = _validate(a, b, "mag", 0.6, "Eduard mag Mango.")
+        assert r.ok
+
+    @pytest.mark.unit
+    def test_rule_order_grounding_before_confidence(self):
+        # An ungrounded relation at low confidence reports grounding first
+        # (rule 2 runs before rule 4).
+        a = FakeEntity(1, "Foo", "thing")
+        b = FakeEntity(2, "Bar", "thing")
+        r = _validate(a, b, "mag", 0.1, "Nothing relevant here.")
+        assert not r.ok
+        assert r.reason == REASON_NOT_GROUNDED
+
+
+# --------------------------------------------------------------------------
+# Regression: the 11 known 2026-05-26 incident relations
+# --------------------------------------------------------------------------
+
+class TestIncidentRegression:
+    """The dialog these came from (paraphrased): Eduard says he likes Mango,
+    his wife Jutta likes Maracuja, they have a son Ben, his mother is Anna
+    Johanna van den Bongard. Hans Filbinger and Kleinenbroich are NEVER
+    mentioned. All garbage relations had subject 'Anna'.
+    """
+
+    # The actual dialog text the validator would see.
+    DIALOG = (
+        "Ich, Eduard van den Bongard, bin mit Jutta van den Bongard geborene "
+        "Deussen verheiratet. Jutta mag Maracujas und Ananas. Mango ist mein "
+        "Lieblingsobst. Anna Johanna van den Bongard ist meine Mutter. Wir "
+        "haben zwei Kinder, Ben und Tom."
+    )
+
+    @pytest.mark.unit
+    def test_self_loop_anna_married_anna(self):
+        anna = FakeEntity(11, "Anna Johanna van den Bongard", "person")
+        r = _validate(anna, anna, "ist_verheiratet_mit", 1.0, self.DIALOG)
+        assert not r.ok and r.reason == REASON_SELF_LOOP
+
+    @pytest.mark.unit
+    def test_self_loop_anna_mother_anna(self):
+        anna = FakeEntity(11, "Anna Johanna van den Bongard", "person")
+        r = _validate(anna, anna, "ist_mutter_von", 1.0, self.DIALOG)
+        assert not r.ok and r.reason == REASON_SELF_LOOP
+
+    @pytest.mark.unit
+    def test_hallucination_anna_married_filbinger(self):
+        anna = FakeEntity(11, "Anna Johanna van den Bongard", "person")
+        hans = FakeEntity(99, "Hans Filbinger", "person")
+        r = _validate(anna, hans, "ist_verheiratet_mit", 1.0, self.DIALOG)
+        assert not r.ok and r.reason == REASON_NOT_GROUNDED
+
+    @pytest.mark.unit
+    def test_hallucination_anna_heisst_kleinenbroich(self):
+        # heißt_auch is not in the type table, so this is caught by grounding:
+        # Kleinenbroich is not in the dialog.
+        anna = FakeEntity(11, "Anna Johanna van den Bongard", "person")
+        kb = FakeEntity(2, "Kleinenbroich", "place")
+        r = _validate(anna, kb, "heißt_auch", 1.0, self.DIALOG)
+        assert not r.ok and r.reason == REASON_NOT_GROUNDED
+
+    @pytest.mark.unit
+    def test_hallucination_anna_vorheriger_name_kleinenbroich(self):
+        anna = FakeEntity(11, "Anna Johanna van den Bongard", "person")
+        kb = FakeEntity(2, "Kleinenbroich", "place")
+        r = _validate(anna, kb, "heiratet_vorheriger_name", 1.0, self.DIALOG)
+        # "heiratet" matches the kinship pattern → object must be person, but
+        # Kleinenbroich is a place → type mismatch (caught before grounding?).
+        # Rule order: grounding (rule 2) runs before type (rule 3). Kleinenbroich
+        # is not in the dialog → NOT_GROUNDED wins.
+        assert not r.ok and r.reason == REASON_NOT_GROUNDED
+
+    @pytest.mark.unit
+    def test_attribution_anna_mag_mango_SURVIVES(self):
+        # This is the 11th relation the validator CANNOT catch: Anna is in the
+        # dialog, Mango is in the dialog, 'mag' is an allowed predicate, conf
+        # is high. The misattribution (it's Eduard who likes Mango) is invisible
+        # to a per-relation validator. Documented limitation — fixed at the
+        # prompt layer (speaker-identity binding), not here.
+        anna = FakeEntity(11, "Anna Johanna van den Bongard", "person")
+        mango = FakeEntity(50, "Mango", "thing")
+        r = _validate(anna, mango, "mag", 1.0, self.DIALOG)
+        assert r.ok, "validator cannot see attribution errors — this is expected"
+
+
+# --------------------------------------------------------------------------
+# load_heuristics
+# --------------------------------------------------------------------------
+
+class FakePromptManager:
+    def __init__(self, config):
+        self._config = config
+
+    def get_config(self, file, key, default=None, lang=None):
+        return self._config
+
+
+class TestLoadHeuristics:
+    @pytest.mark.unit
+    def test_loads_floor_and_rules(self):
+        pm = FakePromptManager({
+            "confidence_floor": 0.7,
+            "predicate_object_type": [
+                {"pattern": "^married_to", "object_type": "person"},
+            ],
+        })
+        h = load_heuristics(pm)
+        assert h["confidence_floor"] == 0.7
+        assert len(h["type_rules"]) == 1
+        pattern, otype = h["type_rules"][0]
+        assert otype == "person"
+        assert pattern.search("married_to")
+
+    @pytest.mark.unit
+    def test_missing_config_degrades_gracefully(self):
+        pm = FakePromptManager(None)
+        h = load_heuristics(pm)
+        assert h["confidence_floor"] == 0.6  # default
+        assert h["type_rules"] == []  # fail-open: no type enforcement
+
+    @pytest.mark.unit
+    def test_malformed_regex_skipped(self):
+        pm = FakePromptManager({
+            "predicate_object_type": [
+                {"pattern": "[invalid(regex", "object_type": "person"},
+                {"pattern": "^valid", "object_type": "place"},
+            ],
+        })
+        h = load_heuristics(pm)
+        # Bad regex skipped, good one kept.
+        assert len(h["type_rules"]) == 1
+        assert h["type_rules"][0][1] == "place"
+
+    @pytest.mark.unit
+    def test_incomplete_entry_skipped(self):
+        pm = FakePromptManager({
+            "predicate_object_type": [
+                {"pattern": "^foo"},  # missing object_type
+                {"object_type": "person"},  # missing pattern
+            ],
+        })
+        h = load_heuristics(pm)
+        assert h["type_rules"] == []
+
+    @pytest.mark.unit
+    def test_non_numeric_floor_falls_back(self):
+        pm = FakePromptManager({"confidence_floor": "not-a-number"})
+        h = load_heuristics(pm)
+        assert h["confidence_floor"] == 0.6
+
+
+# --------------------------------------------------------------------------
+# Production yaml sanity — the in-test HEURISTICS must match the shipped file
+# --------------------------------------------------------------------------
+
+class TestYamlHeuristicsMatchProduction:
+    @pytest.mark.unit
+    def test_production_yaml_loads_and_enforces(self):
+        """Load the real yaml via prompt_manager and confirm the rules fire."""
+        from services.prompt_manager import prompt_manager
+        prompt_manager.reload()
+        h = load_heuristics(prompt_manager)
+
+        # Floor present.
+        assert h["confidence_floor"] == 0.6
+        # At least the two documented rules.
+        assert len(h["type_rules"]) >= 2
+
+        # Kinship predicate → place object must be rejected via the real config.
+        anna = FakeEntity(11, "Anna", "person")
+        kb = FakeEntity(2, "Kleinenbroich", "place")
+        r = validate_relation(
+            subject=anna, obj=kb, predicate="ist_verheiratet_mit",
+            confidence=1.0, source_text="Anna und Kleinenbroich.",
+            heuristics=h,
+        )
+        assert not r.ok and r.reason == REASON_TYPE_MISMATCH

--- a/tests/backend/test_kg_validator.py
+++ b/tests/backend/test_kg_validator.py
@@ -39,7 +39,7 @@ class FakeEntity:
 # Heuristics matching the production yaml (kept in sync by
 # test_yaml_heuristics_match_production below).
 HEURISTICS = {
-    "confidence_floor": 0.6,
+    "confidence_floor": 0.5,
     "type_rules": [
         (re.compile(
             r"^(heiratet|ist_verheiratet|verheiratet_mit|hat_kind|ist_kind_von|"
@@ -129,13 +129,35 @@ class TestSourceGrounding:
         assert r.ok
 
     @pytest.mark.unit
-    def test_multiword_name_one_word_missing_rejected(self):
-        # "Filbinger" present but "Hans" absent → not grounded.
+    def test_canonical_name_grounds_on_partial_mention(self):
+        # F1 fix: resolve_entity may canonicalize a spoken "Eduard" into the
+        # stored "Eduard van den Bongard". The dialog only contains "Eduard".
+        # The relation must STILL ground — one significant word anchors it.
+        # (Pre-fix this was dropped as not_grounded, silently losing the fact.)
+        eduard = FakeEntity(1, "Eduard van den Bongard", "person")
+        mango = FakeEntity(50, "Mango", "thing")
+        r = _validate(eduard, mango, "mag", 0.9, "Eduard mag Mango.")
+        assert r.ok
+
+    @pytest.mark.unit
+    def test_name_with_no_word_present_rejected(self):
+        # Neither "Hans" nor "Filbinger" appears → no significant word anchors
+        # → rejected. This is the hallucination case the rule must still catch.
         anna = FakeEntity(11, "Anna", "person")
         hans = FakeEntity(99, "Hans Filbinger", "person")
         r = _validate(anna, hans, "kennt", 0.9,
-                      "Anna kennt einen Herrn Filbinger nicht.")
-        # "Hans" is absent → reject
+                      "Anna kennt niemanden aus der Politik.")
+        assert not r.ok
+        assert r.reason == REASON_NOT_GROUNDED
+
+    @pytest.mark.unit
+    def test_short_word_does_not_falsely_ground(self):
+        # F3 fix: "Ada" (3 chars) must NOT ground against "Kanada" — prefix
+        # match, not loose substring. "ada" is a substring of "kanada" but
+        # neither prefixes the other.
+        ada = FakeEntity(1, "Ada", "person")
+        b = FakeEntity(2, "Berlin", "place")
+        r = _validate(ada, b, "wohnt_in", 0.9, "Wir waren in Kanada und Berlin.")
         assert not r.ok
         assert r.reason == REASON_NOT_GROUNDED
 
@@ -229,17 +251,19 @@ class TestPredicateObjectType:
 class TestConfidenceFloor:
     @pytest.mark.unit
     def test_below_floor_rejected(self):
+        # Floor is 0.5 (matches the prompt's advertised 0.5-1.0 range).
         a = FakeEntity(1, "Eduard", "person")
         b = FakeEntity(2, "Mango", "thing")
-        r = _validate(a, b, "mag", 0.5, "Eduard mag Mango.")
+        r = _validate(a, b, "mag", 0.49, "Eduard mag Mango.")
         assert not r.ok
         assert r.reason == REASON_LOW_CONFIDENCE
 
     @pytest.mark.unit
     def test_at_floor_passes(self):
+        # 0.5 is exactly the prompt's lower bound — must NOT be dropped.
         a = FakeEntity(1, "Eduard", "person")
         b = FakeEntity(2, "Mango", "thing")
-        r = _validate(a, b, "mag", 0.6, "Eduard mag Mango.")
+        r = _validate(a, b, "mag", 0.5, "Eduard mag Mango.")
         assert r.ok
 
     @pytest.mark.unit
@@ -356,7 +380,7 @@ class TestLoadHeuristics:
     def test_missing_config_degrades_gracefully(self):
         pm = FakePromptManager(None)
         h = load_heuristics(pm)
-        assert h["confidence_floor"] == 0.6  # default
+        assert h["confidence_floor"] == 0.5  # default
         assert h["type_rules"] == []  # fail-open: no type enforcement
 
     @pytest.mark.unit
@@ -387,7 +411,7 @@ class TestLoadHeuristics:
     def test_non_numeric_floor_falls_back(self):
         pm = FakePromptManager({"confidence_floor": "not-a-number"})
         h = load_heuristics(pm)
-        assert h["confidence_floor"] == 0.6
+        assert h["confidence_floor"] == 0.5
 
 
 # --------------------------------------------------------------------------
@@ -403,7 +427,7 @@ class TestYamlHeuristicsMatchProduction:
         h = load_heuristics(prompt_manager)
 
         # Floor present.
-        assert h["confidence_floor"] == 0.6
+        assert h["confidence_floor"] == 0.5
         # At least the two documented rules.
         assert len(h["type_rules"]) >= 2
 

--- a/tests/backend/test_knowledge_graph_service.py
+++ b/tests/backend/test_knowledge_graph_service.py
@@ -415,6 +415,78 @@ class TestExtractAndSave:
         assert entities == []
         assert relations == []
 
+    @pytest.mark.unit
+    async def test_validator_drops_self_loop_and_hallucination(self, kg_service, db_session):
+        """The validator filters bad relations before they are persisted.
+
+        The LLM emits 3 relations against the dialog:
+          1. Eduard lives_in Berlin   — valid (grounded, type ok, conf ok)
+          2. Anna married_to Anna     — self-loop, must be dropped
+          3. Anna married_to Hans Filbinger — Hans not in dialog, must be dropped
+        Only #1 survives. All three entities are still created (entity
+        extraction is independent of relation validation).
+        """
+        llm_response = MagicMock()
+        llm_response.message.content = '''{
+            "entities": [
+                {"name": "Eduard", "type": "person"},
+                {"name": "Berlin", "type": "place"},
+                {"name": "Anna", "type": "person"},
+                {"name": "Hans Filbinger", "type": "person"}
+            ],
+            "relations": [
+                {"subject": "Eduard", "predicate": "lives_in", "object": "Berlin", "confidence": 0.9},
+                {"subject": "Anna", "predicate": "married_to", "object": "Anna", "confidence": 1.0},
+                {"subject": "Anna", "predicate": "married_to", "object": "Hans Filbinger", "confidence": 1.0}
+            ]
+        }'''
+
+        mock_client = AsyncMock()
+        mock_client.chat = AsyncMock(return_value=llm_response)
+        kg_service._chat_client = mock_client
+        kg_service._find_similar_entity = AsyncMock(return_value=None)
+
+        # Note: "Hans Filbinger" is NOT in the dialog text below.
+        entities, relations = await kg_service.extract_and_save(
+            "Eduard lives in Berlin. Anna is my mother.",
+            "Noted.",
+            user_id=None,
+        )
+
+        # All four entities created; only the one valid relation survives.
+        assert len(relations) == 1
+        assert relations[0].predicate == "lives_in"
+        preds = {r.predicate for r in relations}
+        assert "married_to" not in preds
+
+    @pytest.mark.unit
+    async def test_validator_drops_predicate_type_mismatch(self, kg_service, db_session):
+        """A kinship predicate pointing at a place is dropped."""
+        llm_response = MagicMock()
+        llm_response.message.content = '''{
+            "entities": [
+                {"name": "Anna", "type": "person"},
+                {"name": "Kleinenbroich", "type": "place"}
+            ],
+            "relations": [
+                {"subject": "Anna", "predicate": "ist_verheiratet_mit", "object": "Kleinenbroich", "confidence": 1.0}
+            ]
+        }'''
+
+        mock_client = AsyncMock()
+        mock_client.chat = AsyncMock(return_value=llm_response)
+        kg_service._chat_client = mock_client
+        kg_service._find_similar_entity = AsyncMock(return_value=None)
+
+        entities, relations = await kg_service.extract_and_save(
+            "Anna wohnt in Kleinenbroich.",  # both names grounded
+            "Notiert.",
+            user_id=None,
+        )
+
+        # Person-predicate → place object is a type mismatch → dropped.
+        assert relations == []
+
 
 # ==========================================================================
 # Context Retrieval


### PR DESCRIPTION
## Summary

P1 from `tasks/kg-strategy.md`. The deterministic backstop behind the #633 prompt hardening: every knowledge-graph relation candidate is validated before `save_relation`, in BOTH the chat path (`extract_and_save`) and the document path (`extract_from_text`).

The prompt *asks* the LLM to respect grounding / no-self-loops / type rules but can't enforce them. This module enforces them.

## The 4 rules

1. **No self-loop** — `subject_id == object_id` → drop. Catches the 3 self-loop incidents (`Anna ist_verheiratet_mit Anna`).
2. **Source grounding** — at least one significant word (len≥3) of each entity's name prefix-matches a source token (either direction, so `Anna` ↔ `Annas` for German inflection). Catches hallucinations (`Hans Filbinger`, `Kleinenbroich`) that share no token with a dialog that never names them.
3. **Predicate→object-type contract** — regex-keyed heuristic table in `knowledge_graph.yaml`. Kinship verbs → person, location verbs → place. Unknown predicates **allowed** (open vocabulary is deliberate — the table must not become a back-door closed enum). Catches type mismatches.
4. **Confidence floor 0.5** — defense-in-depth, pinned to the prompt's advertised `0.5-1.0` range so it never drops a relation emitted as instructed.

Empirically rejects 10 of the 11 2026-05-26 incident relations. The 11th — `Anna mag Mango` (Eduard's preference misattributed to Anna) — is an attribution error the validator can't see because "Anna" genuinely appears in the dialog. That's fixed at the prompt layer (speaker-identity binding); the root-cause investigation (`tasks/kg-entity-collapse-investigation.md`) confirmed it lives upstream of dedup, not in `resolve_entity`. **That prompt fix is a separate follow-up PR.**

## /review applied (2 adversarial reviewers, converged)

Both flagged the same two **data-loss** bugs — the class the user explicitly said must not happen (KG-from-chat is a MUST HAVE):

- **F1 (HIGH):** grounding checked the *resolved canonical* name with all-words-required. `resolve_entity` merges a spoken "Eduard" into a stored "Eduard van den Bongard", so the genuine relation got dropped. **Fixed** — ground on the discriminating token, not every word.
- **F2 (HIGH):** floor 0.6 contradicted the prompt's `0.5-1.0` and caught zero incident relations. **Fixed** — lowered to 0.5, pinned to the prompt range.
- F3/F4 (MED/LOW): loose short-token over-acceptance + subject-type unchecked. These are over-*acceptance* (let marginal rows through), not data loss — left as documented trade-offs. The substring fast-path that let `Ada` ⊂ `Kanada` was removed.

The reviewers also **refuted** a feared latent bug (that `get_config` can't read root-level yaml keys) — verified it does, so the validator runs with real config, not silently-empty.

## Config degrades fail-open

Missing/malformed yaml → default floor + empty type rules (rule 3 passes everything) rather than blocking all writes.

## Test plan

- [x] `.159`: `test_kg_validator.py` **33/33** — incl. the 11-incident regression, German-inflection edge cases, the canonical-name-merge case (F1), the `Ada`/`Kanada` case (F3), and `TestYamlHeuristicsMatchProduction` (loads + enforces the shipped yaml)
- [x] `.159`: 3 service integration tests pass with `asyncio_mode=auto` — no regression on the existing `Edi lives_in Berlin` path + 2 new drop-the-garbage tests
- [ ] After merge + deploy: watch a family-facts chat session, confirm no new self-loops/hallucinations AND that legitimate facts still land (the F1 fix is the thing to eyeball)

## NOT in scope

- Speaker-identity prompt fix for the attribution error (separate PR — the 11th relation)
- P2 source-span provenance (separate, multi-day)
- `_resolve_owner_user_id` consolidation (#36)

🤖 Generated with [Claude Code](https://claude.com/claude-code)