### PR TITLE
fix(mcp): self-heal a downed MCP session on the next tool call

### DIFF
--- a/src/backend/services/mcp_client.py
+++ b/src/backend/services/mcp_client.py
@@ -637,6 +637,44 @@ _SESSION_DEAD_EXCEPTIONS: tuple[type[BaseException], ...] = (
     ConnectionError,
 )
 
+# Exact message the MCP streamable_http client returns once the server has
+# invalidated our session id — which is what happens when that server's
+# pod/process restarts (mcp/client/streamable_http.py raises this as an McpError
+# with JSON-RPC code 32600). It is NOT one of the transport exceptions above, so
+# without special-casing it the call is mistaken for an application error and
+# never retried.
+_SESSION_TERMINATED_MARKER = "session terminated"
+
+
+def _is_session_dead(exc: BaseException) -> bool:
+    """True if `exc` means the transport/session is dead (vs. an app error).
+
+    Two cases:
+    - the typed transport exceptions (stream closed / connection reset);
+    - the streamable_http "Session terminated" ``McpError`` raised after the
+      server restarts — the case that left the agent unable to reach a bounced
+      MCP server until a manual backend restart.
+
+    Deliberately NARROW: the message check is gated on the exception actually
+    being an ``McpError`` and matches only the SDK's exact "session terminated"
+    signal — NOT a free-text substring over arbitrary exceptions. A genuine
+    application error whose message merely mentions a "session" (e.g. an
+    email/IMAP or API tool surfacing an upstream "session expired") must NOT be
+    treated as transport death, because that would reconnect-and-retry and could
+    double-execute a mutating tool.
+    """
+    if isinstance(exc, _SESSION_DEAD_EXCEPTIONS):
+        return True
+    try:
+        from mcp.shared.exceptions import McpError
+    except Exception:  # noqa: BLE001 - SDK shape guard
+        return False
+    if not isinstance(exc, McpError):
+        return False
+    err = getattr(exc, "error", None)
+    msg = (getattr(err, "message", None) or str(exc) or "").lower()
+    return _SESSION_TERMINATED_MARKER in msg
+
 
 class MCPTransportType(str, Enum):
     STREAMABLE_HTTP = "streamable_http"
@@ -1087,6 +1125,32 @@ class MCPManager:
             await self._connect_server(state)
             return state.connected
 
