### PR TITLE
feat(paperless-audit): re-OCR with local stack + write back, fix false-positive OCR score

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -514,9 +514,13 @@ Automatisierte Metadaten-Prüfung für Paperless-NGX Dokumente via LLM. Opt-in v
 ### Funktionsweise
 
 1. **Scan** — Alle Paperless-Dokumente werden per MCP abgerufen
-2. **OCR-Qualitätsprüfung** — Heuristische Bewertung (1-5) ohne LLM: erkennt Zeichensalat, wiederholte Zeichen, hohe Sonderzeichen-Dichte
+2. **OCR-Qualitätsprüfung** — Heuristische Bewertung (1-5) ohne LLM via `utils/ocr_quality.score_ocr_quality` (geteilt mit der Ingest-Pipeline, damit die „Zeichensalat"-Definition nicht auseinanderdriftet): erkennt fehlende Leerzeichen, echte Stuck-Glyph-Läufe (lange Wiederholung **desselben alphanumerischen** Zeichens — nicht mehr gewöhnliche Spalten-/Punkt-Formatierung) und hohe Sonderzeichen-Dichte
 3. **LLM-Analyse** — 8 Validierungsfelder: Titel, Korrespondent, Dokumenttyp, Tags, Speicherpfad, Datum, Sprache, Archivstatus
 4. **Fix-Modi**: `review` (manuelle Freigabe im Admin UI), `auto_threshold` (ab Konfidenz ≥ Schwellwert), `auto_all`
+
+### Re-OCR (lokaler Stack mit Paperless-Fallback)
+
+Die „Re-OCR"-Aktion läuft **nicht** mehr blind über Paperless' eigene OCR (die mit denselben Einstellungen scheitern würde). Stattdessen pro Dokument: Original-Bytes per MCP `download_document` laden (`truncate=False` — sonst wird das Base64 am LLM-Response-Limit abgeschnitten), lokal mit erzwungener Ganzseiten-OCR (Renfields Docling/EasyOCR-Stack inkl. Garbled-Layer-Recovery) neu erkennen, das Ergebnis bewerten und **nur bei striktem Qualitätsgewinn** den sauberen Text via `update_document(content=…)` zurück nach Paperless schreiben. Schlägt die lokale OCR fehl oder ist sie nicht besser, greift der Fallback auf Paperless' natives `reprocess`. Hinweis: Es wird nur der durchsuchbare Content aktualisiert, das archivierte PDF wird nicht neu erzeugt.
 
 ### Admin UI (`/admin/paperless-audit`)
 

--- a/src/backend/ha_glue/services/paperless_audit_service.py
+++ b/src/backend/ha_glue/services/paperless_audit_service.py
@@ -10,12 +10,16 @@ calls MCP tools for all Paperless interactions.
 """
 
 import asyncio
+import base64
 import hashlib
 import json
 import logging
+import os
 import re
+import tempfile
 from datetime import UTC, datetime
 from difflib import SequenceMatcher
+from pathlib import Path
 from uuid import uuid4
 
 from sqlalchemy import func, select
@@ -39,6 +43,8 @@ class PaperlessAuditService:
         self._running = False
         self._progress = {"current": 0, "total": 0, "current_doc_id": None}
         self._cancel_requested = False
+        # Lazily created on first local re-OCR (mirrors PaperlessMetadataExtractor).
+        self._document_processor = None
 
     async def start(self):
         """Start only if Paperless MCP server is available."""
@@ -613,10 +619,23 @@ class PaperlessAuditService:
         return {"skipped": count}
 
     async def reprocess_documents(self, result_ids: list[int]) -> dict:
-        """Trigger re-OCR for specific results via MCP."""
+        """Re-OCR documents with Renfield's local stack, writing the cleaned
+        text back into Paperless.
+
+        For each result: download the original via MCP, run the local
+        DocumentProcessor with forced full-page OCR (the same engine + garbled
+        recovery a KB ingest uses), and — if the result scores at least as well
+        as the stored content — PATCH Paperless's ``content``. When local OCR
+        can't beat the current text, or anything fails, fall back to
+        Paperless-NGX's own ``reprocess``.
+
+        Returns counts: ``improved`` (written back locally), ``fallback``
+        (delegated to Paperless), ``failed``.
+        """
         from models.database import PaperlessAuditResult
 
-        triggered = 0
+        improved = 0
+        fallback = 0
         failed = 0
 
         async with self._db_factory() as db:
@@ -626,16 +645,124 @@ class PaperlessAuditService:
             results = (await db.execute(stmt)).scalars().all()
 
         for result in results:
-            mcp_result = await self._mcp.execute_tool(
-                "mcp.paperless.reprocess_document",
-                {"document_id": result.paperless_doc_id},
-            )
-            if mcp_result.get("success"):
-                triggered += 1
+            outcome = await self._local_reocr(result)
+            if outcome == "improved":
+                improved += 1
+            elif outcome == "fallback":
+                fallback += 1
             else:
                 failed += 1
 
-        return {"triggered": triggered, "failed": failed}
+        # Keep the legacy "triggered" key (improved + fallback both kicked off
+        # a re-OCR) so existing callers/UI counters keep working.
+        return {
+            "triggered": improved + fallback,
+            "improved": improved,
+            "fallback": fallback,
+            "failed": failed,
+        }
+
+    async def _local_reocr(self, result) -> str:
+        """Re-OCR one audited document locally and write the text back.
+
+        Returns ``"improved"`` (local OCR written back to Paperless),
+        ``"fallback"`` (delegated to Paperless-native reprocess), or
+        ``"failed"``.
+        """
+        doc_id = result.paperless_doc_id
+
+        # 1. Download the original bytes via MCP. truncate=False is essential:
+        #    the base64 file payload is far larger than the LLM-oriented
+        #    response cap, and the generic truncator would byte-cut it
+        #    mid-payload into unparseable JSON (the download is for our OCR
+        #    pipeline, not the LLM context).
+        dl = await self._mcp.execute_tool(
+            "mcp.paperless.download_document",
+            {"document_id": doc_id},
+            truncate=False,
+        )
+        parsed = self._parse_mcp_result(dl) if dl.get("success") else None
+        b64 = (parsed or {}).get("content_base64")
+        if not b64:
+            logger.warning(
+                f"re-OCR: download failed for doc {doc_id} — "
+                "falling back to Paperless reprocess"
+            )
+            return await self._paperless_reprocess(doc_id)
+
+        # 2. Local quality-aware OCR on a temp file (forced full-page OCR:
+        #    the stored content is what the user flagged as suspect).
+        suffix = Path((parsed or {}).get("filename") or f"doc_{doc_id}.pdf").suffix or ".pdf"
+        tmp_path = None
+        new_text = None
+        try:
+            fd, tmp_path = tempfile.mkstemp(suffix=suffix)
+            with os.fdopen(fd, "wb") as fh:
+                fh.write(base64.b64decode(b64))
+            if self._document_processor is None:
+                from services.document_processor import DocumentProcessor
+                self._document_processor = DocumentProcessor()
+            new_text = await self._document_processor.extract_text_only(
+                tmp_path, max_chars=1_000_000, force_ocr=True,
+            )
+        except Exception as e:
+            logger.error(f"re-OCR: local extraction failed for doc {doc_id}: {e}")
+            return await self._paperless_reprocess(doc_id)
+        finally:
+            if tmp_path and os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
+        # 3. Only write back if the local OCR is non-empty and STRICTLY better
+        #    than the stored content. Forcing full-page OCR on an already-good
+        #    text layer re-rasterizes it and can regress quality without
+        #    lowering the coarse 1-5 score; requiring a strict improvement
+        #    means equal-score (incl. already-clean native text) is left
+        #    untouched and delegated to Paperless instead of being clobbered.
+        from utils.ocr_quality import score_ocr_quality
+
+        new_score, new_issues = score_ocr_quality(new_text) if new_text else (1, "No/minimal OCR text")
+        old_score = result.ocr_quality or 1
+        if not new_text or new_score <= old_score:
+            logger.info(
+                f"re-OCR: local result for doc {doc_id} not better "
+                f"(new={new_score} vs old={old_score}) — falling back to Paperless reprocess"
+            )
+            return await self._paperless_reprocess(doc_id)
+
+        upd = await self._mcp.execute_tool(
+            "mcp.paperless.update_document",
+            {"document_id": doc_id, "content": new_text},
+        )
+        if not upd.get("success"):
+            logger.error(
+                f"re-OCR: content write-back failed for doc {doc_id}: {upd.get('message')}"
+            )
+            return "failed"
+
+        # 4. Reflect the improved quality on the audit row.
+        async with self._db_factory() as db:
+            from models.database import PaperlessAuditResult
+
+            row = (await db.execute(
+                select(PaperlessAuditResult).where(PaperlessAuditResult.id == result.id)
+            )).scalar_one_or_none()
+            if row:
+                row.ocr_quality = new_score
+                row.ocr_issues = new_issues
+                await db.commit()
+
+        logger.info(f"re-OCR: wrote local OCR back to Paperless doc {doc_id} (quality {new_score})")
+        return "improved"
+
+    async def _paperless_reprocess(self, doc_id: int) -> str:
+        """Trigger Paperless-NGX's own OCR reprocess (fallback).
+
+        Returns ``"fallback"`` on success, ``"failed"`` otherwise.
+        """
+        res = await self._mcp.execute_tool(
+            "mcp.paperless.reprocess_document", {"document_id": doc_id}
+        )
+        return "fallback" if res.get("success") else "failed"
 
     # Columns allowed for sorting
     _SORTABLE_COLUMNS = {
@@ -1005,35 +1132,16 @@ class PaperlessAuditService:
 
     @staticmethod
     def _check_ocr_quality(content: str) -> tuple[int, str]:
-        """Rate OCR quality 1-5 based on heuristics."""
-        if not content or len(content.strip()) < 20:
-            return 1, "No/minimal OCR text"
+        """Thin delegate to the shared ``utils.ocr_quality.score_ocr_quality``.
 
-        issues = []
-
-        # Check space ratio (garbled text has very few spaces)
-        space_ratio = content.count(" ") / len(content)
-        if space_ratio < 0.03:
-            issues.append("Very few spaces (garbled)")
-
-        # Check for repeated characters
-        if re.search(r'(.)\1{5,}', content):
-            issues.append("Repeated characters")
-
-        # Check alphanumeric ratio
-        alnum = sum(c.isalnum() or c.isspace() for c in content)
-        if alnum / len(content) < 0.6:
-            issues.append("High special char ratio")
-
-        # Check for very short lines (fragmented OCR)
-        lines = [line for line in content.split('\n') if line.strip()]
-        if lines:
-            avg_line_len = sum(len(line) for line in lines) / len(lines)
-            if avg_line_len < 10 and len(lines) > 5:
-                issues.append("Fragmented text (very short lines)")
-
-        score = max(1, 5 - len(issues))
-        return score, "; ".join(issues) or "OK"
+        The heuristic moved into ``utils/ocr_quality.py`` (shared with the
+        ingest pipeline's garbled-layer gate). Notably the old naive
+        ``(.)\\1{5,}`` "Repeated characters" rule was dropped: it tripped on
+        ordinary column padding / dotted leaders and falsely docked clean
+        invoices. See that module for the calibrated replacement.
+        """
+        from utils.ocr_quality import score_ocr_quality
+        return score_ocr_quality(content)
 
     @staticmethod
     def _check_missing_fields(doc: dict) -> list[str]:

--- a/src/backend/services/document_processor.py
+++ b/src/backend/services/document_processor.py
@@ -161,24 +161,14 @@ class DocumentProcessor:
 
     @staticmethod
     def _is_text_garbled(text: str) -> bool:
-        """Erkennt garbled/kaputten embedded Text (Leerzeichen-Verhältnis zu niedrig).
+        """Thin delegate to the shared ``utils.ocr_quality.is_text_garbled``.
 
-        PDFs mit kaputtem Text-Layer enthalten Wörter ohne Leerzeichen
-        (z.B. 'UmschauMarktplatz13Wiesbaden'). Normale Texte haben ~15-25%
-        Leerzeichen. Unter dem konfigurierten Schwellwert (Standard: 3%)
-        wird ein OCR-Re-Lauf empfohlen.
+        Kept as a method so existing call sites / tests are unchanged; the
+        heuristic itself lives in one place now (shared with the Paperless
+        audit's quality score so the two can't drift).
         """
-        if not text or len(text) < 50:
-            return False
-        space_ratio = text.count(' ') / len(text)
-        is_garbled = space_ratio < settings.rag_ocr_space_threshold
-        if is_garbled:
-            logger.warning(
-                f"Garbled embedded text detected (space ratio={space_ratio:.1%} "
-                f"< threshold={settings.rag_ocr_space_threshold:.1%}) — "
-                "re-running with force_full_page_ocr"
-            )
-        return is_garbled
+        from utils.ocr_quality import is_text_garbled
+        return is_text_garbled(text)
 
     async def process_document(
         self,
@@ -645,12 +635,21 @@ class DocumentProcessor:
 
         return chunks
 
-    async def extract_text_only(self, file_path: str, max_chars: int = 50000) -> str | None:
+    async def extract_text_only(
+        self, file_path: str, max_chars: int = 50000, force_ocr: bool = False
+    ) -> str | None:
         """
         Quick text extraction without chunking or embedding.
 
-        For TXT/MD files, reads directly via aiofiles.
-        For other formats, uses Docling conversion + export_to_text().
+        For TXT/MD files, reads directly via aiofiles. For other formats, uses
+        Docling conversion + export_to_text().
+
+        OCR quality recovery — same gates as ``process_document``: honors
+        ``rag_force_ocr`` / the ``force_ocr`` arg, and (for PDFs, when
+        ``rag_ocr_auto_detect`` is on) re-converts with full-page OCR if the
+        embedded text layer is garbled. Callers therefore get the same OCR
+        quality as a fresh KB ingest — they no longer silently keep a
+        mojibake'd text layer.
 
         Returns None on error.
         """
@@ -672,17 +671,33 @@ class DocumentProcessor:
             self._ensure_initialized()
 
             loop = asyncio.get_event_loop()
-            result = await loop.run_in_executor(None, self._convert_document, file_path)
+            use_ocr = force_ocr or settings.rag_force_ocr
+            if use_ocr:
+                result = await loop.run_in_executor(None, self._convert_document_ocr, file_path)
+            else:
+                result = await loop.run_in_executor(None, self._convert_document, file_path)
 
             if result is None:
                 return None
 
             doc = result.document
-            if hasattr(doc, 'export_to_text'):
-                text = doc.export_to_text()
-                return text[:max_chars] if text else None
+            text = doc.export_to_text() if hasattr(doc, 'export_to_text') else ""
 
-            return None
+            # Auto-detect garbled embedded text and re-run with full-page OCR
+            # (PDF only) — the recovery path process_document uses, previously
+            # missing here despite the docstring's claim.
+            if (
+                not use_ocr
+                and settings.rag_ocr_auto_detect
+                and ext == "pdf"
+                and self._is_text_garbled(text)
+            ):
+                logger.info(f"extract_text_only: re-konvertiere mit force_full_page_ocr: {path.name}")
+                ocr_result = await loop.run_in_executor(None, self._convert_document_ocr, file_path)
+                if ocr_result is not None and hasattr(ocr_result.document, 'export_to_text'):
+                    text = ocr_result.document.export_to_text() or text
+
+            return text[:max_chars] if text else None
 
         except Exception as e:
             logger.error(f"extract_text_only Fehler für {file_path}: {e}")

--- a/src/backend/services/mcp_client.py
+++ b/src/backend/services/mcp_client.py
@@ -1270,6 +1270,7 @@ class MCPManager:
         user_permissions: list[str] | None = None,
         user_id: int | None = None,
         progress_sink: ProgressSink | None = None,
+        truncate: bool = True,
     ) -> dict:
         """
         Execute an MCP tool by its namespaced name.
@@ -1289,6 +1290,12 @@ class MCPManager:
                 federation ProgressChunk (enriched with peer identity). F4c
                 uses this to relay "asking Mom's brain…" status to the chat
                 WebSocket. Non-federation tools ignore the sink.
+            truncate: Cap the response at ``mcp_max_response_size`` (default
+                True). Truncation exists to protect the LLM context window; a
+                programmatic caller fetching binary payloads (e.g.
+                ``download_document``'s base64 file bytes) must pass
+                ``truncate=False`` or the JSON envelope is byte-cut mid-payload
+                and becomes unparseable for any non-trivial file.
 
         Returns:
             {"success": bool, "message": str, "data": Any}
@@ -1488,8 +1495,7 @@ class MCPManager:
             text = getattr(item, "text", None)
             if text:
                 # === Response Truncation ===
-                truncated_text = _truncate_response(text)
-                content_parts.append(truncated_text)
+                content_parts.append(_truncate_response(text) if truncate else text)
             raw_data.append(
                 {"type": getattr(item, "type", "unknown"), "text": text}
             )
@@ -1497,7 +1503,8 @@ class MCPManager:
         message = "\n".join(content_parts) if content_parts else "Tool executed"
 
         # Truncate final message if still too large
-        message = _truncate_response(message)
+        if truncate:
+            message = _truncate_response(message)
 
         # NOTE: Credential sanitization is NOT done here — the agent loop
         # needs real API keys in tool results (e.g. Jellyfin stream URLs

--- a/src/backend/services/paperless_metadata_extractor.py
+++ b/src/backend/services/paperless_metadata_extractor.py
@@ -887,9 +887,9 @@ class PaperlessMetadataExtractor:
         Vision-model path is deferred to PR 2b: it requires coordinating
         with the agent client to send image bytes + text, which the
         existing llm_client surface doesn't yet support cleanly. Docling
-        alone covers typed documents (the 80% case) and falls back to
-        EasyOCR for scans via the existing ``rag_ocr_auto_detect``
-        settings on ``DocumentProcessor``.
+        alone covers typed documents (the 80% case); ``extract_text_only``
+        re-runs full-page OCR when ``rag_ocr_auto_detect`` is on and the
+        embedded text layer is garbled (same recovery as a KB ingest).
         """
         if self._document_processor is None:
             from services.document_processor import DocumentProcessor

--- a/src/backend/utils/ocr_quality.py
+++ b/src/backend/utils/ocr_quality.py
@@ -1,0 +1,93 @@
+"""Shared OCR-quality heuristics.
+
+Two consumers, two questions — kept in one module so the definition of
+"garbled" can never drift between them again:
+
+* ``is_text_garbled`` — the binary gate the *ingest* pipeline uses to decide
+  whether to throw away an embedded PDF text layer and re-run full-page OCR
+  (``DocumentProcessor``). Space-ratio only; deliberately narrow so a clean
+  text layer is never needlessly re-rasterized.
+* ``score_ocr_quality`` — the 1..5 advisory score the *Paperless audit* shows
+  per document. Multi-signal, tuned for already-OCR'd content, and
+  intentionally does NOT penalize ordinary table formatting.
+
+Both read the same ``rag_ocr_space_threshold``.
+"""
+from __future__ import annotations
+
+import logging
+import re
+
+from utils.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Below this we don't judge — too little signal either way.
+_MIN_JUDGEABLE_CHARS = 50
+
+# A genuine OCR stuck-glyph artifact is a long run of the SAME alphanumeric
+# character (e.g. "lllllllll", "00000000"). Runs of whitespace or punctuation
+# (column padding, dotted leaders "......", form underscores "____", "====="
+# rules) are ordinary document formatting and must NOT count: the old
+# ``(.)\1{5,}`` rule penalized exactly those and falsely docked 15/26 of the
+# real audit corpus (well-formatted invoices). Restrict to alphanumerics and
+# require a longer run.
+_OCR_STUCK_GLYPH = re.compile(r"([A-Za-z0-9äöüÄÖÜß])\1{7,}")
+
+
+def is_text_garbled(text: str) -> bool:
+    """True if an embedded text layer looks mojibake'd (too few spaces).
+
+    PDFs with a broken text layer run words together
+    ('UmschauMarktplatz13Wiesbaden'); normal prose is ~15-25% spaces. Below
+    ``rag_ocr_space_threshold`` (default 3%) the ingest pipeline re-runs
+    full-page OCR. Short inputs (<50 chars) are never judged garbled.
+    """
+    if not text or len(text) < _MIN_JUDGEABLE_CHARS:
+        return False
+    space_ratio = text.count(" ") / len(text)
+    garbled = space_ratio < settings.rag_ocr_space_threshold
+    if garbled:
+        logger.warning(
+            "Garbled embedded text detected (space ratio=%.1f%% < threshold=%.1f%%) "
+            "— re-running with force_full_page_ocr",
+            space_ratio * 100,
+            settings.rag_ocr_space_threshold * 100,
+        )
+    return garbled
+
+
+def score_ocr_quality(text: str) -> tuple[int, str]:
+    """Rate already-OCR'd document content 1 (worst) .. 5 (clean).
+
+    Returns ``(score, reason)`` where ``reason`` is "OK" or a "; "-joined list
+    of detected issues; each issue costs one point (floor 1). Calibrated for
+    Paperless content, NOT raw PDF text layers.
+    """
+    if not text or len(text.strip()) < 20:
+        return 1, "No/minimal OCR text"
+
+    issues: list[str] = []
+    n = len(text)
+
+    # Garbled mojibake: words run together, almost no spaces.
+    if text.count(" ") / n < settings.rag_ocr_space_threshold:
+        issues.append("Very few spaces (garbled)")
+
+    # Stuck-glyph runs only (see _OCR_STUCK_GLYPH) — not whitespace/punctuation.
+    if _OCR_STUCK_GLYPH.search(text):
+        issues.append("Repeated characters")
+
+    # Mostly non-text (symbols/control chars) => bad recognition.
+    alnum_or_space = sum(c.isalnum() or c.isspace() for c in text)
+    if alnum_or_space / n < 0.6:
+        issues.append("High special char ratio")
+
+    # Many very short lines => fragmented OCR.
+    lines = [ln for ln in text.split("\n") if ln.strip()]
+    if lines:
+        avg_line_len = sum(len(ln) for ln in lines) / len(lines)
+        if avg_line_len < 10 and len(lines) > 5:
+            issues.append("Fragmented text (very short lines)")
+
+    return max(1, 5 - len(issues)), "; ".join(issues) or "OK"

--- a/tests/backend/test_ocr_quality.py
+++ b/tests/backend/test_ocr_quality.py
@@ -1,0 +1,128 @@
+"""Unit tests for the shared OCR-quality heuristics (utils/ocr_quality.py).
+
+Covers both consumers: the ingest pipeline's binary ``is_text_garbled`` gate
+and the Paperless audit's 1..5 ``score_ocr_quality``. The headline case is the
+false-positive regression: well-formatted invoices (column padding, dotted
+leaders) must score 5, not be docked for "Repeated characters" — that bug
+falsely flagged 15/26 documents in the real audit corpus.
+"""
+import pytest
+
+from utils.ocr_quality import is_text_garbled, score_ocr_quality
+
+pytestmark = pytest.mark.unit
+
+
+class TestIsTextGarbled:
+    def test_normal_prose_not_garbled(self):
+        text = "Dies ist ein ganz normaler deutscher Text mit vielen Leerzeichen darin."
+        assert is_text_garbled(text) is False
+
+    def test_no_space_mojibake_is_garbled(self):
+        # ~260 chars, zero spaces => well under the 3% threshold.
+        assert is_text_garbled("UmschauMarktplatzWiesbaden" * 10) is True
+
+    def test_short_text_never_garbled(self):
+        # Under the 50-char floor we don't judge.
+        assert is_text_garbled("NoSpacesHere") is False
+
+    def test_empty_not_garbled(self):
+        assert is_text_garbled("") is False
+
+
+class TestScoreOcrQuality:
+    def test_clean_text_scores_five(self):
+        text = (
+            "Sehr geehrte Damen und Herren,\n\n"
+            "hiermit senden wir Ihnen die Rechnung.\n\n"
+            "Mit freundlichen Gruessen"
+        )
+        score, issues = score_ocr_quality(text)
+        assert score == 5
+        assert issues == "OK"
+
+    def test_empty_scores_one(self):
+        score, issues = score_ocr_quality("")
+        assert score == 1
+        assert "minimal" in issues.lower() or "no" in issues.lower()
+
+    def test_minimal_scores_one(self):
+        score, _ = score_ocr_quality("abc")
+        assert score == 1
+
+    def test_space_aligned_invoice_scores_five(self):
+        """A column-aligned invoice (runs of >=6 spaces) is clean — score 5.
+
+        This is the corpus shape that the old ``(.)\\1{5,}`` rule wrongly
+        docked: aligned columns contain long space runs, but spaces count as
+        text so neither the repeated-char nor the special-char rule fires.
+        """
+        text = (
+            "Position      Menge      Einzelpreis      Gesamt\n"
+            "Webhosting          1          12,00 EUR          12,00 EUR\n"
+            "Domain .de          1           5,00 EUR           5,00 EUR\n"
+            "Summe netto                                       17,00 EUR\n"
+        )
+        score, issues = score_ocr_quality(text)
+        assert score == 5, issues
+        assert issues == "OK"
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            # Column-aligned invoice line items: runs of >=6 spaces.
+            "Position      Menge      Einzelpreis      Gesamt\n"
+            "Webhosting          1          12,00 EUR          12,00 EUR\n",
+            # Table-of-contents dotted leaders embedded in real prose.
+            "Das Inhaltsverzeichnis dieses Dokuments listet alle Abschnitte.\n"
+            "Einleitung und Vorwort des Autors ............................ 1\n"
+            "Der ausfuehrliche Hauptteil mit allen Details .............. 5\n",
+            # Form with underscore fill-in fields among normal labels.
+            "Bitte tragen Sie hier Ihre vollstaendigen Daten leserlich ein.\n"
+            "Name und Vorname der antragstellenden Person: ____________________\n"
+            "Vollstaendige Anschrift inklusive Postleitzahl: ________________\n",
+            # Section rule of equals signs surrounded by content.
+            "Rechnung Nummer 2301 vom dritten Juni zweitausendsechsundzwanzig\n"
+            "==================================\n"
+            "Der faellige Betrag belaeuft sich auf achtzehn Euro insgesamt.\n",
+        ],
+    )
+    def test_ordinary_formatting_not_flagged_as_repeated(self, text):
+        """The false-positive regression: punctuation/whitespace runs are
+        normal formatting and must NOT be scored as 'Repeated characters'.
+
+        (Orthogonal rules like high-special-char ratio may still apply to
+        punctuation-dense fragments — this test only asserts the repeated-char
+        rule no longer false-positives on formatting runs.)
+        """
+        _, issues = score_ocr_quality(text)
+        assert "repeated" not in issues.lower(), issues
+
+    def test_genuine_stuck_glyph_is_flagged(self):
+        """A long run of the SAME alphanumeric char IS a real OCR artifact."""
+        text = "Normal readable text here, and then llllllllll appears mid-sentence."
+        score, issues = score_ocr_quality(text)
+        assert "repeated" in issues.lower()
+        assert score < 5
+
+    def test_garbled_no_spaces_flagged(self):
+        text = "abcdefghijklmnopqrstuvwxyz" * 10
+        score, issues = score_ocr_quality(text)
+        assert score < 5
+        assert "spaces" in issues.lower() or "garbled" in issues.lower()
+
+    def test_high_special_char_ratio_flagged(self):
+        text = "!!@@##$$%%^^&&**(()){{}}||\\//~~``" * 5
+        score, issues = score_ocr_quality(text)
+        assert score < 5
+        assert "special" in issues.lower()
+
+    def test_fragmented_short_lines_flagged(self):
+        text = "\n".join(["ab cd ef"] * 20)
+        score, issues = score_ocr_quality(text)
+        assert score < 5
+        assert "fragmented" in issues.lower() or "short" in issues.lower()
+
+    def test_score_never_below_one(self):
+        score, _ = score_ocr_quality("!@#$%^" * 50)
+        assert score >= 1

