### PR TITLE
feat(paperless): re-integrate v1.7.0 — list_documents fix, taxonomy tools, metadata-only sweep

### DIFF
--- a/.claude/skills/deploy-production/SKILL.md
+++ b/.claude/skills/deploy-production/SKILL.md
@@ -81,8 +81,13 @@ ssh evdb@192.168.1.159
 docker login registry.treehouse.x-idra.de
 
 # Backend (CPU image, ~3.5 GB — torch pinned to +cpu wheels via constraints.txt)
-# Slowest step; budget 10-20 min if requirements.txt changed (deps layer cache miss).
-# 2-4 min if only Python source changed (deps layer cached).
+# Build time (since the Dockerfile reorder — requirements.txt is COPY'd AFTER the
+# heavy torch/ML/audio layers):
+#   - Python source only: ~2-4 min (all deps layers cached)
+#   - requirements.txt change (incl. MCP-server github pin bump): ~3-5 min —
+#     rebuilds only Layers 4-5 (pypi + github); torch/ML/audio stay cached.
+#   - constraints.txt change OR Dockerfile deps-section edit: 10-20 min (full
+#     deps rebuild, the only case that re-pulls torch).
 cd /tmp/renfield-build-vX.Y.Z/src/backend
 docker build \
   -t registry.treehouse.x-idra.de/renfield/backend:latest \

--- a/config/mcp_servers.yaml
+++ b/config/mcp_servers.yaml
@@ -273,6 +273,13 @@ servers:
       - search_documents
       - get_document
       - update_document
+      # Taxonomy reads so the agent can answer "welche Dokumenttypen /
+      # Korrespondenten / Tags habe ich?" directly. The create_* + other
+      # list_* tools stay agent-hidden (the Paperless-Audit subsystem drives
+      # those programmatically) but remain executable.
+      - list_correspondents
+      - list_document_types
+      - list_tags
     examples:
       de:
         - "Suche nach Rechnungen in Paperless"

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -40,9 +40,13 @@ RUN pip install --no-cache-dir --upgrade pip>=25.3 setuptools
 # The constraints file pins torch/torchaudio/torchvision to +cpu wheels from the
 # PyTorch CPU index — prevents transitive deps (docling, easyocr, transformers)
 # from resolving torch to a full CUDA build (saves ~3 GB of nvidia/* wheels).
-COPY requirements.txt constraints.txt ./
-RUN grep -v "github.com" requirements.txt > requirements-pypi.txt \
-    && (grep "github.com" requirements.txt > requirements-github.txt || true)
+# Only constraints.txt is needed for the heavy layers below — they install
+# LITERAL package names, not from requirements.txt. requirements.txt is COPY'd
+# LATER (just before Layer 4) so a dependency bump — especially an MCP-server
+# github pin (the frequent case) — rebuilds only Layers 4-5 (~3 min) and leaves
+# the cached ~1.9 GB torch/ML/audio layers intact. Single canonical
+# requirements.txt is kept; the pypi/github split is generated in-build.
+COPY constraints.txt ./
 
 # Layer 1: torch ecosystem (~700 MB) — biggest single chunk; isolated so the
 # rest of the deps can re-use it from the layer cache on subsequent builds.
@@ -61,6 +65,12 @@ RUN pip install --no-cache-dir \
 RUN pip install --no-cache-dir \
       --constraint constraints.txt \
       faster-whisper piper-tts librosa soundfile noisereduce
+
+# requirements.txt COPY'd HERE (after the heavy layers) so a deps change rebuilds
+# only Layers 4-5 below, not the torch/ML/audio layers above.
+COPY requirements.txt ./
+RUN grep -v "github.com" requirements.txt > requirements-pypi.txt \
+    && (grep "github.com" requirements.txt > requirements-github.txt || true)
 
 # Layer 4: remaining pypi reqs (~600 MB) — fastapi, sqlalchemy, ollama, mcp, etc.
 RUN pip install --no-cache-dir \

--- a/src/backend/prompts/intent.yaml
+++ b/src/backend/prompts/intent.yaml
@@ -36,7 +36,7 @@ de:
       NICHT verwenden für: Geschichte, Wissenschaft, Allgemeinwissen, Erklärungen — das kann aus Trainingsdaten beantwortet werden!
     - mcp.* Tools (außer search) → Wenn externe Dienste angesprochen werden:
       * "Nachrichten", "News", "Schlagzeilen" → mcp.news.search_articles / mcp.news.get_top_headlines
-      * "Dokumente", "Rechnungen", "Belege", "Paperless" → mcp.paperless.search_documents / mcp.paperless.list_documents
+      * "Dokumente", "Rechnungen", "Belege", "Paperless" → mcp.paperless.search_documents
       * "Workflow", "n8n", "Automatisierung" → mcp.n8n.n8n_list_workflows_summary / mcp.n8n.n8n_activate_workflow
       * "Wetter", "Temperatur", "Regen" → mcp.weather.weather_forecast
       * "Filme", "Serien", "Jellyfin", "Medien" → mcp.jellyfin.list_items / mcp.jellyfin.search_items
@@ -104,7 +104,7 @@ en:
       Do NOT use for: history, science, general knowledge, explanations — these can be answered from training data!
     - mcp.* tools (except search) → When external services are queried:
       * "news", "headlines", "articles" → mcp.news.search_articles / mcp.news.get_top_headlines
