### PR TITLE
fix(media): stop agent looping on internal.media_control volume

### DIFF
--- a/src/backend/ha_glue/services/internal_tools.py
+++ b/src/backend/ha_glue/services/internal_tools.py
@@ -787,6 +787,7 @@ class InternalToolService:
                     "action_taken": False,
                 }
 
+            applied_volume = None
             if action == "volume":
                 # Read current volume only for the relative path — a wasted MCP
                 # round-trip on absolute sets is avoided.
@@ -803,6 +804,7 @@ class InternalToolService:
                 target, err = self._resolve_target_volume(params, current_pct)
                 if err:
                     return err
+                applied_volume = target
                 tool_name = "mcp.dlna.set_volume"
                 tool_params = {"renderer_name": renderer_name, "volume": target}
             else:
@@ -824,16 +826,25 @@ class InternalToolService:
                     "action_taken": False,
                 }
 
+            data = {
+                "renderer_name": renderer_name,
+                "room_name": room_name,
+                "action": action,
+                "target_type": "dlna",
+            }
+            if action == "volume":
+                # Echo the resulting level so the agent sees a concrete completed
+                # state and gives final_answer instead of re-issuing the call
+                # (which, for a relative volume_step, would re-apply the delta).
+                data["volume"] = applied_volume
+                message = f"Volume in {room_name} set to {applied_volume}%."
+            else:
+                message = f"Media {action} executed on {room_name} (DLNA: {renderer_name})"
             return {
                 "success": True,
-                "message": f"Media {action} executed on {room_name} (DLNA: {renderer_name})",
+                "message": message,
                 "action_taken": True,
-                "data": {
-                    "renderer_name": renderer_name,
-                    "room_name": room_name,
-                    "action": action,
-                    "target_type": "dlna",
-                },
+                "data": data,
             }
 
         except Exception as e:
@@ -859,6 +870,7 @@ class InternalToolService:
 
             ha_client = HomeAssistantClient()
 
+            applied_volume = None
             if action == "volume":
                 # Read current volume only for the relative path — avoids a
                 # wasted HTTP read on absolute sets.
@@ -871,6 +883,7 @@ class InternalToolService:
                 target, err = self._resolve_target_volume(params, current_pct)
                 if err:
                     return err
+                applied_volume = target
                 volume_level = max(0.0, min(1.0, target / 100.0))
                 await ha_client.call_service(
                     domain="media_player",
@@ -886,15 +899,23 @@ class InternalToolService:
                     entity_id=entity_id,
                 )
 
+            data = {
+                "entity_id": entity_id,
+                "room_name": room_name,
+                "action": action,
+            }
+            if action == "volume":
+                # Echo the resulting level so the agent sees a concrete completed
+                # state and gives final_answer instead of re-issuing the call.
+                data["volume"] = applied_volume
+                message = f"Volume in {room_name} set to {applied_volume}%."
+            else:
+                message = f"Media {action} executed on {room_name}"
             return {
                 "success": True,
-                "message": f"Media {action} executed on {room_name}",
+                "message": message,
                 "action_taken": True,
-                "data": {
-                    "entity_id": entity_id,
-                    "room_name": room_name,
-                    "action": action,
-                },
+                "data": data,
             }
 
         except Exception as e:

--- a/src/backend/prompts/agent.yaml
+++ b/src/backend/prompts/agent.yaml
@@ -53,6 +53,7 @@ de:
     - WICHTIG — Album/Kuenstler abspielen: (1) search_media, (2) internal.play_album_on_dlna(album_id="<id>", renderer_name="<Raum>"). Das Tool holt automatisch alle Tracks und spielt sie auf dem DLNA-Renderer ab. NIEMALS mcp.dlna.play_tracks direkt aufrufen!
     - Einzelnen Song abspielen: (1) search_media(type="Audio"), (2) internal.play_in_room mit api_stream URL.
     - Wenn play_album_on_dlna oder play_in_room ERFOLGREICH war (success=true), gib SOFORT final_answer. NIEMALS dasselbe Play-Tool nochmal aufrufen!
