### PR TITLE
fix: stop /api responses being cached as stale HTML (presence crash hardening)

### DIFF
--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -138,6 +138,12 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
                 "frame-ancestors 'none';"
             )
 
+        # API responses must never be HTTP-cached. If a transient HTML/SPA
+        # fallback is ever served for an /api path (e.g. during a backend
+        # rollout), caching it would replay a non-JSON body to the SPA.
+        if path.startswith("/api/"):
+            response.headers["Cache-Control"] = "no-store"
+
         return response
 
 

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -141,7 +141,9 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         # API responses must never be HTTP-cached. If a transient HTML/SPA
         # fallback is ever served for an /api path (e.g. during a backend
         # rollout), caching it would replay a non-JSON body to the SPA.
-        if path.startswith("/api/"):
+        # Only default when the route hasn't set its own policy (e.g. the TTS
+        # cache route sets no-cache for DLNA renderers — don't clobber it).
+        if path.startswith("/api/") and "cache-control" not in response.headers:
             response.headers["Cache-Control"] = "no-store"
 
         return response

--- a/src/frontend/nginx.conf
+++ b/src/frontend/nginx.conf
@@ -28,6 +28,15 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
+    # /api and /ws are backend routes (ingress-routed). If one ever reaches the
+    # frontend (mis-route / ingress reload), return a non-cacheable 404 instead
+    # of the SPA index.html — a cached HTML body for an API path replays as a
+    # non-JSON response and crashes the SPA. (/health stays the frontend probe.)
+    location ~ ^/(api|ws)(/|$) {
+        add_header Cache-Control "no-store" always;
+        return 404;
+    }
+
     # SPA routing - serve index.html for all routes
     location / {
         try_files $uri $uri/ /index.html;

--- a/src/frontend/src/api/resources/presence.ts
+++ b/src/frontend/src/api/resources/presence.ts
@@ -45,13 +45,15 @@ export interface NewDevicePayload {
 
 async function fetchRooms(): Promise<PresenceRoom[]> {
   const response = await apiClient.get<PresenceRoom[]>('/api/presence/rooms');
-  return response.data ?? [];
+  // Guard against a non-array body (e.g. a stale cached HTML/SPA fallback) so
+  // consumers never crash on `.flatMap`/`.map`.
+  return Array.isArray(response.data) ? response.data : [];
 }
 
 async function fetchDevices(): Promise<BleDevice[]> {
   try {
     const response = await apiClient.get<BleDevice[]>('/api/presence/devices');
-    return response.data ?? [];
+    return Array.isArray(response.data) ? response.data : [];
   } catch {
     // May fail if non-admin
     return [];
@@ -77,7 +79,7 @@ async function fetchHeatmap({ days, userId }: AnalyticsArgs): Promise<unknown[]>
   const params: Record<string, unknown> = { days };
   if (userId) params.user_id = userId;
   const response = await apiClient.get<unknown[]>('/api/presence/analytics/heatmap', { params });
-  return response.data ?? [];
+  return Array.isArray(response.data) ? response.data : [];
 }
 
 async function fetchPredictions({ days, userId }: AnalyticsArgs): Promise<unknown[]> {
@@ -85,7 +87,7 @@ async function fetchPredictions({ days, userId }: AnalyticsArgs): Promise<unknow
   const response = await apiClient.get<unknown[]>('/api/presence/analytics/predictions', {
     params: { user_id: userId, days },
   });
-  return response.data ?? [];
+  return Array.isArray(response.data) ? response.data : [];
 }
 
 async function fetchPresenceStatus(): Promise<{ enabled: boolean }> {

--- a/src/frontend/src/api/resources/rooms.ts
+++ b/src/frontend/src/api/resources/rooms.ts
@@ -38,12 +38,13 @@ export type ConflictResolution = 'skip' | 'link' | 'overwrite';
 
 async function fetchRooms(): Promise<Room[]> {
   const response = await apiClient.get<Room[]>('/api/rooms');
-  return response.data ?? [];
+  // Guard against a non-array body (e.g. a stale cached HTML/SPA fallback).
+  return Array.isArray(response.data) ? response.data : [];
 }
 
 async function fetchHAAreas(): Promise<HAArea[]> {
   const response = await apiClient.get<HAArea[]>('/api/rooms/ha/areas');
-  return response.data ?? [];
+  return Array.isArray(response.data) ? response.data : [];
 }
 
 export interface CreateRoomInput {

--- a/tests/backend/test_security_headers.py
+++ b/tests/backend/test_security_headers.py
@@ -1,0 +1,30 @@
+"""
+Tests for SecurityHeadersMiddleware — focused on the /api no-store policy.
+
+The middleware runs on every response (including 404s for unmatched routes),
+so we probe arbitrary paths without depending on a specific endpoint or auth.
+"""
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_api_responses_are_no_store(async_client: AsyncClient):
+    """Any /api response carries Cache-Control: no-store.
+
+    Regression: a transient HTML/SPA fallback served for an /api path during a
+    backend rollout was HTTP-cached and replayed as a non-JSON body, crashing
+    the presence page. no-store stops the browser caching /api responses.
+    """
+    resp = await async_client.get("/api/__cache_probe__")
+    assert resp.headers.get("cache-control") == "no-store"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_non_api_responses_not_forced_no_store(async_client: AsyncClient):
+    """Non-/api paths are not force-no-store (static assets stay cacheable)."""
+    resp = await async_client.get("/__not_an_api_path__")
+    assert resp.headers.get("cache-control") != "no-store"


### PR DESCRIPTION
## Problem (observed during the PR #764 deploy)

The presence page white-screened (`TypeError: m.flatMap is not a function`, error boundary) **while the backend was fully healthy** (curl returned correct JSON). Root cause: during the backend `Recreate` rollout, a request to `/api/presence/rooms` fell through to the frontend nginx and got served `index.html` (HTTP 200); the **browser HTTP-cached that HTML for the API URL**. Afterwards the app fetched the cached HTML and `PresencePage.tsx:349` did `rooms.flatMap(...)` on a non-array → hard crash. Proven: `fetch(..., {cache:'reload'})` returned correct JSON, and clearing the browser cache fixed it.

This is a transient per-deploy artifact, but it strands users on a white screen until a hard refresh. Hardened three layers:

## Fix

1. **Backend** (`main.py` `SecurityHeadersMiddleware`): add `Cache-Control: no-store` to every `/api/*` response — the browser never HTTP-caches API responses.
2. **Frontend nginx** (`nginx.conf`): `/api` and `/ws` return a non-cacheable **404** instead of falling through to `index.html`, so the frontend can never serve an HTML body for an API path. (`/health` stays the frontend liveness probe; assets + SPA routes unaffected — the regex location is matched before the `/` fallback.)
3. **Frontend data layer** (`api/resources/presence.ts`): the list-fetchers (`rooms`/`devices`/`heatmap`/`predictions`) guard `Array.isArray(...)` so a non-array body degrades to an empty list + empty state instead of crashing. (`fetchPresenceUsers` already did this.)

## Test

`tests/backend/test_security_headers.py`: `/api/*` responses carry `Cache-Control: no-store`; non-`/api` paths do not. Frontend build verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)