+    async def _ensure_connected(self, state: "MCPServerState | None") -> bool:
+        """Best-effort on-demand reconnect immediately before a tool call.
+
+        Root-cause fix for "MCP Server X nicht verbunden" after that server's
+        pod/subprocess restarted: rather than bailing out and waiting for the
+        background refresh tick (or a manual backend restart) to heal the
+        session, a tool call attempts ONE reconnect right here. Mirrors
+        ``probe_server``'s reconnect-on-failure.
+
+        Transport-agnostic: ``_reconnect_server`` → ``_connect_server`` respawns
+        a stdio subprocess or re-establishes a streamable_http session as
+        appropriate, so this works for every configured MCP server. Federation
+        servers have no session and are dispatched before this is reached.
+
+        Returns True iff the server now has a live session.
+        """
+        if state is None:
+            return False
+        if state.connected and state.session is not None:
+            return True
+        logger.info(
+            f"MCP '{state.config.name}' not connected at call time; "
+            f"attempting on-demand reconnect"
+        )
+        return await self._reconnect_server(state)
+
     async def probe_server(self, server_name: str) -> dict:
         """Active probe for an MCP server's session via the universal
         ``tools/list`` method.
@@ -1316,7 +1380,9 @@ class MCPManager:
                 }
             return final_result
 
-        if not state or not state.connected or not state.session:
+        # Self-heal a session that went down since the last call (e.g. the
+        # server's pod restarted) instead of failing the call outright.
+        if not await self._ensure_connected(state):
             return {
                 "success": False,
                 "message": f"MCP Server '{tool_info.server_name}' nicht verbunden",
@@ -1359,10 +1425,12 @@ class MCPManager:
                 timeout=settings.mcp_call_timeout,
             )
 
-        # Try once; on a session-shape exception (transport-layer death —
-        # see _SESSION_DEAD_EXCEPTIONS) reconnect and retry once. Application
-        # errors (McpError, validation) and timeouts fall through immediately:
-        # reconnecting wouldn't help and would tear down a healthy session.
+        # Try once; on a session-death signal (transport exception OR the
+        # streamable_http "Session terminated" McpError after a server bounce —
+        # see _is_session_dead) reconnect and retry once. Genuine application
+        # errors (other McpError, validation) and timeouts fall through
+        # immediately: reconnecting wouldn't help and would tear down a healthy
+        # session over a malformed argument.
         result = None
         last_exc: BaseException | None = None
         for attempt in range(2):
@@ -1377,8 +1445,14 @@ class MCPManager:
                     "message": f"Tool-Aufruf Timeout: {namespaced_name}",
                     "data": None,
                 }
-            except _SESSION_DEAD_EXCEPTIONS as e:
+            except Exception as e:  # noqa: BLE001 - bubble in last_exc
                 last_exc = e
+                if not _is_session_dead(e):
+                    # Application-level error (McpError, schema, etc.). The
+                    # session is fine; just surface the failure.
+                    logger.error(f"MCP tool call failed: {namespaced_name}: {e}")
+                    state.last_error = str(e)
+                    break
                 if attempt == 0:
                     logger.warning(
                         f"MCP session died on {namespaced_name}: {type(e).__name__}: {e}; "
@@ -1395,13 +1469,6 @@ class MCPManager:
                 )
                 state.connected = False
                 state.last_error = str(e)
-            except Exception as e:  # noqa: BLE001 - bubble in last_exc
-                # Application-level error (McpError, schema, etc.). The
-                # session is fine; just surface the failure.
-                last_exc = e
-                logger.error(f"MCP tool call failed: {namespaced_name}: {e}")
-                state.last_error = str(e)
-                break
 
         if result is None:
             return {
@@ -1740,7 +1807,9 @@ class MCPManager:
             yield {"success": False, "message": perm_error, "data": None}
             return
 
-        if not state.connected or not state.session:
+        # Self-heal a session that went down since the last call (e.g. the
+        # server's pod restarted) instead of failing the call outright.
+        if not await self._ensure_connected(state):
             yield {
                 "success": False,
                 "message": f"MCP Server '{tool_info.server_name}' nicht verbunden",

--- a/tests/backend/test_mcp_permissions.py
+++ b/tests/backend/test_mcp_permissions.py
@@ -284,8 +284,14 @@ class TestExecuteToolPermissions:
     @pytest.mark.asyncio
     async def test_none_permissions_skips_check(self):
         """execute_tool() with user_permissions=None skips permission check."""
+        from unittest.mock import AsyncMock
+
         manager, _tool = _make_manager_with_tool()
-        # Will fail at execution (no session), but should pass permission check
+        # The fixture is "connected" with no real session; execute_tool now
+        # attempts an on-demand reconnect for a downed session, so stub it out
+        # to keep this permission-focused unit test hermetic (no network I/O).
+        manager._reconnect_server = AsyncMock(return_value=False)
+        # Will fail at execution (reconnect declined), but should pass permission check
         result = await manager.execute_tool(
             "mcp.weather.get_forecast",
             {"location": "Berlin"},

--- a/tests/backend/test_mcp_reconnect.py
+++ b/tests/backend/test_mcp_reconnect.py
@@ -166,6 +166,158 @@ async def test_execute_tool_does_not_retry_on_application_error(manager_with_too
     assert state.session.call_tool.await_count == 1
 
 
+# ---------------------------------------------------------------------------
+# On-demand reconnect: a tool call against a server that went DOWN since the
+# last call (its pod/subprocess restarted → state.connected=False at call
+# time) must attempt one reconnect instead of bailing with "nicht verbunden".
+# This is the fix for the dlna-mcp regression where a `kubectl set image` on
+# an MCP-server deploy broke the agent's access until a manual backend restart.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ensure_connected_short_circuits_when_connected():
+    """No needless reconnect when the session is already live."""
+    state = _make_state()
+    state.session = MagicMock()
+    mgr = _make_manager(state)
+    mgr._reconnect_server = AsyncMock(return_value=True)  # type: ignore[assignment]
+
+    assert await mgr._ensure_connected(state) is True
+    mgr._reconnect_server.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ensure_connected_reconnects_when_down():
+    """Down session → exactly one reconnect attempt; returns its result."""
+    state = _make_state()
+    state.connected = False
+    state.session = None
+    mgr = _make_manager(state)
+    mgr._reconnect_server = AsyncMock(return_value=True)  # type: ignore[assignment]
+
+    assert await mgr._ensure_connected(state) is True
+    mgr._reconnect_server.assert_awaited_once()
+    assert await mgr._ensure_connected(None) is False  # unknown server
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_tool_self_heals_when_down_at_call_time(manager_with_tool):
+    """Server marked disconnected at call time → reconnect → call proceeds.
+
+    Pre-fix, execute_tool short-circuited with "nicht verbunden" whenever
+    state.connected was False, so a restarted MCP server pod stayed unusable
+    until the background tick or a manual backend restart. Now the call
+    self-heals.
+    """
+    mgr, state = manager_with_tool
+    # Simulate the server's pod having restarted: session is gone.
+    state.connected = False
+    state.session = None
+    success_result = MagicMock(content=[MagicMock(type="text", text="ok")], isError=False)
+
+    async def _fake_reconnect(s):
+        s.connected = True
+        s.session = AsyncMock()
+        s.session.call_tool = AsyncMock(return_value=success_result)
+        return True
+
+    mgr._reconnect_server = _fake_reconnect  # type: ignore[assignment]
+
+    out = await mgr.execute_tool("mcp.srv.ping", {}, user_permissions=None)
+    assert out["success"] is True, out
+    assert out["message"] == "ok"
+    state.session.call_tool.assert_awaited_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_tool_not_connected_when_reconnect_fails(manager_with_tool):
+    """If the on-demand reconnect can't restore the session, fail gracefully."""
+    mgr, state = manager_with_tool
+    state.connected = False
+    state.session = None
+    mgr._reconnect_server = AsyncMock(return_value=False)  # type: ignore[assignment]
+
+    out = await mgr.execute_tool("mcp.srv.ping", {}, user_permissions=None)
+    assert out["success"] is False
+    assert "nicht verbunden" in out["message"]
+    mgr._reconnect_server.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# "Session terminated": the streamable_http McpError raised after the server
+# restarts. It is NOT a transport exception type, so it must be recognised by
+# message and treated as session-death (reconnect + retry), while genuine
+# application McpErrors still fall through without a needless reconnect.
+# ---------------------------------------------------------------------------
+
+
+def _session_terminated_error():
+    """Build the real McpError the MCP SDK raises on a bounced session."""
+    from mcp.shared.exceptions import McpError
+    from mcp.types import ErrorData
+
+    return McpError(ErrorData(code=32600, message="Session terminated"))
+
+
+@pytest.mark.unit
+def test_is_session_dead_classification():
+    from mcp.shared.exceptions import McpError
+    from mcp.types import ErrorData
+
+    from services.mcp_client import _is_session_dead
+
+    # Transport death — typed exceptions + the SDK's "Session terminated" McpError.
+    assert _is_session_dead(_session_terminated_error()) is True
+    assert _is_session_dead(anyio.ClosedResourceError()) is True
+
+    # NOT session death — the classifier is gated on McpError + the exact
+    # "session terminated" signal, so none of these reconnect-and-retry
+    # (which could double-execute a mutating tool):
+    #   - a plain exception whose text mentions a session (not an McpError)
+    assert _is_session_dead(Exception("Session terminated")) is False
+    #   - an application McpError that merely mentions a session (e.g. IMAP)
+    assert _is_session_dead(McpError(ErrorData(code=-32000, message="session expired"))) is False
+    #   - ordinary application errors
+    assert _is_session_dead(McpError(ErrorData(code=-32602, message="Invalid params"))) is False
+    assert _is_session_dead(ValueError("bad argument")) is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_tool_retries_on_session_terminated_mcperror(manager_with_tool):
+    """The bounced-server McpError must trigger reconnect + retry, not fail.
+
+    Reproduces the live dlna-mcp regression: the server pod restarts, the
+    next call raises McpError 'Session terminated', and the agent must recover
+    on the same turn (reconnect to the new pod) rather than reporting failure.
+    """
+    mgr, state = manager_with_tool
+    success_result = MagicMock(content=[MagicMock(type="text", text="ok")], isError=False)
+    state.session.call_tool.side_effect = [
+        _session_terminated_error(),
+        success_result,
+    ]
+    reconnect_calls = 0
+
+    async def _fake_reconnect(s):
+        nonlocal reconnect_calls
+        reconnect_calls += 1
+        s.connected = True
+        return True
+
+    mgr._reconnect_server = _fake_reconnect  # type: ignore[assignment]
+
+    out = await mgr.execute_tool("mcp.srv.ping", {}, user_permissions=None)
+    assert out["success"] is True, out
+    assert reconnect_calls == 1
+    assert state.session.call_tool.await_count == 2
+
+
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_execute_tool_retries_on_httpx_remote_protocol_error(manager_with_tool):


