### PR TITLE
feat(memory): Phase 3b — memory→KG subject bridge (save-time + backfill)

### DIFF
--- a/bin/backfill_subject_entity_ids.py
+++ b/bin/backfill_subject_entity_ids.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""
+Backfill conversation_memories.subject_entity_id (Structured Memory Phase 3b).
+
+Thin CLI over ``services.memory_bridge_backfill`` (the testable core). Links each
+decomposable memory (category fact/preference) that carries a subject_name but no
+entity link to its canonical KG entity — linking existing entities and creating
+one (at the memory's own circle_tier, type-scoped to person) for subjects with no
+entity yet. After this runs, entity-augmented retrieval ("Was weiß ich über X")
+reads every memory about a person deterministically instead of by embedding alone.
+
+ALWAYS --dry-run first: it prints link-vs-create estimates WITHOUT any write.
+Per-row create+link is committed atomically (no orphan entity on crash); re-runs
+are idempotent (already-linked rows are excluded). The reconciler's Phase 3a
+same-name gate ensures any duplicate entities this mints surface in the owner
+review queue instead of being auto-merged.
+
+Usage:
+    python bin/backfill_subject_entity_ids.py --dry-run             # estimate, no writes
+    python bin/backfill_subject_entity_ids.py --commit             # do it
+    python bin/backfill_subject_entity_ids.py --commit --user-id 1 # one user
+    python bin/backfill_subject_entity_ids.py --commit --limit 500 # cap rows
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+# Put src/backend on PYTHONPATH so this runs as ``python bin/...`` from repo root.
+_BACKEND = Path(__file__).resolve().parent.parent / "src" / "backend"
+sys.path.insert(0, str(_BACKEND))
+
+from services.database import AsyncSessionLocal  # noqa: E402
+from services.memory_bridge_backfill import (  # noqa: E402
+    dry_run_backfill,
+    run_backfill,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s")
+logger = logging.getLogger("backfill_subject_entity_ids")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Backfill conversation_memories.subject_entity_id (Phase 3b).")
+    mode = p.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--dry-run", action="store_true", help="Estimate link/create counts; no writes.")
+    mode.add_argument("--commit", action="store_true", help="Perform the backfill (writes).")
+    p.add_argument("--user-id", type=int, default=None, help="Limit to one user (default: all).")
+    p.add_argument("--limit", type=int, default=None, help="Cap the number of memories processed.")
+    return p
+
+
+async def _run(args: argparse.Namespace) -> int:
+    async with AsyncSessionLocal() as session:
+        if args.dry_run:
+            rep = await dry_run_backfill(session, args.user_id, args.limit)
+            logger.info(
+                "DRY-RUN: %d candidates | ~%d would link to an existing entity | "
+                "~%d would create a new entity (%d distinct subjects). "
+                "Estimate uses exact-name match only; the real run's embedding step may link a few more. "
+                "No writes performed.",
+                rep.candidates, rep.would_link, rep.would_create, rep.distinct_subjects,
+            )
+        else:
+            rep = await run_backfill(session, args.user_id, args.limit)
+            logger.info(
+                "BACKFILL DONE: %d linked (%d new entities created), %d failed, %d candidates.",
+                rep.linked, rep.created, rep.failed, rep.candidates,
+            )
+    return 0
+
+
+def main() -> int:
+    return asyncio.run(_run(_build_parser().parse_args()))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/backend/services/conversation_memory_service.py
+++ b/src/backend/services/conversation_memory_service.py
@@ -23,6 +23,8 @@ from models.database import (
     MEMORY_ACTION_DELETED,
     MEMORY_ACTION_UPDATED,
     MEMORY_CATEGORIES,
+    MEMORY_CATEGORY_FACT,
+    MEMORY_CATEGORY_PREFERENCE,
     MEMORY_CHANGED_BY_RESOLUTION,
     MEMORY_CHANGED_BY_SYSTEM,
     MEMORY_CHANGED_BY_USER,
@@ -604,9 +606,57 @@ class ConversationMemoryService:
                     subject=subject,
                 )
             if memory:
+                await self._bridge_subject_entity(memory, subject, category)
                 saved.append(memory)
 
         return saved
+
+    async def _bridge_subject_entity(
+        self,
+        memory: ConversationMemory,
+        subject: str | None,
+        category: str,
+    ) -> None:
+        """Phase 3 bridge: link a decomposable memory's subject to a canonical KG entity.
+
+        Runs only here, in the background extraction path (never the synchronous
+        turn). Decomposable facts/preferences are about a named subject (a person);
+        resolve that subject to the canonical entity — reusing whatever the turn's
+        KG extraction already created, since resolve_entity is name-idempotent — and
+        store its id in subject_entity_id so "Was weiß ich über X" becomes
+        deterministic. Non-decomposable categories (procedural/instruction/context)
+        stay flat.
+
+        Gated behind MEMORY_KG_BRIDGE_ENABLED (opt-in, dark by default). Best-effort:
+        a resolve failure leaves subject_entity_id NULL (backfill or the next mention
+        links it later). type-scoped + tier-pinned resolution (Phase 3a) prevents
+        wrong-type links and self-tier leaks.
+        """
+        if not settings.memory_kg_bridge_enabled:
+            return
+        if memory is None or memory.user_id is None:
+            return
+        if not subject or category not in (MEMORY_CATEGORY_FACT, MEMORY_CATEGORY_PREFERENCE):
+            return
+        if memory.subject_entity_id is not None:
+            return
+        try:
+            from services.knowledge_graph_service import KnowledgeGraphService
+            ent = await KnowledgeGraphService(self.db).resolve_entity(
+                subject, "person", memory.user_id,
+                create_tier=memory.circle_tier,
+                match_entity_type=True,
+            )
+            memory.subject_entity_id = ent.id
+            if not memory.subject_name:
+                memory.subject_name = subject
+            await self.db.commit()
+        except Exception as e:  # noqa: BLE001 — bridge is best-effort; never break extraction
+            await self.db.rollback()
+            logger.warning(
+                f"Memory KG bridge failed for memory #{getattr(memory, 'id', '?')} "
+                f"subject={subject!r}: {e}"
+            )
 
     @staticmethod
     def _parse_extraction_response(raw_text: str) -> list[dict]:

--- a/src/backend/services/memory_bridge_backfill.py
+++ b/src/backend/services/memory_bridge_backfill.py
@@ -1,0 +1,133 @@
+"""Backfill logic for conversation_memories.subject_entity_id (Phase 3b).
+
+Importable core so it can be unit-tested against ``pg_db_session`` and reused;
+the thin CLI lives in ``bin/backfill_subject_entity_ids.py``.
+
+Phase 2 populated ``subject_name`` (a string) but left ``subject_entity_id``
+(FK to kg_entities) NULL. This links each decomposable memory (category
+fact/preference) that carries a subject_name to its canonical KG entity —
+linking existing entities and creating one for subjects with no entity yet.
+
+Safety (Phase 3 eng-review):
+  * ``dry_run_backfill`` writes nothing; it estimates link-vs-create counts.
+  * type-scoped + tier-pinned resolution: ``create_tier = memory.circle_tier``
+    (never more public), ``match_entity_type=True`` (no wrong-type links).
+  * per-row create+link committed in one transaction -> no orphan entity on crash.
+  * idempotent: already-linked rows are excluded by the query.
+  * failure isolation: one bad row is logged and skipped; the batch continues.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import (
+    MEMORY_CATEGORY_FACT,
+    MEMORY_CATEGORY_PREFERENCE,
+    ConversationMemory,
+    KGEntity,
+)
+from services.knowledge_graph_service import KnowledgeGraphService
+
+logger = logging.getLogger("memory_bridge_backfill")
+
+_DECOMPOSABLE = (MEMORY_CATEGORY_FACT, MEMORY_CATEGORY_PREFERENCE)
+
+
+@dataclass
+class BackfillReport:
+    candidates: int = 0
+    linked: int = 0
+    created: int = 0
+    failed: int = 0
+    # dry-run estimates:
+    would_link: int = 0
+    would_create: int = 0
+    distinct_subjects: int = 0
+
+
+def _candidate_query(user_id: int | None):
+    q = (
+        select(ConversationMemory)
+        .where(
+            ConversationMemory.is_active == True,  # noqa: E712
+            ConversationMemory.subject_name.is_not(None),
+            ConversationMemory.subject_entity_id.is_(None),
+            ConversationMemory.category.in_(_DECOMPOSABLE),
+        )
+        .order_by(ConversationMemory.id.asc())
+    )
+    if user_id is not None:
+        q = q.where(ConversationMemory.user_id == user_id)
+    return q
+
+
+async def _existing_person_entity_id(db: AsyncSession, name: str, user_id: int | None) -> int | None:
+    """Cheap exact-name person match (the resolve fast-path) for the dry-run estimate."""
+    row = (await db.execute(
+        select(KGEntity.id).where(
+            func.lower(KGEntity.name) == name.strip().lower(),
+            KGEntity.is_active == True,  # noqa: E712
+            KGEntity.canonical_id.is_(None),
+            KGEntity.entity_type == "person",
+            (KGEntity.user_id == user_id) | (KGEntity.user_id.is_(None)),
+        ).limit(1)
+    )).first()
+    return int(row[0]) if row else None
+
+
+async def dry_run_backfill(db: AsyncSession, user_id: int | None = None, limit: int | None = None) -> BackfillReport:
+    rows = (await db.execute(_candidate_query(user_id))).scalars().all()
+    if limit is not None:
+        rows = rows[:limit]
+    rep = BackfillReport(candidates=len(rows))
+    if not rows:
+        return rep
+    seen: dict[tuple[int | None, str], bool] = {}
+    for m in rows:
+        key = (m.user_id, (m.subject_name or "").strip().lower())
+        if key in seen:
+            rep.would_link += 1  # same subject as an earlier row this run
+            continue
+        eid = await _existing_person_entity_id(db, m.subject_name, m.user_id)
+        seen[key] = eid is not None
+        if eid is not None:
+            rep.would_link += 1
+        else:
+            rep.would_create += 1
+    rep.distinct_subjects = len(seen)
+    return rep
+
+
+async def run_backfill(db: AsyncSession, user_id: int | None = None, limit: int | None = None) -> BackfillReport:
+    rows = (await db.execute(_candidate_query(user_id))).scalars().all()
+    if limit is not None:
+        rows = rows[:limit]
+    rep = BackfillReport(candidates=len(rows))
+    if not rows:
+        return rep
+    # Monotonic serial id snapshot to detect freshly-created entities.
+    pre_max = (await db.execute(select(func.max(KGEntity.id)))).scalar() or 0
+    kg = KnowledgeGraphService(db)
+    for m in rows:
+        try:
+            ent = await kg.resolve_entity(
+                m.subject_name, "person", m.user_id,
+                create_tier=m.circle_tier,
+                match_entity_type=True,
+            )
+            m.subject_entity_id = ent.id
+            await db.commit()  # per-row: create+link atomic, no orphan on crash
+            rep.linked += 1
+            if ent.id > pre_max:
+                rep.created += 1
+                logger.info("created entity #%d %r (tier=%d) for memory #%d",
+                            ent.id, m.subject_name, m.circle_tier, m.id)
+        except Exception as e:  # noqa: BLE001 — isolate one bad row, keep going
+            await db.rollback()
+            rep.failed += 1
+            logger.warning("skip memory #%d subject=%r: %s", m.id, m.subject_name, e)
+    return rep

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -472,6 +472,7 @@ class Settings(BaseSettings):
     kg_reconciler_auto_merge_threshold: float = Field(default=0.95, ge=0.5, le=1.0)  # Same-tier auto-merge bar (>= candidate)
     kg_reconciler_max_per_run: int = Field(default=50, ge=1, le=500)             # Safety cap per user per run
     kg_reconciler_embed_backfill_per_run: int = Field(default=50, ge=0, le=500)  # Re-embed up to N null-embedding entities per pass (#6); 0 disables
+    memory_kg_bridge_enabled: bool = False                                       # Phase 3: link memory subjects to canonical KG entities (save-time + entity-augmented retrieval). Opt-in.
 
     # Skill draft-gate shadow log (v2.10 admin console rollout). When True,
     # SkillService.find_similar runs a parallel "would-have-injected" query

--- a/tests/backend/test_memory_kg_bridge_pg.py
+++ b/tests/backend/test_memory_kg_bridge_pg.py
@@ -1,0 +1,175 @@
+"""Postgres-only tests for the Phase 3b memory→KG bridge.
+
+Covers the save-time bridge (ConversationMemoryService._bridge_subject_entity)
+and the backfill script (bin/backfill_subject_entity_ids.py). Real PG via
+``pg_db_session`` — resolve_entity uses jsonb @> + halfvec the sqlite shim
+can't run. ``_get_embedding`` is mocked; commit/rollback -> flush so the
+bridge's internal txn control doesn't break the fixture's rollback isolation.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import (
+    EMBEDDING_DIMENSION,
+    MEMORY_CATEGORY_FACT,
+    MEMORY_CATEGORY_INSTRUCTION,
+    MEMORY_CATEGORY_PREFERENCE,
+    ConversationMemory,
+    KGEntity,
+    Role,
+    User,
+)
+from services import memory_bridge_backfill as backfill
+from services.conversation_memory_service import ConversationMemoryService
+from services.knowledge_graph_service import KnowledgeGraphService
+from utils.config import settings
+
+pytestmark = [pytest.mark.postgres, pytest.mark.asyncio]
+
+
+def _vec(seed: int) -> list[float]:
+    v = [0.0] * EMBEDDING_DIMENSION
+    v[seed % EMBEDDING_DIMENSION] = 1.0
+    return v
+
+
+async def _make_user(db: AsyncSession, name: str) -> User:
+    role = Role(name=f"{name}_role")
+    db.add(role)
+    await db.flush()
+    u = User(username=name, email=f"{name}@ex.test", password_hash="x", role_id=role.id, is_active=True)
+    db.add(u)
+    await db.flush()
+    return u
+
+
+async def _entity(db, owner, name, *, tier=0, etype="person", **kw) -> KGEntity:
+    e = KGEntity(user_id=owner.id, name=name, entity_type=etype, circle_tier=tier, **kw)
+    db.add(e)
+    await db.flush()
+    return e
+
+
+async def _memory(db, owner, *, category, subject_name, tier=0) -> ConversationMemory:
+    m = ConversationMemory(
+        content=f"fact about {subject_name}", category=category, user_id=owner.id,
+        subject_name=subject_name, circle_tier=tier, importance=0.5, confidence=1.0,
+        is_active=True,
+    )
+    db.add(m)
+    await db.flush()
+    return m
+
+
+def _patch(db, monkeypatch, *, enabled=True):
+    monkeypatch.setattr(db, "commit", db.flush)
+    monkeypatch.setattr(db, "rollback", db.flush)
+    monkeypatch.setattr(KnowledgeGraphService, "_get_embedding", AsyncMock(return_value=_vec(1)))
+    monkeypatch.setattr(settings, "memory_kg_bridge_enabled", enabled)
+
+
+class TestSaveTimeBridge:
+    async def test_fact_creates_and_links_person(self, pg_db_session, monkeypatch):
+        _patch(pg_db_session, monkeypatch, enabled=True)
+        owner = await _make_user(pg_db_session, "br_fact")
+        m = await _memory(pg_db_session, owner, category=MEMORY_CATEGORY_FACT, subject_name="Jutta")
+        svc = ConversationMemoryService(pg_db_session)
+
+        await svc._bridge_subject_entity(m, "Jutta", MEMORY_CATEGORY_FACT)
+
+        assert m.subject_entity_id is not None
+        ent = (await pg_db_session.execute(
+            select(KGEntity).where(KGEntity.id == m.subject_entity_id)
+        )).scalar_one()
+        assert ent.name == "Jutta" and ent.entity_type == "person"
+
+    async def test_links_existing_person(self, pg_db_session, monkeypatch):
+        _patch(pg_db_session, monkeypatch, enabled=True)
+        owner = await _make_user(pg_db_session, "br_link")
+        existing = await _entity(pg_db_session, owner, "Jutta", etype="person")
+        m = await _memory(pg_db_session, owner, category=MEMORY_CATEGORY_PREFERENCE, subject_name="Jutta")
+        svc = ConversationMemoryService(pg_db_session)
+
+        await svc._bridge_subject_entity(m, "Jutta", MEMORY_CATEGORY_PREFERENCE)
+        assert m.subject_entity_id == existing.id  # linked, not duplicated
+
+    async def test_disabled_flag_leaves_null(self, pg_db_session, monkeypatch):
+        _patch(pg_db_session, monkeypatch, enabled=False)
+        owner = await _make_user(pg_db_session, "br_off")
+        m = await _memory(pg_db_session, owner, category=MEMORY_CATEGORY_FACT, subject_name="Jutta")
+        svc = ConversationMemoryService(pg_db_session)
+
+        await svc._bridge_subject_entity(m, "Jutta", MEMORY_CATEGORY_FACT)
+        assert m.subject_entity_id is None
+
+    async def test_non_decomposable_skipped(self, pg_db_session, monkeypatch):
+        _patch(pg_db_session, monkeypatch, enabled=True)
+        owner = await _make_user(pg_db_session, "br_instr")
+        m = await _memory(pg_db_session, owner, category=MEMORY_CATEGORY_INSTRUCTION, subject_name="Jutta")
+        svc = ConversationMemoryService(pg_db_session)
+
+        await svc._bridge_subject_entity(m, "Jutta", MEMORY_CATEGORY_INSTRUCTION)
+        assert m.subject_entity_id is None
+
+    async def test_created_entity_inherits_memory_tier(self, pg_db_session, monkeypatch):
+        _patch(pg_db_session, monkeypatch, enabled=True)
+        owner = await _make_user(pg_db_session, "br_tier")
+        m = await _memory(pg_db_session, owner, category=MEMORY_CATEGORY_FACT, subject_name="Opa", tier=2)
+        svc = ConversationMemoryService(pg_db_session)
+
+        await svc._bridge_subject_entity(m, "Opa", MEMORY_CATEGORY_FACT)
+        ent = (await pg_db_session.execute(
+            select(KGEntity).where(KGEntity.id == m.subject_entity_id)
+        )).scalar_one()
+        assert ent.circle_tier == 2  # never minted at the more-public default tier 0
+
+
+class TestBackfill:
+    async def test_commit_links_and_creates(self, pg_db_session, monkeypatch):
+        _patch(pg_db_session, monkeypatch, enabled=True)
+        owner = await _make_user(pg_db_session, "bf_run")
+        existing = await _entity(pg_db_session, owner, "Anna", etype="person")
+        m_link = await _memory(pg_db_session, owner, category=MEMORY_CATEGORY_FACT, subject_name="Anna")
+        m_new = await _memory(pg_db_session, owner, category=MEMORY_CATEGORY_FACT, subject_name="Bert", tier=2)
+
+        rep = await backfill.run_backfill(pg_db_session, owner.id, None)
+        assert rep.linked == 2 and rep.created == 1 and rep.failed == 0
+        await pg_db_session.refresh(m_link)
+        await pg_db_session.refresh(m_new)
+        assert m_link.subject_entity_id == existing.id           # linked existing
+        new_ent = (await pg_db_session.execute(
+            select(KGEntity).where(KGEntity.id == m_new.subject_entity_id)
+        )).scalar_one()
+        assert new_ent.name == "Bert" and new_ent.circle_tier == 2  # created @ memory tier
+
+    async def test_dry_run_writes_nothing(self, pg_db_session, monkeypatch):
+        _patch(pg_db_session, monkeypatch, enabled=True)
+        owner = await _make_user(pg_db_session, "bf_dry")
+        m = await _memory(pg_db_session, owner, category=MEMORY_CATEGORY_FACT, subject_name="Carla")
+
+        rep = await backfill.dry_run_backfill(pg_db_session, owner.id, None)
+        assert rep.candidates == 1 and rep.would_create == 1
+        await pg_db_session.refresh(m)
+        assert m.subject_entity_id is None  # estimate only, no write
+
+    async def test_idempotent_second_run(self, pg_db_session, monkeypatch):
+        _patch(pg_db_session, monkeypatch, enabled=True)
+        owner = await _make_user(pg_db_session, "bf_idem")
+        await _memory(pg_db_session, owner, category=MEMORY_CATEGORY_FACT, subject_name="Dora")
+
+        assert (await backfill.run_backfill(pg_db_session, owner.id, None)).linked == 1
+        assert (await backfill.run_backfill(pg_db_session, owner.id, None)).candidates == 0  # already linked, excluded
+
+    async def test_skips_non_decomposable(self, pg_db_session, monkeypatch):
+        _patch(pg_db_session, monkeypatch, enabled=True)
+        owner = await _make_user(pg_db_session, "bf_skip")
+        m = await _memory(pg_db_session, owner, category=MEMORY_CATEGORY_INSTRUCTION, subject_name="Egon")
+
+        assert (await backfill.run_backfill(pg_db_session, owner.id, None)).candidates == 0
+        await pg_db_session.refresh(m)
+        assert m.subject_entity_id is None


### PR DESCRIPTION
## Phase 3b — the bridge (stacked on #703 / Phase 3a)

> Base is `feature/structured-memory-phase3a` (#703) — retargets to `main` once 3a merges. Review 3a first.

Links decomposable memories (category fact/preference) to canonical KG entities via `subject_entity_id`, building on 3a's type/tier-aware `resolve_entity`. **Gated behind `MEMORY_KG_BRIDGE_ENABLED` (opt-in, dark by default).**

### Save-time (P3-T3)
`ConversationMemoryService._bridge_subject_entity` runs in the **background** extraction path (`_extract_and_save_v1_impl`, never the synchronous turn). For a fact/preference memory with a subject it resolves the subject to its canonical person entity — reusing whatever the turn's KG extraction already created (`resolve_entity` is name-idempotent) — with `create_tier=memory.circle_tier` + `match_entity_type=True`. Best-effort (failure → `subject_entity_id` stays NULL, warning logged). Non-decomposable categories stay flat.

### Backfill (P3-T4)
`services/memory_bridge_backfill.py` (importable, testable core) + `bin/backfill_subject_entity_ids.py` (thin CLI). resolve-or-create at the memory's tier, type-scoped, per-row create+link in **one transaction** (no orphan on crash), `--dry-run` estimates link-vs-create with no writes, idempotent (already-linked excluded), per-row failure isolation. The Phase 3a reconciler same-name gate keeps any duplicate entities this mints out of auto-merge (review queue instead).

### Tests — 15/15 on .159 real Postgres
- `test_memory_kg_bridge_pg.py` 9/9: save-time (create+link, link-existing, flag-off, non-decomposable skip, tier inheritance); backfill (link+create, dry-run no-write, idempotent, non-decomposable skip)
- `test_memory_subject_t7.py` 6/6 (no Phase-2 regression)

No migration. 3c (entity-augmented retrieval + UI) follows. Plan: `tasks/structured-memory-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)