### PR TITLE
feat(audio): https TTS delivery to DLNA renderers (ADVERTISE_SCHEME)

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -897,33 +897,51 @@ ADVERTISE_IP=192.168.1.100
 
 ```bash
 # Hostname/IP die externe Dienste (HA Media Player, DLNA Renderer) erreichen können
-ADVERTISE_HOST=192.168.1.159
+ADVERTISE_HOST=renfield.local
 
-# Port für ADVERTISE_HOST (Default: 8000, setze 80 wenn über Nginx)
-ADVERTISE_PORT=80
+# URL-Schema (http|https) für die TTS-Audio-URL, die Renderer abrufen
+ADVERTISE_SCHEME=https
+
+# Port für ADVERTISE_HOST (Standard-Ports 80/443 werden in der URL weggelassen)
+ADVERTISE_PORT=443
 ```
+
+`ADVERTISE_HOST`/`ADVERTISE_SCHEME`/`ADVERTISE_PORT` bauen die URL, die das
+Backend an DLNA-Renderer und HA Media Player übergibt, damit diese die
+TTS-Audiodatei (`/api/voice/tts-cache/{id}`) abrufen
+(`AudioOutputService._get_backend_url()`).
 
 **Defaults:**
 - `ADVERTISE_HOST`: None (muss gesetzt werden für HA Media Player / DLNA Output)
+- `ADVERTISE_SCHEME`: `http` (Literal `http|https`; ein Tippfehler wird beim Start abgelehnt)
 - `ADVERTISE_PORT`: `8000`
 
-**Wann benötigt:**
-- Wenn TTS-Ausgabe auf Home Assistant Media Playern oder DLNA Renderern erfolgen soll
-- Der Wert muss eine Adresse sein, die Home Assistant erreichen kann (nicht `localhost`!)
+**Standard-Ports 80 und 443 werden in der URL immer weggelassen** — so kann ein
+`ADVERTISE_PORT`, das nicht zum Schema passt (z.B. `https` + `80`), keine kaputte
+URL `https://host:80` erzeugen. Nur Nicht-Standard-Ports (8000, 8443) erscheinen.
 
-**Beispiele:**
-```bash
-ADVERTISE_HOST=192.168.1.159      # IP-Adresse (empfohlen für DLNA)
-ADVERTISE_HOST=renfield.local     # mDNS Hostname (funktioniert NICHT für DLNA Renderer)
-```
+**Produktion (k8s, aktuell):** `ADVERTISE_HOST=renfield.local`,
+`ADVERTISE_SCHEME=https`, `ADVERTISE_PORT=443`. Die bestehende `renfield-https`
+Traefik-Ingress bedient `https://renfield.local/api/voice/tts-cache/…` (kein
+eigener Route nötig). Das Renfield-Zertifikat hat SAN `renfield.local` +
+`192.168.1.230`.
 
-**Wichtig:** DLNA-Renderer (z.B. HiFiBerry) können mDNS-Hostnamen (`.local`) oft
-nicht auflösen. **IP-Adresse verwenden** wenn DLNA-Ausgabe genutzt wird.
+**Voraussetzung pro Renderer (https):** der Renderer muss `renfield.local`
+auflösen UND dem Zertifikat vertrauen.
+- **Linn / openHome-Renderer:** funktioniert nativ — lösen `renfield.local` per
+  Router-DNS auf und akzeptieren das self-signed Zertifikat (gemessen).
+- **HiFiBerry (gmediarender/gstreamer):** braucht zwei Eintragungen auf dem
+  Gerät — die Renfield-CA im Trust-Store (`/etc/ssl/certs`) **und** einen
+  `/etc/hosts`-Eintrag `192.168.1.230 renfield.local` (systemd-resolved fängt
+  `.local` als mDNS ab und liefert NOTFOUND, bevor DNS gefragt wird). Danach
+  `systemctl restart dlnampris.service`, damit gstreamer den Trust-Store neu lädt.
+- **Fernseher / Samsung:** noch nicht getestet (Tech-Debt, `TODOS.md`).
 
