### PR TITLE
fix(schicht-a): raise LLM num_predict + salvage truncated JSON (doc 43 lost 13 facts)

### DIFF
--- a/src/backend/services/schicht_a_extractor.py
+++ b/src/backend/services/schicht_a_extractor.py
@@ -373,13 +373,17 @@ def _parse_llm_json(raw: str) -> dict | None:
 def _salvage_truncated_json(s: str) -> dict | None:
     """Best-effort recovery of a truncated JSON object.
 
-    Scan with a bracket stack; remember the last position that sits on a clean
-    boundary (just after a complete nested container, or between array
-    elements); cut there, drop the half-written trailing entry, and append the
-    missing closers. Returns a dict or None. Cuts only at array-element / nested-
-    container boundaries (never mid-object-field), so recovered entries are
-    structurally whole; ``_facts_from_payload`` tolerates any that still lack
-    optional fields."""
+    Scan with a bracket stack; remember the last position just after a complete
+    nested container closes (parent still open); cut there, drop the half-written
+    trailing entry, and append the missing closers. Returns a dict or None.
+
+    The cut point is ONLY a container-close boundary — never a comma. Cutting at
+    a comma would land inside a truncated *nested* array (e.g. ``"items":[10,20``)
+    and force-close it as if complete, emitting a plausible-but-wrong value. The
+    close-only rule guarantees the recovered prefix ends at a structurally AND
+    semantically complete element; ``_facts_from_payload`` tolerates any that
+    still lack optional fields. (A truncated first element therefore recovers
+    nothing — accepted: better None than corrupt.)"""
     if not s or s[0] != "{":
         return None
     stack: list[str] = []
@@ -403,8 +407,6 @@ def _salvage_truncated_json(s: str) -> dict | None:
                 stack.pop()
             if stack:  # closed a nested container, parent still open → clean cut
                 cut = i + 1
-        elif ch == "," and stack and stack[-1] == "[":  # between array elements
-            cut = i
     if cut is None:
         return None
     candidate = s[:cut]

--- a/src/backend/services/schicht_a_extractor.py
+++ b/src/backend/services/schicht_a_extractor.py
@@ -239,16 +239,20 @@ class SchichtAExtractor:
 
         client = self._llm_client or get_default_client()
         classification_kwargs = get_classification_chat_kwargs(model)
+        # No num_predict by default (settings value 0) → let the model generate
+        # to completion (bounded by the server context). A fixed cap truncated
+        # rich docs → unparseable JSON → lost facts. Set >0 only to bound a
+        # misbehaving model.
+        options: dict[str, Any] = {"temperature": 0.1}
+        if settings.schicht_a_extraction_num_predict > 0:
+            options["num_predict"] = settings.schicht_a_extraction_num_predict
         response = await client.chat(
             model=model,
             messages=[
                 {"role": "system", "content": system},
                 {"role": "user", "content": user},
             ],
-            options={
-                "temperature": 0.1,
-                "num_predict": settings.schicht_a_extraction_num_predict,
-            },
+            options=options,
             **classification_kwargs,
         )
         raw = extract_response_content(response) or ""
@@ -373,20 +377,29 @@ def _parse_llm_json(raw: str) -> dict | None:
 def _salvage_truncated_json(s: str) -> dict | None:
     """Best-effort recovery of a truncated JSON object.
 
-    Scan with a bracket stack; remember the last position just after a complete
-    nested container closes (parent still open); cut there, drop the half-written
-    trailing entry, and append the missing closers. Returns a dict or None.
+    Scan with a bracket stack and remember the last position that sits on a clean
+    boundary, cut there, drop the half-written trailing entry, and append the
+    missing closers. Returns a dict or None.
 
-    The cut point is ONLY a container-close boundary — never a comma. Cutting at
-    a comma would land inside a truncated *nested* array (e.g. ``"items":[10,20``)
-    and force-close it as if complete, emitting a plausible-but-wrong value. The
-    close-only rule guarantees the recovered prefix ends at a structurally AND
-    semantically complete element; ``_facts_from_payload`` tolerates any that
-    still lack optional fields. (A truncated first element therefore recovers
-    nothing — accepted: better None than corrupt.)"""
+    A boundary is recorded in two cases:
+      1. just after a nested container closes (``}``/``]`` with a parent still
+         open), and
+      2. at a comma **between elements of the OUTERMOST array** only
+         (``arr_depth == 1``).
+
+    The depth gate on (2) is the load-bearing rule: a comma inside a *nested*
+    array (``arr_depth >= 2``, e.g. ``"items":[10,20,30,40``) is NOT a cut point,
+    so a truncated nested array is never force-closed as a complete (wrong)
+    value — its whole enclosing element is dropped via (1) instead. (1) alone
+    can't recover the elements of a truncated top-level array of SCALARS (they
+    don't close with a bracket), which is why (2) is kept rather than removed.
+    ``_facts_from_payload`` tolerates any recovered entry that still lacks
+    optional fields; a truncated FIRST element recovers nothing (None beats
+    corrupt)."""
     if not s or s[0] != "{":
         return None
     stack: list[str] = []
+    arr_depth = 0  # number of currently-open '[' (so we can gate comma cuts)
     in_str = esc = False
     cut: int | None = None
     for i, ch in enumerate(s):
@@ -400,13 +413,27 @@ def _salvage_truncated_json(s: str) -> dict | None:
             continue
         if ch == '"':
             in_str = True
-        elif ch in "{[":
+        elif ch == "{":
             stack.append(ch)
-        elif ch in "}]":
+        elif ch == "[":
+            stack.append(ch)
+            arr_depth += 1
+        elif ch == "}":
             if stack:
                 stack.pop()
             if stack:  # closed a nested container, parent still open → clean cut
                 cut = i + 1
+        elif ch == "]":
+            if stack:
+                stack.pop()
+            if arr_depth > 0:
+                arr_depth -= 1
+            if stack:
+                cut = i + 1
+        elif ch == "," and arr_depth == 1 and stack and stack[-1] == "[":
+            # between elements of the OUTERMOST array — a clean boundary.
+            # Gated to depth 1 so a truncated nested array can't be cut here.
+            cut = i
     if cut is None:
         return None
     candidate = s[:cut]

--- a/src/backend/services/schicht_a_extractor.py
+++ b/src/backend/services/schicht_a_extractor.py
@@ -245,7 +245,10 @@ class SchichtAExtractor:
                 {"role": "system", "content": system},
                 {"role": "user", "content": user},
             ],
-            options={"temperature": 0.1, "num_predict": 1200},
+            options={
+                "temperature": 0.1,
+                "num_predict": settings.schicht_a_extraction_num_predict,
+            },
             **classification_kwargs,
         )
         raw = extract_response_content(response) or ""
