### PR TITLE
feat(reindex): async reindex via document-worker (fix 30s timeout + overlap corruption)

### DIFF
--- a/src/backend/api/routes/knowledge.py
+++ b/src/backend/api/routes/knowledge.py
@@ -660,6 +660,28 @@ async def reindex_document(
             if kb and not await check_kb_access(kb, user, "write", db):
                 raise HTTPException(status_code=403, detail="No write access to this document")
 
+    # Dedupe in-flight reindexes (/review finding): a double-click would enqueue
+    # a second user_reindex, and the worker would purge+rebuild twice — a wasted
+    # OCR pass and a second window where the doc has 0 chunks. If a reindex/ingest
+    # is already queued or running, return the in-flight doc so the client just
+    # tracks the existing run instead of starting another.
+    if doc.status in ("pending", "processing"):
+        response.status_code = 202
+        return DocumentResponse(
+            id=doc.id,
+            filename=doc.filename,
+            title=doc.title,
+            file_type=doc.file_type,
+            file_size=doc.file_size,
+            status=doc.status,
+            error_message=doc.error_message,
+            chunk_count=doc.chunk_count or 0,
+            page_count=doc.page_count,
+            knowledge_base_id=doc.knowledge_base_id,
+            created_at=doc.created_at.isoformat() if doc.created_at else "",
+            processed_at=doc.processed_at.isoformat() if doc.processed_at else None,
+        )
+
     if not await _worker_is_alive():
         raise HTTPException(
             status_code=503,

--- a/src/backend/api/routes/knowledge.py
+++ b/src/backend/api/routes/knowledge.py
@@ -629,44 +629,73 @@ async def delete_document(
 @router.post("/documents/{document_id}/reindex", response_model=DocumentResponse)
 async def reindex_document(
     document_id: int,
+    response: Response,
+    force_ocr: bool = False,
     rag: RAGService = Depends(get_rag_service),
     user: User | None = Depends(get_optional_user),
     db: AsyncSession = Depends(get_db)
 ):
-    """Re-indexiert ein Dokument (löscht alte Chunks und erstellt neue)"""
+    """Re-index a document **asynchronously** via the document-worker (#388).
+
+    Reindex used to run the full Docling/OCR pipeline INLINE in the request.
+    OCR is ~45 s/doc, well past the frontend's 30 s timeout, so the browser
+    errored while the backend kept working; repeat-clicks then spawned
+    OVERLAPPING reindexes that duplicated chunks and raced the Schicht-A fact
+    write-then-purge (observed: doc 43 → 36 chunks, 0 facts). Now it enqueues a
+    ``user_reindex`` task and returns 202. The worker is a single consumer, so
+    concurrent reindex requests for one doc are serialized — no timeout, no
+    overlap, double-clicks are harmless.
+    """
+    doc = await rag.get_document(document_id)
+    if not doc:
+        raise HTTPException(status_code=404, detail=f"Dokument {document_id} nicht gefunden")
     if settings.auth_enabled:
         if not user:
             raise HTTPException(status_code=401, detail="Authentication required")
-        doc = await rag.get_document(document_id)
-        if doc and doc.knowledge_base_id:
+        if doc.knowledge_base_id:
             result = await db.execute(
                 select(KnowledgeBase).where(KnowledgeBase.id == doc.knowledge_base_id)
             )
             kb = result.scalar_one_or_none()
             if kb and not await check_kb_access(kb, user, "write", db):
                 raise HTTPException(status_code=403, detail="No write access to this document")
-    try:
-        document = await rag.reindex_document(document_id)
 
-        return DocumentResponse(
-            id=document.id,
-            filename=document.filename,
-            title=document.title,
-            file_type=document.file_type,
-            file_size=document.file_size,
-            status=document.status,
-            error_message=document.error_message,
-            chunk_count=document.chunk_count or 0,
-            page_count=document.page_count,
-            knowledge_base_id=document.knowledge_base_id,
-            created_at=document.created_at.isoformat() if document.created_at else "",
-            processed_at=document.processed_at.isoformat() if document.processed_at else None
+    if not await _worker_is_alive():
+        raise HTTPException(
+            status_code=503,
+            detail="Dokument-Worker nicht verfügbar — bitte gleich erneut versuchen.",
         )
 
-    except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    # Flip to pending so the list/poll immediately shows it queued. The worker
+    # purges chunks + rebuilds (reindex_document) under the user_reindex trigger.
+    doc.status = "pending"
+    doc.error_message = None
+    await rag.db.commit()
+    await rag.db.refresh(doc)
+
+    queue = DocumentTaskQueue(redis_client=get_redis())
+    await queue.enqueue({
+        "document_id": doc.id,
+        "force_ocr": force_ocr,
+        "user_id": user.id if user else None,
+        "trigger": "user_reindex",
+    })
+
+    response.status_code = 202
+    return DocumentResponse(
+        id=doc.id,
+        filename=doc.filename,
+        title=doc.title,
+        file_type=doc.file_type,
+        file_size=doc.file_size,
+        status=doc.status,  # "pending"
+        error_message=None,
+        chunk_count=doc.chunk_count or 0,
+        page_count=doc.page_count,
+        knowledge_base_id=doc.knowledge_base_id,
+        created_at=doc.created_at.isoformat() if doc.created_at else "",
+        processed_at=None,
+    )
 
 
 @router.post("/documents/move")

--- a/src/backend/workers/document_processor_worker.py
+++ b/src/backend/workers/document_processor_worker.py
@@ -95,10 +95,28 @@ async def _process_entry(
 
     force_ocr = bool(entry.params.get("force_ocr", False))
     user_id = entry.params.get("user_id")
+    # trigger distinguishes an initial upload from an async user-reindex
+    # (#async-reindex). Absent → initial_ingest (back-compat with older entries).
+    trigger = str(entry.params.get("trigger") or "initial_ingest")
     progress = DocumentProgress(redis, doc_id)
     try:
         async with AsyncSessionLocal() as db:
             rag = RAGService(db)
+
+            if trigger == "user_reindex":
+                # Async reindex: ALWAYS reprocess. reindex_document purges the
+                # doc's chunks then rebuilds (records a user_reindex history row,
+                # which has no unique index). The worker is a single consumer, so
+                # concurrent reindex requests for one doc are serialized here —
+                # the overlap that duplicated chunks on the old inline path
+                # cannot happen.
+                await rag.reindex_document(
+                    doc_id, force_ocr=force_ocr, user_id=user_id,
+                )
+                await queue.ack(entry.entry_id)
+                logger.info(f"reindexed doc {doc_id} (entry {entry.entry_id})")
+                return
+
             history = DocumentProcessingHistoryService(db)
 
             # Idempotent consumer. The stream is at-least-once: reclaim_stale

--- a/src/frontend/src/api/resources/knowledge.ts
+++ b/src/frontend/src/api/resources/knowledge.ts
@@ -113,8 +113,11 @@ async function deleteDocumentRequest(id: number): Promise<void> {
   await apiClient.delete(`/api/knowledge/documents/${id}`);
 }
 
-async function reindexDocumentRequest(id: number): Promise<void> {
-  await apiClient.post(`/api/knowledge/documents/${id}/reindex`);
+async function reindexDocumentRequest(id: number): Promise<DocumentRow> {
+  // Async since #async-reindex: returns 202 + the doc row in `pending` so the
+  // caller can poll it to completion (was a synchronous, timeout-prone call).
+  const response = await apiClient.post<DocumentRow>(`/api/knowledge/documents/${id}/reindex`);
+  return response.data;
 }
 
 interface MoveDocumentsInput {

--- a/src/frontend/src/pages/KnowledgePage.tsx
+++ b/src/frontend/src/pages/KnowledgePage.tsx
@@ -249,12 +249,15 @@ export default function KnowledgePage() {
     }
   };
 
-  // Reindex document
+  // Reindex document — async (#async-reindex): the endpoint enqueues a
+  // user_reindex task and returns 202 with the doc in `pending`. Track it for
+  // polling so the row updates pending → processing → completed; onResolved
+  // reloads the list + invalidates facts so an open Fakten panel refreshes.
   const handleReindexDocument = async (id: number) => {
     try {
-      await reindexDocMutation.mutateAsync(id);
-      // D5: re-extraction is async — invalidate now so an open panel drops the
-      // stale set; the onResolved completion handler refetches once it finishes.
+      const doc = await reindexDocMutation.mutateAsync(id);
+      trackDocument(doc as KbDocument);
+      // Drop any stale facts immediately; onResolved refetches when done (D5).
       await queryClient.invalidateQueries({ queryKey: keys.brain.facts(id) });
     } catch {
       alert(t('knowledge.reindexFailed'));

--- a/tests/backend/test_document_worker_idempotent.py
+++ b/tests/backend/test_document_worker_idempotent.py
@@ -44,6 +44,7 @@ def _wire(monkeypatch, *, ingest_status: str | None):
 
     rag = MagicMock()
     rag.process_existing_document = AsyncMock()
+    rag.reindex_document = AsyncMock()
 
     progress = MagicMock()
     progress.set_stage = AsyncMock()
@@ -59,8 +60,11 @@ def _wire(monkeypatch, *, ingest_status: str | None):
     return db, rag, queue
 
 
-def _entry(doc_id: int = 5):
-    return types.SimpleNamespace(entry_id="1-0", params={"document_id": doc_id})
+def _entry(doc_id: int = 5, trigger: str | None = None):
+    params = {"document_id": doc_id}
+    if trigger is not None:
+        params["trigger"] = trigger
+    return types.SimpleNamespace(entry_id="1-0", params=params)
 
 
 async def test_completed_initial_ingest_is_skipped_and_acked(monkeypatch):
@@ -96,4 +100,18 @@ async def test_first_ingest_processes_without_purge(monkeypatch):
 
     db.execute.assert_not_called()  # no purge, no self-heal
     rag.process_existing_document.assert_awaited_once()
+    queue.ack.assert_awaited_once_with("1-0")
+
+
+async def test_user_reindex_always_reprocesses(monkeypatch):
+    """trigger=user_reindex must ALWAYS reprocess via reindex_document — even
+    when initial_ingest is completed (otherwise the idempotent-consumer guard
+    would wrongly skip every reindex). reindex_document purges+rebuilds; the
+    initial-ingest skip path must NOT run."""
+    db, rag, queue = _wire(monkeypatch, ingest_status=ProcessingStatus.COMPLETED.value)
+
+    await worker._process_entry(MagicMock(), queue, _entry(5, trigger="user_reindex"))
+
+    rag.reindex_document.assert_awaited_once()
+    rag.process_existing_document.assert_not_called()  # not the initial-ingest path
     queue.ack.assert_awaited_once_with("1-0")

--- a/tests/frontend/react/pages/KnowledgePage.test.tsx
+++ b/tests/frontend/react/pages/KnowledgePage.test.tsx
@@ -38,7 +38,8 @@ function wire() {
     if (url.includes('/facts')) return Promise.resolve(createMockResponse([]));
     return Promise.resolve(createMockResponse([]));
   });
-  mockedPost.mockResolvedValue(createMockResponse({}));
+  // Async reindex returns 202 + the doc row in 'pending' (trackDocument polls it).
+  mockedPost.mockResolvedValue(createMockResponse({ ...DOC, status: 'pending' }, 202));
 }
 
 describe('KnowledgePage Schicht A integration', () => {


### PR DESCRIPTION
## Problem
`POST /documents/{id}/reindex` ran the full Docling/OCR pipeline **inline** in the request. OCR is ~45s/doc, past the frontend's **30s axios timeout** → the browser errored on every OCR doc while the backend kept working. Reasonable repeat-clicks then spawned **overlapping** reindexes that duplicated chunks and raced the Schicht-A fact write-then-purge.

**Observed live:** doc 43 reindexed 3× from the UI → **36 chunks (3×12) + 0 facts**.

Uploads already solved this via the async worker (#388); reindex was left synchronous.

## Fix
- **Endpoint** enqueues a `user_reindex` task and returns **202** + the doc in `pending` (503 if no worker, mirroring upload). No inline OCR in the request path.
- **Worker** branches on the entry's `trigger`:
  - `user_reindex` → always reprocess via `reindex_document` (purge + rebuild). The worker is a **single consumer**, so concurrent reindex requests for one doc are **serialized** — the overlap that corrupted doc 43 cannot happen.
  - `initial_ingest` (default) → the existing idempotent-consumer guard (#648).
- **Frontend** `reindexDocumentRequest` returns the doc; `handleReindexDocument` tracks it for polling (pending → processing → completed); `onResolved` refetches the list + facts so an open Fakten panel refreshes.

Double-clicks are now harmless; OCR docs reindex reliably.

## Tests (green)
- Worker `user_reindex` branch: always reprocesses even when `initial_ingest` is completed (otherwise the idempotent guard would wrongly skip every reindex). + skip/purge/first-ingest branches.
- `KnowledgePage` reindex test updated for the 202 + track-for-polling flow. Frontend suite green.

## Follow-up (not in this PR)
doc 43 is corrupted (36 chunks, 0 facts) from the old inline overlap — needs one clean reindex (via this new async path) to repair, after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)