### PR TITLE
fix(output-providers): rooms add-output route rejected the generic pair (400)

### DIFF
--- a/src/backend/ha_glue/api/routes/rooms.py
+++ b/src/backend/ha_glue/api/routes/rooms.py
@@ -772,19 +772,11 @@ async def add_output_device(
     if not room:
         raise HTTPException(status_code=404, detail="Room not found")
 
-    # Validate that exactly one device identifier is provided
-    identifiers = [request.renfield_device_id, request.ha_entity_id, request.dlna_renderer_name]
-    set_count = sum(1 for v in identifiers if v)
-    if set_count == 0:
-        raise HTTPException(
-            status_code=400,
-            detail="One of renfield_device_id, ha_entity_id, or dlna_renderer_name must be provided"
-        )
-    if set_count > 1:
-        raise HTTPException(
-            status_code=400,
-            detail="Only one of renfield_device_id, ha_entity_id, or dlna_renderer_name can be provided"
-        )
+    # Device-identity validation (exactly one legacy id OR the
+    # (output_provider, output_target_id) pair) is owned by
+    # OutputRoutingService.add_output_device — it raises ValueError, caught below
+    # as a 400. Don't duplicate a legacy-only guard here: it would reject the
+    # generic pair (samsung/sonos, or any device added via the unified picker).
 
     # Validate output_type
     from models.database import OUTPUT_TYPES

--- a/tests/backend/test_api_rooms.py
+++ b/tests/backend/test_api_rooms.py
@@ -304,6 +304,29 @@ class TestOutputDeviceEndpoints:
         assert data["renfield_device_id"] == test_device.device_id
 
     @pytest.mark.integration
+    async def test_add_output_device_generic_pair(
+        self, async_client: AsyncClient, test_room: Room
+    ):
+        """POST with the (output_provider, output_target_id) pair (unified picker /
+        samsung path) must NOT be rejected by a legacy-only route guard. Regression
+        for the 400 that broke the rooms-page 'Hinzufügen' button."""
+        response = await async_client.post(
+            f"/api/rooms/{test_room.id}/output-devices",
+            json={
+                "output_provider": "samsung",
+                "output_target_id": "192.168.1.47",
+                "output_type": "visual",
+                "priority": 1,
+            },
+        )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["output_provider"] == "samsung"
+        assert data["output_target_id"] == "192.168.1.47"
+        # samsung has no legacy column → stays pair-only
+        assert data["renfield_device_id"] is None and data["ha_entity_id"] is None
+
+    @pytest.mark.integration
     async def test_update_output_device(
         self, async_client: AsyncClient, test_room: Room, db_session: AsyncSession
     ):


### PR DESCRIPTION
Prod hotfix: the rooms-page **Hinzufügen** did nothing — POST `/rooms/{id}/output-devices` returned **400** for the `(output_provider, output_target_id)` pair. The route had its own legacy-only identity guard (the 3 brand columns) that wasn't updated for the pair, rejecting pair-only requests before the service. Removed it; `add_output_device` is the single validation source (raises → existing `except → 400`). Regression test added (pair POST → 200); 8 output-device route tests green on .159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)