### PR TITLE
fix(ui): admin submenu clipped bottom items — CSS-grid accordion

### DIFF
--- a/src/frontend/src/components/Layout.tsx
+++ b/src/frontend/src/components/Layout.tsx
@@ -232,11 +232,15 @@ export default function Layout({ children }: LayoutProps) {
   const railTranslate = hoverCapable ? 'lg:translate-x-0' : '';
   const railFade = hoverCapable ? 'lg:opacity-0 lg:group-hover/sidebar:opacity-100' : '';
   const railOnlyMenuBtn = hoverCapable ? 'hidden lg:flex lg:group-hover/sidebar:hidden' : 'hidden';
+  // CSS-grid 0fr↔1fr accordion: animates to the submenu's *natural* height with
+  // no hardcoded max-height, so it never clips regardless of how many admin items
+  // exist (a fixed max-h-[600px] silently clipped the bottom items once the list
+  // outgrew it). The parent <nav> (overflow-y-auto) scrolls if it exceeds viewport.
   const adminSubmenuCls = hoverCapable
     ? (adminExpanded
-        ? 'max-h-[600px] opacity-100 lg:max-h-0 lg:opacity-0 lg:group-hover/sidebar:max-h-[600px] lg:group-hover/sidebar:opacity-100'
-        : 'max-h-0 opacity-0')
-    : (adminExpanded ? 'max-h-[600px] opacity-100' : 'max-h-0 opacity-0');
+        ? 'grid-rows-[1fr] opacity-100 lg:grid-rows-[0fr] lg:opacity-0 lg:group-hover/sidebar:grid-rows-[1fr] lg:group-hover/sidebar:opacity-100'
+        : 'grid-rows-[0fr] opacity-0')
+    : (adminExpanded ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0');
 
   // Handle logout
   const handleLogout = () => {
@@ -507,15 +511,19 @@ export default function Layout({ children }: LayoutProps) {
                 />
               </button>
 
-              {/* Admin Submenu — hidden in rail, shown on hover when expanded */}
+              {/* Admin Submenu — hidden in rail, shown on hover when expanded.
+                  grid 0fr/1fr collapses to content height; inner overflow-hidden
+                  wrapper does the clipping during the transition. */}
               <div
                 id="admin-menu"
-                className={`overflow-hidden transition-all duration-200 ease-in-out ${adminSubmenuCls}`}
+                className={`grid transition-all duration-200 ease-in-out ${adminSubmenuCls}`}
               >
-                <div className="ml-3 pl-3 border-l border-gray-200 dark:border-gray-700 space-y-1 py-1">
-                  {visibleAdminNav.map((item) => (
-                    <NavLink key={item.href} item={item} onClick={handleNavClick} />
-                  ))}
+                <div className="overflow-hidden">
+                  <div className="ml-3 pl-3 border-l border-gray-200 dark:border-gray-700 space-y-1 py-1">
+                    {visibleAdminNav.map((item) => (
+                      <NavLink key={item.href} item={item} onClick={handleNavClick} />
+                    ))}
+                  </div>
                 </div>
               </div>
             </>


### PR DESCRIPTION
## Problem

In the hamburger/sidebar menu, the **Admin submenu** had grown to **18 items (~868px tall)** but its container was capped at `max-h-[600px]` with `overflow:hidden`. The bottom ~6 items — **Wartung, Einstellungen, Kreise, Fähigkeiten-Inbox, Werkzeug-Gesundheit, Verlaufstrajektorien, Kurator** — were clipped and, because it was `overflow:hidden` (not scroll), completely unreachable. The `600px` was a magic number sized for the expand animation that silently broke as admin pages were added over time.

## Fix

Replaced the fixed `max-h-[600px]` cap with the **CSS-grid `0fr`↔`1fr` accordion** technique (`src/frontend/src/components/Layout.tsx`):
- Outer `div` becomes `grid` with `grid-rows-[0fr]` (collapsed) / `grid-rows-[1fr]` (expanded).
- An inner `overflow-hidden` wrapper does the clipping during the transition.

This animates to the submenu's **natural content height** with no hardcoded number, so it can never clip again no matter how many admin items exist (aligns with the project's "no magic caps" principle). The parent `<nav>` (`overflow-y-auto`) handles scrolling if the whole sidebar exceeds the viewport. Collapse/hover behavior and the 200ms animation are preserved.

## Verification

Measured against the live DOM and a real build:
- Old: 18 items need **868px**, capped at 600 → ~6 items clipped & unreachable.
- New `grid-rows-[1fr]` → renders full **868px**, last item "Kurator" fully inside, zero clip.
- New `grid-rows-[0fr]` → collapses to **0px** → toggle + hover animation intact.
- Confirmed `overflow-hidden` alone collapses the grid item (CSS automatic-minimum-size rule).
- `npm run build` succeeds; compiled CSS contains both `grid-template-rows:0fr` and `:1fr`.

## Notes

- Frontend-only, behavior-preserving — no DESIGN.md token/spacing/motion changes, no i18n strings, dark-mode variants preserved.
- `grid-template-rows` transition needs Safari 16+ / Chrome 107+; older engines still open/close correctly (snap instead of animate) — graceful degradation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)