### PR TITLE
fix(kg): merge-proposal routes 500 in single-user mode (user is None)

### DIFF
--- a/src/backend/api/routes/knowledge_graph.py
+++ b/src/backend/api/routes/knowledge_graph.py
@@ -512,12 +512,15 @@ def _proposal_to_response(p: KgMergeProposal) -> MergeProposalResponse:
     )
 
 
-async def _owned_pending_proposal(db: AsyncSession, proposal_id: int, user: User) -> KgMergeProposal:
+async def _owned_pending_proposal(db: AsyncSession, proposal_id: int, user: User | None) -> KgMergeProposal:
     p = (await db.execute(
         select(KgMergeProposal).where(KgMergeProposal.id == proposal_id)
     )).scalar_one_or_none()
-    # uniform 404 for not-found AND not-owned (don't leak existence cross-user)
-    if p is None or (p.user_id is not None and p.user_id != user.id):
+    # uniform 404 for not-found AND not-owned (don't leak existence cross-user).
+    # Single-user mode (AUTH_ENABLED=false) → user is None and owns everything,
+    # so the ownership branch is skipped.
+    uid = user.id if user else None
+    if p is None or (uid is not None and p.user_id is not None and p.user_id != uid):
         raise HTTPException(status_code=404, detail="Merge proposal not found")
     return p
 
@@ -527,19 +530,23 @@ async def list_merge_proposals(
     db: AsyncSession = Depends(get_db),
     user: User = Depends(require_permission(Permission.KG_VIEW)),
 ):
-    """Pending entity-merge proposals owned by the caller (D3 review queue)."""
-    rows = (await db.execute(
+    """Pending entity-merge proposals owned by the caller (D3 review queue).
+
+    Single-user mode (AUTH_ENABLED=false) → user is None and sees every pending
+    proposal (consistent with the circle filter short-circuit in that mode)."""
+    uid = user.id if user else None
+    q = (
         select(KgMergeProposal)
         .options(
             selectinload(KgMergeProposal.loser),
             selectinload(KgMergeProposal.winner),
         )
-        .where(
-            KgMergeProposal.user_id == user.id,
-            KgMergeProposal.status == KG_MERGE_PROPOSAL_PENDING,
-        )
+        .where(KgMergeProposal.status == KG_MERGE_PROPOSAL_PENDING)
         .order_by(KgMergeProposal.similarity.desc(), KgMergeProposal.created_at.desc())
-    )).scalars().all()
+    )
+    if uid is not None:
+        q = q.where(KgMergeProposal.user_id == uid)
+    rows = (await db.execute(q)).scalars().all()
     proposals = [_proposal_to_response(p) for p in rows]
     return MergeProposalsListResponse(proposals=proposals, total=len(proposals))
 
@@ -559,7 +566,7 @@ async def approve_merge_proposal(
     KG_MANAGE (admin) would dead-end the queue for the household owners it serves."""
     await _owned_pending_proposal(db, proposal_id, user)
     survivor = await KgReconcilerService(db).approve_proposal(
-        proposal_id, resolved_by=user.id,
+        proposal_id, resolved_by=user.id if user else None,
         winner_id=body.winner_id if body else None,
     )
     if survivor is None:
@@ -576,7 +583,7 @@ async def reject_merge_proposal(
     """Reject a pending proposal (no merge; keeps both entities). KG_VIEW +
     ownership (see approve) — the owner resolves their own review queue."""
     await _owned_pending_proposal(db, proposal_id, user)
-    ok = await KgReconcilerService(db).reject_proposal(proposal_id, resolved_by=user.id)
+    ok = await KgReconcilerService(db).reject_proposal(proposal_id, resolved_by=user.id if user else None)
     if not ok:
         raise HTTPException(status_code=409, detail="Proposal already resolved")
     return {"status": "rejected", "proposal_id": proposal_id}
@@ -589,12 +596,31 @@ async def run_reconciler(
 ):
     """Trigger a reconciler pass over the caller's own entities (auto-merge
     same-tier high-confidence dupes; queue cross-tier/gray-zone for review).
