### PR TITLE
fix(media): forward cover art on the play_in_room DLNA path

### DIFF
--- a/src/backend/ha_glue/services/internal_tools.py
+++ b/src/backend/ha_glue/services/internal_tools.py
@@ -378,6 +378,7 @@ class InternalToolService:
                 renderer_name=data.get("dlna_renderer_name"),
                 media_url=media_url,
                 title=title,
+                thumb=thumb,
                 room_name=data.get("room_name", room_name),
                 device_name=data.get("device_name"),
                 params=params,
@@ -525,6 +526,7 @@ class InternalToolService:
         renderer_name: str | None,
         media_url: str,
         title: str | None,
+        thumb: str | None,
         room_name: str,
         device_name: str | None,
         params: dict,
@@ -556,10 +558,15 @@ class InternalToolService:
                     "action_taken": False,
                 }
 
-            tracks = [{"url": media_url, "title": title or "", "artist": "", "album": ""}]
+            track = {"url": media_url, "title": title or "", "artist": "", "album": ""}
+            if thumb:
+                # play_tracks renders cover art from `art_url` (same field the
+                # video path uses); forward it so DLNA single-URL playback shows
+                # the thumbnail instead of a blank tile.
+                track["art_url"] = thumb
             result = await mcp_manager.execute_tool(
                 "mcp.dlna.play_tracks",
-                {"renderer_name": renderer_name, "tracks": _json.dumps(tracks)},
+                {"renderer_name": renderer_name, "tracks": _json.dumps([track])},
             )
             if not result.get("success"):
                 return {
@@ -570,7 +577,7 @@ class InternalToolService:
 
             await self._register_media_follow(
                 params, room_name, "single_url",
-                media_url=media_url, title=title, thumb=None,
+                media_url=media_url, title=title, thumb=thumb,
             )
             return {
                 "success": True,

--- a/tests/backend/test_internal_tools.py
+++ b/tests/backend/test_internal_tools.py
@@ -394,6 +394,7 @@ class TestPlayInRoom:
             result = await internal_tools._play_in_room({
                 "media_url": "http://jellyfin:8096/Audio/abc/universal",
                 "room_name": "Arbeitszimmer",
+                "thumb": "http://jellyfin:8096/Items/abc/Images/Primary",
             })
 
         assert result["success"] is True, result
@@ -406,6 +407,8 @@ class TestPlayInRoom:
         tracks = _json.loads(tool_params["tracks"])
         assert len(tracks) == 1
         assert tracks[0]["url"] == "http://jellyfin:8096/Audio/abc/universal"
+        # Cover art is forwarded as `art_url` (same field the video path uses).
+        assert tracks[0]["art_url"] == "http://jellyfin:8096/Items/abc/Images/Primary"
 
     @pytest.mark.unit
     async def test_play_in_room_room_not_found(self, internal_tools):


### PR DESCRIPTION
Follow-up to #667. `_play_url_on_dlna` dropped the `thumb` the agent supplies, so DLNA single-URL playback (`internal.play_in_room`) showed a blank tile. Forward it as the track's `art_url` (same field the video DLNA path uses) and into media-follow.

- Test: the DLNA-routing case now passes a thumb and asserts the track carries `art_url`. 101 internal-tools tests pass.

Closes the cosmetic follow-up noted in #667. (The other follow-up — force-play on a busy DLNA renderer — is filed as #668, not fixed here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)