### PR TITLE
feat(folder-ingest): watch-folder auto-ingest — backend (T1–T6, T9, T12, T14, T15, T19)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ docker exec -it renfield-backend alembic downgrade -1
 
 **Request Flow:** User → React Frontend → WebSocket/REST → FastAPI Backend → Intent Recognition → Action Execution → MCP/RAG → Streaming Response
 
-**Subsystems:** Intent Recognition, Agent Loop (ReAct), MCP Integration (8+ servers), RAG/Knowledge Base, Conversation Persistence, Hook System (plugin API), Auth/RPBAC, Presence Detection, Media Follow Me, Speaker Recognition, Knowledge Graph, Paperless Audit, Audio Output Routing (+ generic **output providers** behind `OUTPUT_PROVIDERS_ENABLED` — pluggable room media/control targets via an `output_provider:` MCP stanza; new brand = config, not code; see `docs/OUTPUT_ROUTING.md` + `docs/design/output-providers.md`), Proactive Notifications (webhook + privacy-aware delivery — both WS push and TTS are presence-gated for non-public, `PROACTIVE_ENABLED`), Obligation-Deadline Notifier (`OBLIGATION_NOTIFIER_ENABLED`), Device Management, **Circles (access tiers)**
+**Subsystems:** Intent Recognition, Agent Loop (ReAct), MCP Integration (8+ servers), RAG/Knowledge Base, Conversation Persistence, Hook System (plugin API), Auth/RPBAC, Presence Detection, Media Follow Me, Speaker Recognition, Knowledge Graph, Paperless Audit, Audio Output Routing (+ generic **output providers** behind `OUTPUT_PROVIDERS_ENABLED` — pluggable room media/control targets via an `output_provider:` MCP stanza; new brand = config, not code; see `docs/OUTPUT_ROUTING.md` + `docs/design/output-providers.md`), Proactive Notifications (webhook + privacy-aware delivery — both WS push and TTS are presence-gated for non-public, `PROACTIVE_ENABLED`), Obligation-Deadline Notifier (`OBLIGATION_NOTIFIER_ENABLED`), Device Management, **Circles (access tiers)**, **Folder Auto-Ingest** (watch-folder → KB + Paperless; a dedicated filesystem MCP PUSHES files over REST to `POST /api/folder-ingest/document` — no backend mounts, no polling; `FOLDER_INGEST_ENABLED`; see `docs/FOLDER_INGEST.md`)
 
 **Key config:** All via `.env` loaded by `utils/config.py` (Pydantic Settings). Full list: `docs/ENVIRONMENT_VARIABLES.md`.
 
@@ -87,8 +87,9 @@ The agent loop sees a mix of MCP tools (`mcp.<server>.<tool>`) and `internal.*` 
 | `internal.knowledge_search` | Semantic RAG search over the user's knowledge base | `services/knowledge_tool.py` |
 | `internal.list_my_memories` | Enumerate the asker's own conversation memories (preferences/facts/instructions) WITHOUT the per-turn `{memory_context}` vector threshold — backs broad self-knowledge queries ("Was weißt du über mich?") the small auto-injected snapshot can't answer. Reads only the authenticated user's own memories. | `services/memory_list_tool.py` |
 | `internal.forward_attachment_to_paperless` | Forward a chat-attached file to Paperless using real server-stored bytes — prevents the LLM from handling base64 payloads it can't actually see | `services/chat_upload_tool.py` |
+| `internal.ingest_file` | Interactive folder-ingest: the agent points at a file `path` on a watched share; pulls the bytes through the filesystem MCP (`mcp.files.read_file`, `truncate=False` — no 128 KB cap corruption) and runs them through the same `folder_ingest.ingest_document` bridge as the REST push (dedup / owner+tier / Paperless leg identical). Gated by `FOLDER_INGEST_ENABLED`. See `docs/FOLDER_INGEST.md`. | `services/folder_ingest_tool.py` |
 
-Dispatch for these is a special case in `services/action_executor.py` that injects dependencies the generic `intent.startswith("internal.")` hook path cannot provide (`mcp_manager`, `session_id`, and the authenticated `user_id` for `list_my_memories`).
+Dispatch for these is a special case in `services/action_executor.py` that injects dependencies the generic `intent.startswith("internal.")` hook path cannot provide (`mcp_manager`, `session_id`, and the authenticated `user_id` for `list_my_memories` / `ingest_file`).
 
 ### Agent stale-error marker
 

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -512,6 +512,37 @@ Erweitert jeden Treffer-Chunk um benachbarte Chunks aus demselben Dokument für 
 
 ---
 
