### PR TITLE
fix(worker): pin redis socket_timeout > block window — redis-py 8.0 crashloop

### DIFF
--- a/src/backend/services/task_queue.py
+++ b/src/backend/services/task_queue.py
@@ -17,8 +17,22 @@ from typing import Any
 
 import redis.asyncio as aioredis
 from loguru import logger
+from redis.exceptions import TimeoutError as RedisTimeoutError
 
 from utils.config import settings
+
+# redis-py 8.0 changed DEFAULT_SOCKET_TIMEOUT from None to 5s. A client built via
+# from_url() WITHOUT an explicit socket_timeout therefore applies a 5s read timeout
+# to EVERY command — including the blocking ``XREADGROUP ... BLOCK 5000`` in
+# DocumentTaskQueue.read_one(), whose 5s server-side block then races the 5s socket
+# timeout, loses, raises redis.exceptions.TimeoutError, and disconnects the socket on
+# essentially every idle poll (this crashlooped the document worker after the image
+# floated redis to 8.0.0). We pin an explicit socket_timeout STRICTLY GREATER than
+# read_one's block window: the empty BLOCK reply then always arrives before the read
+# times out (returns [] cleanly, connection reused), while xack/xadd/heartbeat still
+# get a sane finite timeout instead of hanging forever. MUST stay > the largest
+# block_ms read_one is ever called with (currently 5_000ms). Verified vs redis-py 8.0.0.
+_REDIS_SOCKET_TIMEOUT_S = 15
 
 
 class TaskQueue:
@@ -143,7 +157,9 @@ class DocumentTaskQueue:
         visibility_ms: int = DEFAULT_VISIBILITY_MS,
     ):
         self.redis_client = redis_client or aioredis.from_url(
-            settings.redis_url, decode_responses=True
+            settings.redis_url,
+            decode_responses=True,
+            socket_timeout=_REDIS_SOCKET_TIMEOUT_S,
         )
         self.consumer_id = consumer_id
         self.stream_key = stream_key
@@ -186,13 +202,28 @@ class DocumentTaskQueue:
     async def read_one(self, block_ms: int = 5_000) -> StreamEntry | None:
         """Block for up to ``block_ms`` ms waiting for a task. Returns
         ``None`` if the window closed with no new entry."""
-        result = await self.redis_client.xreadgroup(
-            groupname=self.group_name,
-            consumername=self.consumer_id,
-            streams={self.stream_key: ">"},
-            count=1,
-            block=block_ms,
-        )
+        try:
+            result = await self.redis_client.xreadgroup(
+                groupname=self.group_name,
+                consumername=self.consumer_id,
+                streams={self.stream_key: ">"},
+                count=1,
+                block=block_ms,
+            )
+        except RedisTimeoutError:
+            # Defense-in-depth. The primary fix is _REDIS_SOCKET_TIMEOUT_S being
+            # set > block_ms at client construction, so a normal idle poll returns
+            # [] (handled below), NOT a timeout. Reaching here means a single read
+            # exceeded the socket timeout (~15s) — redis is genuinely pathological
+            # (overloaded / packets dropped while TCP stays up). Degrade to "no
+            # task" so the worker retries instead of crashing, but WARN so the
+            # stall is visible rather than silently masked.
+            logger.warning(
+                f"DocumentTaskQueue.read_one: redis read timed out after "
+                f">{_REDIS_SOCKET_TIMEOUT_S}s (block_ms={block_ms}); treating as no "
+                f"task. Redis may be overloaded or unreachable at the socket layer."
+            )
+            return None
         if not result:
             return None
         # XREADGROUP returns [(stream_name, [(entry_id, {field: value}), ...])]

--- a/src/backend/workers/document_processor_worker.py
+++ b/src/backend/workers/document_processor_worker.py
@@ -39,7 +39,11 @@ from loguru import logger
 from services.database import AsyncSessionLocal
 from services.progress import DocumentProgress
 from services.rag_service import RAGService
-from services.task_queue import DocumentTaskQueue, StreamEntry
+from services.task_queue import (
+    _REDIS_SOCKET_TIMEOUT_S,
+    DocumentTaskQueue,
+    StreamEntry,
+)
 from utils.config import settings
 
 HEARTBEAT_KEY = "renfield:worker:document:heartbeat"
@@ -111,7 +115,15 @@ async def main() -> None:
     consumer = _pod_name()
     logger.info(f"document-worker starting (consumer={consumer!r})")
 
-    redis = aioredis.from_url(settings.redis_url, decode_responses=True)
+    # socket_timeout > read_one's block window — see _REDIS_SOCKET_TIMEOUT_S.
+    # This client is shared by the blocking read loop AND the heartbeat, so the
+    # explicit timeout must be set here too (passing the client in bypasses
+    # DocumentTaskQueue's own from_url default).
+    redis = aioredis.from_url(
+        settings.redis_url,
+        decode_responses=True,
+        socket_timeout=_REDIS_SOCKET_TIMEOUT_S,
+    )
     queue = DocumentTaskQueue(redis_client=redis, consumer_id=consumer)
     await queue.ensure_group()
 

--- a/tests/backend/test_task_queue.py
+++ b/tests/backend/test_task_queue.py
@@ -278,3 +278,86 @@ class TestClose:
         await queue.close()
 
         mock_redis.close.assert_called_once()
