### PR TITLE
fix(output-providers): back-fill legacy column for legacy providers added via the unified picker

### DIFF
--- a/src/backend/ha_glue/services/output_routing_service.py
+++ b/src/backend/ha_glue/services/output_routing_service.py
@@ -299,8 +299,11 @@ class OutputRoutingService:
 
         Two ways to identify the target:
         - **Generic pair** ``(output_provider, output_target_id)`` — for any
-          provider, including brands with no legacy column (e.g. samsung). Legacy
-          columns stay NULL.
+          provider. For a KNOWN legacy provider (renfield/homeassistant/dlna) the
+          matching brand column is ALSO back-filled, so the legacy resolve/dispatch/
+          availability paths (which still read the brand columns during the soak)
+          keep working for devices added via the unified picker. A new brand with
+          no legacy column (e.g. samsung) stays pair-only → registry dispatch.
         - **Legacy column** — exactly one of renfield_device_id / ha_entity_id /
           dlna_renderer_name. The generic pair is dual-written from it so both
           read paths resolve during the soak (docs/design/output-providers.md).
@@ -316,6 +319,16 @@ class OutputRoutingService:
                     "Provide either the (output_provider, output_target_id) pair "
                     "OR a single legacy id column, not both"
                 )
+            # Back-fill the matching legacy column for known legacy providers so the
+            # existing dispatch paths (which read the brand columns until the
+            # DROP COLUMN cleanup) resolve a unified-picker add. Non-legacy brands
+            # (samsung/sonos) have no column and route via the registry instead.
+            if output_provider == "renfield":
+                renfield_device_id = output_target_id
+            elif output_provider == "homeassistant":
+                ha_entity_id = output_target_id
+            elif output_provider == "dlna":
+                dlna_renderer_name = output_target_id
             if not device_name:
                 device_name = output_target_id
         else:

--- a/tests/backend/test_output_providers_phase2_pg.py
+++ b/tests/backend/test_output_providers_phase2_pg.py
@@ -161,6 +161,31 @@ class TestAddOutputDevice:
         assert dev.device_name == "192.168.1.47"  # auto from target id
         assert dev.target_type == "samsung"
 
+    async def test_explicit_pair_legacy_provider_backfills_brand_column(self, pg_db_session, monkeypatch):
+        # A legacy provider added via the unified picker (pair-only) must also get
+        # its brand column so the legacy dispatch/resolve paths still resolve it.
+        _commit_as_flush(pg_db_session, monkeypatch)
+        room = await _make_room(pg_db_session, "add_pair_dlna")
+        svc = OutputRoutingService(pg_db_session)
+        dev = await svc.add_output_device(
+            room_id=room.id, output_type="visual",
+            output_provider="dlna", output_target_id="Wohnzimmer TV",
+        )
+        assert dev.dlna_renderer_name == "Wohnzimmer TV"   # back-filled
+        assert dev.output_provider == "dlna"
+        assert dev.output_target_id == "Wohnzimmer TV"
+        # HA pair → ha_entity_id back-filled; samsung pair → no legacy column.
+        ha = await svc.add_output_device(
+            room_id=room.id, output_type="audio",
+            output_provider="homeassistant", output_target_id="media_player.x",
+        )
+        assert ha.ha_entity_id == "media_player.x"
+        sam = await svc.add_output_device(
+            room_id=room.id, output_type="visual",
+            output_provider="samsung", output_target_id="192.168.1.47",
+        )
+        assert sam.renfield_device_id is None and sam.ha_entity_id is None and sam.dlna_renderer_name is None
+
     async def test_rejects_pair_plus_legacy(self, pg_db_session, monkeypatch):
         _commit_as_flush(pg_db_session, monkeypatch)
         room = await _make_room(pg_db_session, "add_both")


### PR DESCRIPTION
## What

Flag-on correctness fix found while prepping `OUTPUT_PROVIDERS_ENABLED` enablement (follow-up to #735).

A **renfield / HA / dlna** device added through the new unified picker stored a **pair-only** row (`output_provider`+`output_target_id`, brand column NULL). But the legacy resolve/dispatch/availability paths still read the brand column during the dual-read soak → NULL → broken playback. Existing rows are unaffected (backfilled by the migration / dual-written by the legacy add path); only *new* legacy-provider adds via the picker broke.

This only manifests with the flag **on**, so it never shipped a regression — but it must land before enablement.

## Fix

`add_output_device`'s explicit-pair path now back-fills the matching brand column for known legacy providers (`renfield→renfield_device_id`, `homeassistant→ha_entity_id`, `dlna→dlna_renderer_name`). A new brand with no legacy column (samsung/sonos) stays pair-only → registry dispatch. The full dual-read of the dispatch branches ships with the deferred `DROP COLUMN` cleanup (P2, TODOS.md).

## Test

PG test added (`test_explicit_pair_legacy_provider_backfills_brand_column`): dlna/HA pair → brand column back-filled; samsung pair → no legacy column. 12 phase-2 PG tests green on .159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)