### PR DESCRIPTION
## Problem
When any MCP server's pod/process restarts (e.g. `kubectl set image`/`rollout restart` on `dlna-mcp`, or a stdio subprocess respawn), the backend's session to it dies and the **next tool call fails** ("nicht verbunden" / "Session terminated") until a manual backend restart — recurring for every MCP server on every redeploy. Hit live while bumping `dlna-mcp`.

## Root cause (two gaps)
1. `execute_tool` / `execute_tool_streaming` short-circuited the instant `state.connected` was False — no on-demand reconnect (only the slow background `refresh_tools` tick + backoff, or a manual restart).
2. A server that restarted but was still flagged connected raised `McpError "Session terminated"` (JSON-RPC 32600), which was **misclassified as an application error** and never retried.

## Fix (`services/mcp_client.py`)
- **`_ensure_connected()`** — one on-demand reconnect right before a call (both execute paths); transport-agnostic via `_reconnect_server` → `_connect_server` (stdio respawn / streamable_http re-session). Already-live sessions short-circuit; genuinely-down servers still fail gracefully.
- **`_is_session_dead()`** — typed transport exceptions **plus** the `McpError "Session terminated"` signal → reconnect-and-retry. **Narrow by design** (gated on `isinstance McpError` + the exact "session terminated" string) so a mutating tool's upstream "session expired" app error is NOT retried (would risk double-execution — caught in adversarial review).

Restarting the backend was a band-aid, not the fix.

## Verification
- **191 MCP unit tests pass** (client/reconnect/streaming/permissions/compact/api), +6 new (self-heal, graceful-fail, classifier, no-double-execute, session-terminated reconnect+retry).
- **Live, twice** (rc.2 + tightened rc.3): bounced the dlna pod, **no backend restart** → agent listed renderers in one step.
- **All 10 MCP servers** connected on the new build (verifies the shared path for every server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)