### PR TITLE
feat(paperless): interactive confirm card replaces typed choice syntax

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -33,6 +33,7 @@ Renfield ist ein vollständig offline-fähiger, selbst-gehosteter **digitaler As
 - **OCR-Text im Kontext**: Der Agent sieht den extrahierten Text per `document_context`-Prompt-Block inklusive `[attachment_id=N]`-Marker pro Datei
 - **Natürliche Weiterleitung nach Paperless**: „Lade diese Rechnung nach Paperless hoch" → Agent ruft `internal.forward_attachment_to_paperless(attachment_id=N)` auf; die Datei wird **direkt von Server-Storage** gelesen und als echte Bytes zum Paperless-MCP geleitet — der Agent handhabt nie Base64-Inhalte und kann daher nichts halluzinieren
 - **Session-Scope**: Die Attachment-Lookup ist auf die Chat-Session des Nutzers beschränkt — kein Cross-Session-Zugriff auf fremde Uploads
+- **Interaktive Bestätigungskarte**: Beim Cold-Start-Confirm (erste N Uploads) zeigt der Chat eine klickbare Karte statt einer getippten Syntax — pro unklarem Feld (Korrespondent / Typ / Tags / Speicherpfad) eine Auswahl „vorhandenen Treffer übernehmen / neu anlegen (editierbar) / leer lassen", Vorgaben vorausgewählt (nie „neu"). Der Nutzer klickt und bestätigt; das Frontend sendet eine strukturierte Entscheidung (`paperless_confirm`-WS-Frame) direkt an `internal.paperless_commit_upload`. Die getippte `ja` / `nein` / `1: 2, 2: neu`-Antwort bleibt als Fallback erhalten.
 - **HTTP-Fallback**: `POST /api/chat_upload/{id}/paperless` als direkter Endpoint für Frontend-Buttons (ohne LLM im Loop)
 
 ## Sprach-Interface

