### PR TITLE
docs(tech-debt): log periodic-scheduler daily-tick loss on pod restart (#14)

### DIFF
--- a/docs/TECHNICAL_DEBT.md
+++ b/docs/TECHNICAL_DEBT.md
@@ -2,7 +2,7 @@
 
 Dieses Dokument enthält eine umfassende Analyse der technischen Schulden im gesamten Renfield-System.
 
-**Letzte Aktualisierung:** 2026-05-26 (Frontend-Sweep: TypeScript-Migration als abgeschlossen markiert, alle Major-Dep-Updates als erledigt, Komponentengrößen mit aktuellen Zahlen)
+**Letzte Aktualisierung:** 2026-06-04 (Backend #14 ergänzt: periodische Scheduler verlieren tägliche Ticks bei Pod-Neustart — Befund aus der Self-Learning-Validierung)
 
 ---
 
@@ -10,11 +10,11 @@ Dieses Dokument enthält eine umfassende Analyse der technischen Schulden im ges
 
 | Bereich | Kritisch | Mittel | Niedrig | Gesamt | Behoben |
 |---------|----------|--------|---------|--------|---------|
-| Backend | 0 | 3 | 4 | 9 | 10 |
+| Backend | 0 | 4 | 4 | 10 | 10 |
 | Frontend | 0 | 0 | 2 | 4 | 7 |
 | Satellite | 0 | 3 | 2 | 5 | 5 |
 | Infrastruktur | 0 | 3 | 2 | 6 | 6 |
-| **Gesamt** | **0** | **9** | **10** | **24** | **28** |
+| **Gesamt** | **0** | **10** | **10** | **25** | **28** |
 
 ---
 
@@ -188,6 +188,25 @@ services/
 Optional: Eine kurze Notiz im neuen `CONTRIBUTING.md`-Abschnitt zu Alembic-Best-Practices, parallel zum bestehenden `memory/feedback_alembic_chain_check.md`.
 
 **Aufwand:** ~30 min für die Konvention; bestehende `pc20260527` nicht nachträglich umschreiben (irrelevant für die aktuelle Tabellengröße).
+
+---
+
+#### 14. Periodische Scheduler verlieren tägliche Ticks bei Pod-Neustart
+
+**Status:** Offen — Befund bei Self-Learning-Validierung (2026-06-04).
+
+**Problem:** `_spawn_periodic_task` (`api/lifecycle.py`) implementiert seine Schleife als `sleep(interval)` → `work()` (sleep-then-run). Der erste Tick erfolgt also erst `interval` Sekunden _nach_ dem Pod-Boot, und der Timer startet bei jedem Neustart bei null. Für die täglichen Scheduler (`interval=86400s`) heißt das: startet der Backend-Pod häufiger als alle 24 h neu (Rollout, OOM, k8s-Reschedule), feuert der Tick **nie**. Betroffen v. a. **Skill Curator** und **Trajectory Cleanup** (beide 86400s), sekundär Skill-Shadow-Log-Cleanup und Speaker-Vocab-Rebuild.
+
+**Evidenz:** In Produktion ist `skill_curator_runs` leer trotz `SKILL_CURATOR_ENABLED=true`; das Log zeigt bei jedem Boot „Skill Curator gestartet", aber keinen einzigen abgeschlossenen Lauf — der Pod wird vor Ablauf der 24 h neu gestartet. Die `procedural_skills`-Dedup/Archivierung läuft damit faktisch nie, ebenso wenig die 30-Tage-Trajectory-Retention (Purge).
+
+**Empfehlung:**
+- Run-at-boot-Tick (einmal `work()` vor der Schleife, optional mit kleinem Jitter gegen Boot-Storms bei mehreren Replicas), **oder**
+- persistierter `last_run_at` (z. B. aus `skill_curator_runs` selbst oder einer kleinen `scheduler_state`-Tabelle) + „catch-up wenn überfällig"-Logik beim Boot.
+- Run-at-boot ist die kleinere Änderung; die persistierte Variante ist robuster gegen häufige Neustarts und Multi-Replica-Deployments.
+
+**Aufwand:** ~1–2 h für run-at-boot inkl. Tests; ~halber Tag für die persistierte Catch-up-Variante.
+
+**Tracking:** Eigenes Issue; betrifft alle `_spawn_periodic_task`-Aufrufer mit Intervall ≳ erwarteter Pod-Lebensdauer.
 
 ---
 


### PR DESCRIPTION
Records a finding from the self-learning validation as Backend tech-debt #14 (Mittel).

## The issue

`_spawn_periodic_task` (`api/lifecycle.py`) loops as `sleep(interval)` → `work()`. The first tick of a daily scheduler (`interval=86400s`) therefore fires 24h after pod boot, and the timer resets on every restart. A backend pod that restarts more often than the interval **never runs** the Skill Curator or Trajectory Cleanup.

**Evidence:** `skill_curator_runs` is empty in production despite `SKILL_CURATOR_ENABLED=true` — the log shows "Skill Curator gestartet" on every boot but zero completed runs. `procedural_skills` dedup/archival and 30-day trajectory retention effectively never run.

## What this PR does

Docs-only. Adds entry #14 with run-at-boot vs persisted-`last_run_at` catch-up remediation options, and bumps the Übersicht tally (Backend Mittel 3→4). No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)