--- a/tests/backend/test_paperless_audit.py
+++ b/tests/backend/test_paperless_audit.py
@@ -17,6 +17,7 @@ Tests:
 - API route handler behavior
 """
 
+import base64
 import json
 from datetime import datetime, UTC
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -142,11 +143,18 @@ class TestCheckOcrQuality:
 
     @pytest.mark.unit
     def test_multiple_issues_lower_score(self):
-        """Multiple OCR issues should stack and lower the score."""
-        # Garbled: no spaces + special chars + repeated
+        """Multiple OCR issues should stack and lower the score.
+
+        All-symbol garbage trips both "garbled" (no spaces) and "high special
+        char ratio". It no longer also trips "Repeated characters": punctuation
+        runs are ordinary formatting and that rule now matches only alphanumeric
+        stuck-glyph runs (the false-positive fix). Two stacked issues => 3.
+        """
         text = "!!!!!!@@@@@$$$$$%%%%%^^^^^^" * 5
         score, issues = PaperlessAuditService._check_ocr_quality(text)
-        assert score <= 2
+        assert score <= 3
+        assert "special" in issues.lower()
+        assert "spaces" in issues.lower() or "garbled" in issues.lower()
 
     @pytest.mark.unit
     def test_score_never_below_one(self):
@@ -1191,49 +1199,155 @@ class TestSkipResults:
         assert mock_result.status == "skipped"
 
 
+def _make_audit_row(doc_id=42, result_id=7, ocr_quality=4):
+    row = MagicMock()
+    row.id = result_id
+    row.paperless_doc_id = doc_id
+    row.ocr_quality = ocr_quality
+    return row
+
+
+def _list_query_result(rows):
+    scalars = MagicMock()
+    scalars.all.return_value = rows
+    return MagicMock(scalars=MagicMock(return_value=scalars))
+
+
+def _mcp_router(mcp, responses, sink=None):
+    """Route ``execute_tool`` by tool name, recording calls into ``sink``.
+
+    Accepts extra args/kwargs (e.g. ``truncate=False`` on download_document).
+    """
+    async def _call(tool, params, *args, **kwargs):
+        if sink is not None:
+            sink.append((tool, params))
+        return responses.get(tool, {"success": True, "message": "{}"})
+    mcp.execute_tool.side_effect = _call
+
+
 class TestReprocessDocuments:
-    """Test reprocess_documents method."""
+    """Test reprocess_documents — now a local-OCR-then-write-back pipeline
+    with a Paperless-native reprocess fallback."""
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_reprocess_calls_mcp(self, service, mock_mcp_manager, mock_db_factory):
-        """Should call MCP reprocess_document for each result."""
-        mock_result = MagicMock()
-        mock_result.paperless_doc_id = 42
-
-        mock_session = mock_db_factory._mock_session
-        mock_scalars = MagicMock()
-        mock_scalars.all.return_value = [mock_result]
-        mock_session.execute.return_value = MagicMock(scalars=MagicMock(return_value=mock_scalars))
-
-        mock_mcp_manager.execute_tool.return_value = {"success": True}
+    async def test_fallback_to_paperless_when_download_unavailable(
+        self, service, mock_mcp_manager, mock_db_factory
+    ):
+        """No downloadable bytes => delegate to Paperless reprocess (fallback)."""
+        mock_db_factory._mock_session.execute.return_value = _list_query_result(
+            [_make_audit_row()]
+        )
+        _mcp_router(mock_mcp_manager, {
+            "mcp.paperless.download_document": {"success": True, "message": ""},
+            "mcp.paperless.reprocess_document": {"success": True},
+        })
 
         result = await service.reprocess_documents([1])
-        assert result["triggered"] == 1
+        assert result["fallback"] == 1
         assert result["failed"] == 0
+        assert result["triggered"] == 1  # legacy key = improved + fallback
 
         mock_mcp_manager.execute_tool.assert_called_with(
-            "mcp.paperless.reprocess_document",
-            {"document_id": 42},
+            "mcp.paperless.reprocess_document", {"document_id": 42},
         )
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_reprocess_failure(self, service, mock_mcp_manager, mock_db_factory):
-        """Should count failures when MCP call fails."""
-        mock_result = MagicMock()
-        mock_result.paperless_doc_id = 42
-
-        mock_session = mock_db_factory._mock_session
-        mock_scalars = MagicMock()
-        mock_scalars.all.return_value = [mock_result]
-        mock_session.execute.return_value = MagicMock(scalars=MagicMock(return_value=mock_scalars))
-
-        mock_mcp_manager.execute_tool.return_value = {"success": False}
+    async def test_failure_when_fallback_reprocess_fails(
+        self, service, mock_mcp_manager, mock_db_factory
+    ):
+        """Download unavailable AND Paperless reprocess fails => failed."""
+        mock_db_factory._mock_session.execute.return_value = _list_query_result(
+            [_make_audit_row()]
+        )
+        _mcp_router(mock_mcp_manager, {
+            "mcp.paperless.download_document": {"success": False},
+            "mcp.paperless.reprocess_document": {"success": False},
+        })
 
         result = await service.reprocess_documents([1])
         assert result["triggered"] == 0
         assert result["failed"] == 1
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_local_reocr_writes_back_when_improved(
+        self, service, mock_mcp_manager, mock_db_factory
+    ):
+        """Clean local OCR (better than stored) is PATCHed into Paperless content
+        and the audit row's quality is bumped."""
+        row = _make_audit_row(ocr_quality=4)
+        update_row = MagicMock()
+        mock_db_factory._mock_session.execute.side_effect = [
+            _list_query_result([row]),  # initial list query
+            MagicMock(scalar_one_or_none=MagicMock(return_value=update_row)),  # row bump
+        ]
+        b64 = base64.b64encode(b"%PDF-1.4 fake").decode()
+        calls = []
+        _mcp_router(mock_mcp_manager, {
+            "mcp.paperless.download_document": {
+                "success": True,
+                "message": json.dumps({"content_base64": b64, "filename": "doc_42.pdf"}),
+            },
+            "mcp.paperless.update_document": {"success": True, "message": "{}"},
+        }, sink=calls)
+        service._document_processor = MagicMock()
+        service._document_processor.extract_text_only = AsyncMock(
+            return_value="Sehr geehrte Damen und Herren, hier ist die saubere Rechnung."
+        )
+
+        result = await service.reprocess_documents([7])
+        assert result["improved"] == 1
+        assert result["fallback"] == 0
+        assert result["failed"] == 0
+
+        # download MUST bypass response truncation, or the base64 PDF is
+        # byte-cut into unparseable JSON for any real-sized scan.
+        dl_calls = [
+            c for c in mock_mcp_manager.execute_tool.call_args_list
+            if c.args[0] == "mcp.paperless.download_document"
+        ]
+        assert dl_calls and dl_calls[0].kwargs.get("truncate") is False
+
+        # extract was forced full-page OCR
+        _, kwargs = service._document_processor.extract_text_only.call_args
+        assert kwargs.get("force_ocr") is True
+        # content was written back
+        writes = [p for t, p in calls if t == "mcp.paperless.update_document"]
+        assert writes and "content" in writes[0]
+        # audit row quality bumped to the clean score
+        assert update_row.ocr_quality == 5
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_no_writeback_when_local_ocr_not_better(
+        self, service, mock_mcp_manager, mock_db_factory
+    ):
+        """If forced OCR yields worse text than the stored content, don't
+        overwrite — fall back to Paperless reprocess, never PATCH content."""
+        mock_db_factory._mock_session.execute.return_value = _list_query_result(
+            [_make_audit_row(ocr_quality=5)]
+        )
+        b64 = base64.b64encode(b"%PDF-1.4 fake").decode()
+        calls = []
+        _mcp_router(mock_mcp_manager, {
+            "mcp.paperless.download_document": {
+                "success": True,
+                "message": json.dumps({"content_base64": b64, "filename": "doc_42.pdf"}),
+            },
+            "mcp.paperless.reprocess_document": {"success": True},
+        }, sink=calls)
+        service._document_processor = MagicMock()
+        # No spaces => garbled => scores below the stored 5.
+        service._document_processor.extract_text_only = AsyncMock(
+            return_value="abcdefghij" * 40
+        )
+
+        result = await service.reprocess_documents([7])
+        assert result["fallback"] == 1
+        assert result["improved"] == 0
+        assert not [t for t, _ in calls if t == "mcp.paperless.update_document"]
 
 
 # ============================================================================


