### PR TITLE
fix(satellite): connection robustness — bound handshake, fast reconnect, watchdog (v1.4.0)

### DIFF
--- a/docs/SATELLITE_CONNECTIVITY.md
+++ b/docs/SATELLITE_CONNECTIVITY.md
@@ -1,0 +1,90 @@
+# Satellite Connectivity & Robustness
+
+How a voice satellite (Pi Zero 2 W + ReSpeaker) connects to Renfield, the failure
+modes that make it flaky, and the robustness knobs that let a blip self-heal
+instead of wedging.
+
+## Connection path
+
+```
+satellite (renfield_satellite)
+  └─ single persistent WebSocket → wss://renfield.local/ws/satellite
+        │  (k8s ingress renfield-https: /ws → backend:8000; self-signed cert, verify_tls=false)
+        ▼
+backend  ha_glue/api/websocket/satellite_handler.py  (/ws/satellite)
+  • first message is `register` (id + room + capabilities) → `register_ack`
+  • then: app heartbeat every 30s + WS ping/pong keepalive
+  • SatelliteManager tracks live connections IN MEMORY (lost on a backend restart)
+```
+
+There is no pre-registration: any satellite may connect and is registered fresh
+each time; the room row is created on first connect (`ROOMS_AUTO_CREATE_FROM_SATELLITE`).
+
+## Failure modes (why it gets flaky)
+
+1. **Weak 2.4 GHz WiFi.** The Pi Zero 2 W is single-band 2.4 GHz with a marginal
+   antenna. Measured LAN RTT to a live satellite: 31–475 ms, ~220 ms jitter. Lossy
+   links drop the WS; slow links make every handshake fragile. **This is the
+   dominant cause** — fix it at the network layer (closer AP / mesh node / clean
+   2.4 GHz channel; or a USB-OTG Ethernet adapter for a stationary unit).
+2. **mDNS / boot-window race.** `renfield.local` depends on Avahi + the cluster
+   `mdns-responder`. At boot (before NTP/mDNS are ready) the handshake can time
+   out — these failures appear only in the *satellite* journal, never in backend
+   logs (they never reach FastAPI).
+3. **Device offline.** A powered-off / crashed / WiFi-disassociated Pi shows
+   nothing in backend logs. Check it physically: `ping <ip>`, ARP, the LED. A
+   4-mic-HAT unit can hit the AC108 + onnxruntime same-process kernel crash —
+   mitigate with `use_arecord: true`.
+4. **In-process wedges (fixed in the client).** See below.
+
+## Robustness knobs (`server.*` in `satellite.yaml`)
+
+Tuned defaults live in `provisioning/group_vars/satellites.yml`; override per-host
+in `host_vars/`.
+
+| Key | Default | Purpose |
+|---|---|---|
+| `ping_interval` | `15` | WS keepalive cadence (s) — tighter than the old hardcoded 20 → faster dead-link detection |
+| `ping_timeout` | `8` | drop the link if no pong within (s) |
+| `register_timeout` | `15` | **caps the post-connect `register` handshake.** Without it a slow/hung backend blocked the connect coroutine forever, wedging the satellite in CONNECTING with no reconnect |
+| `max_disconnected_seconds` | `300` | if the satellite can't reconnect for this long, it **exits cleanly so systemd restarts a fresh process** (backstop for any in-process wedge). `0` disables |
+| `reconnect_interval` | `5` | base for the exponential reconnect backoff (5→10→20→40→60 cap) |
+| `heartbeat_interval` | `30` | app heartbeat cadence |
+
+Client behavior fixes (shipped in the satellite package):
+- `_register()` recv is bounded by `register_timeout` (was unbounded).
+- A failed **heartbeat send now triggers reconnect immediately** (was swallowed,
+  leaving a zombie connection until the WS ping timeout ~30 s later).
+- The disconnect watchdog (`max_disconnected_seconds`) exits → systemd
+  `Restart=always` brings up a clean process. `StartLimitIntervalSec=0` in the
+  unit ensures these legitimate restarts never trip systemd's burst limit.
+
+> The watchdog uses a **clean `os._exit`**, never a SIGKILL-mid-restart — so it
+> does not risk the SD-card corruption that bricked a satellite before.
+
+## Diagnosing "X won't connect"
+
+```bash
+# 1. Does the backend ever see it? (zero events ⇒ it never reached FastAPI)
+kubectl -n renfield logs deploy/backend --since=24h | grep -i "sat-<room>\|📡\|👋"
+# 2. Is the device even on the network? (read-only, safe)
+ping <satellite-ip>;  arp -n <satellite-ip>
+# 3. The device's own view (read-only):
+ssh <pi> journalctl -u renfield-satellite -n 200 --no-pager
+#    grep: "Connecting to", "Registered successfully", "Reconnecting in",
+#          "timed out during opening handshake", "register ack not received"
+```
+
+## Deploying changes safely
+
+Satellite **code/config** changes deploy with Ansible **`--tags app`** (avoids the
+driver/service restart that risks bricking the SD card):
+
+```bash
+cd src/satellite/provisioning
+ansible-playbook -i inventory.yml provision.yml --limit satellite-<room> --tags app
+```
+
+⚠️ Never blindly remote-restart a satellite service; a SIGKILL mid-restart can
+corrupt the Pi Zero 2 W SD card. Roll out one host at a time and verify it
+re-registers (backend log `📡 Satellite sat-<room> registered`) before the next.

