### PR TITLE
docs(tech-debt): link #14 tracking to issue #678

### DIFF
--- a/docs/TECHNICAL_DEBT.md
+++ b/docs/TECHNICAL_DEBT.md
@@ -206,7 +206,7 @@ Optional: Eine kurze Notiz im neuen `CONTRIBUTING.md`-Abschnitt zu Alembic-Best-
 
 **Aufwand:** ~1–2 h für run-at-boot inkl. Tests; ~halber Tag für die persistierte Catch-up-Variante.
 
-**Tracking:** Eigenes Issue; betrifft alle `_spawn_periodic_task`-Aufrufer mit Intervall ≳ erwarteter Pod-Lebensdauer.
+**Tracking:** [#678](https://github.com/ebongard/renfield/issues/678); betrifft alle `_spawn_periodic_task`-Aufrufer mit Intervall ≳ erwarteter Pod-Lebensdauer.
 
 ---
 


### PR DESCRIPTION
Wires the tech-debt #14 *Tracking* line to the follow-up issue #678 (periodic schedulers lose daily ticks on pod restart). Docs-only, one line.