+    - Wenn internal.media_control ERFOLGREICH war (success=true), gib SOFORT final_answer mit Bestaetigung (z.B. der neuen Lautstaerke aus data.volume). NIEMALS dasselbe Tool nochmal aufrufen — ein wiederholter volume_step aendert die Lautstaerke ERNEUT!
     - Wenn ein Play-Tool FEHLSCHLAEGT (success=false): Gib SOFORT final_answer mit einer klaren Fehlermeldung. Beschreibe NICHT die Suchergebnisse und gib KEINE URLs oder technische Details aus.
     - Um die Wiedergabe zu stoppen oder Tracks zu wechseln: Nutze mcp.dlna.stop/mcp.dlna.next_track/mcp.dlna.previous_track wenn eine DLNA-Session aktiv ist. Alternativ: internal.media_control mit action (stop/pause/resume/next/previous/volume) und room_name. Fuer Lautstaerke: "auf X% setzen" -> action="volume", volume=X; "um X% leiser/lauter" -> action="volume", volume_step=-X / +X (Prozentpunkte).
     - Beende NICHT mit final_answer, wenn noch offene Schritte aus der AUFGABE übrig sind. "Schick mir X zu Y" erfordert ALLE Schritte: (1) ggf. search, (2) download_document, (3) send_email. Erst NACH dem letzten Schritt darfst du final_answer geben.
@@ -114,6 +115,7 @@ de:
     - Fuer Sensorwerte: Nutze GetLiveContext mit "name" und optional "area"
     - Uebergib NIEMALS "device_class"
     - Lautstaerke eines Raum-Players: Nutze internal.media_control mit room_name (NICHT HassSetVolume/HassSetPosition). "auf X% setzen" → action="volume", volume=X; "um X% leiser/lauter" → action="volume", volume_step=-X / +X (Prozentpunkte). z.B. {{"action": "internal.media_control", "parameters": {{"action": "volume", "volume_step": -20, "room_name": "<aktueller_raum>"}}}}
+    - Wenn internal.media_control ERFOLGREICH war (success=true), gib SOFORT final_answer mit Bestaetigung (z.B. der neuen Lautstaerke aus data.volume). NIEMALS dasselbe Tool nochmal aufrufen — ein wiederholter volume_step aendert die Lautstaerke ERNEUT!
     - Wenn ein Such-Tool 0 Ergebnisse liefert, wiederhole NICHT dieselbe Suche. Versuche: (1) Kuerzeren Suchbegriff, (2) alternative Schreibweise, (3) anderes Tool. Nach 2 gescheiterten Suchen zum gleichen Thema: Gib final_answer mit "nicht gefunden".
     - Die finale Antwort muss natuerlich und auf Deutsch sein
     - Antworte NUR mit JSON
@@ -276,6 +278,7 @@ de:
     - NIEMALS mcp.dlna.play_tracks direkt aufrufen — immer internal.play_album_on_dlna verwenden!
     - NIEMALS get_album_tracks mit einer Artist-ID aufrufen — nutze get_artist_albums fuer Kuenstler
     - Wenn play_album_on_dlna oder play_in_room ERFOLGREICH war (success=true), gib SOFORT final_answer. NIEMALS dasselbe Play-Tool nochmal aufrufen!
+    - Wenn internal.media_control ERFOLGREICH war (success=true), gib SOFORT final_answer mit Bestaetigung (z.B. der neuen Lautstaerke aus data.volume). NIEMALS dasselbe Tool nochmal aufrufen — ein wiederholter volume_step aendert die Lautstaerke ERNEUT!
     - Bei mehreren Treffern: waehle den besten Match nach Titel und Kuenstler
     - Wenn Informationen fehlen, frage den Benutzer
     - Um die Wiedergabe zu stoppen oder Tracks zu wechseln: Nutze mcp.dlna.stop/mcp.dlna.next_track/mcp.dlna.previous_track wenn eine DLNA-Session aktiv ist. Alternativ: internal.media_control mit action (stop/pause/resume/next/previous/volume) und room_name. Fuer Lautstaerke: "auf X% setzen" -> action="volume", volume=X (z.B. {{"action": "internal.media_control", "parameters": {{"action": "volume", "volume": 30}}}}); "um X% leiser/lauter" -> action="volume", volume_step=-X / +X Prozentpunkte (z.B. {{"action": "internal.media_control", "parameters": {{"action": "volume", "volume_step": -20}}}}).
