### PR TITLE
fix(output-providers): dedupe the available-outputs picker by physical device

### DIFF
--- a/src/backend/ha_glue/services/output_routing_service.py
+++ b/src/backend/ha_glue/services/output_routing_service.py
@@ -16,6 +16,7 @@ Routing Algorithm:
 4. If nothing available → return None
 """
 
+import re
 from dataclasses import dataclass
 from enum import Enum
 
@@ -25,6 +26,73 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ha_glue.integrations.homeassistant import HomeAssistantClient
 from models.database import OUTPUT_TYPE_AUDIO, OUTPUT_TYPE_VISUAL, RoomDevice, RoomOutputDevice
+
+# Provider preference when the SAME physical device is exposed by several
+# protocols (lower = preferred): dlna first (gapless album playback), then HA,
+# then renfield, then any MCP brand. Used by _dedupe_output_targets.
+_PROVIDER_RANK = {"dlna": 0, "homeassistant": 1, "renfield": 2}
+
+
+def _device_match_key(name: str) -> str:
+    """Normalize a target name so the same physical speaker exposed via different
+    protocols collapses to one key. Strips DLNA suffixes (``:UPnP AV`` / ``:UpnpAv``),
+    lowercases, drops non-alphanumerics, and collapses consecutive duplicate words
+    (HA friendly names often double the room: "Linn Wohnzimmer Wohnzimmer")."""
+    s = name.split(":", 1)[0].lower()
+    s = re.sub(r"[^a-z0-9]+", " ", s).strip()
+    words: list[str] = []
+    for w in s.split():
+        if not words or words[-1] != w:
+            words.append(w)
+    return " ".join(words)
+
+
+def _clean_display_name(name: str) -> str:
+    """Tidy a display name: strip the DLNA transport suffix + collapse the doubled
+    trailing room word, keeping original casing."""
+    base = name.split(":", 1)[0].strip()
+    words = base.split()
+    out: list[str] = []
+    for w in words:
+        if not out or out[-1].lower() != w.lower():
+            out.append(w)
+    return " ".join(out) or name
+
+
+def _dedupe_output_targets(targets: list[dict]) -> list[dict]:
+    """Collapse the SAME physical device exposed by MULTIPLE providers into one
+    entry (e.g. a Linn shows as both an HA media_player and a DLNA renderer).
+
+    Cross-provider only: two entries that share a normalized name but come from
+    the SAME provider are distinct devices (e.g. two HA "Soundbar" entities) and
+    are BOTH kept. For a real cross-provider duplicate, the preferred provider
+    (`_PROVIDER_RANK`) wins, its capabilities are unioned across the group, and
+    the display name is tidied. First-seen order is preserved.
+    """
+    groups: dict[str, list[dict]] = {}
+    order: list[str] = []
+    for t in targets:
+        k = _device_match_key(t["name"])
+        if k not in groups:
+            groups[k] = []
+            order.append(k)
+        groups[k].append(t)
+
+    deduped: list[dict] = []
+    for k in order:
+        group = groups[k]
+        providers = {t["provider"] for t in group}
+        if len(providers) <= 1:
+            deduped.extend(group)  # same provider → distinct devices, keep all
+            continue
+        # Same physical device on several protocols → keep the preferred provider's
+        # entry, union capabilities across the whole group, tidy the name.
+        winner_provider = min(providers, key=lambda p: _PROVIDER_RANK.get(p, 9))
+        winner = next(t for t in group if t["provider"] == winner_provider)
+        merged_caps = sorted({c for t in group for c in t.get("capabilities", [])})
+        deduped.append({**winner, "capabilities": merged_caps,
+                        "name": _clean_display_name(winner["name"])})
+    return deduped
 
 
 class DeviceAvailability(str, Enum):
@@ -565,7 +633,7 @@ class OutputRoutingService:
                 for r in results:
                     targets.extend(r)
 
-        return targets
+        return _dedupe_output_targets(targets)
 
     async def get_available_dlna_renderers(self) -> list[dict]:
         """

--- a/tests/backend/test_output_providers_phase4.py
+++ b/tests/backend/test_output_providers_phase4.py
@@ -118,3 +118,78 @@ async def test_no_mcp_manager_returns_builtins_only():
     svc = _service()
     out = await svc.get_aggregated_outputs(room_id=1, mcp_manager=None)
     assert {t["provider"] for t in out} == {"renfield", "homeassistant", "dlna"}
