### PR TITLE
fix(media): play_in_room handles DLNA renderers (KeyError 'entity_id')

### DIFF
--- a/docs/ALBUM_QUEUE_PLAYBACK.md
+++ b/docs/ALBUM_QUEUE_PLAYBACK.md
@@ -8,6 +8,8 @@
 
 Wenn ein Benutzer "Spiel das Album X im Arbeitszimmer" sagt, spielt Renfield nur den ersten Track. Der Agent-Loop erkennt das Album korrekt, ruft `get_album_tracks` auf, erhaelt alle Tracks — aber `internal.play_in_room` kann nur **eine einzelne URL** an Home Assistant senden.
 
+> **Update (v2.12.2):** `internal.play_in_room` ist nicht mehr HA-only — es verzweigt jetzt bei `target_type == "dlna"` auf `_play_url_on_dlna()` (`mcp.dlna.play_tracks`, Ein-Track-Queue) statt auf `media_player.play_media`. Vorher führte ein DLNA-Raum dort zu `KeyError: 'entity_id'`. Mehrere Tracks (Album-Queue) laufen weiterhin über `internal.play_album_on_dlna` (Option H unten).
+
 Ziel: Alle Tracks eines Albums sequentiell abspielen, ueber beliebige Wiedergabegeraete.
 
 ## Architektur-Kontext

--- a/src/backend/ha_glue/services/internal_tools.py
+++ b/src/backend/ha_glue/services/internal_tools.py
@@ -367,9 +367,25 @@ class InternalToolService:
             else:
                 return resolve_result
 
-        entity_id = resolve_result["data"]["entity_id"]
-        resolved_room_name = resolve_result["data"]["room_name"]
-        device_name = resolve_result["data"]["device_name"]
+        data = resolve_result["data"]
+
+        # DLNA renderers have no HA entity_id and must be driven through the
+        # DLNA MCP path, not media_player.play_media. Without this branch the
+        # entity_id lookup below KeyErrors on every DLNA room (the agent's
+        # default playback tool was unusable for DLNA-only rooms).
+        if data.get("target_type") == "dlna":
+            return await self._play_url_on_dlna(
+                renderer_name=data.get("dlna_renderer_name"),
+                media_url=media_url,
+                title=title,
+                room_name=data.get("room_name", room_name),
+                device_name=data.get("device_name"),
+                params=params,
+            )
+
+        entity_id = data["entity_id"]
+        resolved_room_name = data["room_name"]
+        device_name = data["device_name"]
 
         # Step 2: Call HA media_player.play_media
         try:
@@ -500,6 +516,79 @@ class InternalToolService:
             return {
                 "success": False,
                 "message": f"Error playing media: {e!s}",
+                "action_taken": False,
+            }
+
+    async def _play_url_on_dlna(
+        self,
+        *,
+        renderer_name: str | None,
+        media_url: str,
+        title: str | None,
+        room_name: str,
+        device_name: str | None,
+        params: dict,
+    ) -> dict:
+        """Play a single already-resolved media URL on a DLNA renderer.
+
+        The DLNA counterpart of the HA `media_player.play_media` path in
+        `_play_in_room`: a room that resolves to a DLNA renderer is played via
+        `mcp.dlna.play_tracks` (a one-item queue), mirroring how
+        `_play_album_on_dlna` sends tracks. Avoids the entity_id assumption that
+        made `_play_in_room` crash on DLNA rooms.
+        """
+        if not renderer_name:
+            return {
+                "success": False,
+                "message": f"No DLNA renderer name for room '{room_name}'",
+                "action_taken": False,
+            }
+        try:
+            import json as _json
+
+            from main import app
+
+            mcp_manager = getattr(app.state, "mcp_manager", None)
+            if not mcp_manager:
+                return {
+                    "success": False,
+                    "message": "MCP manager not available",
+                    "action_taken": False,
+                }
+
+            tracks = [{"url": media_url, "title": title or "", "artist": "", "album": ""}]
+            result = await mcp_manager.execute_tool(
+                "mcp.dlna.play_tracks",
+                {"renderer_name": renderer_name, "tracks": _json.dumps(tracks)},
+            )
+            if not result.get("success"):
+                return {
+                    "success": False,
+                    "message": f"DLNA playback failed: {result.get('message', 'unknown error')}",
+                    "action_taken": False,
+                }
+
+            await self._register_media_follow(
+                params, room_name, "single_url",
+                media_url=media_url, title=title, thumb=None,
+            )
+            return {
+                "success": True,
+                "message": f"Playing on {device_name or renderer_name} in {room_name} (DLNA: {renderer_name})",
+                "action_taken": True,
+                "data": {
+                    "renderer_name": renderer_name,
+                    "room_name": room_name,
+                    "device_name": device_name,
+                    "media_url": media_url,
+                    "target_type": "dlna",
+                },
+            }
+        except Exception as e:
+            logger.error(f"Error playing URL on DLNA renderer '{renderer_name}': {e}")
+            return {
+                "success": False,
+                "message": f"Error playing on DLNA: {e!s}",
                 "action_taken": False,
             }
 

