### PR TITLE
docs: surface proactive notifications in the feature list + subsystems

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ docker exec -it renfield-backend alembic downgrade -1
 
 **Request Flow:** User → React Frontend → WebSocket/REST → FastAPI Backend → Intent Recognition → Action Execution → MCP/RAG → Streaming Response
 
-**Subsystems:** Intent Recognition, Agent Loop (ReAct), MCP Integration (8+ servers), RAG/Knowledge Base, Conversation Persistence, Hook System (plugin API), Auth/RPBAC, Presence Detection, Media Follow Me, Speaker Recognition, Knowledge Graph, Paperless Audit, Audio Output Routing, Notification Privacy, Device Management, **Circles (access tiers)**
+**Subsystems:** Intent Recognition, Agent Loop (ReAct), MCP Integration (8+ servers), RAG/Knowledge Base, Conversation Persistence, Hook System (plugin API), Auth/RPBAC, Presence Detection, Media Follow Me, Speaker Recognition, Knowledge Graph, Paperless Audit, Audio Output Routing, Proactive Notifications (webhook + privacy-aware TTS, `PROACTIVE_ENABLED`), Device Management, **Circles (access tiers)**
 
 **Key config:** All via `.env` loaded by `utils/config.py` (Pydantic Settings). Full list: `docs/ENVIRONMENT_VARIABLES.md`.
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -339,6 +339,13 @@ Home Assistant Automation → POST /api/notifications/webhook
 - **LLM-Enrichment**: Benachrichtigungen werden durch LLM-Kontext angereichert (opt-in)
 - **Suppressions**: Nutzer können bestimmte Benachrichtigungs-Typen unterdrücken (semantisch)
 - **Feedback Learning**: System lernt aus Nutzer-Interaktionen mit Benachrichtigungen (opt-in)
+- **Privacy-aware TTS / Multi-Room-Auslieferung**: Benachrichtigungen werden präsenzabhängig im aktiven Raum vorgelesen; das `privacy`-Feld (public/personal/confidential) steuert, wer sie hört (Presence Detection + Audio Output Routing).
+
+### Konfiguration
+
+- **Master-Switch:** `PROACTIVE_ENABLED=true` (opt-in; aus = `/api/notifications/webhook` antwortet `503`). Webhook-Token via `POST /api/notifications/token` (Admin) generieren und in Home Assistant (`input_text.renfield_webhook_token`) hinterlegen.
+- **MCP-Polling:** `NOTIFICATION_POLLER_ENABLED=true` lässt Renfield MCP-Server (E-Mail, Kalender) aktiv nach Events abfragen, statt nur Push-Webhooks zu empfangen.
+- Vollständiger Einrichtungs-Guide + HA-Vorlagen: [`docs/PROACTIVE_NOTIFICATIONS.md`](PROACTIVE_NOTIFICATIONS.md) und [`docs/PROACTIVE_SCHEDULING_TEMPLATES.md`](PROACTIVE_SCHEDULING_TEMPLATES.md).
 
 ### Erinnerungen
 


### PR DESCRIPTION
Proactive notifications was already documented (dedicated `docs/PROACTIVE_NOTIFICATIONS.md`, README Features, FEATURES.md section) but under-surfaced. This adds the master-switch + setup + privacy-aware TTS delivery to FEATURES.md and names it explicitly in CLAUDE.md's Subsystems line. Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)