### PR TITLE
fix(kg): cast param in json_build_object — entity-merge 500 (IndeterminateDatatypeError)

### DIFF
--- a/src/backend/services/atom_service.py
+++ b/src/backend/services/atom_service.py
@@ -309,7 +309,9 @@ class AtomService:
             )
             await self.db.execute(
                 text(
-                    "UPDATE atoms SET policy = json_build_object('tier', :tier), "
+                    # CAST(:tier AS INTEGER): json_build_object is VARIADIC "any",
+                    # so asyncpg can't infer a bare param's type ($1) -> 500.
+                    "UPDATE atoms SET policy = json_build_object('tier', CAST(:tier AS INTEGER)), "
                     "updated_at = NOW() "
                     "FROM document_facts f "
                     "WHERE atoms.atom_type = :fact_type "

--- a/src/backend/services/knowledge_graph_service.py
+++ b/src/backend/services/knowledge_graph_service.py
@@ -924,10 +924,12 @@ class KnowledgeGraphService:
             "WHERE atoms.atom_type = :edge AND atoms.source_id = r.id::text "
             "  AND (r.subject_id = :w OR r.object_id = :w)"
         ), {"edge": ATOM_TYPE_KG_EDGE, "w": wid})
-        # keep the survivor's own kg_node atom policy in lockstep with merged_tier
+        # keep the survivor's own kg_node atom policy in lockstep with merged_tier.
+        # CAST(:t AS INTEGER): json_build_object is VARIADIC "any", so asyncpg
+        # can't infer a bare param's type -> IndeterminateDatatypeError ($1).
         if winner.atom_id:
             await self.db.execute(text(
-                "UPDATE atoms SET policy = json_build_object('tier', :t), updated_at = NOW() "
+                "UPDATE atoms SET policy = json_build_object('tier', CAST(:t AS INTEGER)), updated_at = NOW() "
                 "WHERE atom_id = :a"
             ), {"t": merged_tier, "a": winner.atom_id})
 

--- a/tests/backend/test_kg_merge_pg.py
+++ b/tests/backend/test_kg_merge_pg.py
@@ -156,6 +156,40 @@ class TestTierInvariant:
         assert rel.circle_tier == 0
 
 
+class TestAtomPolicySync:
+    async def test_winner_atom_policy_follows_merged_tier(self, pg_db_session, monkeypatch):
+        # Regression: the survivor's kg_node atom policy is updated via
+        # json_build_object('tier', CAST(:t AS INTEGER)). Without the cast asyncpg
+        # raised IndeterminateDatatypeError ($1) → 500 on POST /entities/merge.
+        # The other fixtures create bare entities (no atom_id), so this branch
+        # never ran and the bug shipped. Here the winner HAS an atom.
+        from models.database import ATOM_TYPE_KG_NODE, Atom
+        owner = await _make_user(pg_db_session, "mg_atom")
+        # entity first (no atom_id), then the atom it points at — the
+        # kg_entities.atom_id FK requires the atoms row to exist before linking.
+        winner = await _entity(pg_db_session, owner, "Alice", tier=2)
+        loser = await _entity(pg_db_session, owner, "Alice B.", tier=0)
+        aid = "11111111-1111-1111-1111-111111111111"
+        pg_db_session.add(Atom(
+            atom_id=aid, atom_type=ATOM_TYPE_KG_NODE,
+            source_table="kg_entities", source_id=str(winner.id),
+            owner_user_id=owner.id, policy={"tier": 2},
+        ))
+        await pg_db_session.flush()
+        winner.atom_id = aid
+        await pg_db_session.flush()
+        svc = _svc(pg_db_session, monkeypatch)
+
+        # would raise asyncpg IndeterminateDatatypeError before the CAST fix
+        assert await svc.merge_entities(loser.id, winner.id) is not None
+
+        assert winner.circle_tier == 0  # MIN(2, 0)
+        pol = (await pg_db_session.execute(
+            select(Atom.policy).where(Atom.atom_id == winner.atom_id)
+        )).scalar_one()
+        assert pol == {"tier": 0}  # atom policy followed the merged tier
+
+
 class TestMemorySubjectFollows:
     async def test_subject_entity_repointed(self, pg_db_session, monkeypatch):
         owner = await _make_user(pg_db_session, "mg_mem")


### PR DESCRIPTION
## Production 500 caught by the live log monitor

`POST /api/knowledge-graph/entities/merge` 500'd in prod (user hit it while merging two entities):
```
ERROR api.routes.knowledge_graph:merge_entities — asyncpg.IndeterminateDatatypeError:
could not determine data type of parameter $1
```

**Cause:** `json_build_object` is `VARIADIC "any"`, so asyncpg can't infer the type of a bare bind param passed to it. `merge_entities` syncs the survivor's `kg_node` atom policy via `json_build_object('tier', :t)` — but **only when `winner.atom_id` is set**. Every PG merge test used bare `KGEntity` fixtures with no `atom_id`, so that branch never executed and #699 shipped the bug. Real pipeline entities have an atom → the first real merge hit it.

**Fix:**
- `knowledge_graph_service.merge_entities`: `json_build_object('tier', CAST(:t AS INTEGER))`.
- `atom_service.update_tier`: the **same latent bug** on the Schicht-A `document_facts` cascade (pre-existing) — would 500 on retiering a document that has facts. Fixed identically.
- `test_kg_merge_pg.py`: new `TestAtomPolicySync` gives the winner a real `kg_node` atom (respecting the entity→atom FK order) and asserts the policy follows the merged tier. **Fails with IndeterminateDatatypeError before the cast.**

**Verified** on .159 real Postgres: `test_kg_merge_pg.py` **10/10**. (Two `test_atom_service.py::TestUpdateTier` failures are pre-existing stale-mock unit tests — they fail on committed main too and mock `db.execute`, so they neither relate to nor can catch this bug.)

Will redeploy as `v2.13.0-rc.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)