### PR TITLE
fix(chat): bridge Paperless cold-start confirm → commit handoff

### DIFF
--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -311,6 +311,58 @@ def _format_file_size(size_bytes: int | None) -> str:
     return f"{size_bytes / (1024 * 1024):.1f} MB"
 
 
+# --- Paperless cold-start confirm handoff (deterministic bridge) -----------
+# forward_attachment_to_paperless leaves a paperless_pending_confirms row and
+# shows the user a preview; the user's NEXT message is their response. The
+# router/agent has no notion of a pending confirm, so without this bridge the
+# reply ("ja" / "1:neu, 2:x") is treated as a fresh request and the upload never
+# commits. We resolve the pending row per session and, when the message looks
+# like a confirm reply, route it straight to internal.paperless_commit_upload;
+# non-matches fall through to the agent (LLM fallback).
+_CONFIRM_REPLY_RE = re.compile(
+    r"^\s*(ja|nein|yes|no|ok|okay|abbrechen|cancel|neu|new|x)\b", re.IGNORECASE
+)
+_CONFIRM_FIELD_RE = re.compile(r"\b\d+\s*:\s*\S+")  # per-field choice, e.g. "1:neu", "2: x"
+_PENDING_CONFIRM_MAX_AGE_MIN = 60  # ignore abandoned confirms older than this
+
+
+def _looks_like_confirm_reply(text: str) -> bool:
+    """Does this message look like a reply to a Paperless confirm preview
+    (ja/nein, or per-field choices like '1:neu, 2:x')? Only consulted when a
+    pending confirm already exists for the session."""
+    t = (text or "").strip()
+    return bool(_CONFIRM_REPLY_RE.match(t) or _CONFIRM_FIELD_RE.search(t))
+
+
+async def _pending_paperless_confirm(session_id: str) -> str | None:
+    """confirm_token of the most recent *fresh* pending Paperless confirm for
+    this session, else None. The row exists only while a confirm awaits the
+    user (forward creates it; commit/abort deletes it; edit-rounds keep it). A
+    freshness window guards against an abandoned row hijacking a later message."""
+    try:
+        from datetime import datetime, timedelta
+
+        from sqlalchemy import select
+
+        from models.database import PaperlessPendingConfirm
+
+        cutoff = datetime.utcnow() - timedelta(minutes=_PENDING_CONFIRM_MAX_AGE_MIN)
+        async with AsyncSessionLocal() as db:
+            row = (await db.execute(
+                select(PaperlessPendingConfirm)
+                .where(
+                    PaperlessPendingConfirm.session_id == session_id,
+                    PaperlessPendingConfirm.created_at >= cutoff,
+                )
+                .order_by(PaperlessPendingConfirm.created_at.desc())
+                .limit(1)
+            )).scalar_one_or_none()
+            return str(row.confirm_token) if row else None
+    except Exception as e:  # noqa: BLE001 — bridge is best-effort, never block chat
+        logger.warning(f"⚠️ Pending-confirm lookup failed: {e}")
+        return None
+
+
 async def _fetch_document_context(attachment_ids: list[int], lang: str) -> str:
     """Fetch extracted text from uploaded documents and format as prompt context.
 
@@ -834,6 +886,8 @@ async def websocket_endpoint(
             action_result = None
             agent_steps_count = 0
             media_shortcut_handled = False
+            paperless_confirm_handled = False
+            pending_confirm_token = None
 
             if settings.agent_enabled:
                 transport = _detect_media_transport(content)
@@ -873,16 +927,71 @@ async def websocket_endpoint(
                         session_state.last_media_room = room
                         media_shortcut_handled = True
 
+            # === Paperless confirm handoff (pre-memory, pre-router) ===
+            # A fresh pending Paperless confirm + a confirm-like reply → commit
+            # deterministically. The router/agent can't be relied on to
+            # rediscover the 2-step protocol (it doesn't know a confirm is
+            # pending). Non-confirm-like messages fall through to the agent,
+            # which then sees the [PENDING_PAPERLESS_CONFIRM] directive below.
+            if not media_shortcut_handled and message_type == "text" and content and msg_session_id:
+                pending_confirm_token = await _pending_paperless_confirm(msg_session_id)
+                if pending_confirm_token and _looks_like_confirm_reply(content):
+                    try:
+                        from services.action_executor import ActionExecutor
+                        _mcp = getattr(app.state, "mcp_manager", None)
+                        _executor = ActionExecutor(mcp_manager=_mcp, session_id=msg_session_id)
+                        intent = {
+                            "intent": "internal.paperless_commit_upload",
+                            "parameters": {"confirm_token": pending_confirm_token},
+                            "confidence": 1.0,
+                        }
+                        action_result = await _executor.execute(
+                            {
+                                "intent": "internal.paperless_commit_upload",
+                                "parameters": {
+                                    "confirm_token": pending_confirm_token,
+                                    "user_response_text": content,
+                                },
+                                "confidence": 1.0,
+                            },
+                            user_id=user_id,
+                        )
+                        full_response = action_result.get("message", "") or ""
+                        await websocket.send_json(
+                            {"type": "action", "intent": intent, "result": action_result}
+                        )
+                        if full_response:
+                            await websocket.send_json({"type": "stream", "content": full_response})
+                        paperless_confirm_handled = True
+                        logger.info(
+                            f"📎 Paperless confirm handoff → commit token "
+                            f"{pending_confirm_token[:8]} (session {msg_session_id})"
+                        )
+                    except Exception as e:  # noqa: BLE001 — fall through to agent
+                        logger.warning(f"⚠️ Paperless confirm handoff failed: {e}")
+
             # Retrieve memory + document context (skipped for transport shortcuts)
             memory_context = ""
             document_context = ""
-            if not media_shortcut_handled:
+            if not media_shortcut_handled and not paperless_confirm_handled:
                 memory_context = await _retrieve_memory_context(
                     content, user_id=user_id, lang=ollama.default_lang
                 )
                 if attachment_ids:
                     document_context = await _fetch_document_context(
                         attachment_ids, lang=ollama.default_lang
+                    )
+                # LLM fallback: a pending confirm exists but the reply didn't look
+                # like ja/nein/field-choices. Tell the agent so it can still route
+                # to internal.paperless_commit_upload instead of guessing.
+                if pending_confirm_token and not paperless_confirm_handled:
+                    document_context += (
+                        "\n\n[PENDING_PAPERLESS_CONFIRM] Es liegt eine offene "
+                        "Paperless-Bestätigung vor (confirm_token="
+                        f"{pending_confirm_token}). Die aktuelle Nutzernachricht ist "
+                        "wahrscheinlich die Antwort darauf — rufe "
+                        "internal.paperless_commit_upload mit diesem confirm_token und "
+                        "user_response_text=<Nachricht> auf; erfinde keine andere Aktion."
                     )
 
             # Build personality context for agent prompts
@@ -896,7 +1005,7 @@ async def websocket_endpoint(
             # Get router from app state (initialized at startup if agent_enabled)
             agent_router = getattr(app.state, 'agent_router', None)
 
-            if not media_shortcut_handled and settings.agent_enabled and agent_router:
+            if not media_shortcut_handled and not paperless_confirm_handled and settings.agent_enabled and agent_router:
                 # === Unified Router Path ===
                 # Every message goes through router → specialized agent
                 from services.action_executor import ActionExecutor
@@ -1432,7 +1541,7 @@ async def websocket_endpoint(
                     if not intent:
                         intent = {"intent": f"agent.{role.name}", "confidence": 1.0, "parameters": {}}
 
-            elif not media_shortcut_handled:
+            elif not media_shortcut_handled and not paperless_confirm_handled:
                 # === Legacy Ranked Intent Path (agent_enabled=false or no router) ===
                 logger.info("🔍 Extrahiere Ranked Intents...")
                 ranked_intents = await ollama.extract_ranked_intents(

--- a/tests/backend/test_paperless_confirm_handoff.py
+++ b/tests/backend/test_paperless_confirm_handoff.py
@@ -1,0 +1,115 @@
+"""Tests for the Paperless cold-start confirm → commit handoff bridge.
+
+forward_attachment_to_paperless leaves a paperless_pending_confirms row and
+shows the user a preview; the user's NEXT message is their reply. chat_handler
+bridges that deterministically: a fresh pending confirm + a confirm-like reply
+routes straight to internal.paperless_commit_upload (no router/agent guessing).
+
+These cover the two pure-ish seams: the confirm-reply heuristic and the
+per-session pending lookup. Import-stub pattern matches test_media_transport.py.
+"""
+import sys
+from contextlib import asynccontextmanager
+from unittest.mock import MagicMock
+
+_missing_stubs = [
+    "asyncpg", "whisper", "piper", "piper.voice", "speechbrain",
+    "speechbrain.inference", "speechbrain.inference.speaker",
+    "openwakeword", "openwakeword.model",
+]
+import importlib as _importlib
+for _mod in _missing_stubs:
+    if _mod in sys.modules:
+        continue
+    try:
+        _importlib.import_module(_mod)
+    except Exception:  # noqa: BLE001
+        sys.modules[_mod] = MagicMock()
+
+import pytest
+
+from api.websocket.chat_handler import (
+    _looks_like_confirm_reply,
+    _pending_paperless_confirm,
+)
+
+
+class TestLooksLikeConfirmReply:
+    @pytest.mark.unit
+    @pytest.mark.parametrize("msg", [
+        "ja", "Ja", "JA", "ja, mach das", "nein", "nein danke", "yes", "no",
+        "ok", "okay", "abbrechen", "cancel", "neu", "new", "x",
+        "1:neu, 2:x 3:n 4:n5;n",       # the exact failing input from the report
+        "1: 2, 2: neu",                # spaced per-field
+        "3: x",
+    ])
+    def test_confirm_like_replies_match(self, msg):
+        assert _looks_like_confirm_reply(msg) is True
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("msg", [
+        "Was weißt du über mich?",
+        "Bitte lade noch ein weiteres Dokument hoch",
+        "Wie ist das Wetter morgen?",
+        "",
+        "   ",
+        "Erzähl mir von der Rechnung",
+    ])
+    def test_non_confirm_messages_do_not_match(self, msg):
+        assert _looks_like_confirm_reply(msg) is False
+
+
+def _mock_session_returning(row):
+    """AsyncSessionLocal stand-in whose query result yields `row` (or None)."""
+    mock_db = MagicMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none = MagicMock(return_value=row)
+
+    async def _execute(_stmt):
+        return mock_result
+
+    mock_db.execute = _execute
+
+    @asynccontextmanager
+    async def _session():
+        yield mock_db
+
+    return _session
+
+
+@pytest.mark.asyncio
+class TestPendingPaperlessConfirm:
+    @pytest.mark.unit
+    async def test_returns_token_when_fresh_row_exists(self, monkeypatch):
+        row = MagicMock()
+        row.confirm_token = "7e171057-beef-dead"
+        monkeypatch.setattr(
+            "api.websocket.chat_handler.AsyncSessionLocal",
+            _mock_session_returning(row),
+        )
+        token = await _pending_paperless_confirm("session-abc")
+        assert token == "7e171057-beef-dead"
+
+    @pytest.mark.unit
+    async def test_returns_none_when_no_row(self, monkeypatch):
+        monkeypatch.setattr(
+            "api.websocket.chat_handler.AsyncSessionLocal",
+            _mock_session_returning(None),
+        )
+        token = await _pending_paperless_confirm("session-abc")
+        assert token is None
+
+    @pytest.mark.unit
+    async def test_lookup_failure_is_swallowed(self, monkeypatch):
+        """The bridge is best-effort — a DB error must not raise into the chat
+        loop; it returns None and the message falls through to the agent."""
+        @asynccontextmanager
+        async def _boom():
+            raise RuntimeError("db down")
+            yield  # pragma: no cover
+
+        monkeypatch.setattr(
+            "api.websocket.chat_handler.AsyncSessionLocal", _boom,
+        )
+        token = await _pending_paperless_confirm("session-abc")
+        assert token is None


### PR DESCRIPTION
## Symptom
After `forward_attachment_to_paperless` shows the metadata-confirm preview, the user's reply (`ja` / `1:neu, 2:x 3:n`) routed to the generic documents agent, which has no notion of a pending confirm → "keine Datei ausgewählt", upload never commits. The cold-start confirm flow got stuck after step 1 (long-standing gap; `paperless_commit_upload` was registered but nothing told the system the reply belonged to the pending row).

## Fix — deterministic + LLM fallback (`chat_handler`)
- Per-session lookup of the most recent **fresh** `paperless_pending_confirms` row (freshness window guards against an abandoned row hijacking a later message; commit/abort already delete the row, edit-rounds keep it).
- Fresh row + confirm-like reply (`ja`/`nein`/`ok`/`x`/`neu` or per-field `N: choice`) → route **deterministically** to `internal.paperless_commit_upload(confirm_token, user_response_text)`, bypassing the router/agent (which can't reliably rediscover the 2-step protocol). Streams the result; the normal tail persists + sends `done`.
- LLM fallback: pending-but-not-confirm-like → inject a `[PENDING_PAPERLESS_CONFIRM]` directive (with token) into the agent context so it can still commit instead of guessing.
- Confirm-handled flag skips memory/doc retrieval, router path, and legacy ranked-intent path (mirrors `media_shortcut_handled`).

Backend-only; no migration. Completes the flow whose first half was fixed in #653.

## Tests
+ `test_paperless_confirm_handoff.py`: confirm-reply heuristic (incl. the exact failing `1:neu, 2:x 3:n 4:n5;n` input) + per-session pending lookup (token / None / error-swallow). **27 pass**; media-transport + speaker-identity chat_handler tests still green (**57**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)