### PR TITLE
feat(memory): Phase 3a — type/tier-aware resolve_entity + reconciler same-name gate

### DIFF
--- a/src/backend/services/kg_reconciler_service.py
+++ b/src/backend/services/kg_reconciler_service.py
@@ -41,6 +41,28 @@ from utils.config import settings
 _RECONCILER_LOCK_NS = 0x4B47  # "KG"
 
 
+def _norm(s: str | None) -> str:
+    return (s or "").strip().lower()
+
+
+def _name_collision_low_signal(
+    name_a: str | None, name_b: str | None,
+    desc_a: str | None, desc_b: str | None,
+) -> bool:
+    """True when a candidate pair shares a name but lacks signal to tell them apart.
+
+    Same normalized name + (either description empty OR identical descriptions) =>
+    the embedding match is essentially a name match, which cannot distinguish two
+    different real entities that happen to share a name. Such pairs must go to
+    owner review, never auto-merge (Phase 3 P3-T2). When BOTH sides carry distinct
+    non-empty descriptions the similarity is meaningful, so auto-merge stays allowed.
+    """
+    if _norm(name_a) != _norm(name_b):
+        return False
+    da, db = _norm(desc_a), _norm(desc_b)
+    return (not da) or (not db) or (da == db)
+
+
 @dataclass
 class MergeCandidate:
     loser_id: int
@@ -48,6 +70,13 @@ class MergeCandidate:
     similarity: float
     loser_tier: int
     winner_tier: int
+    # Same canonical name + weak disambiguating signal (a missing or identical
+    # description on either side). The embedding similarity is then driven almost
+    # entirely by the shared name, so two genuinely different people ("Anna" the
+    # mother vs "Anna" the friend) look like a dupe. Never auto-merge these —
+    # route to owner review — else the memory↔entity bridge's backfill would feed
+    # the Jutta/Anna conflation back through the reconciler (Phase 3 P3-T2).
+    block_auto_merge: bool = False
 
 
 @dataclass
@@ -88,6 +117,8 @@ class KgReconcilerService:
                    a.circle_tier AS tier_a, b.circle_tier AS tier_b,
                    a.mention_count AS mc_a, b.mention_count AS mc_b,
                    a.first_seen_at AS fs_a, b.first_seen_at AS fs_b,
+                   a.name AS name_a, b.name AS name_b,
+                   a.description AS desc_a, b.description AS desc_b,
                    1 - (a.embedding::halfvec({dim}) <=> b.embedding::halfvec({dim})) AS similarity
             FROM kg_entities a
             JOIN kg_entities b
@@ -130,6 +161,9 @@ class KgReconcilerService:
                 loser_id=loser_id, winner_id=winner_id,
                 similarity=float(r.similarity),
                 loser_tier=loser_tier, winner_tier=winner_tier,
+                block_auto_merge=_name_collision_low_signal(
+                    r.name_a, r.name_b, r.desc_a, r.desc_b,
+                ),
             ))
         return out
 
@@ -255,7 +289,7 @@ class KgReconcilerService:
             if c.loser_id in touched or c.winner_id in touched:
                 continue  # transitive-cluster guard
             try:
-                if c.loser_tier == c.winner_tier and c.similarity >= auto_t:
+                if c.loser_tier == c.winner_tier and c.similarity >= auto_t and not c.block_auto_merge:
                     kg = KnowledgeGraphService(self.db)
                     res = await kg.merge_entities(c.loser_id, c.winner_id)
                     if res is not None:

--- a/src/backend/services/knowledge_graph_service.py
+++ b/src/backend/services/knowledge_graph_service.py
@@ -435,6 +435,8 @@ class KnowledgeGraphService:
         user_role: str | None = None,  # kept for back-compat; ignored under circles
         description: str | None = None,
         extra_types: list[str] | None = None,
+        create_tier: int | None = None,
+        match_entity_type: bool = False,
     ) -> KGEntity:
         """
         Resolve an entity by name, creating or merging as needed.
@@ -452,6 +454,17 @@ class KnowledgeGraphService:
 
         Cross-user entity dedup stays deferred to the named-circles work; v1 is
         per-user (own + unowned only).
+
+        Phase 3 additive params (default = legacy behavior, byte-identical):
+        - ``create_tier``: tier for the create path AND the same-tier embedding
+          search. ``None`` => 0 (self), today's behavior. The memory→entity
+          bridge passes the source memory's ``circle_tier`` so a backfilled
+          household fact doesn't mint a self-tier entity.
+        - ``match_entity_type``: when True, the exact-name and surface-form
+          lookups (and the embedding search) additionally scope to the primary
+          ``entity_type``. Prevents linking e.g. a "Bella" person-fact to a
+          place/thing named Bella. Default False keeps the live extraction path
+          (which trusts the LLM's type) unchanged.
         """
         resolved_type = entity_type if entity_type in KG_ENTITY_TYPES else "thing"
         now = datetime.now(UTC).replace(tzinfo=None)
