### PR TITLE
fix(rag): hybrid-PDF OCR OOM + chunk-from-text-layer on font-decode failure

### DIFF
--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -2021,7 +2021,11 @@ class DocumentProcessingHistory(Base):
     force_ocr = Column(Boolean, nullable=False)
 
     # Nullable: legacy backfill rows + any caller that doesn't know.
-    # Values: 'easyocr' | 'docling_full_page_ocr' (set by document_processor).
+    # Values set by document_processor: 'docling' (standard convert) |
+    # 'docling_full_page_ocr' (forced full-page OCR) | 'poppler_text_layer'
+    # (chunked from the poppler text layer on a font-decode failure) |
+    # legacy 'easyocr'. Free text (no CHECK) — purely audit/display, no
+    # consumer branches on the value.
     ocr_engine = Column(String(50), nullable=True)
 
     chunks_produced = Column(Integer, nullable=True)

--- a/src/backend/services/document_processor.py
+++ b/src/backend/services/document_processor.py
@@ -5,6 +5,7 @@ Handles document parsing, chunking, and metadata extraction for RAG.
 Supports: PDF, DOCX, PPTX, XLSX, HTML, MD, TXT, and images.
 """
 import asyncio
+import gc
 import re
 import shutil
 import subprocess
@@ -62,7 +63,7 @@ class DocumentProcessor:
                 force_full_page_ocr=True,  # OCR auf jeder Seite, embedded Text ignoriert
                 bitmap_area_threshold=0.0,
             )
-            ocr_pipeline_options.images_scale = 2.0  # Höhere Auflösung für bessere OCR-Qualität
+            ocr_pipeline_options.images_scale = settings.rag_ocr_images_scale  # memory-vs-accuracy; see config
             self._ocr_converter = DocumentConverter(
                 format_options={
                     InputFormat.PDF: PdfFormatOption(pipeline_options=ocr_pipeline_options)
@@ -279,32 +280,41 @@ class DocumentProcessor:
             )
             chunks = chunk_result["chunks"]
             dropped = int(chunk_result.get("dropped_low_quality", 0))
-
-            # Per-chunk-rate trigger (sibling of doc-level _is_text_garbled):
-            # if more than rag_chunk_quality_drop_threshold of the emitted
-            # chunks failed the quality gate, the OCR run was probably bad
-            # at the chunk level even if it cleared the doc-level
-            # space-ratio check. Re-convert with force_full_page_ocr.
-            #
-            # Already-forced short-circuit: if this call was ALREADY
-            # invoked with force_ocr=True (or settings.rag_force_ocr) and
-            # the result still trips the per-chunk gate, retrying with
-            # the same setting will give the same result — fail fast with
-            # a distinctive error_message so the maintenance UI can
-            # surface it. Prevents the convergence loop the adversarial
-            # review flagged.
-            #
-            # Note on trigger chaining: when the doc-level _is_text_garbled
-            # path above (lines 173-188) already re-converted the doc, the
-            # NEW chunks may still trip this per-chunk trigger. That re-
-            # converts a second time with the same OCR engine — wasted
-            # GPU but bounded by the already-forced short-circuit (the
-            # second pass below sets force_ocr semantics implicitly via
-            # `_convert_document_ocr`). Worst case: 2 OCR retries on the
-            # same doc before failing. Acceptable cost for the recovery
-            # invariant.
             total_emitted = len(chunks) + dropped
             drop_rate = (dropped / total_emitted) if total_emitted else 0.0
+
+            # Schicht A text-layer extraction, computed ONCE here and reused by BOTH
+            # the re-OCR decision below and the field_text union at the end (a single
+            # poppler pdftotext pass, off the event loop). extract_text_layer returns
+            # "" for non-PDF / no text layer / missing binary, so tl_usable stays
+            # False and behaviour is unchanged for those inputs.
+            text_layer = await loop.run_in_executor(None, self.extract_text_layer, file_path)
+            tl_usable, tl_reason = (False, "absent")
+            if text_layer:
+                tl_usable, tl_reason = self.assess_text_layer_quality(
+                    text_layer, page_count=metadata.get("page_count") or 1
+                )
+
+            # Per-chunk-rate trigger (sibling of doc-level _is_text_garbled): when the
+            # chunker dropped more than rag_chunk_quality_drop_threshold of the emitted
+            # chunks, the conversion that produced them was bad. The RESPONSE depends
+            # on WHY:
+            #   * text layer USABLE → the Docling garbage is a font-decode failure
+            #     (subsetted no-ToUnicode font), NOT a scanned page. force_full_page_ocr
+            #     would re-rasterize and DROP the positioned text-layer tokens (deadline
+            #     dates, Steuernummer) — the exact Schicht A degradation. Chunk from the
+            #     text layer instead and SKIP OCR. Also sidesteps the OOM-prone double
+            #     conversion (two converters + page rasters > 6Gi). Trade-off: a hybrid
+            #     doc that is BOTH font-broken AND has image-only values loses the
+            #     image-only OCR recovery in chunks — rare, since a usable text layer
+            #     means the doc is digital, not scanned.
+            #   * else → genuinely scanned/garbled. Re-convert with force_full_page_ocr,
+            #     FREEING the Standard conversion first so peak memory holds one doc +
+            #     rasters, not two. If the retry ALSO trips → status='failed'.
+            #
+            # Already-forced short-circuit: a call ALREADY invoked with force_ocr=True
+            # that still trips would loop on retry → fail fast with a distinct
+            # error_message so the maintenance UI can tell "tried our best" apart.
             if drop_rate > settings.rag_chunk_quality_drop_threshold:
                 if use_ocr:
                     logger.error(
@@ -318,51 +328,79 @@ class DocumentProcessor:
                         "status": "failed",
                         "error": "ocr_quality_low_after_forced_ocr",
                     }
-                logger.info(
-                    f"Per-chunk quality trigger ({dropped}/{total_emitted} = "
-                    f"{drop_rate:.0%} > {settings.rag_chunk_quality_drop_threshold:.0%}) "
-                    f"— re-konvertiere {path.name} mit force_full_page_ocr"
-                )
-                ocr_result = await loop.run_in_executor(
-                    None, self._convert_document_ocr, file_path
-                )
-                if ocr_result is None:
-                    # The retry converter itself raised — distinct from
-                    # "retry produced still-bad chunks". Surfacing the
-                    # difference matters for triage: this branch means
-                    # the OCR engine choked on the file (corrupt PDF,
-                    # OOM, unsupported variant), not that our quality
-                    # heuristic is too strict.
-                    logger.error(
-                        f"OCR retry conversion FAILED (None result) for "
-                        f"{path.name} — ingesting nothing, marking failed"
+
+                if tl_usable:
+                    logger.info(
+                        f"Per-chunk quality trigger ({dropped}/{total_emitted} = "
+                        f"{drop_rate:.0%}) on {path.name}, but the embedded text layer "
+                        f"is usable ({tl_reason}) — chunking from the text layer and "
+                        f"skipping force-OCR (avoids dropping positioned tokens)"
                     )
-                    return {
-                        "metadata": metadata,
-                        "chunks": [],
-                        "status": "failed",
-                        "error": "ocr_retry_conversion_failed",
-                    }
-                doc = ocr_result.document
-                ocr_engine = "docling_full_page_ocr"
-                chunk_result = await loop.run_in_executor(
-                    None, self._create_chunks, doc
-                )
-                chunks = chunk_result["chunks"]
-                dropped = int(chunk_result.get("dropped_low_quality", 0))
-                total_emitted = len(chunks) + dropped
-                drop_rate = (dropped / total_emitted) if total_emitted else 0.0
-                if drop_rate > settings.rag_chunk_quality_drop_threshold:
-                    logger.error(
-                        f"OCR-quality still bad after retry: {path.name} "
-                        f"(drop_rate={drop_rate:.0%})"
+                    # Free the Standard Docling conversion; we chunk from text now.
+                    # ocr_result is nulled too: if the doc-level auto-detect block
+                    # above already re-OCR'd, it still holds that document tree —
+                    # without this, gc.collect() reclaims nothing and the fix is a
+                    # no-op on the auto-detect→trigger chained path.
+                    result = None
+                    doc = None
+                    ocr_result = None
+                    gc.collect()
+                    chunks = self._simple_chunk(text_layer)
+                    dropped = 0
+                    ocr_engine = "poppler_text_layer"
+                else:
+                    logger.info(
+                        f"Per-chunk quality trigger ({dropped}/{total_emitted} = "
+                        f"{drop_rate:.0%} > {settings.rag_chunk_quality_drop_threshold:.0%}) "
+                        f"— re-konvertiere {path.name} mit force_full_page_ocr"
                     )
-                    return {
-                        "metadata": metadata,
-                        "chunks": chunks,
-                        "status": "failed",
-                        "error": "ocr_quality_low",
-                    }
+                    # Free the Standard conversion BEFORE the OCR pass so peak memory
+                    # holds one doc tree + rasters, not two (the hybrid-doc OOM fix).
+                    # ocr_result is nulled too so an earlier auto-detect re-OCR doc is
+                    # reclaimed before the new converter loads (else the gc.collect()
+                    # frees nothing on the auto-detect→trigger chained path).
+                    result = None
+                    doc = None
+                    ocr_result = None
+                    gc.collect()
+                    ocr_result = await loop.run_in_executor(
+                        None, self._convert_document_ocr, file_path
+                    )
+                    if ocr_result is None:
+                        # The retry converter itself raised — distinct from "retry
+                        # produced still-bad chunks". This branch means the OCR engine
+                        # choked on the file (corrupt PDF, OOM, unsupported variant),
+                        # not that our quality heuristic is too strict.
+                        logger.error(
+                            f"OCR retry conversion FAILED (None result) for "
+                            f"{path.name} — ingesting nothing, marking failed"
+                        )
+                        return {
+                            "metadata": metadata,
+                            "chunks": [],
+                            "status": "failed",
+                            "error": "ocr_retry_conversion_failed",
+                        }
+                    doc = ocr_result.document
+                    ocr_engine = "docling_full_page_ocr"
+                    chunk_result = await loop.run_in_executor(
+                        None, self._create_chunks, doc
+                    )
+                    chunks = chunk_result["chunks"]
+                    dropped = int(chunk_result.get("dropped_low_quality", 0))
+                    total_emitted = len(chunks) + dropped
+                    drop_rate = (dropped / total_emitted) if total_emitted else 0.0
+                    if drop_rate > settings.rag_chunk_quality_drop_threshold:
+                        logger.error(
+                            f"OCR-quality still bad after retry: {path.name} "
+                            f"(drop_rate={drop_rate:.0%})"
+                        )
+                        return {
+                            "metadata": metadata,
+                            "chunks": chunks,
+                            "status": "failed",
+                            "error": "ocr_quality_low",
+                        }
 
             logger.info(
                 f"Dokument verarbeitet: {len(chunks)} Chunks erstellt "
@@ -374,22 +412,20 @@ class DocumentProcessor:
             # positioned tokens Docling drops (right-aligned dates, no-ToUnicode fonts).
             # Neither alone is complete on hybrid PDFs. RAG chunking is unaffected; this
             # only populates result["field_text"] for downstream field extractors.
-            # Run both blocking calls off the event loop (executor), matching how
-            # Docling conversion is dispatched above — a 60s pdftotext or a large
-            # export must not stall concurrent requests.
+            # text_layer + tl_usable were computed once above (reused, not re-run).
+            # On the text-layer-chunk path `doc` is None → docling_text is "" and
+            # field_text falls back to the (good) text layer alone.
             docling_text = ""
-            if hasattr(doc, "export_to_text"):
+            if doc is not None and hasattr(doc, "export_to_text"):
                 docling_text = await loop.run_in_executor(None, doc.export_to_text)
             field_text = docling_text
-            text_layer = await loop.run_in_executor(None, self.extract_text_layer, file_path)
-            if text_layer:
-                usable, reason = self.assess_text_layer_quality(
-                    text_layer, page_count=metadata.get("page_count") or 1
+            if text_layer and tl_usable:
+                field_text = (
+                    f"{docling_text}\n\n===TEXT-LAYER (raw)===\n{text_layer}"
+                    if docling_text else text_layer
                 )
-                if usable:
-                    field_text = f"{docling_text}\n\n===TEXT-LAYER (raw)===\n{text_layer}"
-                else:
-                    logger.info(f"Text-layer union skipped for {path.name}: {reason}")
+            elif text_layer and not tl_usable:
+                logger.info(f"Text-layer union skipped for {path.name}: {tl_reason}")
 
             return {
                 "metadata": metadata,

--- a/src/backend/services/document_processor.py
+++ b/src/backend/services/document_processor.py
@@ -329,6 +329,18 @@ class DocumentProcessor:
                         "error": "ocr_quality_low_after_forced_ocr",
                     }
 
+                # Both remaining branches discard the Standard conversion. Free it —
+                # plus any auto-detect re-OCR tree still held by ocr_result (lines
+                # ~263-268) — and gc.collect() BEFORE either chunking from the text
+                # layer or launching the force-OCR converter, so peak memory never
+                # holds two Docling document trees (the hybrid-doc OOM fix). collect()
+                # rather than relying on refcount drop because Docling trees are
+                # cycle-heavy (parent<->child node refs) and won't free on rebind.
+                result = None
+                doc = None
+                ocr_result = None
+                gc.collect()
+
                 if tl_usable:
                     logger.info(
                         f"Per-chunk quality trigger ({dropped}/{total_emitted} = "
@@ -336,17 +348,15 @@ class DocumentProcessor:
                         f"is usable ({tl_reason}) — chunking from the text layer and "
                         f"skipping force-OCR (avoids dropping positioned tokens)"
                     )
-                    # Free the Standard Docling conversion; we chunk from text now.
-                    # ocr_result is nulled too: if the doc-level auto-detect block
-                    # above already re-OCR'd, it still holds that document tree —
-                    # without this, gc.collect() reclaims nothing and the fix is a
-                    # no-op on the auto-detect→trigger chained path.
-                    result = None
-                    doc = None
-                    ocr_result = None
-                    gc.collect()
-                    chunks = self._simple_chunk(text_layer)
-                    dropped = 0
+                    # Apply the SAME per-chunk quality gate _create_chunks uses, so
+                    # this path can't ingest low-quality spans every other path drops,
+                    # and chunks_dropped_low_quality stays an honest audit signal.
+                    # A doc-level-usable text layer is overwhelmingly clean, so this
+                    # rarely drops anything — it's defense-in-depth, not the main act.
+                    from utils.content_quality import is_low_quality_text
+                    raw = self._simple_chunk(text_layer)
+                    chunks = [c for c in raw if not is_low_quality_text(c.get("text", ""))]
+                    dropped = len(raw) - len(chunks)
                     ocr_engine = "poppler_text_layer"
                 else:
                     logger.info(
@@ -354,15 +364,6 @@ class DocumentProcessor:
                         f"{drop_rate:.0%} > {settings.rag_chunk_quality_drop_threshold:.0%}) "
                         f"— re-konvertiere {path.name} mit force_full_page_ocr"
                     )
-                    # Free the Standard conversion BEFORE the OCR pass so peak memory
-                    # holds one doc tree + rasters, not two (the hybrid-doc OOM fix).
-                    # ocr_result is nulled too so an earlier auto-detect re-OCR doc is
-                    # reclaimed before the new converter loads (else the gc.collect()
-                    # frees nothing on the auto-detect→trigger chained path).
-                    result = None
-                    doc = None
-                    ocr_result = None
-                    gc.collect()
                     ocr_result = await loop.run_in_executor(
                         None, self._convert_document_ocr, file_path
                     )

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -301,6 +301,14 @@ class Settings(BaseSettings):
     rag_force_ocr: bool = False               # Always force full-page OCR (ignores embedded text)
     rag_ocr_auto_detect: bool = True          # Auto-detect garbled embedded text and re-run with OCR
     rag_ocr_space_threshold: float = 0.03    # Space ratio below this triggers auto OCR (default 3%)
+    # Page-raster scale for the force_full_page_ocr converter. Memory during a
+    # full-page-OCR pass scales ~quadratically with this (a multi-page PDF rasters
+    # every page at this factor). 2.0 doubled accuracy-vs-memory; dropped to 1.5 to
+    # keep the OCR re-conversion within the worker/backend 6Gi limit after a hybrid
+    # doc OOM'd ingestion (the Docling-default → force-OCR re-conversion held two
+    # converters + rasters at once). Raise toward 2.0 only if OCR accuracy regresses
+    # AND the memory limit is also raised.
+    rag_ocr_images_scale: float = Field(default=1.5, ge=0.5, le=4.0)
     # Per-chunk-rate trigger that complements rag_ocr_space_threshold.
     # When the chunker drops more than this fraction of chunks as
     # low-quality (utils.content_quality.is_low_quality_text), the

--- a/tests/backend/test_document_processor_quality.py
+++ b/tests/backend/test_document_processor_quality.py
@@ -414,9 +414,11 @@ class TestProcessDocumentTextLayerChunkPath:
         gc.collect() (regression guard for the lingering-reference leak)."""
         f = tmp_path / "hybrid.pdf"
         f.write_bytes(b"%PDF-1.4")