+
+
+# ============================================================================
+# DocumentTaskQueue.read_one — blocking long-poll semantics
+# ============================================================================
+
+
+@pytest.fixture
+def doc_queue(mock_redis):
+    """A DocumentTaskQueue bound to a mock Redis client (injected directly,
+    so no from_url patching needed)."""
+    from services.task_queue import DocumentTaskQueue
+
+    return DocumentTaskQueue(redis_client=mock_redis)
+
+
+class TestDocumentTaskQueueReadOne:
+    """``read_one`` long-polls with ``XREADGROUP BLOCK``. The window-expiry
+    path must yield ``None`` (no task) regardless of which redis-py the image
+    floated to."""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_redis_timeout(self, doc_queue, mock_redis):
+        """Regression: redis-py 8.0 RAISES ``redis.exceptions.TimeoutError`` when
+        a BLOCK read's window expires with no entry (7.x returned ``[]``). The
+        worker poll loop must not crashloop on this — it must read it as "no
+        task". See services/task_queue.py read_one."""
+        from redis.exceptions import TimeoutError as RedisTimeoutError
+
+        mock_redis.xreadgroup = AsyncMock(side_effect=RedisTimeoutError("Timeout reading from redis:6379"))
+
+        result = await doc_queue.read_one(block_ms=5_000)
+
+        assert result is None
+        mock_redis.xreadgroup.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_empty_result(self, doc_queue, mock_redis):
+        """7.x-style empty-window: xreadgroup returns a falsy result → None."""
+        mock_redis.xreadgroup = AsyncMock(return_value=[])
+
+        assert await doc_queue.read_one(block_ms=1) is None
+
+    @pytest.mark.asyncio
+    async def test_returns_entry_on_data(self, doc_queue, mock_redis):
+        """A real stream entry is parsed into a StreamEntry with decoded params."""
+        mock_redis.xreadgroup = AsyncMock(
+            return_value=[("renfield:tasks:document", [("1700000000000-0", {"payload": '{"document_id": 44}'})])]
+        )
+
+        entry = await doc_queue.read_one(block_ms=1)
+
+        assert entry is not None
+        assert entry.entry_id == "1700000000000-0"
+        assert entry.params == {"document_id": 44}
+
+    def test_client_socket_timeout_exceeds_block_window(self):
+        """Root-cause guard. redis-py 8.0 defaults socket_timeout to 5s; a client
+        built without an explicit one races read_one's 5s BLOCK and crashloops the
+        worker. The default-constructed client MUST carry an explicit socket_timeout
+        STRICTLY GREATER than read_one's default block window — assert both the
+        invariant and that the client actually got the value, so a future redis-py
+        default change (or a dropped kwarg) can't silently reintroduce the bug.
+
+        Uses a real lazy from_url client (no connection opened), so it runs without
+        a live redis."""
+        import inspect
+
+        from services.task_queue import DocumentTaskQueue, _REDIS_SOCKET_TIMEOUT_S
+
+        block_default_ms = inspect.signature(
+            DocumentTaskQueue.read_one
+        ).parameters["block_ms"].default
+        assert _REDIS_SOCKET_TIMEOUT_S > block_default_ms / 1000, (
+            f"socket_timeout {_REDIS_SOCKET_TIMEOUT_S}s must exceed block window "
+            f"{block_default_ms}ms or the blocking read races the socket timeout"
+        )
+
+        q = DocumentTaskQueue()  # real from_url, lazy — no socket opened
+        assert (
+            q.redis_client.connection_pool.connection_kwargs.get("socket_timeout")
+            == _REDIS_SOCKET_TIMEOUT_S
+        )


### PR DESCRIPTION
## Incident

The `document-worker` Deployment went into **CrashLoopBackOff** right after the v2.10.10 rollout. Root-caused to a transitive dependency drift, not the v2.10.10 feature code.

## Root cause

`requirements.txt` pins only `redis>=5.0.1` (no upper bound), so the rebuilt image floated to **redis-py 8.0.0**, which changed `DEFAULT_SOCKET_TIMEOUT` from `None` to **5 s**. A `from_url(...)` client built without an explicit `socket_timeout` now applies a 5 s read timeout to **every** command. `DocumentTaskQueue.read_one()` issues `XREADGROUP ... BLOCK 5000`; the 5 s server-side block races the 5 s socket timeout, loses, raises `redis.exceptions.TimeoutError`, and disconnects the socket on essentially **every idle poll** — uncaught, that exits `main()` and crashloops the worker.

Reproduced in the live cluster: blocking read raises consistently at ~5.00 s; `socket_timeout=None` or `socket_timeout=15` returns `[]` cleanly with the connection still usable. It's the only blocking redis read in the backend, which is why `backend`/`dlna-mcp` (same image) stayed healthy.

## Fix

Pin an explicit `socket_timeout = 15 s` (**strictly greater** than `read_one`'s block window) at every `from_url` site (`DocumentTaskQueue` + the worker's shared client):
- The empty `BLOCK` reply arrives before the read times out → returns `[]` cleanly, connection reused (no per-poll reconnect churn).
- `xack`/`xadd`/heartbeat get a sane finite timeout instead of the 5 s race that could silently abandon a just-finished OCR job in the PEL.

`read_one` keeps a now-rare `TimeoutError` catch as defense-in-depth (a read exceeding 15 s = genuinely pathological redis), but **WARN-logs** it so a stall is visible rather than silently masked.

## Tests

4 new `DocumentTaskQueue.read_one` tests: `timeout→None`, `empty→None`, `entry→parsed`, plus a **construction guard** asserting the client's `socket_timeout > block` so a future redis-py default change can't silently reintroduce the bug. Validated on .159: **28 passed** (`test_task_queue` + worker-path).

## Review

Ran `/review`; the adversarial pass correctly identified that a catch-only patch left the 5 s race on `ack`/heartbeat — this PR is the strengthened root-cause version that addresses it.

Ships as **v2.10.11**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>