### PR TITLE
chore(deps): bump renfield-mcp-paperless 1.5.0 → 1.6.0

### DIFF
--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -85,7 +85,7 @@ jsonschema>=4.21.0            # JSON Schema validation for MCP tool inputs
 
 # MCP Servers (standalone packages)
 renfield-mcp-weather @ https://github.com/ebongard/renfield_mcp_weather/archive/refs/heads/main.tar.gz
-renfield-mcp-paperless @ https://github.com/ebongard/renfield-mcp-paperless/archive/refs/tags/v1.5.0.tar.gz
+renfield-mcp-paperless @ https://github.com/ebongard/renfield-mcp-paperless/archive/refs/tags/v1.6.0.tar.gz
 renfield-mcp-mail @ https://github.com/ebongard/renfield-mcp-mail/archive/refs/heads/main.tar.gz
 aiosmtplib>=3.0                  # Required by renfield-mcp-mail (not auto-resolved from archive installs)
 renfield-mcp-jellyfin @ https://github.com/ebongard/renfield-mcp-jellyfin/archive/refs/heads/main.tar.gz


### PR DESCRIPTION
Pulls in `update_document(content=)` (ebongard/renfield-mcp-paperless#8, released as v1.6.0) so the audit **local re-OCR write-back** (#673) actually reaches Paperless. Without it the backend image ships paperless-mcp 1.5.0, whose `update_document` silently drops the `content` kwarg (FastMCP ignores undeclared params) → the write-back no-ops.

Deploy step for the #673 / #8 rollout. Tarball verified reachable (HTTP 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)