### PR TITLE
chore(paperless): configurable cold-start confirm threshold (default 3)

### DIFF
--- a/src/backend/services/chat_upload_tool.py
+++ b/src/backend/services/chat_upload_tool.py
@@ -32,13 +32,15 @@ from pathlib import Path
 
 from loguru import logger
 
+from utils.config import settings
 
-# Cold-start window for the LLM-metadata confirm flow. Design doc § 5:
-# first N uploads per user require explicit confirm; after that the
-# system trusts itself and extraction runs silently. N=10 is
-# conservative — covers "first two weeks of household use" at ~1
-# upload/day without becoming permanent friction.
-_COLD_START_CONFIRM_N = 10
+
+# Cold-start window for the LLM-metadata confirm flow: the first N archives
+# require an explicit confirm; after that the system trusts itself and archives
+# silently. Sourced from settings (default 3) so it's tunable without a code
+# change — `PAPERLESS_COLD_START_CONFIRM_N=0` disables the confirm entirely.
+# (Was a hard-coded 10, which felt like permanent friction in practice.)
+_COLD_START_CONFIRM_N = settings.paperless_cold_start_confirm_n
 
 # Skip-metadata heuristic. The agent can pass ``skip_metadata=True``
 # explicitly when the user said "ohne Metadaten". The tool itself also

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -485,6 +485,10 @@ class Settings(BaseSettings):
     chat_upload_retention_days: int = Field(default=30, ge=1, le=365)
     chat_upload_cleanup_enabled: bool = False
     chat_upload_email_account: str = "primary"
+    # Paperless cold-start confirm ramp: the first N archives show a metadata
+    # confirm; after N the system trusts itself and archives silently. 0 =
+    # never confirm (always silent). Tunable without a code change.
+    paperless_cold_start_confirm_n: int = Field(default=3, ge=0, le=100)
 
     # Federation (v2 — F5a depth + cycle detection)
     # Max number of federation hops a query can traverse before


### PR DESCRIPTION
Makes the Paperless 'trust after N archives' threshold a setting (`PAPERLESS_COLD_START_CONFIRM_N`, default **3**, was a hard-coded 10) so the confirm quiets down after a short safety ramp and is tunable without a code change; `0` disables the confirm entirely. /review (adversarial): approve — no circular import, frozen-at-import bind matches the codebase, `>=` semantics correct, 46 tests green. Backend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)