### PR TITLE
feat(hooks): filter_agent_tools seam for single-role web-chat tool filtering

### DIFF
--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -1339,6 +1339,19 @@ async def websocket_endpoint(
                         server_filter=role.mcp_servers,
                         internal_filter=role.internal_tools,
                     )
+                    # Per-request tool filtering seam (mirrors pre_sub_agent for
+                    # the orchestrator path). Lets a plugin restrict the tool set
+                    # using the classified role + sub_intent before the agent
+                    # loop — e.g. deterministic sub-intent → tool-set filtering.
+                    # run_hooks swallows handler errors, so a faulty filter just
+                    # leaves the registry unfiltered.
+                    from utils.hooks import run_hooks
+                    await run_hooks(
+                        "filter_agent_tools",
+                        registry=tool_registry,
+                        role=role,
+                        message=content,
+                    )
                     agent = AgentService(tool_registry, role=role)
                     executor = ActionExecutor(mcp_manager=mcp_manager, session_id=msg_session_id)
 

--- a/src/backend/utils/hooks.py
+++ b/src/backend/utils/hooks.py
@@ -261,6 +261,16 @@ HOOK_EVENTS: frozenset[str] = frozenset({
     "post_orchestration",
     "pre_sub_agent",
     "post_sub_agent",
+    # Per-request tool filtering for the MAIN agent loop — fired by the
+    # WebSocket chat handler right after AgentToolRegistry.create() and before
+    # AgentService runs, with the classified role (and its `sub_intent`) in
+    # scope. The orchestrator sub-agent path already has `pre_sub_agent`; this
+    # is the symmetric seam for the single-role web-chat loop. Handlers receive
+    # `registry`, `role`, `message` and may mutate `registry._tools` in place to
+    # restrict the tool set (e.g. deterministic sub-intent → tool-set filtering).
+    # Return value is ignored; exceptions are caught (run_hooks) so a faulty
+    # filter degrades to the unfiltered registry rather than breaking the turn.
+    "filter_agent_tools",
     "check_output",
     "extract_context_vars",
     "build_synthesis_context",

--- a/tests/backend/test_hooks.py
+++ b/tests/backend/test_hooks.py
@@ -49,6 +49,7 @@ def test_uplift_events_are_registerable():
         "pre_sub_agent",
         "post_sub_agent",
         "check_output",
+        "filter_agent_tools",
     }
     missing = uplift_events - HOOK_EVENTS
     assert not missing, (
@@ -57,6 +58,59 @@ def test_uplift_events_are_registerable():
     )
     for event in uplift_events:
         register_hook(event, AsyncMock())  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_filter_agent_tools_hook_can_narrow_registry():
+    """A plugin handler on `filter_agent_tools` may mutate the registry in place.
+
+    Mirrors the chat_handler call site: fired with `registry`, `role`, `message`
+    after AgentToolRegistry.create() and before the agent loop. Return value is
+    ignored; the handler restricts the tool set by mutating `registry._tools`.
+    """
+
+    class _Registry:
+        def __init__(self, names):
+            self._tools = {n: object() for n in names}
+
+    registry = _Registry(["a", "b", "c", "d"])
+    role = MagicMock()
+    role.name = "release"
+    role.sub_intent = "deliveries"
+
+    async def _filter(registry=None, role=None, message="", **kwargs):
+        # plugin keeps only tools tied to the classified sub-intent
+        keep = {"a", "b"}
+        for name in list(registry._tools):
+            if name not in keep:
+                registry._tools.pop(name, None)
+
+    register_hook("filter_agent_tools", _filter)
+    results = await run_hooks(
+        "filter_agent_tools", registry=registry, role=role, message="Zeige Deliveries"
+    )
+
+    assert results == []  # handler returns None → no opinion collected
+    assert set(registry._tools) == {"a", "b"}
+
+
+@pytest.mark.asyncio
+async def test_filter_agent_tools_faulty_handler_leaves_registry_unfiltered():
+    """A crashing filter degrades to the unfiltered registry (run_hooks fail-open)."""
+
+    class _Registry:
+        def __init__(self, names):
+            self._tools = {n: object() for n in names}
+
+    registry = _Registry(["a", "b", "c"])
+
+    async def _boom(**kwargs):
+        raise RuntimeError("bad filter config")
+
+    register_hook("filter_agent_tools", _boom)
+    await run_hooks("filter_agent_tools", registry=registry, role=MagicMock(), message="x")
+
+    assert set(registry._tools) == {"a", "b", "c"}  # untouched, no crash
 
 
 # --- run_hooks ---


### PR DESCRIPTION
## What

Adds a new `filter_agent_tools` hook event, fired by the WebSocket `chat_handler` right after `AgentToolRegistry.create()` and before `AgentService` runs, in the single-role (specialized agent loop) branch.

Handlers receive `registry`, `role`, `message` and may mutate `registry._tools` in place to restrict the tool set before the agent loop. The classified `role` carries its `sub_intent`, so a plugin can apply deterministic sub-intent → tool-set narrowing.

## Why

The web-chat agent loop had no seam to restrict the tool set between registry creation and the agent loop — only renfield's own LLM `_preselect_tools` ran, and it doesn't see the classified `sub_intent`. The orchestrator path already has the symmetric `pre_sub_agent` seam; this is its single-role equivalent.

This unblocks the Reva-side TD-02 follow-up: deterministic sub-intent tool filtering on web-chat, at parity with the Teams transport.

## Semantics

- **Fail-open:** `run_hooks` swallows handler exceptions, so a faulty filter degrades to the unfiltered registry rather than breaking the turn.
- **No platform default:** with no handler registered, behavior is unchanged (no-op).
- **Return value ignored:** the contract is mutate-in-place on `registry._tools`.
- Fires only in the agent-loop branch — not for dispatched sub-intents, conversation, or knowledge/RAG paths.

## Tests

`tests/backend/test_hooks.py`:
- `filter_agent_tools` added to the registerable uplift-events set (guards against the `register_hook` ValueError that would abort plugin bootstrap).
- `test_filter_agent_tools_hook_can_narrow_registry` — in-place registry narrowing, return value collected as `[]`.
- `test_filter_agent_tools_faulty_handler_leaves_registry_unfiltered` — fail-open on a crashing handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)