### PR TITLE
feat(rag): make force-OCR opt-in in the purge script (Schicht A T-A0-3)

### DIFF
--- a/bin/purge_low_quality_chunks.py
+++ b/bin/purge_low_quality_chunks.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python3
 """
-Purge low-quality chunks — re-OCR transition tool.
+Purge low-quality chunks — reprocess transition tool.
+
+Default: reprocess low-quality docs through the normal quality gate, which OCRs
+only when the text layer is garbled/absent (and unions the raw text layer in,
+per Schicht A T-A0-2). Pass ``--force-ocr`` ONLY for a batch you know is
+genuinely scanned/garbled — forcing OCR on a good digital PDF degrades it by
+dropping positioned text-layer tokens. (Historically this script hardcoded
+force_ocr=True, which degraded text-layer PDFs; that is now opt-in.)
 
 ASCII flow:
 
@@ -20,8 +27,10 @@ ASCII flow:
                                                        │ yes
                                                        ▼
                                 ┌──────────────────────────────────────┐
-                                │ has_force_ocr_succeeded(doc)?        │ ─yes→ skip
-                                │ (history idempotence guard)          │
+                                │ already processed? (idempotence)     │ ─yes→ skip
+                                │  force mode: has_force_ocr_succeeded │
+                                │  default:    has_successful_gate_    │
+                                │              reprocess               │
                                 └──────────────────────┬───────────────┘
                                                        │ no
                                                        ▼
@@ -39,7 +48,8 @@ ASCII flow:
                                                        │ acquired
                                                        ▼
                                 ┌──────────────────────────────────────┐
-                                │ rag.reindex_document(force_ocr=True, │
+                                │ rag.reindex_document(                │
+                                │   force_ocr=args.force_ocr,          │
                                 │   trigger=SCRIPT_PURGE)              │
                                 │ → history row written by track()     │
                                 └──────────────────────┬───────────────┘
@@ -59,8 +69,15 @@ Safety:
       the two writers race. Mitigation: run the script in an offline
       window with no user-driven reindexes.
     - Dry-run by DEFAULT. Pass ``--apply`` to mutate.
-    - Idempotent across runs: ``has_force_ocr_succeeded`` skips any doc
-      already re-OCR'd, regardless of when.
+    - Gate-decides by DEFAULT. Pass ``--force-ocr`` only for genuinely
+      scanned/garbled batches (forcing OCR on a good text-layer PDF degrades it).
+    - Idempotent in BOTH modes (repeated runs converge):
+      * ``--force-ocr``: ``has_force_ocr_succeeded`` skips docs already force-OCR'd.
+      * default: ``has_successful_gate_reprocess`` skips docs already
+        gate-reprocessed (a ``force_ocr=false`` script_purge success). Old
+        ``force_ocr=true`` rows do NOT count, so a previously force-OCR'd doc is
+        still reprocessed ONCE (recovering text-layer tokens an earlier forced
+        run dropped), then skipped thereafter.
     - Per-doc fault isolation: a single failure is logged and the loop
       continues with the next doc.
 
@@ -159,6 +176,15 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Min # of low-quality chunks in a document to make it a candidate. "
         "Default 1 (any).",
     )
+    p.add_argument(
+        "--force-ocr",
+        action="store_true",
+        help="Force full-page OCR on reprocess (ignores the embedded text layer). "
+        "DEFAULT OFF: reprocess via the normal quality gate, which OCRs only when "
+        "the text layer is garbled/absent. Forcing OCR on a good digital PDF "
+        "DEGRADES it (drops positioned text-layer tokens — see Schicht A T-A0-2). "
+        "Use this only for a batch you KNOW is genuinely scanned/garbled.",
+    )
     return p
 
 
@@ -256,10 +282,12 @@ async def _process_one(
     *,
     apply: bool,
     reason_threshold: int,
+    force_ocr: bool,
 ) -> str:
     """Process one document; returns a result code for the run summary.
 