--- a/src/satellite/provisioning/group_vars/satellites.yml
+++ b/src/satellite/provisioning/group_vars/satellites.yml
@@ -20,6 +20,12 @@ server_url: "wss://renfield.local/ws/satellite"
 server_auto_discover: true
 server_auth_enabled: false
 server_verify_tls: false
+# Connection robustness (Pi Zero 2 W 2.4GHz WiFi is marginal — detect dead links
+# fast and self-heal instead of wedging). See docs/SATELLITE_CONNECTIVITY.md.
+server_ping_interval: 15          # WS keepalive cadence (s)
+server_ping_timeout: 8            # drop the link if no pong within (s)
+server_register_timeout: 15       # cap the post-connect register handshake (s)
+server_max_disconnected_seconds: 300  # exit→systemd restart if unreconnectable this long (0=off)
 
 # Wake word
 wakeword_model: "hey_renfield"

--- a/src/satellite/provisioning/templates/renfield-satellite.service.j2
+++ b/src/satellite/provisioning/templates/renfield-satellite.service.j2
@@ -5,6 +5,13 @@
 Description=Renfield Satellite Voice Assistant
 After=network-online.target sound.target
 Wants=network-online.target
+# The app self-exits after a prolonged disconnect (server.max_disconnected_seconds,
+# ~5 min apart) so systemd brings up a fresh process. Bound the start limit so
+# those slow, legitimate restarts always pass (≈1-2 per 10 min) but a pathological
+# fast crash-loop (which would re-init the AC108 driver every few seconds — a brick
+# risk) is stopped after a burst rather than hammering forever.
+StartLimitIntervalSec=600
+StartLimitBurst=10
 
 [Service]
 Type=simple

--- a/src/satellite/provisioning/templates/satellite.yaml.j2
+++ b/src/satellite/provisioning/templates/satellite.yaml.j2
@@ -12,6 +12,10 @@ server:
   discovery_timeout: 10
   reconnect_interval: 5
   heartbeat_interval: 30
+  ping_interval: {{ server_ping_interval | default(15) }}
+  ping_timeout: {{ server_ping_timeout | default(8) }}
+  register_timeout: {{ server_register_timeout | default(15) }}
+  max_disconnected_seconds: {{ server_max_disconnected_seconds | default(300) }}
   auth_enabled: {{ server_auth_enabled | lower }}
   verify_tls: {{ server_verify_tls | lower }}
 