@@ -475,14 +488,17 @@ class KnowledgeGraphService:
         # Names are no longer unique (the embedding step is same-tier-guarded,
         # so the same name can exist at different tiers), so order
         # deterministically and take first instead of scalar_one.
+        exact_conds = [
+            func.lower(KGEntity.name) == name.lower(),
+            KGEntity.is_active == True,  # noqa: E712
+            KGEntity.canonical_id.is_(None),
+            or_(KGEntity.user_id == user_id, KGEntity.user_id.is_(None)),
+        ]
+        if match_entity_type:
+            exact_conds.append(KGEntity.entity_type == resolved_type)
         q = (
             select(KGEntity)
-            .where(
-                func.lower(KGEntity.name) == name.lower(),
-                KGEntity.is_active == True,  # noqa: E712
-                KGEntity.canonical_id.is_(None),
-                or_(KGEntity.user_id == user_id, KGEntity.user_id.is_(None)),
-            )
+            .where(*exact_conds)
             .order_by(KGEntity.circle_tier.asc(), KGEntity.mention_count.desc())
         )
         existing = (await self.db.execute(q)).scalars().first()
@@ -497,17 +513,21 @@ class KnowledgeGraphService:
         dialect = self.db.bind.dialect.name if self.db.bind is not None else ""
         if dialect == "postgresql":
             sf_user = "AND (user_id = :uid OR user_id IS NULL)" if user_id is not None else ""
+            sf_type = "AND entity_type = :etype" if match_entity_type else ""
             sf_sql = text(f"""
                 SELECT id FROM kg_entities
                 WHERE is_active = true AND canonical_id IS NULL
                   AND surface_forms @> CAST(:sf AS jsonb)
                   {sf_user}
+                  {sf_type}
                 ORDER BY circle_tier ASC, mention_count DESC
                 LIMIT 1
             """)
             sf_params: dict = {"sf": json.dumps([name])}
             if user_id is not None:
                 sf_params["uid"] = user_id
+            if match_entity_type:
+                sf_params["etype"] = resolved_type
             sf_row = (await self.db.execute(sf_sql, sf_params)).fetchone()
             if sf_row:
                 ent = (await self.db.execute(
@@ -522,7 +542,9 @@ class KnowledgeGraphService:
         # (D10), embedded from name+description. A cross-tier or sub-threshold
         # near-duplicate is NOT folded in here; it falls through to "create new"
         # and the background reconciler proposes the review-gated merge.
-        default_tier = 0
+        # create_tier (Phase 3) overrides the legacy self-tier default; clamp to
+        # the valid 0..4 ladder so a bad caller can never mint an out-of-range row.
+        default_tier = 0 if create_tier is None else max(0, min(4, int(create_tier)))
         embedding = None
         try:
             embedding = await self._get_embedding(self._embed_input(name, description))
@@ -532,6 +554,7 @@ class KnowledgeGraphService:
         if embedding:
             similar = await self._find_similar_entity(
                 embedding, user_id=user_id, tier=default_tier,
+                entity_type=resolved_type if match_entity_type else None,
             )
             if similar is not None:
                 _bump(similar)
@@ -627,6 +650,7 @@ class KnowledgeGraphService:
         embedding: list[float],
         user_id: int | None,
         tier: int | None = None,
+        entity_type: str | None = None,
     ) -> KGEntity | None:
         """
         Find the nearest existing entity above the similarity threshold.
@@ -651,6 +675,10 @@ class KnowledgeGraphService:
         if tier is not None:
             tier_filter = "AND circle_tier = :tier"
             params["tier"] = tier
+        type_filter = ""
+        if entity_type is not None:
+            type_filter = "AND entity_type = :etype"
+            params["etype"] = entity_type
 
         # halfvec cast on BOTH sides is mandatory to use idx_kg_entities_embedding_hnsw
         # (built with halfvec_cosine_ops; regular `vector` caps at 2000 dims, prod
@@ -668,6 +696,7 @@ class KnowledgeGraphService:
               AND canonical_id IS NULL
               {user_filter}
               {tier_filter}
+              {type_filter}
             ORDER BY embedding::halfvec({dim}) <=> CAST(:embedding AS halfvec({dim}))
             LIMIT 1
         """)

--- a/tests/backend/test_kg_reconciler_pg.py
+++ b/tests/backend/test_kg_reconciler_pg.py
@@ -57,9 +57,9 @@ async def _make_user(db: AsyncSession, name: str) -> User:
     return u
 
 
