### PR TITLE
fix(agent): record final_answer in context.steps so trajectories aren't dropped

### DIFF
--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -1243,6 +1243,19 @@ class AgentService:
                 summary_text=summary_text,
                 progress_sink=progress_sink,
             ):
+                # _run_impl records tool_call/tool_result/error into
+                # context.steps but yields the terminal final_answer WITHOUT
+                # recording it (it `return`s straight after the yield). The
+                # post-turn bookkeeping classifies the turn from context.steps,
+                # so a missing final_answer makes EVERY turn read as ABORT:
+                # the trajectory is dropped (default capture-set excludes
+                # abort) and turn_success is forced False (no skill auto-
+                # extraction; injected skills mis-recorded as failures).
+                # Record the terminal step here, at the single point every
+                # final_answer streams through, rather than at each of the
+                # ~10 yield sites inside _run_impl.
+                if step.step_type == "final_answer":
+                    context.steps.append(step)
                 yield step
         finally:
             # Publish real token counts from the AgentContext — fires on every

--- a/tests/backend/test_agent_service.py
+++ b/tests/backend/test_agent_service.py
@@ -2268,3 +2268,123 @@ class TestShouldUseNativeFC:
         client_false = MagicMock(supports_native_tools=False)
         assert agent._should_use_native_fc(client_no_attr) is False
         assert agent._should_use_native_fc(client_false) is False
+
+
+class TestTrajectoryStepRecording:
+    """Regression: run() must record the terminal final_answer step into
+    context.steps so the post-turn bookkeeping classifies the turn from a
+    complete step list.
+
+    The bug: _run_impl appended tool_call/tool_result/error to context.steps
+    but yielded final_answer without recording it, so every turn's
+    context.steps lacked a final_answer. outcome_from_steps then returned
+    ABORT for every turn (dropped from agent_trajectories, which excludes
+    abort) and turn_success was forced False (no skill auto-extraction;
+    injected skills mis-recorded as failures).
+    """
+
+    def _helpers(self):
+        # Reuse the mock builders from TestAgentServiceRun without
+        # re-collecting its tests.
+        return TestAgentServiceRun()
+
+    async def _bookkeeping_steps(self, agent, *, ollama, executor, message,
+                                 monkeypatch):
+        """Drive a real agent turn and return the `steps` list that the
+        post-turn bookkeeping dispatch was handed (== context.steps)."""
+        import services.agent_service as agsvc
+
+        captured: dict = {}
+
+        def _capture(**kwargs):
+            captured["steps"] = kwargs.get("steps")
+
+        monkeypatch.setattr(agsvc, "_post_turn_skill_bookkeeping", _capture)
+        monkeypatch.setattr(agsvc, "_spawn_skill_task", lambda *a, **k: None)
+        # Any one self-learning flag makes run() dispatch the bookkeeping.
+        monkeypatch.setattr(agsvc.settings, "trajectory_capture_enabled", True)
+
+        await collect_steps(agent, message=message, ollama=ollama,
+                            executor=executor)
+        return captured.get("steps")
+
+    @pytest.mark.unit
+    async def test_direct_final_answer_recorded_as_success(self, monkeypatch):
+        from models.database import TRAJECTORY_OUTCOME_SUCCESS
+        from services.trajectory_service import outcome_from_steps
+
+        h = self._helpers()
+        ollama = h._make_ollama_mock([
+            '{"action": "final_answer", "answer": "Hallo!", "reason": "x"}'
+        ])
+        agent = AgentService(h._make_registry(), max_steps=5)
+        steps = await self._bookkeeping_steps(
+            agent, ollama=ollama, executor=h._make_executor_mock(),
+            message="Hallo", monkeypatch=monkeypatch,
+        )
+        assert steps is not None
+        assert any(s.step_type == "final_answer" for s in steps)
+        assert outcome_from_steps(steps) == TRAJECTORY_OUTCOME_SUCCESS
+
+    @pytest.mark.unit
+    async def test_tool_then_answer_recorded_as_success(self, monkeypatch):
+        from models.database import TRAJECTORY_OUTCOME_SUCCESS
+        from services.trajectory_service import outcome_from_steps
+
+        h = self._helpers()
+        ollama = h._make_ollama_mock([
+            '{"action": "mcp.homeassistant.get_state", '
+            '"parameters": {"entity_id": "sensor.t"}, "reason": "c"}',
+            '{"action": "final_answer", "answer": "22C", "reason": "d"}',
+        ])
+        executor = h._make_executor_mock([
+            {"success": True, "message": "22C", "action_taken": True}
+        ])
+        agent = AgentService(h._make_registry(), max_steps=5)
+        steps = await self._bookkeeping_steps(
+            agent, ollama=ollama, executor=executor,
+            message="Wie warm?", monkeypatch=monkeypatch,
+        )
+        assert any(s.step_type == "tool_call" for s in steps)
+        assert any(s.step_type == "final_answer" for s in steps)
+        assert outcome_from_steps(steps) == TRAJECTORY_OUTCOME_SUCCESS
+
+    @pytest.mark.unit
+    async def test_failed_tool_then_answer_recorded_as_tool_fail(self, monkeypatch):
+        from models.database import TRAJECTORY_OUTCOME_TOOL_FAIL
+        from services.trajectory_service import outcome_from_steps
+
+        h = self._helpers()
+        ollama = h._make_ollama_mock([
+            '{"action": "mcp.homeassistant.get_state", '
+            '"parameters": {"entity_id": "sensor.t"}, "reason": "c"}',
+            '{"action": "final_answer", "answer": "Konnte nicht lesen", "reason": "d"}',
+        ])
+        executor = h._make_executor_mock([
+            {"success": False, "message": "tool boom", "action_taken": False}
+        ])
+        agent = AgentService(h._make_registry(), max_steps=5)
+        steps = await self._bookkeeping_steps(
+            agent, ollama=ollama, executor=executor,
+            message="Wie warm?", monkeypatch=monkeypatch,
+        )
+        assert any(s.step_type == "final_answer" for s in steps)
+        # final_answer present, but a tool failed → tool_fail (still captured).
+        assert outcome_from_steps(steps) == TRAJECTORY_OUTCOME_TOOL_FAIL
+
+    @pytest.mark.unit
+    def test_no_final_answer_stays_abort(self):
+        """Inverse guard: the fix records final_answer only when one is
+        emitted — it must never fabricate one. A genuine answer-less turn
+        (cancel/timeout before answering) classifies as ABORT and is
+        therefore dropped from capture, exactly as intended."""
+        from models.database import TRAJECTORY_OUTCOME_ABORT
+        from services.agent_service import AgentStep
+        from services.trajectory_service import outcome_from_steps
+
+        steps = [
+            AgentStep(step_number=1, step_type="tool_call", content="", tool="x"),
+            AgentStep(step_number=2, step_type="tool_result", content="ok",
+                      tool="x", success=True),
+        ]
+        assert outcome_from_steps(steps) == TRAJECTORY_OUTCOME_ABORT


