### PR TITLE
fix(frontend): don't @apply plain animate-fade-slide-in class (prod build blocker)

### DIFF
--- a/src/frontend/src/components/MergeProposalCard.tsx
+++ b/src/frontend/src/components/MergeProposalCard.tsx
@@ -81,7 +81,7 @@ export default function MergeProposalCard({ proposal, onApprove, onReject, busy 
   };
 
   return (
-    <li className="merge-proposal-card flex flex-col gap-3">
+    <li className="merge-proposal-card animate-fade-slide-in flex flex-col gap-3">
       <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
         <GitMerge className="w-4 h-4" aria-hidden="true" />
         <span>{t('circles.mergeProposals.whySuggested', { pct })}</span>

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -269,10 +269,10 @@
 
 @utility merge-proposal-card {
   /* Owner review card for a proposed entity merge — warm card holding the
-     two-column compare. Entrance via the existing motion token (reduced-motion
-     already wired for it). */
+     two-column compare. Entrance animation is applied via the plain
+     `animate-fade-slide-in` class on the element (see MergeProposalCard.tsx) —
+     it is a CSS class, not a Tailwind utility, so it can't go through @apply. */
   @apply rounded-lg border border-gray-200 bg-white p-4 shadow-sm
-         animate-fade-slide-in
          dark:bg-gray-800 dark:border-gray-700;
 }
 


### PR DESCRIPTION
## Build-blocking hotfix for the v2.13.0 RC deploy

The production frontend image build failed:
```
[postcss] tailwindcss: src/index.css:1:1: Cannot apply unknown utility class `animate-fade-slide-in`
```

**Cause:** the `merge-proposal-card` `@utility` (added in #699) did `@apply … animate-fade-slide-in …`, but `animate-fade-slide-in` is a plain CSS class (`.animate-fade-slide-in { animation: fadeSlideIn … }`), not a Tailwind utility — so Tailwind 4's `@apply` can't resolve it. Production `npm run build` runs the PostCSS/Tailwind pass; `vitest` + `tsc --noEmit` do not, so it passed #699's local checks and only failed at image-build time.

**Fix:** drop it from the `@apply` and add `animate-fade-slide-in` as a plain `className` on the card `<li>` in `MergeProposalCard.tsx` — exactly how every other call site (Layout, BrainReviewPage, BrainPage, ObligationsPage, FaktenPanel) uses it. Reduced-motion handling is unchanged (the `prefers-reduced-motion` block already targets `.animate-fade-slide-in`).

**Verified:** local `npm run build` now passes the CSS pass (1155 modules transformed; only a local-node_modules `three` drift remains, which the Docker `npm ci` resolves). Will re-cut the RC as `v2.13.0-rc.2` from fixed main and rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)