### PR TITLE
fix(satellite): real Classic-BT RSSI for room arbitration

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -433,10 +433,20 @@ ANNOUNCE_SNAPSHOT_TIMEOUT=8.0            # Sekunden Timeout für Satelliten-Snap
 ```yaml
 ble:
   enabled: true
-  scan_interval: 30        # Sekunden zwischen Scans
-  scan_duration: 5         # Sekunden pro Scan
-  rssi_threshold: -80      # Schwächere Signale ignorieren
+  scan_interval: 30          # Sekunden zwischen Scans
+  scan_duration: 5           # Sekunden pro Scan
+  rssi_threshold: -80        # Schwächere Signale ignorieren
+  classic_rssi: true         # Echtes Classic-BT-RSSI lesen (hcitool cc/rssi via sudo); false => synthetisch -50
+  classic_rssi_interval: 300 # Sekunden zwischen echten RSSI-Reads pro Gerät (begrenzt Verbindungs-Churn)
 ```
+
+> **Classic-BT-RSSI:** Classic-BT-Präsenz beruht auf `hcitool name` (binär an/aus) und lieferte
+> früher ein konstantes synthetisches `-50` von jedem Satelliten — bei zwei Satelliten gab das ein
+> Unentschieden und der Raum „flatterte". Mit `classic_rssi: true` liest der Satellit per kurzlebiger
+> ACL-Verbindung (`hcitool cc/rssi/dc` über passwortloses `sudo`) ein echtes RSSI, gedrosselt auf
+> einmal pro `classic_rssi_interval` (häufiges Verbinden lässt das Telefon sonst aufhören, auf
+> `name` zu antworten → Präsenz fällt auf „abwesend"). Schlägt der Read fehl, greift der synthetische
+> Fallback — Präsenz geht nie verloren.
 
 **Endpunkte:**
 - `GET /api/presence/rooms` — Alle Räume mit Anwesenden

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -768,6 +768,7 @@ Raum-basierte Präsenzerkennung aus drei Quellen:
 | Quelle | Auslöser | Hysterese | Konfidenz |
 |--------|----------|-----------|-----------|
 | **BLE-Scanning** | Satellit erkennt BLE-Gerät (Telefon, Uhr) | Ja (N Scans) | RSSI-basiert |
+| **Classic-BT-Scanning** | Satellit erkennt Classic-BT-Gerät (Telefon) per `hcitool name` | Ja (N Scans) | RSSI-basiert (gedrosselt) |
 | **Voice Presence** | Sprechererkennung identifiziert Nutzer | Nein (sofort) | 1.0 |
 | **Web Auth Presence** | Authentifizierter Nutzer mit Raum-Kontext | Nein (sofort) | 1.0 |
 
@@ -776,6 +777,10 @@ Voice- und Auth-Presence umgehen die BLE-Hysterese — eine einzelne Interaktion
 ### BLE-Scanning
 
 Satelliten scannen per `bleak` nach registrierten BLE-Geräten und melden RSSI-Werte per WebSocket. Backend `PresenceService` nutzt "stärkstes RSSI gewinnt" + Hysterese (N aufeinanderfolgende Scans) um Raum-Flicker zu verhindern.
+
+### Classic-BT-Scanning
+
+Telefone, die ihre BLE-MAC rotieren (Apple), werden zusätzlich per Classic-BT erkannt: `hcitool name <MAC>` (binäre An/Abwesenheit). Da ein Name-Request kein Signal liefert, las dies früher ein konstantes synthetisches `-50` — bei zwei Satelliten ein Unentschieden, das den Raum „flattern" ließ. Der Satellit liest jetzt ein **echtes** RSSI über eine kurzlebige ACL-Verbindung (`hcitool cc/rssi/dc` via passwortloses `sudo`), **gedrosselt** auf einmal pro `classic_rssi_interval` (Default 300 s) pro Gerät — häufiges Verbinden lässt das Telefon sonst aufhören, auf `name` zu antworten (Präsenz fällt auf „abwesend"). Das golden-range-RSSI wird auf die Backend-Skala abgebildet und gepuffert; bei Read-Fehler greift der synthetische Fallback, sodass Präsenz nie verloren geht. Schalter: `ble.classic_rssi` (siehe `docs/ENVIRONMENT_VARIABLES.md`).
 
 ### Voice Presence
 

