### PR TITLE
feat(samsung): wire Samsung TV MCP as an agent-only integration

### DIFF
--- a/.claude/skills/deploy-production/SKILL.md
+++ b/.claude/skills/deploy-production/SKILL.md
@@ -191,6 +191,49 @@ docker run --rm -v /tmp/renfield-build-vX.Y.Z/voice-server:/work -w /work \
 
 **GPU-node driver drift (verified painful, v2.8.0 deploy 2026-05-22).** The `voice-server` Deployment runs on the `k8s-gpu-3` GPU node. If `apt` upgraded that node's NVIDIA driver libraries without a reboot, a *new* voice-server pod CrashLoops with `failed to initialize NVML: Driver/library version mismatch` — the *old* pod keeps running, only new pods fail, so it stays latent until the next voice-server rollout. Fix is a **node reboot**, not an image rollback (a fresh pod on the old image crashes identically). A live `modprobe -r nvidia*` reload fails — `nvidia_uvm` stays held even when `lsof /dev/nvidia*` is empty. Procedure: `kubectl cordon k8s-gpu-3` → delete the `frontend` pod so it reschedules off the node (keeps the UI up) → `ssh ... sudo reboot` → wait for `Ready` → `kubectl uncordon` → `kubectl rollout restart deploy/voice-server`. Confirm `dkms status` has the nvidia module built for the kernel the node will boot into first (a pending kernel update can switch it).
 
+### Samsung-mcp image (build ONLY when `../renfield-mcp-samsung/` changed)
+
+Like dlna-mcp, `samsung-mcp` is a SEPARATE small image built from the Dockerfile
+in the **`renfield-mcp-samsung` repo** (sibling of the renfield repo) — NOT the
+backend image. The backend reaches it over streamable-http only (never imports
+the package), so a Samsung change needs no backend rebuild. It runs on
+`hostNetwork` (SSDP discovery + Wake-on-LAN broadcast + websocket/UPnP to the
+TV) with a small RWO PVC (`samsung-mcp-state`) at `/state` holding the one-time
+pairing token. Own `v0.1.x` versioning, independent of the repo's `vX.Y.Z`.
+
+```bash
+# Rsync the samsung build context (its own repo dir IS the context)
+ssh evdb@192.168.1.159 "mkdir -p /tmp/renfield-samsung-build"
+rsync -avz --delete \
+  --exclude='__pycache__' --exclude='*.pyc' --exclude='.pytest_cache' \
+  --exclude='.venv' --exclude='token.json' --exclude='.git' \
+  ../renfield-mcp-samsung/ evdb@192.168.1.159:/tmp/renfield-samsung-build/
+
+# Build + push on .159 (pure-python / manylinux wheels — no toolchain needed)
+ssh evdb@192.168.1.159
+R=registry.treehouse.x-idra.de/renfield/samsung-mcp
+cd /tmp/renfield-samsung-build
+docker build -t $R:v0.1.N -t $R:latest -f Dockerfile .
+docker push $R:v0.1.N
+docker push $R:latest
+
+# First-ever deploy: apply the manifest (kustomization already includes it):
+kubectl -n renfield apply -f k8s/samsung-mcp.yaml
+# Thereafter, pinned-tag rollout (set image, like dlna-mcp/voice-server):
+kubectl -n renfield set image deploy/samsung-mcp \
+  samsung-mcp=registry.treehouse.x-idra.de/renfield/samsung-mcp:v0.1.N
+kubectl -n renfield rollout status deploy/samsung-mcp --timeout=600s
+```
+
+**One-time TV pairing (after first deploy).** Websocket keys/apps/power-off need
+a one-time "Allow Renfield?" approval on the TV (WoL power-on + DLNA media/volume
+do NOT). Enable on the TV: **Settings → General → External Device Manager →
+Device Connect Manager → Access Notification On**, then trigger any websocket
+tool (e.g. `tv_key`) while the TV is on the Smart Hub home screen and approve the
+popup. The token persists to the `samsung-mcp-state` PVC and survives restarts.
+Set `SAMSUNG_MCP_ENABLED=true` (+ optional `SAMSUNG_TV_HOST` to pin a TV) for the
+backend to register the server.
+
 ### Harbor 504 / "Client Closed Request" on the 2.66 GB pip-install layer
 
 When `requirements.txt` changes (so the deps layer cache misses), Docker tries to upload a single 2.66 GB layer to Harbor. The ingress proxy in front of Harbor has been observed timing out on this with `received unexpected HTTP status: 504 Gateway Timeout` or `unknown: Client Closed Request`. The error reproduces on the same layer ID across multiple retries (verified during the v2.3.0 deploy 2026-05-01 — 4 attempts, same `ed85...` layer, same error).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Renfield is a fully offline-capable, self-hosted **digital assistant** — a per
 
 **LLM:** Local models via Ollama (multi-model: chat, intent, RAG, agent, vision, embeddings).
 