--- a/src/satellite/renfield_satellite/__init__.py
+++ b/src/satellite/renfield_satellite/__init__.py
@@ -5,7 +5,7 @@ A headless voice assistant satellite for the Renfield ecosystem.
 Designed for Raspberry Pi Zero 2 W with ReSpeaker 2-Mics Pi HAT.
 """
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 __author__ = "Renfield Team"
 
 # Lazy imports to allow CLI tools to run without all dependencies

--- a/src/satellite/renfield_satellite/config.py
+++ b/src/satellite/renfield_satellite/config.py
@@ -31,6 +31,15 @@ class ServerConfig:
     discovery_timeout: float = 10.0  # Seconds to wait for discovery
     reconnect_interval: int = 5  # seconds
     heartbeat_interval: int = 30  # seconds
+    # Connection robustness (tuned for the Pi Zero 2 W's marginal 2.4GHz WiFi):
+    # faster dead-link detection + bounded handshake so a blip self-heals instead
+    # of wedging. See docs note in websocket_client.py.
+    ping_interval: int = 15  # WS keepalive ping cadence (was hardcoded 20)
+    ping_timeout: int = 8    # close the link if no pong within this (was 10)
+    register_timeout: float = 15.0  # cap the post-connect register handshake
+    # If the satellite cannot reconnect for this long, exit so systemd restarts a
+    # fresh process (clears any wedged in-process state). 0 disables.
+    max_disconnected_seconds: int = 300
     # Authentication (required when server has WS_AUTH_ENABLED=true)
     auth_enabled: bool = False  # Whether to fetch and use auth token
     auth_token: Optional[str] = None  # Pre-configured token (optional)
@@ -220,6 +229,10 @@ def load_config(config_path: Optional[str] = None) -> Config:
         config.server.discovery_timeout = srv.get("discovery_timeout", config.server.discovery_timeout)
         config.server.reconnect_interval = srv.get("reconnect_interval", config.server.reconnect_interval)
         config.server.heartbeat_interval = srv.get("heartbeat_interval", config.server.heartbeat_interval)
+        config.server.ping_interval = srv.get("ping_interval", config.server.ping_interval)
+        config.server.ping_timeout = srv.get("ping_timeout", config.server.ping_timeout)
+        config.server.register_timeout = srv.get("register_timeout", config.server.register_timeout)
+        config.server.max_disconnected_seconds = srv.get("max_disconnected_seconds", config.server.max_disconnected_seconds)
         config.server.auth_enabled = srv.get("auth_enabled", config.server.auth_enabled)
         config.server.verify_tls = srv.get("verify_tls", config.server.verify_tls)
         if "auth_token" in srv:

--- a/src/satellite/renfield_satellite/network/websocket_client.py
+++ b/src/satellite/renfield_satellite/network/websocket_client.py
@@ -69,6 +69,9 @@ class WebSocketClient:
         heartbeat_interval: int = 30,
         language: str = "de",
         capabilities: Optional[Dict[str, Any]] = None,
+        ping_interval: int = 15,
+        ping_timeout: int = 8,
+        register_timeout: float = 15.0,
     ):
         """
         Initialize WebSocket client.
@@ -93,6 +96,11 @@ class WebSocketClient:
         self.heartbeat_interval = heartbeat_interval
         self.language = language
         self._capabilities = capabilities or {}
+        # Connection robustness knobs (see ServerConfig). Tighter ping = faster
+        # dead-link detection on lossy WiFi; register_timeout bounds the handshake.
+        self._ping_interval = ping_interval
+        self._ping_timeout = ping_timeout
+        self._register_timeout = register_timeout
 
         self._ws: Optional["WebSocketClientProtocol"] = None
         self._state = ConnectionState.DISCONNECTED
@@ -244,8 +252,8 @@ class WebSocketClient:
         try:
             # Build connection kwargs
             connect_kwargs = {
-                "ping_interval": 20,
-                "ping_timeout": 10,
+                "ping_interval": self._ping_interval,
+                "ping_timeout": self._ping_timeout,
             }
 
             # Pass auth token via header instead of URL query parameter