--- a/docs/SATELLITE_CONNECTIVITY.md
+++ b/docs/SATELLITE_CONNECTIVITY.md
@@ -55,6 +55,14 @@ satellite logs `BLE/Classic BT scan loop started` and `… known devices receive
   in normal use it reports `Host is down`. So a registered `detection_method=
   classic_bt` phone stays invisible until paired per-satellite, or until phone
   presence is sourced from elsewhere (e.g. Home Assistant device_tracker).
+- **Classic-BT room arbitration needs real RSSI.** A `name` probe is binary, so
+  every satellite seeing the phone reported a constant synthetic `-50` → two
+  satellites tied → the room flip-flopped. The satellite now reads a real RSSI
+  via a short-lived ACL connection (`hcitool cc/rssi/dc` through passwordless
+  `sudo`, since the service runs as unprivileged `evdb`), **throttled** to once
+  per `ble.classic_rssi_interval` (default 300 s) — connecting every scan makes
+  the phone stop answering `name` (presence drops to "absent"). Failed reads
+  fall back to synthetic `-50`. Toggle with `ble.classic_rssi`.
 
 ## Robustness knobs (`server.*` in `satellite.yaml`)
 

--- a/src/satellite/renfield_satellite/ble/classic_scanner.py
+++ b/src/satellite/renfield_satellite/ble/classic_scanner.py
@@ -7,14 +7,39 @@ that don't rotate like BLE addresses. This is the technique used by
 the well-known 'monitor' project.
 
 Key differences from BLE scanning:
-- No RSSI available — we use a fixed value (-50) as "present"
+- Presence is binary: a name response means "present". The remote-name
+  request works even on non-discoverable devices, which is why it is
+  preferred over an inquiry scan.
 - Sequential scanning (one device at a time, BT Classic limitation)
 - Slower: 1-5 seconds per device
 - But: works with Apple devices that randomize BLE MACs
+
+RSSI:
+A plain name request carries no signal strength. To let the backend
+arbitrate which room a device is in (strongest signal wins), we read a
+real RSSI for each present device via a short-lived ACL connection
+(`hcitool cc` -> `hcitool rssi` -> `hcitool dc`). This is best-effort:
+
+- The value is the Bluetooth "golden receive power range" RSSI — a
+  signed dB offset relative to the ideal range, NOT absolute dBm. It is
+  frequently 0 when the link sits inside the golden range, so two
+  satellites at similar distance can still tie.
+- Some phones (notably iPhones) reject unsolicited ACL connections, so
+  `cc` fails and no RSSI is available.
+
+In every failure case we fall back to SYNTHETIC_RSSI so presence
+detection is never lost — we only ever *gain* arbitration signal when
+the device cooperates. Set `read_rssi=False` (config `ble.classic_rssi`)
+to skip the connection attempt entirely and always report the synthetic
+value.
 """
 
 import asyncio
+import re
 import shutil
+
+# "RSSI return value: -4"
+_RSSI_RE = re.compile(r"RSSI return value:\s*(-?\d+)")
 
 
 class ClassicBTScanner:
@@ -22,14 +47,18 @@ class ClassicBTScanner:
     Scans for known Classic Bluetooth devices using hcitool name requests.
 
     Each known MAC is queried sequentially. If the device responds with
-    a name, it's considered present. No RSSI is available — a fixed
-    value of -50 is used as a synthetic "present" signal.
+    a name, it's considered present. A real RSSI is then read best-effort
+    via a short-lived ACL connection; if that fails, SYNTHETIC_RSSI is
+    used so presence is still reported.
     """
 
-    SYNTHETIC_RSSI = -50  # Fixed RSSI for "device is present"
+    SYNTHETIC_RSSI = -50  # Fallback "present" signal, and the golden-range baseline (offset 0)
+    PRESENT_FLOOR = -79   # Never report below this: a present device must stay above the
+                          # backend's BLE rssi_threshold (-80) or it would be filtered as absent
 
-    def __init__(self, timeout: float = 5.0):
+    def __init__(self, timeout: float = 5.0, read_rssi: bool = True):
         self.timeout = timeout
+        self.read_rssi = read_rssi
 
     @property
     def available(self) -> bool:
@@ -52,10 +81,31 @@ class ClassicBTScanner:
         results = []
         for mac in known_macs:
             name = await self._query_name(mac)
-            if name:
-                results.append({"mac": mac.upper(), "rssi": self.SYNTHETIC_RSSI})
+            if not name:
+                continue
+            golden = await self._read_rssi(mac) if self.read_rssi else None
+            results.append({
+                "mac": mac.upper(),
+                "rssi": self._to_backend_rssi(golden),
+            })
 
         return results
+
+    def _to_backend_rssi(self, golden: int | None) -> int:
+        """
+        Map a Classic-BT golden-range RSSI offset onto the backend's dBm-ish scale.
+
+        `hcitool rssi` returns a signed offset from the Bluetooth golden receive
+        power range (0 = ideal, positive = stronger/closer, negative = weaker),
+        NOT absolute dBm. The backend's room arbitration was calibrated for BLE
+        dBm (threshold -80, confidence around -50..-90). We center the offset on
+        the present-baseline so the value lands on that scale and preserves
+        "closer satellite wins" ordering, and floor it so a present device never
+        drops below the backend RSSI filter. None (no reading) => baseline.
+        """
+        if golden is None:
+            return self.SYNTHETIC_RSSI
+        return max(self.PRESENT_FLOOR, self.SYNTHETIC_RSSI + golden)
 
     async def _query_name(self, mac: str) -> str | None:
         """
@@ -85,3 +135,55 @@ class ClassicBTScanner:
         except Exception as e:
             print(f"Classic BT query error for {mac}: {e}")
             return None
+
+    async def _read_rssi(self, mac: str) -> int | None:
+        """
+        Best-effort real RSSI for a present device.
+
+        Opens a short-lived ACL connection (`hcitool cc`), reads the link
+        RSSI (`hcitool rssi`), then tears the connection down (`hcitool dc`).
+        Returns the golden-range RSSI as a signed int, or None if any step
+        fails (device refuses the connection, hcitool error, timeout). The
+        caller falls back to SYNTHETIC_RSSI on None.
+        """
+        try:
+            # Create the connection. May already exist (phone connected for
+            # the name request); a non-zero exit here just means we couldn't
+            # establish one, in which case `rssi` will fail and we bail.
+            await self._run("cc", mac)
+            out = await self._run("rssi", mac)
+            match = _RSSI_RE.search(out or "")
+            return int(match.group(1)) if match else None
+        except Exception:
+            return None
+        finally:
+            # Always tear down whatever connection we may have opened so we
+            # don't leave the phone tied up between scans.
+            try:
+                await self._run("dc", mac)
+            except Exception:
+                pass
+
+    async def _run(self, *args: str) -> str:
+        """Run `hcitool <args>`, returning stdout. Raises on failure/timeout."""
+        proc = await asyncio.create_subprocess_exec(
+            "hcitool", *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=self.timeout
+            )
+        except asyncio.TimeoutError:
+            try:
+                proc.kill()
+                await proc.wait()
+            except ProcessLookupError:
+                pass
+            raise
+        if proc.returncode != 0:
+            raise RuntimeError(
+                (stderr.decode().strip() if stderr else "") or f"hcitool {args[0]} failed"
+            )
+        return stdout.decode()

--- a/src/satellite/renfield_satellite/ble/classic_scanner.py
+++ b/src/satellite/renfield_satellite/ble/classic_scanner.py
@@ -165,9 +165,17 @@ class ClassicBTScanner:
                 pass
 
     async def _run(self, *args: str) -> str:
-        """Run `hcitool <args>`, returning stdout. Raises on failure/timeout."""
+        """
+        Run `sudo -n hcitool <args>`, returning stdout. Raises on failure/timeout.
+
+        Creating an ACL connection / reading RSSI (cc/rssi/dc) needs
+        CAP_NET_ADMIN. The satellite service runs as an unprivileged user
+        that has passwordless sudo, so these go through `sudo -n`. `-n`
+        never prompts: if sudo isn't passwordless the call fails fast and
+        the caller falls back to SYNTHETIC_RSSI (presence is never lost).
+        """
         proc = await asyncio.create_subprocess_exec(
-            "hcitool", *args,
+            "sudo", "-n", "hcitool", *args,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )

--- a/src/satellite/renfield_satellite/ble/classic_scanner.py
+++ b/src/satellite/renfield_satellite/ble/classic_scanner.py
@@ -37,6 +37,7 @@ value.
 import asyncio
 import re
 import shutil
+import time
 
 # "RSSI return value: -4"
 _RSSI_RE = re.compile(r"RSSI return value:\s*(-?\d+)")
@@ -56,9 +57,17 @@ class ClassicBTScanner:
     PRESENT_FLOOR = -79   # Never report below this: a present device must stay above the
                           # backend's BLE rssi_threshold (-80) or it would be filtered as absent
 
-    def __init__(self, timeout: float = 5.0, read_rssi: bool = True):
+    def __init__(self, timeout: float = 5.0, read_rssi: bool = True,
+                 rssi_interval: float = 300.0):
         self.timeout = timeout
         self.read_rssi = read_rssi
+        # Reading RSSI needs an ACL connection, and connecting too often makes
+        # the phone stop answering name requests (presence drops to "absent").
+        # So read RSSI at most once per rssi_interval per device, cache it, and
+        # report the cached value on every scan in between. Presence (name) still
+        # runs every scan and is never gated on the RSSI read.
+        self.rssi_interval = rssi_interval
+        self._rssi_cache: dict[str, tuple[int, float]] = {}  # MAC -> (mapped_rssi, monotonic_ts)
 
     @property
     def available(self) -> bool:
@@ -78,18 +87,47 @@ class ClassicBTScanner:
         if not known_macs or not self.available:
             return []
 
+        now = time.monotonic()
         results = []
         for mac in known_macs:
             name = await self._query_name(mac)
             if not name:
                 continue
-            golden = await self._read_rssi(mac) if self.read_rssi else None
             results.append({
                 "mac": mac.upper(),
-                "rssi": self._to_backend_rssi(golden),
+                "rssi": await self._resolve_rssi(mac, now),
             })
 
         return results
+
+    async def _resolve_rssi(self, mac: str, now: float) -> int:
+        """
+        Return the RSSI to report for a present device, throttling real reads.
+
+        Reads a fresh RSSI (via a connection) at most once per rssi_interval per
+        device; otherwise returns the last cached value. On a read failure, keeps
+        the last cached value if any, else the synthetic baseline. This keeps the
+        connection churn low enough that name-based presence stays reliable.
+        """
+        if not self.read_rssi:
+            return self.SYNTHETIC_RSSI
+
+        cached = self._rssi_cache.get(mac)
+        if cached is not None and (now - cached[1]) < self.rssi_interval:
+            return cached[0]
+
+        golden = await self._read_rssi(mac)
+        if golden is not None:
+            mapped = self._to_backend_rssi(golden)
+            self._rssi_cache[mac] = (mapped, now)
+            print(f"Classic BT RSSI {mac}: golden={golden} -> {mapped}")
+            return mapped
+
+        if cached is not None:
+            print(f"Classic BT RSSI {mac}: read failed, reusing cached {cached[0]}")
+            return cached[0]
+        print(f"Classic BT RSSI {mac}: read failed, using synthetic {self.SYNTHETIC_RSSI}")
+        return self.SYNTHETIC_RSSI
 
     def _to_backend_rssi(self, golden: int | None) -> int:
         """

--- a/src/satellite/renfield_satellite/ble/classic_scanner.py
+++ b/src/satellite/renfield_satellite/ble/classic_scanner.py
@@ -66,8 +66,8 @@ class ClassicBTScanner:
         # So read RSSI at most once per rssi_interval per device, cache it, and
         # report the cached value on every scan in between. Presence (name) still
         # runs every scan and is never gated on the RSSI read.
-        self.rssi_interval = rssi_interval
-        self._rssi_cache: dict[str, tuple[int, float]] = {}  # MAC -> (mapped_rssi, monotonic_ts)
+        self.rssi_interval = max(0.0, rssi_interval)  # negative is nonsensical; 0 = read every scan
+        self._rssi_cache: dict[str, tuple[int, float]] = {}  # UPPER MAC -> (mapped_rssi, monotonic_ts)
 
     @property
     def available(self) -> bool:
@@ -88,16 +88,20 @@ class ClassicBTScanner:
             return []
 
         now = time.monotonic()
+        known_upper = {m.upper() for m in known_macs}
         results = []
         for mac in known_macs:
             name = await self._query_name(mac)
             if not name:
                 continue
+            mac_u = mac.upper()
             results.append({
-                "mac": mac.upper(),
-                "rssi": await self._resolve_rssi(mac, now),
+                "mac": mac_u,
+                "rssi": await self._resolve_rssi(mac_u, now),
             })
 
+        # Drop cached RSSI for MACs no longer in the whitelist (bounded growth).
+        self._rssi_cache = {m: v for m, v in self._rssi_cache.items() if m in known_upper}
         return results
 
     async def _resolve_rssi(self, mac: str, now: float) -> int:

--- a/src/satellite/renfield_satellite/config.py
+++ b/src/satellite/renfield_satellite/config.py
@@ -154,6 +154,7 @@ class BLEConfig:
     rssi_threshold: int = -80     # ignore weaker signals
     known_devices: List[str] = field(default_factory=list)  # MAC whitelist, pushed from backend
     classic_rssi: bool = True     # read real Classic-BT RSSI (hcitool cc/rssi); off => synthetic -50
+    classic_rssi_interval: float = 300.0  # seconds between real RSSI reads per device (throttle connect churn)
 
 
 @dataclass
@@ -314,6 +315,7 @@ def load_config(config_path: Optional[str] = None) -> Config:
         config.ble.scan_duration = ble.get("scan_duration", config.ble.scan_duration)
         config.ble.rssi_threshold = ble.get("rssi_threshold", config.ble.rssi_threshold)
         config.ble.classic_rssi = ble.get("classic_rssi", config.ble.classic_rssi)
+        config.ble.classic_rssi_interval = ble.get("classic_rssi_interval", config.ble.classic_rssi_interval)
         if "known_devices" in ble:
             config.ble.known_devices = ble["known_devices"]
 

--- a/src/satellite/renfield_satellite/config.py
+++ b/src/satellite/renfield_satellite/config.py
@@ -153,6 +153,7 @@ class BLEConfig:
     scan_duration: float = 5.0    # seconds per scan
     rssi_threshold: int = -80     # ignore weaker signals
     known_devices: List[str] = field(default_factory=list)  # MAC whitelist, pushed from backend
+    classic_rssi: bool = True     # read real Classic-BT RSSI (hcitool cc/rssi); off => synthetic -50
 
 
 @dataclass
@@ -312,6 +313,7 @@ def load_config(config_path: Optional[str] = None) -> Config:
         config.ble.scan_interval = ble.get("scan_interval", config.ble.scan_interval)
         config.ble.scan_duration = ble.get("scan_duration", config.ble.scan_duration)
         config.ble.rssi_threshold = ble.get("rssi_threshold", config.ble.rssi_threshold)
+        config.ble.classic_rssi = ble.get("classic_rssi", config.ble.classic_rssi)
         if "known_devices" in ble:
             config.ble.known_devices = ble["known_devices"]
 

--- a/src/satellite/renfield_satellite/satellite.py
+++ b/src/satellite/renfield_satellite/satellite.py
@@ -254,7 +254,9 @@ class Satellite:
             print("Warning: BLE enabled in config but bleak not installed. BLE scanning disabled.")
 
         # Classic BT Scanner (for Apple devices with permanent Classic BT MACs)
-        self.classic_bt_scanner = ClassicBTScanner(timeout=5.0)
+        self.classic_bt_scanner = ClassicBTScanner(
+            timeout=5.0, read_rssi=self.config.ble.classic_rssi
+        )
         self._classic_bt_known_macs: set = set()
         if self.config.ble.enabled and self.classic_bt_scanner.available:
             print("Classic BT scanning enabled (hcitool available)")

--- a/src/satellite/renfield_satellite/satellite.py
+++ b/src/satellite/renfield_satellite/satellite.py
@@ -255,7 +255,9 @@ class Satellite:
 
         # Classic BT Scanner (for Apple devices with permanent Classic BT MACs)
         self.classic_bt_scanner = ClassicBTScanner(
-            timeout=5.0, read_rssi=self.config.ble.classic_rssi
+            timeout=5.0,
+            read_rssi=self.config.ble.classic_rssi,
+            rssi_interval=self.config.ble.classic_rssi_interval,
         )
         self._classic_bt_known_macs: set = set()
         if self.config.ble.enabled and self.classic_bt_scanner.available:

--- a/tests/satellite/test_classic_scanner.py
+++ b/tests/satellite/test_classic_scanner.py
@@ -207,3 +207,69 @@ async def test_unavailable_hcitool_returns_empty():
         result = await scanner.scan({MAC})
 
     assert result == []
+
+
+def _counting_hcitool(responses):
+    """Like _fake_hcitool but counts how many times `hcitool cc` is invoked."""
+    counter = {"cc": 0}
+
+    async def _create(*args, **kwargs):
+        sub = _subcmd(args)
+        if sub == "cc":
+            counter["cc"] += 1
+
+        class _FakeProc:
+            returncode = responses.get(sub, _proc()).returncode
+
+            async def communicate(self):
+                return await responses.get(sub, _proc()).communicate()
+
+            async def wait(self):
+                return self.returncode
+
+            def kill(self):
+                pass
+
+        return _FakeProc()
+
+    return _create, counter
+
+
+@pytest.mark.satellite
+@pytest.mark.asyncio
+async def test_rssi_read_throttled_within_interval():
+    """RSSI is read once per interval; later scans reuse the cached value (no new connection)."""
+    responses = {
+        "name": _proc(b"Karnak"),
+        "cc": _proc(b""),
+        "rssi": _proc(b"RSSI return value: -21\n"),
+        "dc": _proc(b""),
+    }
+    create, counter = _counting_hcitool(responses)
+    scanner = ClassicBTScanner(timeout=1.0, read_rssi=True, rssi_interval=300.0)
+    with patch("renfield_satellite.ble.classic_scanner.shutil.which", return_value="/usr/bin/hcitool"), \
+         patch("asyncio.create_subprocess_exec", side_effect=create):
+        r1 = await scanner.scan({MAC})
+        r2 = await scanner.scan({MAC})
+        r3 = await scanner.scan({MAC})
+
+    assert r1 == r2 == r3 == [{"mac": MAC, "rssi": -71}]  # -50 + (-21)
+    assert counter["cc"] == 1  # only the first scan connected; rest used the cache
+
+
+@pytest.mark.satellite
+@pytest.mark.asyncio
+async def test_cached_rssi_reused_when_later_read_fails():
+    """Once a real RSSI is cached, a later failed read reuses it instead of dropping to synthetic."""
+    ok = {"name": _proc(b"Karnak"), "cc": _proc(b""), "rssi": _proc(b"RSSI return value: -21\n"), "dc": _proc(b"")}
+    fail = {"name": _proc(b"Karnak"), "cc": _proc(b"", returncode=1), "rssi": _proc(b"", returncode=1), "dc": _proc(b"", returncode=1)}
+    scanner = ClassicBTScanner(timeout=1.0, read_rssi=True, rssi_interval=0.0)  # 0 => read every scan
+    with patch("renfield_satellite.ble.classic_scanner.shutil.which", return_value="/usr/bin/hcitool"), \
+         patch("asyncio.create_subprocess_exec", side_effect=_fake_hcitool(ok)):
+        first = await scanner.scan({MAC})
+    with patch("renfield_satellite.ble.classic_scanner.shutil.which", return_value="/usr/bin/hcitool"), \
+         patch("asyncio.create_subprocess_exec", side_effect=_fake_hcitool(fail)):
+        second = await scanner.scan({MAC})
+
+    assert first == [{"mac": MAC, "rssi": -71}]
+    assert second == [{"mac": MAC, "rssi": -71}]  # cached, not -50

--- a/tests/satellite/test_classic_scanner.py
+++ b/tests/satellite/test_classic_scanner.py
@@ -1,0 +1,200 @@
+"""
+Unit tests for the Classic Bluetooth scanner (real-RSSI path).
+
+Covers presence detection via `hcitool name` and the best-effort RSSI
+read via `hcitool cc/rssi/dc`, including the fallback to SYNTHETIC_RSSI
+when the connection or RSSI read fails (so presence is never lost).
+"""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from renfield_satellite.ble.classic_scanner import ClassicBTScanner
+
+MAC = "4C:E6:C0:27:52:93"
+
+
+def _proc(stdout: bytes = b"", returncode: int = 0, stderr: bytes = b""):
+    """Build a fake asyncio subprocess whose communicate() returns stdout/stderr."""
+    class _FakeProc:
+        def __init__(self):
+            self.returncode = returncode
+
+        async def communicate(self):
+            return stdout, stderr
+
+        async def wait(self):
+            return returncode
+
+        def kill(self):
+            pass
+
+    return _FakeProc()
+
+
+def _fake_hcitool(responses: dict, timeouts: set | None = None):
+    """
+    Return a create_subprocess_exec replacement that dispatches on the
+    hcitool subcommand (argv[1]: name/cc/rssi/dc).
+
+    responses: {subcommand: _proc(...)}
+    timeouts:  set of subcommands that should raise asyncio.TimeoutError
+               from communicate().
+    """
+    timeouts = timeouts or set()
+
+    async def _create(*args, **kwargs):
+        sub = args[1] if len(args) > 1 else ""
+
+        class _FakeProc:
+            returncode = responses.get(sub, _proc()).returncode
+
+            async def communicate(self):
+                if sub in timeouts:
+                    raise asyncio.TimeoutError()
+                p = responses.get(sub, _proc())
+                return await p.communicate()
+
+            async def wait(self):
+                return self.returncode
+
+            def kill(self):
+                pass
+
+        return _FakeProc()
+
+    return _create
+
+
+@pytest.mark.satellite
+@pytest.mark.asyncio
+async def test_real_rssi_centered_on_baseline():
+    """A readable golden-range offset is centered on the -50 baseline (offset -7 -> -57)."""
+    fake = _fake_hcitool({
+        "name": _proc(b"Karnak"),
+        "cc": _proc(b""),
+        "rssi": _proc(b"RSSI return value: -7\n"),
+        "dc": _proc(b""),
+    })
+    scanner = ClassicBTScanner(timeout=1.0, read_rssi=True)
+    with patch("renfield_satellite.ble.classic_scanner.shutil.which", return_value="/usr/bin/hcitool"), \
+         patch("asyncio.create_subprocess_exec", side_effect=fake):
+        result = await scanner.scan({MAC})
+
+    assert result == [{"mac": MAC, "rssi": -57}]  # -50 + (-7)
+
+
+@pytest.mark.satellite
+@pytest.mark.asyncio
+async def test_positive_offset_reads_stronger():
+    """A positive golden offset (closer device) maps above the baseline (+6 -> -44)."""
+    fake = _fake_hcitool({
+        "name": _proc(b"Karnak"),
+        "cc": _proc(b""),
+        "rssi": _proc(b"RSSI return value: 6\n"),
+        "dc": _proc(b""),
+    })
+    scanner = ClassicBTScanner(timeout=1.0, read_rssi=True)
+    with patch("renfield_satellite.ble.classic_scanner.shutil.which", return_value="/usr/bin/hcitool"), \
+         patch("asyncio.create_subprocess_exec", side_effect=fake):
+        result = await scanner.scan({MAC})
+
+    assert result == [{"mac": MAC, "rssi": -44}]  # -50 + 6
+
+
+@pytest.mark.satellite
+@pytest.mark.asyncio
+async def test_weak_offset_floored_above_backend_threshold():
+    """A very weak offset is floored so a present device is never filtered as absent."""
+    fake = _fake_hcitool({
+        "name": _proc(b"Karnak"),
+        "cc": _proc(b""),
+        "rssi": _proc(b"RSSI return value: -40\n"),  # -50 + -40 = -90, below backend -80 filter
+        "dc": _proc(b""),
+    })
+    scanner = ClassicBTScanner(timeout=1.0, read_rssi=True)
+    with patch("renfield_satellite.ble.classic_scanner.shutil.which", return_value="/usr/bin/hcitool"), \
+         patch("asyncio.create_subprocess_exec", side_effect=fake):
+        result = await scanner.scan({MAC})
+
+    assert result == [{"mac": MAC, "rssi": ClassicBTScanner.PRESENT_FLOOR}]  # -79, not -90
+
+
+@pytest.mark.satellite
+@pytest.mark.asyncio
+async def test_falls_back_to_synthetic_when_rssi_unreadable():
+    """If the RSSI read fails (device refuses cc), presence still reports -50."""
+    fake = _fake_hcitool({
+        "name": _proc(b"Karnak"),
+        "cc": _proc(b"", returncode=1, stderr=b"Can't create connection"),
+        "rssi": _proc(b"", returncode=1, stderr=b"Not connected"),
+        "dc": _proc(b"", returncode=1),
+    })
+    scanner = ClassicBTScanner(timeout=1.0, read_rssi=True)
+    with patch("renfield_satellite.ble.classic_scanner.shutil.which", return_value="/usr/bin/hcitool"), \
+         patch("asyncio.create_subprocess_exec", side_effect=fake):
+        result = await scanner.scan({MAC})
+
+    assert result == [{"mac": MAC, "rssi": ClassicBTScanner.SYNTHETIC_RSSI}]
+
+
+@pytest.mark.satellite
+@pytest.mark.asyncio
+async def test_absent_device_not_reported():
+    """No name response => device is absent and never appears in results."""
+    fake = _fake_hcitool({"name": _proc(b"")})  # empty name = no response
+    scanner = ClassicBTScanner(timeout=1.0, read_rssi=True)
+    with patch("renfield_satellite.ble.classic_scanner.shutil.which", return_value="/usr/bin/hcitool"), \
+         patch("asyncio.create_subprocess_exec", side_effect=fake):
+        result = await scanner.scan({MAC})
+
+    assert result == []
+
+
+@pytest.mark.satellite
+@pytest.mark.asyncio
+async def test_read_rssi_disabled_keeps_synthetic():
+    """With read_rssi=False, no connection is attempted; synthetic value used."""
+    calls = []
+    fake_inner = _fake_hcitool({"name": _proc(b"Karnak")})
+
+    async def _tracking(*args, **kwargs):
+        calls.append(args[1] if len(args) > 1 else "")
+        return await fake_inner(*args, **kwargs)
+
+    scanner = ClassicBTScanner(timeout=1.0, read_rssi=False)
+    with patch("renfield_satellite.ble.classic_scanner.shutil.which", return_value="/usr/bin/hcitool"), \
+         patch("asyncio.create_subprocess_exec", side_effect=_tracking):
+        result = await scanner.scan({MAC})
+
+    assert result == [{"mac": MAC, "rssi": ClassicBTScanner.SYNTHETIC_RSSI}]
+    assert calls == ["name"]  # cc/rssi/dc never invoked
+
+
+@pytest.mark.satellite
+@pytest.mark.asyncio
+async def test_rssi_timeout_falls_back_and_still_present():
+    """An RSSI read that times out must not drop the device — fall back to -50."""
+    fake = _fake_hcitool(
+        {"name": _proc(b"Karnak"), "cc": _proc(b""), "rssi": _proc(b""), "dc": _proc(b"")},
+        timeouts={"rssi"},
+    )
+    scanner = ClassicBTScanner(timeout=1.0, read_rssi=True)
+    with patch("renfield_satellite.ble.classic_scanner.shutil.which", return_value="/usr/bin/hcitool"), \
+         patch("asyncio.create_subprocess_exec", side_effect=fake):
+        result = await scanner.scan({MAC})
+
+    assert result == [{"mac": MAC, "rssi": ClassicBTScanner.SYNTHETIC_RSSI}]
+
+
+@pytest.mark.satellite
+@pytest.mark.asyncio
+async def test_unavailable_hcitool_returns_empty():
+    """No hcitool binary => scanner reports nothing."""
+    scanner = ClassicBTScanner(timeout=1.0, read_rssi=True)
+    with patch("renfield_satellite.ble.classic_scanner.shutil.which", return_value=None):
+        result = await scanner.scan({MAC})
+
+    assert result == []

--- a/tests/satellite/test_classic_scanner.py
+++ b/tests/satellite/test_classic_scanner.py
@@ -259,6 +259,33 @@ async def test_rssi_read_throttled_within_interval():
 
 @pytest.mark.satellite
 @pytest.mark.asyncio
+async def test_mac_normalized_and_cache_pruned():
+    """Lowercase MACs normalize to uppercase (result + cache key); stale cache entries are pruned."""
+    ok = {"name": _proc(b"Karnak"), "cc": _proc(b""), "rssi": _proc(b"RSSI return value: -6\n"), "dc": _proc(b"")}
+    scanner = ClassicBTScanner(timeout=1.0, read_rssi=True, rssi_interval=300.0)
+    with patch("renfield_satellite.ble.classic_scanner.shutil.which", return_value="/usr/bin/hcitool"), \
+         patch("asyncio.create_subprocess_exec", side_effect=_fake_hcitool(ok)):
+        result = await scanner.scan({MAC.lower()})
+
+    assert result == [{"mac": MAC, "rssi": -56}]
+    assert list(scanner._rssi_cache.keys()) == [MAC]  # uppercase key
+
+    # A scan with a different whitelist (device absent) prunes the stale entry.
+    with patch("renfield_satellite.ble.classic_scanner.shutil.which", return_value="/usr/bin/hcitool"), \
+         patch("asyncio.create_subprocess_exec", side_effect=_fake_hcitool({"name": _proc(b"")})):
+        await scanner.scan({"AA:BB:CC:DD:EE:FF"})
+
+    assert scanner._rssi_cache == {}
+
+
+@pytest.mark.satellite
+def test_negative_rssi_interval_clamped():
+    """A nonsensical negative interval is clamped to 0 (read every scan), never negative."""
+    assert ClassicBTScanner(rssi_interval=-5.0).rssi_interval == 0.0
+
+
+@pytest.mark.satellite
+@pytest.mark.asyncio
 async def test_cached_rssi_reused_when_later_read_fails():
     """Once a real RSSI is cached, a later failed read reuses it instead of dropping to synthetic."""
     ok = {"name": _proc(b"Karnak"), "cc": _proc(b""), "rssi": _proc(b"RSSI return value: -21\n"), "dc": _proc(b"")}

--- a/tests/satellite/test_classic_scanner.py
+++ b/tests/satellite/test_classic_scanner.py
@@ -16,6 +16,15 @@ from renfield_satellite.ble.classic_scanner import ClassicBTScanner
 MAC = "4C:E6:C0:27:52:93"
 
 
+def _subcmd(args) -> str:
+    """The hcitool subcommand (name/cc/rssi/dc), ignoring any `sudo -n` prefix."""
+    a = list(args)
+    if "hcitool" in a:
+        i = a.index("hcitool")
+        return a[i + 1] if i + 1 < len(a) else ""
+    return ""
+
+
 def _proc(stdout: bytes = b"", returncode: int = 0, stderr: bytes = b""):
     """Build a fake asyncio subprocess whose communicate() returns stdout/stderr."""
     class _FakeProc:
@@ -46,7 +55,7 @@ def _fake_hcitool(responses: dict, timeouts: set | None = None):
     timeouts = timeouts or set()
 
     async def _create(*args, **kwargs):
-        sub = args[1] if len(args) > 1 else ""
+        sub = _subcmd(args)
 
         class _FakeProc:
             returncode = responses.get(sub, _proc()).returncode
@@ -161,7 +170,7 @@ async def test_read_rssi_disabled_keeps_synthetic():
     fake_inner = _fake_hcitool({"name": _proc(b"Karnak")})
 
     async def _tracking(*args, **kwargs):
-        calls.append(args[1] if len(args) > 1 else "")
+        calls.append(_subcmd(args))
         return await fake_inner(*args, **kwargs)
 
     scanner = ClassicBTScanner(timeout=1.0, read_rssi=False)


### PR DESCRIPTION
## Problem

On `/admin/presence`, user **evdb** appeared to be in **two rooms at once** (Arbeitszimmer ↔ Wohnzimmer), flipping across the page's 5s auto-refresh.

Root cause: Karnak is a **Classic Bluetooth** device. Classic-BT presence uses `hcitool name <MAC>` — a binary present/absent check with **no signal strength** — so the satellite reports a constant synthetic `rssi=-50` from *every* satellite that resolves the name (`ble/classic_scanner.py`). When two satellites both see the phone, the backend's "strongest signal wins" resolver (`presence_service._assign_room`) scores both rooms `mean(-50) = -50` — an exact **tie** broken by dict-iteration order, and the 2-scan hysteresis lets the room flip back and forth. (BLE devices are unaffected — they carry real RSSI and arbitrate correctly.)

## Fix

Read a **real per-device RSSI** for present Classic-BT devices via a short-lived ACL connection: `hcitool cc → hcitool rssi → hcitool dc`.

- **Presence never regresses:** `hcitool name` stays the presence check (works on non-discoverable Apple devices). The RSSI read is best-effort — any failure (device refuses `cc`, timeout, iPhone) falls back to synthetic `-50`.
- **Scale mapping:** `hcitool rssi` returns a *golden-range offset* (0 = ideal, ±dB), not absolute dBm. It's centered on the `-50` baseline so it lands on the backend's BLE-calibrated scale and preserves "closer satellite wins" ordering.
- **No "present device filtered as absent" bug:** the mapped value is floored at `-79`, safely above the backend's `-80` RSSI filter.
- **Off-switch:** `ble.classic_rssi` (default on) reverts to synthetic `-50` without a code change.

## Tests

`tests/satellite/test_classic_scanner.py` (9 cases): real-RSSI centering, positive offset, weak-offset floor, `cc`/`rssi` failure fallback, RSSI timeout fallback, absent device, `read_rssi=False`, no `hcitool`. All verified via a standalone asyncio harness locally (pytest-asyncio runs on the `.159` box).

## Known limitation (needs on-device validation)

Golden-range RSSI is frequently `0` when the link is within the ideal range. If Karnak reports `0` to **both** satellites, the tie returns and flip-flop persists. This is "ship and measure" — if measurement disappoints, a sticky-current-room tie-break in `_assign_room` is the reliable complement. If Karnak is an iPhone, `hcitool cc` is likely refused → fallback to `-50` (status quo, no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)