-**Integrations:** Home Assistant, Frigate, n8n, SearXNG, Jellyfin, DLNA, Paperless, Email, Calendar — all via MCP servers.
+**Integrations:** Home Assistant, Frigate, n8n, SearXNG, Jellyfin, DLNA, Samsung TV, Paperless, Email, Calendar — all via MCP servers. (DLNA + Samsung TV run as dedicated `hostNetwork` images — `renfield-mcp-dlna` / `renfield-mcp-samsung` — not in the backend image; all other stdio servers live in the backend image.)
 
 ## KRITISCHE REGELN - IMMER BEACHTEN
 

--- a/config/agent_roles.yaml
+++ b/config/agent_roles.yaml
@@ -49,7 +49,7 @@ roles:
     description:
       de: "Medien: Musik, Filme, Serien, Radio suchen und abspielen (auch in bestimmten Raeumen)"
       en: "Media: search and play music, movies, series, radio (also in specific rooms)"
-    mcp_servers: [jellyfin, dlna, radio]
+    mcp_servers: [jellyfin, dlna, radio, samsung]
     internal_tools: [internal.resolve_room_player, internal.play_in_room, internal.play_album_on_dlna, internal.play_video_on_dlna, internal.media_control, internal.play_radio, internal.save_radio_favorite, internal.list_radio_favorites, internal.remove_radio_favorite]
     max_steps: 6
     prompt_key: agent_prompt_media
@@ -76,7 +76,7 @@ roles:
     description:
       de: "Routinen: Gute-Nacht-Routine, Guten-Morgen-Routine, Schlafenszeit, Aufstehen — mehrstufige Smart-Home-Ablaeufe mit Statusbericht"
       en: "Routines: good-night routine, good-morning routine, bedtime, waking up — multi-step smart home sequences with status briefing"
-    mcp_servers: [homeassistant, calendar, weather, jellyfin, dlna, radio]
+    mcp_servers: [homeassistant, calendar, weather, jellyfin, dlna, radio, samsung]
     internal_tools: [internal.get_all_presence, internal.get_user_location, internal.resolve_room_player, internal.media_control, internal.play_in_room, internal.play_radio]
     max_steps: 15
     prompt_key: agent_prompt_routine

--- a/config/mcp_servers.yaml
+++ b/config/mcp_servers.yaml
@@ -199,6 +199,42 @@ servers:
         - "What media servers are on the network?"
         - "Search the library for Pink Floyd"
 