--- a/docs/design/paperless-llm-metadata.md
+++ b/docs/design/paperless-llm-metadata.md
@@ -291,37 +291,51 @@ Neu anzulegen:    keine
 Passt das so? (ja / nein / was ändern willst du)
 ```
 
-**Known limitations of the free-text form:**
-- No per-field edit affordance (user has to type "ändere den Korrespondent auf Stadtwerke Köln")
-- No tree-picker for storage_path
-- All-or-nothing approval of new taxonomy proposals
+The free-text form is now the **fallback** — the interactive confirm card
+(below) is the primary affordance. Free-text still works (a typed `ja` /
+`nein` / `1: 2, 2: neu` reply is parsed by `_parse_user_choices`), but the
+per-field limitations it had (no edit affordance, all-or-nothing taxonomy
+approval, fragile separator syntax) no longer gate the user, who clicks
+instead of types.
 
-These only apply during the 10-upload cold-start window, so the pain is
-bounded. Mitigated further by the interactive card in PR 5 (below).
+#### interactive confirm card (SHIPPED)
 
-#### PR 5: interactive confirm card (still conditional, rationale shifts)
+> **Status: built.** The free-text mini-syntax (`1: 2, 2: neu`) proved
+> error-prone — a single stray `.` in a reply made the parser reject the
+> whole line, silently fall back to `ja`, and skip new tags the user had
+> agreed to create. Replaced with a clickable per-field picker modelled on
+> Claude Code's option cards.
 
-A chat-embedded card with per-field controls:
-- Inline-edit title
-- Tag chips with remove-X buttons
-- Storage-path tree picker (fed from Paperless's current tree)
-- Per-proposal accept/decline buttons for new taxonomy entries
-- One "Alles gut — ablegen" button
+A chat-embedded card attached to the assistant bubble that streamed the
+preview. Each ambiguous field shows its detected value plus options —
+**use an existing match / create new (editable text) / leave empty** — with
+safe defaults pre-selected (top near-match, never "create"). The user picks
+per field and hits **Ablegen** (or **Abbrechen**); the frontend submits a
+structured decision, no free-text parsing.
 
-Existing infrastructure: Renfield already has Adaptive Cards for the
-orchestrator ([#374](https://github.com/ebongard/renfield/pull/374)) —
-same rail. The card renders, the user clicks, the backend receives a
-structured payload instead of free text.
+**Data flow.** `forward_attachment_to_paperless` adds a structured
+`confirm` payload (`{summary, fields[{idx, field, label, extracted_value,
+options[], default}]}`) to its result `data` via
+`_build_confirm_payload` — `idx` is 1-based over the **full** proposals
+list so it maps straight to `pending.proposals[idx-1]` (same convention as
+`_parse_user_choices`; exact-match fields are hidden from the card without
+shifting indices). `agent_service` relays it as a `paperless_confirm` step →
+`paperless_confirm_request` WS message (deferred behind the preview bubble in
+both the single-agent and orchestrated paths, mirroring the `card` step). The
+card submits a `{type:"paperless_confirm", confirm_token, decisions:[{idx,
+action, value}], abort?}` WS frame, which `chat_handler` routes straight to
+`internal.paperless_commit_upload`; `_decisions_from_structured` maps the
+choices back onto the resolution-anchored `{resolution, action, value}` shape
+`_commit_approved` already consumed. No change to `_commit_approved`.
 
-**When to build.** Because confirm is cold-start-only, PR 5's priority
-is **improving the first 10 uploads**, not replacing permanent confirm.
-Build it if: (a) cold-start quality signal is noisy because users
-rubber-stamp free-text confirms they can't easily edit, or (b) first
-impressions matter enough that "type a German correction" is the wrong
-first experience for new users.
+**Components.** `PaperlessConfirmCard.tsx` (radio per field + editable create
+value), wired through `useChatWebSocket` (`paperless_confirm_request` type) →
+`ChatContext` (`submitPaperlessConfirm`, attaches to the latest assistant
+message) → `ChatMessages`. Reuses `.card` / `.btn-primary` / `.input` tokens;
+i18n under `chat.paperlessConfirm.*`.
 
-If the N = 10 window closes cleanly without much correction activity,
-PR 5 isn't needed.
+This only matters during the cold-start confirm window (first N uploads),
+after which uploads commit silently.
 
 ## Extraction stack (v1)
 

--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -693,6 +693,59 @@ async def websocket_endpoint(
                     session_state.db_session_id = reg_sid
                 continue
 
+            # Structured Paperless-confirm decision from the interactive confirm
+            # card. The card submits {type:"paperless_confirm", confirm_token,
+            # decisions:[{idx,action,value}], abort?} instead of free text, so we
+            # route straight to internal.paperless_commit_upload with the
+            # structured decisions — bypassing the free-text parser entirely.
+            # Handled before WSChatMessage validation (which is Literal["text"]).
+            if isinstance(data, dict) and data.get("type") == "paperless_confirm":
+                confirm_token = data.get("confirm_token")
+                confirm_sid = data.get("session_id") or session_state.db_session_id
+                if not confirm_token:
+                    await send_ws_error(
+                        websocket, WSErrorCode.INVALID_MESSAGE,
+                        "paperless_confirm requires 'confirm_token'",
+                    )
+                    continue
+                try:
+                    from services.action_executor import ActionExecutor
+                    _mcp = getattr(app.state, "mcp_manager", None)
+                    _executor = ActionExecutor(mcp_manager=_mcp, session_id=confirm_sid)
+                    _params = {"confirm_token": confirm_token}
+                    if data.get("abort"):
+                        _params["abort"] = True
+                    else:
+                        _params["decisions"] = data.get("decisions") or []
+                    action_result = await _executor.execute(
+                        {
+                            "intent": "internal.paperless_commit_upload",
+                            "parameters": _params,
+                            "confidence": 1.0,
+                        },
+                        user_id=user_id,
+                    )
+                    await websocket.send_json({
+                        "type": "action",
+                        "intent": {"intent": "internal.paperless_commit_upload"},
+                        "result": action_result,
+                    })
+                    _confirm_msg = action_result.get("message", "") or ""
+                    if _confirm_msg:
+                        await websocket.send_json({"type": "stream", "content": _confirm_msg})
+                    await websocket.send_json({"type": "done"})
+                    logger.info(
+                        f"📎 Paperless confirm card → commit token "
+                        f"{str(confirm_token)[:8]} (session {confirm_sid})"
+                    )
+                except Exception as e:  # noqa: BLE001
+                    logger.warning(f"⚠️ Paperless confirm card handoff failed: {e}")
+                    await send_ws_error(
+                        websocket, WSErrorCode.INTERNAL_ERROR,
+                        "Bestätigung konnte nicht verarbeitet werden.",
+                    )
+                continue
+
             # Validate message
             try:
                 msg = WSChatMessage(**data)

--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -701,7 +701,18 @@ async def websocket_endpoint(
             # Handled before WSChatMessage validation (which is Literal["text"]).
             if isinstance(data, dict) and data.get("type") == "paperless_confirm":
                 confirm_token = data.get("confirm_token")
-                confirm_sid = data.get("session_id") or session_state.db_session_id
+                # Prefer the server-tracked session (set on the `register` frame
+                # / first message) over the client-supplied one — the pending
+                # lookup is session-scoped, so trusting client input here would
+                # let a leaked confirm_token cross session boundaries.
+                confirm_sid = session_state.db_session_id or data.get("session_id")
+                # `user_id` is a loop-body local (first bound after WSChatMessage
+                # validation below), so derive the connection identity locally —
+                # referencing the later local here raises UnboundLocalError when a
+                # confirm frame is the first frame on a (re)connected socket.
+                confirm_user_id = (
+                    auth_result.get("user_id") if isinstance(auth_result, dict) else None
+                )
                 if not confirm_token:
                     await send_ws_error(
                         websocket, WSErrorCode.INVALID_MESSAGE,
@@ -723,7 +734,7 @@ async def websocket_endpoint(
                             "parameters": _params,
                             "confidence": 1.0,
                         },
-                        user_id=user_id,
+                        user_id=confirm_user_id,
                     )
                     await websocket.send_json({
                         "type": "action",
@@ -1357,6 +1368,7 @@ async def websocket_endpoint(
                         deferred_final_answer: str | None = None
                         deferred_card: dict | None = None
                         deferred_replace_text: str | None = None
+                        deferred_paperless_confirm: dict | None = None
 
                         async def _typing_callback() -> None:
                             await websocket.send_json({"type": "typing"})
@@ -1389,6 +1401,12 @@ async def websocket_endpoint(
                                 # 1-line lede via ``replace_text`` to
                                 # collapse the streamed synthesis bubble.
                                 deferred_replace_text = (step.data or {}).get("replace_text")
+                            elif step.step_type == "paperless_confirm":
+                                # Same deferral as `card` — the interactive
+                                # confirm card attaches to the latest assistant
+                                # bubble, so hold it until the synthesis text
+                                # is on the wire.
+                                deferred_paperless_confirm = step.data
                             else:
                                 await websocket.send_json(step_to_ws_message(step))
                             if step.step_type == "tool_result" and step.success and step.data:
@@ -1465,6 +1483,16 @@ async def websocket_endpoint(
                             if deferred_replace_text:
                                 card_msg["replace_text"] = deferred_replace_text
                             await websocket.send_json(card_msg)
+
+                        if deferred_paperless_confirm:
+                            from services.agent_service import AgentStep
+                            await websocket.send_json(step_to_ws_message(
+                                AgentStep(
+                                    step_number=0,
+                                    step_type="paperless_confirm",
+                                    data=deferred_paperless_confirm,
+                                )
+                            ))
 
                         if agent_tool_results:
                             action_result = _build_agent_action_result(agent_tool_results)

--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -1626,6 +1626,7 @@ class AgentService:
                     # capture it here and relay it instead of letting the LLM
                     # summarise (which drops the per-field choices).
                     parallel_preview: tuple[str, Any] | None = None
+                    parallel_confirm_data: dict | None = None
                     for act, res in zip(valid_actions, exec_results):
                         if isinstance(res, Exception):
                             logger.error(f"❌ Parallel tool '{act['action']}' failed: {res}")
@@ -1668,6 +1669,7 @@ class AgentService:
                             parallel_preview = (
                                 res.get("message") or "", _rd["action_required"],
                             )
+                            parallel_confirm_data = _rd
 
                     # Relay an action_required preview verbatim + stop the loop
                     # (mirrors the single-tool short-circuit below).
@@ -1681,6 +1683,17 @@ class AgentService:
                                 f"action_required={parallel_preview[1]}"
                             ),
                         )
+                        # Interactive confirm card (see single-tool path).
+                        if (
+                            isinstance(parallel_confirm_data, dict)
+                            and parallel_confirm_data.get("action_required") == "paperless_confirm"
+                            and parallel_confirm_data.get("confirm")
+                        ):
+                            yield AgentStep(
+                                step_number=step_num,
+                                step_type="paperless_confirm",
+                                data=parallel_confirm_data,
+                            )
                         return
 
                     continue  # Next iteration of ReAct loop
@@ -1891,6 +1904,19 @@ class AgentService:
                             f"action_required={tool_data['action_required']}"
                         ),
                     )
+                    # Interactive confirm card: when the tool supplied a
+                    # structured `confirm` payload, emit it as its own step so
+                    # the frontend renders a clickable picker (the preview text
+                    # above stays as the assistant bubble + fallback). Attaches
+                    # AFTER the final_answer so the bubble exists first (same
+                    # ordering the `card` step relies on).
+                    if tool_data.get("action_required") == "paperless_confirm" \
+                            and tool_data.get("confirm"):
+                        yield AgentStep(
+                            step_number=step_num,
+                            step_type="paperless_confirm",
+                            data=tool_data,
+                        )
                     return
 
             # Check for repeated empty results from the same tool
@@ -2177,6 +2203,20 @@ def step_to_ws_message(step: AgentStep) -> dict:
         if data.get("replace_text"):
             msg["replace_text"] = data["replace_text"]
         return msg
+    elif step.step_type == "paperless_confirm":
+        # Interactive Paperless confirm card. Carries the structured per-field
+        # options the frontend renders as a clickable picker; the user's choice
+        # comes back as a {type:"paperless_confirm"} frame (see chat_handler).
+        data = step.data or {}
+        confirm = data.get("confirm") or {}
+        return {
+            "type": "paperless_confirm_request",
+            "confirm_token": data.get("confirm_token"),
+            "attachment_id": data.get("attachment_id"),
+            "filename": data.get("filename"),
+            "summary": confirm.get("summary") or {},
+            "fields": confirm.get("fields") or [],
+        }
     else:
         return {
             "type": "agent_thinking",

--- a/src/backend/services/chat_upload_tool.py
+++ b/src/backend/services/chat_upload_tool.py
@@ -403,6 +403,14 @@ async def forward_attachment_to_paperless(
                 "confirm_token": confirm_token,
                 "attachment_id": attachment_id,
                 "filename": upload.filename,
+                # Structured payload for the interactive confirm card. The text
+                # preview above stays as the fallback; clients that render the
+                # card use this. `idx` is 1-based over the FULL proposals list so
+                # it maps straight to pending.proposals[idx-1] in the structured
+                # commit path (same convention as _parse_user_choices).
+                "confirm": _build_confirm_payload(
+                    post_fuzzy, extraction_result.metadata.resolutions,
+                ),
             },
         }
     except Exception as e:
@@ -802,3 +810,76 @@ def _render_confirm_message(
         "auf ausdrücklichen Wunsch (`neu`)."
     )
     return "\n".join(lines)
+
+
+def _build_confirm_payload(metadata: dict, resolutions: list) -> dict:
+    """Structured confirm data for the interactive confirm card.
+
+    Mirrors `_render_confirm_message` but emits machine-readable per-field
+    options instead of prose, so the frontend can render a clickable picker
+    and submit a structured decision (no free-text parsing).
+
+    `summary` is the already-resolved metadata (shown read-only on the card).
+    `fields` is one entry per resolution that still needs a user decision.
+    Each field's `idx` is **1-based over the full resolutions list** so it
+    maps straight to `pending.proposals[idx-1]` in the structured commit
+    path — the same index convention `_parse_user_choices` uses, so an
+    exact-match field we don't surface still doesn't shift the indices.
+    """
+    summary = {
+        key: metadata.get(key)
+        for key in (
+            "title", "correspondent", "document_type",
+            "tags", "storage_path", "created_date",
+        )
+    }
+
+    fields = []
+    for i, res in enumerate(resolutions or []):
+        field = res.field if hasattr(res, "field") else res.get("field")
+        extracted = (
+            res.extracted_value if hasattr(res, "extracted_value")
+            else res.get("extracted_value")
+        )
+        near = (
+            list(res.near_matches) if hasattr(res, "near_matches")
+            else list(res.get("near_matches") or [])
+        )
+        needs_decision = (
+            res.requires_user_decision if hasattr(res, "requires_user_decision")
+            else (res.get("status") != "exact" or bool(near))
+        )
+        if not needs_decision:
+            continue
+
+        # Options, in display order: each near-match (pick existing), then
+        # "create new" with the extracted value, then "leave empty".
+        options = [
+            {"action": "use", "value": candidate, "label": candidate}
+            for candidate in near
+        ]
+        options.append({
+            "action": "create",
+            "value": extracted,
+            "label": f"Neu anlegen: „{extracted}“",
+        })
+        options.append({"action": "skip", "value": None, "label": "Leer lassen"})
+
+        # Default mirrors `_default_decisions`: take the top near-match if
+        # present (the "(Vorschlag)" the text preview marks), else leave empty.
+        # NEVER default to "create" — new taxonomy entries only on explicit ask.
+        default = (
+            {"action": "use", "value": near[0]} if near
+            else {"action": "skip", "value": None}
+        )
+
+        fields.append({
+            "idx": i + 1,
+            "field": field,
+            "label": _FIELD_LABELS_DE.get(field, field),
+            "extracted_value": extracted,
+            "options": options,
+            "default": default,
+        })
+
+    return {"summary": summary, "fields": fields}

--- a/src/backend/services/paperless_commit_tool.py
+++ b/src/backend/services/paperless_commit_tool.py
@@ -174,6 +174,28 @@ async def paperless_commit_upload(
     normalised = raw_response.lower()
     resolutions: list[dict[str, Any]] = list(pending.proposals or [])
 
+    # Structured path (interactive confirm card). The frontend submits the
+    # decisions directly as `params["decisions"]` — a list of
+    # {idx, action, value} — so we bypass the free-text `_parse_user_choices`
+    # entirely. `params["abort"]` is the card's "Abbrechen" button.
+    structured = params.get("decisions")
+    if structured is not None or params.get("abort"):
+        if params.get("abort"):
+            return await _abort_pending(pending)
+        if not isinstance(structured, list):
+            return {
+                "success": False,
+                "message": "'decisions' must be a list of {idx, action, value}",
+                "action_taken": False,
+            }
+        decisions = _decisions_from_structured(structured, resolutions)
+        return await _commit_approved(
+            pending,
+            mcp_manager=mcp_manager,
+            user_id=user_id,
+            decisions=decisions,
+        )
+
     if normalised in _ABORT_TOKENS:
         return await _abort_pending(pending)
 
@@ -251,6 +273,43 @@ def _default_decisions(
                 "value": "",
             })
     return out
+
+
+def _decisions_from_structured(
+    structured: list[Any],
+    resolutions: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Map the interactive confirm card's structured decisions onto the
+    resolution-anchored decision shape `_commit_approved` consumes.
+
+    Each entry from the card is ``{idx, action, value}`` where ``idx`` is
+    1-based over the full proposals list (see `_build_confirm_payload`).
+    Entries with an out-of-range idx or an unknown action are dropped — a
+    field the card omits simply gets no decision, and `_commit_approved`
+    falls back to the already-resolved post_fuzzy value for it. "create"
+    backfills the extracted value when the card sent none; "skip" forces
+    an empty value so it never creates or assigns.
+    """
+    decisions: list[dict[str, Any]] = []
+    for entry in structured:
+        if not isinstance(entry, dict):
+            continue
+        idx = entry.get("idx")
+        action = entry.get("action")
+        if action not in ("use", "create", "skip"):
+            continue
+        if not isinstance(idx, int) or idx < 1 or idx > len(resolutions):
+            continue
+        res = resolutions[idx - 1]
+        value = entry.get("value")
+        if action == "create":
+            value = value or _resolution_value(res)
+        elif action == "skip":
+            value = ""
+        else:  # use
+            value = value or ""
+        decisions.append({"resolution": res, "action": action, "value": value})
+    return decisions
 
 
 def _parse_user_choices(

--- a/src/backend/services/paperless_commit_tool.py
+++ b/src/backend/services/paperless_commit_tool.py
@@ -298,16 +298,21 @@ def _decisions_from_structured(
         action = entry.get("action")
         if action not in ("use", "create", "skip"):
             continue
-        if not isinstance(idx, int) or idx < 1 or idx > len(resolutions):
+        # bool is an int subclass — exclude it so {"idx": true} can't alias idx 1.
+        if not isinstance(idx, int) or isinstance(idx, bool):
+            continue
+        if idx < 1 or idx > len(resolutions):
             continue
         res = resolutions[idx - 1]
-        value = entry.get("value")
+        # Coerce to str — a non-string value from a malformed payload would
+        # crash _commit_approved's `.strip()` (caught upstream, but the commit
+        # would silently never fire).
+        raw = entry.get("value")
+        value = raw if isinstance(raw, str) else ""
         if action == "create":
             value = value or _resolution_value(res)
         elif action == "skip":
             value = ""
-        else:  # use
-            value = value or ""
         decisions.append({"resolution": res, "action": action, "value": value})
     return decisions
 

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -183,6 +183,22 @@
     "emailFailed": "E-Mail-Versand fehlgeschlagen",
     "documentIndexing": "Wird indexiert...",
     "documentIndexed": "In Wissensdatenbank indexiert",
+    "paperlessConfirm": {
+      "title": "Dokument in Paperless ablegen",
+      "decisionsHeading": "Bitte pro Feld wählen",
+      "confirm": "Ablegen",
+      "abort": "Abbrechen",
+      "submitted": "Auswahl gesendet",
+      "createValueLabel": "Neuer Eintrag",
+      "summaryFields": {
+        "title": "Titel",
+        "correspondent": "Korrespondent",
+        "document_type": "Dokumenttyp",
+        "tags": "Tags",
+        "storage_path": "Speicherpfad",
+        "created_date": "Ausstellungsdatum"
+      }
+    },
     "agentThinking": "Denkt nach...",
     "agentStepsCount": "{{count}} Schritt ausgeführt",
     "agentStepsCount_other": "{{count}} Schritte ausgeführt",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -183,6 +183,22 @@
     "emailFailed": "Failed to send email",
     "documentIndexing": "Indexing to KB...",
     "documentIndexed": "Indexed to KB",
+    "paperlessConfirm": {
+      "title": "File document in Paperless",
+      "decisionsHeading": "Please choose per field",
+      "confirm": "File it",
+      "abort": "Cancel",
+      "submitted": "Choice submitted",
+      "createValueLabel": "New entry",
+      "summaryFields": {
+        "title": "Title",
+        "correspondent": "Correspondent",
+        "document_type": "Document type",
+        "tags": "Tags",
+        "storage_path": "Storage path",
+        "created_date": "Issue date"
+      }
+    },
     "agentThinking": "Thinking...",
     "agentStepsCount": "{{count}} step completed",
     "agentStepsCount_other": "{{count}} steps completed",

--- a/src/frontend/src/pages/ChatPage/ChatMessages.tsx
+++ b/src/frontend/src/pages/ChatPage/ChatMessages.tsx
@@ -316,6 +316,7 @@ export default function ChatMessages() {
             {/* Interactive Paperless cold-start confirm card */}
             {message.paperlessConfirm && (
               <PaperlessConfirmCard
+                key={message.paperlessConfirm.confirmToken}
                 confirmToken={message.paperlessConfirm.confirmToken}
                 filename={message.paperlessConfirm.filename}
                 summary={message.paperlessConfirm.summary}

--- a/src/frontend/src/pages/ChatPage/ChatMessages.tsx
+++ b/src/frontend/src/pages/ChatPage/ChatMessages.tsx
@@ -6,6 +6,7 @@ import AdaptiveCardRenderer from '../../components/AdaptiveCardRenderer';
 import IntentCorrectionButton from '../../components/IntentCorrectionButton';
 import AttachmentQuickActions from './AttachmentQuickActions';
 import EmailForwardDialog from './EmailForwardDialog';
+import PaperlessConfirmCard from './PaperlessConfirmCard';
 import { useChatContext } from './context/ChatContext';
 import { CitationChip } from '../../components/wissensbasis/CitationChip';
 import { useTraceQuery, type TraceEntity } from '../../api/resources/wissensbasis';
@@ -139,7 +140,7 @@ export default function ChatMessages() {
     messages, loading, historyLoading, speakText, handleFeedbackSubmit,
     actionLoading, actionResult, indexToKb, sendToPaperless, sendToBoth, handleSummarize,
     handleSendViaEmail, emailDialog, confirmSendViaEmail, cancelEmailDialog,
-    sendMessage, sessionId,
+    sendMessage, sessionId, submitPaperlessConfirm,
   } = useChatContext();
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
 
@@ -310,6 +311,19 @@ export default function ChatMessages() {
               <div className="mt-2">
                 <AdaptiveCardRenderer card={message.card} />
               </div>
+            )}
+
+            {/* Interactive Paperless cold-start confirm card */}
+            {message.paperlessConfirm && (
+              <PaperlessConfirmCard
+                confirmToken={message.paperlessConfirm.confirmToken}
+                filename={message.paperlessConfirm.filename}
+                summary={message.paperlessConfirm.summary}
+                fields={message.paperlessConfirm.fields}
+                status={message.paperlessConfirm.status}
+                onSubmit={(token, decisions) => submitPaperlessConfirm(token, { decisions })}
+                onAbort={(token) => submitPaperlessConfirm(token, { abort: true })}
+              />
             )}
 
             {/* Attachment chips */}

--- a/src/frontend/src/pages/ChatPage/PaperlessConfirmCard.tsx
+++ b/src/frontend/src/pages/ChatPage/PaperlessConfirmCard.tsx
@@ -65,6 +65,15 @@ export default function PaperlessConfirmCard({
     return init;
   });
 
+  // Editable "create" text, tracked per field separately from the selection so
+  // it survives toggling to another option and back (the selection's `value`
+  // gets overwritten by use/skip choices).
+  const [createDrafts, setCreateDrafts] = useState<Record<number, string>>(() => {
+    const init: Record<number, string> = {};
+    for (const f of fields) init[f.idx] = f.extracted_value ?? '';
+    return init;
+  });
+
   const summaryRows = useMemo(
     () =>
       (['title', 'correspondent', 'document_type', 'tags', 'storage_path', 'created_date'] as const)
@@ -72,30 +81,34 @@ export default function PaperlessConfirmCard({
     [summary],
   );
 
-  const pickOption = (idx: number, opt: PaperlessConfirmOption, extracted: string | null): void => {
+  const pickOption = (idx: number, opt: PaperlessConfirmOption): void => {
     if (readOnly) return;
     setSelections((prev) => ({
       ...prev,
       [idx]: {
         action: opt.action,
-        // "create" keeps the editable extracted value; others take the option's.
-        value: opt.action === 'create' ? (prev[idx]?.value ?? extracted ?? '') : opt.value,
+        // "create" pulls from the persisted draft; others take the option's.
+        value: opt.action === 'create' ? (createDrafts[idx] ?? '') : opt.value,
       },
     }));
   };
 
   const editCreateValue = (idx: number, value: string): void => {
     if (readOnly) return;
+    setCreateDrafts((prev) => ({ ...prev, [idx]: value }));
     setSelections((prev) => ({ ...prev, [idx]: { action: 'create', value } }));
   };
 
   const handleSubmit = (): void => {
     if (readOnly) return;
-    const decisions = fields.map((f) => ({
-      idx: f.idx,
-      action: selections[f.idx]?.action ?? 'skip',
-      value: selections[f.idx]?.value ?? null,
-    }));
+    const decisions = fields.map((f) => {
+      const action = selections[f.idx]?.action ?? 'skip';
+      const value =
+        action === 'create'
+          ? (createDrafts[f.idx] ?? f.extracted_value ?? '')
+          : (selections[f.idx]?.value ?? null);
+      return { idx: f.idx, action, value };
+    });
     onSubmit(confirmToken, decisions);
   };
 
@@ -136,12 +149,16 @@ export default function PaperlessConfirmCard({
                 </legend>
                 <div className="space-y-1 mt-1">
                   {f.options.map((opt) => {
-                    const selected = sel?.action === opt.action
-                      && (opt.action !== 'use' || sel?.value === opt.value);
+                    // "create" matches on action alone (its value is the
+                    // editable draft); use/skip match on action + value so two
+                    // same-action options can't both highlight.
+                    const selected = opt.action === 'create'
+                      ? sel?.action === 'create'
+                      : sel?.action === opt.action && (sel?.value ?? null) === (opt.value ?? null);
                     return (
                       <label
                         key={optionKey(opt)}
-                        className={`flex items-center gap-2 px-2 py-1 rounded cursor-pointer ${
+                        className={`flex items-center gap-2 px-2 py-2 min-h-[2.75rem] rounded cursor-pointer ${
                           selected
                             ? 'bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300'
                             : 'hover:bg-gray-50 dark:hover:bg-gray-800'
@@ -152,7 +169,7 @@ export default function PaperlessConfirmCard({
                           name={`pl-confirm-${confirmToken}-${f.idx}`}
                           checked={!!selected}
                           disabled={readOnly}
-                          onChange={() => pickOption(f.idx, opt, f.extracted_value)}
+                          onChange={() => pickOption(f.idx, opt)}
                           className="accent-primary-600"
                         />
                         <span>{opt.label}</span>
@@ -163,7 +180,7 @@ export default function PaperlessConfirmCard({
                   {sel?.action === 'create' && (
                     <input
                       type="text"
-                      value={sel.value ?? ''}
+                      value={createDrafts[f.idx] ?? ''}
                       disabled={readOnly}
                       onChange={(e) => editCreateValue(f.idx, e.target.value)}
                       aria-label={t('chat.paperlessConfirm.createValueLabel')}
@@ -187,7 +204,7 @@ export default function PaperlessConfirmCard({
           <button
             type="button"
             onClick={() => onAbort(confirmToken)}
-            className="btn-secondary inline-flex items-center gap-1 text-sm"
+            className="btn-secondary inline-flex items-center gap-1 text-sm min-h-[2.75rem]"
           >
             <X className="w-4 h-4" aria-hidden="true" />
             {t('chat.paperlessConfirm.abort')}
@@ -195,7 +212,7 @@ export default function PaperlessConfirmCard({
           <button
             type="button"
             onClick={handleSubmit}
-            className="btn-primary inline-flex items-center gap-1 text-sm"
+            className="btn-primary inline-flex items-center gap-1 text-sm min-h-[2.75rem]"
           >
             <Check className="w-4 h-4" aria-hidden="true" />
             {t('chat.paperlessConfirm.confirm')}

--- a/src/frontend/src/pages/ChatPage/PaperlessConfirmCard.tsx
+++ b/src/frontend/src/pages/ChatPage/PaperlessConfirmCard.tsx
@@ -1,0 +1,207 @@
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { FileText, Check, X } from 'lucide-react';
+import type {
+  PaperlessConfirmField,
+  PaperlessConfirmOption,
+} from './hooks/useChatWebSocket';
+
+interface PaperlessConfirmCardProps {
+  confirmToken: string;
+  filename?: string | null;
+  summary: Record<string, unknown>;
+  fields: PaperlessConfirmField[];
+  status: 'open' | 'submitted';
+  onSubmit: (
+    confirmToken: string,
+    decisions: { idx: number; action: string; value: string | null }[],
+  ) => void;
+  onAbort: (confirmToken: string) => void;
+}
+
+// Stable key for an option within a field's radio group.
+function optionKey(opt: PaperlessConfirmOption): string {
+  return `${opt.action}:${opt.value ?? ''}`;
+}
+
+function displaySummaryValue(value: unknown): string {
+  if (value === null || value === undefined || value === '') return '—';
+  if (Array.isArray(value)) return value.length ? value.map(String).join(', ') : '—';
+  return String(value);
+}
+
+/**
+ * Interactive Paperless cold-start confirm card. Replaces the typed
+ * "1:n, 2:x" mini-syntax with a per-field clickable picker: each ambiguous
+ * field shows its detected value plus options (use an existing match / create
+ * new / leave empty), defaults pre-selected. Submitting sends a structured
+ * decision over the WS — no free-text parsing.
+ */
+export default function PaperlessConfirmCard({
+  confirmToken,
+  filename,
+  summary,
+  fields,
+  status,
+  onSubmit,
+  onAbort,
+}: PaperlessConfirmCardProps) {
+  const { t } = useTranslation();
+  const readOnly = status === 'submitted';
+
+  // Per-field selection, seeded from each field's backend default. For a
+  // "create" default we also seed the editable value with the extracted text.
+  const [selections, setSelections] = useState<
+    Record<number, { action: string; value: string | null }>
+  >(() => {
+    const init: Record<number, { action: string; value: string | null }> = {};
+    for (const f of fields) {
+      const def = f.default;
+      init[f.idx] = {
+        action: def.action,
+        value: def.action === 'create' ? f.extracted_value : def.value,
+      };
+    }
+    return init;
+  });
+
+  const summaryRows = useMemo(
+    () =>
+      (['title', 'correspondent', 'document_type', 'tags', 'storage_path', 'created_date'] as const)
+        .map((key) => ({ key, value: summary[key] })),
+    [summary],
+  );
+
+  const pickOption = (idx: number, opt: PaperlessConfirmOption, extracted: string | null): void => {
+    if (readOnly) return;
+    setSelections((prev) => ({
+      ...prev,
+      [idx]: {
+        action: opt.action,
+        // "create" keeps the editable extracted value; others take the option's.
+        value: opt.action === 'create' ? (prev[idx]?.value ?? extracted ?? '') : opt.value,
+      },
+    }));
+  };
+
+  const editCreateValue = (idx: number, value: string): void => {
+    if (readOnly) return;
+    setSelections((prev) => ({ ...prev, [idx]: { action: 'create', value } }));
+  };
+
+  const handleSubmit = (): void => {
+    if (readOnly) return;
+    const decisions = fields.map((f) => ({
+      idx: f.idx,
+      action: selections[f.idx]?.action ?? 'skip',
+      value: selections[f.idx]?.value ?? null,
+    }));
+    onSubmit(confirmToken, decisions);
+  };
+
+  return (
+    <div className="mt-2 card border border-gray-200 dark:border-gray-700 p-3 text-sm">
+      <div className="flex items-center gap-2 mb-2 font-medium text-gray-900 dark:text-gray-100">
+        <FileText className="w-4 h-4 flex-shrink-0 text-primary-600 dark:text-primary-400" aria-hidden="true" />
+        <span className="truncate">{filename || t('chat.paperlessConfirm.title')}</span>
+      </div>
+
+      {/* Resolved metadata (read-only preview) */}
+      <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 mb-3 text-gray-600 dark:text-gray-300">
+        {summaryRows.map(({ key, value }) => (
+          <div key={key} className="contents">
+            <dt className="text-gray-400 dark:text-gray-500">
+              {t(`chat.paperlessConfirm.summaryFields.${key}`)}
+            </dt>
+            <dd className="truncate">{displaySummaryValue(value)}</dd>
+          </div>
+        ))}
+      </dl>
+
+      {/* Per-field decisions */}
+      {fields.length > 0 && (
+        <div className="space-y-3">
+          <p className="text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">
+            {t('chat.paperlessConfirm.decisionsHeading')}
+          </p>
+          {fields.map((f) => {
+            const sel = selections[f.idx];
+            return (
+              <fieldset key={f.idx} className="border border-gray-100 dark:border-gray-700 rounded-md p-2">
+                <legend className="px-1 text-gray-700 dark:text-gray-200">
+                  {f.label}
+                  {f.extracted_value ? (
+                    <span className="text-gray-400 dark:text-gray-500"> · „{f.extracted_value}“</span>
+                  ) : null}
+                </legend>
+                <div className="space-y-1 mt-1">
+                  {f.options.map((opt) => {
+                    const selected = sel?.action === opt.action
+                      && (opt.action !== 'use' || sel?.value === opt.value);
+                    return (
+                      <label
+                        key={optionKey(opt)}
+                        className={`flex items-center gap-2 px-2 py-1 rounded cursor-pointer ${
+                          selected
+                            ? 'bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300'
+                            : 'hover:bg-gray-50 dark:hover:bg-gray-800'
+                        } ${readOnly ? 'cursor-default opacity-80' : ''}`}
+                      >
+                        <input
+                          type="radio"
+                          name={`pl-confirm-${confirmToken}-${f.idx}`}
+                          checked={!!selected}
+                          disabled={readOnly}
+                          onChange={() => pickOption(f.idx, opt, f.extracted_value)}
+                          className="accent-primary-600"
+                        />
+                        <span>{opt.label}</span>
+                      </label>
+                    );
+                  })}
+                  {/* Editable value when "create" is selected (fix OCR typos). */}
+                  {sel?.action === 'create' && (
+                    <input
+                      type="text"
+                      value={sel.value ?? ''}
+                      disabled={readOnly}
+                      onChange={(e) => editCreateValue(f.idx, e.target.value)}
+                      aria-label={t('chat.paperlessConfirm.createValueLabel')}
+                      className="input mt-1 w-full text-sm"
+                    />
+                  )}
+                </div>
+              </fieldset>
+            );
+          })}
+        </div>
+      )}
+
+      {readOnly ? (
+        <p className="mt-3 text-xs text-gray-400 dark:text-gray-500 flex items-center gap-1">
+          <Check className="w-3 h-3" aria-hidden="true" />
+          {t('chat.paperlessConfirm.submitted')}
+        </p>
+      ) : (
+        <div className="mt-3 flex gap-2 justify-end">
+          <button
+            type="button"
+            onClick={() => onAbort(confirmToken)}
+            className="btn-secondary inline-flex items-center gap-1 text-sm"
+          >
+            <X className="w-4 h-4" aria-hidden="true" />
+            {t('chat.paperlessConfirm.abort')}
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            className="btn-primary inline-flex items-center gap-1 text-sm"
+          >
+            <Check className="w-4 h-4" aria-hidden="true" />
+            {t('chat.paperlessConfirm.confirm')}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
+++ b/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
@@ -977,12 +977,22 @@ export function ChatProvider({ children }: ChatProviderProps) {
       confirmToken: string,
       payload: { decisions: { idx: number; action: string; value: string | null }[] } | { abort: true },
     ): void => {
-      wsSendMessage({
+      // Only flip the card to read-only if the frame actually went out.
+      // wsSendMessage returns false when the socket isn't OPEN — marking it
+      // 'submitted' anyway would strand the confirm with no retry path.
+      const sent = wsSendMessage({
         type: 'paperless_confirm',
         confirm_token: confirmToken,
         session_id: sessionId,
         ...payload,
       });
+      if (!sent) {
+        setMessages((prev) => [
+          ...prev,
+          { role: 'assistant', content: t('errors.couldNotProcess') },
+        ]);
+        return;
+      }
       setMessages((prev) =>
         prev.map((msg) =>
           msg.paperlessConfirm?.confirmToken === confirmToken
@@ -991,7 +1001,7 @@ export function ChatProvider({ children }: ChatProviderProps) {
         ),
       );
     },
-    [wsSendMessage, sessionId],
+    [wsSendMessage, sessionId, t],
   );
 
   // Register this session on the WS as soon as it's connected, so background

--- a/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
+++ b/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
@@ -38,6 +38,8 @@ import type {
   DoneMessage,
   IntentFeedbackRequestMessage,
   PaperlessCommittedMessage,
+  PaperlessConfirmField,
+  PaperlessConfirmRequestMessage,
   RagContextMessage,
   UploadProcessedMessage,
 } from '../hooks/useChatWebSocket';
@@ -96,6 +98,17 @@ export interface ChatUiMessage {
   federationProgress?: Record<string, FederationProgressEntry>;
   attachments?: MessageAttachment[];
   card?: Record<string, unknown>;
+  // Interactive Paperless confirm card (cold-start upload metadata picker).
+  // Attached to the assistant bubble that streamed the preview; the user
+  // resolves each field and submits a structured decision. `status` flips to
+  // 'submitted' once sent so the card renders read-only.
+  paperlessConfirm?: {
+    confirmToken: string;
+    filename?: string | null;
+    summary: Record<string, unknown>;
+    fields: PaperlessConfirmField[];
+    status: 'open' | 'submitted';
+  };
   // Entities resolved during THIS turn, persisted per-message by Reva's
   // on_pre_save_message. Lets the chip renderer wrap mentions per bubble
   // instead of smearing the session-last reasoning trace across all of them.
@@ -145,6 +158,12 @@ export interface ChatContextValue {
   setInput: Dispatch<SetStateAction<string>>;
   historyLoading: boolean;
   sendMessage: (text: string, fromVoice?: boolean) => Promise<void>;
+  // Submit the user's interactive Paperless-confirm decision (per-field
+  // choices, or an abort) for the given pending confirm_token.
+  submitPaperlessConfirm: (
+    confirmToken: string,
+    payload: { decisions: { idx: number; action: string; value: string | null }[] } | { abort: true },
+  ) => void;
 
   // Session
   sessionId: string | null;
@@ -902,6 +921,32 @@ export function ChatProvider({ children }: ChatProviderProps) {
     });
   }, []);
 
+  // Interactive Paperless confirm request — attach the structured picker to
+  // the assistant bubble that just streamed the preview text (same "most
+  // recent assistant message" attach as handleCard).
+  const handlePaperlessConfirmRequest = useCallback((data: PaperlessConfirmRequestMessage) => {
+    if (!data.confirm_token || !data.fields) return;
+    setMessages((prev) => {
+      const updated = [...prev];
+      for (let i = updated.length - 1; i >= 0; i--) {
+        if (updated[i].role === 'assistant') {
+          updated[i] = {
+            ...updated[i],
+            paperlessConfirm: {
+              confirmToken: data.confirm_token,
+              filename: data.filename,
+              summary: data.summary || {},
+              fields: data.fields,
+              status: 'open',
+            },
+          };
+          break;
+        }
+      }
+      return updated;
+    });
+  }, []);
+
   // WebSocket hook
   const { wsConnected, sendMessage: wsSendMessage, isReady, whenReady } = useChatWebSocket({
     onStreamChunk: handleStreamChunk,
@@ -919,7 +964,35 @@ export function ChatProvider({ children }: ChatProviderProps) {
     onAgentToolResult: handleAgentToolResult,
     onAgentFederationProgress: handleAgentFederationProgress,
     onCard: handleCard,
+    onPaperlessConfirmRequest: handlePaperlessConfirmRequest,
   });
+
+  // Submit the user's structured Paperless-confirm decision over the WS. The
+  // backend routes the {type:"paperless_confirm"} frame straight to
+  // internal.paperless_commit_upload (see chat_handler). We flip the card to
+  // 'submitted' immediately so it renders read-only; the commit's result
+  // arrives as a normal streamed assistant message.
+  const submitPaperlessConfirm = useCallback(
+    (
+      confirmToken: string,
+      payload: { decisions: { idx: number; action: string; value: string | null }[] } | { abort: true },
+    ): void => {
+      wsSendMessage({
+        type: 'paperless_confirm',
+        confirm_token: confirmToken,
+        session_id: sessionId,
+        ...payload,
+      });
+      setMessages((prev) =>
+        prev.map((msg) =>
+          msg.paperlessConfirm?.confirmToken === confirmToken
+            ? { ...msg, paperlessConfirm: { ...msg.paperlessConfirm, status: 'submitted' } }
+            : msg,
+        ),
+      );
+    },
+    [wsSendMessage, sessionId],
+  );
 
   // Register this session on the WS as soon as it's connected, so background
   // pushes (e.g. async chat-upload `upload_processed`) can reach it BEFORE the
@@ -1403,6 +1476,7 @@ export function ChatProvider({ children }: ChatProviderProps) {
     setInput,
     historyLoading,
     sendMessage: sendMessageInternal,
+    submitPaperlessConfirm,
 
     // Session
     sessionId,
@@ -1467,7 +1541,7 @@ export function ChatProvider({ children }: ChatProviderProps) {
     speakText,
     handleFeedbackSubmit,
   }), [
-    messages, loading, input, historyLoading, sendMessageInternal,
+    messages, loading, input, historyLoading, sendMessageInternal, submitPaperlessConfirm,
     sessionId, sidebarOpen, switchConversation, startNewChat, handleDeleteConversation,
     conversations, conversationsLoading,
     wsConnected,

--- a/src/frontend/src/pages/ChatPage/hooks/useChatWebSocket.ts
+++ b/src/frontend/src/pages/ChatPage/hooks/useChatWebSocket.ts
@@ -77,6 +77,33 @@ export interface PaperlessCommittedMessage extends BaseWsMessage {
   message: string;
 }
 
+// Interactive Paperless confirm card. Pushed when an upload needs the user to
+// resolve ambiguous metadata (correspondent / type / tags). The user picks per
+// field and submits a structured decision back (no free-text parsing).
+export interface PaperlessConfirmOption {
+  action: 'use' | 'create' | 'skip';
+  value: string | null;
+  label: string;
+}
+
+export interface PaperlessConfirmField {
+  idx: number;              // 1-based over the backend proposals list
+  field: string;            // correspondent | document_type | storage_path | tag
+  label: string;            // localized field label from the backend
+  extracted_value: string | null;
+  options: PaperlessConfirmOption[];
+  default: { action: 'use' | 'create' | 'skip'; value: string | null };
+}
+
+export interface PaperlessConfirmRequestMessage extends BaseWsMessage {
+  type: 'paperless_confirm_request';
+  confirm_token: string;
+  attachment_id?: number | null;
+  filename?: string | null;
+  summary: Record<string, unknown>;
+  fields: PaperlessConfirmField[];
+}
+
 export interface AgentThinkingMessage extends BaseWsMessage {
   type: 'agent_thinking';
   step?: number;
@@ -129,6 +156,7 @@ interface UseChatWebSocketOptions {
   onDocumentError?: (data: DocumentErrorMessage) => void;
   onUploadProcessed?: (data: UploadProcessedMessage) => void;
   onPaperlessCommitted?: (data: PaperlessCommittedMessage) => void;
+  onPaperlessConfirmRequest?: (data: PaperlessConfirmRequestMessage) => void;
   onAgentThinking?: (data: AgentThinkingMessage) => void;
   onAgentToolCall?: (data: AgentToolCallMessage) => void;
   onAgentToolResult?: (data: AgentToolResultMessage) => void;
@@ -151,6 +179,7 @@ export function useChatWebSocket({
   onDocumentError,
   onUploadProcessed,
   onPaperlessCommitted,
+  onPaperlessConfirmRequest,
   onAgentThinking,
   onAgentToolCall,
   onAgentToolResult,
@@ -244,6 +273,10 @@ export function useChatWebSocket({
       } else if (data.type === 'card') {
         debug.log('Card received');
         onCard?.(data as CardMessage);
+      } else if (data.type === 'paperless_confirm_request') {
+        const msg = data as PaperlessConfirmRequestMessage;
+        debug.log('Paperless confirm request:', msg.filename, `${msg.fields?.length ?? 0} fields`);
+        onPaperlessConfirmRequest?.(msg);
       }
     };
 
@@ -262,7 +295,7 @@ export function useChatWebSocket({
     };
 
     wsRef.current = ws;
-  }, [onStreamChunk, onStreamDone, onAction, onRagContext, onIntentFeedbackRequest, onDocumentProcessing, onDocumentReady, onDocumentError, onAgentThinking, onAgentToolCall, onAgentToolResult, onAgentFederationProgress, onCard]);
+  }, [onStreamChunk, onStreamDone, onAction, onRagContext, onIntentFeedbackRequest, onDocumentProcessing, onDocumentReady, onDocumentError, onUploadProcessed, onPaperlessCommitted, onPaperlessConfirmRequest, onAgentThinking, onAgentToolCall, onAgentToolResult, onAgentFederationProgress, onCard]);
 
   useEffect(() => {
     connectWebSocket();

--- a/tests/backend/test_paperless_confirm_card.py
+++ b/tests/backend/test_paperless_confirm_card.py
@@ -146,6 +146,25 @@ class TestDecisionsFromStructured:
         assert out[0]["value"] == ""
 
     @pytest.mark.unit
+    def test_non_string_value_coerced_to_empty(self):
+        # A malformed payload value (dict/None) must not survive — it would
+        # crash _commit_approved's .strip(). "use" with junk → "".
+        out = _decisions_from_structured(
+            [{"idx": 1, "action": "use", "value": {"x": 1}}],
+            _RESOLUTIONS,
+        )
+        assert out[0]["value"] == ""
+
+    @pytest.mark.unit
+    def test_bool_idx_rejected(self):
+        # bool is an int subclass — must NOT alias idx 1.
+        out = _decisions_from_structured(
+            [{"idx": True, "action": "use", "value": "x"}],
+            _RESOLUTIONS,
+        )
+        assert out == []
+
+    @pytest.mark.unit
     def test_out_of_range_and_unknown_action_dropped(self):
         out = _decisions_from_structured(
             [

--- a/tests/backend/test_paperless_confirm_card.py
+++ b/tests/backend/test_paperless_confirm_card.py
@@ -1,0 +1,304 @@
+"""
+Unit tests for the interactive Paperless confirm card.
+
+Covers the structured (clickable-picker) confirm path that replaces the
+free-text "1:n, 2:x" mini-syntax:
+
+    - ``_build_confirm_payload`` (chat_upload_tool): produces per-field
+      options with a 1-based idx over the FULL proposals list, surfacing
+      only fields that need a decision, with safe defaults.
+    - ``_decisions_from_structured`` (paperless_commit_tool): maps the
+      card's {idx, action, value} entries back onto resolution-anchored
+      decisions, dropping out-of-range / unknown-action entries.
+    - ``paperless_commit_upload`` structured branch: ``params["decisions"]``
+      routes straight to the commit (bypassing the text parser);
+      ``params["abort"]`` aborts.
+
+Pure-unit, heavy mocking. Mirrors test_paperless_commit_tool.py helpers.
+"""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.chat_upload_tool import _build_confirm_payload
+from services.paperless_commit_tool import (
+    _decisions_from_structured,
+    paperless_commit_upload,
+)
+
+
+# ===========================================================================
+# _build_confirm_payload
+# ===========================================================================
+
+_SUMMARY = {
+    "title": "Stromrechnung",
+    "correspondent": "Telekom",
+    "document_type": "Rechnung",
+    "tags": ["wohnung"],
+    "storage_path": "/x",
+    "created_date": None,
+    "ignored_extra": "drop me",
+}
+
+# Mixed bag: fuzzy w/ matches, no-match (needs decision), an EXACT hit that
+# must be skipped from the card WITHOUT shifting later indices, and a tag.
+_RESOLUTIONS = [
+    {"field": "correspondent", "extracted_value": "Telekom",
+     "near_matches": ["Telekom AG", "Telekom GmbH"], "status": "fuzzy"},
+    {"field": "document_type", "extracted_value": "Rechnung",
+     "near_matches": [], "status": "none"},
+    {"field": "storage_path", "extracted_value": "/x",
+     "near_matches": [], "status": "exact"},   # resolved → not surfaced
+    {"field": "tag", "extracted_value": "wohnung",
+     "near_matches": ["Wohnung"], "status": "fuzzy"},
+]
+
+
+class TestBuildConfirmPayload:
+    @pytest.mark.unit
+    def test_summary_carries_only_known_keys(self):
+        payload = _build_confirm_payload(_SUMMARY, _RESOLUTIONS)
+        assert set(payload["summary"]) == {
+            "title", "correspondent", "document_type",
+            "tags", "storage_path", "created_date",
+        }
+        assert payload["summary"]["correspondent"] == "Telekom"
+        assert "ignored_extra" not in payload["summary"]
+
+    @pytest.mark.unit
+    def test_exact_field_skipped_but_index_preserved(self):
+        payload = _build_confirm_payload(_SUMMARY, _RESOLUTIONS)
+        idxs = [f["idx"] for f in payload["fields"]]
+        # correspondent=1, document_type=2, (storage_path=3 EXACT → hidden), tag=4
+        assert idxs == [1, 2, 4]
+        assert [f["field"] for f in payload["fields"]] == [
+            "correspondent", "document_type", "tag",
+        ]
+
+    @pytest.mark.unit
+    def test_options_order_and_actions(self):
+        payload = _build_confirm_payload(_SUMMARY, _RESOLUTIONS)
+        corr = payload["fields"][0]
+        actions = [(o["action"], o["value"]) for o in corr["options"]]
+        assert actions == [
+            ("use", "Telekom AG"),
+            ("use", "Telekom GmbH"),
+            ("create", "Telekom"),
+            ("skip", None),
+        ]
+
+    @pytest.mark.unit
+    def test_default_picks_top_match_when_present(self):
+        payload = _build_confirm_payload(_SUMMARY, _RESOLUTIONS)
+        assert payload["fields"][0]["default"] == {"action": "use", "value": "Telekom AG"}
+
+    @pytest.mark.unit
+    def test_default_skips_when_no_near_match(self):
+        # document_type has no near_matches → default must be skip, never create.
+        payload = _build_confirm_payload(_SUMMARY, _RESOLUTIONS)
+        doctype = payload["fields"][1]
+        assert doctype["default"] == {"action": "skip", "value": None}
+
+    @pytest.mark.unit
+    def test_empty_resolutions_yields_no_fields(self):
+        payload = _build_confirm_payload(_SUMMARY, [])
+        assert payload["fields"] == []
+
+
+# ===========================================================================
+# _decisions_from_structured
+# ===========================================================================
+
+
+class TestDecisionsFromStructured:
+    @pytest.mark.unit
+    def test_maps_idx_to_resolution(self):
+        out = _decisions_from_structured(
+            [{"idx": 1, "action": "use", "value": "Telekom AG"}],
+            _RESOLUTIONS,
+        )
+        assert len(out) == 1
+        assert out[0]["resolution"] is _RESOLUTIONS[0]
+        assert out[0]["action"] == "use"
+        assert out[0]["value"] == "Telekom AG"
+
+    @pytest.mark.unit
+    def test_create_backfills_extracted_value(self):
+        out = _decisions_from_structured(
+            [{"idx": 2, "action": "create", "value": None}],
+            _RESOLUTIONS,
+        )
+        assert out[0]["action"] == "create"
+        assert out[0]["value"] == "Rechnung"  # backfilled from extracted_value
+
+    @pytest.mark.unit
+    def test_skip_forces_empty_value(self):
+        out = _decisions_from_structured(
+            [{"idx": 4, "action": "skip", "value": "leftover"}],
+            _RESOLUTIONS,
+        )
+        assert out[0]["action"] == "skip"
+        assert out[0]["value"] == ""
+
+    @pytest.mark.unit
+    def test_out_of_range_and_unknown_action_dropped(self):
+        out = _decisions_from_structured(
+            [
+                {"idx": 99, "action": "use", "value": "x"},   # out of range
+                {"idx": 1, "action": "bogus"},                # unknown action
+                {"idx": 0, "action": "use"},                  # idx < 1
+                "not-a-dict",                                  # junk
+                {"idx": 1, "action": "use", "value": "Telekom AG"},  # valid
+            ],
+            _RESOLUTIONS,
+        )
+        assert len(out) == 1
+        assert out[0]["value"] == "Telekom AG"
+
+
+# ===========================================================================
+# paperless_commit_upload — structured branch
+# ===========================================================================
+
+
+def _make_pending(*, confirm_token, attachment_id, llm_output, post_fuzzy,
+                  proposals, edit_rounds=0):
+    return SimpleNamespace(
+        confirm_token=confirm_token,
+        attachment_id=attachment_id,
+        session_id="s",
+        user_id=1,
+        llm_output=llm_output,
+        post_fuzzy_output=post_fuzzy,
+        proposals=proposals,
+        edit_rounds=edit_rounds,
+    )
+
+
+def _make_session_factory(*, pending, upload=None):
+    def _factory():
+        session = AsyncMock()
+        session.__aenter__ = AsyncMock(return_value=session)
+        session.__aexit__ = AsyncMock(return_value=False)
+        session.add = MagicMock()
+        session.commit = AsyncMock()
+
+        def _execute(query):
+            result = MagicMock()
+            result.scalar_one_or_none = MagicMock(return_value=pending)
+            result.rowcount = 1
+            return result
+
+        session.execute = AsyncMock(side_effect=lambda q: _execute(q))
+
+        async def _get(model, pk):
+            if model.__name__ == "ChatUpload":
+                return upload
+            if model.__name__ == "PaperlessPendingConfirm":
+                return pending
+            return None
+
+        session.get = _get
+        return session
+
+    return _factory
+
+
+class TestStructuredCommitBranch:
+    @pytest.fixture(autouse=True)
+    def _no_background(self, monkeypatch):
+        monkeypatch.setattr(
+            "services.paperless_commit_tool._spawn_bg", lambda coro: coro.close()
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_structured_decisions_fire_upload(self, tmp_path):
+        file = tmp_path / "rechnung.pdf"
+        file.write_bytes(b"%PDF-1.4 " + b"x" * 200)
+
+        pending = _make_pending(
+            confirm_token="tok-s",
+            attachment_id=7,
+            llm_output={"title": "T"},
+            post_fuzzy={
+                "title": "T", "correspondent": "Stadtwerke",
+                "document_type": "Rechnung", "tags": ["wohnung"],
+                "storage_path": "/x", "created_date": None,
+            },
+            proposals=[],
+        )
+        upload = MagicMock(id=7, filename="rechnung.pdf", file_path=str(file))
+
+        mcp = MagicMock()
+        mcp.execute_tool = AsyncMock(return_value={
+            "success": True,
+            "message": json.dumps({"task_id": "t-9", "document_id": 1}),
+        })
+
+        with patch(
+            "services.database.AsyncSessionLocal",
+            _make_session_factory(pending=pending, upload=upload),
+        ):
+            result = await paperless_commit_upload(
+                {"confirm_token": "tok-s", "decisions": []},
+                mcp_manager=mcp, session_id="s", user_id=1,
+            )
+
+        assert result["success"] is True
+        assert result["action_taken"] is True
+        # Upload fired (structured path bypassed the text parser entirely).
+        upload_call = mcp.execute_tool.await_args_list[0]
+        assert upload_call.args[0] == "mcp.paperless.upload_document"
+        assert upload_call.args[1]["wait_for_consume"] is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_abort_flag_deletes_pending_without_uploading(self):
+        pending = _make_pending(
+            confirm_token="tok-x", attachment_id=7,
+            llm_output={}, post_fuzzy={"title": "T"}, proposals=[],
+        )
+        mcp = MagicMock()
+        mcp.execute_tool = AsyncMock()
+
+        with patch(
+            "services.database.AsyncSessionLocal",
+            _make_session_factory(pending=pending),
+        ):
+            result = await paperless_commit_upload(
+                {"confirm_token": "tok-x", "abort": True},
+                mcp_manager=mcp, session_id="s", user_id=1,
+            )
+
+        assert result["success"] is True
+        assert result["data"]["aborted"] is True
+        mcp.execute_tool.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_non_list_decisions_errors(self):
+        pending = _make_pending(
+            confirm_token="tok-y", attachment_id=7,
+            llm_output={}, post_fuzzy={"title": "T"}, proposals=[],
+        )
+        mcp = MagicMock()
+        mcp.execute_tool = AsyncMock()
+
+        with patch(
+            "services.database.AsyncSessionLocal",
+            _make_session_factory(pending=pending),
+        ):
+            result = await paperless_commit_upload(
+                {"confirm_token": "tok-y", "decisions": "1:neu"},
+                mcp_manager=mcp, session_id="s", user_id=1,
+            )
+
+        assert result["success"] is False
+        assert "decisions" in result["message"].lower()
+        mcp.execute_tool.assert_not_awaited()


### PR DESCRIPTION
## Problem
The Paperless cold-start confirm made the user resolve ambiguous metadata by typing a fragile mini-syntax (`1:n, 2:x`). A stray `.` in a reply (`4:n.5:n`) made `_parse_user_choices` reject the whole line, fall back to `ja`, and **silently skip the new tags the user had agreed to create**.

## Fix
A clickable per-field confirm card (modelled on Claude Code's option cards). Each ambiguous field shows its detected value plus options — **use an existing match / create new (editable) / leave empty** — with safe defaults pre-selected (top near-match, never "create"). The user clicks and hits **Ablegen**; the frontend submits a structured decision over the WS, no free-text parsing. The typed `ja`/`nein`/`1: 2, 2: neu` path stays as a fallback.

## Data flow
```
forward_attachment_to_paperless → result.data.confirm {summary, fields[{idx,field,label,extracted_value,options[],default}]}
agent_service → paperless_confirm step → paperless_confirm_request WS msg (deferred behind the preview bubble, single + orchestrated paths)
PaperlessConfirmCard → submit {type:"paperless_confirm", confirm_token, decisions:[{idx,action,value}], abort?}
chat_handler → internal.paperless_commit_upload → _decisions_from_structured → _commit_approved (UNCHANGED)
```
`idx` is 1-based over the **full** proposals list (same convention as `_parse_user_choices`), so exact-match fields are hidden without shifting indices.

## Review (`/review`)
Scope CLEAN. Found + fixed: 2× P1 (UnboundLocalError on a first-frame confirm after reconnect; frontend marking the card "submitted" on a closed socket), 3× P2 (client-supplied `session_id` weakening session scoping; orchestrated-path card ordering; create-value lost on toggle), 3× P3 (non-string value / bool idx guards; touch targets; card key).

## Tests
`test_paperless_confirm_card.py` (15) — payload shape, idx preservation across exact-match fields, structured decision mapping + defensive guards, structured commit + abort. Regression: 100 + 27 related backend tests green. Frontend `tsc` + eslint clean; DESIGN.md tokens + dark mode + i18n verified.

## Docs
`docs/design/paperless-llm-metadata.md` (card marked shipped + data flow), `docs/FEATURES.md` (bullet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)