-    Result codes: ``skipped_already_re_ocrd``, ``skipped_below_threshold``,
+    Result codes: ``skipped_already_re_ocrd`` (force mode),
+    ``skipped_already_reprocessed`` (default mode), ``skipped_below_threshold``,
     ``skipped_locked_by_script``, ``skipped_row_locked``, ``would_purge``
     (dry-run), ``purged`` (apply), ``error``.
     """
@@ -271,11 +299,21 @@ async def _process_one(
         if low_q < reason_threshold:
             return "skipped_below_threshold"
 
-        # Idempotence: has any prior force_ocr=True succeeded for this doc?
+        # Idempotence guards (both ensure repeated runs converge):
+        #   --force-ocr mode: skip docs already force-OCR'd (don't re-force).
+        #   default mode:     skip docs already GATE-reprocessed (force_ocr=false
+        #                     script_purge success). A doc's *old* force_ocr=true
+        #                     rows do NOT count here, so the recovery pass still
+        #                     reprocesses the previously force-OCR'd corpus once;
+        #                     after that the force_ocr=false row makes it skip.
         hist = DocumentProcessingHistoryService(session)
-        if await hist.has_force_ocr_succeeded(doc_id):
-            logger.info("doc_id=%s already re-OCR'd → skip", doc_id)
-            return "skipped_already_re_ocrd"
+        if force_ocr:
+            if await hist.has_force_ocr_succeeded(doc_id):
+                logger.info("doc_id=%s already force-OCR'd → skip", doc_id)
+                return "skipped_already_re_ocrd"
+        elif await hist.has_successful_gate_reprocess(doc_id):
+            logger.info("doc_id=%s already gate-reprocessed → skip", doc_id)
+            return "skipped_already_reprocessed"
 
         if not apply:
             logger.info(
@@ -318,10 +356,14 @@ async def _process_one(
             rag = RAGService(session)
             await rag.reindex_document(
                 document_id=doc_id,
-                force_ocr=True,
+                force_ocr=force_ocr,
                 trigger=ProcessingTrigger.SCRIPT_PURGE,
             )
-            logger.info("doc_id=%s purged + re-OCR'd", doc_id)
+            logger.info(
+                "doc_id=%s purged + reprocessed (%s)",
+                doc_id,
+                "forced OCR" if force_ocr else "gate-decided",
+            )
             return "purged"
         except Exception as e:
             # Per-doc fault isolation — log and let the caller continue.
@@ -371,6 +413,7 @@ async def _run(args: argparse.Namespace) -> int:
                 doc_id,
                 apply=args.apply,
                 reason_threshold=args.reason_threshold,
+                force_ocr=args.force_ocr,
             )
             counters[code] = counters.get(code, 0) + 1
 

--- a/src/backend/services/document_processing_history.py
+++ b/src/backend/services/document_processing_history.py
@@ -216,6 +216,35 @@ class DocumentProcessingHistoryService:
         )
         return bool(result.scalar())
 
+    async def has_successful_gate_reprocess(self, document_id: int) -> bool:
+        """True iff a COMPLETED ``script_purge`` history row exists for this doc
+        with ``force_ocr=false`` — i.e. the cleanup script already reprocessed it
+        in gate-decided (non-forced) mode.
+
+        Default-mode idempotence guard for ``bin/purge_low_quality_chunks.py``:
+        the first gate reprocess runs (recovering a doc an earlier *forced* run
+        may have degraded), then subsequent runs skip it so repeated runs
+        converge. Deliberately distinct from ``has_force_ocr_succeeded`` — old
+        ``force_ocr=true`` rows do NOT count, so the recovery pass still
+        reprocesses the previously force-OCR'd corpus exactly once. (``trigger``
+        is quoted — it is a Postgres reserved word.)
+        """
+        result = await self.db.execute(
+            text(
+                """
+                SELECT EXISTS (
+                    SELECT 1 FROM document_processing_history
+                    WHERE document_id = :document_id
+                      AND force_ocr = false
+                      AND "trigger" = 'script_purge'
+                      AND status = 'completed'
+                )
+                """
+            ),
+            {"document_id": document_id},
+        )
+        return bool(result.scalar())
+
     async def latest(self, document_id: int) -> DocumentProcessingHistory | None:
         """Most-recent history row for a doc by ``started_at``. For admin UX
         (deferred item C)."""

--- a/src/backend/services/rag_service.py
+++ b/src/backend/services/rag_service.py
@@ -1038,9 +1038,11 @@ class RAGService:
         the same Document row (no new row created — distinct from
         ``ingest_document``, which always inserts).
 
-        ``force_ocr`` flips Docling's full-page OCR on; the cleanup script
-        calls this with ``force_ocr=True, trigger=SCRIPT_PURGE`` so the
-        history row records both the engine choice and the trigger.
+        ``force_ocr`` flips Docling's full-page OCR on. The cleanup script
+        (``bin/purge_low_quality_chunks.py``) passes ``trigger=SCRIPT_PURGE``
+        and ``force_ocr=False`` by DEFAULT (gate-decides) — only ``--force-ocr``
+        passes ``True``. Forcing OCR on a good text-layer PDF degrades it
+        (Schicht A T-A0-2/T-A0-3); the history row records both engine + trigger.
 
         ``parent_chunk_id`` self-FK was promoted to ``ON DELETE CASCADE`` in
         pc20260530 — the bulk delete below relies on that for the

--- a/tests/backend/test_purge_low_quality_chunks.py
+++ b/tests/backend/test_purge_low_quality_chunks.py
@@ -61,10 +61,15 @@ class TestArgValidation:
         assert ns.limit is None
         assert ns.batch_size == 500
         assert ns.reason_threshold == 1
+        assert ns.force_ocr is False  # T-A0-3: gate-decides by default, no blanket force-OCR
 
     def test_apply_flag(self):
         ns = purge._build_parser().parse_args(["--apply"])
         assert ns.apply is True
+
+    def test_force_ocr_flag(self):
+        ns = purge._build_parser().parse_args(["--force-ocr"])
+        assert ns.force_ocr is True
 
     def test_batch_size_zero_rejected(self):
         ns = purge._build_parser().parse_args(["--batch-size", "0"])
@@ -196,6 +201,7 @@ class TestPgIntegration:
                 doc_id=doc.id,
                 apply=False,
                 reason_threshold=1,
+                force_ocr=False,
             )
 
         assert code == "would_purge"
@@ -204,13 +210,13 @@ class TestPgIntegration:
     async def test_below_threshold_skipped(self, committing_session):
         doc = await _make_doc_with_chunks(committing_session, good_chunks=2, bad_chunks=0)
         code = await purge._process_one(
-            lock_conn=None, doc_id=doc.id, apply=False, reason_threshold=1,
+            lock_conn=None, doc_id=doc.id, apply=False, reason_threshold=1, force_ocr=False,
         )
         assert code == "skipped_below_threshold"
 
-    async def test_already_re_ocrd_skipped(self, committing_session):
-        """has_force_ocr_succeeded must short-circuit even in dry-run mode
-        so the operator sees an honest report of what still needs work."""
+    async def test_already_force_ocrd_skipped_in_force_mode(self, committing_session):
+        """In --force-ocr mode, has_force_ocr_succeeded short-circuits so we
+        don't re-force a doc already force-OCR'd."""
         doc = await _make_doc_with_chunks(committing_session, bad_chunks=2)
         # Pre-seed the history table with a completed force_ocr row.
         svc = DocumentProcessingHistoryService(committing_session)
@@ -218,15 +224,43 @@ class TestPgIntegration:
         await svc.close_success(hid, 5, 2, "docling_full_page_ocr")
 
         code = await purge._process_one(
-            lock_conn=None, doc_id=doc.id, apply=False, reason_threshold=1,
+            lock_conn=None, doc_id=doc.id, apply=False, reason_threshold=1, force_ocr=True,
         )
         assert code == "skipped_already_re_ocrd"
+
+    async def test_default_mode_reprocesses_previously_force_ocrd(self, committing_session):
+        """T-A0-3: in default (gate-decided) mode, a doc with a prior successful
+        force-OCR is NOT skipped — it is reprocessed so it can recover text-layer
+        tokens an earlier forced run dropped (the doc-44 degradation class)."""
+        doc = await _make_doc_with_chunks(committing_session, bad_chunks=2)
+        svc = DocumentProcessingHistoryService(committing_session)
+        hid = await svc.open(doc.id, force_ocr=True, trigger=ProcessingTrigger.SCRIPT_PURGE)
+        await svc.close_success(hid, 5, 2, "docling_full_page_ocr")
+
+        code = await purge._process_one(
+            lock_conn=None, doc_id=doc.id, apply=False, reason_threshold=1, force_ocr=False,
+        )
+        assert code == "would_purge"  # NOT skipped — old force_ocr=true row doesn't count
+
+    async def test_default_mode_skips_already_gate_reprocessed(self, committing_session):
+        """T-A0-3 convergence: once a doc has a successful gate reprocess
+        (force_ocr=false script_purge), default mode skips it so repeated runs
+        terminate instead of re-deleting + re-embedding it every run."""
+        doc = await _make_doc_with_chunks(committing_session, bad_chunks=2)
+        svc = DocumentProcessingHistoryService(committing_session)
+        hid = await svc.open(doc.id, force_ocr=False, trigger=ProcessingTrigger.SCRIPT_PURGE)
+        await svc.close_success(hid, 5, 2, "docling")
+
+        code = await purge._process_one(
+            lock_conn=None, doc_id=doc.id, apply=False, reason_threshold=1, force_ocr=False,
+        )
+        assert code == "skipped_already_reprocessed"
 
     async def test_reason_threshold_gating(self, committing_session):
         """A doc with 1 bad chunk should be skipped when --reason-threshold 3."""
         doc = await _make_doc_with_chunks(committing_session, bad_chunks=1)
         code = await purge._process_one(
-            lock_conn=None, doc_id=doc.id, apply=False, reason_threshold=3,
+            lock_conn=None, doc_id=doc.id, apply=False, reason_threshold=3, force_ocr=False,
         )
         assert code == "skipped_below_threshold"
 
@@ -254,10 +288,12 @@ class TestPgIntegration:
                     doc_id=doc.id,
                     apply=True,
                     reason_threshold=1,
+                    force_ocr=False,
                 )
             assert code == "purged"
             mock_reindex.assert_awaited_once()
-            assert mock_reindex.call_args.kwargs["force_ocr"] is True
+            # T-A0-3: default path reprocesses WITHOUT forcing OCR (gate decides).
+            assert mock_reindex.call_args.kwargs["force_ocr"] is False
             assert mock_reindex.call_args.kwargs["trigger"] == ProcessingTrigger.SCRIPT_PURGE
         finally:
             await lock_conn.close()


### PR DESCRIPTION
## What & why

`bin/purge_low_quality_chunks.py` hardcoded `reindex_document(force_ocr=True)` for every low-quality doc. T-A0-2 (#637) proved forced full-page OCR **degrades good-text-layer PDFs** — it drops positioned text-layer tokens (the doc-44 deadline). This was the v2.10.7 cleanup that lost text-layer content corpus-wide. The reindex API route already defaulted `force_ocr=False`; this script was the **only bulk `force_ocr=True` caller** in the repo.

## Change

- `--force-ocr` flag, **default OFF**. Default path reprocesses through the normal quality gate (OCRs only when the text layer is garbled/absent).
- `reindex_document(force_ocr=args.force_ocr)`; docstring + ASCII flow updated.

## Convergence (review F1)

Both modes are now idempotent so repeated runs terminate:
- `--force-ocr`: `has_force_ocr_succeeded` skips docs already force-OCR'd.
- default: **new** `has_successful_gate_reprocess` skips docs already gate-reprocessed (a `force_ocr=false` script_purge success). Old `force_ocr=true` rows deliberately do **not** count — so the **T-A0-4** recovery pass reprocesses the previously-force-OCR'd corpus exactly **once**, then converges. Without this, a doc that stayed low-quality after a gate reprocess would be re-deleted + re-embedded every run forever.

Also corrected the stale `reindex_document` docstring (review F5).

## Validation

- Arg-parse tests **9/9 on `.159`**; collection clean with the new history method.
- New raw SQL (reserved-word `"trigger"` column, quoted) **validated against the live Postgres**.
- DB-backed `_process_one` behavior tests (incl. both convergence tests) are Postgres-only and **skip in the `.159` container** — they need a full-Postgres run (same gap as #637).

## Reviewed

`/review` (Claude structured + adversarial; Codex unavailable): F1 convergence + F5 docstring fixed and folded in; F3/F4 verified safe.

## Sequencing note
**T-A0-4 (run this script to recover the corpus) has no effect until T-A0-2 (#637) is deployed** — the current prod image has no poppler, so reprocessing now would re-chunk Docling-only and still drop the positioned tokens. Order: merge #637 + this → build/deploy the poppler-utils image → T-A0-4 → T-A0-5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)