+  # --- Samsung Smart TV (Tizen) MCP Server ---
+  # Dedicated Python MCP server (renfield-mcp-samsung) for Samsung TV control:
+  # websocket remote (keys/apps/power-off), Wake-on-LAN power-on, and DLNA media.
+  # Companion to the dlna server — Samsung's vendor channels are NOT DLNA ops.
+  # Runs as a dedicated hostNetwork image (SSDP + WoL + websocket to the TV).
+  # AGENT-ONLY for now: chat-driven control. Room-view selection arrives with the
+  # generic output-provider architecture (docs/design/output-providers.md).
+  - name: samsung
+    transport: streamable_http
+    url: "${SAMSUNG_MCP_URL:-http://host.docker.internal:9092/mcp}"
+    enabled: "${SAMSUNG_MCP_ENABLED:-false}"
+    refresh_interval: 300
+    example_intent: mcp.samsung.tv_power
+    prompt_tools:
+      - tv_discover
+      - tv_info
+      - tv_power
+      - tv_navigate
+      - tv_volume
+      - tv_channel
+      - tv_launch
+      - tv_apps
+      - tv_current_app
+      - tv_media
+    examples:
+      de:
+        - "Schalte den Samsung Fernseher ein"
+        - "Starte Netflix auf dem Fernseher"
+        - "Mach den Fernseher leiser"
+        - "Wechsle auf HDMI am Samsung TV"
+      en:
+        - "Turn on the Samsung TV"
+        - "Launch Netflix on the TV"
+        - "Turn the TV volume down"
+        - "Switch to HDMI on the Samsung TV"
+
   # --- n8n MCP Server (Workflow Builder + Node Catalog) ---
   # npm: n8n-mcp (czlonkowski/n8n-mcp)
   # Provides: Workflow CRUD, node catalog (1,084+ nodes),

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -1228,6 +1228,10 @@ TUNEIN_PARTNER_ID=                     # Optional: TuneIn Partner ID für höher
 # DLNA (Media Renderer Control)
 DLNA_MCP_ENABLED=true
 
+# Samsung Smart TV (Tizen — websocket remote, Wake-on-LAN, DLNA media)
+# Agent-only: chat-driven TV control. Dedicated hostNetwork image (renfield-mcp-samsung).
+SAMSUNG_MCP_ENABLED=true
+
 # n8n (Workflow Automation)
 N8N_MCP_ENABLED=true
 
@@ -1281,6 +1285,15 @@ HOME_ASSISTANT_URL=http://homeassistant.local:8123
 # DLNA MCP Server URL (läuft als Host-Service, nicht im Docker)
 # Default: http://host.docker.internal:9091/mcp
 DLNA_MCP_URL=http://host.docker.internal:9091/mcp
+
+# Samsung TV MCP Server URL (dediziertes hostNetwork-Image, nicht im Backend)
+# Default: http://host.docker.internal:9092/mcp ; in k8s: http://samsung-mcp:9092/mcp
+SAMSUNG_MCP_URL=http://host.docker.internal:9092/mcp
+# Optional: feste TV-IP (überspringt SSDP) + Identität im Pairing-Popup
+# SAMSUNG_TV_HOST=192.168.1.47
+# SAMSUNG_CLIENT_NAME=Renfield
+# Pairing-Token-Persistenz (in k8s: PVC samsung-mcp-state an /state gemountet)
+# RENFIELD_STATE_DIR=/state
 
 # n8n Base URL
 N8N_BASE_URL=http://192.168.1.78:5678

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -1230,6 +1230,8 @@ DLNA_MCP_ENABLED=true
 
 # Samsung Smart TV (Tizen — websocket remote, Wake-on-LAN, DLNA media)
 # Agent-only: chat-driven TV control. Dedicated hostNetwork image (renfield-mcp-samsung).
+# Ships DARK: the k8s configmap sets this false; flip to true only AFTER the
+# samsung-mcp image is built and the one-time TV pairing is done.
 SAMSUNG_MCP_ENABLED=true
 
 # n8n (Workflow Automation)

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -15,6 +15,8 @@ data:
   OLLAMA_FALLBACK_URL: ""
   # DLNA MCP runs on hostNetwork (any worker); the `dlna-mcp` Service routes to it.
   DLNA_MCP_URL: "http://dlna-mcp:9091/mcp"
+  # Samsung TV MCP — same hostNetwork pattern; the `samsung-mcp` Service routes to it.
+  SAMSUNG_MCP_URL: "http://samsung-mcp:9092/mcp"
 
   # External integrations
   HOME_ASSISTANT_URL: "http://192.168.1.80:8123"
