### PR TITLE
fix(deps): cap transformers<5 — restore Docling on torch 2.6 (all docs were failing)

### DIFF
--- a/docs/KUBERNETES_DEPLOYMENT.md
+++ b/docs/KUBERNETES_DEPLOYMENT.md
@@ -82,6 +82,8 @@ Harbor is the registry. A `harbor-pull-secret` of type `kubernetes.io/dockerconf
 
 The backend image had ballooned to 7.5 GB because transitive deps in `docling`, `easyocr`, and `transformers` upgraded torch to a CUDA build, dragging in `nvidia/*` wheels (2.7 GB) and `triton` (641 MB). `src/backend/constraints.txt` pins `torch`/`torchaudio`/`torchvision` to `+cpu` wheels from the PyTorch CPU index so pip's resolver cannot upgrade. Final image: ~3.5 GB, which pushes through Harbor's proxy without the 504 timeouts that the old layer had.
 
+**`transformers` must stay capped `<5`** (`requirements.txt`). Since the torch pin holds at the **2.6.0 +cpu** wheel, an unbounded `transformers` resolves to a 5.x release that references `torch.float8_e8m0fnu` (added only in torch ≥ 2.7). That breaks the Docling import chain at runtime (`AttributeError: module 'torch' has no attribute 'float8_e8m0fnu'` → `Could not import module 'AutoProcessor'` → "Docling nicht installiert"), so **every** document fails processing (`status=failed`). `transformers>=4.47.0,<5` resolves to 4.57.x (with `huggingface_hub` 0.36.x), which `docling-ibm-models` (`>=4.42`) accepts and which keeps `rt_detr_v2` support. Only the **document-worker** runs Docling, so a worker-only image roll fixes this with zero API downtime. Reprocess already-failed docs by moving them from the watch-share `processed/` back to `incomming/` (the folder-ingest D2 matrix re-ingests a `failed` row on re-push).
+
 ## Manifest Structure
 
 ```

--- a/src/backend/constraints.txt
+++ b/src/backend/constraints.txt
@@ -3,3 +3,9 @@
 torch==2.6.0+cpu
 torchaudio==2.6.0+cpu
 torchvision==0.21.0+cpu
+
+# Cap transformers <5 here (not only in requirements.txt) so the Dockerfile's
+# Layer-2 literal install (`pip install transformers …`) never pulls 5.x in the
+# first place. transformers 5.x references torch.float8_e8m0fnu (torch >=2.7);
+# prod torch is 2.6, so 5.x breaks the Docling import chain. See requirements.txt.
+transformers<5

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -22,7 +22,7 @@ openai>=1.55.0                # OpenAI-compatible client for llama-server / vLLM
 docling>=2.0.0                # IBM Docling for document parsing (includes docling-ibm-models)
 docling-core>=2.0.0           # Docling core functionality
 easyocr>=1.7.0                # EasyOCR for force_full_page_ocr on German/English PDFs
-transformers>=4.47.0          # Required for rt_detr_v2 model support
+transformers>=4.47.0,<5       # rt_detr_v2 support; cap <5 — transformers 5.x needs torch>=2.7 (torch.float8_e8m0fnu); prod torch is 2.6 (CPU). docling-ibm-models allows >=4.42
 pgvector>=0.2.4               # PostgreSQL vector extension for SQLAlchemy
 aiofiles>=23.2.0              # Async file operations
 


### PR DESCRIPTION
## Problem

Every document in the knowledge base was showing **`fehlgeschlagen`** (status=failed) in Wissensbasis. Root cause is a dependency regression, **not** the folder-ingest feature:

- `src/backend/requirements.txt` had an unbounded `transformers>=4.47.0`
- A recent rebuild resolved it to **transformers 5.10.2**
- transformers 5.x references `torch.float8_e8m0fnu` (added only in **torch ≥ 2.7**)
- Production runs **torch 2.6.0+cpu** (pinned via `constraints.txt`)

So the Docling import chain died at runtime:
```
AttributeError: module 'torch' has no attribute 'float8_e8m0fnu'
 -> ModuleNotFoundError: Could not import module 'AutoProcessor'
 -> "Docling ist nicht installiert" -> every document -> status=failed
```
(The "Docling nicht installiert" log is misleading — Docling *is* installed; it's a transformers↔torch version incompatibility.)

## Fix

Pin **`transformers>=4.47.0,<5`** → resolves to **4.57.6** (with `huggingface_hub` 0.36.x), the combo that worked before the regression. `docling-ibm-models` allows `>=4.42`, and `rt_detr_v2` support is retained.

## Validation

- Built + import-tested against the live backend image: `transformers 4.57.6`, `AutoProcessor` + `docling.DocumentConverter` both import cleanly.
- **Deployed to prod** as a surgical hotfix image (backend `v2.13.0-rc.30`, worker + backend) and re-processed the two previously-failed real PDFs:
  - `regfish-101094000.pdf` → doc 58, **completed** (3 chunks, 10 KG entities)
  - `2026_06_06_21_12_35.pdf` → doc 59, **completed**
- Only the **document-worker** runs Docling, so the roll caused **zero API downtime**.

This PR is the durable source fix; prod currently runs the derived hotfix image, and the next clean source build bakes the pin in.

## Docs

`docs/KUBERNETES_DEPLOYMENT.md` — added the transformers-cap rationale next to the torch+cpu constraints note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)