--- a/tests/backend/test_internal_tools.py
+++ b/tests/backend/test_internal_tools.py
@@ -362,6 +362,52 @@ class TestPlayInRoom:
         )
 
     @pytest.mark.unit
+    async def test_play_in_room_dlna_routes_to_dlna_not_ha(self, internal_tools):
+        """A room resolving to a DLNA renderer plays via mcp.dlna.play_tracks
+        (one-item queue) instead of HA media_player — and must NOT KeyError on
+        the absent entity_id (the regression that crashed DLNA-room playback)."""
+        import json as _json
+        from types import ModuleType
+
+        resolve_result = {
+            "success": True,
+            "message": "Found DLNA renderer",
+            "action_taken": True,
+            "data": {
+                "target_type": "dlna",
+                "dlna_renderer_name": '55" Interactive Signage Flip',
+                "room_name": "Arbeitszimmer",
+                "device_name": "Flip",
+                # note: no entity_id — exactly the shape that used to KeyError
+            },
+        }
+        mock_mgr = MagicMock()
+        mock_mgr.execute_tool = AsyncMock(return_value={"success": True, "message": "ok"})
+        fake_main = ModuleType("main")
+        fake_main.app = MagicMock()
+        fake_main.app.state.mcp_manager = mock_mgr
+
+        with patch.object(internal_tools, "_resolve_room_player",
+                          new_callable=AsyncMock, return_value=resolve_result), \
+             patch.object(internal_tools, "_register_media_follow", new_callable=AsyncMock), \
+             patch.dict(sys.modules, {"main": fake_main}):
+            result = await internal_tools._play_in_room({
+                "media_url": "http://jellyfin:8096/Audio/abc/universal",
+                "room_name": "Arbeitszimmer",
+            })
+
+        assert result["success"] is True, result
+        assert result["data"]["target_type"] == "dlna"
+        assert result["data"]["renderer_name"] == '55" Interactive Signage Flip'
+        # Routed to the DLNA path with a single-track queue — NOT HA play_media.
+        tool_name, tool_params = mock_mgr.execute_tool.await_args.args
+        assert tool_name == "mcp.dlna.play_tracks"
+        assert tool_params["renderer_name"] == '55" Interactive Signage Flip'
+        tracks = _json.loads(tool_params["tracks"])
+        assert len(tracks) == 1
+        assert tracks[0]["url"] == "http://jellyfin:8096/Audio/abc/universal"
+
+    @pytest.mark.unit
     async def test_play_in_room_room_not_found(self, internal_tools):
         """Unknown room returns error without calling HA."""
         resolve_result = {


### PR DESCRIPTION
## Problem
`internal.play_in_room` — the agent's default "play X in room Y" tool — crashed with `KeyError: 'entity_id'` for any room backed by a **DLNA renderer**. It read `resolve_result["data"]["entity_id"]` unconditionally and routed to Home Assistant `media_player.play_media`, but `_resolve_room_player` returns `target_type:"dlna"` + `dlna_renderer_name` and **no** `entity_id` for DLNA rooms. Surfaced to the user as "Wiedergabe-Tool nicht verfügbar". Found via the v2.12.1 post-release playback smoke test.

## Fix
Branch on `target_type == "dlna"` (as `_media_control` already does) → new `_play_url_on_dlna()` plays the single media_url via `mcp.dlna.play_tracks` (one-item queue, mirroring `_play_album_on_dlna`). HA rooms unchanged.

## Verification
- 101 internal-tools unit tests pass, incl. a new DLNA-routing case (resolver returns DLNA target with no `entity_id` → plays via `mcp.dlna.play_tracks`, asserts no KeyError + single-track queue).
- `/review`: ship-as-is (adversarial pass, no correctness bug; HA path byte-equivalent).
- Live (`v2.12.2-rc.1`): real DLNA playback (track 1/16) + clean stop verified.

## Follow-ups (pre-existing / cosmetic, not in scope)
- Force-play on a *busy* DLNA renderer is silently ignored.
- Cover art not forwarded on the single-URL DLNA path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)