-    KG_VIEW: acts only on run_for_user(user.id) — the caller's own graph."""
-    report = await KgReconcilerService(db).run_for_user(user.id)
+    KG_VIEW: acts only on the caller's own graph. Single-user mode
+    (AUTH_ENABLED=false) → user is None → reconcile every active user's graph,
+    aggregating the report (mirrors the boot scheduler)."""
+    svc = KgReconcilerService(db)
+    uid = user.id if user else None
+    if uid is not None:
+        report = await svc.run_for_user(uid)
+        candidates, auto_merged, proposed, backfilled, notes = (
+            report.candidates, report.auto_merged, report.proposed,
+            report.embedded_backfilled, report.notes,
+        )
+    else:
+        candidates = auto_merged = proposed = backfilled = 0
+        notes: list[str] = []
+        for active_uid in await svc.list_active_user_ids():
+            r = await svc.run_for_user(active_uid)
+            candidates += r.candidates
+            auto_merged += r.auto_merged
+            proposed += r.proposed
+            backfilled += r.embedded_backfilled
+            notes.extend(r.notes)
     return ReconcilerRunResponse(
-        candidates=report.candidates,
-        auto_merged=report.auto_merged,
-        proposed=report.proposed,
-        embedded_backfilled=report.embedded_backfilled,
-        notes=report.notes,
+        candidates=candidates,
+        auto_merged=auto_merged,
+        proposed=proposed,
+        embedded_backfilled=backfilled,
+        notes=notes,
     )

--- a/tests/backend/test_kg_reconciler_pg.py
+++ b/tests/backend/test_kg_reconciler_pg.py
@@ -275,6 +275,41 @@ class TestApproveReject:
         )).scalar_one()
         assert c_row.is_active is True and c_row.canonical_id is None
 
+    async def test_single_user_mode_routes_user_none(self, pg_db_session, monkeypatch):
+        # AUTH_ENABLED=false → require_permission yields user=None. The routes
+        # must not crash on user.id and the operator sees/acts on everything.
+        from api.routes.knowledge_graph import (
+            list_merge_proposals,
+            reject_merge_proposal,
+            run_reconciler,
+        )
+        owner = await _make_user(pg_db_session, "rt_single")
+        a = await _entity(pg_db_session, owner, "Alice", tier=0, mention=2, emb=_unit(6))
+        b = await _entity(pg_db_session, owner, "Alice B.", tier=2, mention=9, emb=_unit(6))
+        p = KgMergeProposal(
+            user_id=owner.id, loser_entity_id=a.id, winner_entity_id=b.id,
+            similarity=0.9, loser_tier=0, winner_tier=2, reason=KG_MERGE_REASON_CROSS_TIER,
+        )
+        pg_db_session.add(p)
+        await pg_db_session.flush()
+        _recon(pg_db_session, monkeypatch)  # patch commit/rollback + embedding
+
+        # list: user=None sees the pending proposal (no AttributeError on user.id)
+        listed = await list_merge_proposals(db=pg_db_session, user=None)
+        assert listed.total == 1
+        assert listed.proposals[0].winner.id == b.id
+
+        # reject: user=None resolves the owner's own queue
+        rejected = await reject_merge_proposal(p.id, db=pg_db_session, user=None)
+        assert rejected["status"] == "rejected"
+        assert (await list_merge_proposals(db=pg_db_session, user=None)).total == 0
+
+        # run: user=None aggregates over all active users (here: just `owner`).
+        # The cross-tier (a,b) pair is found again (rejection doesn't suppress
+        # re-discovery) and proposed — proving the aggregation path executed.
+        report = await run_reconciler(db=pg_db_session, user=None)
+        assert report.candidates == 1 and report.proposed == 1
+
     async def test_approve_override_winner(self, pg_db_session, monkeypatch):
         # D2 survivor toggle: owner keeps the LESS-mentioned entity instead of
         # the reconciler's default (more-mentioned) winner.


### PR DESCRIPTION
## Production hotfix for the v2.13.0 RC (caught by post-deploy browser E2E)

After the rc.2 rollout, `curl /health` was green but the **browser E2E** on the `/wissen` review lens surfaced a 500:
```
GET /api/knowledge-graph/merge-proposals → 500
api/routes/knowledge_graph.py:538 list_merge_proposals
  KgMergeProposal.user_id == user.id
  AttributeError: 'NoneType' object has no attribute 'id'
```

**Cause:** production runs `AUTH_ENABLED=false` (single-user mode), where `require_permission` yields `user=None`. The four new merge-proposal routes (#699) + `_owned_pending_proposal` call `user.id` directly. The rest of this router already handles it with `user.id if user else None` (lines 126, 314) — the new routes missed the guard.

**Fix:**
- `list_merge_proposals`: drop the `user_id` filter when `user is None` (single-user sees all pending — consistent with the circle-filter short-circuit in that mode).
- `_owned_pending_proposal`: skip the ownership branch when `user is None`.
- `approve`/`reject`: `resolved_by = user.id if user else None`.
- `run_reconciler`: when `user is None`, reconcile every active user's graph and aggregate (mirrors the boot scheduler) instead of `run_for_user(None)` (which matches no rows).

**Verified** on .159 real Postgres: `test_kg_reconciler_pg.py` **12/12**, incl. new `test_single_user_mode_routes_user_none` (calls the route fns directly with `user=None`: list sees the proposal, reject resolves it, run aggregates — no AttributeError).

Will redeploy as `v2.13.0-rc.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)