### PR TITLE
feat(email-ingest): Phase 1 backend — route + bridge + per-mailbox routing (ships dark)

### DIFF
--- a/src/backend/alembic/versions/pc20260614_email_ingest_log.py
+++ b/src/backend/alembic/versions/pc20260614_email_ingest_log.py
@@ -1,0 +1,56 @@
+"""email_ingest_log — per-attachment provenance + idempotency ledger
+
+Revision ID: pc20260614_email_ingest
+Revises: pc20260613_pl_docid
+Create Date: 2026-06-09
+
+Backs email-mailbox auto-ingest (Phase 1): the renfield-mcp-email-ingest watcher
+pushes each allowlisted attachment to POST /api/email-ingest/document; one row
+per (mailbox_id, message_id, attachment_sha256) records provenance (sender,
+subject) + the 4-state outcome and gives the watcher idempotency on re-push.
+
+UNIQUE (mailbox_id, message_id, attachment_sha256) keyed by mailbox so two
+spheres never cross-dedup. document_id FK is ON DELETE SET NULL (a purged doc
+leaves the audit row). Additive; ships dark behind EMAIL_INGEST_ENABLED. Fully
+transactional.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "pc20260614_email_ingest"
+down_revision = "pc20260613_pl_docid"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "email_ingest_log",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("mailbox_id", sa.String(length=120), nullable=False),
+        sa.Column("message_id", sa.String(length=998), nullable=False),
+        sa.Column("attachment_sha256", sa.String(length=64), nullable=False),
+        sa.Column(
+            "document_id",
+            sa.Integer(),
+            sa.ForeignKey("documents.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("sender", sa.String(length=320), nullable=True),
+        sa.Column("subject", sa.Text(), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.UniqueConstraint(
+            "mailbox_id", "message_id", "attachment_sha256",
+            name="uq_email_ingest_mailbox_msg_attachment",
+        ),
+    )
+    op.create_index("ix_email_ingest_log_mailbox_id", "email_ingest_log", ["mailbox_id"])
+    op.create_index("ix_email_ingest_log_document_id", "email_ingest_log", ["document_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_email_ingest_log_document_id", table_name="email_ingest_log")
+    op.drop_index("ix_email_ingest_log_mailbox_id", table_name="email_ingest_log")
+    op.drop_table("email_ingest_log")

--- a/src/backend/api/routes/email_ingest.py
+++ b/src/backend/api/routes/email_ingest.py
@@ -96,6 +96,10 @@ def _build_paperless_leg(request: Request):
         return None
     from services.folder_ingest_paperless import make_paperless_leg
 
+    # TODO(email-ingest phase 2): thread the per-mailbox owner (ingest_email_document
+    # resolves it) into make_paperless_leg(user_id=...) so the Paperless extractor's
+    # learned-examples are owner-scoped, as folder-ingest already does. Phase-1-safe:
+    # the correspondent resolve-or-create does not depend on user_id.
     return make_paperless_leg(mcp_manager, user_id=None)
 
 

--- a/src/backend/api/routes/email_ingest.py
+++ b/src/backend/api/routes/email_ingest.py
@@ -1,0 +1,240 @@
+"""Email-ingest push endpoint (Phase 1) — the REST seam the dedicated
+``renfield-mcp-email-ingest`` watcher pushes email attachments to.
+
+``POST /api/email-ingest/document`` (multipart: ``file`` + ``metadata`` JSON with
+``mailbox_id`` + ``message_id`` + ``filename`` [+ ``sender``/``subject``/``sha256``/
+``mime``]). Bearer-auth'd by a revocable SystemSetting token (separate from the
+folder-ingest token). The backend owns the SPHERE: it resolves ``mailbox_id`` →
+``owner/tier/kb`` server-side; the watcher never sends a tier/owner. An unknown
+``mailbox_id`` → ``failed``.
+
+Same 4-state transport contract as folder-ingest: ``status`` ∈
+ingested|duplicate|retry|failed (all HTTP 200); ``503`` → retry (disabled / no
+worker), ``401/403`` → fatal token error.
+"""
+
+import json
+
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    Form,
+    Header,
+    HTTPException,
+    Request,
+    UploadFile,
+)
+from loguru import logger
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.routes.knowledge import _worker_is_alive
+from models.permissions import Permission
+from services.api_rate_limiter import limiter
+from services.auth_service import require_permission
+from services.database import get_db
+from services.email_ingest import (
+    EMAIL_INGEST_CONTRACT_VERSION,
+    generate_email_ingest_token,
+    ingest_email_document,
+    resolve_mailbox_target,
+    verify_email_ingest_token,
+)
+from services.folder_ingest import IngestStatus
+from utils.config import settings
+
+router = APIRouter()
+
+_CHUNK = 1024 * 1024  # 1 MiB streaming read
+
+
+class EmailIngestResponse(BaseModel):
+    """The 4-state push response. ``status`` ∈ ingested|duplicate|retry|failed."""
+
+    status: str
+    document_id: int | None = None
+    detail: str | None = None
+    contract_version: str = EMAIL_INGEST_CONTRACT_VERSION
+
+
+class EmailIngestTokenResponse(BaseModel):
+    token: str
+
+
+class EmailIngestHealthResponse(BaseModel):
+    """Config-alignment handshake for the watcher: it can confirm its configured
+    mailbox_ids are known to the backend routing table (the email analog of
+    folder-ingest's kb_resolved), so a two-surface mismatch surfaces loudly."""
+
+    enabled: bool
+    mailbox_ids: list[str]
+    to_paperless: bool
+    token_ok: bool
+    max_file_size_mb: int
+    allowed_extensions: list[str]
+    contract_version: str = EMAIL_INGEST_CONTRACT_VERSION
+
+
+def _build_paperless_leg(request: Request):
+    """Real Paperless leg when ``email_ingest_to_paperless`` is on and the MCP
+    manager is available, else None (no-op settled). OCR-correspondent only
+    (decision #3) — same ``make_paperless_leg`` as folder-ingest. Kept at the
+    route edge so the Paperless/MCP import stays out of the bridge.
+
+    ``user_id`` is left None in Phase 1: the per-mailbox owner isn't threaded to
+    the extractor's learned-examples (a per-user refinement); the correspondent
+    resolve-or-create does not depend on it."""
+    if not settings.email_ingest_to_paperless:
+        return None
+    mcp_manager = getattr(request.app.state, "mcp_manager", None)
+    if mcp_manager is None:
+        logger.warning(
+            "email-ingest: to_paperless is on but no MCP manager — skipping "
+            "Paperless filing for this push"
+        )
+        return None
+    from services.folder_ingest_paperless import make_paperless_leg
+
+    return make_paperless_leg(mcp_manager, user_id=None)
+
+
+@router.post("/document", response_model=EmailIngestResponse)
+@limiter.limit(settings.api_rate_limit_default)
+async def ingest_pushed_email(
+    request: Request,
+    file: UploadFile = File(...),
+    metadata: str = Form(...),
+    authorization: str | None = Header(None),
+    x_email_ingest_contract: str | None = Header(None),
+    db: AsyncSession = Depends(get_db),
+):
+    """Receive one pushed email attachment and run it through the email-ingest
+    bridge (which reuses the folder-ingest pipeline). See the module docstring."""
+    if (
+        x_email_ingest_contract
+        and x_email_ingest_contract != EMAIL_INGEST_CONTRACT_VERSION
+    ):
+        logger.warning(
+            f"email-ingest: contract skew — watcher sent {x_email_ingest_contract!r}, "
+            f"backend is {EMAIL_INGEST_CONTRACT_VERSION!r}; processing leniently"
+        )
+
+    # 1. Feature gate (transient 503/retry).
+    if not settings.email_ingest_enabled:
+        raise HTTPException(
+            status_code=503,
+            detail={"message": "Email ingest is disabled", "reason": "feature_disabled"},
+        )
+
+    # 2. Bearer token (constant-time). 401 missing, 403 wrong — both fatal in the watcher.
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
+    token = authorization.removeprefix("Bearer ").strip()
+    if not await verify_email_ingest_token(db, token):
+        raise HTTPException(status_code=403, detail="Invalid email-ingest token")
+
+    # 3. Worker-alive gate (enqueuing into a stream nobody consumes → orphan).
+    if not await _worker_is_alive():
+        raise HTTPException(
+            status_code=503,
+            detail={"message": "Document worker unavailable", "reason": "worker_unavailable"},
+        )
+
+    # 4. Parse metadata. Missing filename/mailbox_id → failed (won't self-heal).
+    try:
+        raw = json.loads(metadata)
+        if not isinstance(raw, dict):
+            raise ValueError("metadata is not an object")
+        filename = str(raw.get("filename") or "").strip()
+        mailbox_id = str(raw.get("mailbox_id") or "").strip()
+        if not filename:
+            raise ValueError("metadata is missing a filename")
+        if not mailbox_id:
+            raise ValueError("metadata is missing a mailbox_id")
+    except (json.JSONDecodeError, ValueError, TypeError) as exc:
+        logger.warning(f"email-ingest: malformed metadata: {exc}")
+        return EmailIngestResponse(status=IngestStatus.FAILED.value, detail="malformed_metadata")
+
+    # 5. Stream the body with an early size abort. Oversize → failed (terminal).
+    max_bytes = settings.max_file_size_mb * 1024 * 1024
+    buf = bytearray()
+    while chunk := await file.read(_CHUNK):
+        buf.extend(chunk)
+        if len(buf) > max_bytes:
+            logger.warning(
+                f"email-ingest: {filename!r} exceeds {settings.max_file_size_mb} MB "
+                f"ceiling (stream abort)"
+            )
+            return EmailIngestResponse(status=IngestStatus.FAILED.value, detail="file_too_large")
+    file_bytes = bytes(buf)
+
+    # 6. Delegate to the bridge (server-authoritative sphere routing inside).
+    # Any residual transient failure → 503/retry, never a raw 500 — the watcher
+    # leaves the email in the inbox and re-pushes rather than mis-moving it.
+    try:
+        result = await ingest_email_document(
+            file_bytes,
+            db=db,
+            mailbox_id=mailbox_id,
+            message_id=str(raw.get("message_id") or "").strip(),
+            filename=filename,
+            sender=raw.get("sender"),
+            subject=raw.get("subject"),
+            mime=raw.get("mime"),
+            sha256=raw.get("sha256"),
+            paperless_leg=_build_paperless_leg(request),
+        )
+    except Exception as exc:  # noqa: BLE001 - never 500 the push contract
+        logger.error(f"email-ingest: unexpected error processing {filename!r}: {exc}")
+        raise HTTPException(
+            status_code=503,
+            detail={"message": "Transient ingest error", "reason": "internal_error"},
+        ) from exc
+    return EmailIngestResponse(
+        status=result.status.value, document_id=result.document_id, detail=result.detail
+    )
+
+
+@router.get("/health", response_model=EmailIngestHealthResponse)
+@limiter.limit(settings.api_rate_limit_default)
+async def health(
+    request: Request,
+    authorization: str | None = Header(None),
+    db: AsyncSession = Depends(get_db),
+):
+    """Config-alignment handshake (Bearer-auth'd). Reports the known mailbox_ids
+    so the watcher can detect a routing-table mismatch; does NOT 503 when
+    disabled (the ``enabled`` flag is in the body)."""
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
+    token = authorization.removeprefix("Bearer ").strip()
+    if not await verify_email_ingest_token(db, token):
+        raise HTTPException(status_code=403, detail="Invalid email-ingest token")
+
+    mailbox_ids = [
+        str(m.get("id", "")).strip()
+        for m in settings.email_ingest_mailboxes
+        if resolve_mailbox_target(str(m.get("id", "")))
+    ]
+    return EmailIngestHealthResponse(
+        enabled=settings.email_ingest_enabled,
+        mailbox_ids=mailbox_ids,
+        to_paperless=settings.email_ingest_to_paperless,
+        token_ok=True,
+        max_file_size_mb=settings.max_file_size_mb,
+        allowed_extensions=settings.allowed_extensions_list,
+    )
+
+
+@router.post("/token", response_model=EmailIngestTokenResponse)
+@limiter.limit(settings.api_rate_limit_admin)
+async def mint_token(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user=Depends(require_permission(Permission.SETTINGS_MANAGE)),
+):
+    """Generate or rotate the email-ingest Bearer token (admin). Returns the
+    plaintext once — store it in the watcher's secret."""
+    token = await generate_email_ingest_token(db)
+    return EmailIngestTokenResponse(token=token)

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -24,6 +24,7 @@ from api.routes import (
     chat,
     chat_upload,
     circles,
+    email_ingest,
     federation_audit,
     federation_pairing,
     federation_query,
@@ -179,6 +180,7 @@ app.include_router(config_routes.router, prefix="/api/config", tags=["Config"])
 app.include_router(speakers.router, prefix="/api/speakers", tags=["Speakers"])
 app.include_router(knowledge.router, prefix="/api/knowledge", tags=["Knowledge"])
 app.include_router(folder_ingest.router, prefix="/api/folder-ingest", tags=["Folder Ingest"])
+app.include_router(email_ingest.router, prefix="/api/email-ingest", tags=["Email Ingest"])
 app.include_router(memory.router, prefix="/api/memory", tags=["Memory"])
 app.include_router(preferences.router, prefix="/api/preferences", tags=["Preferences"])
 app.include_router(mcp_routes.router, prefix="/api/mcp", tags=["MCP"])

--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -542,6 +542,44 @@ class PaperlessUploadTracking(Base):
     swept_at = Column(DateTime, nullable=True, index=True)
 
 
+class EmailIngestLog(Base):
+    """Per-attachment provenance + idempotency ledger for email auto-ingest.
+
+    The renfield-mcp-email-ingest watcher pushes each allowlisted attachment to
+    POST /api/email-ingest/document; the bridge records one row per
+    (mailbox_id, message_id, attachment_sha256) here. Two jobs:
+
+    - **Provenance/audit:** which email (mailbox + Message-ID + sender/subject)
+      a given Document came from — not stored on Document itself.
+    - **Idempotency:** the UNIQUE (mailbox_id, message_id, attachment_sha256)
+      lets a re-pushed email short-circuit to `duplicate` even before the
+      content-hash dedup (and keyed by mailbox so two spheres never collide).
+
+    ``document_id`` is the resulting Document (NULL when the push was rejected
+    before a row was created, e.g. failed/oversize); ``status`` mirrors the
+    4-state IngestStatus the bridge returned.
+    """
+    __tablename__ = "email_ingest_log"
+    __table_args__ = (
+        UniqueConstraint(
+            "mailbox_id", "message_id", "attachment_sha256",
+            name="uq_email_ingest_mailbox_msg_attachment",
+        ),
+    )
+
+    id = Column(Integer, primary_key=True)
+    mailbox_id = Column(String(120), nullable=False, index=True)
+    message_id = Column(String(998), nullable=False)  # RFC 5322 line-length cap
+    attachment_sha256 = Column(String(64), nullable=False)
+    document_id = Column(
+        Integer, ForeignKey("documents.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    sender = Column(String(320), nullable=True)  # RFC 5321 max addr length
+    subject = Column(Text, nullable=True)
+    status = Column(String(20), nullable=True)  # IngestStatus value at record time
+    created_at = Column(DateTime, default=_utcnow)
+
+
 # Document Processing Status Constants
 DOC_STATUS_PENDING = "pending"
 DOC_STATUS_PROCESSING = "processing"
@@ -1667,6 +1705,10 @@ SETTING_NOTIFICATION_WEBHOOK_TOKEN = "notification.webhook_token"
 # folder-ingest push (POST /api/folder-ingest/document). Minted by the admin
 # token route (T14), verified constant-time on every push.
 SETTING_FOLDER_INGEST_TOKEN = "folder_ingest.token"
+# Revocable Bearer token the renfield-mcp-email-ingest server presents on the
+# email-ingest push (POST /api/email-ingest/document). Separate from the
+# folder-ingest token so the two watchers are independently revocable.
+SETTING_EMAIL_INGEST_TOKEN = "email_ingest.token"
 
 SYSTEM_SETTING_KEYS = [
     SETTING_WAKEWORD_KEYWORD,
@@ -1674,6 +1716,7 @@ SYSTEM_SETTING_KEYS = [
     SETTING_WAKEWORD_COOLDOWN_MS,
     SETTING_NOTIFICATION_WEBHOOK_TOKEN,
     SETTING_FOLDER_INGEST_TOKEN,
+    SETTING_EMAIL_INGEST_TOKEN,
 ]
 
 

--- a/src/backend/services/email_ingest.py
+++ b/src/backend/services/email_ingest.py
@@ -21,7 +21,6 @@ and never cross-record (the ledger keys on ``mailbox_id``).
 from __future__ import annotations
 
 import hashlib
-import secrets
 from dataclasses import dataclass
 
 from loguru import logger
@@ -32,8 +31,6 @@ from models.database import (
     SETTING_EMAIL_INGEST_TOKEN,
     EmailIngestLog,
     KnowledgeBase,
-    SystemSetting,
-    User,
 )
 from services.folder_ingest import (
     IngestMeta,
@@ -41,6 +38,12 @@ from services.folder_ingest import (
     IngestStatus,
     PaperlessLeg,
     ingest_document,
+)
+from services.ingest_common import (
+    generate_ingest_token,
+    get_ingest_token,
+    resolve_user_id,
+    verify_ingest_token,
 )
 from utils.config import settings
 
@@ -68,7 +71,14 @@ def resolve_mailbox_target(mailbox_id: str) -> MailboxTarget | None:
     if not mid:
         return None
     for entry in settings.email_ingest_mailboxes:
-        if str(entry.get("id", "")).strip() == mid:
+        # Defensive: a malformed routing entry (non-dict, non-numeric tier, …)
+        # must NOT crash routing for OTHER mailboxes (or 500 the /health probe).
+        # Skip the bad entry and keep scanning.
+        try:
+            if not isinstance(entry, dict):
+                continue
+            if str(entry.get("id", "")).strip() != mid:
+                continue
             tier = min(max(int(entry.get("tier", 0)), 0), 4)  # clamp to ladder
             return MailboxTarget(
                 mailbox_id=mid,
@@ -76,6 +86,9 @@ def resolve_mailbox_target(mailbox_id: str) -> MailboxTarget | None:
                 tier=tier,
                 kb_name=str(entry.get("kb") or "").strip() or "Eingang",
             )
+        except (ValueError, TypeError, AttributeError) as exc:
+            logger.warning(f"email-ingest: skipping malformed mailbox entry {entry!r}: {exc}")
+            continue
     return None
 
 
@@ -96,21 +109,9 @@ async def _resolve_kb(db: AsyncSession, kb_name: str) -> KnowledgeBase:
 
 
 async def _resolve_owner(db: AsyncSession, owner: str) -> int | None:
-    """Resolve ``owner`` (username or numeric id) to a user id; ``""`` → None."""
-    target = (owner or "").strip()
-    if not target:
-        return None
-    user = (
-        await db.execute(select(User).where(User.username == target))
-    ).scalar_one_or_none()
-    if user is None and target.isdigit():
-        user = (
-            await db.execute(select(User).where(User.id == int(target)))
-        ).scalar_one_or_none()
-    if user is None:
-        logger.warning(f"email-ingest: owner {target!r} not found; using ownerless")
-        return None
-    return user.id
+    """Resolve the mailbox's ``owner`` (username/id) to a user id; ``""`` → None.
+    Thin wrapper over the shared resolver (folder-ingest uses the same)."""
+    return await resolve_user_id(db, owner)
 
 
 async def _record_ledger(
@@ -180,12 +181,15 @@ async def ingest_email_document(
     kb = await _resolve_kb(db, target.kb_name)
     owner_user_id = await _resolve_owner(db, target.owner)
 
+    # Coerce optional metadata to str|None — a watcher could send a non-string
+    # (e.g. {"sha256": 123}) which would crash downstream `.lower()` / DB writes.
+    sha = str(sha256).strip() if sha256 not in (None, "") else None
     meta = IngestMeta(
         filename=filename,
         root=target.mailbox_id,  # provenance: which mailbox
         relpath=f"{message_id}/{filename}",  # provenance: which message + attachment
-        sha256=sha256,
-        mime=mime,
+        sha256=sha,
+        mime=(str(mime) if mime else None),
     )
     result = await ingest_document(
         file_bytes,
@@ -197,16 +201,19 @@ async def ingest_email_document(
         paperless_leg=paperless_leg,
     )
 
-    attachment_sha = (sha256 or "").lower() or hashlib.sha256(file_bytes).hexdigest()
-    await _record_ledger(
-        db,
-        mailbox_id=target.mailbox_id,
-        message_id=message_id or "",
-        attachment_sha256=attachment_sha,
-        sender=sender,
-        subject=subject,
-        result=result,
-    )
+    # Record provenance + idempotency keyed by the CONTENT hash (matches
+    # ingest_document's dedup key). Skip transient RETRY: a re-push that later
+    # succeeds would otherwise leave an orphan row keyed by a stale hash.
+    if result.status is not IngestStatus.RETRY:
+        await _record_ledger(
+            db,
+            mailbox_id=target.mailbox_id,
+            message_id=str(message_id or ""),
+            attachment_sha256=hashlib.sha256(file_bytes).hexdigest(),
+            sender=(str(sender) if sender else None),
+            subject=(str(subject) if subject else None),
+            result=result,
+        )
     return result
 
 
@@ -216,34 +223,13 @@ async def ingest_email_document(
 # ---------------------------------------------------------------------------
 
 async def get_email_ingest_token(db: AsyncSession) -> str | None:
-    setting = (
-        await db.execute(
-            select(SystemSetting).where(SystemSetting.key == SETTING_EMAIL_INGEST_TOKEN)
-        )
-    ).scalar_one_or_none()
-    return setting.value if setting else None
+    return await get_ingest_token(db, SETTING_EMAIL_INGEST_TOKEN)
 
 
 async def generate_email_ingest_token(db: AsyncSession) -> str:
-    """Mint/rotate the email-ingest token; persist to SystemSetting. Returns the
-    plaintext token (shown once to the admin)."""
-    token = secrets.token_urlsafe(48)
-    existing = (
-        await db.execute(
-            select(SystemSetting).where(SystemSetting.key == SETTING_EMAIL_INGEST_TOKEN)
-        )
-    ).scalar_one_or_none()
-    if existing:
-        existing.value = token
-    else:
-        db.add(SystemSetting(key=SETTING_EMAIL_INGEST_TOKEN, value=token))
-    await db.commit()
-    logger.info("🔑 email-ingest token (re)generated")
-    return token
+    """Mint/rotate the email-ingest token (shown once to the admin)."""
+    return await generate_ingest_token(db, SETTING_EMAIL_INGEST_TOKEN)
 
 
 async def verify_email_ingest_token(db: AsyncSession, token: str) -> bool:
-    stored = await get_email_ingest_token(db)
-    if not stored:
-        return False
-    return secrets.compare_digest(stored, token)
+    return await verify_ingest_token(db, SETTING_EMAIL_INGEST_TOKEN, token)

--- a/src/backend/services/email_ingest.py
+++ b/src/backend/services/email_ingest.py
@@ -1,0 +1,249 @@
+"""Email-ingest bridge — backend seam for email-mailbox auto-ingest (Phase 1).
+
+The dedicated ``renfield-mcp-email-ingest`` watcher pushes each allowlisted
+attachment to ``POST /api/email-ingest/document`` (Bearer); the route hands the
+bytes + email provenance (mailbox_id, message_id, sender, subject) here. This
+module **reuses the folder-ingest bridge** (``ingest_document``) wholesale —
+dedup (D2), KB filing, owner/tier, the 4-state contract, and the Paperless leg
+(incl. correspondent resolve-or-create) — and adds only:
+
+  - server-authoritative **per-mailbox sphere routing** (mailbox_id → owner/tier/kb),
+  - the ``email_ingest_log`` provenance + idempotency ledger,
+  - an email-specific Bearer token (independently revocable).
+
+Sphere routing is server-side ON PURPOSE: the watcher sends a ``mailbox_id``,
+never a tier/owner, so a leaked push token can't file company invoices at an
+arbitrary tier. An unknown ``mailbox_id`` → ``failed``. Two mailboxes routing to
+different KBs never cross-dedup (``ingest_document`` keys on ``(file_hash, kb)``)
+and never cross-record (the ledger keys on ``mailbox_id``).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from dataclasses import dataclass
+
+from loguru import logger
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import (
+    SETTING_EMAIL_INGEST_TOKEN,
+    EmailIngestLog,
+    KnowledgeBase,
+    SystemSetting,
+    User,
+)
+from services.folder_ingest import (
+    IngestMeta,
+    IngestResult,
+    IngestStatus,
+    PaperlessLeg,
+    ingest_document,
+)
+from utils.config import settings
+
+# Cross-repo push-contract version (mirrors FOLDER_INGEST_CONTRACT_VERSION).
+# Sent in the request + response header; bump on ANY request/response shape or
+# IngestStatus change.
+EMAIL_INGEST_CONTRACT_VERSION = "1"
+
+
+@dataclass(frozen=True)
+class MailboxTarget:
+    """Resolved server-authoritative sphere routing for one mailbox_id."""
+
+    mailbox_id: str
+    owner: str  # username / numeric id / "" (ownerless)
+    tier: int  # circle tier 0-4
+    kb_name: str
+
+
+def resolve_mailbox_target(mailbox_id: str) -> MailboxTarget | None:
+    """Look up ``mailbox_id`` in the server-side routing table
+    (``settings.email_ingest_mailboxes``). ``None`` when unknown — the route maps
+    that to FAILED so a stray/forged mailbox_id never files anywhere."""
+    mid = (mailbox_id or "").strip()
+    if not mid:
+        return None
+    for entry in settings.email_ingest_mailboxes:
+        if str(entry.get("id", "")).strip() == mid:
+            tier = min(max(int(entry.get("tier", 0)), 0), 4)  # clamp to ladder
+            return MailboxTarget(
+                mailbox_id=mid,
+                owner=str(entry.get("owner", "") or "").strip(),
+                tier=tier,
+                kb_name=str(entry.get("kb") or "").strip() or "Eingang",
+            )
+    return None
+
+
+async def _resolve_kb(db: AsyncSession, kb_name: str) -> KnowledgeBase:
+    """Get-or-create the mailbox's target KB by name (mirrors folder-ingest)."""
+    kb = (
+        await db.execute(select(KnowledgeBase).where(KnowledgeBase.name == kb_name))
+    ).scalar_one_or_none()
+    if kb:
+        return kb
+    kb = KnowledgeBase(
+        name=kb_name, description="Auto-ingested documents from watched email mailboxes"
+    )
+    db.add(kb)
+    await db.commit()
+    await db.refresh(kb)
+    return kb
+
+
+async def _resolve_owner(db: AsyncSession, owner: str) -> int | None:
+    """Resolve ``owner`` (username or numeric id) to a user id; ``""`` → None."""
+    target = (owner or "").strip()
+    if not target:
+        return None
+    user = (
+        await db.execute(select(User).where(User.username == target))
+    ).scalar_one_or_none()
+    if user is None and target.isdigit():
+        user = (
+            await db.execute(select(User).where(User.id == int(target)))
+        ).scalar_one_or_none()
+    if user is None:
+        logger.warning(f"email-ingest: owner {target!r} not found; using ownerless")
+        return None
+    return user.id
+
+
+async def _record_ledger(
+    db: AsyncSession,
+    *,
+    mailbox_id: str,
+    message_id: str,
+    attachment_sha256: str,
+    sender: str | None,
+    subject: str | None,
+    result: IngestResult,
+) -> None:
+    """Idempotent provenance/audit row keyed (mailbox_id, message_id, sha).
+    Best-effort — a ledger write failure never changes the 4-state result."""
+    try:
+        existing = (
+            await db.execute(
+                select(EmailIngestLog).where(
+                    EmailIngestLog.mailbox_id == mailbox_id,
+                    EmailIngestLog.message_id == message_id,
+                    EmailIngestLog.attachment_sha256 == attachment_sha256,
+                )
+            )
+        ).scalar_one_or_none()
+        if existing:
+            existing.document_id = result.document_id or existing.document_id
+            existing.status = result.status.value
+        else:
+            db.add(
+                EmailIngestLog(
+                    mailbox_id=mailbox_id,
+                    message_id=message_id,
+                    attachment_sha256=attachment_sha256,
+                    document_id=result.document_id,
+                    sender=sender,
+                    subject=subject,
+                    status=result.status.value,
+                )
+            )
+        await db.commit()
+    except Exception as exc:  # noqa: BLE001 - ledger is best-effort
+        logger.warning(f"email-ingest: ledger write failed (non-fatal): {exc}")
+        await db.rollback()
+
+
+async def ingest_email_document(
+    file_bytes: bytes,
+    *,
+    db: AsyncSession,
+    mailbox_id: str,
+    message_id: str,
+    filename: str,
+    sender: str | None = None,
+    subject: str | None = None,
+    mime: str | None = None,
+    sha256: str | None = None,
+    paperless_leg: PaperlessLeg | None = None,
+) -> IngestResult:
+    """Route one pushed email attachment through the reused folder-ingest bridge
+    with server-authoritative per-mailbox sphere routing, then record provenance.
+    Returns the same 4-state ``IngestResult`` the watcher keys its move on."""
+    target = resolve_mailbox_target(mailbox_id)
+    if target is None:
+        logger.warning(f"email-ingest: unknown mailbox_id {mailbox_id!r}; rejecting")
+        return IngestResult(IngestStatus.FAILED, detail="unknown_mailbox")
+
+    kb = await _resolve_kb(db, target.kb_name)
+    owner_user_id = await _resolve_owner(db, target.owner)
+
+    meta = IngestMeta(
+        filename=filename,
+        root=target.mailbox_id,  # provenance: which mailbox
+        relpath=f"{message_id}/{filename}",  # provenance: which message + attachment
+        sha256=sha256,
+        mime=mime,
+    )
+    result = await ingest_document(
+        file_bytes,
+        meta,
+        db=db,
+        kb_id=kb.id,
+        owner_user_id=owner_user_id,
+        default_tier=target.tier,
+        paperless_leg=paperless_leg,
+    )
+
+    attachment_sha = (sha256 or "").lower() or hashlib.sha256(file_bytes).hexdigest()
+    await _record_ledger(
+        db,
+        mailbox_id=target.mailbox_id,
+        message_id=message_id or "",
+        attachment_sha256=attachment_sha,
+        sender=sender,
+        subject=subject,
+        result=result,
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Bearer token (mirrors folder_ingest's helpers, SETTING_EMAIL_INGEST_TOKEN —
+# separate so the two watchers are independently revocable).
+# ---------------------------------------------------------------------------
+
+async def get_email_ingest_token(db: AsyncSession) -> str | None:
+    setting = (
+        await db.execute(
+            select(SystemSetting).where(SystemSetting.key == SETTING_EMAIL_INGEST_TOKEN)
+        )
+    ).scalar_one_or_none()
+    return setting.value if setting else None
+
+
+async def generate_email_ingest_token(db: AsyncSession) -> str:
+    """Mint/rotate the email-ingest token; persist to SystemSetting. Returns the
+    plaintext token (shown once to the admin)."""
+    token = secrets.token_urlsafe(48)
+    existing = (
+        await db.execute(
+            select(SystemSetting).where(SystemSetting.key == SETTING_EMAIL_INGEST_TOKEN)
+        )
+    ).scalar_one_or_none()
+    if existing:
+        existing.value = token
+    else:
+        db.add(SystemSetting(key=SETTING_EMAIL_INGEST_TOKEN, value=token))
+    await db.commit()
+    logger.info("🔑 email-ingest token (re)generated")
+    return token
+
+
+async def verify_email_ingest_token(db: AsyncSession, token: str) -> bool:
+    stored = await get_email_ingest_token(db)
+    if not stored:
+        return False
+    return secrets.compare_digest(stored, token)

--- a/src/backend/services/folder_ingest.py
+++ b/src/backend/services/folder_ingest.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import hashlib
 import os
-import secrets
 import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -46,14 +45,18 @@ from models.database import (
     SETTING_FOLDER_INGEST_TOKEN,
     Document,
     KnowledgeBase,
-    SystemSetting,
-    User,
 )
 
 # paperless_state values that mean "the Paperless leg is settled" — either it
 # was filed/duplicate (done) or terminally rejected for a non-duplicate reason
 # (failed). Both stop the D2 matrix re-running the leg; only None/unset retries.
 _PAPERLESS_SETTLED = (PAPERLESS_STATE_DONE, PAPERLESS_STATE_FAILED)
+from services.ingest_common import (
+    generate_ingest_token,
+    get_ingest_token,
+    resolve_user_id,
+    verify_ingest_token,
+)
 from services.rag_service import DuplicateDocumentError, RAGService
 from services.redis_client import get_redis
 from services.task_queue import DocumentTaskQueue
@@ -398,43 +401,19 @@ def _cleanup(file_path: str) -> None:
 
 async def get_folder_ingest_token(db: AsyncSession) -> str | None:
     """Return the stored folder-ingest Bearer token, or None if unset."""
-    setting = (
-        await db.execute(
-            select(SystemSetting).where(
-                SystemSetting.key == SETTING_FOLDER_INGEST_TOKEN
-            )
-        )
-    ).scalar_one_or_none()
-    return setting.value if setting else None
+    return await get_ingest_token(db, SETTING_FOLDER_INGEST_TOKEN)
 
 
 async def generate_folder_ingest_token(db: AsyncSession) -> str:
     """Mint a new folder-ingest token (rotating any existing one) and persist
     it to SystemSetting. Returns the plaintext token (shown once to the admin)."""
-    token = secrets.token_urlsafe(48)
-    existing = (
-        await db.execute(
-            select(SystemSetting).where(
-                SystemSetting.key == SETTING_FOLDER_INGEST_TOKEN
-            )
-        )
-    ).scalar_one_or_none()
-    if existing:
-        existing.value = token
-    else:
-        db.add(SystemSetting(key=SETTING_FOLDER_INGEST_TOKEN, value=token))
-    await db.commit()
-    logger.info("🔑 folder-ingest token (re)generated")
-    return token
+    return await generate_ingest_token(db, SETTING_FOLDER_INGEST_TOKEN)
 
 
 async def verify_folder_ingest_token(db: AsyncSession, token: str) -> bool:
     """Constant-time compare a presented Bearer token against the stored one.
     False when no token is configured (feature unprovisioned)."""
-    stored = await get_folder_ingest_token(db)
-    if not stored:
-        return False
-    return secrets.compare_digest(stored, token)
+    return await verify_ingest_token(db, SETTING_FOLDER_INGEST_TOKEN, token)
 
 
 # ---------------------------------------------------------------------------
@@ -483,19 +462,4 @@ async def resolve_owner_user_id(db: AsyncSession) -> int | None:
     """Resolve ``folder_ingest_target_user`` (username or numeric id) to a user
     id. Empty config → None (the bridge/worker handle an ownerless enqueue the
     same way the upload route does for unauthenticated single-user mode)."""
-    target = settings.folder_ingest_target_user.strip()
-    if not target:
-        return None
-    user = (
-        await db.execute(select(User).where(User.username == target))
-    ).scalar_one_or_none()
-    if user is None and target.isdigit():
-        user = (
-            await db.execute(select(User).where(User.id == int(target)))
-        ).scalar_one_or_none()
-    if user is None:
-        logger.warning(
-            f"folder-ingest: target_user {target!r} not found; using ownerless"
-        )
-        return None
-    return user.id
+    return await resolve_user_id(db, settings.folder_ingest_target_user)

--- a/src/backend/services/ingest_common.py
+++ b/src/backend/services/ingest_common.py
@@ -1,0 +1,69 @@
+"""Shared helpers for the ingest bridges (folder-ingest, email-ingest).
+
+Factored out of folder_ingest so a second ingest source (email) reuses the
+revocable-Bearer-token plumbing and the username/id → user-id resolution instead
+of copying them a third time. Each bridge keeps its own ``SETTING_*`` key and a
+thin named wrapper (the routes import the named functions), so a security fix to
+the token compare / rotation lands in one place.
+"""
+
+from __future__ import annotations
+
+import secrets
+
+from loguru import logger
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import SystemSetting, User
+
+
+async def get_ingest_token(db: AsyncSession, key: str) -> str | None:
+    """The stored Bearer token for ``key`` (a SystemSetting), or None."""
+    setting = (
+        await db.execute(select(SystemSetting).where(SystemSetting.key == key))
+    ).scalar_one_or_none()
+    return setting.value if setting else None
+
+
+async def generate_ingest_token(db: AsyncSession, key: str) -> str:
+    """Mint/rotate the token at ``key`` and persist it. Returns the plaintext."""
+    token = secrets.token_urlsafe(48)
+    existing = (
+        await db.execute(select(SystemSetting).where(SystemSetting.key == key))
+    ).scalar_one_or_none()
+    if existing:
+        existing.value = token
+    else:
+        db.add(SystemSetting(key=key, value=token))
+    await db.commit()
+    logger.info(f"🔑 ingest token (re)generated for {key}")
+    return token
+
+
+async def verify_ingest_token(db: AsyncSession, key: str, presented: str) -> bool:
+    """Constant-time compare ``presented`` against the stored token at ``key``.
+    False when none is configured (feature unprovisioned)."""
+    stored = await get_ingest_token(db, key)
+    if not stored:
+        return False
+    return secrets.compare_digest(stored, presented)
+
+
+async def resolve_user_id(db: AsyncSession, target: str) -> int | None:
+    """Resolve a username or numeric-id string to a user id; ``""`` → None
+    (ownerless). Used by both ingest bridges for the configured owner."""
+    target = (target or "").strip()
+    if not target:
+        return None
+    user = (
+        await db.execute(select(User).where(User.username == target))
+    ).scalar_one_or_none()
+    if user is None and target.isdigit():
+        user = (
+            await db.execute(select(User).where(User.id == int(target)))
+        ).scalar_one_or_none()
+    if user is None:
+        logger.warning(f"ingest: target user {target!r} not found; using ownerless")
+        return None
+    return user.id

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -539,6 +539,18 @@ class Settings(BaseSettings):
     folder_ingest_default_tier: int = Field(default=0, ge=0, le=4)  # circle tier at create
     folder_ingest_to_paperless: bool = True
     folder_ingest_notify_on_filed: bool = True
+
+    # Email-mailbox auto-ingest (Phase 1; ships dark). The dedicated
+    # renfield-mcp-email-ingest watcher PUSHES attachments to
+    # POST /api/email-ingest/document; the backend owns the SPHERE routing here
+    # (server-authoritative — the watcher only sends a mailbox_id). Each entry:
+    #   {"id": "<stable mailbox id>", "owner": "<username|id|''>",
+    #    "tier": <0-4>, "kb": "<target KB name>"}
+    # Set as a JSON env (EMAIL_INGEST_MAILBOXES) or via the renfield-mcp-config
+    # ConfigMap. An unknown mailbox_id on a push → failed (route).
+    email_ingest_enabled: bool = False
+    email_ingest_to_paperless: bool = True
+    email_ingest_mailboxes: list[dict] = Field(default_factory=list)
     # Paperless cold-start confirm ramp: the first N archives show a metadata
     # confirm; after N the system trusts itself and archives silently. 0 =
     # never confirm (always silent). Tunable without a code change.

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -1,6 +1,7 @@
 """
 Konfiguration und Settings
 """
+import json
 import os
 from functools import lru_cache
 
@@ -546,11 +547,14 @@ class Settings(BaseSettings):
     # (server-authoritative — the watcher only sends a mailbox_id). Each entry:
     #   {"id": "<stable mailbox id>", "owner": "<username|id|''>",
     #    "tier": <0-4>, "kb": "<target KB name>"}
-    # Set as a JSON env (EMAIL_INGEST_MAILBOXES) or via the renfield-mcp-config
-    # ConfigMap. An unknown mailbox_id on a push → failed (route).
+    # Stored as a JSON STRING (EMAIL_INGEST_MAILBOXES_JSON, or the
+    # renfield-mcp-config ConfigMap) and parsed by the email_ingest_mailboxes
+    # property — graceful: a malformed value falls back to [] rather than
+    # crashing the backend at import (a raw list[dict] env would). An unknown
+    # mailbox_id on a push → failed (route).
     email_ingest_enabled: bool = False
     email_ingest_to_paperless: bool = True
-    email_ingest_mailboxes: list[dict] = Field(default_factory=list)
+    email_ingest_mailboxes_json: str = ""
     # Paperless cold-start confirm ramp: the first N archives show a metadata
     # confirm; after N the system trusts itself and archives silently. 0 =
     # never confirm (always silent). Tunable without a code change.
@@ -806,6 +810,25 @@ class Settings(BaseSettings):
     def allowed_extensions_list(self) -> list[str]:
         """Gibt allowed_extensions als Liste zurück"""
         return [ext.strip().lower() for ext in self.allowed_extensions.split(",")]
+
+    @property
+    def email_ingest_mailboxes(self) -> list[dict]:
+        """Parsed email-ingest routing table from ``email_ingest_mailboxes_json``.
+        Graceful: a malformed JSON value logs + falls back to ``[]`` so a config
+        typo can't crash the backend at import (a typed ``list[dict]`` env would).
+        """
+        raw = (self.email_ingest_mailboxes_json or "").strip()
+        if not raw:
+            return []
+        try:
+            data = json.loads(raw)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            logger.warning("email_ingest_mailboxes_json is not valid JSON; using []")
+            return []
+        if not isinstance(data, list):
+            logger.warning("email_ingest_mailboxes_json is not a JSON list; using []")
+            return []
+        return [e for e in data if isinstance(e, dict)]
 
     @property
     def supported_languages_list(self) -> list[str]:

--- a/tests/backend/test_email_ingest.py
+++ b/tests/backend/test_email_ingest.py
@@ -45,7 +45,9 @@ _MAILBOXES = [
 # ---------------------------------------------------------------------------
 
 def _patch_mailboxes(monkeypatch, boxes=_MAILBOXES):
-    monkeypatch.setattr(svc.settings, "email_ingest_mailboxes", boxes)
+    # email_ingest_mailboxes is now a parsed property over the JSON string field;
+    # set the backing field so the graceful-parse path is exercised too.
+    monkeypatch.setattr(svc.settings, "email_ingest_mailboxes_json", json.dumps(boxes))
 
 
 def test_resolve_known_mailbox(monkeypatch):
@@ -70,6 +72,29 @@ def test_resolve_clamps_tier_and_defaults_kb(monkeypatch):
     t = resolve_mailbox_target("clamp")
     assert t.tier == 4  # 9 clamped to the 0-4 ladder
     assert t.kb_name == "Eingang"  # empty kb → default
+
+
+def test_resolve_skips_malformed_entry_before_valid(monkeypatch):
+    # A bad entry (non-numeric tier, a non-dict) must NOT crash routing for a
+    # VALID mailbox that sits after it in the list.
+    boxes = [
+        {"id": "bad", "owner": "", "tier": "abc", "kb": "X"},  # tier int() raises
+        "not-a-dict",  # entry.get() would raise
+        {"id": "good", "owner": "", "tier": 1, "kb": "Good KB"},
+    ]
+    _patch_mailboxes(monkeypatch, boxes)
+    assert resolve_mailbox_target("good") == MailboxTarget("good", "", 1, "Good KB")
+    assert resolve_mailbox_target("bad") is None  # the malformed one is skipped
+
+
+def test_config_property_graceful_on_bad_json(monkeypatch):
+    # A malformed EMAIL_INGEST_MAILBOXES_JSON must fall back to [] (never crash).
+    monkeypatch.setattr(svc.settings, "email_ingest_mailboxes_json", "not json{")
+    assert svc.settings.email_ingest_mailboxes == []
+    monkeypatch.setattr(svc.settings, "email_ingest_mailboxes_json", '{"not":"a list"}')
+    assert svc.settings.email_ingest_mailboxes == []
+    monkeypatch.setattr(svc.settings, "email_ingest_mailboxes_json", "")
+    assert svc.settings.email_ingest_mailboxes == []
 
 
 # ---------------------------------------------------------------------------
@@ -278,9 +303,7 @@ async def test_happy_path_returns_ingested(client, token_set, monkeypatch):
 @pytest.mark.integration
 async def test_unknown_mailbox_routes_to_failed(client, token_set, monkeypatch):
     # End-to-end through the real wrapper (mailboxes table empty) → unknown → failed.
-    from api.routes import email_ingest as route
-    monkeypatch.setattr(route.settings, "email_ingest_mailboxes", [])
-    monkeypatch.setattr(svc.settings, "email_ingest_mailboxes", [])
+    monkeypatch.setattr(svc.settings, "email_ingest_mailboxes_json", "[]")
     r = await client.post(URL, **_multipart(mailbox_id="ghost"), headers=_auth())
     assert r.status_code == 200 and r.json()["status"] == "failed"
     assert r.json()["detail"] == "unknown_mailbox"
@@ -288,9 +311,7 @@ async def test_unknown_mailbox_routes_to_failed(client, token_set, monkeypatch):
 
 @pytest.mark.integration
 async def test_health_reports_known_mailbox_ids(client, token_set, monkeypatch):
-    from api.routes import email_ingest as route
-    monkeypatch.setattr(route.settings, "email_ingest_mailboxes", _MAILBOXES)
-    monkeypatch.setattr(svc.settings, "email_ingest_mailboxes", _MAILBOXES)
+    monkeypatch.setattr(svc.settings, "email_ingest_mailboxes_json", json.dumps(_MAILBOXES))
     r = await client.get("/api/email-ingest/health", headers=_auth())
     assert r.status_code == 200
     body = r.json()

--- a/tests/backend/test_email_ingest.py
+++ b/tests/backend/test_email_ingest.py
@@ -1,0 +1,310 @@
+"""Tests for email-mailbox auto-ingest (Phase 1).
+
+Two layers:
+- the `email_ingest` bridge (server-authoritative per-mailbox routing, the token
+  helpers, the wrapper over the reused `ingest_document`);
+- the `POST /api/email-ingest/document` route status-code + 4-state contract.
+
+The folder-ingest bridge it delegates to is covered by test_folder_ingest*.py;
+here it is mocked at the wrapper/route boundary except where wiring is asserted.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from slowapi.errors import RateLimitExceeded
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import services.email_ingest as svc
+from models.database import SETTING_EMAIL_INGEST_TOKEN, SystemSetting
+from services.email_ingest import (
+    EMAIL_INGEST_CONTRACT_VERSION,
+    MailboxTarget,
+    ingest_email_document,
+    resolve_mailbox_target,
+)
+from services.folder_ingest import IngestResult, IngestStatus
+
+pytestmark = [pytest.mark.unit]
+
+URL = "/api/email-ingest/document"
+TEST_TOKEN = "email-ingest-test-token-abc123"
+
+_MAILBOXES = [
+    {"id": "buchhaltung-xidra", "owner": "admin", "tier": 2, "kb": "x-idra Buchhaltung"},
+    {"id": "privat", "owner": "", "tier": 0, "kb": "Privat Eingang"},
+    {"id": "clamp", "owner": "", "tier": 9, "kb": ""},  # tier over-range + empty kb
+]
+
+
+# ---------------------------------------------------------------------------
+# resolve_mailbox_target — server-authoritative routing (pure)
+# ---------------------------------------------------------------------------
+
+def _patch_mailboxes(monkeypatch, boxes=_MAILBOXES):
+    monkeypatch.setattr(svc.settings, "email_ingest_mailboxes", boxes)
+
+
+def test_resolve_known_mailbox(monkeypatch):
+    _patch_mailboxes(monkeypatch)
+    t = resolve_mailbox_target("buchhaltung-xidra")
+    assert t == MailboxTarget("buchhaltung-xidra", "admin", 2, "x-idra Buchhaltung")
+
+
+def test_resolve_unknown_mailbox_is_none(monkeypatch):
+    _patch_mailboxes(monkeypatch)
+    assert resolve_mailbox_target("does-not-exist") is None
+
+
+def test_resolve_empty_id_is_none(monkeypatch):
+    _patch_mailboxes(monkeypatch)
+    assert resolve_mailbox_target("") is None
+    assert resolve_mailbox_target("   ") is None
+
+
+def test_resolve_clamps_tier_and_defaults_kb(monkeypatch):
+    _patch_mailboxes(monkeypatch)
+    t = resolve_mailbox_target("clamp")
+    assert t.tier == 4  # 9 clamped to the 0-4 ladder
+    assert t.kb_name == "Eingang"  # empty kb → default
+
+
+# ---------------------------------------------------------------------------
+# ingest_email_document — wrapper routing + the unknown-mailbox guard
+# ---------------------------------------------------------------------------
+
+async def test_unknown_mailbox_is_failed_without_touching_db(monkeypatch):
+    _patch_mailboxes(monkeypatch)
+    db = AsyncMock()  # must NOT be used on the reject path
+    result = await ingest_email_document(
+        b"%PDF-1.4", db=db, mailbox_id="forged", message_id="m1", filename="x.pdf"
+    )
+    assert result.status is IngestStatus.FAILED
+    assert result.detail == "unknown_mailbox"
+    db.execute.assert_not_called()
+
+
+async def test_known_mailbox_routes_sphere_to_ingest_document(monkeypatch):
+    # Wiring: the resolved (kb_id, owner, tier) reach ingest_document; the
+    # watcher never supplies them. KB/owner resolution + ledger are stubbed so
+    # this isolates the routing wiring.
+    _patch_mailboxes(monkeypatch)
+    monkeypatch.setattr(svc, "_resolve_kb", AsyncMock(return_value=MagicMock(id=42)))
+    monkeypatch.setattr(svc, "_resolve_owner", AsyncMock(return_value=7))
+    monkeypatch.setattr(svc, "_record_ledger", AsyncMock())
+    ingest = AsyncMock(return_value=IngestResult(IngestStatus.INGESTED, document_id=99))
+    monkeypatch.setattr(svc, "ingest_document", ingest)
+
+    out = await ingest_email_document(
+        b"%PDF-1.4", db=AsyncMock(), mailbox_id="buchhaltung-xidra",
+        message_id="m1", filename="rechnung.pdf",
+    )
+    assert out.status is IngestStatus.INGESTED and out.document_id == 99
+    _, kwargs = ingest.call_args
+    assert kwargs["kb_id"] == 42
+    assert kwargs["owner_user_id"] == 7
+    assert kwargs["default_tier"] == 2  # the mailbox's tier, server-side
+
+
+async def test_ledger_recorded_with_provenance(monkeypatch):
+    _patch_mailboxes(monkeypatch)
+    monkeypatch.setattr(svc, "_resolve_kb", AsyncMock(return_value=MagicMock(id=1)))
+    monkeypatch.setattr(svc, "_resolve_owner", AsyncMock(return_value=None))
+    monkeypatch.setattr(svc, "ingest_document",
+                        AsyncMock(return_value=IngestResult(IngestStatus.INGESTED, document_id=5)))
+    rec = AsyncMock()
+    monkeypatch.setattr(svc, "_record_ledger", rec)
+
+    await ingest_email_document(
+        b"%PDF-1.4", db=AsyncMock(), mailbox_id="privat", message_id="<msg-7@x>",
+        filename="bill.pdf", sender="vendor@acme.de", subject="Invoice 7",
+    )
+    _, k = rec.call_args
+    assert k["mailbox_id"] == "privat" and k["message_id"] == "<msg-7@x>"
+    assert k["sender"] == "vendor@acme.de" and k["subject"] == "Invoice 7"
+    assert len(k["attachment_sha256"]) == 64  # content hash when no sha supplied
+
+
+# ---------------------------------------------------------------------------
+# token helpers (real PG via db_session)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+async def test_token_generate_then_verify_roundtrip(db_session: AsyncSession):
+    assert await svc.verify_email_ingest_token(db_session, "anything") is False  # unset
+    tok = await svc.generate_email_ingest_token(db_session)
+    assert await svc.verify_email_ingest_token(db_session, tok) is True
+    assert await svc.verify_email_ingest_token(db_session, "wrong") is False
+
+
+# ---------------------------------------------------------------------------
+# route: POST /api/email-ingest/document — status + 4-state contract
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+async def client(db_session: AsyncSession):
+    from api.routes import email_ingest as route
+    from services.api_rate_limiter import limiter, rate_limit_exceeded_handler
+    from services.auth_service import get_current_user
+    from services.database import get_db
+
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
+    app.include_router(route.router, prefix="/api/email-ingest")
+
+    async def _override_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[get_current_user] = lambda: MagicMock(id=1, username="admin")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+
+
+def _auth(token: str = TEST_TOKEN) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _multipart(filename="invoice.pdf", content=b"%PDF-1.4 hello", mailbox_id="privat", **meta):
+    md = {"filename": filename, "mailbox_id": mailbox_id, "message_id": "<m1@x>"}
+    md.update(meta)
+    return {
+        "files": {"file": (filename, content, "application/pdf")},
+        "data": {"metadata": json.dumps(md)},
+    }
+
+
+@pytest.fixture
+async def token_set(db_session: AsyncSession) -> str:
+    db_session.add(SystemSetting(key=SETTING_EMAIL_INGEST_TOKEN, value=TEST_TOKEN))
+    await db_session.commit()
+    return TEST_TOKEN
+
+
+@pytest.fixture(autouse=True)
+def _feature_enabled(request, monkeypatch):
+    if request.node.name == "test_503_when_disabled":
+        return
+    from api.routes import email_ingest as route
+    monkeypatch.setattr(route.settings, "email_ingest_enabled", True)
+
+
+@pytest.fixture(autouse=True)
+def _worker_alive(request, monkeypatch):
+    if request.node.name == "test_503_when_worker_down":
+        return
+    from api.routes import email_ingest as route
+    monkeypatch.setattr(route, "_worker_is_alive", AsyncMock(return_value=True))
+
+
+@pytest.mark.integration
+async def test_503_when_disabled(client, token_set):
+    from api.routes import email_ingest as route
+    with patch.object(route.settings, "email_ingest_enabled", False):
+        r = await client.post(URL, **_multipart(), headers=_auth())
+    assert r.status_code == 503 and r.json()["detail"]["reason"] == "feature_disabled"
+
+
+@pytest.mark.integration
+async def test_401_missing_auth(client, token_set):
+    assert (await client.post(URL, **_multipart())).status_code == 401
+
+
+@pytest.mark.integration
+async def test_403_wrong_token(client, token_set):
+    assert (await client.post(URL, **_multipart(), headers=_auth("nope"))).status_code == 403
+
+
+@pytest.mark.integration
+async def test_403_when_no_token_provisioned(client):
+    assert (await client.post(URL, **_multipart(), headers=_auth("anything"))).status_code == 403
+
+
+@pytest.mark.integration
+async def test_503_when_worker_down(client, token_set, monkeypatch):
+    from api.routes import email_ingest as route
+    monkeypatch.setattr(route, "_worker_is_alive", AsyncMock(return_value=False))
+    r = await client.post(URL, **_multipart(), headers=_auth())
+    assert r.status_code == 503 and r.json()["detail"]["reason"] == "worker_unavailable"
+
+
+@pytest.mark.integration
+async def test_malformed_metadata_is_failed(client, token_set):
+    r = await client.post(
+        URL, files={"file": ("x.pdf", b"%PDF", "application/pdf")},
+        data={"metadata": "not json"}, headers=_auth(),
+    )
+    assert r.status_code == 200 and r.json()["status"] == "failed"
+    assert r.json()["detail"] == "malformed_metadata"
+
+
+@pytest.mark.integration
+async def test_missing_mailbox_id_is_failed(client, token_set):
+    md = {"filename": "x.pdf", "message_id": "<m@x>"}  # no mailbox_id
+    r = await client.post(
+        URL, files={"file": ("x.pdf", b"%PDF", "application/pdf")},
+        data={"metadata": json.dumps(md)}, headers=_auth(),
+    )
+    assert r.status_code == 200 and r.json()["status"] == "failed"
+
+
+@pytest.mark.integration
+async def test_oversize_is_failed(client, token_set, monkeypatch):
+    from api.routes import email_ingest as route
+    monkeypatch.setattr(route.settings, "max_file_size_mb", 0)  # any non-empty body trips it
+    r = await client.post(URL, **_multipart(content=b"x" * 2048), headers=_auth())
+    assert r.status_code == 200 and r.json()["status"] == "failed"
+    assert r.json()["detail"] == "file_too_large"
+
+
+@pytest.mark.integration
+async def test_happy_path_returns_ingested(client, token_set, monkeypatch):
+    from api.routes import email_ingest as route
+    monkeypatch.setattr(
+        route, "ingest_email_document",
+        AsyncMock(return_value=IngestResult(IngestStatus.INGESTED, document_id=5, detail="enqueued")),
+    )
+    r = await client.post(URL, **_multipart(), headers=_auth())
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "ingested" and body["document_id"] == 5
+    assert body["contract_version"] == EMAIL_INGEST_CONTRACT_VERSION
+
+
+@pytest.mark.integration
+async def test_unknown_mailbox_routes_to_failed(client, token_set, monkeypatch):
+    # End-to-end through the real wrapper (mailboxes table empty) → unknown → failed.
+    from api.routes import email_ingest as route
+    monkeypatch.setattr(route.settings, "email_ingest_mailboxes", [])
+    monkeypatch.setattr(svc.settings, "email_ingest_mailboxes", [])
+    r = await client.post(URL, **_multipart(mailbox_id="ghost"), headers=_auth())
+    assert r.status_code == 200 and r.json()["status"] == "failed"
+    assert r.json()["detail"] == "unknown_mailbox"
+
+
+@pytest.mark.integration
+async def test_health_reports_known_mailbox_ids(client, token_set, monkeypatch):
+    from api.routes import email_ingest as route
+    monkeypatch.setattr(route.settings, "email_ingest_mailboxes", _MAILBOXES)
+    monkeypatch.setattr(svc.settings, "email_ingest_mailboxes", _MAILBOXES)
+    r = await client.get("/api/email-ingest/health", headers=_auth())
+    assert r.status_code == 200
+    body = r.json()
+    assert body["enabled"] is True
+    assert set(body["mailbox_ids"]) == {"buchhaltung-xidra", "privat", "clamp"}
+    assert body["token_ok"] is True
+
+
+@pytest.mark.integration
+async def test_health_401_without_token(client):
+    assert (await client.get("/api/email-ingest/health")).status_code == 401
+
+
+@pytest.mark.integration
+async def test_token_mint_returns_token(client):
+    r = await client.post("/api/email-ingest/token")
+    assert r.status_code == 200 and len(r.json()["token"]) > 20


### PR DESCRIPTION
Phase 1 of email-mailbox auto-ingest (plan: `tasks/email-ingest-plan.md`, PR #750). Backend only, **ships dark behind `EMAIL_INGEST_ENABLED=false`**. The watcher (Phase 2) and deploy (Phase 3) follow.

## What it does
Mirrors folder-ingest and **reuses its bridge wholesale**. The dedicated `renfield-mcp-email-ingest` watcher (Phase 2) will push each attachment to `POST /api/email-ingest/document`; the backend runs it through the same `ingest_document` (dedup/KB/owner/tier/4-state/Paperless leg + correspondent resolve-or-create) and adds only:

- **Server-authoritative per-mailbox sphere routing** — `mailbox_id → owner/tier/kb` decided by the backend (`email_ingest_mailboxes`); the watcher never sends a tier/owner, so a leaked push token can't escalate. Unknown `mailbox_id` → `failed`.
- **`email_ingest_log` provenance + idempotency ledger** (UNIQUE `mailbox_id,message_id,attachment_sha256`, keyed by mailbox so spheres never cross-dedup).
- **Separate, independently-revocable Bearer token.**
- `GET /health` reports known `mailbox_ids` as the two-surface handshake.

## Files
`services/email_ingest.py` · `api/routes/email_ingest.py` · `services/ingest_common.py` (shared token + user-resolve helpers) · `email_ingest_log` model + migration `pc20260614` · `config` · `main.py` registration.

## /review — ran high-effort, all findings fixed before this PR
- **#1 correctness:** `resolve_mailbox_target` skips a malformed routing entry instead of 500-ing `/health` or poisoning other mailboxes; metadata coerced to str.
- **#2 correctness:** ledger keys by the content hash + skips transient RETRY (no orphan rows).
- **#7 footgun:** `email_ingest_mailboxes` is a JSON-string field + graceful property — a malformed env falls back to `[]` instead of crashing the backend at import.
- **#3/#4 DRY:** extracted `services/ingest_common.py`; folder-ingest + email-ingest share the token triplet + `resolve_user_id` (~60 lines de-duped; folder-ingest behavior preserved, its tests still green).
- **#5:** per-mailbox-owner → Paperless learned-examples marked as a phase-2 TODO.

## Tests
74 passed / 8 skipped across email + folder suites (0 folder-ingest regression). Single alembic head `pc20260614`. New tests cover routing/clamp/unknown-mailbox/wiring/ledger/token + route 4-state contract + the new defensive-parse and graceful-config paths.

## Note
Docs (`docs/EMAIL_INGEST.md` + CLAUDE.md subsystem line) are deferred to when the feature is end-to-end usable (Phase 2/3) — there's no user-facing surface yet. Flag if you'd prefer them now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)