### PR TITLE
fix(media): give smart_home role internal.media_control so volume commands work

### DIFF
--- a/config/agent_roles.yaml
+++ b/config/agent_roles.yaml
@@ -18,7 +18,12 @@ roles:
       de: "Smart Home: Licht, Schalter, Sensoren, Heizung, Szenen steuern, Temperatur/Luftfeuchte in Raeumen abfragen (NICHT Musik/Medien, NICHT Aussenwetter)"
       en: "Smart home: control lights, switches, sensors, heating, scenes, query temperature/humidity in rooms (NOT music/media, NOT outdoor weather)"
     mcp_servers: [homeassistant]
-    internal_tools: [internal.resolve_room_player, internal.play_in_room]
+    # internal.media_control is the canonical room-volume path (HA media_players
+    # AND DLNA renderers). Volume commands ("lauter/leiser", "auf X% setzen")
+    # route here as smart_home/volume_control, so the role needs it — otherwise
+    # the agent has no working volume tool (HassSetVolume was removed because it
+    # can't target DLNA renderers and bypasses room routing).
+    internal_tools: [internal.resolve_room_player, internal.play_in_room, internal.media_control]
     max_steps: 4
     prompt_key: agent_prompt_smart_home
     model: "qwen3:8b"

--- a/src/backend/prompts/agent.yaml
+++ b/src/backend/prompts/agent.yaml
@@ -113,6 +113,7 @@ de:
     - Fuer Helligkeiten/Farben: Nutze HassLightSet mit "area"+"domain" oder "name"
     - Fuer Sensorwerte: Nutze GetLiveContext mit "name" und optional "area"
     - Uebergib NIEMALS "device_class"
+    - Lautstaerke eines Raum-Players: Nutze internal.media_control mit room_name (NICHT HassSetVolume/HassSetPosition). "auf X% setzen" → action="volume", volume=X; "um X% leiser/lauter" → action="volume", volume_step=-X / +X (Prozentpunkte). z.B. {{"action": "internal.media_control", "parameters": {{"action": "volume", "volume_step": -20, "room_name": "<aktueller_raum>"}}}}
     - Wenn ein Such-Tool 0 Ergebnisse liefert, wiederhole NICHT dieselbe Suche. Versuche: (1) Kuerzeren Suchbegriff, (2) alternative Schreibweise, (3) anderes Tool. Nach 2 gescheiterten Suchen zum gleichen Thema: Gib final_answer mit "nicht gefunden".
     - Die finale Antwort muss natuerlich und auf Deutsch sein
     - Antworte NUR mit JSON
@@ -681,6 +682,7 @@ en:
     - For brightness/colors: Use HassLightSet with "area"+"domain" or "name"
     - For sensor values: Use GetLiveContext with "name" and optionally "area"
     - NEVER pass "device_class"
+    - Volume of a room player: Use internal.media_control with room_name (NOT HassSetVolume/HassSetPosition). "set to X%" → action="volume", volume=X; "X% quieter/louder" → action="volume", volume_step=-X / +X (percentage points). e.g. {{"action": "internal.media_control", "parameters": {{"action": "volume", "volume_step": -20, "room_name": "<current_room>"}}}}
     - If a search tool returns 0 results, do NOT repeat the same search. Try: (1) Shorter query, (2) alternative spelling, (3) different tool. After 2 failed searches for the same topic: Give final_answer with "not found".
     - The final answer must be natural and in English
     - Reply ONLY with JSON

--- a/tests/backend/test_agent_router.py
+++ b/tests/backend/test_agent_router.py
@@ -40,7 +40,11 @@ SAMPLE_CONFIG = {
                 "en": "Smart home: lights, switches, sensors",
             },
             "mcp_servers": ["homeassistant"],
