### PR TITLE
feat(router): lint sub_intent utterances that shadow a role utterance

### DIFF
--- a/src/backend/services/semantic_router.py
+++ b/src/backend/services/semantic_router.py
@@ -27,6 +27,37 @@ _KEYWORD_BOOST: dict[str, list[str]] = {}
 _KEYWORD_BOOST_AMOUNT = 0.15
 
 
+def find_shadowed_sub_intent_utterances(
+    roles: dict[str, "AgentRole"],
+) -> dict[tuple[str, str], list[str]]:
+    """Find sub_intent utterances that are byte-identical to a role utterance.
+
+    ``classify`` indexes role-level and sub_intent utterances together and breaks
+    a tie in favour of the role (strict ``>`` — see the sub_intent loop). So a
+    sub_intent utterance that exactly equals one of its parent role's utterances
+    ties at sim=1.000 and the role always wins: the sub_intent is *never* selected
+    for that phrasing. That is almost always a config mistake (the sub_intent's
+    dispatch handler or tool filter silently never fires for those words).
+
+    Returns ``{(role, sub_intent): [shadowed utterances]}`` for any such overlap.
+    Pure/side-effect-free so it is cheap to unit-test; ``initialize`` calls it and
+    logs a WARNING per offending sub_intent.
+    """
+    shadowed: dict[tuple[str, str], list[str]] = {}
+    for name, role in roles.items():
+        role_utts = {str(u) for u in (role.utterances or [])}
+        if not role_utts:
+            continue
+        for si_name, si_def in (role.sub_intent_definitions or {}).items():
+            if not isinstance(si_def, dict):
+                continue
+            si_utts = {str(u) for u in (si_def.get("utterances") or [])}
+            overlap = sorted(role_utts & si_utts)
+            if overlap:
+                shadowed[(name, si_name)] = overlap
+    return shadowed
+
+
 class SemanticRouter:
     """Embedding-based fast classifier for agent routing.
 
@@ -87,6 +118,20 @@ class SemanticRouter:
 
         self._ollama_client = client
         self._initialized = True
+
+        # Lint: a sub_intent utterance identical to a role-level utterance can
+        # never win the sim=1.000 tie (ties go to the role in classify), so the
+        # sub_intent silently never fires for that phrasing. Surface it loudly
+        # at init rather than letting a plugin's dispatch/tool-filter no-op.
+        for (rname, siname), overlap in find_shadowed_sub_intent_utterances(roles).items():
+            logger.warning(
+                f"SemanticRouter: sub_intent '{rname}/{siname}' has "
+                f"{len(overlap)} utterance(s) identical to role-level utterances "
+                f"of '{rname}': {overlap}. These tie at sim=1.000 and ties go to "
+                f"the role, so '{rname}/{siname}' will NEVER be classified for "
+                f"those phrasings — move them out of the role's utterances."
+            )
+
         total_utterances = (
             sum(len(v) for v in self._role_embeddings.values())
             + sum(len(v) for v in self._sub_intent_embeddings.values())

--- a/tests/backend/test_semantic_router.py
+++ b/tests/backend/test_semantic_router.py
@@ -1,0 +1,104 @@
+"""Tests for SemanticRouter helpers.
+
+Covers ``find_shadowed_sub_intent_utterances`` — the init-time lint that catches
+sub_intent utterances which are byte-identical to a role-level utterance (they
+tie at sim=1.000 and ``classify`` breaks ties toward the role, so the sub_intent
+silently never fires for that phrasing).
+"""
+
+import pytest
+
+from services.agent_router import AgentRole
+from services.semantic_router import find_shadowed_sub_intent_utterances
+
+
+def _role(name, utterances=None, sub_intents=None):
+    return AgentRole(
+        name=name,
+        description={"en": name, "de": name},
+        utterances=utterances,
+        sub_intent_definitions=sub_intents,
+    )
+
+
+@pytest.mark.unit
+class TestFindShadowedSubIntentUtterances:
+    def test_detects_exact_duplicate(self):
+        roles = {
+            "release": _role(
+                "release",
+                utterances=["Show me active deliveries", "Show release details"],
+                sub_intents={
+                    "deliveries": {
+                        "utterances": ["Show me active deliveries", "Show tracked items"]
+                    }
+                },
+            )
+        }
+        result = find_shadowed_sub_intent_utterances(roles)
+        assert result == {("release", "deliveries"): ["Show me active deliveries"]}
+
+    def test_clean_config_returns_empty(self):
+        roles = {
+            "release": _role(
+                "release",
+                utterances=["Show release details"],
+                sub_intents={"deliveries": {"utterances": ["Show tracked items"]}},
+            )
+        }
+        assert find_shadowed_sub_intent_utterances(roles) == {}
+
+    def test_role_without_utterances_skipped(self):
+        roles = {
+            "release": _role(
+                "release",
+                utterances=None,
+                sub_intents={"deliveries": {"utterances": ["Show tracked items"]}},
+            )
+        }
+        assert find_shadowed_sub_intent_utterances(roles) == {}
+
+    def test_multiple_overlaps_sorted(self):
+        roles = {
+            "release": _role(
+                "release",
+                utterances=["Who is in the release team?", "Resolve team members", "Show folders"],
+                sub_intents={
+                    "teams": {
+                        "utterances": [
+                            "Resolve team members",
+                            "Who is in the release team?",
+                            "Who is the QA?",
+                        ]
+                    }
+                },
+            )
+        }
+        result = find_shadowed_sub_intent_utterances(roles)
+        assert result == {
+            ("release", "teams"): ["Resolve team members", "Who is in the release team?"]
+        }
+
+    def test_non_dict_sub_intent_def_is_ignored(self):
+        # sub_intent_definitions occasionally carries non-dict values (raw desc);
+        # the lint must not crash on them.
+        roles = {"release": _role("release", utterances=["x"], sub_intents={"bogus": "not-a-dict"})}
+        assert find_shadowed_sub_intent_utterances(roles) == {}
+
+    def test_only_offending_sub_intent_reported(self):
+        roles = {
+            "release": _role(
+                "release",
+                utterances=["dup phrase", "role only"],
+                sub_intents={
+                    "good": {"utterances": ["unique phrase"]},
+                    "bad": {"utterances": ["dup phrase"]},
+                },
+            )
+        }
+        result = find_shadowed_sub_intent_utterances(roles)
+        assert result == {("release", "bad"): ["dup phrase"]}
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What

Adds `find_shadowed_sub_intent_utterances(roles)` to `semantic_router.py` and calls it from `SemanticRouter.initialize`, logging a WARNING per offending sub_intent at startup.

## Why

`classify` indexes role-level and per-role sub_intent utterances together and breaks ties toward the **role** (strict `>` in the sub_intent loop). So a sub_intent utterance that is **byte-identical** to one of its parent role's utterances ties at sim=1.000 and the role always wins — the sub_intent is **never** classified for that phrasing. Any dispatch handler or tool filter keyed on it then silently no-ops, with no signal anywhere.

This bit a downstream plugin (Reva): three filtered sub-intents (`release/deliveries`, `release/teams`, `jira/agile`) had their most common phrasings duplicated at the role level, so the deterministic tool filter never fired for them and quietly fell back to LLM pre-selection. The misconfig was invisible until a live dogfood.

## What it does

- `find_shadowed_sub_intent_utterances` is pure / side-effect-free → cheap to unit-test.
- `initialize` logs one WARNING per offending `(role, sub_intent)`, naming the exact shadowed phrases and the fix ("move them out of the role's utterances").
- Renfield's own `config/agent_roles.yaml` ships **0 utterances / 0 sub_intents**, so this is a no-op until a plugin adds utterance-bearing sub_intents — it's a guardrail for plugin authors, not a behavior change.

## Tests

`tests/backend/test_semantic_router.py` — 6 unit cases: exact dup, clean config, role-without-utterances, multiple overlaps (sorted), non-dict sub_intent def (robustness), only-offender-reported. All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)