### PR TITLE
docs(todos): track prod enablement of obligation→calendar sync

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -125,6 +125,15 @@ moves to P2 with per-category sign/net handling.
 - **[P2] Stored situation questionnaire.** P1 asks situation + non-doc inputs (commute km, home-office days) inline each time; persist a small profile if it gets repetitive.
 - **[P3] CSV/PDF dossier export + ELSTER/ERiC field mapping.** Export per-Anlage; optionally map to ELSTER fields. Filing stays out of scope.
 
+### Enable obligation → calendar sync in PRODUCTION (code shipped; blocked on calendar-MCP config)
+The reconciler shipped + is deployed (v2.13.0-rc.21, 2026-06-07) but is **OFF in prod** — the Calendar MCP isn't configured there. The notifier + digest were enabled this deploy; calendar sync was held. Prerequisites to turn it on:
+1. **Add `calendar_accounts.yaml` to the `renfield-mcp-config` ConfigMap** — per-user accounts (`name`/`label`/`type` ews|google|caldav/`visibility` owner|shared/`owner_id`). Currently absent (ConfigMap has only agent_roles/kg_scopes/mail_accounts/mcp_servers).
+2. **Add the calendar backend credentials to `renfield-env`** — the `CALENDAR_WORK_*` / `CALENDAR_VEREIN_*` (or equivalent) username/password the `mcp_servers.yaml` calendar block reads; plus `CALENDAR_CONFIG=/config/calendar_accounts.yaml` (and mount the yaml into the pod). No `CALENDAR_*` keys exist in `renfield-env` today.
+3. **Flip `CALENDAR_ENABLED=true` + `OBLIGATION_CALENDAR_SYNC_ENABLED=true`** in `renfield-env`, restart backend (Recreate + cuda gate — pre-check `cuda.local:8081/health`).
+4. **Each user picks a calendar** in the agenda's "Kalender-Sync" selector (no pref → no sync; the selector is hidden until `list_calendars` returns writable calendars).
+- **Verify after:** the calendar MCP appears in `GET /api/mcp/servers` (empty today); a test obligation creates an event; clearing the pref tears the events down.
+- **Needs:** real calendar credentials (operator-provided). **Why P2, not done:** can't provision creds without the operator. See [[reference_deploy_set_image_pinned]] for the deploy mechanics.
+
 ### Paperless PR 4 inline follow-ups (documented in code, filed here)
 All three have clear triggers but were out of PR 4 scope. Inline `# ...` comments in the relevant files carry full context.
 - **Multi-replica `pg_try_advisory_lock`.** Current `asyncio.Lock` only covers a single process; k8s with >1 backend replica needs DB-level coordination. Source: `src/backend/services/paperless_ui_edit_sweeper.py` (top-of-file comment on `_sweep_lock`).


### PR DESCRIPTION
Records the deferred PROD enablement of the obligation→calendar sync (code shipped in v2.13.0-rc.21, but OFF in prod — the Calendar MCP isn't configured there).

The notifier + digest were enabled this deploy; calendar sync was held. TODOS now captures the exact prerequisites: add calendar_accounts.yaml to the renfield-mcp-config ConfigMap, add CALENDAR_* creds to renfield-env, flip CALENDAR_ENABLED + OBLIGATION_CALENDAR_SYNC_ENABLED (restart backend), each user picks a calendar.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)