+### Folder Auto-Ingest (Watch-Folder → KB + Paperless)
+
+Ein dedizierter Filesystem-MCP-Server überwacht Ordner (lokal/SMB/NFS) und
+**PUSHT** neue Dateien per REST an `POST /api/folder-ingest/document` (Bearer).
+Das Backend mountet die Shares NICHT — die Bytes reisen im Multipart-Body. Siehe
+`docs/FOLDER_INGEST.md`. Off by default; flag-aus = byte-identisch.
+
+```bash
+FOLDER_INGEST_ENABLED=false           # Feature-Schalter (Push-Route + internal.ingest_file)
+FOLDER_INGEST_KB_NAME=Eingang         # Ziel-Knowledge-Base (wird bei Bedarf angelegt)
+FOLDER_INGEST_TARGET_USER=            # Owner der auto-abgelegten Dokumente (Username/ID; leer → Admin/erster User)
+FOLDER_INGEST_DEFAULT_TIER=0          # Circle-Tier beim Anlegen (0=self … 4=public)
+FOLDER_INGEST_TO_PAPERLESS=true       # zusätzlich in Paperless ablegen
+FOLDER_INGEST_NOTIFY_ON_FILED=true    # Bestätigungs-Notification nach Ablage
+```
+
+Wiederverwendet `MAX_FILE_SIZE_MB`, `ALLOWED_EXTENSIONS`, `UPLOAD_DIR` (siehe RAG/Upload).
+Der Bearer-Token liegt revozierbar in `SystemSetting` (nicht in `.env`) — per
+`POST /api/folder-ingest/token` (Admin, `settings.manage`) erzeugen/rotieren. Der
+MCP prüft die Konfig-Ausrichtung beim Start via `GET /api/folder-ingest/health`.
+
+**Defaults:**
+- `FOLDER_INGEST_ENABLED`: `false`
+- `FOLDER_INGEST_KB_NAME`: `Eingang`
+- `FOLDER_INGEST_TARGET_USER`: `""` (leer → Admin/erster User)
+- `FOLDER_INGEST_DEFAULT_TIER`: `0`
+- `FOLDER_INGEST_TO_PAPERLESS`: `true`
+- `FOLDER_INGEST_NOTIFY_ON_FILED`: `true`
+
+---
+
 ### Conversation Memory (Langzeitgedaechtnis)
 
 ```bash

--- a/docs/FOLDER_INGEST.md
+++ b/docs/FOLDER_INGEST.md
@@ -1,0 +1,136 @@
+# Folder Auto-Ingest
+
+Drop a file into a watched folder → it is ingested into the knowledge base **and**
+Paperless automatically, for local, SMB, and NFS shares.
+
+> **Status.** The **backend** side (this document) is complete: the push endpoint,
+> the health/token routes, the interactive `internal.ingest_file` agent tool, the
+> completion+Paperless-aware dedup, owner/tier filing, and the Paperless leg. The
+> **dedicated `renfield-mcp-filesystem` server** that watches the folders and pushes
+> files is a separate deployment that is **not built yet** — until it exists, files
+> reach the backend only via the interactive `internal.ingest_file` tool (the agent
+> pulling a file through any filesystem MCP that exposes `read_file`) or a manual
+> `POST` to the endpoint below.
+
+## Architecture
+
+```
+renfield-mcp-filesystem (dedicated, owns share access — NOT the backend)
+  • watches roots, acts on a settled NEW file (create-only)
+  • on a settled file → HTTP multipart PUSH to the backend (Bearer)
+  • moves the file by the 4-state response: ingested|duplicate → processed/ ;
+                                            retry → leave in inbox ; failed → failed/
+        │  POST /api/folder-ingest/document   [multipart: file + metadata json]
+        ▼
+backend  services/folder_ingest.py  (shared bridge)
+  persist a recovery byte copy → dedup vs the Document row → race-safe create +
+  enqueue on the Redis doc stream → Paperless leg → respond 4-state
+        ▼
+  document worker (async): OCR / chunk / embed + KG / Schicht-A hooks
+```
+
+**Hard constraints:** the network shares are **never mounted into the backend** (the
+MCP is the sole access boundary), and there is **no polling and no WebSocket** — the
+MCP pushes over REST the instant it detects a settled new file.
+
+## Enable it
+
+1. Set the config (see `docs/ENVIRONMENT_VARIABLES.md` → *Folder Auto-Ingest*):
+
+   ```bash
+   FOLDER_INGEST_ENABLED=true
+   FOLDER_INGEST_KB_NAME=Eingang          # target KB (auto-created)
+   FOLDER_INGEST_TARGET_USER=             # owner of auto-filed docs (empty → admin/first user)
+   FOLDER_INGEST_DEFAULT_TIER=0           # circle tier at create (0=self … 4=public)
+   FOLDER_INGEST_TO_PAPERLESS=true
+   ```
+
+2. Mint the Bearer token (admin, `settings.manage`). The token lives in `SystemSetting`,
+   not `.env`, so it is revocable without a redeploy:
+
+   ```bash
+   curl -X POST https://<host>/api/folder-ingest/token \
+        -H "Authorization: Bearer <your-admin-jwt>"
+   # → {"token": "…"}   # store this in the filesystem MCP's secret
+   ```
+
+3. Point the filesystem MCP at the backend (`RENFIELD_URL` + the token) and at the
+   shares to watch. (MCP setup ships with that server.)
+
+## The 4-state response contract
+
+The push response body's `status` is load-bearing — the MCP moves the source file by
+it. **`ingested` means *enqueued*, not OCR'd.** All four are HTTP 200.
+
+| `status`    | meaning                                                        | MCP action               |
+|-------------|----------------------------------------------------------------|--------------------------|
+| `ingested`  | new row created + enqueued                                     | move → `processed/`      |
+| `duplicate` | row exists, completed, Paperless leg settled                   | move → `processed/`      |
+| `retry`     | worker down, or row pending/processing, or Paperless unsettled | **leave in inbox**, re-push |
+| `failed`    | terminal reject (bad ext, empty, oversize, malformed metadata) | move → `failed/`         |
+
+Transport-level outcomes use status codes the MCP maps separately:
+
+| code      | meaning                                              | MCP action                       |
+|-----------|------------------------------------------------------|----------------------------------|
+| `401`/`403` | missing / wrong token                              | **fatal config error** — stop, don't move |
+| `503`     | feature disabled (`reason: feature_disabled`) or worker down (`reason: worker_unavailable`) | retry |
+
+Every response (and 4-state body) carries `contract_version`; the MCP sends its own
+version in the `X-Folder-Ingest-Contract` request header. A mismatch is logged as a
+skew WARNING but processed leniently (the request shape is backward-compatible).
+
+## Health handshake
+
+The MCP pings `GET /api/folder-ingest/health` (same Bearer token) on startup and
+periodically to catch config drift before it silently misroutes files:
+
+```json
+{ "enabled": true, "kb_name": "Eingang", "kb_resolved": true, "token_ok": true,
+  "max_file_size_mb": 50, "allowed_extensions": ["pdf", "docx", …],
+  "contract_version": "1" }
+```
+
+A wrong token → `401`/`403` (the MCP knows its token is bad = fatal). When the feature
+is **disabled** health still returns `200` with `enabled: false` (definitive "feature
+off" — distinct from the push route's transient `503`).
+
+## Interactive path (`internal.ingest_file`)
+
+Besides the auto push, the agent can ingest a file the user points at:
+`internal.ingest_file({path})` pulls the bytes through the filesystem MCP
+(`mcp.files.read_file`, `truncate=False`) and runs them through the **same** bridge —
+dedup / owner+tier / Paperless filing are identical. The asking user owns what they
+ingest (falling back to `FOLDER_INGEST_TARGET_USER` in single-user mode).
+
+## Behavior notes
+
+- **Dedup (completion + Paperless aware).** A re-pushed file is only a `duplicate` when
+  the row is `completed` **and** the Paperless leg is settled. A previously `failed`
+  document is re-ingested; a `completed`-but-Paperless-missing document re-runs **only**
+  the Paperless leg.
+- **Owner / tier.** Auto-filed documents are owned by `FOLDER_INGEST_TARGET_USER` at
+  `FOLDER_INGEST_DEFAULT_TIER` (default 0 = self/private), regardless of the KB.
+- **Paperless leg.** Uploads non-blocking, then awaits the consume verdict via the
+  Paperless MCP. A Paperless **duplicate** counts as terminal success (the document is
+  already there). Paperless filing never fails the KB ingest.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| MCP logs `401`/`403` on every push | token missing / wrong | re-mint via `POST /api/folder-ingest/token`, update the MCP secret |
+| Nothing ingests, push gets `503 feature_disabled` | `FOLDER_INGEST_ENABLED=false` | enable the flag + restart the backend |
+| Push gets `503 worker_unavailable` | document worker pod down | check the worker pod; it self-heals when back (the file stays in the inbox) |
+| File lands in `failed/` | bad extension / empty / oversize / malformed metadata | check `ALLOWED_EXTENSIONS` + `MAX_FILE_SIZE_MB`; inspect the file |
+| Document is in the KB but **not** in Paperless | a transient Paperless outage during the first ingest (known gap, P2) | the file already moved to `processed/`, so it is not auto-retried — re-push it, or it surfaces in Paperless's own failed-task log; a future reconciler will re-file `paperless_state != done` docs |
+| Document re-fails on every worker restart | poison document (terminal pipeline error) | the worker marks it `status=failed` + acks (it stops looping); fix or remove the file, then re-push |
+
+## Where it lives
+
+- Bridge: `services/folder_ingest.py` (dedup, 4-state, owner/tier, token helpers, resolvers)
+- Paperless leg: `services/folder_ingest_paperless.py`
+- Routes: `api/routes/folder_ingest.py` (`POST /document`, `GET /health`, `POST /token`)
+- Interactive tool: `services/folder_ingest_tool.py` (+ dispatch in `services/action_executor.py`)
+- Worker terminal-failure handling: `workers/document_processor_worker.py`
+- Paperless MCP consume-poll: `renfield-mcp-paperless` `await_consume_result` (v1.8.0+)

--- a/src/backend/alembic/versions/pc20260612_doc_paperless_state.py
+++ b/src/backend/alembic/versions/pc20260612_doc_paperless_state.py
@@ -1,0 +1,37 @@
+"""documents.paperless_state — folder-ingest Paperless leg marker
+
+Revision ID: pc20260612_pl_state
+Revises: pc20260611_gen_title
+Create Date: 2026-06-08
+
+Adds ``documents.paperless_state``: a small string marker the folder-ingest
+bridge (services/folder_ingest.py) uses to record whether a document has been
+filed into Paperless, so a re-pushed already-completed document runs ONLY the
+still-missing Paperless step rather than re-ingesting the whole pipeline (D2),
+and so a Paperless duplicate-marker reject counts as terminal success (D10).
+
+Values (see models.database.PAPERLESS_STATE_*): NULL = never attempted (all
+existing rows + normal non-folder uploads stay NULL), "pending"/"failed" =
+retryable, "done" = terminal (filed / duplicate / skipped). Additive + nullable
++ unindexed (the bridge reads it only after locating the row by file_hash).
+Fully transactional.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "pc20260612_pl_state"
+down_revision = "pc20260611_gen_title"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "documents",
+        sa.Column("paperless_state", sa.String(length=20), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("documents", "paperless_state")

--- a/src/backend/api/routes/folder_ingest.py
+++ b/src/backend/api/routes/folder_ingest.py
@@ -30,15 +30,19 @@ from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.routes.knowledge import _worker_is_alive
+from models.permissions import Permission
 from services.api_rate_limiter import limiter
+from services.auth_service import require_permission
 from services.database import get_db
 from services.folder_ingest import (
     FOLDER_INGEST_CONTRACT_VERSION,
     IngestMeta,
     IngestStatus,
+    generate_folder_ingest_token,
     ingest_document,
     resolve_owner_user_id,
     resolve_target_kb,
+    target_kb_exists,
     verify_folder_ingest_token,
 )
 from utils.config import settings
@@ -54,6 +58,25 @@ class FolderIngestResponse(BaseModel):
     status: str
     document_id: int | None = None
     detail: str | None = None
+    contract_version: str = FOLDER_INGEST_CONTRACT_VERSION
+
+
+class FolderIngestTokenResponse(BaseModel):
+    token: str
+
+
+class FolderIngestHealthResponse(BaseModel):
+    """Config snapshot the filesystem MCP pings on startup + periodically to
+    detect two-surface mismatches (DX-1) — a wrong token surfaces as 401/403
+    (fatal in the MCP), everything else is reported here so the MCP can log one
+    loud error instead of silently misrouting every file."""
+
+    enabled: bool
+    kb_name: str
+    kb_resolved: bool
+    token_ok: bool
+    max_file_size_mb: int
+    allowed_extensions: list[str]
     contract_version: str = FOLDER_INGEST_CONTRACT_VERSION
 
 
@@ -167,3 +190,45 @@ async def ingest_pushed_document(
         document_id=result.document_id,
         detail=result.detail,
     )
+
+
+@router.get("/health", response_model=FolderIngestHealthResponse)
+@limiter.limit(settings.api_rate_limit_default)
+async def health(
+    request: Request,
+    authorization: str | None = Header(None),
+    db: AsyncSession = Depends(get_db),
+):
+    """Config-alignment handshake for the filesystem MCP (DX-1). Bearer-auth'd
+    with the same token as the push: a wrong/missing token is 401/403 (fatal in
+    the MCP). Unlike the push route this does NOT 503 when disabled — the
+    ``enabled`` flag is reported in the body so the MCP can tell "backend up,
+    feature off" (definitive, stop) from the push route's transient 503."""
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
+    token = authorization.removeprefix("Bearer ").strip()
+    if not await verify_folder_ingest_token(db, token):
+        raise HTTPException(status_code=403, detail="Invalid folder-ingest token")
+
+    return FolderIngestHealthResponse(
+        enabled=settings.folder_ingest_enabled,
+        kb_name=settings.folder_ingest_kb_name,
+        kb_resolved=await target_kb_exists(db),
+        token_ok=True,  # reaching here means the presented token matched
+        max_file_size_mb=settings.max_file_size_mb,
+        allowed_extensions=settings.allowed_extensions_list,
+    )
+
+
+@router.post("/token", response_model=FolderIngestTokenResponse)
+@limiter.limit(settings.api_rate_limit_admin)
+async def mint_token(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user=Depends(require_permission(Permission.SETTINGS_MANAGE)),
+):
+    """Generate or rotate the folder-ingest Bearer token (admin). Without this
+    there is no way to produce the token the whole feature depends on (DX-2).
+    Returns the plaintext token once — store it in the MCP's secret."""
+    token = await generate_folder_ingest_token(db)
+    return FolderIngestTokenResponse(token=token)

--- a/src/backend/api/routes/folder_ingest.py
+++ b/src/backend/api/routes/folder_ingest.py
@@ -1,0 +1,194 @@
+"""Folder-ingest push endpoint (T3) — the REST seam the dedicated
+``renfield-mcp-filesystem`` server pushes settled new files to.
+
+One route: ``POST /api/folder-ingest/document`` (multipart: ``file`` +
+``metadata`` JSON). Authenticated by a revocable Bearer token in SystemSetting
+(NOT a user JWT), like the notifications webhook. The backend never mounts the
+share — the bytes ride the multipart body.
+
+The body's ``status`` is the load-bearing 4-state contract (D9): the MCP moves
+the source file by it (``ingested|duplicate`` → processed/, ``retry`` → leave in
+inbox, ``failed`` → failed/). All four are HTTP 200. Transport-level failures
+use status codes the MCP maps separately: ``503`` → retry (feature disabled or
+worker down), ``401/403`` → fatal config error (token) — never a file move.
+"""
+
+import json
+
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    Form,
+    Header,
+    HTTPException,
+    Request,
+    UploadFile,
+)
+from loguru import logger
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.routes.knowledge import _worker_is_alive
+from models.database import KnowledgeBase, User
+from services.api_rate_limiter import limiter
+from services.database import get_db
+from services.folder_ingest import (
+    FOLDER_INGEST_CONTRACT_VERSION,
+    IngestMeta,
+    IngestStatus,
+    ingest_document,
+    verify_folder_ingest_token,
+)
+from utils.config import settings
+
+router = APIRouter()
+
+_CHUNK = 1024 * 1024  # 1 MiB streaming read
+
+
+class FolderIngestResponse(BaseModel):
+    """The 4-state push response. ``status`` ∈ ingested|duplicate|retry|failed."""
+
+    status: str
+    document_id: int | None = None
+    detail: str | None = None
+    contract_version: str = FOLDER_INGEST_CONTRACT_VERSION
+
+
+async def _resolve_target_kb(db: AsyncSession) -> KnowledgeBase:
+    """Get-or-create the configured folder-ingest target KB. Mirrors the
+    chat-upload default-KB pattern so a fresh install just works."""
+    kb = (
+        await db.execute(
+            select(KnowledgeBase).where(
+                KnowledgeBase.name == settings.folder_ingest_kb_name
+            )
+        )
+    ).scalar_one_or_none()
+    if kb:
+        return kb
+    kb = KnowledgeBase(
+        name=settings.folder_ingest_kb_name,
+        description="Auto-ingested documents from watched folders",
+    )
+    db.add(kb)
+    await db.commit()
+    await db.refresh(kb)
+    return kb
+
+
+async def _resolve_owner_user_id(db: AsyncSession) -> int | None:
+    """Resolve ``folder_ingest_target_user`` (username or numeric id) to a user
+    id. Empty config → None (the bridge/worker handle an ownerless enqueue the
+    same way the upload route does for unauthenticated single-user mode)."""
+    target = settings.folder_ingest_target_user.strip()
+    if not target:
+        return None
+    user = (
+        await db.execute(select(User).where(User.username == target))
+    ).scalar_one_or_none()
+    if user is None and target.isdigit():
+        user = (
+            await db.execute(select(User).where(User.id == int(target)))
+        ).scalar_one_or_none()
+    if user is None:
+        logger.warning(
+            f"folder-ingest: target_user {target!r} not found; enqueuing ownerless"
+        )
+        return None
+    return user.id
+
+
+@router.post("/document", response_model=FolderIngestResponse)
+@limiter.limit(settings.api_rate_limit_default)
+async def ingest_pushed_document(
+    request: Request,
+    file: UploadFile = File(...),
+    metadata: str = Form(...),
+    authorization: str | None = Header(None),
+    db: AsyncSession = Depends(get_db),
+):
+    """Receive one pushed file from the filesystem MCP and run it through the
+    shared folder-ingest bridge. See the module docstring for the contract."""
+    # 1. Feature gate — a forgotten flag is a transient "nothing's happening"
+    # (retry), distinct from the token-fatal path below (DX-3). The MCP's
+    # health probe (T14) is the loud disabled-detector; here we just 503.
+    if not settings.folder_ingest_enabled:
+        raise HTTPException(
+            status_code=503,
+            detail={"message": "Folder ingest is disabled", "reason": "feature_disabled"},
+        )
+
+    # 2. Bearer token (constant-time). 401 = missing header, 403 = wrong token;
+    # both are FATAL config errors in the MCP (do not move the file to failed/).
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
+    token = authorization.removeprefix("Bearer ").strip()
+    if not await verify_folder_ingest_token(db, token):
+        raise HTTPException(status_code=403, detail="Invalid folder-ingest token")
+
+    # 3. Worker-alive gate (reuse knowledge.py:_worker_is_alive). Enqueuing into
+    # a stream nobody consumes would orphan the doc → 503/retry instead.
+    if not await _worker_is_alive():
+        raise HTTPException(
+            status_code=503,
+            detail={"message": "Document worker unavailable", "reason": "worker_unavailable"},
+        )
+
+    # 4. Parse metadata. Malformed → failed (the MCP must move it to failed/, not
+    # retry forever — garbage metadata won't self-heal). A client-supplied
+    # knowledge_base_id is ignored: IngestMeta does not read it, so the token's
+    # single (target_user, kb_name) scope cannot be overridden by the pusher.
+    try:
+        meta = IngestMeta.from_dict(json.loads(metadata))
+    except (json.JSONDecodeError, ValueError, TypeError) as exc:
+        logger.warning(f"folder-ingest: malformed metadata: {exc}")
+        return FolderIngestResponse(status=IngestStatus.FAILED.value, detail="malformed_metadata")
+
+    # 5. Stream the body with an early size abort — never clone an unbounded
+    # `await file.read()` into RAM. Oversize → failed (terminal, won't shrink).
+    max_bytes = settings.max_file_size_mb * 1024 * 1024
+    buf = bytearray()
+    while chunk := await file.read(_CHUNK):
+        buf.extend(chunk)
+        if len(buf) > max_bytes:
+            logger.warning(
+                f"folder-ingest: {meta.filename!r} exceeds "
+                f"{settings.max_file_size_mb} MB ceiling (stream abort)"
+            )
+            return FolderIngestResponse(status=IngestStatus.FAILED.value, detail="file_too_large")
+    file_bytes = bytes(buf)
+
+    # 6. Resolve the server-side target KB + owner, then delegate to the bridge.
+    # paperless_leg stays None until T5 wires the real PaperlessMetadataExtractor
+    # leg; for now Paperless filing is recorded as settled by the bridge's no-op.
+    #
+    # Any unexpected failure here (Redis enqueue down, concurrent KB-create
+    # IntegrityError, …) must surface as a 503/retry, NOT a raw 500: the MCP
+    # leaves the file in the inbox and re-pushes rather than mis-moving it. The
+    # bridge already maps its own known errors to FAILED/RETRY; this guards the
+    # residual transient ones so the 4-state transport contract never breaks.
+    try:
+        kb = await _resolve_target_kb(db)
+        owner_user_id = await _resolve_owner_user_id(db)
+        result = await ingest_document(
+            file_bytes,
+            meta,
+            db=db,
+            kb_id=kb.id,
+            owner_user_id=owner_user_id,
+            paperless_leg=None,
+        )
+    except Exception as exc:  # noqa: BLE001 - never 500 the push contract
+        logger.error(f"folder-ingest: unexpected error processing {meta.filename!r}: {exc}")
+        raise HTTPException(
+            status_code=503,
+            detail={"message": "Transient ingest error", "reason": "internal_error"},
+        ) from exc
+    return FolderIngestResponse(
+        status=result.status.value,
+        document_id=result.document_id,
+        detail=result.detail,
+    )

--- a/src/backend/api/routes/folder_ingest.py
+++ b/src/backend/api/routes/folder_ingest.py
@@ -27,11 +27,9 @@ from fastapi import (
 )
 from loguru import logger
 from pydantic import BaseModel
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.routes.knowledge import _worker_is_alive
-from models.database import KnowledgeBase, User
 from services.api_rate_limiter import limiter
 from services.database import get_db
 from services.folder_ingest import (
@@ -39,6 +37,8 @@ from services.folder_ingest import (
     IngestMeta,
     IngestStatus,
     ingest_document,
+    resolve_owner_user_id,
+    resolve_target_kb,
     verify_folder_ingest_token,
 )
 from utils.config import settings
@@ -55,28 +55,6 @@ class FolderIngestResponse(BaseModel):
     document_id: int | None = None
     detail: str | None = None
     contract_version: str = FOLDER_INGEST_CONTRACT_VERSION
-
-
-async def _resolve_target_kb(db: AsyncSession) -> KnowledgeBase:
-    """Get-or-create the configured folder-ingest target KB. Mirrors the
-    chat-upload default-KB pattern so a fresh install just works."""
-    kb = (
-        await db.execute(
-            select(KnowledgeBase).where(
-                KnowledgeBase.name == settings.folder_ingest_kb_name
-            )
-        )
-    ).scalar_one_or_none()
-    if kb:
-        return kb
-    kb = KnowledgeBase(
-        name=settings.folder_ingest_kb_name,
-        description="Auto-ingested documents from watched folders",
-    )
-    db.add(kb)
-    await db.commit()
-    await db.refresh(kb)
-    return kb
 
 
 def _build_paperless_leg(request: Request, owner_user_id: int | None):
@@ -96,28 +74,6 @@ def _build_paperless_leg(request: Request, owner_user_id: int | None):
     from services.folder_ingest_paperless import make_paperless_leg
 
     return make_paperless_leg(mcp_manager, user_id=owner_user_id)
-
-
-async def _resolve_owner_user_id(db: AsyncSession) -> int | None:
-    """Resolve ``folder_ingest_target_user`` (username or numeric id) to a user
-    id. Empty config → None (the bridge/worker handle an ownerless enqueue the
-    same way the upload route does for unauthenticated single-user mode)."""
-    target = settings.folder_ingest_target_user.strip()
-    if not target:
-        return None
-    user = (
-        await db.execute(select(User).where(User.username == target))
-    ).scalar_one_or_none()
-    if user is None and target.isdigit():
-        user = (
-            await db.execute(select(User).where(User.id == int(target)))
-        ).scalar_one_or_none()
-    if user is None:
-        logger.warning(
-            f"folder-ingest: target_user {target!r} not found; enqueuing ownerless"
-        )
-        return None
-    return user.id
 
 
 @router.post("/document", response_model=FolderIngestResponse)
@@ -189,14 +145,15 @@ async def ingest_pushed_document(
     # bridge already maps its own known errors to FAILED/RETRY; this guards the
     # residual transient ones so the 4-state transport contract never breaks.
     try:
-        kb = await _resolve_target_kb(db)
-        owner_user_id = await _resolve_owner_user_id(db)
+        kb = await resolve_target_kb(db)
+        owner_user_id = await resolve_owner_user_id(db)
         result = await ingest_document(
             file_bytes,
             meta,
             db=db,
             kb_id=kb.id,
             owner_user_id=owner_user_id,
+            default_tier=settings.folder_ingest_default_tier,
             paperless_leg=_build_paperless_leg(request, owner_user_id),
         )
     except Exception as exc:  # noqa: BLE001 - never 500 the push contract

--- a/src/backend/api/routes/folder_ingest.py
+++ b/src/backend/api/routes/folder_ingest.py
@@ -106,10 +106,26 @@ async def ingest_pushed_document(
     file: UploadFile = File(...),
     metadata: str = Form(...),
     authorization: str | None = Header(None),
+    x_folder_ingest_contract: str | None = Header(None),
     db: AsyncSession = Depends(get_db),
 ):
     """Receive one pushed file from the filesystem MCP and run it through the
     shared folder-ingest bridge. See the module docstring for the contract."""
+    # Contract-version skew check (DX-7). The MCP sends its contract version in
+    # the X-Folder-Ingest-Contract header; a mismatch is logged loudly (and the
+    # response always carries OUR version so the MCP can detect skew too) but is
+    # NOT fatal here — the request shape has been backward-compatible so far, so
+    # we process leniently rather than reject a file over a version bump.
+    if (
+        x_folder_ingest_contract
+        and x_folder_ingest_contract != FOLDER_INGEST_CONTRACT_VERSION
+    ):
+        logger.warning(
+            f"folder-ingest: contract skew — MCP sent "
+            f"{x_folder_ingest_contract!r}, backend is "
+            f"{FOLDER_INGEST_CONTRACT_VERSION!r}; processing leniently"
+        )
+
     # 1. Feature gate — a forgotten flag is a transient "nothing's happening"
     # (retry), distinct from the token-fatal path below (DX-3). The MCP's
     # health probe (T14) is the loud disabled-detector; here we just 503.

--- a/src/backend/api/routes/folder_ingest.py
+++ b/src/backend/api/routes/folder_ingest.py
@@ -79,6 +79,25 @@ async def _resolve_target_kb(db: AsyncSession) -> KnowledgeBase:
     return kb
 
 
+def _build_paperless_leg(request: Request, owner_user_id: int | None):
+    """The real Paperless leg when ``folder_ingest_to_paperless`` is on and the
+    MCP manager is available, else None (the bridge then records the leg as a
+    no-op settled — nothing to file). Kept out of the bridge so the import of
+    the Paperless/MCP stack stays at the route edge."""
+    if not settings.folder_ingest_to_paperless:
+        return None
+    mcp_manager = getattr(request.app.state, "mcp_manager", None)
+    if mcp_manager is None:
+        logger.warning(
+            "folder-ingest: to_paperless is on but no MCP manager — skipping "
+            "Paperless filing for this push"
+        )
+        return None
+    from services.folder_ingest_paperless import make_paperless_leg
+
+    return make_paperless_leg(mcp_manager, user_id=owner_user_id)
+
+
 async def _resolve_owner_user_id(db: AsyncSession) -> int | None:
     """Resolve ``folder_ingest_target_user`` (username or numeric id) to a user
     id. Empty config → None (the bridge/worker handle an ownerless enqueue the
@@ -161,9 +180,8 @@ async def ingest_pushed_document(
             return FolderIngestResponse(status=IngestStatus.FAILED.value, detail="file_too_large")
     file_bytes = bytes(buf)
 
-    # 6. Resolve the server-side target KB + owner, then delegate to the bridge.
-    # paperless_leg stays None until T5 wires the real PaperlessMetadataExtractor
-    # leg; for now Paperless filing is recorded as settled by the bridge's no-op.
+    # 6. Resolve the server-side target KB + owner, build the Paperless leg
+    # (when filing is enabled), then delegate to the bridge.
     #
     # Any unexpected failure here (Redis enqueue down, concurrent KB-create
     # IntegrityError, …) must surface as a 503/retry, NOT a raw 500: the MCP
@@ -179,7 +197,7 @@ async def ingest_pushed_document(
             db=db,
             kb_id=kb.id,
             owner_user_id=owner_user_id,
-            paperless_leg=None,
+            paperless_leg=_build_paperless_leg(request, owner_user_id),
         )
     except Exception as exc:  # noqa: BLE001 - never 500 the push contract
         logger.error(f"folder-ingest: unexpected error processing {meta.filename!r}: {exc}")

--- a/src/backend/api/routes/knowledge.py
+++ b/src/backend/api/routes/knowledge.py
@@ -22,7 +22,7 @@ from models.permissions import Permission, has_permission
 from services.auth_service import get_optional_user
 from services.database import get_db
 from services.progress import DocumentProgress
-from services.rag_service import RAGService
+from services.rag_service import DuplicateDocumentError, RAGService
 from services.redis_client import get_redis
 from services.task_queue import DocumentTaskQueue
 from utils.config import settings
@@ -357,52 +357,28 @@ async def upload_document(
         )
 
     try:
-        doc = await rag.create_document_record(
+        # Shared race-safe create (D3): the uq_documents_file_hash_kb
+        # concurrent-insert race is handled in one place
+        # (rag.create_document_record_safe), reused by the folder-ingest
+        # bridge. A concurrent winner surfaces as DuplicateDocumentError.
+        doc = await rag.create_document_record_safe(
             file_path=str(file_path),
             knowledge_base_id=knowledge_base_id,
             filename=file.filename,
             file_hash=file_hash,
         )
-    except IntegrityError as ie:
-        # Distinguish the concurrent-upload race (unique-constraint
-        # violation on our uq_documents_file_hash_kb index) from other
-        # IntegrityErrors (FK, NOT NULL) which are genuinely 500-worthy
-        # — we don't want to paper over those with a misleading 409.
-        orig_err = str(ie.orig) if ie.orig else str(ie)
-        is_hash_race = "uq_documents_file_hash_kb" in orig_err
-        if not is_hash_race:
-            await rag.db.rollback()
-            if file_path.exists():
-                try:
-                    os.remove(file_path)
-                except OSError as cleanup_err:
-                    logger.warning(f"failed to clean up orphan upload {file_path}: {cleanup_err}")
-            logger.error(f"Unexpected IntegrityError on Document insert: {orig_err}")
-            raise HTTPException(status_code=500, detail="Database integrity error")
-
+    except DuplicateDocumentError as dup:
         # Concurrent-upload race: someone else committed the same
-        # (file_hash, knowledge_base_id) pair between our SELECT-based
-        # dup check and this INSERT. Convert to the same 409 response
-        # the pre-insert check produces so the frontend just opens the
-        # duplicate dialog either way. Clean up the orphan file and
-        # fetch the winning row for the payload.
+        # (file_hash, knowledge_base_id) pair between our SELECT-based dup
+        # check and the INSERT. Clean up the orphan file and return the same
+        # 409 the pre-insert check produces so the frontend opens the
+        # duplicate dialog either way.
         if file_path.exists():
             try:
                 os.remove(file_path)
             except OSError as cleanup_err:
                 logger.warning(f"failed to clean up orphan upload {file_path}: {cleanup_err}")
-        await rag.db.rollback()
-        winner_q = await rag.db.execute(
-            select(Document).where(
-                Document.file_hash == file_hash,
-                Document.knowledge_base_id == knowledge_base_id,
-            )
-        )
-        winner = winner_q.scalar_one_or_none()
-        logger.warning(
-            f"Concurrent duplicate upload detected for hash {file_hash[:16]}... "
-            f"(kb={knowledge_base_id}); returning 409 with winner id={winner.id if winner else 'unknown'}"
-        )
+        winner = dup.winner
         raise HTTPException(
             status_code=409,
             detail={
@@ -418,6 +394,16 @@ async def upload_document(
                 },
             },
         )
+    except IntegrityError:
+        # Non-hash-race integrity error (FK / NOT NULL): the helper already
+        # rolled back and re-raised. Keep the original opaque 500 — don't leak
+        # the failed INSERT statement + driver error in the response body.
+        if file_path.exists():
+            try:
+                os.remove(file_path)
+            except OSError as cleanup_err:
+                logger.warning(f"failed to clean up orphan upload {file_path}: {cleanup_err}")
+        raise HTTPException(status_code=500, detail="Database integrity error")
     except Exception as e:
         if file_path.exists():
             try:

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -28,6 +28,7 @@ from api.routes import (
     federation_pairing,
     federation_query,
     feedback,
+    folder_ingest,
     intents,
     knowledge,
     memory,
@@ -177,6 +178,7 @@ app.include_router(settings_routes.router, prefix="/api/settings", tags=["Settin
 app.include_router(config_routes.router, prefix="/api/config", tags=["Config"])
 app.include_router(speakers.router, prefix="/api/speakers", tags=["Speakers"])
 app.include_router(knowledge.router, prefix="/api/knowledge", tags=["Knowledge"])
+app.include_router(folder_ingest.router, prefix="/api/folder-ingest", tags=["Folder Ingest"])
 app.include_router(memory.router, prefix="/api/memory", tags=["Memory"])
 app.include_router(preferences.router, prefix="/api/preferences", tags=["Preferences"])
 app.include_router(mcp_routes.router, prefix="/api/mcp", tags=["MCP"])

--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -1659,12 +1659,17 @@ SETTING_WAKEWORD_KEYWORD = "wakeword.keyword"
 SETTING_WAKEWORD_THRESHOLD = "wakeword.threshold"
 SETTING_WAKEWORD_COOLDOWN_MS = "wakeword.cooldown_ms"
 SETTING_NOTIFICATION_WEBHOOK_TOKEN = "notification.webhook_token"
+# Revocable Bearer token the renfield-mcp-filesystem server presents on the
+# folder-ingest push (POST /api/folder-ingest/document). Minted by the admin
+# token route (T14), verified constant-time on every push.
+SETTING_FOLDER_INGEST_TOKEN = "folder_ingest.token"
 
 SYSTEM_SETTING_KEYS = [
     SETTING_WAKEWORD_KEYWORD,
     SETTING_WAKEWORD_THRESHOLD,
     SETTING_WAKEWORD_COOLDOWN_MS,
     SETTING_NOTIFICATION_WEBHOOK_TOKEN,
+    SETTING_FOLDER_INGEST_TOKEN,
 ]
 
 

--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -250,6 +250,15 @@ class Document(Base):
     page_count = Column(Integer, nullable=True)
     chunk_count = Column(Integer, default=0)
 
+    # Folder-ingest Paperless leg (D2/D10). Tracks whether this document has
+    # been filed into Paperless by the folder-ingest bridge, so a re-pushed
+    # already-completed document runs ONLY the still-missing Paperless step
+    # instead of re-ingesting. NULL = never attempted (normal uploads, and
+    # existing rows pre-migration); see PAPERLESS_STATE_* constants below.
+    # "done" (filed / duplicate-marker terminal / skipped) is the only value
+    # that counts as paperless-done for the dedup matrix.
+    paperless_state = Column(String(20), nullable=True)
+
     # Timestamps
     created_at = Column(DateTime, default=_utcnow)
     processed_at = Column(DateTime, nullable=True)
@@ -536,6 +545,15 @@ DOC_STATUS_COMPLETED = "completed"
 DOC_STATUS_FAILED = "failed"
 
 DOC_STATUSES = [DOC_STATUS_PENDING, DOC_STATUS_PROCESSING, DOC_STATUS_COMPLETED, DOC_STATUS_FAILED]
+
+# Folder-ingest Paperless leg state (Document.paperless_state). NULL = the
+# Paperless step was never attempted for this row. "pending"/"failed" are
+# retryable (not paperless-done); only "done" terminates the leg — it covers a
+# successful file, a Paperless duplicate-marker reject (D10, the doc is already
+# there), and the to_paperless-disabled skip.
+PAPERLESS_STATE_PENDING = "pending"
+PAPERLESS_STATE_DONE = "done"
+PAPERLESS_STATE_FAILED = "failed"
 
 
 # Chunk Type Constants

--- a/src/backend/services/action_executor.py
+++ b/src/backend/services/action_executor.py
@@ -100,6 +100,19 @@ class ActionExecutor:
                 user_id=user_id,
             )
 
+        # Platform-owned internal tool: interactive folder-ingest. The agent
+        # passes a file ``path`` on a watched share; the tool pulls the bytes
+        # through the filesystem MCP (truncate=False) and runs them through the
+        # same ingest bridge as the REST push path. mcp_manager + the
+        # authenticated user_id (the file's owner) are injected here.
+        if intent == "internal.ingest_file":
+            from services.folder_ingest_tool import ingest_file
+            return await ingest_file(
+                parameters,
+                mcp_manager=self.mcp_manager,
+                user_id=user_id,
+            )
+
         # Paperless commit (second half of the two-tool confirm flow).
         # Reads a pending-confirm row created by forward_attachment_to_paperless
         # during the cold-start window (first N uploads) and finalises the

--- a/src/backend/services/folder_ingest.py
+++ b/src/backend/services/folder_ingest.py
@@ -465,6 +465,20 @@ async def resolve_target_kb(db: AsyncSession) -> KnowledgeBase:
     return kb
 
 
+async def target_kb_exists(db: AsyncSession) -> bool:
+    """Whether the configured folder-ingest target KB already exists. SELECT
+    only — unlike :func:`resolve_target_kb` it does NOT create the KB, so the
+    health handshake can report provisioning state without a side effect."""
+    kb_id = (
+        await db.execute(
+            select(KnowledgeBase.id).where(
+                KnowledgeBase.name == settings.folder_ingest_kb_name
+            )
+        )
+    ).scalar_one_or_none()
+    return kb_id is not None
+
+
 async def resolve_owner_user_id(db: AsyncSession) -> int | None:
     """Resolve ``folder_ingest_target_user`` (username or numeric id) to a user
     id. Empty config → None (the bridge/worker handle an ownerless enqueue the

--- a/src/backend/services/folder_ingest.py
+++ b/src/backend/services/folder_ingest.py
@@ -45,7 +45,9 @@ from models.database import (
     PAPERLESS_STATE_FAILED,
     SETTING_FOLDER_INGEST_TOKEN,
     Document,
+    KnowledgeBase,
     SystemSetting,
+    User,
 )
 
 # paperless_state values that mean "the Paperless leg is settled" — either it
@@ -193,6 +195,7 @@ async def ingest_document(
     db: AsyncSession,
     kb_id: int | None,
     owner_user_id: int | None = None,
+    default_tier: int | None = None,
     paperless_leg: PaperlessLeg | None = None,
     force_ocr: bool = False,
 ) -> IngestResult:
@@ -201,9 +204,11 @@ async def ingest_document(
 
     Steps: (0) persist a recovery byte copy, (1) reject bad ext/oversize,
     (2) completion+Paperless-aware dedup (D2), (3) race-safe create (D3) +
-    enqueue, (4) Paperless leg, (5) respond. The owner/tier override (D4) is
-    derived from the target KB here; the explicit ``folder_ingest_target_user``
-    / ``folder_ingest_default_tier`` wiring lands in T6.
+    enqueue, (4) Paperless leg, (5) respond. D4 owner/tier: ``owner_user_id``
+    (the configured ``folder_ingest_target_user``, None → KB owner / first user)
+    and ``default_tier`` (the configured ``folder_ingest_default_tier``, None →
+    KB default tier) are applied as overrides at create — auto-filed documents
+    are owned by the configured user at the configured tier regardless of the KB.
 
     ``paperless_leg`` is the Paperless-filing seam: pass the real leg (T5) to
     file into Paperless, or ``None`` to skip filing entirely — the latter marks
@@ -312,6 +317,8 @@ async def ingest_document(
                 knowledge_base_id=kb_id,
                 filename=meta.filename,
                 file_hash=file_hash,
+                owner_user_id_override=owner_user_id,  # D4: configured owner
+                circle_tier_override=default_tier,  # D4: configured tier
             )
         except DuplicateDocumentError as dup:
             # Lost-race: a concurrent push committed the same (hash, kb)
@@ -428,3 +435,53 @@ async def verify_folder_ingest_token(db: AsyncSession, token: str) -> bool:
     if not stored:
         return False
     return secrets.compare_digest(stored, token)
+
+
+# ---------------------------------------------------------------------------
+# Target KB + owner resolution (shared by the push route and the
+# internal.ingest_file agent tool). Both file into the single configured
+# (folder_ingest_kb_name, folder_ingest_target_user) destination.
+# ---------------------------------------------------------------------------
+
+async def resolve_target_kb(db: AsyncSession) -> KnowledgeBase:
+    """Get-or-create the configured folder-ingest target KB. Mirrors the
+    chat-upload default-KB pattern so a fresh install just works."""
+    kb = (
+        await db.execute(
+            select(KnowledgeBase).where(
+                KnowledgeBase.name == settings.folder_ingest_kb_name
+            )
+        )
+    ).scalar_one_or_none()
+    if kb:
+        return kb
+    kb = KnowledgeBase(
+        name=settings.folder_ingest_kb_name,
+        description="Auto-ingested documents from watched folders",
+    )
+    db.add(kb)
+    await db.commit()
+    await db.refresh(kb)
+    return kb
+
+
+async def resolve_owner_user_id(db: AsyncSession) -> int | None:
+    """Resolve ``folder_ingest_target_user`` (username or numeric id) to a user
+    id. Empty config → None (the bridge/worker handle an ownerless enqueue the
+    same way the upload route does for unauthenticated single-user mode)."""
+    target = settings.folder_ingest_target_user.strip()
+    if not target:
+        return None
+    user = (
+        await db.execute(select(User).where(User.username == target))
+    ).scalar_one_or_none()
+    if user is None and target.isdigit():
+        user = (
+            await db.execute(select(User).where(User.id == int(target)))
+        ).scalar_one_or_none()
+    if user is None:
+        logger.warning(
+            f"folder-ingest: target_user {target!r} not found; using ownerless"
+        )
+        return None
+    return user.id

--- a/src/backend/services/folder_ingest.py
+++ b/src/backend/services/folder_ingest.py
@@ -42,10 +42,16 @@ from models.database import (
     DOC_STATUS_FAILED,
     DOC_STATUS_PENDING,
     PAPERLESS_STATE_DONE,
+    PAPERLESS_STATE_FAILED,
     SETTING_FOLDER_INGEST_TOKEN,
     Document,
     SystemSetting,
 )
+
+# paperless_state values that mean "the Paperless leg is settled" — either it
+# was filed/duplicate (done) or terminally rejected for a non-duplicate reason
+# (failed). Both stop the D2 matrix re-running the leg; only None/unset retries.
+_PAPERLESS_SETTLED = (PAPERLESS_STATE_DONE, PAPERLESS_STATE_FAILED)
 from services.rag_service import DuplicateDocumentError, RAGService
 from services.redis_client import get_redis
 from services.task_queue import DocumentTaskQueue
@@ -131,7 +137,7 @@ async def classify_existing(
     if doc is None:
         return _Decision.CREATE, None
     if doc.status == DOC_STATUS_COMPLETED:
-        if doc.paperless_state == PAPERLESS_STATE_DONE:
+        if doc.paperless_state in _PAPERLESS_SETTLED:
             return _Decision.DUPLICATE, doc
         return _Decision.PAPERLESS_ONLY, doc
     if doc.status == DOC_STATUS_FAILED:
@@ -254,17 +260,23 @@ async def ingest_document(
 
     if decision is _Decision.PAPERLESS_ONLY:
         # KB ingest is complete but the Paperless leg never settled. Run only
-        # the still-missing leg, then report duplicate (the KB already has it,
-        # so the MCP moves the file to processed/).
+        # the still-missing leg. If it settles (filed/duplicate/terminal-reject)
+        # report duplicate so the MCP moves the file to processed/; if it
+        # couldn't settle (upload error / consume still pending) report retry so
+        # the MCP re-pushes and the leg is attempted again.
         try:
-            await leg(db, existing, file_bytes, meta)
+            settled = await leg(db, existing, file_bytes, meta)
         except Exception as exc:  # noqa: BLE001 - leg failure is non-fatal
             logger.warning(f"folder-ingest: Paperless-only leg failed: {exc}")
             return IngestResult(
                 IngestStatus.RETRY, document_id=existing.id, detail="paperless_retry"
             )
+        if settled:
+            return IngestResult(
+                IngestStatus.DUPLICATE, document_id=existing.id, detail="paperless_filed"
+            )
         return IngestResult(
-            IngestStatus.DUPLICATE, document_id=existing.id, detail="paperless_filed"
+            IngestStatus.RETRY, document_id=existing.id, detail="paperless_pending"
         )
 
     # decision is CREATE or REINGEST: run the full pipeline.
@@ -316,7 +328,7 @@ async def ingest_document(
             if (
                 winner is not None
                 and winner.status == DOC_STATUS_COMPLETED
-                and winner.paperless_state == PAPERLESS_STATE_DONE
+                and winner.paperless_state in _PAPERLESS_SETTLED
             ):
                 return IngestResult(
                     IngestStatus.DUPLICATE,
@@ -343,8 +355,12 @@ async def ingest_document(
     )
 
     # 4. Paperless leg (best-effort — never fails the KB ingest; the row is
-    # already enqueued). A leg failure leaves paperless_state un-done so a
-    # later D2 PAPERLESS_ONLY pass retries it.
+    # already enqueued, so we respond INGESTED regardless of the leg). The leg
+    # records its own outcome on paperless_state. KNOWN GAP: on this CREATE path
+    # the response is INGESTED → the MCP moves the file to processed/, so a leg
+    # that didn't settle (transient Paperless outage) is NOT auto-retried — the
+    # document is in the KB but missing from Paperless until a manual re-push or
+    # a future paperless-reconciler (P2). A leg exception is likewise swallowed.
     try:
         await leg(db, doc, file_bytes, meta)
     except Exception as exc:  # noqa: BLE001

--- a/src/backend/services/folder_ingest.py
+++ b/src/backend/services/folder_ingest.py
@@ -1,0 +1,357 @@
+"""Folder-ingest bridge — the shared service behind watch-folder auto-ingest.
+
+The dedicated ``renfield-mcp-filesystem`` server pushes a settled new file to
+``POST /api/folder-ingest/document`` (Bearer); the route reads the bytes
+(stream-hash, early size abort) and hands them here. This module is also the
+target of the interactive ``internal.ingest_file`` agent tool, which pulls the
+bytes via the filesystem MCP. Either way the backend never mounts the share —
+bytes arrive as a parameter.
+
+The load-bearing seam is the **4-state result** (D9). The MCP keys its move
+decision off it, and ``ingested`` means *enqueued*, not OCR'd:
+
+    ingested   new row created + enqueued (202-equivalent)  -> move to processed/
+    duplicate  row exists, completed, Paperless leg settled  -> move to processed/
+    retry      worker down OR row pending/processing          -> leave in inbox, re-push
+    failed     terminal reject (bad ext, oversize, ...)        -> move to failed/
+
+Idempotency: the inbox IS the queue. A lost HTTP response → the MCP re-pushes →
+the completion+Paperless-aware dedup (D2) returns ``duplicate``/``retry`` (never
+a 500). The backend persists its own byte copy (step 0) so a worker retry
+survives the MCP having moved the source file.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+import aiofiles
+from loguru import logger
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import (
+    DOC_STATUS_COMPLETED,
+    DOC_STATUS_FAILED,
+    DOC_STATUS_PENDING,
+    PAPERLESS_STATE_DONE,
+    Document,
+)
+from services.rag_service import DuplicateDocumentError, RAGService
+from services.redis_client import get_redis
+from services.task_queue import DocumentTaskQueue
+from utils.config import settings
+
+
+class IngestStatus(str, Enum):
+    """The 4-state response contract (D9). The MCP moves the source file by
+    this value, so the names are part of the cross-repo seam — do not rename
+    without bumping ``FOLDER_INGEST_CONTRACT_VERSION``."""
+
+    INGESTED = "ingested"
+    DUPLICATE = "duplicate"
+    RETRY = "retry"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class IngestResult:
+    status: IngestStatus
+    document_id: int | None = None
+    detail: str | None = None
+
+
+@dataclass(frozen=True)
+class IngestMeta:
+    """Parsed metadata that rides alongside the pushed bytes."""
+
+    filename: str
+    root: str | None = None
+    relpath: str | None = None
+    sha256: str | None = None
+    mime: str | None = None
+
+    @classmethod
+    def from_dict(cls, raw: dict) -> "IngestMeta":
+        filename = str(raw.get("filename") or raw.get("relpath") or "").strip()
+        if not filename:
+            raise ValueError("metadata is missing a filename")
+        return cls(
+            filename=os.path.basename(filename.replace("\x00", "")),
+            root=raw.get("root"),
+            relpath=raw.get("relpath"),
+            sha256=raw.get("sha256"),
+            mime=raw.get("mime"),
+        )
+
+
+class _Decision(str, Enum):
+    """Outcome of the dedup classification against the existing Document row.
+    Kept separate from :class:`IngestStatus` because one decision
+    (``PAPERLESS_ONLY``) does work before resolving to a response state."""
+
+    CREATE = "create"  # no row → run the full pipeline
+    DUPLICATE = "duplicate"  # completed AND Paperless-done → nothing to do
+    REINGEST = "reingest"  # status=failed → re-run the full pipeline
+    PAPERLESS_ONLY = "paperless_only"  # completed but Paperless not yet done
+    RETRY = "retry"  # pending/processing → don't double-enqueue
+
+
+async def classify_existing(
+    db: AsyncSession, file_hash: str, kb_id: int | None
+) -> tuple[_Decision, Document | None]:
+    """Completion+Paperless-aware dedup (D2). Pure read against the
+    ``(file_hash, knowledge_base_id)`` row; the orchestrator turns the
+    decision into a 4-state response. Factored out so the risky SQL branch is
+    unit-tested directly against real Postgres."""
+    doc = (
+        await db.execute(
+            select(Document).where(
+                Document.file_hash == file_hash,
+                Document.knowledge_base_id == kb_id,
+            )
+        )
+    ).scalar_one_or_none()
+
+    if doc is None:
+        return _Decision.CREATE, None
+    if doc.status == DOC_STATUS_COMPLETED:
+        if doc.paperless_state == PAPERLESS_STATE_DONE:
+            return _Decision.DUPLICATE, doc
+        return _Decision.PAPERLESS_ONLY, doc
+    if doc.status == DOC_STATUS_FAILED:
+        return _Decision.REINGEST, doc
+    # pending / processing — the worker still owns this row.
+    return _Decision.RETRY, doc
+
+
+# A Paperless leg is an injected coroutine so the orchestrator stays testable
+# and T5 can swap in the real PaperlessMetadataExtractor (D5) + duplicate-marker
+# detection (D10) without touching the dedup/4-state control flow. It MUST set
+# ``doc.paperless_state`` and commit, and returns True when the leg is settled
+# (filed / duplicate / skipped) — i.e. paperless-done for the D2 matrix.
+PaperlessLeg = Callable[
+    [AsyncSession, Document, bytes, IngestMeta], Awaitable[bool]
+]
+
+
+async def _noop_paperless_leg(
+    db: AsyncSession, doc: Document, file_bytes: bytes, meta: IngestMeta
+) -> bool:
+    """Default when Paperless filing is disabled or no leg is supplied: mark
+    the leg settled so a re-push of this document dedups cleanly (D2).
+    Idempotent — a no-op if the leg already settled."""
+    if doc.paperless_state == PAPERLESS_STATE_DONE:
+        return True
+    doc.paperless_state = PAPERLESS_STATE_DONE
+    await db.commit()
+    return True
+
+
+def _ext_ok(filename: str) -> bool:
+    ext = Path(filename).suffix.lstrip(".").lower()
+    return bool(ext) and ext in settings.allowed_extensions_list
+
+
+async def _persist_bytes(file_bytes: bytes, filename: str) -> str:
+    """Step 0 (D9): write the recovery copy to ``upload_dir`` BEFORE any
+    create/enqueue, so a worker retry survives the MCP moving the source."""
+    upload_dir = Path(settings.upload_dir)
+    upload_dir.mkdir(parents=True, exist_ok=True)
+    safe_name = os.path.basename((filename or "unknown").replace("\x00", ""))
+    file_path = upload_dir / f"{uuid.uuid4().hex}_{safe_name}"
+    async with aiofiles.open(file_path, "wb") as f:
+        await f.write(file_bytes)
+    return str(file_path)
+
+
+async def ingest_document(
+    file_bytes: bytes,
+    meta: IngestMeta,
+    *,
+    db: AsyncSession,
+    kb_id: int | None,
+    owner_user_id: int | None = None,
+    paperless_leg: PaperlessLeg | None = None,
+    force_ocr: bool = False,
+) -> IngestResult:
+    """Run the folder-ingest pipeline for one pushed file and return the
+    4-state result (D9). See the module docstring for the contract.
+
+    Steps: (0) persist a recovery byte copy, (1) reject bad ext/oversize,
+    (2) completion+Paperless-aware dedup (D2), (3) race-safe create (D3) +
+    enqueue, (4) Paperless leg, (5) respond. The owner/tier override (D4) is
+    derived from the target KB here; the explicit ``folder_ingest_target_user``
+    / ``folder_ingest_default_tier`` wiring lands in T6.
+
+    ``paperless_leg`` is the Paperless-filing seam: pass the real leg (T5) to
+    file into Paperless, or ``None`` to skip filing entirely — the latter marks
+    ``paperless_state='done'`` (nothing to file ⇒ settled), so the caller maps
+    ``folder_ingest_to_paperless=False`` to ``None``. It is NEVER defaulted to a
+    silent no-op while Paperless is meant to be on: the caller owns that choice.
+    """
+    # 1. Reject bad extension / empty / oversize up front (before touching
+    # disk/DB).
+    if not _ext_ok(meta.filename):
+        logger.warning(f"folder-ingest: rejected extension for {meta.filename!r}")
+        return IngestResult(IngestStatus.FAILED, detail="extension_not_allowed")
+    if not file_bytes:
+        # A 0-byte push (scanner artifact / truncated-to-empty transfer) would
+        # otherwise create an empty Document that pollutes retrieval. Terminal.
+        logger.warning(f"folder-ingest: empty file rejected for {meta.filename!r}")
+        return IngestResult(IngestStatus.FAILED, detail="empty_file")
+    max_bytes = settings.max_file_size_mb * 1024 * 1024
+    if len(file_bytes) > max_bytes:
+        logger.warning(
+            f"folder-ingest: {meta.filename!r} exceeds "
+            f"{settings.max_file_size_mb} MB ceiling"
+        )
+        return IngestResult(IngestStatus.FAILED, detail="file_too_large")
+
+    file_hash = hashlib.sha256(file_bytes).hexdigest()
+    if meta.sha256 and meta.sha256.lower() != file_hash:
+        # The MCP's pre-push hash disagrees with the bytes we received —
+        # a truncated/corrupted transfer. Retryable; the MCP re-pushes.
+        logger.warning(
+            f"folder-ingest: sha256 mismatch for {meta.filename!r} "
+            f"(meta={meta.sha256[:16]}... actual={file_hash[:16]}...)"
+        )
+        return IngestResult(IngestStatus.RETRY, detail="sha256_mismatch")
+
+    # No leg supplied ⇒ Paperless filing is off for this call; the no-op leg
+    # records the leg as settled so a re-push dedups cleanly (D2).
+    leg = paperless_leg or _noop_paperless_leg
+
+    # 2. Dedup against the existing row (D2).
+    decision, existing = await classify_existing(db, file_hash, kb_id)
+
+    if decision is _Decision.DUPLICATE:
+        return IngestResult(
+            IngestStatus.DUPLICATE, document_id=existing.id, detail="already_ingested"
+        )
+
+    if decision is _Decision.RETRY:
+        # The worker still owns this row (pending/processing). Don't
+        # double-enqueue; the MCP leaves the file in the inbox and re-pushes.
+        return IngestResult(
+            IngestStatus.RETRY, document_id=existing.id, detail="in_progress"
+        )
+
+    if decision is _Decision.PAPERLESS_ONLY:
+        # KB ingest is complete but the Paperless leg never settled. Run only
+        # the still-missing leg, then report duplicate (the KB already has it,
+        # so the MCP moves the file to processed/).
+        try:
+            await leg(db, existing, file_bytes, meta)
+        except Exception as exc:  # noqa: BLE001 - leg failure is non-fatal
+            logger.warning(f"folder-ingest: Paperless-only leg failed: {exc}")
+            return IngestResult(
+                IngestStatus.RETRY, document_id=existing.id, detail="paperless_retry"
+            )
+        return IngestResult(
+            IngestStatus.DUPLICATE, document_id=existing.id, detail="paperless_filed"
+        )
+
+    # decision is CREATE or REINGEST: run the full pipeline.
+    try:
+        file_path = await _persist_bytes(file_bytes, meta.filename)
+    except OSError as exc:
+        # Disk full / permission denied writing the recovery copy. Transient —
+        # the MCP leaves the file in the inbox and re-pushes rather than losing
+        # it to failed/.
+        logger.error(f"folder-ingest: persist failed for {meta.filename!r}: {exc}")
+        return IngestResult(IngestStatus.RETRY, detail="persist_error")
+
+    if decision is _Decision.REINGEST:
+        # A prior terminal failure (D9 worker-set status=failed). Re-point the
+        # row at the fresh recovery copy, reset the KB-pipeline state, and
+        # re-enqueue rather than spawning a second row for the same (hash, kb).
+        # paperless_state is preserved: if the Paperless leg already settled
+        # ('done') a re-file would duplicate, so the idempotent leg skips it;
+        # if it never settled it re-runs below.
+        stale_path = existing.file_path
+        existing.file_path = file_path
+        existing.status = DOC_STATUS_PENDING
+        existing.error_message = None
+        await db.commit()
+        if stale_path and stale_path != file_path:
+            _cleanup(stale_path)  # the prior failed copy is now orphaned
+        doc = existing
+    else:
+        rag = RAGService(db)
+        try:
+            doc = await rag.create_document_record_safe(
+                file_path=file_path,
+                knowledge_base_id=kb_id,
+                filename=meta.filename,
+                file_hash=file_hash,
+            )
+        except DuplicateDocumentError as dup:
+            # Lost-race: a concurrent push committed the same (hash, kb)
+            # between our classify SELECT and the INSERT. Drop the orphan copy
+            # and report on the winner — retry if it's still in flight, else
+            # duplicate. Never a 500 (idempotency property).
+            _cleanup(file_path)
+            winner = dup.winner
+            # Mirror the classify_existing matrix on the winning row: only a
+            # completed AND Paperless-settled winner is a terminal duplicate.
+            # A completed-but-Paperless-missing (or still-in-flight) winner is
+            # RETRY, so the re-push routes through PAPERLESS_ONLY / pending next
+            # pass instead of being moved to processed/ with Paperless unfiled.
+            if (
+                winner is not None
+                and winner.status == DOC_STATUS_COMPLETED
+                and winner.paperless_state == PAPERLESS_STATE_DONE
+            ):
+                return IngestResult(
+                    IngestStatus.DUPLICATE,
+                    document_id=winner.id,
+                    detail="concurrent_winner",
+                )
+            return IngestResult(
+                IngestStatus.RETRY,
+                document_id=winner.id if winner else None,
+                detail="concurrent_in_progress",
+            )
+        except Exception as exc:  # noqa: BLE001
+            _cleanup(file_path)
+            logger.error(f"folder-ingest: create failed for {meta.filename!r}: {exc}")
+            return IngestResult(IngestStatus.FAILED, detail="create_error")
+
+    queue = DocumentTaskQueue(redis_client=get_redis())
+    await queue.enqueue(
+        {
+            "document_id": doc.id,
+            "force_ocr": force_ocr,
+            "user_id": owner_user_id,
+        }
+    )
+
+    # 4. Paperless leg (best-effort — never fails the KB ingest; the row is
+    # already enqueued). A leg failure leaves paperless_state un-done so a
+    # later D2 PAPERLESS_ONLY pass retries it.
+    try:
+        await leg(db, doc, file_bytes, meta)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            f"folder-ingest: Paperless leg failed for doc {doc.id} "
+            f"(KB ingest unaffected): {exc}"
+        )
+
+    return IngestResult(
+        IngestStatus.INGESTED, document_id=doc.id, detail="enqueued"
+    )
+
+
+def _cleanup(file_path: str) -> None:
+    try:
+        if os.path.exists(file_path):
+            os.remove(file_path)
+    except OSError as exc:
+        logger.warning(f"folder-ingest: failed to clean up {file_path}: {exc}")

--- a/src/backend/services/folder_ingest.py
+++ b/src/backend/services/folder_ingest.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import secrets
 import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -41,12 +42,20 @@ from models.database import (
     DOC_STATUS_FAILED,
     DOC_STATUS_PENDING,
     PAPERLESS_STATE_DONE,
+    SETTING_FOLDER_INGEST_TOKEN,
     Document,
+    SystemSetting,
 )
 from services.rag_service import DuplicateDocumentError, RAGService
 from services.redis_client import get_redis
 from services.task_queue import DocumentTaskQueue
 from utils.config import settings
+
+# Cross-repo push-contract version (DX-7). Sent in the request + response
+# header; the MCP treats an unknown response status as `retry` and logs a skew
+# WARN. Mirror of auth/provider_contract.py::PROVIDER_RESULT_CONTRACT_VERSION.
+# Bump on ANY change to the request/response shape or the IngestStatus names.
+FOLDER_INGEST_CONTRACT_VERSION = "1"
 
 
 class IngestStatus(str, Enum):
@@ -355,3 +364,51 @@ def _cleanup(file_path: str) -> None:
             os.remove(file_path)
     except OSError as exc:
         logger.warning(f"folder-ingest: failed to clean up {file_path}: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Bearer token management (mirrors NotificationService.{get,generate,verify}_
+# webhook_token). The token authenticates the MCP→backend push; it lives in
+# SystemSetting so it is revocable without a redeploy. generate_ backs the
+# admin mint route (T14); verify_ guards the push route (T3).
+# ---------------------------------------------------------------------------
+
+async def get_folder_ingest_token(db: AsyncSession) -> str | None:
+    """Return the stored folder-ingest Bearer token, or None if unset."""
+    setting = (
+        await db.execute(
+            select(SystemSetting).where(
+                SystemSetting.key == SETTING_FOLDER_INGEST_TOKEN
+            )
+        )
+    ).scalar_one_or_none()
+    return setting.value if setting else None
+
+
+async def generate_folder_ingest_token(db: AsyncSession) -> str:
+    """Mint a new folder-ingest token (rotating any existing one) and persist
+    it to SystemSetting. Returns the plaintext token (shown once to the admin)."""
+    token = secrets.token_urlsafe(48)
+    existing = (
+        await db.execute(
+            select(SystemSetting).where(
+                SystemSetting.key == SETTING_FOLDER_INGEST_TOKEN
+            )
+        )
+    ).scalar_one_or_none()
+    if existing:
+        existing.value = token
+    else:
+        db.add(SystemSetting(key=SETTING_FOLDER_INGEST_TOKEN, value=token))
+    await db.commit()
+    logger.info("🔑 folder-ingest token (re)generated")
+    return token
+
+
+async def verify_folder_ingest_token(db: AsyncSession, token: str) -> bool:
+    """Constant-time compare a presented Bearer token against the stored one.
+    False when no token is configured (feature unprovisioned)."""
+    stored = await get_folder_ingest_token(db)
+    if not stored:
+        return False
+    return secrets.compare_digest(stored, token)

--- a/src/backend/services/folder_ingest_paperless.py
+++ b/src/backend/services/folder_ingest_paperless.py
@@ -1,0 +1,189 @@
+"""The folder-ingest Paperless leg (T5/T10) — the real ``PaperlessLeg`` the
+push route wires into ``folder_ingest.ingest_document`` when
+``folder_ingest_to_paperless`` is on.
+
+It files the document into Paperless and records the outcome on
+``Document.paperless_state`` so the D2 dedup matrix never re-runs a settled leg:
+
+  - extract metadata (best-effort, D5) from the document's persisted recovery
+    copy via the now-ChatUpload-decoupled ``PaperlessMetadataExtractor``;
+  - ``mcp.paperless.upload_document(wait_for_consume=False)`` — returns fast on
+    accept (Paperless decides duplicate/parse-failure later, in consume);
+  - ``mcp.paperless.await_consume_result(task_id)`` — the MCP polls the consume
+    task and reports the terminal outcome, classifying Paperless's duplicate
+    marker (D10) so the marker-string knowledge lives in the MCP, not here.
+
+State mapping (``paperless_state``):
+  - success / duplicate  → ``done``   (filed, or already there) — leg settled.
+  - non-duplicate failure → ``failed`` (Paperless rejected it; retry won't help)
+                                       — leg settled (terminal, prevents a loop).
+  - upload error / pending-timeout → left un-set — NOT settled, retried later.
+
+The leg returns True when settled (done or failed), False when it should be
+retried. Best-effort throughout: a Paperless hiccup never fails the KB ingest
+(the bridge already enqueued the document).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+
+from loguru import logger
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import (
+    PAPERLESS_STATE_DONE,
+    PAPERLESS_STATE_FAILED,
+    Document,
+)
+from services.folder_ingest import _PAPERLESS_SETTLED, IngestMeta, PaperlessLeg
+
+
+def _parse_paperless_result(mcp_result: dict | None) -> dict:
+    """Unwrap the MCPManager envelope to the paperless tool's own dict.
+
+    The tool's return (``{task_id, ...}`` / ``{status, ...}`` / ``{error}``) is
+    JSON-encoded in ``mcp_result["message"]``; ``mcp_result["success"]`` is the
+    transport-level envelope flag. Returns ``{"error": ...}`` on a transport
+    failure or an unparseable body."""
+    if not mcp_result or not mcp_result.get("success"):
+        return {"error": (mcp_result or {}).get("message") or "mcp_transport_error"}
+    msg = mcp_result.get("message")
+    if isinstance(msg, str):
+        try:
+            inner = json.loads(msg)
+            if isinstance(inner, dict):
+                return inner
+        except (json.JSONDecodeError, TypeError):
+            pass
+    return {"error": "unparseable_paperless_response"}
+
+
+def make_paperless_leg(
+    mcp_manager,
+    *,
+    user_id: int | None = None,
+    lang: str = "de",
+    await_timeout_s: float | None = None,
+) -> PaperlessLeg:
+    """Build a ``PaperlessLeg`` closure over the MCP manager + owner. The route
+    passes the result to ``ingest_document(paperless_leg=...)`` when Paperless
+    filing is enabled; ``None`` is passed when it is off."""
+
+    async def _leg(
+        db: AsyncSession, doc: Document, file_bytes: bytes, meta: IngestMeta
+    ) -> bool:
+        # Idempotent: a re-push of an already-settled leg (done OR terminally
+        # failed) does nothing. In practice classify_existing already routes a
+        # settled doc to DUPLICATE so the leg isn't called — this is defence in
+        # depth for any direct caller.
+        if doc.paperless_state in _PAPERLESS_SETTLED:
+            return True
+
+        # 1. Best-effort metadata extraction (D5) from the persisted recovery
+        # copy. Failure → bare upload (filename title only), never fatal.
+        upload_params: dict = {
+            "title": meta.filename,
+            "filename": meta.filename,
+            "file_content_base64": base64.b64encode(file_bytes).decode("ascii"),
+            # We drive the consume poll ourselves via await_consume_result, so
+            # the upload returns immediately on accept.
+            "wait_for_consume": False,
+        }
+        try:
+            from services.paperless_metadata_extractor import PaperlessMetadataExtractor
+
+            extractor = PaperlessMetadataExtractor(mcp_manager=mcp_manager)
+            extraction = await extractor.extract_from_file(
+                doc.file_path, user_id=user_id, lang=lang
+            )
+            if extraction.error:
+                logger.info(
+                    f"folder-ingest paperless: metadata extraction skipped "
+                    f"({extraction.error}); bare upload for doc {doc.id}"
+                )
+            else:
+                m = extraction.metadata
+                if m.title:
+                    upload_params["title"] = m.title
+                if m.correspondent:
+                    upload_params["correspondent"] = m.correspondent
+                if m.document_type:
+                    upload_params["document_type"] = m.document_type
+                if m.tags:
+                    upload_params["tags"] = m.tags
+        except Exception as exc:  # noqa: BLE001 - extractor is best-effort
+            logger.warning(
+                f"folder-ingest paperless: extractor error for doc {doc.id} "
+                f"(bare upload): {exc}"
+            )
+
+        # 2. Upload (non-blocking). Distinguish a TRANSPORT failure (MCP
+        # unreachable — envelope success=False) from a TOOL-LEVEL rejection
+        # (Paperless said no: bad field / 4xx / config — a body with `error`).
+        # Transport → transient, leave unset, retry. Tool rejection → terminal:
+        # re-sending the same bytes+metadata yields the same answer, so record
+        # FAILED (settled) rather than looping forever on PAPERLESS_ONLY re-pushes.
+        upload_raw = await mcp_manager.execute_tool(
+            "mcp.paperless.upload_document", upload_params
+        )
+        if not upload_raw or not upload_raw.get("success"):
+            logger.warning(
+                f"folder-ingest paperless: MCP transport failure uploading "
+                f"doc {doc.id}; will retry"
+            )
+            return False
+        upload = _parse_paperless_result(upload_raw)
+        task_id = upload.get("task_id")
+        if upload.get("error") or not task_id:
+            doc.paperless_state = PAPERLESS_STATE_FAILED
+            await db.commit()
+            logger.warning(
+                f"folder-ingest paperless: Paperless rejected doc {doc.id} "
+                f"({upload.get('error') or 'no task_id'}); recorded failed"
+            )
+            return True
+
+        # 3. Await the consume verdict via the MCP (it owns the duplicate-marker
+        # knowledge — D10).
+        outcome = _parse_paperless_result(
+            await mcp_manager.execute_tool(
+                "mcp.paperless.await_consume_result",
+                {"task_id": task_id, "timeout_s": await_timeout_s},
+            )
+        )
+        status = outcome.get("status")
+
+        if status in ("success", "duplicate"):
+            doc.paperless_state = PAPERLESS_STATE_DONE
+            await db.commit()
+            logger.info(
+                f"folder-ingest paperless: doc {doc.id} {status} "
+                f"(paperless_id={outcome.get('document_id')})"
+            )
+            return True
+
+        if status == "failure":
+            # Paperless rejected the document for a non-duplicate reason — it
+            # won't succeed on retry, so record a terminal FAILED state. Settled
+            # (don't loop); the KB still has the document, only Paperless filing
+            # is skipped (observable in Paperless's own failed-task log).
+            doc.paperless_state = PAPERLESS_STATE_FAILED
+            await db.commit()
+            logger.warning(
+                f"folder-ingest paperless: doc {doc.id} consume FAILED "
+                f"(non-duplicate): {outcome.get('detail')}"
+            )
+            return True
+
+        # pending (consume still running past the timeout) or an error reaching
+        # the task endpoint → not settled; leave paperless_state unset so a later
+        # pass retries.
+        logger.info(
+            f"folder-ingest paperless: doc {doc.id} consume not terminal "
+            f"({status or outcome.get('error')}); will retry"
+        )
+        return False
+
+    return _leg

--- a/src/backend/services/folder_ingest_tool.py
+++ b/src/backend/services/folder_ingest_tool.py
@@ -1,0 +1,134 @@
+"""``internal.ingest_file`` — the interactive folder-ingest agent tool (T6).
+
+The auto path is the REST push (MCP → backend). This is the agent-driven path:
+the user points at a file on a watched share and the agent ingests it. The
+bytes are pulled through the filesystem MCP (``mcp.files.read_file`` with
+``truncate=False`` so the 128 KB execute_tool cap doesn't corrupt the payload),
+NOT off the backend disk — the no-mount constraint holds. Everything after the
+read goes through the same ``folder_ingest.ingest_document`` bridge as the push
+route, so dedup / owner+tier / Paperless filing behave identically.
+
+Dispatched as a platform-core internal tool in ``services/action_executor.py``
+(it needs ``mcp_manager`` + the authenticated ``user_id`` injected).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+
+from loguru import logger
+
+from services.folder_ingest import (
+    IngestMeta,
+    IngestStatus,
+    ingest_document,
+    resolve_owner_user_id,
+    resolve_target_kb,
+)
+from utils.config import settings
+
+
+def _fail(message: str) -> dict:
+    return {"success": False, "message": message, "action_taken": False}
+
+
+def _unwrap_mcp(raw: dict | None) -> dict:
+    """Unwrap the MCPManager envelope to the files-tool's own dict (its return
+    is JSON-encoded in ``message``). ``{"error": ...}`` on transport failure /
+    unparseable body."""
+    if not raw or not raw.get("success"):
+        return {"error": (raw or {}).get("message") or "mcp_transport_error"}
+    msg = raw.get("message")
+    if isinstance(msg, str):
+        try:
+            inner = json.loads(msg)
+            if isinstance(inner, dict):
+                return inner
+        except (json.JSONDecodeError, TypeError):
+            pass
+    return {"error": "unparseable_read_file_response"}
+
+
+async def ingest_file(parameters: dict, *, mcp_manager, user_id: int | None = None) -> dict:
+    """Ingest a file the agent points at (``{path}``) via the filesystem MCP.
+
+    Returns the standard internal-tool envelope. The 4-state ingest result is
+    surfaced in ``data.status`` so the agent can explain duplicate / retry
+    outcomes to the user.
+    """
+    path = (parameters or {}).get("path")
+    if not path or not isinstance(path, str):
+        return _fail("ingest_file requires a 'path' string pointing at a watched file.")
+    if not settings.folder_ingest_enabled:
+        return _fail("Folder ingest is disabled (set FOLDER_INGEST_ENABLED).")
+    if mcp_manager is None:
+        return _fail("The filesystem MCP is unavailable; cannot read the file.")
+
+    # 1. Pull the full file through the filesystem MCP (truncate=False).
+    body = _unwrap_mcp(
+        await mcp_manager.execute_tool(
+            "mcp.files.read_file", {"path": path, "truncate": False}
+        )
+    )
+    b64 = body.get("content_base64") or body.get("content")
+    if body.get("error") or not b64:
+        return _fail(f"Could not read {path}: {body.get('error') or 'no content returned'}")
+    try:
+        # validate=True so a corrupt/truncated payload fails loudly instead of
+        # silently dropping non-alphabet chars into garbage bytes (mirrors the
+        # paperless MCP's strict decode).
+        file_bytes = base64.b64decode(b64, validate=True)
+    except Exception:
+        return _fail(f"The filesystem MCP returned invalid base64 for {path}.")
+
+    filename = body.get("filename") or os.path.basename(path)
+    try:
+        meta = IngestMeta.from_dict({"filename": filename, "relpath": path, "root": "internal"})
+    except ValueError as exc:
+        return _fail(f"Bad file metadata: {exc}")
+
+    # 2. Don't enqueue into a stream no worker is consuming.
+    from api.routes.knowledge import _worker_is_alive
+
+    if not await _worker_is_alive():
+        return _fail("The document worker is unavailable right now; try again shortly.")
+
+    # 3. Build the Paperless leg (when enabled) + resolve the destination, then
+    # run the shared bridge. The asker owns what they ingest (user_id); fall
+    # back to the configured target_user only in unauthenticated single-user mode.
+    from services.database import AsyncSessionLocal
+
+    leg = None
+    if settings.folder_ingest_to_paperless:
+        from services.folder_ingest_paperless import make_paperless_leg
+
+        leg = make_paperless_leg(mcp_manager, user_id=user_id)
+
+    async with AsyncSessionLocal() as db:
+        kb = await resolve_target_kb(db)
+        owner = user_id if user_id is not None else await resolve_owner_user_id(db)
+        result = await ingest_document(
+            file_bytes,
+            meta,
+            db=db,
+            kb_id=kb.id,
+            owner_user_id=owner,
+            default_tier=settings.folder_ingest_default_tier,
+            paperless_leg=leg,
+        )
+
+    logger.info(f"internal.ingest_file: {filename} → {result.status.value} (doc {result.document_id})")
+    human = {
+        IngestStatus.INGESTED: f"Ingested {filename} (document {result.document_id}); it is being indexed.",
+        IngestStatus.DUPLICATE: f"{filename} is already in the knowledge base — nothing to do.",
+        IngestStatus.RETRY: f"{filename} couldn't be ingested right now; please try again shortly.",
+        IngestStatus.FAILED: f"{filename} was rejected ({result.detail}).",
+    }[result.status]
+    return {
+        "success": result.status is not IngestStatus.FAILED,
+        "message": human,
+        "action_taken": result.status is IngestStatus.INGESTED,
+        "data": {"status": result.status.value, "document_id": result.document_id},
+    }

--- a/src/backend/services/paperless_metadata_extractor.py
+++ b/src/backend/services/paperless_metadata_extractor.py
@@ -789,15 +789,43 @@ class PaperlessMetadataExtractor:
                 metadata=PaperlessMetadata(),
                 error=f"Attachment {attachment_id} not found",
             )
+        return await self.extract_from_file(
+            upload.file_path, user_id=user_id, lang=lang
+        )
 
+    async def extract_from_file(
+        self,
+        file_path: str,
+        *,
+        user_id: int | None = None,
+        lang: str = "de",
+    ) -> ExtractionResult:
+        """Run the pipeline on a file on disk (no ChatUpload row needed).
+
+        The folder-ingest Paperless leg uses this against the document's
+        persisted recovery copy — the extractor is no longer coupled to the
+        chat-upload table. OCR the file, then delegate to
+        :meth:`extract_from_doc_text`.
+        """
         # 2. Extract text (Docling; vision-model path is PR 2b refinement).
-        doc_text = await self._extract_text(upload.file_path)
+        doc_text = await self._extract_text(file_path)
         if not doc_text:
             return ExtractionResult(
                 metadata=PaperlessMetadata(),
                 error="Konnte Dokument nicht lesen (OCR lieferte keinen Text).",
             )
+        return await self.extract_from_doc_text(doc_text, user_id=user_id, lang=lang)
 
+    async def extract_from_doc_text(
+        self,
+        doc_text: str,
+        *,
+        user_id: int | None = None,
+        lang: str = "de",
+    ) -> ExtractionResult:
+        """Run taxonomy → LLM → validate on already-extracted document text.
+        The text-source-agnostic core of the pipeline (steps 3-6); both the
+        ChatUpload path and the folder-ingest file path land here."""
         # 3. Fetch + prune taxonomy.
         taxonomy = await self._fetch_taxonomy()
         if taxonomy is None:
@@ -840,7 +868,7 @@ class PaperlessMetadataExtractor:
                 error="LLM lieferte keine gueltige JSON-Antwort.",
             )
 
-        # 5. Validate + fuzzy-match + clamp.
+        # 6. Validate + fuzzy-match + clamp.
         try:
             metadata = validate_extraction(parsed, taxonomy)
         except ValueError as exc:

--- a/src/backend/services/rag_service.py
+++ b/src/backend/services/rag_service.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 from sqlalchemy import delete, func, select, text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 # Keep strong references to fire-and-forget background tasks so they are not
@@ -47,6 +48,19 @@ class _ProcessorFailed(Exception):
     ``process_existing_document``'s ``history.track()`` block so the history
     row closes as ``failed``, then swallowed at the outer return to preserve
     the legacy contract (handled processor failure → return None)."""
+
+
+class DuplicateDocumentError(Exception):
+    """A document with the same ``(file_hash, knowledge_base_id)`` already
+    exists — surfaced as a ``uq_documents_file_hash_kb`` IntegrityError from a
+    concurrent insert. Carries the winning row (may be ``None`` if it could
+    not be re-fetched). Raised by :meth:`RAGService.create_document_record_safe`
+    so every caller (the upload route and the folder-ingest bridge) handles the
+    race in exactly one place (D3)."""
+
+    def __init__(self, winner: "Document | None"):
+        self.winner = winner
+        super().__init__("duplicate document")
 
 
 class RAGService:
@@ -284,6 +298,52 @@ class RAGService:
             f"status=pending, atom_id={atom_id}, tier={kb_default_tier}"
         )
         return doc
+
+    async def create_document_record_safe(
+        self,
+        *,
+        file_path: str,
+        knowledge_base_id: int | None = None,
+        filename: str | None = None,
+        file_hash: str | None = None,
+    ) -> Document:
+        """:meth:`create_document_record` plus concurrent-hash-race handling.
+
+        Shared by the upload route and the folder-ingest bridge so the
+        ``uq_documents_file_hash_kb`` race lives in exactly one place (D3).
+        On a concurrent insert of the same ``(file_hash, knowledge_base_id)``
+        pair, rolls back and raises :class:`DuplicateDocumentError` carrying the
+        winning row. Any other ``IntegrityError`` (FK / NOT NULL) is rolled back
+        and re-raised so the caller can surface a genuine 500 rather than
+        papering over it with a misleading duplicate.
+        """
+        try:
+            return await self.create_document_record(
+                file_path=file_path,
+                knowledge_base_id=knowledge_base_id,
+                filename=filename,
+                file_hash=file_hash,
+            )
+        except IntegrityError as ie:
+            orig_err = str(ie.orig) if ie.orig else str(ie)
+            await self.db.rollback()
+            if "uq_documents_file_hash_kb" not in orig_err:
+                logger.error(f"Unexpected IntegrityError on Document insert: {orig_err}")
+                raise
+            winner = (
+                await self.db.execute(
+                    select(Document).where(
+                        Document.file_hash == file_hash,
+                        Document.knowledge_base_id == knowledge_base_id,
+                    )
+                )
+            ).scalar_one_or_none()
+            logger.warning(
+                f"Concurrent duplicate insert for hash "
+                f"{(file_hash or '')[:16]}... (kb={knowledge_base_id}); "
+                f"winner id={winner.id if winner else 'unknown'}"
+            )
+            raise DuplicateDocumentError(winner) from ie
 
     async def process_existing_document(
         self,

--- a/src/backend/services/rag_service.py
+++ b/src/backend/services/rag_service.py
@@ -234,6 +234,8 @@ class RAGService:
         knowledge_base_id: int | None = None,
         filename: str | None = None,
         file_hash: str | None = None,
+        owner_user_id_override: int | None = None,
+        circle_tier_override: int | None = None,
     ) -> Document:
         """Insert a ``Document`` row with status=pending and return it.
 
@@ -248,6 +250,14 @@ class RAGService:
         here, at the same time as the Document, so every document that
         exists in the DB is access-controlled from the first commit. Chunks
         created later inherit ``circle_tier`` from the document.
+
+        ``owner_user_id_override`` / ``circle_tier_override`` (D4): when set,
+        they replace the KB-derived owner / default tier for the atoms row +
+        the document's ``circle_tier``. The folder-ingest bridge passes the
+        configured ``folder_ingest_target_user`` + ``folder_ingest_default_tier``
+        so auto-filed documents are owned by the configured user at the
+        configured tier regardless of the target KB. None preserves the legacy
+        KB-derived behaviour (the upload route passes neither).
         """
         actual_filename = filename or os.path.basename(file_path)
 
@@ -263,7 +273,13 @@ class RAGService:
                 kb_owner_id = kb_info.owner_id
                 kb_default_tier = int(kb_info.default_circle_tier or 0)
 
-        atom_owner = await self._resolve_owner_user_id(kb_owner_id)
+        # D4 overrides win over the KB-derived values when provided.
+        if circle_tier_override is not None:
+            kb_default_tier = int(circle_tier_override)
+        if owner_user_id_override is not None:
+            atom_owner: int | None = owner_user_id_override
+        else:
+            atom_owner = await self._resolve_owner_user_id(kb_owner_id)
 
         # Pre-create the atoms row so the Document.atom_id FK has a valid
         # target when the document INSERT fires. Skipped only in empty-users
@@ -306,6 +322,8 @@ class RAGService:
         knowledge_base_id: int | None = None,
         filename: str | None = None,
         file_hash: str | None = None,
+        owner_user_id_override: int | None = None,
+        circle_tier_override: int | None = None,
     ) -> Document:
         """:meth:`create_document_record` plus concurrent-hash-race handling.
 
@@ -316,6 +334,9 @@ class RAGService:
         winning row. Any other ``IntegrityError`` (FK / NOT NULL) is rolled back
         and re-raised so the caller can surface a genuine 500 rather than
         papering over it with a misleading duplicate.
+
+        ``owner_user_id_override`` / ``circle_tier_override`` are forwarded to
+        :meth:`create_document_record` (D4 owner/tier for folder-ingest).
         """
         try:
             return await self.create_document_record(
@@ -323,6 +344,8 @@ class RAGService:
                 knowledge_base_id=knowledge_base_id,
                 filename=filename,
                 file_hash=file_hash,
+                owner_user_id_override=owner_user_id_override,
+                circle_tier_override=circle_tier_override,
             )
         except IntegrityError as ie:
             orig_err = str(ie.orig) if ie.orig else str(ie)

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -526,6 +526,19 @@ class Settings(BaseSettings):
     chat_upload_retention_days: int = Field(default=30, ge=1, le=365)
     chat_upload_cleanup_enabled: bool = False
     chat_upload_email_account: str = "primary"
+
+    # Folder-ingest (watch-folder auto-ingest via renfield-mcp-filesystem).
+    # The dedicated Filesystem MCP pushes settled files to
+    # POST /api/folder-ingest/document; the backend never mounts the shares.
+    # The Bearer token lives in SystemSetting (revocable), not here. Owner/tier
+    # (D4) and the Paperless leg toggle are consumed in later tasks (T5/T6);
+    # the push route (T3) uses enabled + kb_name + target_user.
+    folder_ingest_enabled: bool = False
+    folder_ingest_kb_name: str = "Eingang"  # target KB; auto-created on first push
+    folder_ingest_target_user: str = ""  # owner username/id; empty → admin/first user
+    folder_ingest_default_tier: int = Field(default=0, ge=0, le=4)  # circle tier at create
+    folder_ingest_to_paperless: bool = True
+    folder_ingest_notify_on_filed: bool = True
     # Paperless cold-start confirm ramp: the first N archives show a metadata
     # confirm; after N the system trusts itself and archives silently. 0 =
     # never confirm (always silent). Tunable without a code change.

--- a/src/backend/workers/document_processor_worker.py
+++ b/src/backend/workers/document_processor_worker.py
@@ -33,12 +33,20 @@ import asyncio
 import os
 import signal
 
+import httpx
 import redis.asyncio as aioredis
 from loguru import logger
+from redis import exceptions as redis_exceptions
 from sqlalchemy import delete, text
+from sqlalchemy.exc import DisconnectionError, InterfaceError, OperationalError
 
-from models.database import DocumentChunk
+from models.database import DOC_STATUS_FAILED, Document, DocumentChunk
 from services.database import AsyncSessionLocal
+
+try:  # ollama is in the worker's import graph (rag embedding client); guard
+    from ollama import ResponseError as _OllamaResponseError  # packaging drift
+except Exception:  # pragma: no cover - defensive
+    _OllamaResponseError = None
 from services.document_processing_history import (
     DocumentProcessingHistoryService,
     ProcessingStatus,
@@ -61,6 +69,69 @@ def _pod_name() -> str:
     """Identify this worker instance. In k8s the env var ``POD_NAME`` is set
     via downward API; outside k8s we fall back to hostname for dev runs."""
     return os.environ.get("POD_NAME") or os.environ.get("HOSTNAME", "worker-local")
+
+
+# Exceptions that mean "the infrastructure blinked" — the LLM/embedding host is
+# down, the DB connection dropped, Redis is unreachable. These are RETRYABLE: we
+# leave the entry un-ACKed so reclaim_stale re-delivers it on the next boot.
+# Everything ELSE reaching the worker is treated as TERMINAL (a poison document
+# / genuine bug) — re-running it would just fail again and pile the entry up in
+# the PEL forever, so we mark the row failed and ACK it. The folder-ingest D2
+# matrix then lets a re-push REINGEST a failed row, and a manual reindex still
+# works; both beat an unbounded retry of a doc that can never succeed.
+_TRANSIENT_EXC: tuple[type[BaseException], ...] = (
+    asyncio.TimeoutError,  # embedding timeout (rag_service wraps embeds in wait_for)
+    httpx.ConnectError,
+    httpx.ConnectTimeout,
+    httpx.ReadTimeout,
+    httpx.WriteTimeout,
+    httpx.PoolTimeout,
+    httpx.RemoteProtocolError,  # Ollama dropped the connection mid-stream
+    redis_exceptions.ConnectionError,
+    redis_exceptions.TimeoutError,
+    OperationalError,  # DB connection lost / server unavailable
+    InterfaceError,
+    DisconnectionError,
+)
+
+
+def _is_transient_error(exc: BaseException) -> bool:
+    """True for infra blips that warrant a PEL retry (see _TRANSIENT_EXC)."""
+    if isinstance(exc, _TRANSIENT_EXC):
+        return True
+    # A reachable-but-degraded Ollama raises ollama.ResponseError: a 5xx (503
+    # model loading, 502/504 gateway) is retryable; a 4xx (bad request / model
+    # not found) is a terminal config/data error. Host-down arrives earlier as
+    # httpx.ConnectError, already covered above.
+    if _OllamaResponseError is not None and isinstance(exc, _OllamaResponseError):
+        return getattr(exc, "status_code", 0) >= 500
+    return False
+
+
+async def _mark_document_failed(doc_id, error: BaseException) -> bool:
+    """Persist ``status=failed`` for a terminally-failed doc in a FRESH session.
+    process_existing_document already marks failed on its stage-2/3 + Docling
+    paths, but an error from the reindex / status-probe / chunk-purge steps (or
+    a half-rolled-back session) might not have — this guarantees the row
+    reflects the terminal failure so the UI and the D2 REINGEST branch see it.
+
+    Returns True when the row's terminal state is recorded (committed, already
+    failed, or the row is gone — all stable to ACK), False when it could NOT be
+    persisted so the caller should leave the entry in the PEL for reclaim rather
+    than ACK away a failure it failed to record."""
+    try:
+        async with AsyncSessionLocal() as db:
+            doc = await db.get(Document, doc_id)
+            if doc is None:
+                return True  # row vanished — nothing to retry, safe to ack
+            if doc.status != DOC_STATUS_FAILED:
+                doc.status = DOC_STATUS_FAILED
+                doc.error_message = str(error)[:2000]
+                await db.commit()
+            return True
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"could not mark doc {doc_id} failed: {e}")
+        return False
 
 
 async def _heartbeat_loop(
@@ -169,7 +240,32 @@ async def _process_entry(
         logger.info(f"processed doc {doc_id} (entry {entry.entry_id})")
     except Exception as e:
         logger.exception(f"task {entry.entry_id} for doc {doc_id} failed: {e}")
-        # Deliberately NOT ack'ing — reclaim_stale picks it up next time.
+        if _is_transient_error(e):
+            # Infra blip (LLM/embedding host down, DB/Redis dropped). Leave the
+            # entry un-ACKed so reclaim_stale re-delivers it on the next boot.
+            logger.warning(
+                f"task {entry.entry_id} for doc {doc_id}: transient "
+                f"{type(e).__name__} — leaving in PEL for reclaim"
+            )
+        else:
+            # Terminal/poison doc: mark failed + ACK so it stops piling up in the
+            # PEL and re-failing every restart. D2 REINGEST / manual reindex can
+            # still retry the row deliberately. Only ACK once the failed state is
+            # actually recorded — if we couldn't persist it (e.g. DB blip while
+            # marking), leave the entry in the PEL so reclaim retries rather than
+            # silently dropping a doc whose terminal status we never wrote.
+            if await _mark_document_failed(doc_id, e):
+                await queue.ack(entry.entry_id)
+                logger.error(
+                    f"task {entry.entry_id} for doc {doc_id}: terminal "
+                    f"{type(e).__name__} — marked failed and acked"
+                )
+            else:
+                logger.error(
+                    f"task {entry.entry_id} for doc {doc_id}: terminal "
+                    f"{type(e).__name__} but could not record failed status — "
+                    f"leaving in PEL for reclaim"
+                )
     finally:
         try:
             await progress.clear()

--- a/tests/backend/test_action_executor.py
+++ b/tests/backend/test_action_executor.py
@@ -109,6 +109,28 @@ class TestActionExecutorRouting:
         assert "unknown intent" in result["message"].lower()
 
     @pytest.mark.unit
+    async def test_route_internal_ingest_file(self, action_executor):
+        """internal.ingest_file is dispatched to the folder-ingest tool with the
+        injected mcp_manager + authenticated user_id."""
+        intent_data = {
+            "intent": "internal.ingest_file",
+            "parameters": {"path": "/inbox/invoice.pdf"},
+            "confidence": 0.9,
+        }
+        sentinel = {"success": True, "message": "ok", "action_taken": True}
+        with patch(
+            "services.folder_ingest_tool.ingest_file",
+            new=AsyncMock(return_value=sentinel),
+        ) as mock_tool:
+            result = await action_executor.execute(intent_data, user_id=7)
+
+        assert result is sentinel
+        mock_tool.assert_awaited_once()
+        _, kwargs = mock_tool.await_args
+        assert kwargs["user_id"] == 7
+        assert kwargs["mcp_manager"] is action_executor.mcp_manager
+
+    @pytest.mark.unit
     async def test_route_knowledge_intent(self, action_executor):
         """Test: Knowledge Intent wird an RAG-Service geroutet"""
         intent_data = {

--- a/tests/backend/test_document_worker_failure_handling.py
+++ b/tests/backend/test_document_worker_failure_handling.py
@@ -1,0 +1,261 @@
+"""Unit tests for the document-worker's terminal-vs-transient failure handling (T4).
+
+Before T4 the worker's ``except`` never ACKed, so a poison document
+(non-retryable bug) sat un-ACKed and re-failed on every reclaim/restart forever,
+and its row never reached ``status=failed`` deterministically. Now:
+
+- TRANSIENT infra blips (LLM/embedding host down, DB/Redis dropped) → left
+  un-ACKed for reclaim_stale to retry (the old behaviour, preserved).
+- TERMINAL/poison errors → row marked failed + entry ACKed, so it stops
+  accumulating in the PEL and the folder-ingest D2 REINGEST branch can re-drive
+  it deliberately.
+
+Pure unit tests — collaborators are mocked; no DB / Redis.
+"""
+from __future__ import annotations
+
+import asyncio
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from redis import exceptions as redis_exceptions
+from sqlalchemy.exc import OperationalError
+
+import workers.document_processor_worker as worker
+from models.database import DOC_STATUS_FAILED
+from services.document_processing_history import ProcessingStatus
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+class _FakeSessionCM:
+    def __init__(self, db):
+        self._db = db
+
+    async def __aenter__(self):
+        return self._db
+
+    async def __aexit__(self, *_a):
+        return False
+
+
+def _wire(monkeypatch, *, ingest_status=None, process_side_effect=None, reindex_side_effect=None):
+    """Patch the worker's collaborators; return (rag, queue)."""
+    db = MagicMock()
+    db.execute = AsyncMock()
+    db.commit = AsyncMock()
+
+    history = MagicMock()
+    history.initial_ingest_status = AsyncMock(return_value=ingest_status)
+
+    rag = MagicMock()
+    rag.process_existing_document = AsyncMock(side_effect=process_side_effect)
+    rag.reindex_document = AsyncMock(side_effect=reindex_side_effect)
+
+    progress = MagicMock()
+    progress.set_stage = AsyncMock()
+    progress.clear = AsyncMock()
+
+    monkeypatch.setattr(worker, "AsyncSessionLocal", lambda: _FakeSessionCM(db))
+    monkeypatch.setattr(worker, "RAGService", MagicMock(return_value=rag))
+    monkeypatch.setattr(worker, "DocumentProcessingHistoryService", MagicMock(return_value=history))
+    monkeypatch.setattr(worker, "DocumentProgress", MagicMock(return_value=progress))
+
+    queue = MagicMock()
+    queue.ack = AsyncMock()
+    return rag, queue
+
+
+def _entry(doc_id: int = 5, trigger: str | None = None):
+    params = {"document_id": doc_id}
+    if trigger is not None:
+        params["trigger"] = trigger
+    return types.SimpleNamespace(entry_id="1-0", params=params)
+
+
+# ---------------------------------------------------------------------------
+# The classifier
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        asyncio.TimeoutError(),
+        httpx.ConnectError("conn refused"),
+        httpx.ConnectTimeout("slow"),
+        httpx.ReadTimeout("slow"),
+        httpx.PoolTimeout("pool"),
+        httpx.RemoteProtocolError("dropped"),
+        redis_exceptions.ConnectionError("redis down"),
+        redis_exceptions.TimeoutError("redis slow"),
+        OperationalError("stmt", {}, Exception("server closed the connection")),
+    ],
+)
+def test_transient_classifier_true(exc):
+    assert worker._is_transient_error(exc) is True
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [ValueError("bad data"), KeyError("missing"), RuntimeError("bug"), TypeError("x")],
+)
+def test_transient_classifier_false_for_terminal(exc):
+    assert worker._is_transient_error(exc) is False
+
+
+def _ollama_err(status_code: int):
+    """An ollama.ResponseError instance with a given status_code, built without
+    invoking __init__ (constructor signature varies across ollama versions)."""
+    if worker._OllamaResponseError is None:
+        pytest.skip("ollama not importable in this environment")
+    exc = worker._OllamaResponseError.__new__(worker._OllamaResponseError)
+    exc.status_code = status_code
+    return exc
+
+
+@pytest.mark.parametrize("status", [500, 502, 503, 504])
+def test_ollama_5xx_is_transient(status):
+    # A reachable-but-degraded Ollama (model loading / gateway) → retry.
+    assert worker._is_transient_error(_ollama_err(status)) is True
+
+
+@pytest.mark.parametrize("status", [400, 404, 422])
+def test_ollama_4xx_is_terminal(status):
+    # A 4xx (bad request / model not found) is a terminal config/data error.
+    assert worker._is_transient_error(_ollama_err(status)) is False
+
+
+# ---------------------------------------------------------------------------
+# _process_entry ack decision
+# ---------------------------------------------------------------------------
+
+async def test_transient_error_left_in_pel_not_acked(monkeypatch):
+    rag, queue = _wire(monkeypatch, process_side_effect=asyncio.TimeoutError())
+    mark = AsyncMock()
+    monkeypatch.setattr(worker, "_mark_document_failed", mark)
+
+    await worker._process_entry(MagicMock(), queue, _entry(5))
+
+    queue.ack.assert_not_called()  # stays in PEL for reclaim
+    mark.assert_not_called()  # not a terminal failure
+
+
+async def test_transient_httpx_connecterror_not_acked(monkeypatch):
+    rag, queue = _wire(monkeypatch, process_side_effect=httpx.ConnectError("down"))
+    monkeypatch.setattr(worker, "_mark_document_failed", AsyncMock())
+
+    await worker._process_entry(MagicMock(), queue, _entry(5))
+
+    queue.ack.assert_not_called()
+
+
+async def test_terminal_error_marks_failed_and_acks(monkeypatch):
+    rag, queue = _wire(monkeypatch, process_side_effect=ValueError("poison doc"))
+    mark = AsyncMock(return_value=True)
+    monkeypatch.setattr(worker, "_mark_document_failed", mark)
+
+    await worker._process_entry(MagicMock(), queue, _entry(7))
+
+    mark.assert_awaited_once()
+    assert mark.await_args.args[0] == 7  # the doc_id
+    queue.ack.assert_awaited_once_with("1-0")  # removed from PEL — no infinite loop
+
+
+async def test_terminal_error_in_reindex_path_marks_failed_and_acks(monkeypatch):
+    # A terminal failure on the user-reindex branch must also stop looping.
+    rag, queue = _wire(
+        monkeypatch,
+        ingest_status=ProcessingStatus.COMPLETED.value,
+        reindex_side_effect=RuntimeError("reindex blew up"),
+    )
+    mark = AsyncMock(return_value=True)
+    monkeypatch.setattr(worker, "_mark_document_failed", mark)
+
+    await worker._process_entry(MagicMock(), queue, _entry(9, trigger="user_reindex"))
+
+    rag.reindex_document.assert_awaited_once()
+    mark.assert_awaited_once()
+    queue.ack.assert_awaited_once_with("1-0")
+
+
+async def test_terminal_error_not_acked_when_mark_failed_cannot_persist(monkeypatch):
+    # If we can't even record the failed status (DB blip while marking), DON'T
+    # ack — leave the entry in the PEL for reclaim rather than dropping a doc
+    # whose terminal state was never written.
+    rag, queue = _wire(monkeypatch, process_side_effect=ValueError("poison doc"))
+    monkeypatch.setattr(worker, "_mark_document_failed", AsyncMock(return_value=False))
+
+    await worker._process_entry(MagicMock(), queue, _entry(7))
+
+    queue.ack.assert_not_called()
+
+
+async def test_success_path_still_acks_without_marking_failed(monkeypatch):
+    # Regression: the happy path is unchanged — ack, no mark-failed.
+    rag, queue = _wire(monkeypatch, ingest_status=None)
+    mark = AsyncMock()
+    monkeypatch.setattr(worker, "_mark_document_failed", mark)
+
+    await worker._process_entry(MagicMock(), queue, _entry(5))
+
+    rag.process_existing_document.assert_awaited_once()
+    queue.ack.assert_awaited_once_with("1-0")
+    mark.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _mark_document_failed
+# ---------------------------------------------------------------------------
+
+async def test_mark_document_failed_sets_status(monkeypatch):
+    doc = MagicMock(status="processing")
+    db = MagicMock()
+    db.get = AsyncMock(return_value=doc)
+    db.commit = AsyncMock()
+    monkeypatch.setattr(worker, "AsyncSessionLocal", lambda: _FakeSessionCM(db))
+
+    ok = await worker._mark_document_failed(5, ValueError("boom"))
+
+    assert ok is True
+    assert doc.status == DOC_STATUS_FAILED
+    assert "boom" in doc.error_message
+    db.commit.assert_awaited_once()
+
+
+async def test_mark_document_failed_idempotent_when_already_failed(monkeypatch):
+    doc = MagicMock(status=DOC_STATUS_FAILED)
+    db = MagicMock()
+    db.get = AsyncMock(return_value=doc)
+    db.commit = AsyncMock()
+    monkeypatch.setattr(worker, "AsyncSessionLocal", lambda: _FakeSessionCM(db))
+
+    ok = await worker._mark_document_failed(5, ValueError("boom"))
+
+    assert ok is True  # state already correct → stable to ack
+    db.commit.assert_not_called()  # already failed → no redundant write
+
+
+async def test_mark_document_failed_missing_doc_is_noop(monkeypatch):
+    db = MagicMock()
+    db.get = AsyncMock(return_value=None)  # row vanished
+    db.commit = AsyncMock()
+    monkeypatch.setattr(worker, "AsyncSessionLocal", lambda: _FakeSessionCM(db))
+
+    ok = await worker._mark_document_failed(5, ValueError("boom"))  # must not raise
+
+    assert ok is True  # nothing to retry → safe to ack
+    db.commit.assert_not_called()
+
+
+async def test_mark_document_failed_returns_false_on_db_error(monkeypatch):
+    # Could not persist the failed status → False so the caller leaves the entry
+    # in the PEL instead of acking.
+    db = MagicMock()
+    db.get = AsyncMock(side_effect=RuntimeError("db down"))
+    monkeypatch.setattr(worker, "AsyncSessionLocal", lambda: _FakeSessionCM(db))
+
+    ok = await worker._mark_document_failed(5, ValueError("boom"))
+
+    assert ok is False

--- a/tests/backend/test_folder_ingest.py
+++ b/tests/backend/test_folder_ingest.py
@@ -404,6 +404,27 @@ async def test_ingest_create_decision_enqueues_and_is_ingested(monkeypatch):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_ingest_create_passes_owner_and_tier_overrides(monkeypatch):
+    # D4: the configured owner + tier are forwarded to create as overrides.
+    created = MagicMock(id=20)
+    _patch_pipeline(monkeypatch, decision=_Decision.CREATE, created_doc=created)
+    rag = MagicMock()
+    rag.create_document_record_safe = AsyncMock(return_value=created)
+    monkeypatch.setattr(fi, "RAGService", MagicMock(return_value=rag))
+
+    await ingest_document(
+        _PDF, _meta(), db=AsyncMock(), kb_id=7, owner_user_id=9, default_tier=2,
+        paperless_leg=AsyncMock(return_value=True),
+    )
+
+    _, kwargs = rag.create_document_record_safe.await_args
+    assert kwargs["owner_user_id_override"] == 9
+    assert kwargs["circle_tier_override"] == 2
+    assert kwargs["knowledge_base_id"] == 7
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_ingest_create_paperless_leg_failure_still_ingested(monkeypatch):
     # The Paperless leg is best-effort: a failure must NOT fail the KB ingest
     # (the row is already enqueued).

--- a/tests/backend/test_folder_ingest.py
+++ b/tests/backend/test_folder_ingest.py
@@ -25,6 +25,7 @@ from models.database import (
     DOC_STATUS_PENDING,
     DOC_STATUS_PROCESSING,
     PAPERLESS_STATE_DONE,
+    PAPERLESS_STATE_FAILED,
     Document,
 )
 from services.folder_ingest import (
@@ -192,6 +193,21 @@ async def test_classify_completed_paperless_done_is_duplicate(pg_db_session):
 
 @pytest.mark.database
 @pytest.mark.asyncio
+async def test_classify_completed_paperless_failed_is_duplicate(pg_db_session):
+    # A terminally-tried Paperless leg ('failed' — non-duplicate reject) is
+    # SETTLED, so a re-push dedups instead of looping the leg.
+    await _insert_doc(
+        pg_db_session,
+        file_hash="h_plfail",
+        status=DOC_STATUS_COMPLETED,
+        paperless_state=PAPERLESS_STATE_FAILED,
+    )
+    decision, _ = await classify_existing(pg_db_session, "h_plfail", None)
+    assert decision is _Decision.DUPLICATE
+
+
+@pytest.mark.database
+@pytest.mark.asyncio
 async def test_classify_completed_paperless_missing_is_paperless_only(pg_db_session):
     # completed but paperless_state NULL → run only the Paperless leg.
     await _insert_doc(
@@ -350,6 +366,21 @@ async def test_ingest_paperless_only_leg_failure_is_retry(monkeypatch):
     )
     assert out.status is IngestStatus.RETRY
     assert out.detail == "paperless_retry"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ingest_paperless_only_unsettled_leg_is_retry(monkeypatch):
+    # The leg ran without raising but couldn't settle (upload error / pending) →
+    # RETRY so the MCP re-pushes and the leg is attempted again.
+    existing = MagicMock(id=11)
+    _patch_pipeline(monkeypatch, decision=_Decision.PAPERLESS_ONLY, existing=existing)
+    leg = AsyncMock(return_value=False)
+    out = await ingest_document(
+        _PDF, _meta(), db=AsyncMock(), kb_id=None, paperless_leg=leg
+    )
+    assert out.status is IngestStatus.RETRY
+    assert out.detail == "paperless_pending"
 
 
 @pytest.mark.unit

--- a/tests/backend/test_folder_ingest.py
+++ b/tests/backend/test_folder_ingest.py
@@ -1,0 +1,128 @@
+"""Tests for the folder-ingest feature (watch-folder auto-ingest).
+
+Increment 1 covers the shared race-safe create helper (D3,
+``RAGService.create_document_record_safe``) that both the upload route and
+the folder-ingest bridge use, so the ``uq_documents_file_hash_kb``
+concurrent-insert race is handled in exactly one place.
+
+The classification logic (hash-race vs other IntegrityError) is unit-tested
+with mocks: ``create_document_record`` commits internally, which is
+incompatible with the rollback-isolated ``pg_db_session`` fixture, and the
+behaviour under test is purely "given an IntegrityError, classify and react",
+not the constraint itself. The constraint's real enforcement is covered
+end-to-end by the route tests + the .159 E2E.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from services.rag_service import DuplicateDocumentError, RAGService
+
+
+def _integrity_error(message: str) -> IntegrityError:
+    """Build an IntegrityError whose ``str(orig)`` carries ``message`` —
+    mirrors how asyncpg surfaces a unique-violation through SQLAlchemy."""
+    return IntegrityError("INSERT INTO documents ...", {}, Exception(message))
+
+
+def _bare_rag(create_side_effect=None, create_return=None) -> RAGService:
+    """A RAGService with the heavy __init__ bypassed (no DocumentProcessor),
+    wired with an AsyncMock db and a stubbed create_document_record."""
+    rag = RAGService.__new__(RAGService)
+    rag.db = AsyncMock()
+    rag.create_document_record = AsyncMock(
+        side_effect=create_side_effect, return_value=create_return
+    )
+    return rag
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_safe_create_passthrough_returns_document():
+    sentinel = object()
+    rag = _bare_rag(create_return=sentinel)
+
+    out = await rag.create_document_record_safe(
+        file_path="/x.pdf", knowledge_base_id=1, filename="x.pdf", file_hash="h"
+    )
+
+    assert out is sentinel
+    rag.db.rollback.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_safe_create_hash_race_raises_duplicate_with_winner():
+    rag = _bare_rag(
+        create_side_effect=_integrity_error(
+            'duplicate key value violates unique constraint "uq_documents_file_hash_kb"'
+        )
+    )
+    winner = MagicMock(id=42)
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = winner
+    # Wire rollback + execute as children of ONE parent so mock_calls records
+    # their relative ORDER: the rollback MUST precede the winner SELECT, else a
+    # real asyncpg session is still in InFailedSqlTransaction and the SELECT
+    # raises. The mocked db has no session state, so without this ordering check
+    # a SELECT-before-rollback reorder would pass green.
+    manager = MagicMock()
+    manager.rollback = AsyncMock()
+    manager.execute = AsyncMock(return_value=result)
+    rag.db.rollback = manager.rollback
+    rag.db.execute = manager.execute
+
+    with pytest.raises(DuplicateDocumentError) as excinfo:
+        await rag.create_document_record_safe(
+            file_path="/x.pdf", knowledge_base_id=1, filename="x.pdf", file_hash="h"
+        )
+
+    assert excinfo.value.winner is winner
+    rag.db.rollback.assert_awaited_once()
+    ordered = [c[0] for c in manager.mock_calls]
+    assert ordered.index("rollback") < ordered.index("execute"), (
+        f"rollback must precede the winner SELECT; got order {ordered}"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_safe_create_other_integrity_error_reraises():
+    # A non-hash-race IntegrityError (FK / NOT NULL) must NOT be masked as a
+    # duplicate — it re-raises so the caller can surface a genuine 500.
+    rag = _bare_rag(
+        create_side_effect=_integrity_error(
+            'insert violates foreign key constraint "fk_documents_kb"'
+        )
+    )
+
+    with pytest.raises(IntegrityError):
+        await rag.create_document_record_safe(
+            file_path="/x.pdf", knowledge_base_id=1, filename="x.pdf", file_hash="h"
+        )
+
+    rag.db.rollback.assert_awaited_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_safe_create_hash_race_winner_unfetchable_is_none():
+    # If the winning row can't be re-fetched (already gone), the error still
+    # raises with winner=None rather than blowing up.
+    rag = _bare_rag(
+        create_side_effect=_integrity_error(
+            'duplicate key value violates unique constraint "uq_documents_file_hash_kb"'
+        )
+    )
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = None
+    rag.db.execute = AsyncMock(return_value=result)
+
+    with pytest.raises(DuplicateDocumentError) as excinfo:
+        await rag.create_document_record_safe(
+            file_path="/x.pdf", knowledge_base_id=1, filename="x.pdf", file_hash="h"
+        )
+
+    assert excinfo.value.winner is None

--- a/tests/backend/test_folder_ingest.py
+++ b/tests/backend/test_folder_ingest.py
@@ -18,6 +18,22 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from sqlalchemy.exc import IntegrityError
 
+import services.folder_ingest as fi
+from models.database import (
+    DOC_STATUS_COMPLETED,
+    DOC_STATUS_FAILED,
+    DOC_STATUS_PENDING,
+    DOC_STATUS_PROCESSING,
+    PAPERLESS_STATE_DONE,
+    Document,
+)
+from services.folder_ingest import (
+    IngestMeta,
+    IngestStatus,
+    _Decision,
+    classify_existing,
+    ingest_document,
+)
 from services.rag_service import DuplicateDocumentError, RAGService
 
 
@@ -126,3 +142,350 @@ async def test_safe_create_hash_race_winner_unfetchable_is_none():
         )
 
     assert excinfo.value.winner is None
+
+
+# ===========================================================================
+# T2 — completion+Paperless-aware dedup matrix (D2), against real Postgres.
+#
+# classify_existing is SELECT-only (no commit), so it runs safely inside the
+# rollback-isolated pg_db_session: rows are pushed with flush(), the decision
+# is asserted, teardown rolls back. This is the risky SQL branch the eng
+# review flagged — it gets real-PG coverage, not the sqlite shim.
+# ===========================================================================
+
+async def _insert_doc(db, *, file_hash, status, paperless_state=None, kb_id=None):
+    doc = Document(
+        filename="invoice.pdf",
+        file_path=f"/uploads/{file_hash}.pdf",
+        knowledge_base_id=kb_id,
+        file_hash=file_hash,
+        status=status,
+        paperless_state=paperless_state,
+        circle_tier=0,
+    )
+    db.add(doc)
+    await db.flush()
+    return doc
+
+
+@pytest.mark.database
+@pytest.mark.asyncio
+async def test_classify_no_row_is_create(pg_db_session):
+    decision, doc = await classify_existing(pg_db_session, "missinghash", None)
+    assert decision is _Decision.CREATE
+    assert doc is None
+
+
+@pytest.mark.database
+@pytest.mark.asyncio
+async def test_classify_completed_paperless_done_is_duplicate(pg_db_session):
+    await _insert_doc(
+        pg_db_session,
+        file_hash="h_done",
+        status=DOC_STATUS_COMPLETED,
+        paperless_state=PAPERLESS_STATE_DONE,
+    )
+    decision, doc = await classify_existing(pg_db_session, "h_done", None)
+    assert decision is _Decision.DUPLICATE
+    assert doc is not None
+
+
+@pytest.mark.database
+@pytest.mark.asyncio
+async def test_classify_completed_paperless_missing_is_paperless_only(pg_db_session):
+    # completed but paperless_state NULL → run only the Paperless leg.
+    await _insert_doc(
+        pg_db_session,
+        file_hash="h_nopl",
+        status=DOC_STATUS_COMPLETED,
+        paperless_state=None,
+    )
+    decision, _ = await classify_existing(pg_db_session, "h_nopl", None)
+    assert decision is _Decision.PAPERLESS_ONLY
+
+
+@pytest.mark.database
+@pytest.mark.asyncio
+async def test_classify_failed_is_reingest(pg_db_session):
+    await _insert_doc(pg_db_session, file_hash="h_fail", status=DOC_STATUS_FAILED)
+    decision, _ = await classify_existing(pg_db_session, "h_fail", None)
+    assert decision is _Decision.REINGEST
+
+
+@pytest.mark.database
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [DOC_STATUS_PENDING, DOC_STATUS_PROCESSING])
+async def test_classify_in_flight_is_retry(pg_db_session, status):
+    await _insert_doc(pg_db_session, file_hash=f"h_{status}", status=status)
+    decision, _ = await classify_existing(pg_db_session, f"h_{status}", None)
+    assert decision is _Decision.RETRY
+
+
+@pytest.mark.database
+@pytest.mark.asyncio
+async def test_classify_is_scoped_by_kb(pg_db_session):
+    # Same hash in a different KB must not match (the uniqueness key is the
+    # (file_hash, knowledge_base_id) pair). Here the only row is kb=None;
+    # a lookup scoped to a different (non-existent) kb id finds nothing.
+    await _insert_doc(
+        pg_db_session,
+        file_hash="h_kb",
+        status=DOC_STATUS_COMPLETED,
+        paperless_state=PAPERLESS_STATE_DONE,
+        kb_id=None,
+    )
+    decision, _ = await classify_existing(pg_db_session, "h_kb", 999)
+    assert decision is _Decision.CREATE
+
+
+# ===========================================================================
+# T2 — 4-state response mapping (D9), orchestrator control flow.
+#
+# The dedup SELECT, byte persistence, create, and enqueue are mocked at their
+# seams so these assert the branch→response mapping itself. The real SQL is
+# covered by the classify tests above; the real create-race by the helper
+# tests; the .159 E2E covers the full wiring.
+# ===========================================================================
+
+_PDF = b"%PDF-1.4 minimal test bytes"
+
+
+def _meta(filename="invoice.pdf", sha256=None):
+    return IngestMeta(filename=filename, sha256=sha256)
+
+
+def _patch_pipeline(monkeypatch, *, decision, existing=None, created_doc=None):
+    """Wire classify_existing + the create/persist/enqueue seams. Returns the
+    enqueue AsyncMock so a test can assert (not) enqueued."""
+    monkeypatch.setattr(
+        fi, "classify_existing", AsyncMock(return_value=(decision, existing))
+    )
+    monkeypatch.setattr(fi, "_persist_bytes", AsyncMock(return_value="/uploads/x.pdf"))
+
+    enqueue = AsyncMock()
+    monkeypatch.setattr(
+        fi, "DocumentTaskQueue", MagicMock(return_value=MagicMock(enqueue=enqueue))
+    )
+    monkeypatch.setattr(fi, "get_redis", MagicMock(return_value=MagicMock()))
+
+    if created_doc is not None:
+        rag = MagicMock()
+        rag.create_document_record_safe = AsyncMock(return_value=created_doc)
+        monkeypatch.setattr(fi, "RAGService", MagicMock(return_value=rag))
+    return enqueue
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ingest_bad_extension_is_failed():
+    out = await ingest_document(_PDF, _meta("notes.exe"), db=AsyncMock(), kb_id=None)
+    assert out.status is IngestStatus.FAILED
+    assert out.detail == "extension_not_allowed"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ingest_oversize_is_failed(monkeypatch):
+    monkeypatch.setattr(fi.settings, "max_file_size_mb", 1)
+    big = b"x" * (2 * 1024 * 1024)  # 2 MB > 1 MB ceiling
+    # ext must pass first, so use a .pdf name
+    out = await ingest_document(big, _meta("big.pdf"), db=AsyncMock(), kb_id=None)
+    assert out.status is IngestStatus.FAILED
+    assert out.detail == "file_too_large"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ingest_sha_mismatch_is_retry():
+    out = await ingest_document(
+        _PDF, _meta(sha256="deadbeef" * 8), db=AsyncMock(), kb_id=None
+    )
+    assert out.status is IngestStatus.RETRY
+    assert out.detail == "sha256_mismatch"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ingest_duplicate_decision_maps_to_duplicate(monkeypatch):
+    existing = MagicMock(id=7)
+    _patch_pipeline(monkeypatch, decision=_Decision.DUPLICATE, existing=existing)
+    out = await ingest_document(_PDF, _meta(), db=AsyncMock(), kb_id=None)
+    assert out.status is IngestStatus.DUPLICATE
+    assert out.document_id == 7
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ingest_in_flight_decision_maps_to_retry(monkeypatch):
+    existing = MagicMock(id=8)
+    enqueue = _patch_pipeline(monkeypatch, decision=_Decision.RETRY, existing=existing)
+    out = await ingest_document(_PDF, _meta(), db=AsyncMock(), kb_id=None)
+    assert out.status is IngestStatus.RETRY
+    assert out.document_id == 8
+    enqueue.assert_not_awaited()  # must NOT double-enqueue an in-flight row
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ingest_paperless_only_runs_leg_and_reports_duplicate(monkeypatch):
+    existing = MagicMock(id=9)
+    _patch_pipeline(monkeypatch, decision=_Decision.PAPERLESS_ONLY, existing=existing)
+    leg = AsyncMock(return_value=True)
+    out = await ingest_document(
+        _PDF, _meta(), db=AsyncMock(), kb_id=None, paperless_leg=leg
+    )
+    assert out.status is IngestStatus.DUPLICATE
+    assert out.document_id == 9
+    leg.assert_awaited_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ingest_paperless_only_leg_failure_is_retry(monkeypatch):
+    existing = MagicMock(id=10)
+    _patch_pipeline(monkeypatch, decision=_Decision.PAPERLESS_ONLY, existing=existing)
+    leg = AsyncMock(side_effect=RuntimeError("paperless down"))
+    out = await ingest_document(
+        _PDF, _meta(), db=AsyncMock(), kb_id=None, paperless_leg=leg
+    )
+    assert out.status is IngestStatus.RETRY
+    assert out.detail == "paperless_retry"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ingest_create_decision_enqueues_and_is_ingested(monkeypatch):
+    created = MagicMock(id=11)
+    enqueue = _patch_pipeline(
+        monkeypatch, decision=_Decision.CREATE, created_doc=created
+    )
+    leg = AsyncMock(return_value=True)
+    out = await ingest_document(
+        _PDF, _meta(), db=AsyncMock(), kb_id=None, owner_user_id=3, paperless_leg=leg
+    )
+    assert out.status is IngestStatus.INGESTED
+    assert out.document_id == 11
+    enqueue.assert_awaited_once()
+    # owner rides the enqueue payload as user_id (worker scoping).
+    assert enqueue.await_args.args[0]["user_id"] == 3
+    leg.assert_awaited_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ingest_create_paperless_leg_failure_still_ingested(monkeypatch):
+    # The Paperless leg is best-effort: a failure must NOT fail the KB ingest
+    # (the row is already enqueued).
+    created = MagicMock(id=12)
+    enqueue = _patch_pipeline(
+        monkeypatch, decision=_Decision.CREATE, created_doc=created
+    )
+    leg = AsyncMock(side_effect=RuntimeError("paperless down"))
+    out = await ingest_document(
+        _PDF, _meta(), db=AsyncMock(), kb_id=None, paperless_leg=leg
+    )
+    assert out.status is IngestStatus.INGESTED
+    enqueue.assert_awaited_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ingest_reingest_decision_reenqueues_failed_row(monkeypatch):
+    existing = MagicMock(id=13, status=DOC_STATUS_FAILED)
+    existing.file_path = "/uploads/old_failed.pdf"  # the prior failed copy
+    db = AsyncMock()
+    enqueue = _patch_pipeline(
+        monkeypatch, decision=_Decision.REINGEST, existing=existing
+    )
+    cleanup = MagicMock()
+    monkeypatch.setattr(fi, "_cleanup", cleanup)
+    leg = AsyncMock(return_value=True)
+    out = await ingest_document(_PDF, _meta(), db=db, kb_id=None, paperless_leg=leg)
+    assert out.status is IngestStatus.INGESTED
+    assert out.document_id == 13
+    # the failed row is reset to pending + re-pointed at the fresh recovery copy,
+    # then re-enqueued and the (idempotent) Paperless leg re-runs.
+    assert existing.status == DOC_STATUS_PENDING
+    assert existing.file_path == "/uploads/x.pdf"
+    cleanup.assert_called_once_with("/uploads/old_failed.pdf")  # stale copy removed
+    enqueue.assert_awaited_once()
+    leg.assert_awaited_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ingest_concurrent_winner_completed_is_duplicate(monkeypatch):
+    # CREATE path, but create_document_record_safe loses the race and raises
+    # DuplicateDocumentError whose winner is already completed AND Paperless-
+    # settled → duplicate.
+    winner = MagicMock(
+        id=14, status=DOC_STATUS_COMPLETED, paperless_state=PAPERLESS_STATE_DONE
+    )
+    _patch_pipeline(monkeypatch, decision=_Decision.CREATE)
+    rag = MagicMock()
+    rag.create_document_record_safe = AsyncMock(
+        side_effect=DuplicateDocumentError(winner)
+    )
+    monkeypatch.setattr(fi, "RAGService", MagicMock(return_value=rag))
+    monkeypatch.setattr(fi, "_cleanup", MagicMock())
+
+    out = await ingest_document(_PDF, _meta(), db=AsyncMock(), kb_id=None)
+    assert out.status is IngestStatus.DUPLICATE
+    assert out.document_id == 14
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ingest_concurrent_winner_in_flight_is_retry(monkeypatch):
+    winner = MagicMock(id=15, status=DOC_STATUS_PROCESSING, paperless_state=None)
+    _patch_pipeline(monkeypatch, decision=_Decision.CREATE)
+    rag = MagicMock()
+    rag.create_document_record_safe = AsyncMock(
+        side_effect=DuplicateDocumentError(winner)
+    )
+    monkeypatch.setattr(fi, "RAGService", MagicMock(return_value=rag))
+    monkeypatch.setattr(fi, "_cleanup", MagicMock())
+
+    out = await ingest_document(_PDF, _meta(), db=AsyncMock(), kb_id=None)
+    assert out.status is IngestStatus.RETRY
+    assert out.document_id == 15
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ingest_concurrent_winner_completed_paperless_missing_is_retry(monkeypatch):
+    # Completed winner but Paperless never settled → RETRY (not a terminal
+    # move-to-processed), so the re-push routes through PAPERLESS_ONLY.
+    winner = MagicMock(id=16, status=DOC_STATUS_COMPLETED, paperless_state=None)
+    _patch_pipeline(monkeypatch, decision=_Decision.CREATE)
+    rag = MagicMock()
+    rag.create_document_record_safe = AsyncMock(
+        side_effect=DuplicateDocumentError(winner)
+    )
+    monkeypatch.setattr(fi, "RAGService", MagicMock(return_value=rag))
+    monkeypatch.setattr(fi, "_cleanup", MagicMock())
+
+    out = await ingest_document(_PDF, _meta(), db=AsyncMock(), kb_id=None)
+    assert out.status is IngestStatus.RETRY
+    assert out.document_id == 16
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ingest_empty_file_is_failed():
+    out = await ingest_document(b"", _meta("scan.pdf"), db=AsyncMock(), kb_id=None)
+    assert out.status is IngestStatus.FAILED
+    assert out.detail == "empty_file"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ingest_persist_failure_is_retry(monkeypatch):
+    # Disk-full while writing the recovery copy → transient RETRY, not FAILED.
+    _patch_pipeline(monkeypatch, decision=_Decision.CREATE, created_doc=MagicMock(id=17))
+    monkeypatch.setattr(
+        fi, "_persist_bytes", AsyncMock(side_effect=OSError("No space left"))
+    )
+    out = await ingest_document(_PDF, _meta(), db=AsyncMock(), kb_id=None)
+    assert out.status is IngestStatus.RETRY
+    assert out.detail == "persist_error"

--- a/tests/backend/test_folder_ingest_paperless.py
+++ b/tests/backend/test_folder_ingest_paperless.py
@@ -1,0 +1,232 @@
+"""Tests for the folder-ingest Paperless leg (T5/T10).
+
+The leg files a document into Paperless and records the terminal outcome on
+``Document.paperless_state``. It drives two MCP tools — ``upload_document``
+(non-blocking) then ``await_consume_result`` (the MCP owns the duplicate-marker
+knowledge) — and a best-effort metadata extraction. All collaborators are
+mocked here; the MCP-side polling + duplicate classification is covered in the
+renfield-mcp-paperless test suite.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import services.folder_ingest_paperless as leg_mod
+from models.database import PAPERLESS_STATE_DONE, PAPERLESS_STATE_FAILED
+from services.folder_ingest import IngestMeta
+from services.folder_ingest_paperless import (
+    _parse_paperless_result,
+    make_paperless_leg,
+)
+from services.paperless_metadata_extractor import ExtractionResult, PaperlessMetadata
+
+# Module-level unit mark; async tests are picked up by asyncio_mode=auto. The
+# sync _parse_* tests stay sync (no spurious asyncio mark).
+pytestmark = [pytest.mark.unit]
+
+_PDF = b"%PDF-1.4 hello world bytes"
+
+
+def _envelope(inner: dict) -> dict:
+    """Mimic the MCPManager envelope: tool dict JSON-encoded in `message`."""
+    return {"success": True, "message": json.dumps(inner)}
+
+
+def _mcp(upload_inner: dict | None = None, await_inner: dict | None = None):
+    """A mock mcp_manager whose execute_tool dispatches by tool name."""
+    upload_inner = upload_inner if upload_inner is not None else {"task_id": "t1"}
+    await_inner = await_inner if await_inner is not None else {"status": "success", "document_id": 5}
+
+    async def _execute(tool, params):
+        if tool == "mcp.paperless.upload_document":
+            return _envelope(upload_inner)
+        if tool == "mcp.paperless.await_consume_result":
+            return _envelope(await_inner)
+        raise AssertionError(f"unexpected tool {tool}")
+
+    mgr = MagicMock()
+    mgr.execute_tool = AsyncMock(side_effect=_execute)
+    return mgr
+
+
+def _patch_extractor(monkeypatch, *, metadata=None, error=None):
+    """Patch PaperlessMetadataExtractor so extract_from_file returns a
+    controlled ExtractionResult."""
+    result = ExtractionResult(
+        metadata=metadata or PaperlessMetadata(), doc_text="text", error=error
+    )
+    inst = MagicMock()
+    inst.extract_from_file = AsyncMock(return_value=result)
+    monkeypatch.setattr(
+        "services.paperless_metadata_extractor.PaperlessMetadataExtractor",
+        MagicMock(return_value=inst),
+    )
+    return inst
+
+
+def _doc(paperless_state=None):
+    return MagicMock(id=1, paperless_state=paperless_state, file_path="/uploads/x.pdf")
+
+
+def _meta():
+    return IngestMeta(filename="invoice.pdf")
+
+
+# ---------------------------------------------------------------------------
+# _parse_paperless_result
+# ---------------------------------------------------------------------------
+
+def test_parse_unwraps_envelope():
+    assert _parse_paperless_result(_envelope({"task_id": "t9"})) == {"task_id": "t9"}
+
+
+def test_parse_transport_failure_is_error():
+    out = _parse_paperless_result({"success": False, "message": "boom"})
+    assert "error" in out
+
+
+def test_parse_none_is_error():
+    assert "error" in _parse_paperless_result(None)
+
+
+def test_parse_unparseable_message_is_error():
+    assert "error" in _parse_paperless_result({"success": True, "message": "not json"})
+
+
+# ---------------------------------------------------------------------------
+# leg outcomes
+# ---------------------------------------------------------------------------
+
+async def test_idempotent_skip_when_already_done(monkeypatch):
+    mgr = _mcp()
+    leg = make_paperless_leg(mgr)
+    doc = _doc(paperless_state=PAPERLESS_STATE_DONE)
+    db = AsyncMock()
+
+    assert await leg(db, doc, _PDF, _meta()) is True
+    mgr.execute_tool.assert_not_called()  # no upload — already settled
+
+
+async def test_success_marks_done(monkeypatch):
+    _patch_extractor(monkeypatch)
+    leg = make_paperless_leg(_mcp(await_inner={"status": "success", "document_id": 7}))
+    doc, db = _doc(), AsyncMock()
+
+    assert await leg(db, doc, _PDF, _meta()) is True
+    assert doc.paperless_state == PAPERLESS_STATE_DONE
+    db.commit.assert_awaited()
+
+
+async def test_duplicate_marks_done(monkeypatch):
+    _patch_extractor(monkeypatch)
+    leg = make_paperless_leg(_mcp(await_inner={"status": "duplicate", "detail": "dup"}))
+    doc, db = _doc(), AsyncMock()
+
+    assert await leg(db, doc, _PDF, _meta()) is True
+    assert doc.paperless_state == PAPERLESS_STATE_DONE  # D10: duplicate is terminal success
+
+
+async def test_non_duplicate_failure_marks_failed_and_settles(monkeypatch):
+    _patch_extractor(monkeypatch)
+    leg = make_paperless_leg(_mcp(await_inner={"status": "failure", "detail": "bad pdf"}))
+    doc, db = _doc(), AsyncMock()
+
+    # settled (True) so the bridge stops looping, but recorded as FAILED (not in
+    # Paperless) — distinct from done.
+    assert await leg(db, doc, _PDF, _meta()) is True
+    assert doc.paperless_state == PAPERLESS_STATE_FAILED
+
+
+async def test_pending_is_unsettled(monkeypatch):
+    _patch_extractor(monkeypatch)
+    leg = make_paperless_leg(_mcp(await_inner={"status": "pending", "detail": "timeout"}))
+    doc, db = _doc(), AsyncMock()
+
+    assert await leg(db, doc, _PDF, _meta()) is False  # retry later
+    assert doc.paperless_state is None  # left unset
+    db.commit.assert_not_awaited()
+
+
+async def test_upload_tool_rejection_is_terminal_failed(monkeypatch):
+    _patch_extractor(monkeypatch)
+    # Paperless/tool rejected the upload (bad field / 4xx / config) — a body
+    # error with envelope success=True. Re-sending won't help → terminal FAILED,
+    # settled (True) so PAPERLESS_ONLY doesn't loop.
+    leg = make_paperless_leg(_mcp(upload_inner={"error": "Unknown correspondent"}))
+    doc, db = _doc(), AsyncMock()
+
+    assert await leg(db, doc, _PDF, _meta()) is True
+    assert doc.paperless_state == PAPERLESS_STATE_FAILED
+
+
+async def test_upload_transport_failure_is_unsettled(monkeypatch):
+    _patch_extractor(monkeypatch)
+    # MCP unreachable (envelope success=False) → transient, leave unset, retry.
+    mgr = MagicMock()
+    mgr.execute_tool = AsyncMock(return_value={"success": False, "message": "mcp down"})
+    leg = make_paperless_leg(mgr)
+    doc, db = _doc(), AsyncMock()
+
+    assert await leg(db, doc, _PDF, _meta()) is False
+    assert doc.paperless_state is None
+
+
+async def test_idempotent_skip_when_already_failed(monkeypatch):
+    # A settled-failed doc is skipped too (defence in depth).
+    mgr = _mcp()
+    leg = make_paperless_leg(mgr)
+    assert await leg(AsyncMock(), _doc(paperless_state=PAPERLESS_STATE_FAILED), _PDF, _meta()) is True
+    mgr.execute_tool.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# metadata wiring
+# ---------------------------------------------------------------------------
+
+async def test_extracted_metadata_passed_to_upload(monkeypatch):
+    _patch_extractor(
+        monkeypatch,
+        metadata=PaperlessMetadata(
+            title="Stromrechnung", correspondent="Stadtwerke",
+            document_type="Rechnung", tags=["energie"],
+        ),
+    )
+    mgr = _mcp()
+    leg = make_paperless_leg(mgr)
+    await leg(AsyncMock(), _doc(), _PDF, _meta())
+
+    upload_call = mgr.execute_tool.await_args_list[0]
+    params = upload_call.args[1]
+    assert params["title"] == "Stromrechnung"
+    assert params["correspondent"] == "Stadtwerke"
+    assert params["document_type"] == "Rechnung"
+    assert params["tags"] == ["energie"]
+    assert params["wait_for_consume"] is False  # we drive the consume poll ourselves
+
+
+async def test_extractor_error_falls_back_to_bare_upload(monkeypatch):
+    _patch_extractor(monkeypatch, error="Paperless-Taxonomie nicht erreichbar")
+    mgr = _mcp()
+    leg = make_paperless_leg(mgr)
+    await leg(AsyncMock(), _doc(), _PDF, _meta())
+
+    params = mgr.execute_tool.await_args_list[0].args[1]
+    assert params["title"] == "invoice.pdf"  # filename fallback
+    assert "correspondent" not in params  # no metadata on error
+
+
+async def test_extractor_exception_does_not_break_leg(monkeypatch):
+    inst = MagicMock()
+    inst.extract_from_file = AsyncMock(side_effect=RuntimeError("docling boom"))
+    monkeypatch.setattr(
+        "services.paperless_metadata_extractor.PaperlessMetadataExtractor",
+        MagicMock(return_value=inst),
+    )
+    mgr = _mcp()
+    leg = make_paperless_leg(mgr)
+
+    # extractor blew up → bare upload still proceeds → success
+    assert await leg(AsyncMock(), _doc(), _PDF, _meta()) is True

--- a/tests/backend/test_folder_ingest_route.py
+++ b/tests/backend/test_folder_ingest_route.py
@@ -410,3 +410,99 @@ async def test_generate_rotates_and_invalidates_old(db_session: AsyncSession):
     assert first != second
     assert await verify_folder_ingest_token(db_session, first) is False
     assert await verify_folder_ingest_token(db_session, second) is True
+
+
+# ===========================================================================
+# T9 / T15 — the cross-repo push contract (lock test) + contract-version skew.
+#
+# These pin the exact wire shape BOTH repos depend on. A change here is a
+# breaking change to the renfield-mcp-filesystem ↔ backend seam and MUST be
+# accompanied by a FOLDER_INGEST_CONTRACT_VERSION bump. If one of these fails,
+# do not "fix the test" — bump the contract version and update the MCP.
+# ===========================================================================
+
+CONTRACT_HEADER = "X-Folder-Ingest-Contract"
+
+
+def test_contract_version_pinned():
+    # Bump deliberately when the request/response shape or status names change.
+    assert FOLDER_INGEST_CONTRACT_VERSION == "1"
+
+
+def test_ingest_status_values_pinned():
+    # The 4-state names the MCP keys its file-move decision off — exact strings.
+    assert IngestStatus.INGESTED.value == "ingested"
+    assert IngestStatus.DUPLICATE.value == "duplicate"
+    assert IngestStatus.RETRY.value == "retry"
+    assert IngestStatus.FAILED.value == "failed"
+    assert {s.value for s in IngestStatus} == {"ingested", "duplicate", "retry", "failed"}
+
+
+def test_response_shape_pinned():
+    from api.routes.folder_ingest import FolderIngestResponse
+
+    fields = set(FolderIngestResponse.model_fields)
+    assert fields == {"status", "document_id", "detail", "contract_version"}
+
+
+def test_metadata_consumes_documented_keys_and_ignores_extras():
+    from services.folder_ingest import IngestMeta
+
+    meta = IngestMeta.from_dict(
+        {
+            "filename": "invoice.pdf",
+            "root": "inbox",
+            "relpath": "2026/invoice.pdf",
+            "sha256": "abc123",
+            "mime": "application/pdf",
+            "knowledge_base_id": 999,  # client override — MUST be ignored
+        }
+    )
+    assert meta.filename == "invoice.pdf"
+    assert meta.root == "inbox"
+    assert meta.relpath == "2026/invoice.pdf"
+    assert meta.sha256 == "abc123"
+    assert meta.mime == "application/pdf"
+    assert not hasattr(meta, "knowledge_base_id")
+
+
+@pytest.mark.integration
+async def test_response_carries_contract_version(client: AsyncClient, token_set: str, monkeypatch):
+    from api.routes import folder_ingest as route
+
+    monkeypatch.setattr(
+        route, "ingest_document",
+        AsyncMock(return_value=IngestResult(IngestStatus.INGESTED, document_id=1)),
+    )
+    r = await client.post(URL, **_multipart(), headers=_auth())
+    assert r.json()["contract_version"] == FOLDER_INGEST_CONTRACT_VERSION
+
+
+@pytest.mark.integration
+async def test_matching_contract_header_processed(client: AsyncClient, token_set: str, monkeypatch):
+    from api.routes import folder_ingest as route
+
+    monkeypatch.setattr(
+        route, "ingest_document",
+        AsyncMock(return_value=IngestResult(IngestStatus.INGESTED, document_id=1)),
+    )
+    headers = {**_auth(), CONTRACT_HEADER: FOLDER_INGEST_CONTRACT_VERSION}
+    r = await client.post(URL, **_multipart(), headers=headers)
+    assert r.status_code == 200
+    assert r.json()["status"] == "ingested"
+
+
+@pytest.mark.integration
+async def test_contract_skew_header_is_lenient_not_fatal(client: AsyncClient, token_set: str, monkeypatch):
+    # A skewed contract version is logged loudly but NOT rejected — the request
+    # shape has stayed backward-compatible, so we process rather than lose a file.
+    from api.routes import folder_ingest as route
+
+    monkeypatch.setattr(
+        route, "ingest_document",
+        AsyncMock(return_value=IngestResult(IngestStatus.INGESTED, document_id=1)),
+    )
+    headers = {**_auth(), CONTRACT_HEADER: "999"}
+    r = await client.post(URL, **_multipart(), headers=headers)
+    assert r.status_code == 200
+    assert r.json()["status"] == "ingested"

--- a/tests/backend/test_folder_ingest_route.py
+++ b/tests/backend/test_folder_ingest_route.py
@@ -1,0 +1,258 @@
+"""Endpoint tests for POST /api/folder-ingest/document (T3).
+
+Exercises the status-code contract the dedicated filesystem MCP depends on:
+503→retry (disabled / worker-down), 401/403 (token, fatal in the MCP), and the
+4-state 200 body (ingested|duplicate|retry|failed). The bridge itself
+(folder_ingest.ingest_document) is unit-tested separately in
+test_folder_ingest.py; here it is mocked at the route boundary except for the
+extension-reject case, which proves the real route→bridge wiring.
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from slowapi.errors import RateLimitExceeded
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import SETTING_FOLDER_INGEST_TOKEN, SystemSetting
+from services.folder_ingest import (
+    FOLDER_INGEST_CONTRACT_VERSION,
+    IngestResult,
+    IngestStatus,
+)
+
+URL = "/api/folder-ingest/document"
+TEST_TOKEN = "folder-ingest-test-token-abc123"
+
+
+@pytest.fixture
+async def client(db_session: AsyncSession):
+    """A self-contained app mounting ONLY the folder-ingest router, with get_db
+    overridden to the test session. Avoids importing the whole app (the build
+    box's source tree can sit behind HEAD), keeping these route tests isolated
+    to the endpoint under test."""
+    from api.routes import folder_ingest as route
+    from services.api_rate_limiter import limiter, rate_limit_exceeded_handler
+    from services.database import get_db
+
+    app = FastAPI()
+    app.state.limiter = limiter  # the @limiter.limit decorator reads this
+    app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
+    app.include_router(route.router, prefix="/api/folder-ingest")
+
+    async def _override_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_db
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+def _auth(token: str = TEST_TOKEN) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _multipart(filename: str = "invoice.pdf", content: bytes = b"%PDF-1.4 hello", **meta):
+    md = {"filename": filename, "root": "inbox", "relpath": filename}
+    md.update(meta)
+    return {
+        "files": {"file": (filename, content, "application/pdf")},
+        "data": {"metadata": json.dumps(md)},
+    }
+
+
+@pytest.fixture
+async def token_set(db_session: AsyncSession) -> str:
+    db_session.add(SystemSetting(key=SETTING_FOLDER_INGEST_TOKEN, value=TEST_TOKEN))
+    await db_session.commit()
+    return TEST_TOKEN
+
+
+@pytest.fixture(autouse=True)
+def _feature_enabled(request, monkeypatch):
+    """The route 503s when folder_ingest_enabled is false (and the ambient
+    .env ships it off). Force it on except for the test that asserts the
+    disabled path."""
+    if request.node.name == "test_503_when_disabled":
+        return
+    from api.routes import folder_ingest as route
+
+    monkeypatch.setattr(route.settings, "folder_ingest_enabled", True)
+
+
+@pytest.fixture(autouse=True)
+def _worker_alive(request, monkeypatch):
+    """Pretend the document worker heartbeat is fresh, except where a test
+    drives the worker-down path."""
+    if request.node.name == "test_503_when_worker_down":
+        return
+    from api.routes import folder_ingest as route
+
+    monkeypatch.setattr(route, "_worker_is_alive", AsyncMock(return_value=True))
+
+
+@pytest.mark.integration
+async def test_503_when_disabled(client: AsyncClient, token_set: str):
+    from api.routes import folder_ingest as route
+
+    # explicit: feature off
+    with patch.object(route.settings, "folder_ingest_enabled", False):
+        r = await client.post(URL, **_multipart(), headers=_auth())
+    assert r.status_code == 503
+    assert r.json()["detail"]["reason"] == "feature_disabled"
+
+
+@pytest.mark.integration
+async def test_401_missing_auth(client: AsyncClient, token_set: str):
+    r = await client.post(URL, **_multipart())  # no Authorization header
+    assert r.status_code == 401
+
+
+@pytest.mark.integration
+async def test_403_wrong_token(client: AsyncClient, token_set: str):
+    r = await client.post(URL, **_multipart(), headers=_auth("nope"))
+    assert r.status_code == 403
+
+
+@pytest.mark.integration
+async def test_403_when_no_token_provisioned(client: AsyncClient):
+    # No SystemSetting row at all → verify returns False → 403 (not a 500).
+    r = await client.post(URL, **_multipart(), headers=_auth("anything"))
+    assert r.status_code == 403
+
+
+@pytest.mark.integration
+async def test_503_when_worker_down(client: AsyncClient, token_set: str, monkeypatch):
+    from api.routes import folder_ingest as route
+
+    monkeypatch.setattr(route, "_worker_is_alive", AsyncMock(return_value=False))
+    r = await client.post(URL, **_multipart(), headers=_auth())
+    assert r.status_code == 503
+    assert r.json()["detail"]["reason"] == "worker_unavailable"
+
+
+@pytest.mark.integration
+async def test_malformed_metadata_is_failed(client: AsyncClient, token_set: str):
+    r = await client.post(
+        URL,
+        files={"file": ("x.pdf", b"%PDF", "application/pdf")},
+        data={"metadata": "this is not json"},
+        headers=_auth(),
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == IngestStatus.FAILED.value
+    assert body["detail"] == "malformed_metadata"
+    assert body["contract_version"] == FOLDER_INGEST_CONTRACT_VERSION
+
+
+@pytest.mark.integration
+async def test_oversize_streams_to_failed(client: AsyncClient, token_set: str, monkeypatch):
+    from api.routes import folder_ingest as route
+
+    monkeypatch.setattr(route.settings, "max_file_size_mb", 1)
+    big = b"x" * (2 * 1024 * 1024)  # 2 MiB > 1 MiB ceiling
+    r = await client.post(
+        URL, **_multipart(content=big), headers=_auth()
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == IngestStatus.FAILED.value
+    assert body["detail"] == "file_too_large"
+
+
+@pytest.mark.integration
+async def test_bad_extension_is_failed_real_bridge(client: AsyncClient, token_set: str):
+    # No mock of the bridge: the real ingest_document rejects the extension
+    # before any disk/DB work, proving the route→bridge wiring + 4-state map.
+    r = await client.post(URL, **_multipart(filename="malware.exe"), headers=_auth())
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == IngestStatus.FAILED.value
+    assert body["detail"] == "extension_not_allowed"
+
+
+@pytest.mark.integration
+async def test_happy_path_ingested(client: AsyncClient, token_set: str, monkeypatch):
+    from api.routes import folder_ingest as route
+
+    fake = AsyncMock(
+        return_value=IngestResult(IngestStatus.INGESTED, document_id=99, detail="enqueued")
+    )
+    monkeypatch.setattr(route, "ingest_document", fake)
+    r = await client.post(URL, **_multipart(), headers=_auth())
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "ingested"
+    assert body["document_id"] == 99
+    assert body["contract_version"] == FOLDER_INGEST_CONTRACT_VERSION
+    # the route resolved a server-side KB + ownerless enqueue and passed no leg
+    _, kwargs = fake.await_args
+    assert kwargs["kb_id"] is not None
+    assert kwargs["paperless_leg"] is None
+
+
+@pytest.mark.integration
+async def test_retry_state_passthrough(client: AsyncClient, token_set: str, monkeypatch):
+    from api.routes import folder_ingest as route
+
+    monkeypatch.setattr(
+        route,
+        "ingest_document",
+        AsyncMock(return_value=IngestResult(IngestStatus.RETRY, document_id=5, detail="in_progress")),
+    )
+    r = await client.post(URL, **_multipart(), headers=_auth())
+    assert r.status_code == 200
+    assert r.json()["status"] == "retry"
+
+
+@pytest.mark.integration
+async def test_client_kb_override_ignored(
+    client: AsyncClient, token_set: str, db_session: AsyncSession, monkeypatch
+):
+    # A pusher that sticks knowledge_base_id in metadata cannot redirect the
+    # ingest: IngestMeta drops it and the route resolves the KB server-side.
+    from sqlalchemy import select
+
+    from api.routes import folder_ingest as route
+    from models.database import KnowledgeBase
+
+    fake = AsyncMock(
+        return_value=IngestResult(IngestStatus.INGESTED, document_id=1)
+    )
+    monkeypatch.setattr(route, "ingest_document", fake)
+    r = await client.post(
+        URL, **_multipart(knowledge_base_id=999999), headers=_auth()
+    )
+    assert r.status_code == 200
+    # Prove it positively: kb_id is the id of the server-side configured KB,
+    # not the client's 999999 (a bare `!= 999999` would pass trivially).
+    expected_kb = (
+        await db_session.execute(
+            select(KnowledgeBase).where(
+                KnowledgeBase.name == route.settings.folder_ingest_kb_name
+            )
+        )
+    ).scalar_one()
+    _, kwargs = fake.await_args
+    assert kwargs["kb_id"] == expected_kb.id
+
+
+@pytest.mark.integration
+async def test_unexpected_error_is_503_not_500(client: AsyncClient, token_set: str, monkeypatch):
+    # An unexpected failure in the bridge (e.g. Redis enqueue down) must surface
+    # as 503/retry so the MCP re-pushes — never a raw 500 that breaks the
+    # transport contract.
+    from api.routes import folder_ingest as route
+
+    monkeypatch.setattr(
+        route, "ingest_document", AsyncMock(side_effect=RuntimeError("redis down"))
+    )
+    r = await client.post(URL, **_multipart(), headers=_auth())
+    assert r.status_code == 503
+    assert r.json()["detail"]["reason"] == "internal_error"

--- a/tests/backend/test_folder_ingest_route.py
+++ b/tests/backend/test_folder_ingest_route.py
@@ -36,6 +36,7 @@ async def client(db_session: AsyncSession):
     to the endpoint under test."""
     from api.routes import folder_ingest as route
     from services.api_rate_limiter import limiter, rate_limit_exceeded_handler
+    from services.auth_service import get_current_user
     from services.database import get_db
 
     app = FastAPI()
@@ -47,6 +48,10 @@ async def client(db_session: AsyncSession):
         yield db_session
 
     app.dependency_overrides[get_db] = _override_db
+    # The admin token-mint route depends on require_permission → get_current_user.
+    # Provide a stub user; the per-permission gate is exercised by patching
+    # auth_enabled in the token tests (the enforcement itself is require_permission's).
+    app.dependency_overrides[get_current_user] = lambda: MagicMock(id=1, username="admin")
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
     ) as c:
@@ -287,3 +292,121 @@ async def test_unexpected_error_is_503_not_500(client: AsyncClient, token_set: s
     r = await client.post(URL, **_multipart(), headers=_auth())
     assert r.status_code == 503
     assert r.json()["detail"]["reason"] == "internal_error"
+
+
+# ===========================================================================
+# T14 — health handshake (DX-1) + admin token mint (DX-2)
+# ===========================================================================
+
+HEALTH_URL = "/api/folder-ingest/health"
+TOKEN_URL = "/api/folder-ingest/token"
+
+
+@pytest.mark.integration
+async def test_health_401_without_auth(client: AsyncClient, token_set: str):
+    r = await client.get(HEALTH_URL)
+    assert r.status_code == 401
+
+
+@pytest.mark.integration
+async def test_health_403_wrong_token(client: AsyncClient, token_set: str):
+    r = await client.get(HEALTH_URL, headers=_auth("nope"))
+    assert r.status_code == 403
+
+
+@pytest.mark.integration
+async def test_health_snapshot(client: AsyncClient, token_set: str):
+    r = await client.get(HEALTH_URL, headers=_auth())
+    assert r.status_code == 200
+    body = r.json()
+    assert body["enabled"] is True  # autouse fixture forces it on
+    assert body["token_ok"] is True
+    assert body["contract_version"] == FOLDER_INGEST_CONTRACT_VERSION
+    assert isinstance(body["allowed_extensions"], list) and "pdf" in body["allowed_extensions"]
+    assert body["max_file_size_mb"] >= 1
+    assert "kb_name" in body and "kb_resolved" in body
+
+
+@pytest.mark.integration
+async def test_health_reports_disabled_without_503(client: AsyncClient, token_set: str):
+    # Unlike the push route, health does NOT 503 when disabled — it reports
+    # enabled:False so the MCP can distinguish "feature off" from "worker down".
+    from api.routes import folder_ingest as route
+
+    with patch.object(route.settings, "folder_ingest_enabled", False):
+        r = await client.get(HEALTH_URL, headers=_auth())
+    assert r.status_code == 200
+    assert r.json()["enabled"] is False
+
+
+@pytest.mark.integration
+async def test_health_kb_resolved_reflects_existence(
+    client: AsyncClient, token_set: str, db_session: AsyncSession
+):
+    from api.routes import folder_ingest as route
+    from models.database import KnowledgeBase
+
+    # No KB yet → kb_resolved False.
+    r = await client.get(HEALTH_URL, headers=_auth())
+    assert r.json()["kb_resolved"] is False
+
+    # Create the configured KB → kb_resolved True (SELECT-only, no side effect).
+    db_session.add(KnowledgeBase(name=route.settings.folder_ingest_kb_name, description="x"))
+    await db_session.commit()
+    r = await client.get(HEALTH_URL, headers=_auth())
+    assert r.json()["kb_resolved"] is True
+
+
+@pytest.mark.integration
+async def test_token_mint_returns_and_persists(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch
+):
+    # auth_enabled False → require_permission short-circuits to allow (the stub
+    # user from the fixture). This proves the route mints + persists; the
+    # permission ENFORCEMENT itself is require_permission's own concern.
+    from services import auth_service
+
+    monkeypatch.setattr(auth_service.settings, "auth_enabled", False)
+
+    r = await client.post(TOKEN_URL)
+    assert r.status_code == 200
+    token = r.json()["token"]
+    assert token and len(token) > 20
+
+    # Persisted in SystemSetting + verifiable.
+    from services.folder_ingest import verify_folder_ingest_token
+
+    assert await verify_folder_ingest_token(db_session, token) is True
+
+
+# ---------------------------------------------------------------------------
+# Token helpers (service level)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+async def test_generate_then_verify_roundtrip(db_session: AsyncSession):
+    from services.folder_ingest import (
+        generate_folder_ingest_token,
+        get_folder_ingest_token,
+        verify_folder_ingest_token,
+    )
+
+    assert await get_folder_ingest_token(db_session) is None
+    token = await generate_folder_ingest_token(db_session)
+    assert await get_folder_ingest_token(db_session) == token
+    assert await verify_folder_ingest_token(db_session, token) is True
+    assert await verify_folder_ingest_token(db_session, "wrong") is False
+
+
+@pytest.mark.integration
+async def test_generate_rotates_and_invalidates_old(db_session: AsyncSession):
+    from services.folder_ingest import (
+        generate_folder_ingest_token,
+        verify_folder_ingest_token,
+    )
+
+    first = await generate_folder_ingest_token(db_session)
+    second = await generate_folder_ingest_token(db_session)
+    assert first != second
+    assert await verify_folder_ingest_token(db_session, first) is False
+    assert await verify_folder_ingest_token(db_session, second) is True

--- a/tests/backend/test_folder_ingest_route.py
+++ b/tests/backend/test_folder_ingest_route.py
@@ -9,7 +9,7 @@ extension-reject case, which proves the real route→bridge wiring.
 """
 
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -241,6 +241,37 @@ async def test_client_kb_override_ignored(
     ).scalar_one()
     _, kwargs = fake.await_args
     assert kwargs["kb_id"] == expected_kb.id
+
+
+def _fake_request(mcp_manager):
+    req = MagicMock()
+    req.app.state.mcp_manager = mcp_manager
+    return req
+
+
+def test_build_paperless_leg_none_when_disabled(monkeypatch):
+    from api.routes import folder_ingest as route
+
+    monkeypatch.setattr(route.settings, "folder_ingest_to_paperless", False)
+    assert route._build_paperless_leg(_fake_request(MagicMock()), 1) is None
+
+
+def test_build_paperless_leg_none_when_no_mcp(monkeypatch):
+    from api.routes import folder_ingest as route
+
+    monkeypatch.setattr(route.settings, "folder_ingest_to_paperless", True)
+    # app.state has no mcp_manager attribute → getattr returns None
+    req = MagicMock()
+    req.app.state = MagicMock(spec=[])  # no mcp_manager
+    assert route._build_paperless_leg(req, 1) is None
+
+
+def test_build_paperless_leg_built_when_enabled(monkeypatch):
+    from api.routes import folder_ingest as route
+
+    monkeypatch.setattr(route.settings, "folder_ingest_to_paperless", True)
+    leg = route._build_paperless_leg(_fake_request(MagicMock()), 1)
+    assert leg is not None and callable(leg)
 
 
 @pytest.mark.integration

--- a/tests/backend/test_folder_ingest_tool.py
+++ b/tests/backend/test_folder_ingest_tool.py
@@ -1,0 +1,165 @@
+"""Tests for the internal.ingest_file agent tool (T6).
+
+The interactive folder-ingest path: pull a file's bytes through the filesystem
+MCP (truncate=False) and run them through the shared ingest bridge. All
+collaborators (MCP, DB session, bridge) are mocked.
+"""
+from __future__ import annotations
+
+import base64
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import services.folder_ingest_tool as tool_mod
+from services.folder_ingest import IngestResult, IngestStatus
+from services.folder_ingest_tool import ingest_file
+
+pytestmark = [pytest.mark.unit]
+
+_B64 = base64.b64encode(b"%PDF-1.4 real bytes").decode("ascii")
+
+
+class _FakeCM:
+    def __init__(self, db):
+        self._db = db
+
+    async def __aenter__(self):
+        return self._db
+
+    async def __aexit__(self, *_a):
+        return False
+
+
+def _mcp(read_inner: dict | None = None):
+    read_inner = read_inner if read_inner is not None else {
+        "content_base64": _B64, "filename": "invoice.pdf"
+    }
+    mgr = MagicMock()
+    mgr.execute_tool = AsyncMock(
+        return_value={"success": True, "message": json.dumps(read_inner)}
+    )
+    return mgr
+
+
+def _wire(monkeypatch, *, ingest_result=None, worker_alive=True, to_paperless=False):
+    """Patch the tool's collaborators. Returns the ingest_document AsyncMock."""
+    monkeypatch.setattr(tool_mod.settings, "folder_ingest_enabled", True)
+    monkeypatch.setattr(tool_mod.settings, "folder_ingest_to_paperless", to_paperless)
+    monkeypatch.setattr(tool_mod.settings, "folder_ingest_default_tier", 0)
+
+    ingest = AsyncMock(
+        return_value=ingest_result
+        or IngestResult(IngestStatus.INGESTED, document_id=42, detail="enqueued")
+    )
+    monkeypatch.setattr(tool_mod, "ingest_document", ingest)
+    monkeypatch.setattr(tool_mod, "resolve_target_kb", AsyncMock(return_value=MagicMock(id=1)))
+    monkeypatch.setattr(tool_mod, "resolve_owner_user_id", AsyncMock(return_value=None))
+    monkeypatch.setattr("services.database.AsyncSessionLocal", lambda: _FakeCM(MagicMock()))
+    monkeypatch.setattr(
+        "api.routes.knowledge._worker_is_alive", AsyncMock(return_value=worker_alive)
+    )
+    return ingest
+
+
+@pytest.mark.asyncio
+async def test_missing_path_fails():
+    out = await ingest_file({}, mcp_manager=_mcp())
+    assert out["success"] is False
+    assert out["action_taken"] is False
+
+
+@pytest.mark.asyncio
+async def test_disabled_fails(monkeypatch):
+    monkeypatch.setattr(tool_mod.settings, "folder_ingest_enabled", False)
+    out = await ingest_file({"path": "/inbox/x.pdf"}, mcp_manager=_mcp())
+    assert out["success"] is False
+    assert "disabled" in out["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_no_mcp_manager_fails(monkeypatch):
+    monkeypatch.setattr(tool_mod.settings, "folder_ingest_enabled", True)
+    out = await ingest_file({"path": "/inbox/x.pdf"}, mcp_manager=None)
+    assert out["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_read_file_error_fails(monkeypatch):
+    _wire(monkeypatch)
+    mgr = MagicMock()
+    mgr.execute_tool = AsyncMock(
+        return_value={"success": True, "message": json.dumps({"error": "not found"})}
+    )
+    out = await ingest_file({"path": "/inbox/missing.pdf"}, mcp_manager=mgr)
+    assert out["success"] is False
+    assert "missing.pdf" in out["message"]
+
+
+@pytest.mark.asyncio
+async def test_invalid_base64_fails(monkeypatch):
+    _wire(monkeypatch)
+    mgr = _mcp(read_inner={"content_base64": "!!!not base64!!!", "filename": "x.pdf"})
+    out = await ingest_file({"path": "/inbox/x.pdf"}, mcp_manager=mgr)
+    assert out["success"] is False
+    assert "base64" in out["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_worker_down_fails(monkeypatch):
+    _wire(monkeypatch, worker_alive=False)
+    out = await ingest_file({"path": "/inbox/x.pdf"}, mcp_manager=_mcp())
+    assert out["success"] is False
+    assert "worker" in out["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_happy_path_ingested(monkeypatch):
+    ingest = _wire(monkeypatch)
+    out = await ingest_file({"path": "/inbox/invoice.pdf"}, mcp_manager=_mcp(), user_id=9)
+
+    assert out["success"] is True
+    assert out["action_taken"] is True
+    assert out["data"] == {"status": "ingested", "document_id": 42}
+    # the asker (user_id) owns the file; tier from config; KB resolved server-side
+    _, kwargs = ingest.await_args
+    assert kwargs["owner_user_id"] == 9
+    assert kwargs["default_tier"] == 0
+    assert kwargs["kb_id"] == 1
+
+
+@pytest.mark.asyncio
+async def test_read_file_called_with_truncate_false(monkeypatch):
+    _wire(monkeypatch)
+    mgr = _mcp()
+    await ingest_file({"path": "/inbox/x.pdf"}, mcp_manager=mgr, user_id=1)
+    tool, params = mgr.execute_tool.await_args.args
+    assert tool == "mcp.files.read_file"
+    assert params == {"path": "/inbox/x.pdf", "truncate": False}
+
+
+@pytest.mark.asyncio
+async def test_duplicate_is_friendly_no_action(monkeypatch):
+    _wire(monkeypatch, ingest_result=IngestResult(IngestStatus.DUPLICATE, document_id=7))
+    out = await ingest_file({"path": "/inbox/x.pdf"}, mcp_manager=_mcp(), user_id=1)
+    assert out["success"] is True
+    assert out["action_taken"] is False
+    assert out["data"]["status"] == "duplicate"
+
+
+@pytest.mark.asyncio
+async def test_failed_reports_unsuccessful(monkeypatch):
+    _wire(monkeypatch, ingest_result=IngestResult(IngestStatus.FAILED, detail="extension_not_allowed"))
+    out = await ingest_file({"path": "/inbox/x.exe"}, mcp_manager=_mcp(), user_id=1)
+    assert out["success"] is False
+    assert out["action_taken"] is False
+
+
+@pytest.mark.asyncio
+async def test_owner_falls_back_to_configured_when_unauthenticated(monkeypatch):
+    ingest = _wire(monkeypatch)
+    monkeypatch.setattr(tool_mod, "resolve_owner_user_id", AsyncMock(return_value=3))
+    await ingest_file({"path": "/inbox/x.pdf"}, mcp_manager=_mcp(), user_id=None)
+    _, kwargs = ingest.await_args
+    assert kwargs["owner_user_id"] == 3  # configured target_user, not None

--- a/tests/backend/test_paperless_metadata_extractor.py
+++ b/tests/backend/test_paperless_metadata_extractor.py
@@ -775,6 +775,54 @@ class TestExtractorIntegration:
 
     @pytest.mark.asyncio
     @pytest.mark.unit
+    async def test_extract_from_file_no_chatupload(self, tmp_path):
+        """The folder-ingest path: extract straight from a file on disk, with
+        NO ChatUpload row (decoupling, D5). _load_upload must not be touched."""
+        file = tmp_path / "doc.pdf"
+        file.write_text("dummy")
+
+        llm_client = MagicMock()
+        llm_client.chat = AsyncMock(return_value=SimpleNamespace(
+            message=SimpleNamespace(
+                content='{"title": "T", "correspondent": "Finanzamt Neuss", '
+                        '"document_type": "Rechnung", "tags": [], '
+                        '"new_entry_proposals": []}',
+            ),
+        ))
+        doc_proc = MagicMock()
+        doc_proc.extract_text_only = AsyncMock(return_value="Finanzamt Neuss Bescheid")
+
+        async def _mcp_execute(tool_name: str, params: dict):
+            if "correspondents" in tool_name:
+                return {"success": True, "message": '{"items": [{"name": "Finanzamt Neuss"}]}'}
+            if "document_types" in tool_name:
+                return {"success": True, "message": '{"items": [{"name": "Rechnung"}]}'}
+            if "tags" in tool_name:
+                return {"success": True, "message": '{"items": []}'}
+            if "storage_paths" in tool_name:
+                return {"success": True, "message": '{"paths": []}'}
+            return {"success": False}
+
+        mcp = MagicMock()
+        mcp.execute_tool = AsyncMock(side_effect=_mcp_execute)
+
+        extractor = PaperlessMetadataExtractor(
+            mcp_manager=mcp, llm_client=llm_client, document_processor=doc_proc,
+        )
+        extractor._load_upload = AsyncMock(side_effect=AssertionError("must not load a ChatUpload"))
+
+        with patch("services.paperless_metadata_extractor.settings") as s:
+            s.paperless_extraction_model = "qwen3:8b"
+            s.ollama_vision_model = ""
+            s.ollama_chat_model = ""
+            result = await extractor.extract_from_file(str(file), lang="de")
+
+        assert result.error is None
+        assert result.metadata.correspondent == "Finanzamt Neuss"
+        extractor._load_upload.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
     async def test_extract_passes_learned_examples_to_prompt(self, tmp_path):
         """When the retriever returns past confirm-diffs, those flow
         into the LLM prompt as additional in-context examples."""

--- a/tests/backend/test_rag_service_split.py
+++ b/tests/backend/test_rag_service_split.py
@@ -104,6 +104,35 @@ async def test_create_document_record_defaults_filename_from_path(db_session):
     assert doc.status == DOC_STATUS_PENDING
 
 
+@pytest.mark.unit
+@pytest.mark.database
+async def test_create_document_record_applies_d4_overrides(
+    db_session, test_user, test_knowledge_base_with_owner
+):
+    """D4: owner_user_id_override + circle_tier_override replace the KB-derived
+    owner/tier on the Document and its atoms row (folder-ingest)."""
+    from sqlalchemy import select as _select
+
+    from models.database import Atom
+
+    rag = RAGService(db_session)
+    doc = await rag.create_document_record(
+        file_path="/tmp/d4.pdf",
+        knowledge_base_id=test_knowledge_base_with_owner.id,
+        filename="d4.pdf",
+        file_hash="sha256:d4override",
+        owner_user_id_override=test_user.id,
+        circle_tier_override=3,
+    )
+
+    assert doc.circle_tier == 3  # override, not the KB default
+    assert doc.atom_id is not None
+    atom = (
+        await db_session.execute(_select(Atom).where(Atom.atom_id == doc.atom_id))
+    ).scalar_one()
+    assert atom.owner_user_id == test_user.id
+
+
 # ---------------------------------------------------------------------------
 # process_existing_document
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

The **backend** side of watch-folder auto-ingest: drop a file in a watched folder → it is ingested into the knowledge base **and** Paperless automatically. A dedicated filesystem MCP (separate repo, not built yet) PUSHes files over REST to the backend — **no backend mounts, no polling, no WebSocket**.

This PR is backend-complete; the dedicated `renfield-mcp-filesystem` watcher/pusher is a follow-up. Until it exists, files reach the backend via the interactive `internal.ingest_file` agent tool or a manual POST. Full operator guide: `docs/FOLDER_INGEST.md`.

> **Pairs with** ebongard/renfield-mcp-paperless#11 (the `await_consume_result` MCP tool the Paperless leg drives). Merge that first.

## The load-bearing seam: the 4-state response contract (D9)

`POST /api/folder-ingest/document` returns `ingested | duplicate | retry | failed` (all HTTP 200) — the MCP moves the source file by it. `ingested` means *enqueued*, not OCR'd. Transport failures use `401/403` (token, fatal) / `503` (disabled or worker-down, retry).

## Highlights

- **Shared race-safe create helper** (T1) — `create_document_record_safe` factors the `uq_documents_file_hash_kb` race handling out of the upload route; both paths use it.
- **Bridge + completion+Paperless-aware dedup** (T2, D2) — `services/folder_ingest.py`: persist-bytes recovery copy → `classify_existing` (completed+settled → duplicate, failed → reingest, completed+paperless-missing → paperless-only, pending → retry) → race-safe create + enqueue → Paperless leg → 4-state result. New `Document.paperless_state` (migration `pc20260612`, verified real upgrade+downgrade).
- **Push route** (T3) — Bearer scoped-token (constant-time), streaming read with early size-abort, server-side KB+owner resolve (client `knowledge_base_id` ignored), top-level guard → 503-retry never a raw 500.
- **Worker terminal-failure handling** (T4) — terminal/poison docs are marked `status=failed` + ACKed (stop looping the PEL); transient infra blips stay un-ACKed for reclaim. Classifier covers timeout/httpx/redis/SQLAlchemy/ollama-5xx.
- **Real Paperless leg** (T5/T10) — non-blocking upload → `await_consume_result` (MCP owns the duplicate-marker knowledge). State: success/duplicate→`done`, non-dup-reject→`failed` (terminal), transport/pending→retry. `PaperlessMetadataExtractor` decoupled from `ChatUpload`.
- **D4 owner/tier override + `internal.ingest_file`** (T6) — auto-filed docs owned by `folder_ingest_target_user` at `folder_ingest_default_tier`; interactive agent tool pulls bytes via `mcp.files.read_file(truncate=False)` through the same bridge.
- **Health handshake + admin token-mint** (T14) — `GET /health` (config snapshot; `enabled:false` not 503 when off) + `POST /token` (admin `SETTINGS_MANAGE`).
- **Contract-version skew check + lock test** (T15/T9) + **docs** (T12/T19).

## Config (all opt-in, flag-off byte-identical)

`FOLDER_INGEST_ENABLED` (default false), `_KB_NAME`, `_TARGET_USER`, `_DEFAULT_TIER`, `_TO_PAPERLESS`, `_NOTIFY_ON_FILED`. Bearer token in `SystemSetting` (revocable). See `docs/ENVIRONMENT_VARIABLES.md`.

## Known gap (documented in code, P2)

A CREATE-path transient Paperless outage leaves the doc in the KB but unfiled in Paperless with no auto-retry (file already moved to `processed/`) — needs a future paperless-reconciler.

## Tests

All green on the .159 build box (CI is non-functional for this project). Each task `/review`'d, fixes folded in. Migration `pc20260612` verified via real `alembic upgrade`+`downgrade`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)