@@ -328,7 +331,13 @@ def _facts_from_payload(payload: dict) -> list[ExtractedFact]:
 
 def _parse_llm_json(raw: str) -> dict | None:
     """Parse an LLM response to a dict; tolerate markdown fences + surrounding
-    prose. Returns None if nothing parseable (caller treats as failure)."""
+    prose. Returns None if nothing parseable (caller treats as failure).
+
+    Defense-in-depth: if the strict parse fails — overwhelmingly because the
+    response was truncated at the token cap mid-JSON (unbalanced braces / an
+    unterminated string) — fall back to ``_salvage_truncated_json`` so the
+    complete leading entries survive instead of discarding the whole batch
+    (the old behavior, which cost doc 43 all 14 of its facts)."""
     if not raw:
         return None
     text = raw.strip()
@@ -339,11 +348,88 @@ def _parse_llm_json(raw: str) -> dict | None:
         if text.endswith("```"):
             text = text[:-3]
         text = text.strip()
-    first, last = text.find("{"), text.rfind("}")
-    if first < 0 or last <= first:
+    first = text.find("{")
+    if first < 0:
         return None
+    body = text[first:]
+    last = body.rfind("}")
+    if last > 0:
+        try:
+            parsed = json.loads(body[:last + 1])
+            if isinstance(parsed, dict):
+                return parsed
+        except json.JSONDecodeError:
+            pass
+    salvaged = _salvage_truncated_json(body)
+    if salvaged is not None:
+        logger.warning(
+            "Schicht A: LLM JSON unparseable (likely truncated at the token "
+            "cap) — salvaged %d complete obligation(s) from the partial payload",
+            len(salvaged.get("obligations") or []),
+        )
+    return salvaged
+
+
+def _salvage_truncated_json(s: str) -> dict | None:
+    """Best-effort recovery of a truncated JSON object.
+
+    Scan with a bracket stack; remember the last position that sits on a clean
+    boundary (just after a complete nested container, or between array
+    elements); cut there, drop the half-written trailing entry, and append the
+    missing closers. Returns a dict or None. Cuts only at array-element / nested-
+    container boundaries (never mid-object-field), so recovered entries are
+    structurally whole; ``_facts_from_payload`` tolerates any that still lack
+    optional fields."""
+    if not s or s[0] != "{":
+        return None
+    stack: list[str] = []
+    in_str = esc = False
+    cut: int | None = None
+    for i, ch in enumerate(s):
+        if in_str:
+            if esc:
+                esc = False
+            elif ch == "\\":
+                esc = True
+            elif ch == '"':
+                in_str = False
+            continue
+        if ch == '"':
+            in_str = True
+        elif ch in "{[":
+            stack.append(ch)
+        elif ch in "}]":
+            if stack:
+                stack.pop()
+            if stack:  # closed a nested container, parent still open → clean cut
+                cut = i + 1
+        elif ch == "," and stack and stack[-1] == "[":  # between array elements
+            cut = i
+    if cut is None:
+        return None
+    candidate = s[:cut]
+    # Recompute the still-open containers for the candidate and close them.
+    st: list[str] = []
+    in_str = esc = False
+    for ch in candidate:
+        if in_str:
+            if esc:
+                esc = False
+            elif ch == "\\":
+                esc = True
+            elif ch == '"':
+                in_str = False
+            continue
+        if ch == '"':
+            in_str = True
+        elif ch in "{[":
+            st.append(ch)
+        elif ch in "}]":
+            if st:
+                st.pop()
+    closers = "".join("}" if c == "{" else "]" for c in reversed(st))
     try:
-        parsed = json.loads(text[first:last + 1])
+        parsed = json.loads(candidate + closers)
     except json.JSONDecodeError:
         return None
     return parsed if isinstance(parsed, dict) else None

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -336,11 +336,15 @@ class Settings(BaseSettings):
     # the obligation/alert layer that consumes these facts isn't wired yet.
     schicht_a_extraction_enabled: bool = False
     schicht_a_extraction_model: str = ""             # empty => ollama_chat_model || ollama_model
-    # Output-token budget for the obligation/universal LLM pass. 1200 truncated
-    # the JSON on content-rich docs (e.g. multi-line-item invoices) → unparseable
-    # → all LLM facts silently lost (doc 43: 0 instead of 14). 4096 fits realistic
-    # household docs; the parser also salvages a truncated tail as defense-in-depth.
-    schicht_a_extraction_num_predict: int = 4096
+    # Output-token cap for the obligation/universal LLM pass. The old fixed 1200
+    # cap (→ OpenAI max_tokens) silently truncated rich docs' JSON → unparseable
+    # → all LLM facts lost (doc 43: 1 vs 14). Output size tracks fact DENSITY, not
+    # doc size, so no fixed cap is safe. 0 = no cap: let the model generate to
+    # completion, bounded by the server context (verified: the densest real doc,
+    # an invoice, completes at ~3.2k chars well within context). Set >0 only to
+    # deliberately bound a misbehaving model. The parser also salvages a truncated
+    # tail as defense-in-depth.
+    schicht_a_extraction_num_predict: int = 0
 
     # Conversation Memory (Long-term)
     memory_enabled: bool = False                                             # Opt-in

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -336,6 +336,11 @@ class Settings(BaseSettings):
     # the obligation/alert layer that consumes these facts isn't wired yet.
     schicht_a_extraction_enabled: bool = False
     schicht_a_extraction_model: str = ""             # empty => ollama_chat_model || ollama_model
+    # Output-token budget for the obligation/universal LLM pass. 1200 truncated
+    # the JSON on content-rich docs (e.g. multi-line-item invoices) → unparseable
+    # → all LLM facts silently lost (doc 43: 0 instead of 14). 4096 fits realistic
+    # household docs; the parser also salvages a truncated tail as defense-in-depth.
+    schicht_a_extraction_num_predict: int = 4096
 
     # Conversation Memory (Long-term)
     memory_enabled: bool = False                                             # Opt-in

--- a/tests/backend/test_schicht_a_extractor.py
+++ b/tests/backend/test_schicht_a_extractor.py
@@ -33,6 +33,8 @@ from services.schicht_a_extractor import (  # noqa: E402
     _facts_from_payload,
     _parse_amount,
     _parse_date,
+    _parse_llm_json,
+    _salvage_truncated_json,
     extract_identifiers,
     normalize_field_text,
 )
@@ -250,3 +252,50 @@ class TestExtract:
         result = await SchichtAExtractor(llm_client=client).extract("   ", lang="de")
         assert result.facts == []
         client.chat.assert_not_called()
+
+
+# ===================================================== truncated-JSON salvage
+class TestSalvageTruncatedJson:
+    """num_predict truncation cut the LLM JSON mid-object → strict parse failed
+    → the whole batch was discarded (doc 43 lost all 14 facts). The salvage
+    recovers the complete leading entries instead."""
+
+    # Mirrors the real doc-43 failure: two complete obligations, then a third
+    # cut off mid-value with an unterminated string (the token cap hit).
+    TRUNCATED = (
+        '{\n  "obligations": [\n'
+        '    {"kind": "zahlung", "date": "2024-11-15", '
+        '"amount": {"value": 33.82, "currency": "EUR"}},\n'
+        '    {"kind": "abschlag", "date": "2024-12-01", '
+        '"amount": {"value": 51.0, "currency": "EUR"}},\n'
+        '    {"kind": "zahlung", "date": "2025-10-15", "amount": {"value": 51.0, '
+        '"excerpt": "15.05.2025, 5 = 15.10'
+    )
+
+    def test_strict_parse_fails_on_truncation(self):
+        import json
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(self.TRUNCATED)
+
+    def test_salvage_recovers_complete_entries(self):
+        payload = _salvage_truncated_json(self.TRUNCATED)
+        assert payload is not None
+        # The two complete obligations survive; the half-written third is dropped.
+        obs = payload["obligations"]
+        assert len(obs) == 2
+        assert obs[0]["kind"] == "zahlung" and obs[0]["amount"]["value"] == 33.82
+        assert obs[1]["kind"] == "abschlag"
+
+    def test_parse_llm_json_uses_salvage(self):
+        payload = _parse_llm_json(self.TRUNCATED)
+        assert payload is not None
+        facts = _facts_from_payload(payload)
+        assert len(facts) >= 2  # both complete obligations became facts
+
+    def test_complete_json_unaffected(self):
+        good = '{"obligations": [{"kind": "zahlung", "date": "2024-11-15"}], "universal_facts": {}}'
+        assert _parse_llm_json(good)["obligations"][0]["kind"] == "zahlung"
+
+    def test_garbage_returns_none(self):
+        assert _salvage_truncated_json("not json at all") is None
+        assert _parse_llm_json("not json at all") is None

--- a/tests/backend/test_schicht_a_extractor.py
+++ b/tests/backend/test_schicht_a_extractor.py
@@ -317,6 +317,13 @@ class TestSalvageTruncatedJson:
         assert obs[0]["kind"] == "a"
         assert all("items" not in o for o in obs)  # no half-array smuggled in
 
+    def test_top_level_array_comma_cut_still_recovers_scalars(self):
+        """The comma branch is KEPT (not dropped) but depth-gated: it still
+        recovers complete scalars from a truncated OUTERMOST array — the case
+        the container-close rule alone can't handle (scalars don't bracket-close).
+        Proves we didn't take the shortcut of removing the branch."""
+        assert _salvage_truncated_json('{"vals": [1, 2, 3, 4') == {"vals": [1, 2, 3]}
+
     @pytest.mark.parametrize("bad", [
         "{",
         "}}}}",

--- a/tests/backend/test_schicht_a_extractor.py
+++ b/tests/backend/test_schicht_a_extractor.py
@@ -299,3 +299,36 @@ class TestSalvageTruncatedJson:
     def test_garbage_returns_none(self):
         assert _salvage_truncated_json("not json at all") is None
         assert _parse_llm_json("not json at all") is None
+
+    def test_truncated_nested_array_drops_element_not_completes_it(self):
+        """/review finding 4: cutting at a comma inside a truncated nested array
+        would present it as complete (e.g. [10,20,30,40<cut> → [10,20,30]) — a
+        plausible-but-wrong value. The close-only cut rule must DROP the element
+        with the truncated array, not silently complete it."""
+        s = (
+            '{"obligations": ['
+            '{"kind": "a", "date": "2024-01-01"}, '
+            '{"kind": "b", "items": [10, 20, 30, 40'
+        )
+        payload = _salvage_truncated_json(s)
+        assert payload is not None
+        obs = payload["obligations"]
+        assert len(obs) == 1          # only the fully-complete first element
+        assert obs[0]["kind"] == "a"
+        assert all("items" not in o for o in obs)  # no half-array smuggled in
+
+    @pytest.mark.parametrize("bad", [
+        "{",
+        "}}}}",
+        '{"x": "ends with backslash \\',     # unterminated string + trailing escape
+        '{"obligations": "not a list"',       # wrong-typed, truncated
+        '{"obligations": [{"kind": "trunc',   # first element incomplete → None
+        "",
+    ])
+    def test_no_crash_on_adversarial_input(self, bad):
+        """Untrusted LLM text must never raise — returns None or a dict, and a
+        returned dict must survive _facts_from_payload."""
+        out = _salvage_truncated_json(bad)
+        assert out is None or isinstance(out, dict)
+        if isinstance(out, dict):
+            _facts_from_payload(out)  # must not raise


### PR DESCRIPTION
## Root cause (analysed live)
The Schicht A obligation/universal LLM pass capped output at **`num_predict=1200`**. On a content-rich doc the model's JSON truncates mid-object → `_parse_llm_json` returns `None` → `extract()` **discards the entire LLM batch**, keeping only deterministic identifiers.

**Observed:** doc 43 (`NEW Niederrhein Energie und Wasser` invoice) stored **1 fact** (the regex IBAN) instead of 14. Worker log: `Schicht A LLM extraction failed: unparseable LLM response`.

**Proven** by replaying the exact call on doc 43's text:
| `num_predict` | JSON | parses? | facts |
|---|---|---|---|
| 1200 (old) | 2819 chars, truncated mid-object | ❌ | **0** |
| 4000 | complete | ✅ | **14** |

This silently under-extracts on *every* doc whose JSON exceeds the cap (docs 40/41/44 happened to fit).

## Fix (two layers)
1. **Configurable cap** — `settings.schicht_a_extraction_num_predict`, default **4096**.
2. **Salvage** — `_parse_llm_json` falls back to `_salvage_truncated_json` on a failed strict parse: a bracket-stack scan cuts at the last clean array-element / nested-container boundary and appends the missing closers, so complete leading entries survive even if a doc still exceeds the cap. Warns when it salvages. Removes the silent-total-loss failure mode for good.

## Tests
36/36 extractor tests green on .159, incl. 5 new salvage tests (recovers complete obligations from a doc-43-shaped truncated payload; drops the half-written trailing entry; leaves complete JSON untouched; returns None on garbage).

## Follow-up
Re-extract the corpus (reindex — now async + safe) so docs that silently under-counted recover their facts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)