-            "internal_tools": ["internal.resolve_room_player", "internal.play_in_room"],
+            "internal_tools": [
+                "internal.resolve_room_player",
+                "internal.play_in_room",
+                "internal.media_control",
+            ],
             "max_steps": 4,
             "prompt_key": "agent_prompt_smart_home",
         },
@@ -224,9 +228,33 @@ class TestParseRoles:
         assert role.name == "smart_home"
         assert role.mcp_servers == ["homeassistant"]
         assert "internal.resolve_room_player" in role.internal_tools
+        # Volume commands ("lauter/leiser", "auf X% setzen") route to smart_home,
+        # so the role MUST carry the canonical room-volume tool. Without it the
+        # agent has no working volume path (HassSetVolume was removed for being
+        # DLNA-incompatible) — the gap that shipped broken in v2.13.0-rc.13.
+        assert "internal.media_control" in role.internal_tools
         assert role.max_steps == 4
         assert role.prompt_key == "agent_prompt_smart_home"
         assert role.has_agent_loop is True
+
+    @pytest.mark.unit
+    def test_real_config_smart_home_has_media_control(self):
+        """Regression guard against the real config/agent_roles.yaml (not the
+        SAMPLE_CONFIG mock): the smart_home role must include internal.media_control
+        so volume commands routed there can actually adjust volume. Skips when the
+        repo config isn't present (e.g. the image-stripped test container)."""
+        from pathlib import Path
+
+        config_file = next(
+            (p / "config" / "agent_roles.yaml"
+             for p in Path(__file__).resolve().parents
+             if (p / "config" / "agent_roles.yaml").exists()),
+            None,
+        )
+        if config_file is None:
+            pytest.skip("config/agent_roles.yaml not present in this environment")
+        roles = _parse_roles(load_roles_config(str(config_file)))
+        assert "internal.media_control" in roles["smart_home"].internal_tools
 
     @pytest.mark.unit
     def test_conversation_role_no_agent_loop(self):


### PR DESCRIPTION
## Why
Follow-up to #717 / v2.13.0-rc.13. That release added relative volume to \`internal.media_control\` and removed the DLNA-incompatible \`HassSetVolume\`. But **post-deploy log inspection** showed volume commands ("Erhöhe/Setze die Lautstärke") route to the **smart_home** role — whose \`internal_tools\` never included \`internal.media_control\`. So the role was left with no working volume tool and the agent flailed:

```
Router: 'Setze die Lautstärke auf 10' → smart_home
step 1: internal.resolve_room_player
step 2: mcp.homeassistant.HassSetPosition  → MCP rejects ('speaker' invalid device_class)
step 3: mcp.homeassistant.HassSetVolume    → ⚠️ Invalid tool (correctly removed)
step 4: internal.resolve_room_player ...    → gives up / fakes success
```

\`internal.media_control\` lived only in the \`media\` role, which volume never routes to.

## What
- \`config/agent_roles.yaml\`: add \`internal.media_control\` to \`smart_home.internal_tools\` (ConfigMap-only; no image change needed for this part).
- \`src/backend/prompts/agent.yaml\`: add volume guidance (\`volume\` / \`volume_step\` percentage-points, with \`room_name\`) to \`agent_prompt_smart_home\` (DE + EN).
- \`tests/backend/test_agent_router.py\`: SAMPLE_CONFIG fixture updated; \`test_smart_home_role_properties\` now asserts \`internal.media_control\`; new \`test_real_config_smart_home_has_media_control\` loads the real \`agent_roles.yaml\` (skips if absent).

## Tests
`.159`: my new/edited tests pass; the 2 \`*actual_config*\` failures are **pre-existing/environmental** (verified — the pre-change test file from \`main\` fails them identically; the test container doesn't ship a usable \`agent_roles.yaml\`).

## Deploy
- \`agent_roles.yaml\` → recreate \`renfield-mcp-config\` ConfigMap + restart backend.
- \`agent.yaml\` prompt is in the image → backend image rebuild + roll backend/dlna-mcp/document-worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)