### PR TITLE
fix(router): content-creation requests no longer route to the n8n workflow agent

### DIFF
--- a/config/agent_roles.yaml
+++ b/config/agent_roles.yaml
@@ -57,8 +57,8 @@ roles:
 
   workflow:
     description:
-      de: "Automatisierungen: n8n Workflows erstellen, bearbeiten, verwalten, ausfuehren"
-      en: "Automations: create, edit, manage, execute n8n workflows"
+      de: "n8n-Automatisierung NUR: n8n-Workflows / Automations-Pipelines erstellen, bearbeiten, verwalten, ausfuehren. NICHT fuer das Verfassen/Erstellen von Texten, Dokumenten, Fragebögen, Checklisten, Konzepten oder Plänen (das ist 'conversation'/'general') — nicht hierher nur weil 'erstelle' oder 'Programm' vorkommt"
+      en: "n8n automation ONLY: create, edit, manage, execute n8n workflows / automation pipelines. NOT for writing/creating text, documents, questionnaires, checklists, concepts or plans (that is 'conversation'/'general') — not here just because the words 'create' or 'program' appear"
     mcp_servers: [n8n]
     max_steps: 10
     prompt_key: agent_prompt_workflow
@@ -98,6 +98,6 @@ roles:
 
   conversation:
     description:
-      de: "Konversation: Smalltalk, Allgemeinwissen, Meinungen — KEINE Aktion und KEINE Weitergabe einer Nachricht an eine Person (eine Nachricht ausrichten gehoert zu 'presence')"
-      en: "Conversation: smalltalk, general knowledge, opinions — NO action and NOT relaying a message to a person (relaying a message belongs to 'presence')"
+      de: "Konversation & Texterstellung: Smalltalk, Allgemeinwissen, Meinungen, sowie das Verfassen/Erstellen von Texten, Dokumenten, Fragebögen, Checklisten, Konzepten, Plänen, Vorlagen — KEINE Aktion und KEINE Weitergabe einer Nachricht an eine Person (eine Nachricht ausrichten gehoert zu 'presence')"
+      en: "Conversation & writing: smalltalk, general knowledge, opinions, and writing/creating text, documents, questionnaires, checklists, concepts, plans, templates — NO action and NOT relaying a message to a person (relaying a message belongs to 'presence')"
     # No agent loop - direct LLM response


### PR DESCRIPTION
## Problem

"Erstelle mir einen Fragebogen/questionnaire um die Implementierung … in einem Programm zu überprüfen" produced an awkward, inconsistent answer. The agent-router (qwen3:8b) classified it as the **`workflow`** role (n8n automation) — because that role's description led with **"n8n Workflows erstellen"**, and the words *erstelle* + *Programm* + *Implementierung* over-triggered it. The n8n agent (only n8n tools) then apologized that "this isn't really an n8n workflow," produced the questionnaire anyway, and offered to convert it to a workflow. On other runs the same misrouting can yield a worse/empty result.

## Fix (`config/agent_roles.yaml`)

- **`workflow`**: scoped to n8n automation **ONLY**, with an explicit NOT-clause for writing/creating text, documents, questionnaires, checklists, concepts, plans (mirrors the existing `NICHT`-clauses on `smart_home`/`research`), and "not here just because 'create'/'program' appears".
- **`conversation`**: explicitly covers writing/creating documents, so content generation lands on the clean **direct-LLM path** (no tools, no caveats).

## Tested live

ConfigMap `renfield-mcp-config` (key `agent_roles.yaml`) patched + backend restarted (it's already fixed in prod):
- `"Erstelle mir einen Fragebogen …"` → **conversation** (was `workflow`)
- `"Erstelle mir einen n8n Workflow …"` → **workflow** (preserved — produced a real n8n Schedule-Trigger design)

Router's own reasoning on the questionnaire: *"…nicht um eine Automatisierung (workflow), da kein technischer Workflow…"*.

Note: `agent_roles.yaml` is ConfigMap-served (not in the image), so no image build — the live ConfigMap is already patched; this PR keeps the repo source of truth in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)