### PR TITLE
docs(lifecycle): correct stale speaker-vocab-rebuild cadence comment (#678)

### DIFF
--- a/src/backend/api/lifecycle.py
+++ b/src/backend/api/lifecycle.py
@@ -197,9 +197,11 @@ def _schedule_reminder_checker():
 def _schedule_speaker_vocab_rebuild():
     """Periodically rebuild the per-user STT vocabulary table (Phase B-3 follow-up).
 
-    Sleep-first cadence — a freshly-restarted pod doesn't hammer the DB on
-    every boot. First rebuild happens after one interval; cold-start
-    callers see the platform default until then.
+    Runs at boot (``run_at_boot=True`` below), then every interval. The
+    daily interval is longer than a typical pod lifetime, so a sleep-first
+    cadence would mean the rebuild never runs on a pod that recycles
+    sooner (#678); the boot tick guarantees cold-start callers get a fresh
+    vocabulary instead of the platform default.
     """
     if not settings.speaker_vocab_capture_enabled:
         return


### PR DESCRIPTION
Follow-up to #680. The `_schedule_speaker_vocab_rebuild` docstring still described the old sleep-first cadence ("First rebuild happens after one interval; cold-start callers see the platform default until then"), which `run_at_boot=True` made inaccurate — the rebuild now runs at boot. Updates the comment to match the behavior and records why (daily interval exceeds a typical pod lifetime, so sleep-first would never run on a recycling pod).

Comment-only, no behavior change.