### PR DESCRIPTION
## Problem

`agent_trajectories` was always empty in production despite `TRAJECTORY_CAPTURE_ENABLED=true` — and not because of low usage.

`_run_impl` appends `tool_call`/`tool_result`/`error` steps to `context.steps`, but yields the terminal `final_answer` **without** recording it (it `return`s straight after the `yield` — e.g. `agent_service.py:1717`, vs the `error_step` appended at 1736). The post-turn bookkeeping classifies the turn from `context.steps`, so a missing `final_answer` made **every** turn read as `ABORT`:

- `outcome_from_steps` → `ABORT`; the default capture-set `success,tool_fail` drops it before insert → no trajectory row ever written (`trajectory_service.py:155-158`).
- `turn_success = has_final and not has_error` → always `False` (`agent_service.py:2287-2289`) → **skill auto-extraction never fired** (only the seed skills ever existed), and **every injected skill was mis-recorded as a failure** via `record_outcome` — which, now that injection works (v2.12.10), would steadily push skills toward auto-demotion.

`tool_outcome_stats` being empty is separate and benign — it keys on `tool_result` steps (which *are* recorded); it's empty only because tool-using agent turns are rare here.

## Fix

Record the terminal step at the single point every `final_answer` streams through — the `run()` wrapper's `async for` — rather than at each of the ~10 `final_answer` yield sites inside `_run_impl`. `_run_impl` keeps recording tool/error steps; the wrapper only adds the `final_answer` it omits. Append-before-yield, so the `finally` dispatch always sees the complete list, even under early consumer cancellation.

## Tests

`TestTrajectoryStepRecording` drives **real** `run()` turns and asserts the bookkeeping sees a `final_answer` with the right outcome:
- direct answer → `success`
- tool + answer → `success`
- failed tool + answer → `tool_fail`
- no answer (cancel/timeout) → `abort` (inverse guard — the fix never fabricates a `final_answer`)

Full `test_agent_service.py` suite stays green (116 passed).

## Review

Independent adversarial review: no criticals. Confirmed no double-append, all `final_answer` paths flow through the wrapper, ordering is safe under early cancellation, and no agent behavior change (mid-turn `context.steps` consumers are step-type-gated). Added the ABORT guard test per its one actionable suggestion.

## Scope note

`thinking` / `paperless_confirm` steps remain unrecorded — intentional. They don't affect outcome/`turn_success` classification; a `paperless_confirm` turn (preview delivered, tool succeeded) correctly classifies as `success`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)