@@ -625,6 +628,7 @@ en:
     - IMPORTANT — Playing albums/artists: (1) search_media, (2) internal.play_album_on_dlna(album_id="<id>", renderer_name="<room>"). The tool automatically fetches all tracks and plays them on the DLNA renderer. NEVER call mcp.dlna.play_tracks directly!
     - Playing a single song: (1) search_media(type="Audio"), (2) internal.play_in_room with the api_stream URL.
     - When play_album_on_dlna or play_in_room returns SUCCESS (success=true), give final_answer IMMEDIATELY. NEVER call the same play tool again!
+    - When internal.media_control returns SUCCESS (success=true), give final_answer IMMEDIATELY confirming the result (e.g. the new volume from data.volume). NEVER call the same tool again — a repeated volume_step changes the volume AGAIN!
     - When a play tool FAILS (success=false): Give final_answer IMMEDIATELY with a clear error message. Do NOT describe search results and do NOT output URLs or technical details.
     - To stop playback or skip tracks: Use mcp.dlna.stop/mcp.dlna.next_track/mcp.dlna.previous_track if a DLNA session is active. Alternatively: internal.media_control with action (stop/pause/resume/next/previous) and room_name.
     - Do NOT give final_answer if there are still open steps from the TASK. "Send me X to Y" requires ALL steps: (1) optionally search, (2) download_document, (3) send_email. Only give final_answer AFTER the last step is completed.
@@ -683,6 +687,7 @@ en:
     - For sensor values: Use GetLiveContext with "name" and optionally "area"
     - NEVER pass "device_class"
     - Volume of a room player: Use internal.media_control with room_name (NOT HassSetVolume/HassSetPosition). "set to X%" → action="volume", volume=X; "X% quieter/louder" → action="volume", volume_step=-X / +X (percentage points). e.g. {{"action": "internal.media_control", "parameters": {{"action": "volume", "volume_step": -20, "room_name": "<current_room>"}}}}
+    - When internal.media_control returns SUCCESS (success=true), give final_answer IMMEDIATELY confirming the result (e.g. the new volume from data.volume). NEVER call the same tool again — a repeated volume_step changes the volume AGAIN!
     - If a search tool returns 0 results, do NOT repeat the same search. Try: (1) Shorter query, (2) alternative spelling, (3) different tool. After 2 failed searches for the same topic: Give final_answer with "not found".
     - The final answer must be natural and in English
     - Reply ONLY with JSON
@@ -836,6 +841,7 @@ en:
     - NEVER call mcp.dlna.play_tracks directly — always use internal.play_album_on_dlna!
     - NEVER call get_album_tracks with an artist ID — use get_artist_albums for artists
     - When play_album_on_dlna or play_in_room returns SUCCESS (success=true), give final_answer IMMEDIATELY. NEVER call the same play tool again!
+    - When internal.media_control returns SUCCESS (success=true), give final_answer IMMEDIATELY confirming the result (e.g. the new volume from data.volume). NEVER call the same tool again — a repeated volume_step changes the volume AGAIN!
     - When multiple results exist, choose the best match by title and artist
     - If information is missing, ask the user
     - To stop playback or skip tracks: Use mcp.dlna.stop/mcp.dlna.next_track/mcp.dlna.previous_track if a DLNA session is active. Alternatively: internal.media_control with action (stop/pause/resume/next/previous/volume) and room_name. For volume: "set to X%" -> action="volume", volume=X (e.g. {{"action": "internal.media_control", "parameters": {{"action": "volume", "volume": 30}}}}); "X% quieter/louder" -> action="volume", volume_step=-X / +X percentage points (e.g. {{"action": "internal.media_control", "parameters": {{"action": "volume", "volume_step": -20}}}}).

--- a/tests/backend/test_internal_tools.py
+++ b/tests/backend/test_internal_tools.py
@@ -1947,6 +1947,49 @@ class TestRelativeVolume:
         call_kwargs = mock_ha_client.call_service.call_args
         assert call_kwargs.kwargs["service_data"]["volume_level"] == pytest.approx(0.3)
 
