### PR TITLE
fix(wissen): substitute {facts} into the title prompt (was literal → empty)

### DIFF
--- a/src/backend/services/schicht_a_extractor.py
+++ b/src/backend/services/schicht_a_extractor.py
@@ -355,9 +355,18 @@ async def generate_document_title(
     system = prompt_manager.get(
         "schicht_a_title", "system", default=_TITLE_SYSTEM_DEFAULT, lang=lang,
     )
-    user = prompt_manager.get(
+    # Substitute {facts} ourselves (not via prompt_manager kwargs): prompt_manager
+    # returns the DEFAULT verbatim when the key isn't in the YAML, so a kwarg would
+    # never reach the default template. .replace (not .format) is brace-safe — fact
+    # values can contain literal braces.
+    user_template = prompt_manager.get(
         "schicht_a_title", "user", default=_TITLE_USER_DEFAULT, lang=lang,
-        facts=_facts_to_block(facts),
+    )
+    facts_block = _facts_to_block(facts)
+    user = (
+        user_template.replace("{facts}", facts_block)
+        if "{facts}" in user_template
+        else f"{user_template}\n{facts_block}"
     )
     try:
         client = llm_client or get_default_client()

--- a/tests/backend/test_document_title.py
+++ b/tests/backend/test_document_title.py
@@ -63,6 +63,19 @@ async def test_generates_title_from_facts():
     assert len(client.calls) == 1  # one LLM call
 
 
+async def test_facts_actually_reach_the_user_prompt():
+    # Regression for the prompt_manager-default bug: {facts} must be substituted,
+    # not passed literally — else the LLM gets no facts.
+    client = _FakeClient('{"title": "x"}')
+    facts = [_f("identifier", "kontoinhaber", "BFS health finance GmbH"),
+             _f("identifier", "mahnnummer", "70660643")]
+    await generate_document_title(facts, lang="de", llm_client=client)
+    user_msg = next(m["content"] for m in client.calls[0]["messages"] if m["role"] == "user")
+    assert "BFS health finance GmbH" in user_msg
+    assert "70660643" in user_msg
+    assert "{facts}" not in user_msg  # placeholder was substituted, not left literal
+
+
 async def test_empty_facts_returns_none_without_llm():
     client = _FakeClient('{"title": "should not be used"}')
     assert await generate_document_title([], llm_client=client) is None


### PR DESCRIPTION
Dry-run produced garbage titles: prompt_manager.get returns the default template verbatim (no kwarg substitution) when the key isn't in YAML, so {facts} stayed literal and the LLM got no facts. Fix: substitute {facts} ourselves (.replace, brace-safe). Regression test added; 9 green.