-**Port 80 vs 8000:** Der Backend-Container exposed Port 8000 nur auf `127.0.0.1`.
-Für externe Zugriffe (DLNA, HA) muss der Traffic über Nginx (Port 80) laufen.
-Setze `ADVERTISE_PORT=80` in Produktion. Nginx leitet `/api/voice/tts-cache/`
-über plain HTTP (ohne HTTPS-Redirect) an den Backend weiter.
+Mit `ADVERTISE_SCHEME=http` (oder Default) verhält sich alles byte-identisch wie
+zuvor — eine reine Plain-HTTP-URL. Diese wird allerdings von Renderern nicht
+abgerufen, wenn sie hinter dem Traefik-https-Redirect liegt (stiller Fehler:
+der Renderer meldet „playing", lädt aber nie). Details + Messungen:
+`docs/MESSAGE_RELAY.md` → „TTS-Audio-Auslieferung an Renderer".
 
 **Ohne ADVERTISE_HOST:**
 - TTS wird nur auf Renfield-Geräten (Satellites, Web Panels) abgespielt

--- a/docs/MESSAGE_RELAY.md
+++ b/docs/MESSAGE_RELAY.md
@@ -92,6 +92,42 @@ are in the room but one carries no tracked device, the camera sees 2 while only 
 is tracked → blocked (→ the "message waiting" + `force` flow). Annoying but
 private; `force` resolves it.
 
+## TTS-Audio-Auslieferung an Renderer (DLNA / HA media_player)
+
+Wenn die Ansage auf einem DLNA-Renderer (statt einem Renfield-Satellite) landet,
+synthetisiert das Backend das WAV, legt es im TTS-Cache ab und übergibt dem
+Renderer eine **URL** (`/api/voice/tts-cache/{id}`), die der Renderer dann selbst
+**abruft**. Die URL baut `AudioOutputService._get_backend_url()` aus
+`ADVERTISE_SCHEME` + `ADVERTISE_HOST` (+ `ADVERTISE_PORT`).
+
+**Warum das früher still fehlschlug:** Mit `http://renfield.local` (Port 80) bekam
+der Renderer eine URL hinter dem Traefik-`http→https`-Redirect. Der HiFiBerry
+(gstreamer, event-silent) meldete `state=playing` **ohne Fehler**, rief die URL
+aber **nie** ab (0 GETs im Access-Log) → keine Audioausgabe, kein sichtbarer
+Fehler. Die einzige Bodenwahrheit ist das Backend-Access-Log.
+
+**Lösung (Prod):** `ADVERTISE_SCHEME=https`, `ADVERTISE_HOST=renfield.local`,
+`ADVERTISE_PORT=443`. Der Renderer holt `https://renfield.local/api/voice/tts-cache/…`
+über die bestehende `renfield-https` Ingress — kein eigener Traefik-Route, kein
+Plain-HTTP-Loch.
+
+**Pro-Renderer-Voraussetzung** (gemessen, nicht angenommen):
+
+| Renderer | löst `renfield.local` auf | akzeptiert self-signed cert | Setup |
+|---|---|---|---|
+| Linn / openHome | ✅ Router-DNS | ✅ (gemessen, ohne CA) | keins |
+| HiFiBerry (gstreamer) | ❌ `.local`→mDNS-Quirk | ❌ strikt | CA in `/etc/ssl/certs` **+** `/etc/hosts`-Eintrag `192.168.1.230 renfield.local` **+** `systemctl restart dlnampris.service` |
+| Fernseher / Samsung | ? | ? | ungetestet (Tech-Debt) |
+
+Hintergrund HiFiBerry: nsswitch ist `hosts: files resolve [!UNAVAIL=return] dns` —
+systemd-`resolve` greift `.local` als mDNS und liefert NOTFOUND, bevor `dns`
+gefragt wird; deshalb scheitert die Auflösung trotz vorhandenem DNS-Eintrag.
+`curl` umgeht das (eigener c-ares-Resolver), gstreamer (`getaddrinfo`) nicht.
+Diese Geräte-Eintragungen überleben einen Reboot, aber **nicht** ein
+HiFiBerryOS-Update (Tech-Debt: nach Update neu setzen).
+
+Mit `ADVERTISE_SCHEME=http` ist das Verhalten byte-identisch zu vorher.
+
 ## Where it lives
 
 - Tool + gate: `ha_glue/services/internal_tools.py` (`_announce_in_room`, `internal.announce_in_room`)

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -131,9 +131,13 @@ data:
   AGENT_STEP_TIMEOUT: "60"
   AGENT_TOTAL_TIMEOUT: "300"
 
-  # Presentation
+  # Presentation — URL handed to DLNA renderers / HA media_player to fetch
+  # backend-served TTS audio. https over renfield.local (cert SAN covers the name
+  # + 192.168.1.230); the existing renfield-https ingress serves /api/voice/tts-cache.
+  # Renderers must resolve renfield.local + trust the cert — see docs/MESSAGE_RELAY.md.
   ADVERTISE_HOST: "renfield.local"
-  ADVERTISE_PORT: "80"
+  ADVERTISE_SCHEME: "https"
+  ADVERTISE_PORT: "443"
 
   # Satellites
   SATELLITE_LATEST_VERSION: "1.3.0"

--- a/src/backend/ha_glue/services/audio_output_service.py
+++ b/src/backend/ha_glue/services/audio_output_service.py
@@ -304,14 +304,15 @@ class AudioOutputService:
 
         The scheme is ADVERTISE_SCHEME (http|https). https is only reachable by
         renderers that can resolve ADVERTISE_HOST and trust its TLS cert — see
-        docs/MESSAGE_RELAY.md ("TTS audio delivery to renderers").
+        docs/MESSAGE_RELAY.md ("TTS audio delivery to renderers"). Standard ports
+        (80/443) are omitted regardless of scheme, so an ADVERTISE_PORT left at a
+        standard value can't mismatch the scheme.
         """
         if settings.advertise_host:
-            scheme = (settings.advertise_scheme or "http").lower()
+            scheme = settings.advertise_scheme
             host = settings.advertise_host
             port = settings.advertise_port
-            default_port = 443 if scheme == "https" else 80
-            if port and port != default_port:
+            if port and port not in (80, 443):
                 return f"{scheme}://{host}:{port}"
             return f"{scheme}://{host}"
 

--- a/src/backend/ha_glue/services/audio_output_service.py
+++ b/src/backend/ha_glue/services/audio_output_service.py
@@ -301,13 +301,19 @@ class AudioOutputService:
         Priority:
         1. ADVERTISE_HOST from settings (recommended for HA integration)
         2. BACKEND_INTERNAL_URL for Docker networking (default: http://backend:8000)
+
+        The scheme is ADVERTISE_SCHEME (http|https). https is only reachable by
+        renderers that can resolve ADVERTISE_HOST and trust its TLS cert — see
+        docs/MESSAGE_RELAY.md ("TTS audio delivery to renderers").
         """
         if settings.advertise_host:
+            scheme = (settings.advertise_scheme or "http").lower()
             host = settings.advertise_host
             port = settings.advertise_port
-            if port and port != 80:
-                return f"http://{host}:{port}"
-            return f"http://{host}"
+            default_port = 443 if scheme == "https" else 80
+            if port and port != default_port:
+                return f"{scheme}://{host}:{port}"
+            return f"{scheme}://{host}"
 
         # Use internal Docker URL - works when HA and Renfield are on same Docker network
         logger.debug(f"Using internal backend URL: {settings.backend_internal_url}")

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -153,6 +153,7 @@ class Settings(BaseSettings):
     # Output Routing
     advertise_host: str | None = None  # Hostname/IP that external services (like HA) can reach
     advertise_port: int = 8000            # Port for advertise_host
+    advertise_scheme: str = "http"        # URL scheme for advertise_host-built media URLs (http|https). https requires renderers to resolve+trust advertise_host's cert.
     backend_internal_url: str = "http://backend:8000"  # Internal URL for Docker networking (fallback when advertise_host not set)
 
     # Wake Word Detection

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -4,6 +4,7 @@ Konfiguration und Settings
 import json
 import os
 from functools import lru_cache
+from typing import Literal
 
 from loguru import logger
 from pydantic import Field, SecretStr, model_validator
@@ -153,7 +154,7 @@ class Settings(BaseSettings):
     # Output Routing
     advertise_host: str | None = None  # Hostname/IP that external services (like HA) can reach
     advertise_port: int = 8000            # Port for advertise_host
-    advertise_scheme: str = "http"        # URL scheme for advertise_host-built media URLs (http|https). https requires renderers to resolve+trust advertise_host's cert.
+    advertise_scheme: Literal["http", "https"] = "http"  # URL scheme for advertise_host-built media URLs. https requires renderers to resolve+trust advertise_host's cert. Pair https with ADVERTISE_PORT=443.
     backend_internal_url: str = "http://backend:8000"  # Internal URL for Docker networking (fallback when advertise_host not set)
 
     # Wake Word Detection

--- a/tests/backend/test_audio_output_service.py
+++ b/tests/backend/test_audio_output_service.py
@@ -334,6 +334,7 @@ class TestBackendURL:
         mock_s = MagicMock()
         mock_s.advertise_host = "renfield.local"
         mock_s.advertise_port = 8000
+        mock_s.advertise_scheme = "http"
 
         with patch("ha_glue.services.audio_output_service.settings", mock_s), \
              patch("ha_glue.services.audio_output_service.HomeAssistantClient"):
@@ -341,6 +342,42 @@ class TestBackendURL:
             url = svc._get_backend_url()
 
         assert url == "http://renfield.local:8000"
+
+    def test_url_http_default_port_omitted(self):
+        """Port 80 is omitted for http."""
+        mock_s = MagicMock()
+        mock_s.advertise_host = "192.168.1.230"
+        mock_s.advertise_port = 80
+        mock_s.advertise_scheme = "http"
+
+        with patch("ha_glue.services.audio_output_service.settings", mock_s), \
+             patch("ha_glue.services.audio_output_service.HomeAssistantClient"):
+            svc = AudioOutputService()
+            assert svc._get_backend_url() == "http://192.168.1.230"
+
+    def test_url_https_scheme_omits_443(self):
+        """https scheme produces an https:// URL; the default 443 is omitted."""
+        mock_s = MagicMock()
+        mock_s.advertise_host = "renfield.local"
+        mock_s.advertise_port = 443
+        mock_s.advertise_scheme = "https"
+
+        with patch("ha_glue.services.audio_output_service.settings", mock_s), \
+             patch("ha_glue.services.audio_output_service.HomeAssistantClient"):
+            svc = AudioOutputService()
+            assert svc._get_backend_url() == "https://renfield.local"
+
+    def test_url_https_nonstandard_port_kept(self):
+        """A non-default port is kept for https."""
+        mock_s = MagicMock()
+        mock_s.advertise_host = "renfield.local"
+        mock_s.advertise_port = 8443
+        mock_s.advertise_scheme = "https"
+
+        with patch("ha_glue.services.audio_output_service.settings", mock_s), \
+             patch("ha_glue.services.audio_output_service.HomeAssistantClient"):
+            svc = AudioOutputService()
+            assert svc._get_backend_url() == "https://renfield.local:8443"
 
     def test_url_falls_back_to_internal(self):
         """Falls back to backend_internal_url when advertise_host is None."""

--- a/tests/backend/test_audio_output_service.py
+++ b/tests/backend/test_audio_output_service.py
@@ -379,6 +379,19 @@ class TestBackendURL:
             svc = AudioOutputService()
             assert svc._get_backend_url() == "https://renfield.local:8443"
 
+    def test_url_https_with_leftover_port_80_omits_it(self):
+        """A standard port (80/443) is omitted regardless of scheme, so https left
+        with the http default port can't produce a broken https://host:80."""
+        mock_s = MagicMock()
+        mock_s.advertise_host = "renfield.local"
+        mock_s.advertise_port = 80
+        mock_s.advertise_scheme = "https"
+
+        with patch("ha_glue.services.audio_output_service.settings", mock_s), \
+             patch("ha_glue.services.audio_output_service.HomeAssistantClient"):
+            svc = AudioOutputService()
+            assert svc._get_backend_url() == "https://renfield.local"
+
     def test_url_falls_back_to_internal(self):
         """Falls back to backend_internal_url when advertise_host is None."""
         mock_s = MagicMock()


### PR DESCRIPTION
## Problem

Relay/announce TTS was **silent on DLNA renderers** (the "ich habe nichts gehört" report). `AudioOutputService._get_backend_url()` hardcoded `http://`, so with `ADVERTISE_HOST=renfield.local` the renderer was handed a URL behind Traefik's `http→https` redirect and **never fetched it** — a fully silent failure: the event-silent HiFiBerry reported `state=playing` with no error while the backend access log showed **zero GETs**.

## Fix

- Add `advertise_scheme: Literal["http","https"]` (default `http` → byte-identical when unset).
- `_get_backend_url()` emits `{scheme}://{host}` and **omits both standard ports (80 + 443)** regardless of scheme, so an `ADVERTISE_PORT` left at a standard value can't produce a broken `https://host:80`.
- Kept on `advertise_host` (not a scheme-prefixed host) so `zeroconf` — which reads `ADVERTISE_HOST` directly and appends `.local` — is unaffected.

Prod config (`k8s/configmap.yaml` updated to match): `ADVERTISE_HOST=renfield.local, ADVERTISE_SCHEME=https, ADVERTISE_PORT=443`. The **existing `renfield-https` ingress** serves `https://renfield.local/api/voice/tts-cache/…` — no new Traefik route needed.

## Measured per-renderer reality (tested, not assumed)

| Renderer | resolves `renfield.local` | accepts self-signed cert | setup |
|---|---|---|---|
| Linn / openHome | ✅ router DNS | ✅ (no CA) | none — native |
| HiFiBerry (gstreamer) | ❌ `.local`→mDNS quirk | ❌ strict | CA + `/etc/hosts` + `dlnampris.service` restart |
| Fernseher / Samsung TV | ? | ? | **untested — tech-debt** |

(HiFiBerry: nsswitch `resolve [!UNAVAIL=return]` makes systemd-resolved grab `.local` as mDNS and return NOTFOUND before DNS; `curl`/c-ares works, `gstreamer`/getaddrinfo doesn't.)

## Verification

- `tests/backend/test_audio_output_service.py::TestBackendURL` — 6/6 green on `.159` (http/https, port-omit, https+leftover-80, non-standard port, fallback).
- **Deployed v2.17.1** to the private cluster; health `ok`; **audibly verified** end-to-end (real WAV → `GET … 200 OK` → "Das Essen ist fertig" played on the HiFiBerry Arbeitszimmer over TLS).

## Tech-debt (filed in TODOS.md)

- Test Fernseher/Samsung TV renderers on https (sentinel play can WoL-power-on a TV).
- HiFiBerry CA + `/etc/hosts` reset on a HiFiBerryOS update → fold into Ansible provisioning.
- Per-renderer scheme if a TV can't do https (vs the single global `ADVERTISE_SCHEME`).

Docs: `docs/MESSAGE_RELAY.md` (new "TTS audio delivery to renderers" section), `docs/ENVIRONMENT_VARIABLES.md` (ADVERTISE_SCHEME + corrected the stale plain-HTTP guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)