### PR TITLE
fix(lifecycle): run daily schedulers at boot so they survive pod restarts (#678)

### DIFF
--- a/docs/TECHNICAL_DEBT.md
+++ b/docs/TECHNICAL_DEBT.md
@@ -2,7 +2,7 @@
 
 Dieses Dokument enthält eine umfassende Analyse der technischen Schulden im gesamten Renfield-System.
 
-**Letzte Aktualisierung:** 2026-06-04 (Backend #14 ergänzt: periodische Scheduler verlieren tägliche Ticks bei Pod-Neustart — Befund aus der Self-Learning-Validierung)
+**Letzte Aktualisierung:** 2026-06-04 (Backend #14 behoben: `run_at_boot` für die täglichen Scheduler, #678)
 
 ---
 
@@ -10,11 +10,11 @@ Dieses Dokument enthält eine umfassende Analyse der technischen Schulden im ges
 
 | Bereich | Kritisch | Mittel | Niedrig | Gesamt | Behoben |
 |---------|----------|--------|---------|--------|---------|
-| Backend | 0 | 4 | 4 | 10 | 10 |
+| Backend | 0 | 3 | 4 | 9 | 11 |
 | Frontend | 0 | 0 | 2 | 4 | 7 |
 | Satellite | 0 | 3 | 2 | 5 | 5 |
 | Infrastruktur | 0 | 3 | 2 | 6 | 6 |
-| **Gesamt** | **0** | **10** | **10** | **25** | **28** |
+| **Gesamt** | **0** | **9** | **10** | **24** | **29** |
 
 ---
 
@@ -191,9 +191,11 @@ Optional: Eine kurze Notiz im neuen `CONTRIBUTING.md`-Abschnitt zu Alembic-Best-
 
 ---
 
-#### 14. Periodische Scheduler verlieren tägliche Ticks bei Pod-Neustart
+#### ~~14. Periodische Scheduler verlieren tägliche Ticks bei Pod-Neustart~~ ✅ Behoben
 
-**Status:** Offen — Befund bei Self-Learning-Validierung (2026-06-04).
+**Status:** ✅ Behoben (2026-06-04, #678) — opt-in `run_at_boot` in `_spawn_periodic_task`: ein Tick direkt nach Spawn, vor dem ersten `sleep(interval)`. Aktiviert für die vier täglichen Scheduler (Skill Curator, Trajectory Cleanup, Skill Shadow-Log Cleanup, Speaker-Vocab-Rebuild). Kurz-Intervall-Scheduler behalten den Default (ihr erster Tick fällt ohnehin in eine normale Pod-Lebensdauer). Boot-Run-Fehler werden geloggt und geschluckt (fällt in die Intervall-Schleife durch); `CancelledError` während des Boot-Ticks propagiert sauber (Shutdown). Unit-Tests in `tests/backend/test_lifecycle_scheduler.py`. Die persistierte `last_run_at`-Catch-up-Variante bleibt für ein etwaiges Multi-Replica-Deployment offen, ist aber für den aktuellen Single-Replica-Betrieb nicht nötig.
+
+**Ursprünglicher Befund (2026-06-04):**
 
 **Problem:** `_spawn_periodic_task` (`api/lifecycle.py`) implementiert seine Schleife als `sleep(interval)` → `work()` (sleep-then-run). Der erste Tick erfolgt also erst `interval` Sekunden _nach_ dem Pod-Boot, und der Timer startet bei jedem Neustart bei null. Für die täglichen Scheduler (`interval=86400s`) heißt das: startet der Backend-Pod häufiger als alle 24 h neu (Rollout, OOM, k8s-Reschedule), feuert der Tick **nie**. Betroffen v. a. **Skill Curator** und **Trajectory Cleanup** (beide 86400s), sekundär Skill-Shadow-Log-Cleanup und Speaker-Vocab-Rebuild.
 

--- a/src/backend/api/lifecycle.py
+++ b/src/backend/api/lifecycle.py
@@ -32,6 +32,7 @@ def _spawn_periodic_task(
     interval: int,
     work: Callable[[], Awaitable[None]],
     started_msg: str,
+    run_at_boot: bool = False,
 ) -> None:
     """Spawn a fire-and-forget background task that runs ``work`` every
     ``interval`` seconds.
@@ -46,12 +47,32 @@ def _spawn_periodic_task(
       - ``started_msg`` is logged at INFO on spawn so log aggregation
         sees the same "X scheduler started" line as before this helper
         existed.
+      - ``run_at_boot`` (opt-in): run one tick promptly after spawn,
+        BEFORE the first ``sleep(interval)``, then fall into the normal
+        cadence. Required for schedulers whose ``interval`` is on the
+        order of (or longer than) the pod's lifetime: the plain
+        sleep-then-work loop fires its first tick ``interval`` seconds
+        after boot and the timer resets on every restart, so a pod that
+        recycles more often than ``interval`` NEVER runs the work (#678).
+        Leave False for short-interval schedulers — they reach their
+        first real tick well within a normal pod lifetime.
 
     Gates (``settings.X_enabled``) are the caller's responsibility — they
     decide whether the scheduler runs AT ALL, distinct from the loop
     body which decides what work happens per tick.
     """
     async def _loop() -> None:
+        if run_at_boot:
+            try:
+                await work()
+            # CancelledError (BaseException, not Exception) is intentionally
+            # NOT caught here: a shutdown cancel during the boot tick should
+            # propagate so the task settles as cancelled, same as the loop
+            # below. Only a genuine work() failure is logged and swallowed,
+            # so a transient boot-run error still falls into the interval
+            # loop instead of disabling the scheduler.
+            except Exception as e:  # noqa: BLE001
+                logger.warning(f"{name} failed (boot run): {e}")
         while True:
             try:
                 await asyncio.sleep(interval)
@@ -195,6 +216,7 @@ def _schedule_speaker_vocab_rebuild():
         interval=interval,
         work=_tick,
         started_msg=f"✅ Speaker vocab rebuild scheduled (interval={interval}s)",
+        run_at_boot=True,  # daily interval — see #678
     )
 
 
@@ -320,6 +342,7 @@ def _schedule_trajectory_cleanup():
             f"(interval={settings.trajectory_cleanup_interval}s, "
             f"retention={settings.trajectory_retention_days}d)"
         ),
+        run_at_boot=True,  # daily interval — see #678
     )
 
 
@@ -367,6 +390,7 @@ def _schedule_skill_curator():
             f"duplicate_threshold={settings.skill_curator_duplicate_threshold}, "
             f"stale_days={settings.skill_curator_stale_days})"
         ),
