### PR TITLE
fix(chat): scroll the messages container, not the window (Safari)

### DIFF
--- a/src/frontend/src/pages/ChatPage/ChatMessages.tsx
+++ b/src/frontend/src/pages/ChatPage/ChatMessages.tsx
@@ -142,7 +142,7 @@ export default function ChatMessages() {
     handleSendViaEmail, emailDialog, confirmSendViaEmail, cancelEmailDialog,
     sendMessage, sessionId, submitPaperlessConfirm,
   } = useChatContext();
-  const messagesEndRef = useRef<HTMLDivElement | null>(null);
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
 
   // Fetch the wissensbasis reasoning trace for this session so we can
   // wrap entity mentions in the assistant prose with CitationChips.
@@ -155,13 +155,20 @@ export default function ChatMessages() {
     [traceQ.data?.trace?.entities],
   );
 
-  // Auto-scroll to bottom when messages change
+  // Auto-scroll to bottom when messages change. Scroll the CONTAINER directly
+  // rather than calling scrollIntoView() on a sentinel: in Safari, scrollIntoView
+  // walks up and scrolls every scrollable ancestor — including the window — so on
+  // each new message it scrolled the whole page and pushed the chat + input out of
+  // view. Scrolling the container's scrollTop can only move this region, never the
+  // window, so it fixes Safari and behaves identically elsewhere.
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    const el = scrollContainerRef.current;
+    if (el) el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
   }, [messages]);
 
   return (
     <div
+      ref={scrollContainerRef}
       className="flex-1 overflow-y-auto card space-y-4 mb-4 mx-4 md:mx-0"
       role="log"
       aria-live="polite"
@@ -442,9 +449,6 @@ export default function ChatMessages() {
           onCancel={cancelEmailDialog}
         />
       )}
-
-      {/* Scroll anchor */}
-      <div ref={messagesEndRef} />
     </div>
   );
 }

--- a/tests/frontend/react/pages/ChatMessages.autoscroll.test.tsx
+++ b/tests/frontend/react/pages/ChatMessages.autoscroll.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * Regression: ChatMessages must auto-scroll its OWN container to the bottom on
+ * new messages — never via Element.scrollIntoView(). In Safari, scrollIntoView()
+ * scrolls every scrollable ancestor including the window, which scrolled the whole
+ * page on each sent message and pushed the chat + input out of view. Scrolling the
+ * container's scrollTop can only move that region, never the window.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import ChatMessages from '../../../../src/frontend/src/pages/ChatPage/ChatMessages';
+import { renderWithRouter } from '../test-utils';
+import {
+  useChatContext,
+  type ChatContextValue,
+} from '../../../../src/frontend/src/pages/ChatPage/context/ChatContext';
+import { buildChatContextValue } from '../test-chat-mock';
+
+vi.mock('../../../../src/frontend/src/pages/ChatPage/context/ChatContext', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../../../src/frontend/src/pages/ChatPage/context/ChatContext')
+  >('../../../../src/frontend/src/pages/ChatPage/context/ChatContext');
+  return {
+    ...actual,
+    useChatContext: vi.fn<() => ChatContextValue>(),
+  };
+});
+
+describe('ChatMessages — auto-scroll (Safari window-scroll regression)', () => {
+  beforeEach(() => {
+    vi.mocked(useChatContext).mockReturnValue(
+      buildChatContextValue({
+        messages: [
+          { role: 'user', content: 'hi' },
+          { role: 'assistant', content: 'hello' },
+        ],
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('scrolls its own container, not the window via scrollIntoView', () => {
+    const scrollTo = vi.spyOn(Element.prototype, 'scrollTo');
+    const scrollIntoView = vi.spyOn(Element.prototype, 'scrollIntoView');
+
+    renderWithRouter(<ChatMessages />);
+
+    // The auto-scroll happened on the container...
+    expect(scrollTo).toHaveBeenCalled();
+    // ...and NOT via the window-scrolling scrollIntoView (the Safari bug).
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    // It scrolls to the bottom (top === the element's scrollHeight).
+    const [arg] = scrollTo.mock.calls[0];
+    expect(arg).toMatchObject({ behavior: 'smooth' });
+  });
+});

--- a/tests/frontend/react/setup.ts
+++ b/tests/frontend/react/setup.ts
@@ -83,3 +83,10 @@ Object.defineProperty(window, 'ResizeObserver', {
   writable: true,
   value: ResizeObserverMock,
 });
+
+// jsdom implements neither Element.scrollTo nor Element.scrollIntoView. Several
+// components auto-scroll on render (e.g. ChatMessages scrolls its container to the
+// bottom on new messages); stub both globally so the effects are no-ops in tests
+// instead of throwing. Individual tests can spy on these as needed.
+Element.prototype.scrollTo = vi.fn();
+Element.prototype.scrollIntoView = vi.fn();


### PR DESCRIPTION
## Bug
In **Safari**, typing a chat message and pressing Enter scrolled the whole page so the chat (and input) was no longer visible.

## Root cause
`ChatMessages` auto-scrolled to the latest message via `messagesEndRef.scrollIntoView({behavior:'smooth'})` on every `messages` change. Safari's `scrollIntoView()` scrolls **every** scrollable ancestor — including the window — so each sent message scrolled the document. Chrome only scrolls the nearest scroll container, which is why it was Safari-specific.

## Fix
Hold a ref on the `overflow-y-auto` messages container and scroll **its own** `scrollTop` to the bottom (`container.scrollTo({top: scrollHeight, behavior:'smooth'})`). A container scroll cannot move the window, so it fixes Safari and behaves identically in Chrome. The now-dead `messagesEndRef` sentinel is removed.

## Tests
- `setup.ts`: jsdom implements neither `Element.scrollTo` nor `scrollIntoView` — stubbed both globally (matches the existing `matchMedia`/`IntersectionObserver` mocks) so auto-scroll effects are no-ops instead of throwing.
- New `ChatMessages.autoscroll.test.tsx`: asserts the container's `scrollTo` is used and `scrollIntoView` is **not** (guards against reverting to the window-scrolling API).

Targeted tests pass (`ChatMessages.autoscroll`, `ChatMessages.federationProgress`, `ChatPage`, `ChatUpload`). The React suite has pre-existing order-dependent flakiness (the clean baseline fails ~10 tests in unrelated files that shift run-to-run); the files this PR touches pass in isolation.

## Deploy note
Frontend-only. Needs a frontend image rebuild + rollout; users must hard-refresh / clear the PWA service-worker cache to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)