### PR DESCRIPTION
## Problem

Two issues in the Paperless audit, both confirmed against the live corpus (26 audited docs):

1. **Re-OCR was a blind `mcp.paperless.reprocess_document`** — it re-ran Paperless's own OCR with the same settings, so a doc that OCR'd badly once would almost certainly OCR badly again.
2. **The OCR-quality heuristic false-flagged 15/26 documents** for "Repeated characters" because its `(.)\1{5,}` rule tripped on ordinary column padding / dotted leaders on clean invoices. (0/26 docs actually had bad OCR — min score 4.)

## What

**L1 — shared heuristic.** New `utils/ocr_quality.py` owns both `is_text_garbled` (ingest gate) and `score_ocr_quality` (audit score) so the two can't drift. The naive repeated-char rule is replaced by one matching only long runs of the **same alphanumeric** char (genuine stuck-glyph artifacts), not formatting. `_is_text_garbled` and `_check_ocr_quality` delegate here.

**L2 — fix a latent bug.** `DocumentProcessor.extract_text_only` claimed (docstring) to fall back to OCR for bad text layers but ran only the plain converter. It now honors `rag_force_ocr`/`force_ocr` + the `rag_ocr_auto_detect` garbled-layer → full-page-OCR recovery, like `process_document`. Fixes all callers (chat upload, metadata extractor).

