### PR TITLE
chore(deps): bump renfield-mcp-paperless v1.7.0 → v1.8.0

### DIFF
--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -85,7 +85,7 @@ jsonschema>=4.21.0            # JSON Schema validation for MCP tool inputs
 
 # MCP Servers (standalone packages)
 renfield-mcp-weather @ https://github.com/ebongard/renfield_mcp_weather/archive/refs/heads/main.tar.gz
-renfield-mcp-paperless @ https://github.com/ebongard/renfield-mcp-paperless/archive/refs/tags/v1.7.0.tar.gz
+renfield-mcp-paperless @ https://github.com/ebongard/renfield-mcp-paperless/archive/refs/tags/v1.8.0.tar.gz
 renfield-mcp-mail @ https://github.com/ebongard/renfield-mcp-mail/archive/refs/heads/main.tar.gz
 aiosmtplib>=3.0                  # Required by renfield-mcp-mail (not auto-resolved from archive installs)
 renfield-mcp-jellyfin @ https://github.com/ebongard/renfield-mcp-jellyfin/archive/refs/heads/main.tar.gz


### PR DESCRIPTION
Bumps the backend's `renfield-mcp-paperless` pin to **v1.8.0** ([release](https://github.com/ebongard/renfield-mcp-paperless/releases/tag/v1.8.0)) so the backend image includes the `await_consume_result` tool.

The folder-ingest **Paperless leg** (`services/folder_ingest_paperless.py`, merged in #743) calls `mcp.paperless.await_consume_result` to learn the consume verdict (filed / duplicate / failure). Without this bump that tool isn't in the image, so the leg can never settle a Paperless upload. Deploy prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)