### PR TITLE
docs: cross-cluster LLM/voice ingress exposure + IP-allowlist hardening

### DIFF
--- a/docs/KUBERNETES_DEPLOYMENT.md
+++ b/docs/KUBERNETES_DEPLOYMENT.md
@@ -190,6 +190,35 @@ Satellites and browsers resolve `renfield.local` via multicast DNS. The `mdns-re
 
 For clients whose resolvers bypass mDNS (e.g., `getent hosts renfield.local` via DNS-only on some systems), the site's upstream DNS also carries the record.
 
+## Cross-cluster service exposure (LLM / voice)
+
+Some GPU-backed services in the `renfield` namespace are exposed to **other clusters** on the LAN over Traefik `*.test.local` hostnames (VIP `192.168.1.230`), not just to in-cluster pods. Today the external consumer is the **Reva** prod cluster (`192.168.99.0/24`), which uses this cluster as its router/embeddings + voice tier:
+
+| Hostname | Backend Service | Port | External consumer |
+|---|---|---|---|
+| `ollama.test.local` | `ollama` | 11434 | Reva router / embeddings |
+| `voice.test.local` | `voice-server` | 8080 | Reva voice (`VOICE_SERVER_URL`) |
+| `llama-agent.test.local` | `llama-server-agent` | 8080 | (dormant — agent normally scaled to 0) |
+
+> In-cluster Renfield (`backend`) reaches these same services via the ClusterIP Services (`voice-server:8080`, `ollama:11434`) and does **not** use these ingresses.
+
+**Security — IP allowlist.** `ollama`/`llama-server` have no built-in auth, so these ingresses are gated by a Traefik `IPAllowList` middleware (`llm-ingress-allowlist`, namespace `renfield`) restricting the source to the consuming cluster's subnet — otherwise any LAN host could drive unauthenticated, uncapped inference on the GPU (DoS / cost-abuse).
+
+```yaml
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata: { name: llm-ingress-allowlist, namespace: renfield }
+spec:
+  ipAllowList:
+    sourceRange:
+      - 192.168.99.0/24      # Reva prod cluster (append new consumer subnets here)
+```
+Attached per-ingress via `traefik.ingress.kubernetes.io/router.middlewares: renfield-llm-ingress-allowlist@kubernetescrd`.
+
+**Prerequisite:** `traefik-web-service` must run `externalTrafficPolicy: Local`. With MetalLB-L2 + the default `Cluster` policy, kube-proxy SNATs the client to a node IP before Traefik sees it, so `IPAllowList` (which matches the direct TCP remote) would gate node IPs and fail silently. The consuming cluster appears by its **node** LAN IP (Calico `natOutgoing` SNATs the pod IP), so allowlist on the node subnet, not pod IPs.
+
+Manifests live in the cluster repo (`private_k8s/renfield-llm-voice-ingress.yaml`, `private_k8s/traefik.yaml`). Cross-referenced from Reva at `docs/operations/security-hardening.md` §11.
+
 ## Deploy Sequence
 
 ```bash

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -144,6 +144,16 @@ The circuit breaker protects against cascading failures when the LLM or agent lo
 
 Implementation: `src/backend/utils/circuit_breaker.py`
 
+## Cross-Cluster LLM/Voice Ingress Allowlist
+
+When GPU services in the `renfield` namespace are exposed to **other clusters** over Traefik `*.test.local` ingresses (e.g. acting as the LLM/voice tier for a Reva prod cluster — see [KUBERNETES_DEPLOYMENT.md](KUBERNETES_DEPLOYMENT.md#cross-cluster-service-exposure-llm--voice)), those endpoints must be IP-restricted. `ollama` / `llama-server` have **no built-in auth**, so an open `*.test.local` ingress lets any LAN host drive unauthenticated, uncapped inference on the GPU (DoS / cost-abuse).
+
+**Control:** a Traefik `IPAllowList` middleware (`llm-ingress-allowlist`) on each external LLM/voice ingress, `sourceRange` = the consuming cluster's node subnet.
+
+**Prerequisite:** `traefik-web-service` must use `externalTrafficPolicy: Local`. With MetalLB-L2 + the default `Cluster` policy, kube-proxy SNATs the client to a node IP before Traefik sees it, defeating any source-IP allowlist. Because Calico `natOutgoing` SNATs the consumer's pod IP to its node IP, allowlist the **node** subnet (not pod CIDRs — clusters often share the `172.16/16` pod range).
+
+> In-cluster consumers use the ClusterIP Services directly and are unaffected by this gate.
+
 ## Secrets Management
 
 Production uses Docker Compose file-based secrets (`/run/secrets/`) instead of `.env` for sensitive values. See [SECRETS_MANAGEMENT.md](SECRETS_MANAGEMENT.md) for details.


### PR DESCRIPTION
## What

Documents the security model for exposing GPU services (`ollama` / `voice-server` / `llama-server-agent`) to **other clusters** over Traefik `*.test.local` ingresses — the topology where this cluster acts as the LLM/voice tier for a Reva prod cluster.

These endpoints have **no built-in auth**, so an open `*.test.local` ingress lets any LAN host drive unauthenticated, uncapped inference on the GPU (DoS / cost-abuse). This was tracked as TD-21 on the Reva side and is now closed by a Traefik `IPAllowList` middleware.

## Changes (docs only)

- **`docs/KUBERNETES_DEPLOYMENT.md`** — new *"Cross-cluster service exposure (LLM/voice)"* section: the exposed-ingress table, the `IPAllowList` middleware, the `externalTrafficPolicy: Local` prerequisite, the node-IP-not-pod-CIDR caveat, and the note that in-cluster consumers use ClusterIP Services and are unaffected.
- **`docs/SECURITY.md`** — new *"Cross-Cluster LLM/Voice Ingress Allowlist"* section.

## Why the `externalTrafficPolicy: Local` note matters

With MetalLB-L2 + the default `Cluster` policy, kube-proxy SNATs every external client to a node IP before Traefik sees it, so a source-IP allowlist silently gates node IPs instead of the real client. The consuming cluster also appears by its **node** IP (Calico `natOutgoing` SNATs the pod IP), and prod/test clusters often share the `172.16/16` pod CIDR — so the allowlist must key on the node subnet, not pod IPs.

The manifests themselves live in the cluster repo (`private_k8s`); this PR is the platform-doc counterpart. Cross-referenced from Reva at `docs/operations/security-hardening.md` §11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)