### PR TITLE
fix(voice): DLNA renderer TTS compat — HEAD + audio/x-wav + .wav, deliver over http://renfield.local

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -160,7 +160,8 @@ HOME_ASSISTANT_TOKEN=DEIN_HA_TOKEN_HIER
 # Zeroconf/mDNS für Satellites
 # -----------------------------------------------------------------------------
 ADVERTISE_HOST=renfield.local
-ADVERTISE_PORT=8000
+ADVERTISE_SCHEME=http   # http|https; http for DLNA-renderer TTS (Samsung can't do self-signed)
+ADVERTISE_PORT=8000     # k8s prod uses 80 for the DLNA-TTS URL (see docs/OUTPUT_ROUTING.md)
 
 # -----------------------------------------------------------------------------
 # Frigate (optional)

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -900,15 +900,15 @@ ADVERTISE_IP=192.168.1.100
 ADVERTISE_HOST=renfield.local
 
 # URL-Schema (http|https) für die TTS-Audio-URL, die Renderer abrufen
-ADVERTISE_SCHEME=https
+ADVERTISE_SCHEME=http
 
 # Port für ADVERTISE_HOST (Standard-Ports 80/443 werden in der URL weggelassen)
-ADVERTISE_PORT=443
+ADVERTISE_PORT=80
 ```
 
 `ADVERTISE_HOST`/`ADVERTISE_SCHEME`/`ADVERTISE_PORT` bauen die URL, die das
 Backend an DLNA-Renderer und HA Media Player übergibt, damit diese die
-TTS-Audiodatei (`/api/voice/tts-cache/{id}`) abrufen
+TTS-Audiodatei (`/api/voice/tts-cache/{id}.wav`) abrufen
 (`AudioOutputService._get_backend_url()`).
 
 **Defaults:**
@@ -917,31 +917,27 @@ TTS-Audiodatei (`/api/voice/tts-cache/{id}`) abrufen
 - `ADVERTISE_PORT`: `8000`
 
 **Standard-Ports 80 und 443 werden in der URL immer weggelassen** — so kann ein
-`ADVERTISE_PORT`, das nicht zum Schema passt (z.B. `https` + `80`), keine kaputte
-URL `https://host:80` erzeugen. Nur Nicht-Standard-Ports (8000, 8443) erscheinen.
+`ADVERTISE_PORT`, das nicht zum Schema passt, keine kaputte URL erzeugen. Nur
+Nicht-Standard-Ports (8000, 8443) erscheinen.
 
 **Produktion (k8s, aktuell):** `ADVERTISE_HOST=renfield.local`,
-`ADVERTISE_SCHEME=https`, `ADVERTISE_PORT=443`. Die bestehende `renfield-https`
-Traefik-Ingress bedient `https://renfield.local/api/voice/tts-cache/…` (kein
-eigener Route nötig). Das Renfield-Zertifikat hat SAN `renfield.local` +
-`192.168.1.230`.
+`ADVERTISE_SCHEME=http`, `ADVERTISE_PORT=80` → `http://renfield.local/api/voice/tts-cache/{id}.wav`.
+Die `backend-tts-cache-http` IngressRoute (eigener `web`-Entrypoint-Route ohne
+`http→https`-Redirect) bedient diesen Pfad plain. **Bewusst http, nicht https:**
+Samsung-TVs akzeptieren das self-signed Zertifikat nicht; http funktioniert auf
+allen Renderern.
 
