### PR TITLE
polish(output-providers): tidy DLNA singleton names + disambiguate same-name devices

### DIFF
--- a/src/backend/ha_glue/services/output_routing_service.py
+++ b/src/backend/ha_glue/services/output_routing_service.py
@@ -64,6 +64,13 @@ def _clean_display_name(name: str) -> str:
     return " ".join(words[:keep]) or name
 
 
+def _short_id(target_id: str) -> str:
+    """A short distinguisher from a target id — the last dotted segment
+    (e.g. ``media_player.buro`` → ``buro``). Used to disambiguate two distinct
+    devices that share a display name."""
+    return target_id.rsplit(".", 1)[-1] or target_id
+
+
 def _dedupe_output_targets(targets: list[dict]) -> list[dict]:
     """Collapse the SAME physical device exposed by MULTIPLE providers into one
     entry (e.g. a Linn shows as both an HA media_player and a DLNA renderer).
@@ -88,7 +95,9 @@ def _dedupe_output_targets(targets: list[dict]) -> list[dict]:
         group = groups[k]
         providers = {t["provider"] for t in group}
         if len(providers) <= 1:
-            deduped.extend(group)  # same provider → distinct devices, keep all
+            # Same provider → distinct devices; keep all, but tidy each name
+            # (polish 1: strip the DLNA ":UPnP AV" suffix on singletons too).
+            deduped.extend({**t, "name": _clean_display_name(t["name"])} for t in group)
             continue
         # Same physical device on several protocols → keep the preferred provider's
         # entry, union capabilities across the whole group, tidy the name.
@@ -97,7 +106,19 @@ def _dedupe_output_targets(targets: list[dict]) -> list[dict]:
         merged_caps = sorted({c for t in group for c in t.get("capabilities", [])})
         deduped.append({**winner, "capabilities": merged_caps,
                         "name": _clean_display_name(winner["name"])})
-    return deduped
+
+    # Polish 2: disambiguate entries that still share a display name (two distinct
+    # devices both named e.g. "Soundbar") by appending a short id distinguisher.
+    name_counts: dict[str, int] = {}
+    for t in deduped:
+        name_counts[t["name"].casefold()] = name_counts.get(t["name"].casefold(), 0) + 1
+    result: list[dict] = []
+    for t in deduped:
+        if name_counts[t["name"].casefold()] > 1 and t["target_id"]:
+            result.append({**t, "name": f"{t['name']} ({_short_id(t['target_id'])})"})
+        else:
+            result.append(t)
+    return result
 
 
 class DeviceAvailability(str, Enum):

--- a/tests/backend/test_output_providers_phase4.py
+++ b/tests/backend/test_output_providers_phase4.py
@@ -174,7 +174,8 @@ def test_dedupe_collapses_cross_provider_prefers_dlna_merges_caps():
 
 
 def test_dedupe_keeps_same_provider_same_name_as_distinct():
-    # Two different HA entities both named "Soundbar" → must NOT merge
+    # Two different HA entities both named "Soundbar" → must NOT merge, and get
+    # disambiguated by a short id (polish 2).
     targets = [
         _t("homeassistant", "media_player.buro", "Soundbar", ["audio"]),
         _t("homeassistant", "media_player.118", "Soundbar", ["audio"]),
@@ -182,6 +183,21 @@ def test_dedupe_keeps_same_provider_same_name_as_distinct():
     out = _dedupe_output_targets(targets)
     assert len(out) == 2
     assert {t["target_id"] for t in out} == {"media_player.buro", "media_player.118"}
+    assert {t["name"] for t in out} == {"Soundbar (buro)", "Soundbar (118)"}
+
+
+def test_singleton_dlna_name_is_tidied():
+    # polish 1: a DLNA-only device (no merge) still gets its :UPnP AV suffix stripped
+    out = _dedupe_output_targets([_t("dlna", "Linn Garten:UPnP AV", "Linn Garten:UPnP AV", ["audio"])])
+    assert out[0]["name"] == "Linn Garten"
+
+
+def test_unique_names_not_disambiguated():
+    out = _dedupe_output_targets([
+        _t("homeassistant", "media_player.a", "Küche", ["audio"]),
+        _t("homeassistant", "media_player.b", "Fernseher", ["audio"]),
+    ])
+    assert {t["name"] for t in out} == {"Küche", "Fernseher"}
 
 
 def test_dedupe_preserves_singletons_and_order():


### PR DESCRIPTION
Two picker polishes (display-only): (1) strip the DLNA `:UPnP AV` suffix from singleton entries too ("Linn Garten:UPnP AV" → "Linn Garten"); (2) disambiguate two distinct devices sharing a display name (two HA "Soundbar"s → "Soundbar (buro)" / "Soundbar (192_168_1_118)"). Filtering/dispatch unchanged. 4 new tests, 49 green.