### PR TITLE
fix(chat): register WS session on connect so upload pushes are delivered

### DIFF
--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -677,6 +677,22 @@ async def websocket_endpoint(
             # value automatically (Python 3.7+ context propagation).
             voice_originated.set(False)
 
+            # Lightweight session-register frame (client sends it on WS open /
+            # when it has a session_id). Registers the connection NOW so
+            # background pushes — e.g. the async chat-upload `upload_processed`
+            # event — can reach this session BEFORE the user's first text
+            # message. Without this, register_ws_connection only fires on the
+            # first chat message, so an upload-then-wait flow leaves the session
+            # unregistered and notify_session silently no-ops (chip stuck in
+            # "processing"). WSChatMessage is Literal["text"], so handle the
+            # register frame before that validation.
+            if isinstance(data, dict) and data.get("type") == "register":
+                reg_sid = data.get("session_id")
+                if reg_sid:
+                    register_ws_connection(reg_sid, websocket)
+                    session_state.db_session_id = reg_sid
+                continue
+
             # Validate message
             try:
                 msg = WSChatMessage(**data)
@@ -1864,11 +1880,11 @@ WICHTIG: Nutze die ECHTEN Daten aus dem Ergebnis! Gib NUR die Antwort, KEIN JSON
 
     except WebSocketDisconnect:
         if session_state.db_session_id:
-            unregister_ws_connection(session_state.db_session_id)
+            unregister_ws_connection(session_state.db_session_id, websocket)
         logger.info("👋 WebSocket Verbindung getrennt")
     except Exception as e:
         if session_state.db_session_id:
-            unregister_ws_connection(session_state.db_session_id)
+            unregister_ws_connection(session_state.db_session_id, websocket)
         logger.error(f"❌ WebSocket Fehler: {e}")
         import traceback
         logger.error(traceback.format_exc())

--- a/src/backend/api/websocket/shared.py
+++ b/src/backend/api/websocket/shared.py
@@ -207,8 +207,16 @@ def register_ws_connection(session_id: str, websocket: WebSocket) -> None:
     _ws_connections[session_id] = websocket
 
 
-def unregister_ws_connection(session_id: str) -> None:
-    """Unregister a WebSocket connection. No-op if not registered."""
+def unregister_ws_connection(session_id: str, websocket: "WebSocket | None" = None) -> None:
+    """Unregister a session's WebSocket connection. No-op if not registered.
+
+    Identity-aware: when ``websocket`` is given, only pop if the stored socket
+    IS that socket. Two tabs can share a session_id (localStorage), and the
+    register-on-connect effect means a later tab overwrites the entry — without
+    this guard, the first tab's disconnect would evict the live tab and kill its
+    pushes. Pass the disconnecting socket so it can only remove its own entry."""
+    if websocket is not None and _ws_connections.get(session_id) is not websocket:
+        return
     _ws_connections.pop(session_id, None)
 
 

--- a/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
+++ b/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
@@ -910,6 +910,18 @@ export function ChatProvider({ children }: ChatProviderProps) {
     onCard: handleCard,
   });
 