@@ -284,6 +292,14 @@ class WebSocketClient:
         except Exception as e:
             print(f"Connection failed: {e}")
             self._state = ConnectionState.DISCONNECTED
+            # Close any half-open socket (e.g. a register-timeout leaves the WS
+            # open) so it doesn't dangle until the next connect() cleanup.
+            if self._ws is not None:
+                try:
+                    await self._ws.close()
+                except Exception:
+                    pass
+                self._ws = None
             if self._on_error:
                 self._on_error(str(e))
             return False
@@ -336,8 +352,16 @@ class WebSocketClient:
 
         await self._send(message)
 
-        # Wait for ack
-        response = await self._ws.recv()
+        # Wait for ack — BOUNDED. Without a timeout a slow/hung backend (e.g.
+        # stuck creating the room row) would block this coroutine forever, wedging
+        # the satellite in CONNECTING with no reconnect ever firing. On timeout we
+        # raise, which propagates out of connect() → reconnect/backoff kicks in.
+        try:
+            response = await asyncio.wait_for(self._ws.recv(), timeout=self._register_timeout)
+        except asyncio.TimeoutError:
+            raise Exception(
+                f"register ack not received within {self._register_timeout}s"
+            )
         data = json.loads(response)
 
         if data.get("type") == "register_ack":
@@ -573,7 +597,18 @@ class WebSocketClient:
             except asyncio.CancelledError:
                 break
             except Exception as e:
-                print(f"Heartbeat error: {e}")
+                # A failed heartbeat send means the link is already dead. Don't
+                # swallow + keep looping (the old behavior left a zombie until the
+                # WS ping timeout fired ~30s later) — surface it as a disconnect so
+                # the reconnect path starts immediately.
+                print(f"Heartbeat send failed, treating as disconnect: {e}")
+                self._state = ConnectionState.DISCONNECTED
+                if self._on_disconnected:
+                    try:
+                        self._on_disconnected()
+                    except Exception:
+                        pass
+                break
 
     async def send_wakeword_detected(
         self,

--- a/src/satellite/renfield_satellite/satellite.py
+++ b/src/satellite/renfield_satellite/satellite.py
@@ -11,6 +11,7 @@ Orchestrates all satellite components:
 
 import asyncio
 import math
+import os
 import struct
 import time
 from enum import Enum
@@ -209,6 +210,9 @@ class Satellite:
             server_url=self.config.server.url,  # May be None if using auto-discovery
             reconnect_interval=self.config.server.reconnect_interval,
             heartbeat_interval=self.config.server.heartbeat_interval,
+            ping_interval=self.config.server.ping_interval,
+            ping_timeout=self.config.server.ping_timeout,
+            register_timeout=self.config.server.register_timeout,
             language=self.config.satellite.language,
             # Real hardware capabilities so the fleet page reflects THIS
             # device, not a hardcoded "3 LEDs" for every satellite.
@@ -434,8 +438,30 @@ class Satellite:
         """
         attempts = 0
         max_backoff = 60
+        disconnect_start = time.monotonic()
+        max_disconnected = getattr(self.config.server, "max_disconnected_seconds", 0)
 
         while self._running:
+            # Disconnect watchdog: if we've been unable to reconnect for too long,
+            # exit so systemd (Restart=always) brings up a FRESH process. This is
+            # the backstop for any in-process wedge the reconnect loop can't clear
+            # (a clean exit, never the SIGKILL-mid-restart that risks the SD card).
+            if max_disconnected and (time.monotonic() - disconnect_start) > max_disconnected:
+                # NEVER restart mid-OTA: the installer does a non-atomic
+                # rmtree+copytree of the install dir, so an os._exit during it
+                # would leave a half-written install — exactly the brick we're
+                # trying to avoid. Defer the watchdog (fresh window) until the
+                # update finishes.
+                if self.update_manager.current_stage != UpdateStage.IDLE:
+                    print("Disconnect watchdog deferred: OTA update in progress")
+                    disconnect_start = time.monotonic()
+                else:
+                    print(
+                        f"Disconnected >{max_disconnected}s after {attempts} attempts; "
+                        "exiting for a clean systemd restart"
+                    )
+                    os._exit(1)
+
             attempts += 1
             backoff = min(self.config.server.reconnect_interval * (2 ** (attempts - 1)), max_backoff)
 

--- a/tests/satellite/test_websocket_client_robustness.py
+++ b/tests/satellite/test_websocket_client_robustness.py
@@ -1,0 +1,140 @@
+"""Connection-robustness tests for the satellite WebSocket client.
+
+Covers the fixes for the flaky-connectivity work (2026-06-10):
+- `_register()` no longer blocks forever on a slow/hung backend (it had no
+  timeout — a known wedge that left the satellite in CONNECTING with no reconnect)
+- a failed heartbeat send now triggers reconnect immediately instead of being
+  swallowed (which left a zombie connection until the WS ping timeout)
+- the tighter ping / register-timeout knobs are plumbed through + have safe defaults
+"""
+
+import asyncio
+import json
+
+import pytest
+
+from renfield_satellite.config import ServerConfig, load_config
+from renfield_satellite.network.websocket_client import (
+    ConnectionState,
+    WebSocketClient,
+)
+
+
+def _client(**kw):
+    return WebSocketClient(satellite_id="sat-test", room="TestRoom",
+                           server_url="wss://x/ws/satellite", **kw)
+
+
+class _HangingWS:
+    async def send(self, _msg):
+        pass
+
+    async def recv(self):
+        await asyncio.Event().wait()  # never resolves — simulates a hung backend
+
+
+class _AckWS:
+    def __init__(self, ack):
+        self._ack = ack
+        self.sent = []
+
+    async def send(self, msg):
+        self.sent.append(msg)
+
+    async def recv(self):
+        return json.dumps(self._ack)
+
+
+class _FailingWS:
+    async def send(self, _msg):
+        raise ConnectionError("broken pipe")
+
+
+# -- _register timeout --------------------------------------------------------
+
+@pytest.mark.satellite
+async def test_register_times_out_instead_of_wedging():
+    c = _client(register_timeout=0.05)
+    c._ws = _HangingWS()
+    with pytest.raises(Exception, match="register ack not received"):
+        await c._register()
+
+
+@pytest.mark.satellite
+async def test_register_succeeds_within_timeout():
+    c = _client(register_timeout=5)
+    c._ws = _AckWS({
+        "type": "register_ack", "success": True,
+        "config": {"wake_words": ["hey_renfield"], "threshold": 0.6},
+        "protocol_version": "1.0",
+    })
+    got = {}
+    c._on_connected = lambda sc: got.update(wake=sc.wake_words, thr=sc.threshold)
+    await c._register()
+    assert got["wake"] == ["hey_renfield"] and got["thr"] == 0.6
+
+
+# -- heartbeat-failure → reconnect -------------------------------------------
+
+@pytest.mark.satellite
+async def test_heartbeat_send_failure_triggers_disconnect():
+    c = _client(heartbeat_interval=0)  # don't wait between ticks
+    c._running = True
+    c._ws = _FailingWS()
+    fired = {"n": 0}
+    c._on_disconnected = lambda: fired.__setitem__("n", fired["n"] + 1)
+
+    # Loop must fire the disconnect callback once and then exit (not spin/swallow).
+    await asyncio.wait_for(c._heartbeat_loop(), timeout=2)
+
+    assert fired["n"] == 1
+    assert c._state == ConnectionState.DISCONNECTED
+
+
+# -- knobs plumbed + safe defaults -------------------------------------------
+
+@pytest.mark.satellite
+def test_robustness_knobs_stored():
+    c = _client(ping_interval=15, ping_timeout=8, register_timeout=12)
+    assert c._ping_interval == 15
+    assert c._ping_timeout == 8
+    assert c._register_timeout == 12
+
+
+@pytest.mark.satellite
+def test_robustness_knobs_default_to_serverconfig_values():
+    # Constructor defaults match ServerConfig so a no-arg caller gets the tuned
+    # values (no drift between the two default sets).
+    c = _client()
+    assert c._ping_interval == ServerConfig().ping_interval == 15
+    assert c._ping_timeout == ServerConfig().ping_timeout == 8
+    assert c._register_timeout == 15
+
+
+# -- config wiring ------------------------------------------------------------
+
+@pytest.mark.satellite
+def test_serverconfig_robustness_defaults():
+    s = ServerConfig()
+    assert s.ping_interval == 15
+    assert s.ping_timeout == 8
+    assert s.register_timeout == 15
+    assert s.max_disconnected_seconds == 300
+
+
+@pytest.mark.satellite
+def test_config_loads_robustness_knobs(tmp_path):
+    p = tmp_path / "satellite.yaml"
+    p.write_text(
+        "server:\n"
+        "  url: wss://renfield.local/ws/satellite\n"
+        "  ping_interval: 12\n"
+        "  ping_timeout: 6\n"
+        "  register_timeout: 9\n"
+        "  max_disconnected_seconds: 240\n"
+    )
+    cfg = load_config(str(p))
+    assert cfg.server.ping_interval == 12
+    assert cfg.server.ping_timeout == 6
+    assert cfg.server.register_timeout == 9
+    assert cfg.server.max_disconnected_seconds == 240


### PR DESCRIPTION
## Summary

Hardens the voice-satellite WebSocket client so the chronically flaky Pi Zero 2 W 2.4 GHz WiFi self-heals instead of wedging. Prompted by the Wohnzimmer satellite not connecting + overall flakiness.

### Diagnosis (what triggered this)
- **Wohnzimmer** is fully offline (`192.168.1.24`: 100% ping loss, incomplete ARP, stale mDNS) — the backend logged **zero** `sat-wohnzimmer` events in 19 h. Needs a physical check (separate from this PR).
- The one reachable satellite (Arbeitszimmer) answers at **31–475 ms / ~220 ms jitter on a LAN** — marginal 2.4 GHz reception. On top of that the client had real wedge paths that turn a blip into a stuck connection.

### Client robustness fixes
- **Bounded register handshake** — `_register()`'s `recv()` now times out (`server.register_timeout`, 15 s). Was unbounded: a slow/hung backend froze the connect coroutine in CONNECTING with no reconnect ever firing.
- **Fast reconnect on heartbeat failure** — a failed heartbeat send now fires `_on_disconnected` + breaks (was swallowed, leaving a ~30 s zombie connection).
- **Tighter, configurable WS keepalive** — `ping_interval` 20→15 s, `ping_timeout` 10→8 s.
- **Disconnect watchdog** — unreconnectable for `server.max_disconnected_seconds` (300 s) ⇒ clean `os._exit` so systemd brings up a fresh process. **Never a SIGKILL-mid-restart** (no SD-card brick), and it **defers while an OTA update is in progress** (the installer does a non-atomic rmtree+copytree).

### Config / provisioning
- New `server.*` knobs through `ServerConfig` + loader + `group_vars` + `satellite.yaml.j2`.
- systemd: `StartLimitIntervalSec=600` / `StartLimitBurst=10` — slow watchdog restarts always pass, but a pathological fast crash-loop (which would re-init the AC108 driver every few seconds — a brick risk) is stopped after a burst.

### Review
Self-reviewed (adversarial). Two safety findings fixed before this PR: the watchdog firing mid-OTA-write (**HIGH** → now guarded) and an over-eager disabled start-limit (**MED** → bounded).

### Tests
7 new robustness tests + 21 existing config tests green (28 total).

### Docs
`docs/SATELLITE_CONNECTIVITY.md` — connection path, failure modes, knobs, diagnosis recipe, and the `--tags app` safe-deploy procedure.

## Deploy (NOT done here — brick-sensitive)
`ansible-playbook -i inventory.yml provision.yml --limit satellite-<room> --tags app`, **one host at a time**, verifying each re-registers before the next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)