+        # Word-rich enough to clear the per-chunk quality gate (number-heavy text
+        # alone trips the low-wordlike-ratio filter — that's the gate working).
         clean = (
-            "Finanzverwaltung NRW. Steuernummer: 114/5876/5293. "
-            "Frist: 23.07.2026. " * 4
+            "Finanzverwaltung NRW Muenster. Ihre Steuernummer lautet "
+            "114/5876/5293. Die Frist zur Aktivierung endet am 23.07.2026. " * 4
         )
         # First chunking (of the auto-detect re-OCR'd doc) is 3/4 garbage → trigger.
         self._wire(
@@ -439,6 +441,99 @@ class TestProcessDocumentTextLayerChunkPath:
         processor._convert_document_ocr.assert_called_once()
         joined = " ".join(c["text"] for c in result["chunks"])
         assert "114/5876/5293" in joined
+
+    async def test_poppler_path_applies_quality_gate(
+        self, processor, tmp_path, monkeypatch
+    ):
+        """The poppler-chunk path runs the SAME per-chunk quality gate as
+        _create_chunks. A text layer the assessor called usable but whose
+        _simple_chunk output is low-quality is dropped, and
+        chunks_dropped_low_quality reflects it (NOT hardcoded 0) — so this path
+        can't ingest spans every other path rejects, and keeps the audit signal."""
+        f = tmp_path / "hybrid.pdf"
+        f.write_bytes(b"%PDF-1.4")
+        self._wire(
+            processor,
+            first_chunks=[GARBAGE_CHUNK, GARBAGE_CHUNK, GARBAGE_CHUNK, CLEAN_CHUNK],
+            text_layer=GARBAGE_CHUNK,   # single low-quality segment
+            tl_usable=True,
+        )
+        monkeypatch.setattr(
+            "services.document_processor.settings.rag_ocr_auto_detect", False
+        )
+
+        result = await processor.process_document(str(f), force_ocr=False)
+
+        assert result["status"] == "completed"
+        assert result["ocr_engine"] == "poppler_text_layer"
+        assert result["chunks"] == []                     # garbage span was gated out
+        assert result["chunks_dropped_low_quality"] == 1  # honest count, not 0
+
+    async def test_poppler_path_frees_memory_before_chunking(
+        self, processor, tmp_path, monkeypatch
+    ):
+        """OOM regression guard: the trigger path must release the Docling
+        conversion via gc.collect() before chunking from the text layer. Patches
+        gc.collect and asserts it ran — reverting the free+collect lines (the
+        actual memory fix) fails this test instead of silently passing."""
+        f = tmp_path / "hybrid.pdf"
+        f.write_bytes(b"%PDF-1.4")
+        clean = "Steuernummer 114/5876/5293, Frist 23.07.2026. " * 6
+        self._wire(
+            processor,
+            first_chunks=[GARBAGE_CHUNK, GARBAGE_CHUNK, GARBAGE_CHUNK, CLEAN_CHUNK],
+            text_layer=clean,
+            tl_usable=True,
+        )
+        collect_spy = MagicMock()
+        monkeypatch.setattr("services.document_processor.gc.collect", collect_spy)
+        monkeypatch.setattr(
+            "services.document_processor.settings.rag_ocr_auto_detect", False
+        )
+
+        result = await processor.process_document(str(f), force_ocr=False)
+
+        assert result["ocr_engine"] == "poppler_text_layer"
+        collect_spy.assert_called()   # conversion freed before chunking from text
+
+
+def test_ocr_converter_uses_configured_images_scale(monkeypatch):
+    """Wiring guard: the force-OCR converter must apply
+    settings.rag_ocr_images_scale, not a hardcoded constant. Captures the
+    PdfPipelineOptions the OCR converter is built from and asserts images_scale
+    came from settings — reverting line 66 to a literal fails this."""
+    import types
+
+    import services.document_processor as dp
+
+    captured = types.SimpleNamespace(opts=None)
+
+    class _Opts:
+        def __init__(self):
+            self.ocr_options = None
+            self.images_scale = None
+            captured.opts = self
+
+    # docling may be REAL in the test container, so stub the validating/heavy
+    # classes (_ensure_initialized imports them locally) and keep only the
+    # line-66 wiring under test: PdfPipelineOptions().images_scale = settings.…
+    pipeline_mod = sys.modules["docling.datamodel.pipeline_options"]
+    conv_mod = sys.modules["docling.document_converter"]
+    chunk_mod = sys.modules["docling.chunking"]
+    monkeypatch.setattr(pipeline_mod, "PdfPipelineOptions", _Opts, raising=False)
+    monkeypatch.setattr(
+        pipeline_mod, "EasyOcrOptions", lambda **k: MagicMock(), raising=False
+    )
+    monkeypatch.setattr(conv_mod, "PdfFormatOption", MagicMock, raising=False)
+    monkeypatch.setattr(conv_mod, "DocumentConverter", MagicMock, raising=False)
+    monkeypatch.setattr(chunk_mod, "HybridChunker", MagicMock, raising=False)
+    monkeypatch.setattr(dp.settings, "rag_ocr_images_scale", 1.25)
+
+    p = dp.DocumentProcessor()
+    p._ensure_initialized()
+
+    assert captured.opts is not None
+    assert captured.opts.images_scale == 1.25
 
 
 def test_images_scale_config_default_within_bounds():

--- a/tests/backend/test_document_processor_quality.py
+++ b/tests/backend/test_document_processor_quality.py
@@ -313,3 +313,138 @@ class TestProcessDocumentReOCRTrigger:
         assert result["chunks"] == []
         # Sanity: the converter was called exactly once for retry.
         assert processor._convert_document_ocr.call_count == 1
+
+
+# ============================== text-layer-chunk path (hybrid-PDF OOM/degrade fix)
+@pytest.mark.asyncio
+class TestProcessDocumentTextLayerChunkPath:
+    """When the per-chunk trigger fires but a poppler text layer is USABLE, the
+    Docling garbage is a font-decode failure (subsetted no-ToUnicode font), NOT a
+    scan. We chunk from the text layer and SKIP force-OCR — recovering positioned
+    tokens into the chunks AND avoiding the OOM-prone double conversion."""
+
+    def _wire(self, processor, *, first_chunks, text_layer, tl_usable, second_chunks=None):
+        result_obj = MagicMock()
+        result_obj.document = MagicMock()
+        result_obj.document.export_to_text = MagicMock(return_value="garbage docling export")
+        calls = {"n": 0}
+
+        def chunk_side_effect(d):
+            calls["n"] += 1
+            picked = first_chunks if calls["n"] == 1 else (second_chunks or [])
+            return iter([_mock_chunk(t, i) for i, t in enumerate(picked)])
+
+        processor._chunker.chunk.side_effect = chunk_side_effect
+        processor._convert_document = MagicMock(return_value=result_obj)
+        processor._convert_document_ocr = MagicMock(return_value=result_obj)
+        processor._extract_metadata = MagicMock(
+            return_value={"title": "t", "file_type": "pdf", "page_count": 1}
+        )
+        # Shadow the static/class methods on the instance to isolate the decision.
+        processor.extract_text_layer = MagicMock(return_value=text_layer)
+        processor.assess_text_layer_quality = MagicMock(
+            return_value=(tl_usable, "usable" if tl_usable else "garbled")
+        )
+
+    async def test_usable_text_layer_chunks_from_poppler_and_skips_ocr(
+        self, processor, tmp_path, monkeypatch
+    ):
+        """3/4 Docling garbage (trigger fires) + usable poppler text layer →
+        chunk from the text layer, ocr_engine='poppler_text_layer', and the
+        degrading force-OCR pass is NOT run. Recovered tokens land in the CHUNKS
+        (not just field_text)."""
+        f = tmp_path / "hybrid.pdf"
+        f.write_bytes(b"%PDF-1.4")
+        clean = (
+            "Finanzverwaltung NRW Muenster. Ihre Steuernummer: 114/5876/5293. "
+            "Datum: 17.04.2026. Frist zur Aktivierung: 23.07.2026. " * 4
+        )
+        self._wire(
+            processor,
+            first_chunks=[GARBAGE_CHUNK, GARBAGE_CHUNK, GARBAGE_CHUNK, CLEAN_CHUNK],
+            text_layer=clean,
+            tl_usable=True,
+        )
+        monkeypatch.setattr(
+            "services.document_processor.settings.rag_ocr_auto_detect", False
+        )
+
+        result = await processor.process_document(str(f), force_ocr=False)
+
+        assert result["status"] == "completed"
+        assert result["ocr_engine"] == "poppler_text_layer"
+        # The whole point: NO degrading force-OCR pass.
+        processor._convert_document_ocr.assert_not_called()
+        joined = " ".join(c["text"] for c in result["chunks"])
+        assert "114/5876/5293" in joined          # recovered token now retrievable in CHUNKS
+        assert "23.07.2026" in joined             # the dropped deadline date too
+        assert "114/5876/5293" in result["field_text"]
+
+    async def test_unusable_text_layer_still_force_ocrs(
+        self, processor, tmp_path, monkeypatch
+    ):
+        """Trigger fires but NO usable text layer (genuine scan) → the existing
+        force_full_page_ocr path runs unchanged."""
+        f = tmp_path / "scan.pdf"
+        f.write_bytes(b"%PDF-1.4")
+        self._wire(
+            processor,
+            first_chunks=[GARBAGE_CHUNK, GARBAGE_CHUNK, GARBAGE_CHUNK, CLEAN_CHUNK],
+            second_chunks=[CLEAN_CHUNK, CLEAN_CHUNK, CLEAN_CHUNK, CLEAN_CHUNK],
+            text_layer="",          # scan → no text layer
+            tl_usable=False,
+        )
+        monkeypatch.setattr(
+            "services.document_processor.settings.rag_ocr_auto_detect", False
+        )
+
+        result = await processor.process_document(str(f), force_ocr=False)
+
+        assert result["status"] == "completed"
+        assert result["ocr_engine"] == "docling_full_page_ocr"
+        processor._convert_document_ocr.assert_called_once()
+
+    async def test_auto_detect_then_trigger_takes_poppler_path(
+        self, processor, tmp_path, monkeypatch
+    ):
+        """Chained path the OOM leak lived on: the doc-level auto-detect re-OCR
+        fires FIRST (binding ocr_result), THEN the per-chunk trigger fires on the
+        re-OCR'd chunks. With a usable text layer it must still take the poppler
+        path — no SECOND force-OCR — and ocr_result must be released before
+        gc.collect() (regression guard for the lingering-reference leak)."""
+        f = tmp_path / "hybrid.pdf"
+        f.write_bytes(b"%PDF-1.4")
+        clean = (
+            "Finanzverwaltung NRW. Steuernummer: 114/5876/5293. "
+            "Frist: 23.07.2026. " * 4
+        )
+        # First chunking (of the auto-detect re-OCR'd doc) is 3/4 garbage → trigger.
+        self._wire(
+            processor,
+            first_chunks=[GARBAGE_CHUNK, GARBAGE_CHUNK, GARBAGE_CHUNK, CLEAN_CHUNK],
+            text_layer=clean,
+            tl_usable=True,
+        )
+        # Force the doc-level auto-detect branch to fire (binds ocr_result).
+        processor._is_text_garbled = MagicMock(return_value=True)
+        monkeypatch.setattr(
+            "services.document_processor.settings.rag_ocr_auto_detect", True
+        )
+
+        result = await processor.process_document(str(f), force_ocr=False)
+
+        assert result["status"] == "completed"
+        assert result["ocr_engine"] == "poppler_text_layer"
+        # Auto-detect re-OCR'd ONCE; the poppler path must not force-OCR again.
+        processor._convert_document_ocr.assert_called_once()
+        joined = " ".join(c["text"] for c in result["chunks"])
+        assert "114/5876/5293" in joined
+
+
+def test_images_scale_config_default_within_bounds():
+    """OOM knob: the force-OCR raster scale is configurable and defaults to a
+    value that keeps the re-conversion within the 6Gi limit."""
+    from utils.config import settings
+
+    assert 0.5 <= settings.rag_ocr_images_scale <= 4.0
+    assert settings.rag_ocr_images_scale == 1.5


### PR DESCRIPTION
## Problem

Two coupled defects surfaced on **hybrid PDFs** — digital documents whose text uses a subsetted, no-ToUnicode font that Docling/pymupdf cannot decode (→ garbage), where only poppler `pdftotext -layout` reads the content fully (e.g. doc-44: Steuernummer `114/5876/5293`, deadline `23.07.2026`).

1. **OOM (exit 137).** When the per-chunk quality trigger fired, the `force_full_page_ocr` re-conversion ran **while the Standard Docling conversion was still resident** — two converters + page rasters (`images_scale=2.0` ≈ 4× pixel memory) exceeded the 6Gi pod limit and OOM-killed ingestion (hit during the T-A0-4 canary on doc-44).

2. **Degradation.** `force_full_page_ocr` re-rasterizes the page and **drops the positioned text-layer tokens** (right-aligned dates, Steuernummer) that only poppler reads on these docs — the exact Schicht A degradation. Force-OCR was the wrong response to a font-decode failure.

## Fix

- **Memory:** the prior conversion (`result`/`doc`, plus any auto-detect re-OCR `ocr_result`) is dropped and `gc.collect()`'d **before** the OCR pass, so peak memory holds one doc tree, not two. Raster scale is now configurable via `rag_ocr_images_scale` (default **1.5**, down from a hardcoded 2.0; memory scales ~quadratically).
- **Degradation:** when the trigger fires but the embedded text layer is **usable**, the garbage is a font-decode failure, not a scan → chunk from the text layer (`ocr_engine="poppler_text_layer"`) and **skip** the degrading OCR pass. This recovers the positioned tokens into the **RAG chunks**, not just `field_text`.
- Genuinely-scanned docs (no usable text layer) take the existing force-OCR path **unchanged**.
- `extract_text_layer` is computed **once** and reused by both the re-OCR decision and the `field_text` union.

## Tests

6 new cases in `test_document_processor_quality.py`:
- usable text layer → poppler-chunk path, force-OCR skipped, tokens land in chunks **and** field_text
- unusable text layer → existing force-OCR path unchanged
- **auto-detect → per-chunk-trigger chained path** (regression guard for the lingering-`ocr_result` OOM leak found in review)
- `images_scale` config bound

**53 passed** (`test_document_processor_quality.py` + `test_document_processor.py`) on .159. `test_rag_service_quality.py` 5 passed after correcting stale build-box deps.

## Review

`/review` adversarial pass found a real leak: with the doc-level auto-detect re-OCR firing first, nulling `result`/`doc` left `ocr_result` referencing the doc tree, so `gc.collect()` freed nothing on exactly the chained path the fix targets. Fixed in both trigger branches + added the chained-path regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)