### PR TITLE
fix(chat-upload): resolve Paperless attachment from session when id is absent

### DIFF
--- a/src/backend/services/chat_upload_tool.py
+++ b/src/backend/services/chat_upload_tool.py
@@ -57,6 +57,10 @@ CHAT_UPLOAD_TOOLS: dict = {
             "Forward a file the user has attached to this chat to Paperless-NGX "
             "for OCR and archiving. Reads the file from server storage using the "
             "attachment_id shown in the UPLOADED DOCUMENT section of this prompt. "
+            "If no attachment_id is shown (e.g. the user asks in a follow-up "
+            "message), call this tool WITHOUT attachment_id — the server resolves "
+            "the most recent completed upload in this chat session. Never invent "
+            "an attachment_id. "
             "Do NOT pass file_content_base64 — the tool does that internally from "
             "real file bytes. Preferred over mcp.paperless.upload_document for "
             "user-attached files. "
@@ -69,7 +73,9 @@ CHAT_UPLOAD_TOOLS: dict = {
         "parameters": {
             "attachment_id": (
                 "Integer ID of the attachment shown in the UPLOADED DOCUMENT "
-                "section. Required."
+                "section. OPTIONAL — omit it if no id is shown and the server "
+                "will use the most recent completed upload in this chat session. "
+                "Never guess or fabricate an id."
             ),
             "title": (
                 "Optional Paperless document title. Defaults to the attachment "
@@ -168,26 +174,35 @@ async def forward_attachment_to_paperless(
             auth-disabled), the cold-start check is bypassed and
             extraction always runs with confirm.
     """
-    attachment_id_raw = params.get("attachment_id")
-    if attachment_id_raw is None:
-        return {
-            "success": False,
-            "message": "Parameter 'attachment_id' is required",
-            "action_taken": False,
-        }
-    try:
-        attachment_id = int(attachment_id_raw)
-    except (TypeError, ValueError):
-        return {
-            "success": False,
-            "message": f"'attachment_id' must be an integer, got: {attachment_id_raw!r}",
-            "action_taken": False,
-        }
-
     if mcp_manager is None:
         return {
             "success": False,
             "message": "MCP manager not available — Paperless MCP not wired in",
+            "action_taken": False,
+        }
+
+    # attachment_id is a HINT, not a hard requirement. The agent often forwards
+    # as a follow-up message ("auch an Paperless schicken") that carries no bound
+    # attachment, or guesses an id that isn't in this session. Parse leniently —
+    # an unresolvable id falls through to the session fallback below instead of
+    # failing with a confusing "not found" (or the agent fabricating an id).
+    attachment_id_raw = params.get("attachment_id")
+    attachment_id: int | None = None
+    if attachment_id_raw is not None:
+        try:
+            attachment_id = int(attachment_id_raw)
+        except (TypeError, ValueError):
+            attachment_id = None
+
+    # Nothing to resolve from: no usable id AND no session to fall back on.
+    # Return without touching the DB.
+    if attachment_id is None and session_id is None:
+        return {
+            "success": False,
+            "message": (
+                "Kein hochgeladenes Dokument gefunden. Bitte hänge die Datei an "
+                "und warte, bis der Upload abgeschlossen ist."
+            ),
             "action_taken": False,
         }
 
@@ -198,18 +213,48 @@ async def forward_attachment_to_paperless(
         from services.database import AsyncSessionLocal
 
         async with AsyncSessionLocal() as db:
-            query = select(ChatUpload).where(ChatUpload.id == attachment_id)
-            if session_id is not None:
-                query = query.where(ChatUpload.session_id == session_id)
-            result = await db.execute(query)
-            upload = result.scalar_one_or_none()
+            upload = None
+            if attachment_id is not None:
+                query = select(ChatUpload).where(ChatUpload.id == attachment_id)
+                if session_id is not None:
+                    query = query.where(ChatUpload.session_id == session_id)
+                upload = (await db.execute(query)).scalar_one_or_none()
+
+            # Session fallback: resolve to the most recent completed upload in
+            # THIS chat session when the agent passed no/unresolvable id. Scoped
+            # to session_id, so it can never reach another user's upload.
+            if upload is None and session_id is not None:
+                fb = (
+                    select(ChatUpload)
+                    .where(
+                        ChatUpload.session_id == session_id,
+                        ChatUpload.status == "completed",
+                        ChatUpload.extracted_text.isnot(None),
+                    )
+                    .order_by(ChatUpload.id.desc())
+                    .limit(1)
+                )
+                upload = (await db.execute(fb)).scalar_one_or_none()
+                if upload is not None:
+                    logger.info(
+                        "forward_attachment_to_paperless: no usable attachment_id "
+                        "(%r); session fallback → upload %s (%s)",
+                        attachment_id_raw, upload.id, upload.filename,
+                    )
 
         if not upload:
             return {
                 "success": False,
-                "message": f"Attachment {attachment_id} not found",
+                "message": (
+                    "In diesem Chat ist kein hochgeladenes Dokument vorhanden. "
+                    "Bitte hänge die Datei an und warte, bis der Upload "
+                    "abgeschlossen ist, bevor du sie an Paperless schickst."
+                ),
                 "action_taken": False,
             }
+
+        # Authoritative from here on — the fallback may have resolved the id.
+        attachment_id = upload.id
 
         if not upload.file_path or not Path(upload.file_path).is_file():
             return {

--- a/tests/backend/test_chat_upload_tool.py
+++ b/tests/backend/test_chat_upload_tool.py
@@ -82,20 +82,23 @@ def _mock_db_returning(upload, captured_query_holder: list | None = None):
 class TestForwardAttachmentToPaperless:
 
     @pytest.mark.unit
-    async def test_missing_attachment_id(self):
-        """Required attachment_id triggers a clear error, no DB/MCP access."""
+    async def test_no_id_no_session_returns_no_document(self):
+        """No attachment_id AND no session to fall back on → clear no-document
+        message, no DB/MCP access (nothing to resolve)."""
         result = await forward_attachment_to_paperless({}, mcp_manager=MagicMock())
         assert result["success"] is False
-        assert "attachment_id" in result["message"]
+        assert "dokument" in result["message"].lower()
 
     @pytest.mark.unit
-    async def test_non_integer_attachment_id(self):
-        """Non-integer attachment_id is rejected with a message including the bad value."""
+    async def test_non_integer_attachment_id_without_session(self):
+        """A non-integer id is treated as 'no usable id' (a hint, not a hard
+        requirement); with no session to fall back on, returns the no-document
+        message instead of a type error."""
         result = await forward_attachment_to_paperless(
             {"attachment_id": "not-a-number"}, mcp_manager=MagicMock()
         )
         assert result["success"] is False
-        assert "integer" in result["message"].lower()
+        assert "dokument" in result["message"].lower()
 
     @pytest.mark.unit
     async def test_missing_mcp_manager(self):
@@ -107,8 +110,9 @@ class TestForwardAttachmentToPaperless:
         assert "mcp" in result["message"].lower()
 
     @pytest.mark.unit
-    async def test_attachment_not_found(self):
-        """Unknown attachment_id returns a not-found error."""
+    async def test_unknown_id_and_empty_session_returns_no_document(self):
+        """Unknown id AND no completed upload in the session → clear no-document
+        message (no leak of the fabricated/guessed id)."""
         stubs = _stub_db_module()
         try:
             with patch(
@@ -117,12 +121,51 @@ class TestForwardAttachmentToPaperless:
                 create=True,
             ):
                 result = await forward_attachment_to_paperless(
-                    {"attachment_id": 999}, mcp_manager=AsyncMock()
+                    {"attachment_id": 999},
+                    mcp_manager=AsyncMock(),
+                    session_id="session-abc",
                 )
         finally:
             _teardown_stubs(stubs)
         assert result["success"] is False
-        assert "999" in result["message"]
+        assert "dokument" in result["message"].lower()
+
+    @pytest.mark.unit
+    async def test_session_fallback_resolves_latest_upload(self):
+        """No attachment_id in the message (agent forwards as a follow-up) → the
+        tool resolves the most recent completed upload in the session instead of
+        failing or making the agent guess an id."""
+        pdf_bytes = b"%PDF-1.4\n" + b"f" * 200
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            f.write(pdf_bytes)
+            tmp_path = f.name
+        try:
+            upload = _make_upload(
+                file_path=tmp_path, filename="Fallback.pdf", session_id="session-abc"
+            )
+            mock_mcp = AsyncMock()
+            mock_mcp.execute_tool = AsyncMock(return_value={
+                "success": True,
+                "message": json.dumps({"task_id": "fb-1"}),
+            })
+            stubs = _stub_db_module()
+            try:
+                with patch(
+                    "services.database.AsyncSessionLocal",
+                    _mock_db_returning(upload),
+                    create=True,
+                ):
+                    result = await forward_attachment_to_paperless(
+                        {"skip_metadata": True},  # no attachment_id passed
+                        mcp_manager=mock_mcp,
+                        session_id="session-abc",
+                    )
+            finally:
+                _teardown_stubs(stubs)
+            assert result["success"] is True
+            assert result["data"]["attachment_id"] == 42
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
 
     @pytest.mark.unit
     async def test_file_missing_on_disk(self):

--- a/tests/backend/test_chat_upload_tool_paperless.py
+++ b/tests/backend/test_chat_upload_tool_paperless.py
@@ -739,19 +739,23 @@ class TestPaperlessTaskPolling:
 class TestForwardAttachmentValidation:
     @pytest.mark.asyncio
     @pytest.mark.unit
-    async def test_missing_attachment_id_errors(self):
+    async def test_missing_attachment_id_no_session_returns_no_document(self):
+        # attachment_id is now optional: with no id AND no session to fall back
+        # on, return a clear no-document message (was: 'attachment_id required').
         result = await forward_attachment_to_paperless({}, mcp_manager=MagicMock())
         assert result["success"] is False
-        assert "attachment_id" in result["message"]
+        assert "dokument" in result["message"].lower()
 
     @pytest.mark.asyncio
     @pytest.mark.unit
-    async def test_non_integer_attachment_id_errors(self):
+    async def test_non_integer_attachment_id_no_session_returns_no_document(self):
+        # A non-integer id is treated as 'no usable id' (a hint, not a hard
+        # error); with no session it falls through to the no-document message.
         result = await forward_attachment_to_paperless(
             {"attachment_id": "abc"}, mcp_manager=MagicMock(),
         )
         assert result["success"] is False
-        assert "integer" in result["message"].lower()
+        assert "dokument" in result["message"].lower()
 
     @pytest.mark.asyncio
     @pytest.mark.unit


### PR DESCRIPTION
## Symptom
User attaches a file, then asks *"auch an Paperless schicken"* in a **follow-up** message. That message carries no bound `attachment_id`, so the agent fabricated an id (guessed `1`) or got "Attachment N not found" — the file never reached Paperless, even though it was uploaded and indexed to the KB.

## Root cause
`forward_attachment_to_paperless` treated `attachment_id` as a hard requirement and only looked it up by that exact id. A message without a bound attachment left the agent with nothing → forced guess.

## Fix
Treat `attachment_id` as a **hint**, not a requirement:
- Parse leniently (missing/invalid → `None`, no hard error).
- When unresolved, fall back to the **most recent completed upload in the same chat session** (`status=completed`, `extracted_text` present, `ORDER BY id DESC`). Scoped to `session_id` — can never reach another user's upload (#442 intact).
- With neither a usable id nor a session: clear no-document message, **never fabricate an id**.
- Tool schema updated: `attachment_id` is OPTIONAL; if none is shown, call without it (server resolves session's latest); never guess.

Not caused by the rc.4 deploy — pre-existing gap in a weeks-old path.

## Tests
+ session-fallback-resolves, + unknown-id/empty-session → no-document; updated the two strict-contract tests to the new optional contract. **42 pass** (`test_chat_upload_tool.py` + `test_chat_upload_tool_paperless.py`, `asyncio_mode=auto`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)