### PR TITLE
docs(dlna): document GetTransportInfo poll fallback (v2.12.5)

### DIFF
--- a/docs/ALBUM_QUEUE_PLAYBACK.md
+++ b/docs/ALBUM_QUEUE_PLAYBACK.md
@@ -415,7 +415,26 @@ Eigenstaendiger MCP-Server der als UPnP/DLNA **Control Point** agiert. Nutzt `as
               └──────────┘
 ```
 
-Event-basiert via UPnP SUBSCRIBE (`LAST_CHANGE`) — **kein Polling**.
+Event-basiert via UPnP SUBSCRIBE (`LAST_CHANGE`) — kein Polling im Normalbetrieb.
+
+**Ausnahme: Event-stille Renderer (GetTransportInfo-Poll-Fallback, v2.12.5).**
+Manche Renderer (z. B. HiFiBerryOS) senden **nie** `LAST_CHANGE`-Events. Der
+gecachte `_transport_state` bleibt dann leer, und `get_status` konnte den
+Renderer-State nur als `unknown` melden — eine begonnene Wiedergabe ließ sich
+nicht positiv bestätigen. Deshalb pollt der DLNA-MCP für diese Renderer aktiv
+`GetTransportInfo`:
+
+- `get_status` ruft vor dem Status-Mapping einen einmaligen, per
+  `asyncio.wait_for` auf 3 s budgetierten Poll auf (`async_update()` fächert in
+  mehrere sequenzielle SOAP-Calls auf — der erste Poll ist ein größerer Burst —
+  jeweils mit dem 5-s-Default der Library; ohne Budget könnte ein hängender
+  Renderer das Tool zehnersekundenlang blockieren).
+- Die Wiedergabe-Bestätigung in `start()` pollt als Fallback, wenn (noch) kein
+  Event vorliegt, und kann so weiterhin `PLAYING` bestätigen bzw. bei
+  `STOPPED`/`NO_MEDIA_PRESENT` (z. B. nicht erreichbarer Stream) sauber fehlschlagen.
+
+Event-emittierende Renderer bleiben rein event-getrieben; der Poll greift nur,
+solange noch kein State aus einem Event vorliegt.
 
 | | |
 |---|---|


### PR DESCRIPTION
Documents the v2.12.5 DLNA-MCP change ([renfield-mcp-dlna#5](https://github.com/ebongard/renfield-mcp-dlna/pull/5)): event-silent renderers (HiFiBerryOS) now get an active, `asyncio.wait_for`-bounded `GetTransportInfo` poll so `get_status` can positively confirm playback instead of reporting `unknown`.

Updates `docs/ALBUM_QUEUE_PLAYBACK.md`'s "kein Polling" claim to record the exception and the 3s poll budget rationale.

Ships alongside the renfield backend `v2.12.5` deploy (rebuilds with the new dlna github-tarball SHA via `GITHUB_DEPS_REV`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)