-      * "documents", "invoices", "receipts", "Paperless" → mcp.paperless.search_documents / mcp.paperless.list_documents
+      * "documents", "invoices", "receipts", "Paperless" → mcp.paperless.search_documents
       * "workflow", "n8n", "automation" → mcp.n8n.n8n_list_workflows_summary / mcp.n8n.n8n_activate_workflow
       * "weather", "temperature", "rain" → mcp.weather.weather_forecast
       * "movies", "series", "Jellyfin", "media" → mcp.jellyfin.list_items / mcp.jellyfin.search_items

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -85,7 +85,7 @@ jsonschema>=4.21.0            # JSON Schema validation for MCP tool inputs
 
 # MCP Servers (standalone packages)
 renfield-mcp-weather @ https://github.com/ebongard/renfield_mcp_weather/archive/refs/heads/main.tar.gz
-renfield-mcp-paperless @ https://github.com/ebongard/renfield-mcp-paperless/archive/refs/tags/v1.6.0.tar.gz
+renfield-mcp-paperless @ https://github.com/ebongard/renfield-mcp-paperless/archive/refs/tags/v1.7.0.tar.gz
 renfield-mcp-mail @ https://github.com/ebongard/renfield-mcp-mail/archive/refs/heads/main.tar.gz
 aiosmtplib>=3.0                  # Required by renfield-mcp-mail (not auto-resolved from archive installs)
 renfield-mcp-jellyfin @ https://github.com/ebongard/renfield-mcp-jellyfin/archive/refs/heads/main.tar.gz

--- a/src/backend/services/paperless_ui_edit_sweeper.py
+++ b/src/backend/services/paperless_ui_edit_sweeper.py
@@ -92,13 +92,12 @@ _SWEEP_BATCH_SIZE = 50
 # Substring emitted by ``_truncate_response`` in ``mcp_client.py`` when
 # the response exceeds ``mcp_max_response_size`` (10 KB default) and
 # can't be slimmed to fit. A truncated ``get_document`` response means
-# we literally cannot compare against the original metadata — the
-# mismatch could be real or it could be a byte-truncation artefact.
-# The proper fix lives on the MCP server side (a narrow
-# ``get_document_metadata`` tool without the OCR content, or an
-# ``include_content=False`` flag). Until that lands, we detect and
-# skip rather than pollute the learning corpus with partial-data
-# diffs.
+# we literally cannot compare against the original metadata.
+# The server-side fix HAS landed: we now read get_document with
+# ``include_content=False`` (paperless-mcp >= v1.7.0), so the OCR text is
+# omitted and the metadata response can't reach the cap. This marker +
+# the skip path below are now a DEFENSIVE FALLBACK — kept in case a
+# future/older MCP version still returns content and truncates.
 _TRUNCATION_MARKER = "[... Response truncated"
 
 
@@ -283,8 +282,12 @@ async def _detect_edit(
     timestamp is outside ``_EDIT_WINDOW_AFTER_UPLOAD``, the diff is
     dropped as taxonomy drift (the design intent of the 1 h window).
     """
+    # Metadata-only read: the sweeper diffs metadata, never the OCR content.
+    # include_content=False (paperless-mcp >= v1.7.0) keeps the response small
+    # so it can't hit the size cap and get truncated (the old skip path).
     result = await mcp_manager.execute_tool(
-        "mcp.paperless.get_document", {"document_id": document_id},
+        "mcp.paperless.get_document",
+        {"document_id": document_id, "include_content": False},
     )
     if not result or not result.get("success"):
         return None

--- a/tests/backend/test_paperless_ui_edit_sweeper.py
+++ b/tests/backend/test_paperless_ui_edit_sweeper.py
@@ -85,6 +85,21 @@ class TestDetectEdit:
 
     @pytest.mark.asyncio
     @pytest.mark.unit
+    async def test_get_document_requested_metadata_only(self):
+        """The sweeper must read metadata-only (include_content=False) so the
+        response can't be size-truncated (paperless-mcp >= v1.7.0)."""
+        mcp = MagicMock()
+        mcp.execute_tool = AsyncMock(return_value={
+            "success": True,
+            "message": json.dumps({"title": "T"}),
+        })
+        await _detect_edit(mcp_manager=mcp, document_id=42, original={"title": "T"})
+        mcp.execute_tool.assert_awaited_once_with(
+            "mcp.paperless.get_document", {"document_id": 42, "include_content": False},
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
     async def test_correspondent_changed_returns_diff(self):
         mcp = MagicMock()
         mcp.execute_tool = AsyncMock(return_value={


### PR DESCRIPTION
Re-integration of the paperless MCP into renfield. The audit subsystem already used v1.6.0's new tools (create_*/list_*/search/upload-with-fields) + the `content` OCR write-back (`_local_reocr`) — so this closes the residual gaps:

- **#1** `intent.yaml`: drop the non-existent `mcp.paperless.list_documents` from the router prompt (v1.6.0+ only has `search_documents`) — the router could otherwise pick a missing tool.
- **#2** `mcp_servers.yaml`: expose `list_correspondents`/`list_document_types`/`list_tags` to the agent ("welche Dokumenttypen/Korrespondenten habe ich?"). create_* + other list_* stay agent-hidden (audit subsystem drives them).
- **#3** UI-edit sweeper reads `get_document(include_content=False)` — metadata-only, so the response can't hit the 10 KB cap + get truncated (the old skip path). Requires **paperless-mcp v1.7.0** (adds `include_content`; ebongard/renfield-mcp-paperless#10) → requirements pin bumped v1.6.0→v1.7.0 (load-bearing: without it FastMCP silently drops the param).

**Tests**: paperless v1.7.0 suite 160 pass; sweeper 25 pass (incl. a metadata-only-call assertion); review clean.

**Deploy**: requirements.txt pin change → backend rebuild (paperless v1.7.0 baked) + ConfigMap for the new prompt_tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)