### PR TITLE
fix(skills): guard admin=None derefs in single-user mode (curator run 500)

### DIFF
--- a/src/backend/api/routes/skills.py
+++ b/src/backend/api/routes/skills.py
@@ -421,9 +421,11 @@ async def approve_skill(
     corpus. Idempotent — approving an already-approved skill is a no-op
     (returns the row unchanged).
     """
+    # AUTH_ENABLED=false (single-user mode) yields admin=None — guard the deref.
+    admin_id = admin.id if admin else None
     skill = await _load_for_admin(db, skill_id)
     if skill.status == SKILL_STATUS_APPROVED:
-        return _to_response(skill, is_owner=(skill.user_id == admin.id))
+        return _to_response(skill, is_owner=(skill.user_id == admin_id))
 
     if skill.status not in (SKILL_STATUS_DRAFT, SKILL_STATUS_REJECTED):
         raise HTTPException(
@@ -439,10 +441,10 @@ async def approve_skill(
     await db.commit()
     SkillService.invalidate_has_skills_cache()
     logger.info(
-        f"🧠 Skill #{skill.id} approved by admin={admin.id} "
+        f"🧠 Skill #{skill.id} approved by admin={admin_id} "
         f"({skill.title!r})"
     )
-    return _to_response(skill, is_owner=(skill.user_id == admin.id))
+    return _to_response(skill, is_owner=(skill.user_id == admin_id))
 
 
 @router.post("/{skill_id}/reject", response_model=SkillResponse)
@@ -455,9 +457,11 @@ async def reject_skill(
 ):
     """Admin: flip a draft skill to rejected (excluded from retrieval,
     kept for audit). Idempotent."""
+    # AUTH_ENABLED=false (single-user mode) yields admin=None — guard the deref.
+    admin_id = admin.id if admin else None
     skill = await _load_for_admin(db, skill_id)
     if skill.status == SKILL_STATUS_REJECTED:
-        return _to_response(skill, is_owner=(skill.user_id == admin.id))
+        return _to_response(skill, is_owner=(skill.user_id == admin_id))
 
     if skill.status != SKILL_STATUS_DRAFT:
         raise HTTPException(
@@ -469,10 +473,10 @@ async def reject_skill(
     await db.commit()
     SkillService.invalidate_has_skills_cache()
     logger.info(
-        f"🧠 Skill #{skill.id} rejected by admin={admin.id} "
+        f"🧠 Skill #{skill.id} rejected by admin={admin_id} "
         f"({skill.title!r})"
     )
-    return _to_response(skill, is_owner=(skill.user_id == admin.id))
+    return _to_response(skill, is_owner=(skill.user_id == admin_id))
 
 
 # ----------------------------------------------------------------- pin
@@ -614,13 +618,17 @@ async def run_curator(
     need per-user inspection, filter the response from GET
     /curator/runs by ``triggered_by_user_id``.
     """
+    # AUTH_ENABLED=false (single-user mode) yields admin=None — guard every
+    # deref or the route 500s (see reference: routes single-user-mode user None).
+    admin_id = admin.id if admin else None
+    admin_username = admin.username if admin else None
     svc = SkillCuratorService(db)
     logger.info(
-        f"🧹 Curator manual run requested: admin_id={admin.id} "
-        f"admin_username={admin.username!r} target_user_id={body.user_id!r}"
+        f"🧹 Curator manual run requested: admin_id={admin_id} "
+        f"admin_username={admin_username!r} target_user_id={body.user_id!r}"
     )
     run_row = await svc.run_curator(
-        triggered_by_user_id=admin.id,
+        triggered_by_user_id=admin_id,
         run_type=CURATOR_RUN_TYPE_MANUAL,
     )
     return _curator_run_to_response(run_row)

--- a/src/backend/api/routes/trajectories.py
+++ b/src/backend/api/routes/trajectories.py
@@ -168,9 +168,11 @@ async def export_jsonl(
     # the audit lands even if the client disconnects mid-stream.
     if not require_redacted:
         client_host = request.client.host if request.client else "unknown"
+        # AUTH_ENABLED=false (single-user mode) yields admin=None — guard the deref.
         logger.warning(
             "🔓 Trajectory export with require_redacted=false: "
-            f"admin_user_id={admin.id} admin_username={admin.username!r} "
+            f"admin_user_id={admin.id if admin else None} "
+            f"admin_username={(admin.username if admin else None)!r} "
             f"remote={client_host} outcome={outcome!r} "
             f"since_days={since_days} flagged_only={flagged_only}"
         )

--- a/tests/backend/test_skills_routes.py
+++ b/tests/backend/test_skills_routes.py
@@ -560,3 +560,21 @@ class TestCuratorRun:
             "/api/skills/curator/run", json={"user_id": auth_as_owner.id},
         )
         assert resp.status_code in (401, 403)
+
+    async def test_single_user_mode_no_500(
+        self, async_client: AsyncClient, app_with_test_db, patched_embed,
+        monkeypatch,
+    ):
+        """AUTH_ENABLED=false (single-user mode) → require_permission yields
+        admin=None. The route must not 500 dereferencing admin.id
+        (regression: 'NoneType' object has no attribute 'id')."""
+        from services.auth_service import get_current_user
+        monkeypatch.setattr(
+            "services.auth_service.settings.auth_enabled", False, raising=False,
+        )
+        app_with_test_db.dependency_overrides[get_current_user] = lambda: None
+        resp = await async_client.post("/api/skills/curator/run", json={})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["run_type"] == "manual"
+        assert body["triggered_by_user_id"] is None

--- a/tests/backend/test_skills_routes.py
+++ b/tests/backend/test_skills_routes.py
@@ -572,8 +572,13 @@ class TestCuratorRun:
         monkeypatch.setattr(
             "services.auth_service.settings.auth_enabled", False, raising=False,
         )
+        # app is a shared singleton — pop the override in finally so it can't
+        # leak get_current_user=None into later tests (mirrors auth_as_admin).
         app_with_test_db.dependency_overrides[get_current_user] = lambda: None
-        resp = await async_client.post("/api/skills/curator/run", json={})
+        try:
+            resp = await async_client.post("/api/skills/curator/run", json={})
+        finally:
+            app_with_test_db.dependency_overrides.pop(get_current_user, None)
         assert resp.status_code == 200
         body = resp.json()
         assert body["run_type"] == "manual"


### PR DESCRIPTION
## Problem

The **"Jetzt ausführen"** button on `/admin/curator` returned **500**. Backend traceback:

```
File "/app/api/routes/skills.py", line 619, in run_curator
    f"🧹 Curator manual run requested: admin_id={admin.id} "
AttributeError: 'NoneType' object has no attribute 'id'
```

Prod runs `AUTH_ENABLED=false` (single-user mode). In that mode `require_permission(ADMIN)` returns `None` (`auth_service.py:371-372`), and the `POST /api/skills/curator/run` handler dereferenced `admin.id` / `admin.username` when writing the audit row + log line → unhandled `AttributeError` → 500 on every click. (The page's `GET /curator/runs` works because it never touches `admin.id`.)

## Fix

Guard the deref: `admin_id = admin.id if admin else None`. The `skill_curator_runs.triggered_by_user_id` column is already nullable (scheduled runs leave it NULL), so `None` is valid.

Swept all route handlers for the same `require_permission`-result-dereferenced pattern. Most already guard correctly (`x.id if x else None`). Fixed the **3 identical latent 500s** that didn't:
- `skills.py` skill **approve** / **reject** (`admin.id` — the Skills Inbox buttons)
- `trajectories.py` `export_jsonl` verbatim-export audit log (`admin.id`/`admin.username`, only the `require_redacted=false` branch)

## Test

`tests/backend/test_skills_routes.py::TestCuratorRun::test_single_user_mode_no_500` — with `auth_enabled=False` and `get_current_user → None`, `POST /curator/run` returns **200** with `triggered_by_user_id=None` instead of 500. (Runs on the `.159` box.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)