-async def _entity(db, owner, name, *, tier=0, mention=1, emb=None, etype="person") -> KGEntity:
+async def _entity(db, owner, name, *, tier=0, mention=1, emb=None, etype="person", desc=None) -> KGEntity:
     e = KGEntity(user_id=owner.id, name=name, entity_type=etype, circle_tier=tier,
-                 mention_count=mention, embedding=emb)
+                 mention_count=mention, embedding=emb, description=desc)
     db.add(e)
     await db.flush()
     return e
@@ -108,6 +108,35 @@ class TestRunForUser:
             select(KGEntity).where(KGEntity.id == loser.id)
         )).scalar_one()
         assert tomb.is_active is False and tomb.canonical_id is not None
+
+    async def test_same_name_low_signal_proposes_not_merges(self, pg_db_session, monkeypatch):
+        # P3-T2: two same-tier entities sharing a name with empty descriptions are
+        # high-similarity but indistinguishable (could be two different people).
+        # They must NOT auto-merge — route to review — else the memory bridge's
+        # backfill would feed the Jutta/Anna conflation back through the reconciler.
+        owner = await _make_user(pg_db_session, "rec_namecol")
+        await _entity(pg_db_session, owner, "Anna", tier=0, mention=2, emb=_unit(6))
+        await _entity(pg_db_session, owner, "Anna", tier=0, mention=9, emb=_unit(6))
+        rec = _recon(pg_db_session, monkeypatch)
+
+        report = await rec.run_for_user(owner.id)
+        assert report.auto_merged == 0   # blocked
+        assert report.proposed == 1      # routed to owner review instead
+        assert await _count_pending(pg_db_session, owner.id) == 1
+
+    async def test_same_name_distinct_descriptions_still_auto_merges(self, pg_db_session, monkeypatch):
+        # Control: same name BUT both sides carry distinct non-empty descriptions,
+        # so the embedding similarity is meaningful — auto-merge stays allowed.
+        owner = await _make_user(pg_db_session, "rec_namedesc")
+        await _entity(pg_db_session, owner, "Anna", tier=0, mention=2, emb=_unit(6),
+                      desc="meine Mutter, wohnt in Bonn")
+        await _entity(pg_db_session, owner, "Anna", tier=0, mention=9, emb=_unit(6),
+                      desc="Kollegin im Büro")
+        rec = _recon(pg_db_session, monkeypatch)
+
+        report = await rec.run_for_user(owner.id)
+        assert report.auto_merged == 1
+        assert report.proposed == 0
 
     async def test_cross_tier_proposes_not_merges(self, pg_db_session, monkeypatch):
         owner = await _make_user(pg_db_session, "rec_cross")

--- a/tests/backend/test_kg_resolve_cascade_pg.py
+++ b/tests/backend/test_kg_resolve_cascade_pg.py
@@ -130,3 +130,65 @@ class TestCreateNew:
         got = await svc.resolve_entity("Quux", "spaceship", owner.id)
         assert got.entity_type == "thing"
         assert got.entity_types == ["thing"]