**L3 — audit re-OCR via Renfield's stack.** `reprocess_documents` now: download original via MCP → local forced full-page OCR → score → write clean text back via `update_document(content=)` **only if strictly better**, else fall back to Paperless-native reprocess. Return dict gains `improved`/`fallback`; legacy `triggered` retained.

> KB re-ingest was dropped from the original "Both" target — Paperless docs have no Renfield-KB linkage, so there's nothing local to re-ingest.

## Review fixes folded in (`/code-review` high)

- **Feature-killing bug:** `execute_tool` truncates *every* response at 128KB (LLM-context guard), byte-cutting the base64 download mid-payload for any real-sized PDF → the local path silently always fell back. Added `truncate=False` opt-out; the download uses it. Without this the feature was dead for every scan large enough to need re-OCR.
- Write-back guard tightened `>=` → strict `>` so an equal-score forced-OCR pass can't clobber a clean native text layer.

## Tests (run on .159)

ocr+audit **102/102** · document_processor+chat_upload+metadata **240/240** · mcp_client **157/157**. New `test_ocr_quality.py` (17, incl. the invoice false-positive regression) + audit re-OCR pipeline tests (incl. a `truncate=False` regression guard).

## Coordinated with / deploy

Depends on **ebongard/renfield-mcp-paperless#8** (`update_document(content=)`). **Deploy both together** — the paperless-mcp server must be redeployed or the write-back silently no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)