### PR TITLE
chore(k8s): point deploy/dlna-mcp at the dedicated dlna-mcp image

### DIFF
--- a/.claude/skills/deploy-production/SKILL.md
+++ b/.claude/skills/deploy-production/SKILL.md
@@ -204,9 +204,17 @@ When you hit this in the future: don't keep retrying blindly past 3 attempts —
 ```bash
 kubectl config use-context renfield-private
 
-# Rolling restart to pull the new :latest. ALL FOUR deploys must be
-# rolled (dlna-mcp also runs the backend image).
-kubectl -n renfield rollout restart deploy/backend deploy/dlna-mcp deploy/document-worker deploy/frontend
+# Backend image powers `backend` + `document-worker` (NOT dlna-mcp anymore —
+# see below). Roll both on a backend change. frontend is its own image.
+kubectl -n renfield rollout restart deploy/backend deploy/document-worker deploy/frontend
+
+# dlna-mcp is now a SEPARATE small image (registry/renfield/dlna-mcp, built from
+# the Dockerfile in the renfield-mcp-dlna repo — like voice-server). It does NOT
+# run the backend image. Roll it ONLY when the dlna image changed:
+#   build+push registry/renfield/dlna-mcp:v0.1.N on .159, then:
+#   kubectl -n renfield set image deploy/dlna-mcp dlna-mcp=registry.treehouse.x-idra.de/renfield/dlna-mcp:v0.1.N
+# (The backend reaches dlna-mcp over HTTP only — it never imports the package —
+# so a dlna change does NOT need a backend rebuild, and vice versa.)
 
 # Or pin an explicit tag (force-pulls even if :latest is cached on the node)
 kubectl -n renfield set image deploy/backend \

--- a/k8s/dlna-mcp.yaml
+++ b/k8s/dlna-mcp.yaml
@@ -51,9 +51,11 @@ spec:
         - name: harbor-pull-secret
       containers:
         - name: dlna-mcp
-          image: registry.treehouse.x-idra.de/renfield/backend:latest
+          # Dedicated small image (see renfield-mcp-dlna/Dockerfile) — no longer
+          # the 3.5 GB backend image. ENTRYPOINT is renfield-mcp-dlna, so no
+          # `command:` override needed. The backend reaches this over HTTP only.
+          image: registry.treehouse.x-idra.de/renfield/dlna-mcp:v0.1.0
           imagePullPolicy: Always
-          command: ["/opt/venv/bin/renfield-mcp-dlna"]
           env:
             - name: MCP_TRANSPORT
               value: streamable-http


### PR DESCRIPTION
## Why
`deploy/dlna-mcp` ran the 3.5 GB backend image with `command: renfield-mcp-dlna`. But the backend **never imports** the dlna package — it reaches it only over HTTP (`mcp.dlna.*` → `dlna-mcp:9091`). So a dedicated small image is strictly better:
- `pip install .` pulls dlna's **real** deps (async-upnp-client≥0.47, defusedxml, ifaddr) — kills the `--no-deps` mirroring trap.
- ~200 MB vs 3.5 GB; independent release cadence (no backend rebuild + GITHUB_DEPS_REV/CDN-staleness dance per dlna change).

## What
- `k8s/dlna-mcp.yaml`: image → `registry/renfield/dlna-mcp:v0.1.0`, drop the `command:` (the image ENTRYPOINT is `renfield-mcp-dlna`). hostNetwork/ports/env/probes unchanged.
- Dockerfile lives in ebongard/renfield-mcp-dlna (PR alongside).

## Status
Already built + pushed (`dlna-mcp:v0.1.0`, digest 13710fbf, 192 MB) and applied — `deploy/dlna-mcp` is live on the dedicated image (serving on 9091, SSDP discovery intact, OpenHome backend present → Linn now uses OpenHome). Backend reaches it (HTTP 406 on bare GET = listening). This PR lands the manifest so git matches prod.

## Follow-ups (not in this PR)
- Slim backend `requirements.txt` (drop renfield-mcp-dlna + async-upnp-client + python-didl-lite — backend doesn't import them) — needs a backend rebuild.
- Update `/deploy-production` (dlna is now its own image, like voice-server).
- Phase 2/3: expose the 7 new dlna tools (seek/set_play_mode/get_mute/status + media-server browsing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)