### PR TITLE
feat(mcp): register the files watch-folder MCP server stanza

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Renfield is a fully offline-capable, self-hosted **digital assistant** — a per
 
 **LLM:** Local models via Ollama (multi-model: chat, intent, RAG, agent, vision, embeddings).
 
-**Integrations:** Home Assistant, Frigate, n8n, SearXNG, Jellyfin, DLNA, Samsung TV, Paperless, Email, Calendar — all via MCP servers. (DLNA + Samsung TV run as dedicated `hostNetwork` images — `renfield-mcp-dlna` / `renfield-mcp-samsung` — not in the backend image; all other stdio servers live in the backend image.)
+**Integrations:** Home Assistant, Frigate, n8n, SearXNG, Jellyfin, DLNA, Samsung TV, Paperless, Email, Calendar, Filesystem (watch-folders) — all via MCP servers. (DLNA + Samsung TV run as dedicated `hostNetwork` images — `renfield-mcp-dlna` / `renfield-mcp-samsung`; the watch-folder server runs as its own dedicated `streamable_http` deployment — `renfield-mcp-filesystem`, the `files` stanza, holds the SMB/local credentials the backend must not — not in the backend image; all other stdio servers live in the backend image.)
 
 ## KRITISCHE REGELN - IMMER BEACHTEN
 

--- a/config/mcp_servers.yaml
+++ b/config/mcp_servers.yaml
@@ -353,6 +353,41 @@ servers:
         - "Find documents from Telekom"
         - "Send this document to Paperless"
 
+  # --- Filesystem watch-folder MCP Server ---
+  # Dedicated Python MCP server (renfield-mcp-filesystem) that watches local/SMB
+  # folders and PUSHES settled new files into the backend over REST
+  # (POST /api/folder-ingest/document) — no backend mounts, event-driven, no
+  # polling. This streamable_http connection is for the INTERACTIVE path only
+  # (browse + on-demand ingest); the auto-push path does not use this client.
+  # Runs as a dedicated deployment (like dlna/samsung), not in the backend image.
+  # GitHub: https://github.com/ebongard/renfield-mcp-filesystem
+  # See docs/FOLDER_INGEST.md.
+  - name: files
+    transport: streamable_http
+    url: "${FILES_MCP_URL:-http://renfield-mcp-filesystem:8080/mcp}"
+    enabled: "${FILES_MCP_ENABLED:-false}"
+    refresh_interval: 300
+    example_intent: mcp.files.list_watch_folders
+    # read_file + move_file are intentionally NOT in the agent prompt: read_file
+    # returns base64 the LLM can't usefully handle (it is used UNDER THE HOOD by
+    # the platform tool internal.ingest_file, which pulls real bytes with
+    # truncate=False), and move_file is a destructive op the watcher drives. Both
+    # remain executable for those internal paths — prompt_tools only filters the
+    # agent-visible list (mirrors the paperless upload_document exclusion).
+    prompt_tools:
+      - list_watch_folders
+      - list_files
+      - get_file_info
+    examples:
+      de:
+        - "Welche Ordner werden ueberwacht?"
+        - "Liste die Dateien im Eingang-Ordner"
+        - "Lies das PDF aus dem Dokumente-Ordner ein"
+      en:
+        - "Which folders are being watched?"
+        - "List the files in the inbox folder"
+        - "Ingest the PDF from the documents folder"
+
   # --- Email MCP Server ---
   # Custom Python MCP server for multi-account email (IMAP/SMTP).
   # Requires: MAIL_ACCOUNTS_CONFIG env var pointing to YAML config file


### PR DESCRIPTION
Registers the dedicated **renfield-mcp-filesystem** watch-folder server in `config/mcp_servers.yaml` so the backend can reach its interactive tools.

## What

Adds the `files` `streamable_http` stanza (default-off via `FILES_MCP_ENABLED`, url `FILES_MCP_URL`). This connection is for the **interactive path only** — browse + on-demand ingest via the agent. The **auto-push path does not use it**: the MCP pushes settled files directly to `POST /api/folder-ingest/document` (the seam landed in #743).

- Dedicated deployment (like dlna/samsung), **not** in the backend image — it holds the SMB/local credentials the backend must not.
- `prompt_tools` is **browse-only** (`list_watch_folders` / `list_files` / `get_file_info`). `read_file` + `move_file` are agent-hidden: `read_file` returns base64 used *under the hood* by the platform tool `internal.ingest_file` (`truncate=False`), and `move_file` is the watcher's destructive op — both stay executable (mirrors the `paperless.upload_document` exclusion).
- CLAUDE.md integrations/topology note updated.

## The server

The `renfield-mcp-filesystem` server it points at: https://github.com/ebongard/renfield-mcp-filesystem (event-driven local/SMB watcher, 69 tests incl. a live inotify integration test). It is **not deployed yet**; this stanza stays dark (`FILES_MCP_ENABLED=false`) until the image is built + the server deployed.

## Verification

`config/mcp_servers.yaml` parses cleanly; `files` stanza present between `paperless` and `email`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)