@@ -115,6 +117,9 @@ data:
   N8N_MCP_ENABLED: "true"
   EMAIL_MCP_ENABLED: "true"
   DLNA_MCP_ENABLED: "true"
+  # Samsung TV ships dark: flip to "true" AFTER the samsung-mcp image is built and
+  # the one-time TV pairing is done (see deploy-production skill). URL is wired above.
+  SAMSUNG_MCP_ENABLED: "false"
   WEATHER_ENABLED: "true"
   SEARCH_ENABLED: "true"
   NEWS_ENABLED: "true"

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ollama.yaml
   - searxng.yaml
   - dlna-mcp.yaml
+  - samsung-mcp.yaml
   - mdns-responder.yaml
   - backend.yaml
   - frontend.yaml

--- a/k8s/samsung-mcp.yaml
+++ b/k8s/samsung-mcp.yaml
@@ -10,8 +10,13 @@
 # Token persistence: the one-time "Allow Renfield?" websocket pairing issues a
 # token saved to $RENFIELD_STATE_DIR/token.json. A small RWO PVC mounted at /state
 # keeps it across restarts. WoL power-on + DLNA media/volume do NOT need the token;
-# only websocket keys/apps/power-off do. RWO is fine because hostPort already pins
-# the pod to one node (single instance), matching strategy: Recreate.
+# only websocket keys/apps/power-off do. RWO + strategy:Recreate matches the
+# postgres/redis pattern: the single replica terminates before its replacement
+# starts, so Longhorn detaches and reattaches the volume on reschedule (no
+# Multi-Attach). hostPort:9092 only caps it at one instance per node — it does
+# NOT pin the node, and no nodeSelector is needed (a TV-control server shouldn't
+# be less reschedulable than the database, which runs the same way unpinned).
+# Losing the token only re-triggers the one-time pairing popup; it never crashes.
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -23,6 +28,7 @@ metadata:
     app.kubernetes.io/part-of: renfield
 spec:
   accessModes: [ReadWriteOnce]
+  storageClassName: longhorn
   resources:
     requests:
       storage: 64Mi

--- a/k8s/samsung-mcp.yaml
+++ b/k8s/samsung-mcp.yaml
@@ -1,0 +1,122 @@
+# Samsung Smart TV MCP Server — runs on host network so SSDP discovery, the
+# Wake-on-LAN broadcast (255.255.255.255:9 / the TV's subnet), and the websocket +
+# UPnP control channels can reach the TV on the LAN. Like dlna-mcp, Calico CNI
+# does not forward multicast/broadcast between pod-net and host-net, so
+# `hostNetwork: true` is required.
+#
+# Scheduler picks any worker node; `hostPort: 9092` ensures at most one instance
+# per node. The ClusterIP Service ("samsung-mcp") gives backend a stable DNS name.
+#
+# Token persistence: the one-time "Allow Renfield?" websocket pairing issues a
+# token saved to $RENFIELD_STATE_DIR/token.json. A small RWO PVC mounted at /state
+# keeps it across restarts. WoL power-on + DLNA media/volume do NOT need the token;
+# only websocket keys/apps/power-off do. RWO is fine because hostPort already pins
+# the pod to one node (single instance), matching strategy: Recreate.
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: samsung-mcp-state
+  namespace: renfield
+  labels:
+    app.kubernetes.io/name: samsung-mcp
+    app.kubernetes.io/part-of: renfield
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 64Mi
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: samsung-mcp
+  namespace: renfield
+  labels:
+    app.kubernetes.io/name: samsung-mcp
+    app.kubernetes.io/part-of: renfield
+spec:
+  selector:
+    app.kubernetes.io/name: samsung-mcp
+  ports:
+    - port: 9092
+      targetPort: 9092
+      protocol: TCP
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: samsung-mcp
+  namespace: renfield
+  labels:
+    app.kubernetes.io/name: samsung-mcp
+    app.kubernetes.io/part-of: renfield
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: samsung-mcp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: samsung-mcp
+        app.kubernetes.io/part-of: renfield
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      imagePullSecrets:
+        - name: harbor-pull-secret
+      containers:
+        - name: samsung-mcp
+          # Dedicated small image (see renfield-mcp-samsung/Dockerfile). ENTRYPOINT
+          # is renfield-mcp-samsung, so no `command:` override needed. The backend
+          # reaches this over streamable-http only.
+          image: registry.treehouse.x-idra.de/renfield/samsung-mcp:v0.1.0
+          imagePullPolicy: Always
+          env:
+            - name: MCP_TRANSPORT
+              value: streamable-http
+            - name: MCP_HOST
+              value: "0.0.0.0"
+            - name: MCP_PORT
+              value: "9092"
+            - name: RENFIELD_STATE_DIR
+              value: /state
+            # Optional: pin a TV by IP to skip SSDP, and set the pairing-popup
+            # identity. Wire from the configmap/secret when known.
+            # - name: SAMSUNG_TV_HOST
+            #   value: "192.168.1.47"
+            - name: SAMSUNG_CLIENT_NAME
+              value: Renfield
+          volumeMounts:
+            - name: state
+              mountPath: /state
+          ports:
+            - containerPort: 9092
+              hostPort: 9092
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: 9092
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 9092
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+      volumes:
+        - name: state
+          persistentVolumeClaim:
+            claimName: samsung-mcp-state