+
+
+class TestPhase3CreateTier:
+    async def test_create_tier_honored(self, pg_db_session, monkeypatch):
+        # Phase 3: a backfilled household (tier 2) fact must mint a tier-2 entity,
+        # not the legacy hardcoded tier-0.
+        owner = await _make_user(pg_db_session, "rc_ct")
+        svc = _svc(pg_db_session, monkeypatch, embed=_vec(40))
+        got = await svc.resolve_entity("Hausmeister", "person", owner.id, create_tier=2)
+        assert got.id is not None and got.circle_tier == 2
+
+    async def test_create_tier_clamped(self, pg_db_session, monkeypatch):
+        owner = await _make_user(pg_db_session, "rc_clamp")
+        svc = _svc(pg_db_session, monkeypatch, embed=_vec(41))
+        got = await svc.resolve_entity("Out", "person", owner.id, create_tier=99)
+        assert got.circle_tier == 4  # clamped to the top of the 0..4 ladder
+
+    async def test_create_tier_scopes_embedding_search(self, pg_db_session, monkeypatch):
+        # An identical-embedding candidate at tier 0 must NOT be folded into when
+        # create_tier=2 (same-tier guard now keyed on create_tier) -> new tier-2 row.
+        owner = await _make_user(pg_db_session, "rc_ct_emb")
+        t0 = await _entity(pg_db_session, owner, "Bonn", tier=0, etype="place", embedding=_vec(42))
+        svc = _svc(pg_db_session, monkeypatch, embed=_vec(42))  # cosine 1.0
+        got = await svc.resolve_entity("Bnn", "place", owner.id, create_tier=2)
+        assert got.id != t0.id and got.circle_tier == 2
+
+
+class TestPhase3MatchEntityType:
+    async def test_exact_name_wrong_type_skipped_when_scoped(self, pg_db_session, monkeypatch):
+        # A "Bella" PLACE must not absorb a "Bella" PERSON resolve when type-scoped.
+        owner = await _make_user(pg_db_session, "rc_mt_exact")
+        place = await _entity(pg_db_session, owner, "Bella", tier=0, etype="place")
+        svc = _svc(pg_db_session, monkeypatch, embed=_vec(50))
+
+        scoped = await svc.resolve_entity("Bella", "person", owner.id, match_entity_type=True)
+        assert scoped.id != place.id and scoped.entity_type == "person"
+
+    async def test_exact_name_matches_cross_type_by_default(self, pg_db_session, monkeypatch):
+        # Control: without the flag, resolution stays type-blind (legacy behavior).
+        owner = await _make_user(pg_db_session, "rc_mt_default")
+        place = await _entity(pg_db_session, owner, "Bella", tier=0, etype="place")
+        svc = _svc(pg_db_session, monkeypatch, embed=_vec(51))
+
+        got = await svc.resolve_entity("Bella", "person", owner.id)  # no flag
+        assert got.id == place.id and got.entity_type == "place"  # matched the place
+
+    async def test_surface_form_wrong_type_skipped_when_scoped(self, pg_db_session, monkeypatch):
+        owner = await _make_user(pg_db_session, "rc_mt_sf")
+        place = await _entity(pg_db_session, owner, "Bonn", tier=0, etype="place",
+                              surface_forms=["Beuel"])
+        svc = _svc(pg_db_session, monkeypatch, embed=_vec(52))
+
+        scoped = await svc.resolve_entity("Beuel", "person", owner.id, match_entity_type=True)
+        assert scoped.id != place.id and scoped.entity_type == "person"
+
+    async def test_embedding_wrong_type_skipped_when_scoped(self, pg_db_session, monkeypatch):
+        owner = await _make_user(pg_db_session, "rc_mt_emb")
+        place = await _entity(pg_db_session, owner, "Bella", tier=0, etype="place", embedding=_vec(53))
+        svc = _svc(pg_db_session, monkeypatch, embed=_vec(53))  # cosine 1.0, same tier
+
+        scoped = await svc.resolve_entity("Bella2", "person", owner.id, match_entity_type=True)
+        assert scoped.id != place.id and scoped.entity_type == "person"


### PR DESCRIPTION
## Phase 3a — primitive fixes (prerequisite for the memory→KG bridge)

Phase 3 bridges flat `conversation_memories` to the canonical KG. The `/plan-eng-review` outside voice verified two **P0s in the shipped resolver** that would have let the bridge *recreate* the Jutta/Anna conflation it exists to fix. 3a fixes the primitives first (decision P3-D2), backward-compatibly, before any bridge code.

### What was broken (verified in code)
- `resolve_entity` was **tier-hardcoded to 0** (`knowledge_graph_service.py:525`, no tier param) and **type-blind** — exact-name (`:480`), surface-form (`:502`) and the embedding search never scoped `entity_type`. Resolving "Bella" (a person) would link to a `place`/`thing` named Bella.
- the Phase-1 reconciler would **auto-merge** backfilled same-name entities → two different "Anna"s collapse.

### Changes (additive, backward-compatible)
**P3-T1** — `resolve_entity` gains:
- `create_tier: int|None` — tier for the create path + same-tier embedding search (clamped 0..4). `None` = legacy tier-0.
- `match_entity_type: bool` — when True, exact-name + surface-form + embedding search scope to the primary `entity_type`. Default False = live extraction path byte-identical.
- `_find_similar_entity` gains an optional `entity_type` filter.

**P3-T2** — reconciler gate: a candidate pair sharing a normalized name with a **weak disambiguating signal** (empty or identical descriptions) never auto-merges — it routes to owner review. Distinct non-empty descriptions still auto-merge. Closes the conflation feedback loop.

### Tests — 38/38 on .159 real Postgres
- `test_kg_resolve_cascade_pg.py`: 7 new (create_tier honored/clamped/scopes-embedding; type-scoping on exact/surface-form/embedding + a type-blind control)
- `test_kg_reconciler_pg.py`: 2 new (same-name low-signal → proposes not merges; same-name distinct-descriptions → still auto-merges)
- existing cascade/merge tests pass unchanged (proves backward-compat)

No migration. Part of the Phase 3 plan (`tasks/structured-memory-plan.md`, ENG CLEARED). 3b (save-time bridge + backfill) + 3c (entity-augmented retrieval + UI) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)