+    # --- loop-prevention: volume success echoes the resulting level so the agent
+    #     gives final_answer instead of re-issuing (a repeated volume_step would
+    #     re-apply the delta — the rc.13 +10% → +30% loop bug) ---
+
+    @pytest.mark.unit
+    async def test_volume_result_echoes_level_dlna(self, internal_tools):
+        """DLNA volume success returns the resulting level in data.volume + message."""
+        async def _exec(tool_name, tool_params):
+            if tool_name == "mcp.dlna.get_volume":
+                return {"success": True, "volume": 40}
+            return {"success": True, "message": "ok"}
+
+        mock_mcp_manager = MagicMock()
+        mock_mcp_manager.execute_tool = AsyncMock(side_effect=_exec)
+
+        with patch.object(internal_tools, "_resolve_room_player",
+                          new_callable=AsyncMock, return_value=self._dlna_resolve()), \
+             self._patch_main_app(mock_mcp_manager):
+            result = await internal_tools._media_control({
+                "action": "volume", "room_name": "Arbeitszimmer", "volume_step": 15,
+            })
+
+        assert result["success"] is True
+        assert result["data"]["volume"] == 55  # 40 + 15
+        assert "55" in result["message"]
+
+    @pytest.mark.unit
+    async def test_volume_result_echoes_level_ha(self, internal_tools):
+        """HA volume success returns the resulting level in data.volume + message."""
+        mock_ha_client = MagicMock()
+        mock_ha_client.call_service = AsyncMock(return_value=True)
+
+        with patch.object(internal_tools, "_resolve_room_player",
+                          new_callable=AsyncMock, return_value=self._ha_resolve()), \
+             patch("ha_glue.integrations.homeassistant.HomeAssistantClient", return_value=mock_ha_client):
+            result = await internal_tools._media_control({
+                "action": "volume", "room_name": "Arbeitszimmer", "volume": 65,
+            })
+
+        assert result["success"] is True
+        assert result["data"]["volume"] == 65
+        assert "65" in result["message"]
+
 
 # ============================================================================
 # Test play_album_on_dlna


### PR DESCRIPTION
## Why
Post-deploy log inspection of the relative-volume path (after #718's hotfix made \`smart_home\` reach \`internal.media_control\`) found the agent **looping**:

```
Nachricht: 'Lautstärke um 10% erhöhen' → Router: media
step 1: internal.media_control {volume_step: 10} → success=True
step 2: internal.media_control {volume_step: 10} → success=True
step 3: internal.media_control {volume_step: 10} → success=True
⚠️ Agent infinite loop detected at step 3
```

Each \`volume_step\` re-reads current and re-adds the delta, so **+10% became ~+30%**, and the turn ended on a loop warning, not a clean answer. Two causes:
1. The "success → final_answer, never repeat" rule existed only for the \`play_*\` tools, not \`internal.media_control\`.
2. The volume success message (\`"Media volume executed on …"\`) didn't echo the resulting level — no concrete completion signal for the LLM.

## What
- \`internal_tools.py\`: volume success now echoes the resulting level — message \`"Volume in <room> set to N%."\` + \`data.volume\` — for both HA and DLNA. Non-volume actions unchanged.
- \`prompts/agent.yaml\`: add the \`internal.media_control\` success→final_answer/never-repeat rule to \`agent_prompt\`, \`agent_prompt_media\`, \`agent_prompt_smart_home\` (DE + EN). **Deliberately not** added to \`agent_prompt_routine\` (the Good Night routine must continue past its \`media_control\` stop step).
- \`test_internal_tools.py\`: assert \`data.volume\` + message echo the resulting level (HA + DLNA).

## Tests
`.159`: **124 passed** in test_internal_tools.py (+2 new). \`agent.yaml\` parses; added prompt lines are plain text (no brace-escaping concern). Review clean.

## Deploy
Both files are in the image → **bundles with #718's pending prompt rebuild**: one backend image build + roll backend/dlna-mcp/document-worker ships #718's smart_home guidance + this loop fix together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)