### PR TITLE
feat(paperless): trust-after-N in single-user mode + verbatim confirm preview in parallel

### DIFF
--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -1620,6 +1620,12 @@ class AgentService:
 
                     # Yield results and add to context
                     no_result = "No result" if lang == "en" else "Kein Ergebnis"
+                    # An action_required tool (e.g. paperless confirm) returns a
+                    # preview the user MUST see verbatim. The single-tool
+                    # short-circuit below never runs in the parallel path, so
+                    # capture it here and relay it instead of letting the LLM
+                    # summarise (which drops the per-field choices).
+                    parallel_preview: tuple[str, Any] | None = None
                     for act, res in zip(valid_actions, exec_results):
                         if isinstance(res, Exception):
                             logger.error(f"❌ Parallel tool '{act['action']}' failed: {res}")
@@ -1652,6 +1658,30 @@ class AgentService:
                         context.steps.append(result_step)
                         context.tool_results.append(res)
                         yield result_step
+
+                        _rd = res.get("data")
+                        if (
+                            parallel_preview is None
+                            and isinstance(_rd, dict)
+                            and _rd.get("action_required")
+                        ):
+                            parallel_preview = (
+                                res.get("message") or "", _rd["action_required"],
+                            )
+
+                    # Relay an action_required preview verbatim + stop the loop
+                    # (mirrors the single-tool short-circuit below).
+                    if parallel_preview is not None and parallel_preview[0]:
+                        yield AgentStep(
+                            step_number=step_num,
+                            step_type="final_answer",
+                            content=parallel_preview[0],
+                            reason=(
+                                "Relaying tool preview verbatim — "
+                                f"action_required={parallel_preview[1]}"
+                            ),
+                        )
+                        return
 
                     continue  # Next iteration of ReAct loop
 