+  // Register this session on the WS as soon as it's connected, so background
+  // pushes (e.g. async chat-upload `upload_processed`) can reach it BEFORE the
+  // first chat message — otherwise an upload-then-wait flow leaves the chip
+  // stuck in "processing" because the backend only registered the session on
+  // the first text message. Re-runs on reconnect (wsConnected flips) and on
+  // session change. wsSendMessage re-checks readyState and no-ops if not open.
+  useEffect(() => {
+    if (wsConnected && sessionId) {
+      wsSendMessage({ type: 'register', session_id: sessionId });
+    }
+  }, [wsConnected, sessionId, wsSendMessage]);
+
   // Handle transcription from audio recording
   const handleTranscription = useCallback((text: string) => {
     debug.log('Transcription received:', text);

--- a/tests/backend/test_websocket.py
+++ b/tests/backend/test_websocket.py
@@ -363,6 +363,66 @@ class TestWebSocketSessionManagement:
         updated = await room_service.get_device(device.device_id)
         assert updated.is_online is False
 
+    @pytest.mark.unit
+    async def test_notify_session_requires_registration(self):
+        """Delivery contract behind the async-upload push: notify_session only
+        reaches a session that has been registered via register_ws_connection.
+        An unregistered session no-ops (returns False) — which is why the chat
+        WS must register on connect (a `register` frame), not just on the first
+        text message, or an upload-then-wait push is silently dropped."""
+        from unittest.mock import AsyncMock
+
+        from api.websocket.shared import (
+            notify_session,
+            register_ws_connection,
+            unregister_ws_connection,
+        )
+
+        sid = "session-notify-contract-test"
+        # Unregistered → no delivery.
+        assert await notify_session(sid, {"type": "upload_processed"}) is False
+
+        ws = MagicMock()
+        ws.send_json = AsyncMock()
+        register_ws_connection(sid, ws)
+        try:
+            assert await notify_session(sid, {"type": "upload_processed", "upload_id": 7}) is True
+            ws.send_json.assert_awaited_once()
+            assert ws.send_json.await_args.args[0]["upload_id"] == 7
+        finally:
+            unregister_ws_connection(sid)
+
+        # After unregister → no delivery again.
+        assert await notify_session(sid, {"type": "upload_processed"}) is False
+
+    @pytest.mark.unit
+    async def test_unregister_is_identity_aware(self):
+        """Two tabs share a session_id (localStorage); the later tab's register
+        overwrites the entry. A disconnecting first tab must NOT evict the live
+        second tab — unregister(sid, ws) only pops when the stored socket IS ws."""
+        from unittest.mock import AsyncMock
+
+        from api.websocket.shared import (
+            _ws_connections,
+            notify_session,
+            register_ws_connection,
+            unregister_ws_connection,
+        )
+
+        sid = "session-identity-test"
+        ws_a = MagicMock(); ws_a.send_json = AsyncMock()
+        ws_b = MagicMock(); ws_b.send_json = AsyncMock()
+        register_ws_connection(sid, ws_a)
+        register_ws_connection(sid, ws_b)  # tab B wins the entry
+        try:
+            # Tab A disconnects — must not remove tab B's live entry.
+            unregister_ws_connection(sid, ws_a)
+            assert _ws_connections.get(sid) is ws_b
+            assert await notify_session(sid, {"type": "upload_processed"}) is True
+            ws_b.send_json.assert_awaited_once()
+        finally:
+            unregister_ws_connection(sid)  # unconditional cleanup
+
 
 # ============================================================================
 # WebSocket Rate Limiting Tests


### PR DESCRIPTION
## Symptom
After rc.7 (async upload), the attachment chip stayed stuck on "wird verarbeitet …" even though the backend finished extraction and fired the `upload_processed` push.

## Root cause
`notify_session(session_id, …)` delivers only to a session in `_ws_connections`, which `register_ws_connection()` populated **only on the first chat message** (`chat_handler.py:775`). The upload-then-wait flow uploads before any message → session unregistered → `notify_session` returned `False` and the push was silently dropped (no log; the bg task only logs on exception).

## Fix
- **chat_handler**: handle a lightweight `register` frame (isinstance-guarded, peeked before the `WSChatMessage` text-only validation) → `register_ws_connection(sid)` immediately.
- **ChatContext**: send `{type:"register", session_id}` on WS connect + reconnect (effect on `wsConnected`+`sessionId`), so the push is deliverable before extraction finishes.
- **shared.unregister_ws_connection** is now identity-aware (/review): two tabs can share a localStorage session_id; unregister only pops when the stored socket IS this socket, so a disconnecting tab can't evict a live co-tab.

## Tests
notify_session delivery contract (unregistered → dropped / registered → delivered) + identity-aware unregister. 4 pass.

## Deferred (acknowledged in /review + automated security)
The `register` frame trusts the client session_id with no ownership check — identical to the pre-existing first-message register path, moot under `AUTH_ENABLED=false`, and a naive check would reject legitimate brand-new chats (no Conversation row yet). Proper multi-user hardening gates both paths + handles new-session binding → tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)