+
+
+# --- dedupe (same physical device exposed by multiple providers) -------------
+
+from ha_glue.services.output_routing_service import (  # noqa: E402
+    _clean_display_name,
+    _device_match_key,
+    _dedupe_output_targets,
+)
+
+
+def test_match_key_collapses_ha_and_dlna_names():
+    # HA friendly name (doubled room) vs DLNA renderer name → same key
+    assert _device_match_key("Linn Wohnzimmer Wohnzimmer") == _device_match_key("Linn Wohnzimmer:UPnP AV")
+    assert _device_match_key("HiFiBerry Arbeitszimmer") == _device_match_key("HiFiBerry Arbeitszimmer")
+    # distinct devices → distinct keys
+    assert _device_match_key("Linn Küche:UpnpAv") != _device_match_key("Linn Garten:UPnP AV")
+
+
+def test_clean_display_name():
+    assert _clean_display_name("Linn Wohnzimmer:UPnP AV") == "Linn Wohnzimmer"
+    assert _clean_display_name("Linn Wohnzimmer Wohnzimmer") == "Linn Wohnzimmer"
+
+
+def _t(provider, target_id, name, caps, reachable=True):
+    return {"provider": provider, "target_id": target_id, "name": name,
+            "capabilities": caps, "room_hint": None, "reachable": reachable}
+
+
+def test_dedupe_collapses_cross_provider_prefers_dlna_merges_caps():
+    targets = [
+        _t("homeassistant", "media_player.linn_wz", "Linn Wohnzimmer Wohnzimmer", ["audio", "transport"]),
+        _t("dlna", "Linn Wohnzimmer:UPnP AV", "Linn Wohnzimmer:UPnP AV", ["audio", "video"]),
+    ]
+    out = _dedupe_output_targets(targets)
+    assert len(out) == 1
+    assert out[0]["provider"] == "dlna"                       # dlna preferred
+    assert out[0]["target_id"] == "Linn Wohnzimmer:UPnP AV"
+    assert out[0]["name"] == "Linn Wohnzimmer"               # tidied
+    assert out[0]["capabilities"] == ["audio", "transport", "video"]  # unioned
+
+
+def test_dedupe_keeps_same_provider_same_name_as_distinct():
+    # Two different HA entities both named "Soundbar" → must NOT merge
+    targets = [
+        _t("homeassistant", "media_player.buro", "Soundbar", ["audio"]),
+        _t("homeassistant", "media_player.118", "Soundbar", ["audio"]),
+    ]
+    out = _dedupe_output_targets(targets)
+    assert len(out) == 2
+    assert {t["target_id"] for t in out} == {"media_player.buro", "media_player.118"}
+
+
+def test_dedupe_preserves_singletons_and_order():
+    targets = [
+        _t("renfield", "sat-1", "Kitchen Sat", ["audio"]),
+        _t("samsung", "192.168.1.47", "Living Room TV", ["video", "power"]),
+    ]
+    out = _dedupe_output_targets(targets)
+    assert [t["target_id"] for t in out] == ["sat-1", "192.168.1.47"]
+
+
+async def test_aggregation_dedupes_ha_dlna_overlap():
+    # get_aggregated_outputs end-to-end: HA + dlna both expose "Wohnzimmer Speaker"
+    svc = _service()
+    svc.get_available_renfield_devices = AsyncMock(return_value=[])
+    svc.get_available_ha_media_players = AsyncMock(return_value=[
+        {"entity_id": "media_player.wz", "friendly_name": "Wohnzimmer Speaker"},
+    ])
+    svc.get_available_dlna_renderers = AsyncMock(return_value=[
+        {"name": "Wohnzimmer Speaker:UPnP AV", "friendly_name": "Wohnzimmer Speaker:UPnP AV"},
+    ])
+    out = await svc.get_aggregated_outputs(room_id=1, mcp_manager=None)
+    assert len(out) == 1
+    assert out[0]["provider"] == "dlna" and out[0]["name"] == "Wohnzimmer Speaker"


### PR DESCRIPTION
Prod feedback: the unified output picker showed each speaker twice (HA + DLNA both expose the same UPnP devices — Linn, HiFiBerry). `get_aggregated_outputs` now collapses the same physical device across providers into one entry (normalized-name match, strips DLNA suffix + doubled room word). **Cross-provider only** — two same-named entities from the *same* provider (two HA "Soundbar"s) stay distinct. Preferred provider wins (dlna>HA>renfield), caps unioned, name tidied. degraded-not-dropped preserved. 7 new tests; 46 green on .159.