-**Voraussetzung pro Renderer (https):** der Renderer muss `renfield.local`
-auflösen UND dem Zertifikat vertrauen.
-- **Linn / openHome-Renderer:** funktioniert nativ — lösen `renfield.local` per
-  Router-DNS auf und akzeptieren das self-signed Zertifikat (gemessen).
-- **HiFiBerry (gmediarender/gstreamer):** braucht zwei Eintragungen auf dem
-  Gerät — die Renfield-CA im Trust-Store (`/etc/ssl/certs`) **und** einen
-  `/etc/hosts`-Eintrag `192.168.1.230 renfield.local` (systemd-resolved fängt
-  `.local` als mDNS ab und liefert NOTFOUND, bevor DNS gefragt wird). Danach
-  `systemctl restart dlnampris.service`, damit gstreamer den Trust-Store neu lädt.
-- **Fernseher / Samsung:** noch nicht getestet (Tech-Debt, `TODOS.md`).
+**Pro-Renderer-Status (gemessen über http://renfield.local):**
+- **Linn / openHome + Samsung TV (Q60CA / 8 Series):** funktionieren nativ — lösen
+  `renfield.local` per Router-DNS auf, kein Geräte-Setup. (Samsung erst nach dem
+  DLNA-Compliance-Fix: HEAD-Support + `audio/x-wav` + `.wav` — vorher UPnP 716.)
+- **HiFiBerry (gmediarender/gstreamer):** braucht nur den `/etc/hosts`-Eintrag
+  `192.168.1.230 renfield.local` (systemd-resolved fängt `.local` als mDNS ab) —
+  via `provision-hifiberry.yml`. **Über http keine CA nötig** (die war nur für die
+  https-Episode da).
+- **55" Signage Flip:** eigener Quirk (404 im dlna-mcp-Confirm), separat.
 
-Mit `ADVERTISE_SCHEME=http` (oder Default) verhält sich alles byte-identisch wie
-zuvor — eine reine Plain-HTTP-URL. Diese wird allerdings von Renderern nicht
-abgerufen, wenn sie hinter dem Traefik-https-Redirect liegt (stiller Fehler:
-der Renderer meldet „playing", lädt aber nie). Details + Messungen:
-`docs/MESSAGE_RELAY.md` → „TTS-Audio-Auslieferung an Renderer".
+Details + Messungen: `docs/MESSAGE_RELAY.md` → „TTS-Audio-Auslieferung an Renderer".
 
 **Ohne ADVERTISE_HOST:**
 - TTS wird nur auf Renfield-Geräten (Satellites, Web Panels) abgespielt

--- a/docs/MESSAGE_RELAY.md
+++ b/docs/MESSAGE_RELAY.md
@@ -96,37 +96,48 @@ private; `force` resolves it.
 
 Wenn die Ansage auf einem DLNA-Renderer (statt einem Renfield-Satellite) landet,
 synthetisiert das Backend das WAV, legt es im TTS-Cache ab und übergibt dem
-Renderer eine **URL** (`/api/voice/tts-cache/{id}`), die der Renderer dann selbst
-**abruft**. Die URL baut `AudioOutputService._get_backend_url()` aus
+Renderer eine **URL** (`/api/voice/tts-cache/{id}.wav`), die der Renderer dann
+selbst **abruft**. Die URL baut `AudioOutputService._get_backend_url()` aus
 `ADVERTISE_SCHEME` + `ADVERTISE_HOST` (+ `ADVERTISE_PORT`).
 
-**Warum das früher still fehlschlug:** Mit `http://renfield.local` (Port 80) bekam
-der Renderer eine URL hinter dem Traefik-`http→https`-Redirect. Der HiFiBerry
-(gstreamer, event-silent) meldete `state=playing` **ohne Fehler**, rief die URL
-aber **nie** ab (0 GETs im Access-Log) → keine Audioausgabe, kein sichtbarer
-Fehler. Die einzige Bodenwahrheit ist das Backend-Access-Log.
+**Auslieferung (Prod): `http://renfield.local/api/voice/tts-cache/{id}.wav`.**
+Plain http (kein https) — bedient von der `backend-tts-cache-http` IngressRoute
+(eigener Route auf dem `web`-Entrypoint, ohne den `http→https`-Redirect). Bewusst
+**kein https**, weil Samsung-TVs das self-signed Zertifikat nicht akzeptieren;
+http funktioniert dagegen auf **allen** Renderern. Auflösung von `renfield.local`:
+Linn/Samsung per Router-DNS, HiFiBerry per `/etc/hosts` (siehe
+`provision-hifiberry.yml` — der CA-Teil ist für http nicht mehr nötig, nur der
+`/etc/hosts`-Eintrag).
 
-**Lösung (Prod):** `ADVERTISE_SCHEME=https`, `ADVERTISE_HOST=renfield.local`,
-`ADVERTISE_PORT=443`. Der Renderer holt `https://renfield.local/api/voice/tts-cache/…`
-über die bestehende `renfield-https` Ingress — kein eigener Traefik-Route, kein
-Plain-HTTP-Loch.
+**Zwei stille Fehlerquellen, beide auf UNSERER Seite (gemessen):**
+1. **Falsche URL/Scheme.** Früher `http://renfield.local:80` hinter dem
+   Traefik-`http→https`-Redirect → der Renderer holte die URL nie (0 GETs); der
+   event-silent HiFiBerry meldete trotzdem `state=playing`. Einzige Bodenwahrheit
+   ist das Backend-Access-Log.
+2. **DLNA-Resource war non-compliant** → Samsung lehnte mit UPnP **716
+   „Resource not found"** ab (Linn/HiFiBerry sind lenient und schluckten es). Drei
+   Bugs, alle gefixt:
+   - **HEAD → 405.** DLNA-Renderer schicken ein HEAD vor dem GET; die
+     `/api/voice/tts-cache`-Route war GET-only. Jetzt GET **+ HEAD**.
+   - **Falscher MIME.** Das DIDL defaultete auf `audio/flac`; das `GetProtocolInfo`
+     des TVs listet **`audio/x-wav`** (nicht `audio/wav`/`flac`). Route liefert jetzt
+     `Content-Type: audio/x-wav` + `Content-Length`, und der DLNA-Play-Pfad gibt
+     `mime_type=audio/x-wav` mit (→ passendes protocolInfo).
+   - **Keine Extension.** URL endet jetzt auf `.wav` (Route akzeptiert + strippt sie).
 
-**Pro-Renderer-Voraussetzung** (gemessen, nicht angenommen):
+**Pro-Renderer-Status (gemessen über `http://renfield.local`):**
 
-| Renderer | löst `renfield.local` auf | akzeptiert self-signed cert | Setup |
+| Renderer | löst `renfield.local` | spielt TTS (http) | Setup |
 |---|---|---|---|
-| Linn / openHome | ✅ Router-DNS | ✅ (gemessen, ohne CA) | keins |
-| HiFiBerry (gstreamer) | ❌ `.local`→mDNS-Quirk | ❌ strikt | CA in `/etc/ssl/certs` **+** `/etc/hosts`-Eintrag `192.168.1.230 renfield.local` **+** `systemctl restart dlnampris.service` |
-| Fernseher / Samsung | ? | ? | ungetestet (Tech-Debt) |
+| Linn / openHome | ✅ Router-DNS | ✅ | keins |
+| Samsung TV (Q60CA / 8 Series) | ✅ Router-DNS | ✅ (nach HEAD/x-wav/.wav-Fix) | keins |
+| HiFiBerry (gstreamer) | per `/etc/hosts` | ✅ | `/etc/hosts`-Eintrag (`provision-hifiberry.yml`); **CA nicht mehr nötig** |
+| 55" Signage Flip | ✅ | ⚠️ eigener Quirk (404 im dlna-mcp-Confirm) — separat |
 
-Hintergrund HiFiBerry: nsswitch ist `hosts: files resolve [!UNAVAIL=return] dns` —
-systemd-`resolve` greift `.local` als mDNS und liefert NOTFOUND, bevor `dns`
-gefragt wird; deshalb scheitert die Auflösung trotz vorhandenem DNS-Eintrag.
-`curl` umgeht das (eigener c-ares-Resolver), gstreamer (`getaddrinfo`) nicht.
-Diese Geräte-Eintragungen überleben einen Reboot, aber **nicht** ein
-HiFiBerryOS-Update (Tech-Debt: nach Update neu setzen).
-
-Mit `ADVERTISE_SCHEME=http` ist das Verhalten byte-identisch zu vorher.
+Mit `ADVERTISE_SCHEME=http` (Default) byte-identisch zur Pre-https-Episode.
+Hintergrund HiFiBerry-`.local`: nsswitch `hosts: files resolve [!UNAVAIL=return] dns`
+→ systemd-`resolve` greift `.local` als mDNS (NOTFOUND vor `dns`); `curl`
+(c-ares) umgeht das, gstreamer (`getaddrinfo`) nicht → daher der `/etc/hosts`-Eintrag.
 
 ## Where it lives
 

--- a/docs/OUTPUT_ROUTING.md
+++ b/docs/OUTPUT_ROUTING.md
@@ -31,18 +31,20 @@ Erste Marke: **Samsung TV** (`renfield-mcp-samsung`) — wird damit room-auswäh
 
 ### ADVERTISE_HOST Konfiguration
 
-Damit HA Media Player und DLNA Renderer die TTS-Audio-Dateien vom Renfield-Backend abrufen können, muss `ADVERTISE_HOST` in der `.env` Datei gesetzt werden:
+Damit HA Media Player und DLNA Renderer die TTS-Audio-Dateien vom Renfield-Backend abrufen können, müssen `ADVERTISE_HOST`/`ADVERTISE_SCHEME`/`ADVERTISE_PORT` gesetzt sein. Das Backend baut daraus die URL `…/api/voice/tts-cache/{id}.wav`, die der Renderer selbst abruft.
 
 ```bash
-# .env
-ADVERTISE_HOST=192.168.1.159  # IP-Adresse des Renfield-Servers
-ADVERTISE_PORT=80             # Port 80 = Nginx (empfohlen für Produktion)
+# .env (k8s-Prod-Werte)
+ADVERTISE_HOST=renfield.local  # per DNS (Linn/Samsung) bzw. /etc/hosts (HiFiBerry) auflösbar
+ADVERTISE_SCHEME=http          # NICHT https — Samsung-TVs akzeptieren self-signed nicht; http geht überall
+ADVERTISE_PORT=80
 ```
 
 **Wichtig:**
-- **IP-Adresse verwenden**, nicht mDNS (`.local`) — DLNA-Renderer können mDNS oft nicht auflösen
-- **Port 80** verwenden — Port 8000 ist nur auf `127.0.0.1` gebunden und von extern nicht erreichbar
-- Nginx muss `/api/voice/tts-cache/` über **plain HTTP** weiterleiten (ohne HTTPS-Redirect), da DLNA-Renderer kein HTTPS/self-signed Certs unterstützen
+- **`http`, nicht `https`** — DLNA-Renderer (v.a. Samsung-TVs) akzeptieren das self-signed Zertifikat nicht; plain http funktioniert auf allen Renderern.
+- Der Pfad `/api/voice/tts-cache/` muss **plain HTTP ohne HTTPS-Redirect** bedient werden — in k8s über die `backend-tts-cache-http` Traefik-IngressRoute (eigener `web`-Entrypoint-Route, `priority: 100`), nicht Nginx.
+- DLNA-Renderer schicken ein **HEAD vor dem GET** und verlangen `audio/x-wav` + eine `.wav`-Resource — die Route bedient das (sonst Samsung-UPnP-716). Details: `docs/MESSAGE_RELAY.md` → „TTS-Audio-Auslieferung an Renderer".
+- Geräte-Setup: Linn/Samsung brauchen keins; HiFiBerry braucht den `/etc/hosts`-Eintrag aus `provision-hifiberry.yml` (über http **keine CA** nötig).
 
 ## Konfiguration über das Frontend
 
@@ -272,20 +274,22 @@ User spricht zum Tablet: "Wie ist das Wetter?"
 
 ### TTS wird nicht auf HA Media Player / DLNA Renderer abgespielt
 
-1. **ADVERTISE_HOST prüfen:**
+1. **ADVERTISE_* prüfen:**
    ```bash
-   docker exec renfield-backend env | grep ADVERTISE
+   kubectl -n renfield exec deploy/backend -c backend -- env | grep ADVERTISE
    ```
-   Muss auf erreichbare IP gesetzt sein (nicht `.local` für DLNA!).
+   Prod: `ADVERTISE_HOST=renfield.local`, `ADVERTISE_SCHEME=http`, `ADVERTISE_PORT=80`.
 
 2. **Kann der Renderer die URL erreichen?**
    ```bash
-   # Von einem anderen Gerät im LAN testen:
-   curl http://<ADVERTISE_HOST>/api/voice/tts-cache/test
-   # Erwartung: 404 (Not Found) = Endpoint erreichbar
-   # 301 = HTTPS-Redirect (Nginx-Konfig prüfen)
-   # Connection refused = Port/IP falsch
+   # Von einem anderen Gerät im LAN testen (HEAD, wie ein DLNA-Renderer):
+   curl -I http://renfield.local/api/voice/tts-cache/test
+   # Erwartung: 404 (Not Found) = Endpoint erreichbar (HEAD wird bedient)
+   # 405 = HEAD nicht unterstützt (alte Version → Samsung-716)
+   # 301 = HTTPS-Redirect → die backend-tts-cache-http IngressRoute fehlt/greift nicht
+   # Connection refused = Route/Host falsch
    ```
+   Auf dem Renderer-Gerät selbst muss `renfield.local` auflösen (Linn/Samsung: Router-DNS; HiFiBerry: `/etc/hosts`).
 
 3. **Media Player Status prüfen:**
    ```bash

--- a/k8s/backend-tts-cache-route.yaml
+++ b/k8s/backend-tts-cache-route.yaml
@@ -1,0 +1,22 @@
+# Plain-http (no https-redirect) route for the TTS audio cache so DLNA renderers
+# can fetch backend-served TTS over http://renfield.local/api/voice/tts-cache/{id}.wav
+# (ADVERTISE_SCHEME=http). DLNA renderers — notably Samsung TVs — can't use the
+# self-signed https cert, and plain http works on all renderers. This route lives
+# on the `web` entrypoint WITHOUT the renfield-https-redirect middleware, with a
+# high priority so it beats the host-level redirect router for this path only.
+# Everything else on http still redirects to https. See docs/MESSAGE_RELAY.md.
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: backend-tts-cache-http
+  namespace: renfield
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: "PathPrefix(`/api/voice/tts-cache`)"
+      kind: Rule
+      priority: 100
+      services:
+        - name: backend
+          port: 8000

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -132,12 +132,14 @@ data:
   AGENT_TOTAL_TIMEOUT: "300"
 
   # Presentation — URL handed to DLNA renderers / HA media_player to fetch
-  # backend-served TTS audio. https over renfield.local (cert SAN covers the name
-  # + 192.168.1.230); the existing renfield-https ingress serves /api/voice/tts-cache.
-  # Renderers must resolve renfield.local + trust the cert — see docs/MESSAGE_RELAY.md.
+  # backend-served TTS audio: http://renfield.local/api/voice/tts-cache/...
+  # http (not https) because Samsung TVs can't do the self-signed cert; the
+  # `backend-tts-cache-http` IngressRoute serves this path plain (no redirect).
+  # Renderers resolve renfield.local via DNS (Linn/Samsung) or /etc/hosts
+  # (HiFiBerry, see provision-hifiberry.yml). See docs/MESSAGE_RELAY.md.
   ADVERTISE_HOST: "renfield.local"
-  ADVERTISE_SCHEME: "https"
-  ADVERTISE_PORT: "443"
+  ADVERTISE_SCHEME: "http"
+  ADVERTISE_PORT: "80"
 
   # Satellites
   SATELLITE_LATEST_VERSION: "1.3.0"

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
   - middleware-https-redirect.yaml
   - ingress.yaml
   - external-llm-ingress.yaml
+  - backend-tts-cache-route.yaml
   - shared-pvcs.yaml
   - document-worker.yaml
 

--- a/src/backend/api/routes/voice.py
+++ b/src/backend/api/routes/voice.py
@@ -8,7 +8,7 @@ Multi-language support:
 from io import BytesIO
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, UploadFile
-from fastapi.responses import StreamingResponse
+from fastapi.responses import Response, StreamingResponse
 from loguru import logger
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -175,21 +175,30 @@ async def text_to_speech(request: Request, tts_request: TTSRequest, _user=Depend
         logger.error(f"❌ TTS Fehler: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
-@router.get("/tts-cache/{audio_id}")
-async def get_tts_cache(audio_id: str):
-    """Serve cached TTS audio files.
+@router.api_route("/tts-cache/{audio_id}", methods=["GET", "HEAD"])
+async def get_tts_cache(audio_id: str, request: Request):
+    """Serve cached TTS audio files for HA media players / DLNA renderers.
 
-    Used by HA media players that fetch pre-generated TTS via HTTP.
     The actual cache lookup runs through the `fetch_tts_audio_cache`
     hook so ha_glue owns the cache storage and platform has no
     direct coupling to `audio_output_service`. On pro deploys (no
     ha_glue handler), the endpoint returns 404 — which is fine
     because pro deploys don't have HA media players calling it.
+
+    DLNA renderers (notably Samsung TVs) send a **HEAD** before the GET and
+    treat any non-2xx HEAD as "resource not found" (UPnP error 716), so the
+    route serves HEAD too — returning the headers (Content-Type/-Length)
+    without a body. The mime is `audio/x-wav` (the WAV mime Samsung advertises
+    in GetProtocolInfo; `audio/wav` is rejected), and a trailing `.wav` in the
+    path is accepted + stripped so the URL can carry a recognizable extension.
     """
     from utils.hooks import run_hooks
 
+    # Accept (and strip) a trailing ".wav" so the advertised URL has an extension.
+    cache_id = audio_id[:-4] if audio_id.endswith(".wav") else audio_id
+
     audio_bytes = None
-    results = await run_hooks("fetch_tts_audio_cache", audio_id=audio_id)
+    results = await run_hooks("fetch_tts_audio_cache", audio_id=cache_id)
     for result in results:
         if isinstance(result, (bytes, bytearray)):
             audio_bytes = bytes(result)
@@ -203,13 +212,19 @@ async def get_tts_cache(audio_id: str):
     if not audio_bytes:
         raise HTTPException(status_code=404, detail="Audio not found or expired")
 
+    headers = {
+        "Content-Disposition": f"inline; filename={cache_id}.wav",
+        "Cache-Control": "no-cache",
+        "Content-Length": str(len(audio_bytes)),
+    }
+    # HEAD: same headers, no body (DLNA renderers probe with HEAD first).
+    if request.method == "HEAD":
+        return Response(status_code=200, media_type="audio/x-wav", headers=headers)
+
     return StreamingResponse(
         BytesIO(audio_bytes),
-        media_type="audio/wav",
-        headers={
-            "Content-Disposition": f"inline; filename={audio_id}.wav",
-            "Cache-Control": "no-cache",
-        },
+        media_type="audio/x-wav",
+        headers=headers,
     )
 
 

--- a/src/backend/ha_glue/services/audio_output_service.py
+++ b/src/backend/ha_glue/services/audio_output_service.py
@@ -149,7 +149,12 @@ class AudioOutputService:
             return False
 
         base_url = self._get_backend_url()
-        audio_url = f"{base_url}/api/voice/tts-cache/{audio_id}"
+        # `.wav` extension + the audio/x-wav mime hint below: DLNA renderers
+        # (notably Samsung TVs) reject an extensionless / wrong-mime resource
+        # with UPnP 716. audio/x-wav is the WAV mime Samsung advertises in
+        # GetProtocolInfo (audio/wav is NOT). The tts-cache route strips the
+        # trailing .wav. See docs/MESSAGE_RELAY.md.
+        audio_url = f"{base_url}/api/voice/tts-cache/{audio_id}.wav"
 
         try:
             from main import app
@@ -158,7 +163,7 @@ class AudioOutputService:
                 logger.warning(f"MCP manager not available for DLNA playback on {renderer_name}")
                 return False
 
-            tracks = [{"url": audio_url, "title": "Renfield TTS"}]
+            tracks = [{"url": audio_url, "title": "Renfield TTS", "mime_type": "audio/x-wav"}]
             logger.info(f"🔊 DLNA play_tracks: renderer={renderer_name}, url={audio_url}")
             result = await mcp_manager.execute_tool(
                 "mcp.dlna.play_tracks",
@@ -210,9 +215,10 @@ class AudioOutputService:
             return False
 
         # Build the URL for HA to fetch the audio
-        # Use the backend's advertise host or fallback to localhost
+        # Use the backend's advertise host or fallback to localhost.
+        # `.wav` extension so renderers/HA see a recognizable media URL.
         base_url = self._get_backend_url()
-        audio_url = f"{base_url}/api/voice/tts-cache/{audio_id}"
+        audio_url = f"{base_url}/api/voice/tts-cache/{audio_id}.wav"
 
         # Store original volume for restoration (if we're changing it)
         original_volume = None

--- a/tests/backend/test_voice.py
+++ b/tests/backend/test_voice.py
@@ -263,7 +263,53 @@ class TestTTSCacheAPI:
             _hooks["fetch_tts_audio_cache"].remove(_fake_fetch)
 
         assert response.status_code == 200
-        assert response.headers["content-type"] == "audio/wav"
+        # audio/x-wav: the WAV mime Samsung TVs advertise in GetProtocolInfo
+        # (audio/wav is rejected with UPnP 716).
+        assert response.headers["content-type"] == "audio/x-wav"
+        assert response.headers["content-length"] == str(len(cached_audio))
+
+    @pytest.mark.integration
+    async def test_tts_cache_head(self, async_client: AsyncClient):
+        """HEAD must succeed with headers but no body — DLNA renderers (Samsung)
+        probe with HEAD before GET and treat a non-2xx HEAD as 716."""
+        from utils.hooks import _hooks
+
+        cached_audio = b'RIFF' + b'\x00' * 100
+
+        async def _fake_fetch(*, audio_id):
+            return cached_audio
+
+        _hooks["fetch_tts_audio_cache"].append(_fake_fetch)
+        try:
+            response = await async_client.head("/api/voice/tts-cache/valid-audio-id")
+        finally:
+            _hooks["fetch_tts_audio_cache"].remove(_fake_fetch)
+
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "audio/x-wav"
+        assert response.headers["content-length"] == str(len(cached_audio))
+        assert response.content == b""
+
+    @pytest.mark.integration
+    async def test_tts_cache_wav_suffix_stripped(self, async_client: AsyncClient):
+        """A trailing .wav in the path is accepted and stripped before the cache
+        lookup, so the advertised URL can carry a recognizable extension."""
+        from utils.hooks import _hooks
+
+        seen_ids = []
+
+        async def _fake_fetch(*, audio_id):
+            seen_ids.append(audio_id)
+            return b'RIFF' + b'\x00' * 100
+
+        _hooks["fetch_tts_audio_cache"].append(_fake_fetch)
+        try:
+            response = await async_client.get("/api/voice/tts-cache/valid-audio-id.wav")
+        finally:
+            _hooks["fetch_tts_audio_cache"].remove(_fake_fetch)
+
+        assert response.status_code == 200
+        assert seen_ids == ["valid-audio-id"]  # .wav stripped before lookup
 
 
 # ============================================================================


### PR DESCRIPTION
## Problem

DLNA renderers — **Samsung TVs** in particular — rejected TTS playback with UPnP **716 "Resource not found"**. Root cause was **three non-compliant bits in our own resource** that the lenient Linn/HiFiBerry renderers happened to tolerate (not a Samsung problem):

1. **HEAD → 405.** `/api/voice/tts-cache/{id}` was GET-only. DLNA renderers send a **HEAD before the GET** and read a non-2xx HEAD as 716.
2. **Wrong mime.** The DIDL defaulted to `audio/flac`; the TV's own `ConnectionManager.GetProtocolInfo` advertises **`audio/x-wav`** (NOT `audio/wav`/`flac`).
3. **No `.wav`** extension / `Content-Type: audio/x-wav`.

## Fix

- `api/routes/voice.py`: serve **GET + HEAD** (HEAD = headers, no body), `Content-Type: audio/x-wav` + `Content-Length`, and accept + strip a trailing `.wav` before the cache lookup.
- `ha_glue/services/audio_output_service.py`: advertise the URL with a `.wav` suffix + pass `mime_type=audio/x-wav` on the DLNA track (→ matching `protocolInfo`).
- **Delivery flipped to `http://renfield.local`** (`ADVERTISE_SCHEME=http`, `ADVERTISE_PORT=80`) — Samsung can't use the self-signed cert, and plain http works on **every** renderer. The new `backend-tts-cache-http` IngressRoute serves the path plain (no https-redirect) on the `web` entrypoint.

This supersedes #758's `https` scheme value (the `ADVERTISE_SCHEME` mechanism stays) and makes #759's HiFiBerry **CA** step moot — over http only the `/etc/hosts` entry is needed (filed P3 to strip the CA from the playbook).

## Validation

- **Live on real hardware over `http://renfield.local`:** Samsung Q60CA ✅, Samsung 8 Series ✅, HiFiBerry ✅, Linn ✅ (13× `GET …/tts_val.wav → 200`). HEAD now `200`, was `405`.
- Diagnosis technique: queried the renderer's own `GetProtocolInfo` (Sink) for accepted formats instead of guessing; confirmed the HEAD-before-GET behavior from the web.
- `/review`: clean (`[]`).
- Tests: HEAD 200/no-body, `audio/x-wav` + Content-Length, `.wav`-suffix-stripped. (The `app_with_test_db` integration fixture can't run in the bare build-box `docker exec` — all 15 file tests error identically, not this change; live hardware covers the behavior.)

## Docs (full sweep)

`MESSAGE_RELAY.md`, `ENVIRONMENT_VARIABLES.md`, `OUTPUT_ROUTING.md`, `DEPLOYMENT.md`, `k8s/configmap.yaml` + the IngressRoute manifest. TODOS.md updated (Samsung resolved; Flip-404, dlna-mcp `audio/flac` default, #759-CA-strip filed P3).

Deployed as **v2.17.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)