--- a/src/backend/services/chat_upload_tool.py
+++ b/src/backend/services/chat_upload_tool.py
@@ -631,26 +631,60 @@ async def _run_extraction(
         return None
 
 
-async def _get_confirms_used(user_id: int | None) -> int:
-    """Read ``users.paperless_confirms_used`` for the cold-start check.
+# Single-user (AUTH-off) cold-start counter. There's no user row to hang
+# ``paperless_confirms_used`` on, so the trust-after-N ramp is tracked in a
+# global SystemSetting key instead — otherwise the confirm would fire forever.
+_SINGLEUSER_CONFIRMS_KEY = "paperless.singleuser_confirms_used"
 
-    Returns 0 when ``user_id`` is None (auth-disabled dev) so extraction
-    always runs with confirm in that mode — the operator can decide to
-    flip the flag via the admin UI once they're comfortable.
+
+async def _get_confirms_used(user_id: int | None) -> int:
+    """Read the cold-start confirm counter. Per-user (``users.
+    paperless_confirms_used``) when known; a global SystemSetting key in
+    single-user / auth-disabled mode so trust-after-N works without a user id.
     """
-    if user_id is None:
-        return 0
     from sqlalchemy import select
 
-    from models.database import User
+    from models.database import SystemSetting, User
     from services.database import AsyncSessionLocal
 
     async with AsyncSessionLocal() as db:
+        if user_id is None:
+            row = await db.get(SystemSetting, _SINGLEUSER_CONFIRMS_KEY)
+            if row is None:
+                return 0
+            try:
+                return int(json.loads(row.value))
+            except (ValueError, TypeError):
+                return 0
         result = await db.execute(
             select(User.paperless_confirms_used).where(User.id == user_id)
         )
-        value = result.scalar()
-    return int(value or 0)
+        return int(result.scalar() or 0)
+
+
+async def _bump_confirms_used(db, user_id: int | None) -> None:
+    """Increment the cold-start confirm counter on the given session (no commit).
+    Per-user when known; the global SystemSetting key in single-user mode."""
+    from sqlalchemy import update
+
+    from models.database import SystemSetting, User
+
+    if user_id is not None:
+        await db.execute(
+            update(User)
+            .where(User.id == user_id)
+            .values(paperless_confirms_used=User.paperless_confirms_used + 1)
+        )
+        return
+    row = await db.get(SystemSetting, _SINGLEUSER_CONFIRMS_KEY)
+    if row is None:
+        db.add(SystemSetting(key=_SINGLEUSER_CONFIRMS_KEY, value=json.dumps(1)))
+    else:
+        try:
+            cur = int(json.loads(row.value))
+        except (ValueError, TypeError):
+            cur = 0
+        row.value = json.dumps(cur + 1)
 
 
 def _extraction_to_upload_params(post_fuzzy: dict) -> dict:

--- a/src/backend/services/paperless_commit_tool.py
+++ b/src/backend/services/paperless_commit_tool.py
@@ -663,9 +663,8 @@ async def _finalize_paperless_commit(
     # message persisted to the conversation so it survives a reload or a dropped
     # WS push (the live push below is best-effort and no-ops on a gone socket).
     try:
-        from sqlalchemy import update as _update
-
-        from models.database import PaperlessUploadTracking, User
+        from models.database import PaperlessUploadTracking
+        from services.chat_upload_tool import _bump_confirms_used
         from services.conversation_service import ConversationService
         from services.database import AsyncSessionLocal
         async with AsyncSessionLocal() as db:
@@ -677,12 +676,11 @@ async def _finalize_paperless_commit(
                     original_metadata=dict(user_approved),
                     doc_text=doc_text,
                 ))
-            if status == "completed" and user_id is not None:
-                await db.execute(
-                    _update(User)
-                    .where(User.id == user_id)
-                    .values(paperless_confirms_used=User.paperless_confirms_used + 1)
-                )
+            # Bump the cold-start trust counter ONLY on a confirmed consume.
+            # Per-user when known; a global SystemSetting key in single-user mode
+            # (else the confirm would fire on every archive forever).
+            if status == "completed":
+                await _bump_confirms_used(db, user_id)
             if session_id:
                 await ConversationService(db).save_message(
                     session_id, "assistant", message, user_id=user_id,

--- a/tests/backend/test_chat_upload_tool.py
+++ b/tests/backend/test_chat_upload_tool.py
@@ -455,3 +455,83 @@ def test_chat_upload_tools_declares_both_confirm_flow_steps():
     # confirm_token (required) and user_response_text.
     assert "confirm_token" in commit["parameters"]
     assert "user_response_text" in commit["parameters"]
+
+
+# ── cold-start confirm counter: single-user (AUTH-off) global key ──────────
+
+
+class TestColdStartConfirmCounter:
+    """In single-user mode (user_id=None) the 'trust after N' counter is tracked
+    in a global SystemSetting key instead of users.paperless_confirms_used, so
+    the confirm doesn't fire on every archive forever."""
+
+    @pytest.mark.unit
+    async def test_bump_singleuser_creates_then_increments_setting(self):
+        from types import SimpleNamespace
+
+        from services.chat_upload_tool import _SINGLEUSER_CONFIRMS_KEY, _bump_confirms_used
+
+        # No row yet → create with value 1.
+        db = MagicMock()
+        db.get = AsyncMock(return_value=None)
+        db.add = MagicMock()
+        db.execute = AsyncMock()
+        await _bump_confirms_used(db, None)
+        added = db.add.call_args.args[0]
+        assert added.key == _SINGLEUSER_CONFIRMS_KEY
+        assert json.loads(added.value) == 1
+        db.execute.assert_not_awaited()  # single-user path doesn't touch User
+
+        # Existing row → increment in place.
+        row = SimpleNamespace(key=_SINGLEUSER_CONFIRMS_KEY, value=json.dumps(4))
+        db2 = MagicMock()
+        db2.get = AsyncMock(return_value=row)
+        db2.add = MagicMock()
+        await _bump_confirms_used(db2, None)
+        assert json.loads(row.value) == 5
+        db2.add.assert_not_called()
+
+    @pytest.mark.unit
+    async def test_bump_per_user_updates_user_row(self):
+        from services.chat_upload_tool import _bump_confirms_used
+
+        db = MagicMock()
+        db.execute = AsyncMock()
+        db.add = MagicMock()
+        db.get = AsyncMock()
+        await _bump_confirms_used(db, 7)
+        db.execute.assert_awaited_once()  # update(User)... issued
+        db.add.assert_not_called()
+        db.get.assert_not_called()
+
+    @pytest.mark.unit
+    async def test_get_singleuser_reads_setting(self, monkeypatch):
+        from types import SimpleNamespace
+
+        from services.chat_upload_tool import _SINGLEUSER_CONFIRMS_KEY, _get_confirms_used
+
+        db = MagicMock()
+        db.get = AsyncMock(return_value=SimpleNamespace(
+            key=_SINGLEUSER_CONFIRMS_KEY, value=json.dumps(9),
+        ))
+
+        @asynccontextmanager
+        async def _sess():
+            yield db
+
+        monkeypatch.setattr("services.database.AsyncSessionLocal", _sess, raising=False)
+        assert await _get_confirms_used(None) == 9
+
+    @pytest.mark.unit
+    async def test_get_singleuser_zero_when_no_setting(self, monkeypatch):
+        from services.chat_upload_tool import _get_confirms_used
+
+        db = MagicMock()
+        db.get = AsyncMock(return_value=None)
+
+        @asynccontextmanager
+        async def _sess():
+            yield db
+
+        monkeypatch.setattr("services.database.AsyncSessionLocal", _sess, raising=False)
+        assert await _get_confirms_used(None) == 0


### PR DESCRIPTION
## Why ("why must I confirm every Paperless archive?")
Two issues:

1. **Confirm fired on every archive.** The cold-start confirm trusts itself after `_COLD_START_CONFIRM_N` (10) archives, but the counter lived on `users.paperless_confirms_used`. In single-user mode (`AUTH_ENABLED=false`) `user_id` is `None` → `WHERE User.id = NULL` always read 0 → never reached the threshold → confirmed forever.
2. **Preview arrived paraphrased** ("mit 'Ja' bestätigen", losing the per-field choices) when `forward_attachment_to_paperless` ran **in parallel** with another tool — the single-tool `action_required` short-circuit never runs in the parallel path, so the LLM summarized it.

## Fix
1. Track the cold-start counter in a global `SystemSetting` key (`paperless.singleuser_confirms_used`) when `user_id` is `None`. `_get_confirms_used(None)` reads it; new `_bump_confirms_used(db, user_id)` increments per-user or the global key. The finalizer bumps it **only on a confirmed consume**. → single-user goes silent after N too.
2. The parallel executor captures an `action_required` result and relays its message **verbatim** as `final_answer` + returns (mirrors the single-tool short-circuit), so the full field preview reaches the user.

## /review (adversarial) — approve as-is
Fail-safe direction correct (missing/corrupt counter → 0 → confirm); ORM persistence on the shared finalizer session sound; parallel relay structurally identical to the proven single-tool path. One LOW/benign note: single-user counter is read-modify-write (a truly-concurrent double consume could lose one increment → at most one extra prompt); not worth dialect-specific SQL under AUTH-off.

## Tests
+4 single-user counter tests; 93 upload/commit + 140 agent tests pass. Backend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)