### PR DESCRIPTION
## What

Wires the new **Samsung Smart TV (Tizen) MCP server** (`renfield-mcp-samsung`) into Renfield as an **agent-only** integration: chat-driven TV control (websocket remote keys/apps/power-off, Wake-on-LAN power-on, DLNA media). No room-view change — room-selectable TVs arrive later via the generic output-provider architecture (`docs/design/output-providers.md`).

## Changes

- **`config/mcp_servers.yaml`** — `samsung` block: `streamable_http` on `:9092`, `SAMSUNG_MCP_*`-gated (ships dark), 10 `prompt_tools`, de/en examples.
- **`config/agent_roles.yaml`** — grant `samsung` to the `media` + `routine` roles (TV control / good-night power-off).
- **`k8s/samsung-mcp.yaml`** — `hostNetwork` Deployment + ClusterIP Service + a small RWO Longhorn PVC at `/state` for one-time pairing-token persistence; registered in `kustomization.yaml`.
- **`k8s/configmap.yaml`** — `SAMSUNG_MCP_URL` (cluster `samsung-mcp` Service) + `SAMSUNG_MCP_ENABLED=false` (dark until built + paired).
- **Docs** — `docs/ENVIRONMENT_VARIABLES.md` (`SAMSUNG_MCP_*` + optional `SAMSUNG_TV_HOST`/`SAMSUNG_CLIENT_NAME`), `CLAUDE.md` (integration + dedicated-image topology), deploy-production skill (image build/push/rollout + one-time TV pairing steps).

The image itself (Dockerfile + `.dockerignore`) is committed in the **`renfield-mcp-samsung` repo** — a separate push/PR there (it's a dedicated hostNetwork image like `dlna-mcp`, not in the backend image).

## Review

`/review` + adversarial pass run. 3 issues found and fixed:
- configmap missing `SAMSUNG_MCP_URL`/`ENABLED` (in-cluster backend would hit the unresolvable `host.docker.internal` default).
- PVC missing `storageClassName: longhorn` (risk of a `Pending` claim).
- corrected a false manifest comment about hostPort pinning → documented the real postgres/redis RWO+Recreate rationale (no `nodeSelector`; a TV server shouldn't be less reschedulable than the database).

## Rollout

Ships **dark** (`SAMSUNG_MCP_ENABLED=false`). To go live: build+push the `samsung-mcp` image on .159, apply the manifest, complete the one-time TV pairing, then flip `SAMSUNG_MCP_ENABLED=true` (steps in the deploy-production skill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)