+        run_at_boot=True,  # daily interval — see #678
     )
 
 
@@ -417,6 +441,7 @@ def _schedule_skill_shadow_log_cleanup():
             f"(interval={settings.skill_shadow_log_cleanup_interval}s, "
             f"retention={settings.skill_shadow_log_retention_days}d)"
         ),
+        run_at_boot=True,  # daily interval — see #678
     )
 
 

--- a/tests/backend/test_lifecycle_scheduler.py
+++ b/tests/backend/test_lifecycle_scheduler.py
@@ -1,0 +1,115 @@
+"""Unit tests for ``api.lifecycle._spawn_periodic_task`` (#678).
+
+The daily schedulers (Skill Curator, Trajectory Cleanup, Skill Shadow-Log
+Cleanup, Speaker Vocab rebuild) run on an 86400s interval. The plain
+sleep-then-work loop fires its first tick a full interval after boot and
+the timer resets on every pod restart, so a pod that recycles more often
+than the interval never runs the work — observed as an empty
+``skill_curator_runs`` table in production. The ``run_at_boot`` opt-in
+runs one tick promptly after spawn to close that gap.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from api import lifecycle
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+@pytest.fixture(autouse=True)
+async def _clean_startup_tasks():
+    """Cancel + drain any task a test spawned, and restore the registry."""
+    before = list(lifecycle._startup_tasks)
+    yield
+    added = [t for t in lifecycle._startup_tasks if t not in before]
+    for t in added:
+        t.cancel()
+    for t in added:
+        try:
+            await t
+        except BaseException:  # noqa: BLE001 — best-effort teardown
+            pass
+    lifecycle._startup_tasks[:] = before
+
+
+def _spawn(**kwargs) -> asyncio.Task:
+    """Spawn via the helper and return the Task it registered."""
+    n = len(lifecycle._startup_tasks)
+    lifecycle._spawn_periodic_task(**kwargs)
+    assert len(lifecycle._startup_tasks) == n + 1
+    return lifecycle._startup_tasks[-1]
+
+
+async def test_run_at_boot_runs_work_promptly():
+    """With run_at_boot=True the first tick must fire without waiting the
+    (here 1h) interval."""
+    ran = asyncio.Event()
+
+    async def work():
+        ran.set()
+
+    _spawn(name="t", interval=3600, work=work,
+           started_msg="x", run_at_boot=True)
+
+    await asyncio.wait_for(ran.wait(), timeout=1.0)
+
+
+async def test_default_does_not_run_at_boot():
+    """Default (run_at_boot=False) preserves the legacy cadence: nothing
+    runs until the first interval elapses."""
+    calls = 0
+
+    async def work():
+        nonlocal calls
+        calls += 1
+
+    _spawn(name="t", interval=3600, work=work, started_msg="x")
+
+    await asyncio.sleep(0.05)
+    assert calls == 0
+
+
+async def test_boot_run_exception_swallowed_and_loop_survives():
+    """A boot-run failure must be logged and swallowed, with the task
+    falling through into the interval loop (not crashing)."""
+    boot_ran = asyncio.Event()
+    calls = 0
+
+    async def work():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            boot_ran.set()
+            raise RuntimeError("boom on boot")
+
+    task = _spawn(name="t", interval=3600, work=work,
+                  started_msg="x", run_at_boot=True)
+
+    await asyncio.wait_for(boot_ran.wait(), timeout=1.0)
+    await asyncio.sleep(0)     # let the swallowed error settle into sleep(3600)
+    assert calls == 1          # boot tick ran
+    assert not task.done()     # exception swallowed → now in the interval loop
+
+
+async def test_cancel_during_boot_run_terminates_cleanly():
+    """Cancelling while the boot tick is in-flight ends the task without
+    leaking an unexpected exception (shutdown path)."""
+    entered = asyncio.Event()
+
+    async def work():
+        entered.set()
+        await asyncio.sleep(10)  # block inside the boot run
+
+    task = _spawn(name="t", interval=3600, work=work,
+                  started_msg="x", run_at_boot=True)
+
+    await asyncio.wait_for(entered.wait(), timeout=1.0)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    assert task.done()


### PR DESCRIPTION
Closes #678.

## Problem

`_spawn_periodic_task` (`api/lifecycle.py`) looped as `sleep(interval)` → `work()`. The first tick of a daily scheduler (`86400s`) therefore fired 24h after boot, and the timer reset on every pod restart. A backend pod that recycles more often than the interval **never ran** the work — `skill_curator_runs` was empty in production despite `SKILL_CURATOR_ENABLED=true`, and the 30-day trajectory retention purge never ran.

## Fix

Opt-in `run_at_boot` on the helper: one tick promptly after spawn, before the first `sleep`, then the normal cadence. Enabled on the four daily schedulers (Skill Curator, Trajectory Cleanup, Skill Shadow-Log Cleanup, Speaker Vocab rebuild). Short-interval schedulers keep the default — their first real tick lands well within a normal pod lifetime.

- Boot-run failures are logged and swallowed, so a transient error still falls into the interval loop instead of disabling the scheduler.
- `CancelledError` during the boot tick propagates (it's `BaseException`, not caught by `except Exception`), so a shutdown cancel settles the task as cancelled — single cancel suffices.

Chose run-at-boot over the persisted-`last_run_at` catch-up (the issue's option 2); the latter is only needed for multi-replica and is noted as still-open in tech-debt #14.

## Tests

`tests/backend/test_lifecycle_scheduler.py` — run-at-boot fires promptly, default does not run at boot, boot-run exception is swallowed and the loop survives, cancel during the boot tick terminates cleanly. 4/4 pass on .159.

## Review

Independent adversarial review (no criticals); applied both its suggestions — let `CancelledError` propagate from the boot run (honest cancelled-state) and replaced a `sleep(0.05)` timing dependency with an Event.

## Docs

tech-debt #14 marked ✅ Behoben.

🤖 Generated with [Claude Code](https://claude.com/claude-code)