### PR TITLE
fix(voice): auto-recover wake-word listening after WS reconnect / suspend

### DIFF
--- a/docs/WAKEWORD_CONFIGURATION.md
+++ b/docs/WAKEWORD_CONFIGURATION.md
@@ -243,6 +243,36 @@ case 'config_update':
   break;
 ```
 
+### Web Listening Recovery
+
+The browser wake-word engine (`useWakeWord` + onnxruntime WASM) runs **locally**
+on the mic and is independent of the backend chat WebSocket. It can still be left
+stranded paused (`isEnabled: true`, `isListening: false`, nothing detecting) in
+three ways, all of which previously needed a manual page reload:
+
+1. A **backend `Recreate` rollout** (deploy / ConfigMap reload) drops the chat WS
+   *mid-turn*. On wake-word detection the engine is paused for recording and only
+   resumes on the backend's `done` frame — which never arrives once the socket is
+   gone. This is the "doesn't listen any longer after a deploy" symptom.
+2. An **engine error** (audio pipeline disruption). `useWakeWord` now flips
+   `isListening: false` on error so the status dot is honest (yellow, not a lying
+   green) and recovery can fire.
+3. **Tab suspend / laptop sleep / network loss** stalling the engine.
+
+`ChatContext` re-arms the engine on three recovery triggers — chat-WS **reconnect**
+(edge-triggered on `wsConnected`), tab becoming **visible** (`visibilitychange`),
+and network coming back **online**. A pure `shouldRearmWakeWord` predicate
+(`pages/ChatPage/context/wakeWordRecovery.ts`) gates the resume: it skips the
+happy path (already listening), an active capture, and a live wake-word turn. An
+in-flight start latch in `useWakeWord` coalesces simultaneous triggers (e.g. a
+laptop wake firing all three at once) so the engine can't double-start.
+
+On reconnect, a chat turn that was streaming over the dropped WS is dead: the
+stuck "thinking" spinner is cleared, the half-streamed bubble is finalized, and an
+`errors.connectionInterrupted` message is shown. This is keyed on a
+streaming-turn flag (not raw `loading`) so a REST-fallback turn, which completes
+on its own, is never falsely interrupted.
+
 ## Environment Variables
 
 | Variable | Description | Default |
@@ -288,3 +318,16 @@ make test-backend ARGS="tests/backend/test_wakeword_config.py -v"
 1. Verify backend has model files in `src/frontend/node_modules/openwakeword-wasm-browser/models/`
 2. Check network connectivity from satellite to backend
 3. Check available disk space on satellite
+
+### Web Wake Word Stops Listening (after a deploy / sleep)
+
+The browser engine auto-recovers on chat-WS reconnect, tab-visible, and
+network-online (see **Frontend Integration → Web Listening Recovery**). If it
+stays silent:
+
+1. Confirm the chat WS is connected (chat header shows "Verbunden"). A backend
+   `Recreate` rollout briefly drops it; recovery fires once it reconnects.
+2. Check the wake-word status dot: green pulse = listening, yellow = paused/errored.
+3. Verify mic permission is still granted and the `/wakeword-models/*.onnx` +
+   `/ort/*` assets load (200) — these are static, not `/api`.
+4. Last resort: hard-reload the page (Cmd+Shift+R).

--- a/src/frontend/src/hooks/useWakeWord.ts
+++ b/src/frontend/src/hooks/useWakeWord.ts
@@ -139,6 +139,12 @@ export function useWakeWord({
   const unsubscribersRef = useRef<Array<() => void>>([]);
   const callbacksRef = useRef({ onWakeWordDetected, onSpeechStart, onSpeechEnd, onError, onReady });
   const isEnabledRef = useRef(false); // Ref to avoid stale closure in resume()
+  // In-flight guard around engine.start(). isListening only flips true AFTER
+  // the async start resolves, so without this two near-simultaneous resume()
+  // calls (e.g. tab-visible + network-online + WS-reconnect all firing on a
+  // laptop wake) would both pass the isListening check and start() the engine
+  // twice. Coalesces concurrent starts across both enable() and resume().
+  const isStartingRef = useRef(false);
 
   // Keep callbacks ref updated
   useEffect(() => {
@@ -176,10 +182,11 @@ export function useWakeWord({
 
   // Enable wake word listening
   const enable = useCallback(async () => {
-    if (isListening || isLoading) return;
+    if (isListening || isLoading || isStartingRef.current) return;
 
     setIsLoading(true);
     setError(null);
+    isStartingRef.current = true;
 
     try {
       // Lazy load the wake word engine module
@@ -226,6 +233,13 @@ export function useWakeWord({
 
       const unsubError = engine.on('error', (err: Error) => {
         setError(err);
+        // The engine errored — it is no longer detecting. Reflect that in
+        // isListening (it previously stayed stale-true, lying to the UI) so the
+        // status dot goes yellow AND the recovery triggers in ChatContext
+        // (WS-reconnect / tab-visible / network-online) can resume it: their
+        // guard requires !isListening. isEnabled stays true so the user's
+        // intent is preserved and the resume path stays open.
+        setIsListening(false);
         callbacksRef.current.onError?.(err);
       });
 
@@ -280,6 +294,7 @@ export function useWakeWord({
         callbacksRef.current.onError?.(error);
       }
     } finally {
+      isStartingRef.current = false;
       setIsLoading(false);
     }
   }, [isListening, isLoading, initEngine]);
@@ -358,8 +373,13 @@ export function useWakeWord({
       debug.log('⚠️ resume() skipped: no engine');
       return;
     }
+    if (isStartingRef.current) {
+      debug.log('⚠️ resume() skipped: a start is already in flight');
+      return;
+    }
 
     try {
+      isStartingRef.current = true;
       debug.log('▶️ Starting wake word engine...');
       await engineRef.current.start({
         gain: WAKEWORD_CONFIG.defaults.gain,
@@ -369,6 +389,8 @@ export function useWakeWord({
     } catch (err) {
       console.error('Failed to resume wake word:', err);
       setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      isStartingRef.current = false;
     }
   }, [isListening]); // Removed isEnabled from deps since we use ref
 

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -955,7 +955,8 @@
     "forbidden": "Zugriff verweigert",
     "serverError": "Serverfehler",
     "validationError": "Validierungsfehler",
-    "couldNotProcess": "Entschuldigung, es gab einen Fehler bei der Verarbeitung deiner Anfrage."
+    "couldNotProcess": "Entschuldigung, es gab einen Fehler bei der Verarbeitung deiner Anfrage.",
+    "connectionInterrupted": "Die Verbindung wurde während der Antwort unterbrochen. Bitte versuche es erneut."
   },
   "errorBoundary": {
     "title": "Etwas ist schiefgelaufen",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -955,7 +955,8 @@
     "forbidden": "Access denied",
     "serverError": "Server error",
     "validationError": "Validation error",
-    "couldNotProcess": "Sorry, there was an error processing your request."
+    "couldNotProcess": "Sorry, there was an error processing your request.",
+    "connectionInterrupted": "The connection was interrupted during the response. Please try again."
   },
   "errorBoundary": {
     "title": "Something went wrong",

--- a/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
+++ b/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
@@ -48,6 +48,7 @@ import type { Conversation } from '../../../types/chat';
 import type { TraceEntity } from '../../../api/resources/wissensbasis';
 import { useConfirmDialog } from '../../../components/ConfirmDialog';
 import { drainSentenceTts, type SentenceStreamState } from './sentenceStream';
+import { shouldRearmWakeWord } from './wakeWordRecovery';
 
 const SESSION_STORAGE_KEY = 'renfield_current_session';
 // How long sendMessageInternal waits for the WebSocket handshake before
@@ -281,6 +282,18 @@ export function ChatProvider({ children }: ChatProviderProps) {
   const wakeWordActivatedRef = useRef(false);
   const wakeWordEnabledRef = useRef(false);
   const audioContextUnlockedRef = useRef<AudioContext | null>(null);
+  // Wake-word reconnect-recovery refs — read inside the wsConnected-edge
+  // effect below so it doesn't re-subscribe to every listening/recording
+  // change (which would let it fire mid normal turn). See wakeWordRecovery.ts.
+  const wakeWordListeningRef = useRef(false);
+  const recordingRef = useRef(false);
+  const resumeWakeWordRef = useRef<() => Promise<void>>(async () => undefined);
+  const hasConnectedRef = useRef(false);
+  // True while a chat turn is streaming over the WS (set after a successful
+  // wsSendMessage, cleared on `done`). Lets reconnect recovery interrupt ONLY a
+  // dead WS stream — never a REST-fallback turn, which completes on its own and
+  // would otherwise get a spurious "connection interrupted" message.
+  const wsStreamingTurnRef = useRef(false);
 
   // Voice input tracking
   const lastInputChannelRef = useRef<'text' | 'voice'>('text');
@@ -662,6 +675,8 @@ export function ChatProvider({ children }: ChatProviderProps) {
       }
       return prev;
     });
+    // Turn finished cleanly — no longer a live WS stream for reconnect to interrupt.
+    wsStreamingTurnRef.current = false;
     setLoading(false);
   }, [resumeWakeWord]);
 
@@ -1024,6 +1039,9 @@ export function ChatProvider({ children }: ChatProviderProps) {
 
   // Handle recording error
   const handleRecordingError = useCallback((errorMessage: string) => {
+    // The turn errored and is being reported now — clear the streaming-turn
+    // latch so a later benign WS reconnect doesn't re-flag it as interrupted.
+    wsStreamingTurnRef.current = false;
     setMessages((prev) => [...prev, { role: 'assistant', content: errorMessage }]);
     setLoading(false);
   }, []);
@@ -1173,6 +1191,95 @@ export function ChatProvider({ children }: ChatProviderProps) {
   const startRecording = VOICE_STREAM_ENABLED ? startStreamRecording : audioRec.startRecording;
   const toggleRecording = VOICE_STREAM_ENABLED ? toggleStreamRecording : audioRec.toggleRecording;
 
+  // Keep the latest wake-word/recording values in refs so the recovery effects
+  // below read them without depending on (and re-running for) every
+  // isListening/recording change — which would let them fire in the middle of
+  // a normal turn. Runs after every render (cheap ref writes).
+  useEffect(() => {
+    wakeWordListeningRef.current = wakeWord.isListening;
+    recordingRef.current = recording;
+    resumeWakeWordRef.current = resumeWakeWord;
+  });
+
+  // Resume a stranded wake-word engine when a recovery trigger fires (chat-WS
+  // reconnect, tab becoming visible, network back online). The local engine is
+  // independent of the WS, but it can be left paused — by a mid-turn WS drop, an
+  // engine error (useWakeWord flips isListening:false), or a tab/network
+  // suspend — with no `done` frame to resume it, until a manual reload. The
+  // guards (see wakeWordRecovery.ts) skip the happy path (already listening),
+  // an active capture, and a live wake-word turn. Reads live refs so callers
+  // can stay edge-triggered.
+  const attemptWakeWordRearm = useCallback((trigger: string) => {
+    if (
+      shouldRearmWakeWord({
+        isRecoveryTrigger: true,
+        wakeWordEnabled: wakeWordEnabledRef.current,
+        isListening: wakeWordListeningRef.current,
+        recording: recordingRef.current,
+        wakeWordActivated: wakeWordActivatedRef.current,
+      })
+    ) {
+      debug.log(`🔁 ${trigger} — re-arming stranded wake word`);
+      setWakeWordStatus('listening');
+      void resumeWakeWordRef.current();
+    }
+  }, []);
+
+  // Chat-WS reconnect recovery. A backend Recreate rollout (deploy / ConfigMap
+  // reload) drops the WS; if it dropped mid-turn the turn is dead (its `done`
+  // will never arrive on the new socket). Clear the stuck "thinking" spinner +
+  // tell the user, clear the mid-turn latch, then re-arm wake word. Edge-
+  // triggered on wsConnected ONLY (other values via refs) so it cannot fire
+  // mid normal turn when isListening/recording churn.
+  useEffect(() => {
+    if (!wsConnected) return;
+    const isReconnect = hasConnectedRef.current;
+    hasConnectedRef.current = true;
+    if (!isReconnect) return; // initial connect — useWakeWord auto-enable handles startup
+    // A WS chat turn in flight when the socket dropped is dead — its stream
+    // won't resume on the new socket. Clear the stuck "thinking" spinner and
+    // tell the user. Guarded on the streaming-turn ref (NOT loading) so a
+    // REST-fallback turn, which completes on its own, isn't falsely interrupted.
+    if (wsStreamingTurnRef.current) {
+      wsStreamingTurnRef.current = false;
+      setLoading(false);
+      // Finalize any half-streamed assistant bubble (else it spins forever and
+      // its speak/intent UI never shows), then append the interruption note.
+      setMessages((prev) => {
+        const last = prev[prev.length - 1];
+        const finalized =
+          last && last.role === 'assistant' && last.streaming
+            ? [...prev.slice(0, -1), { ...last, streaming: false }]
+            : prev;
+        return [...finalized, { role: 'assistant', content: t('errors.connectionInterrupted') }];
+      });
+    }
+    // The dead turn's latch must be cleared so the resume guards apply here
+    // and in handleRecordingStop (if a capture is still running).
+    wakeWordActivatedRef.current = false;
+    attemptWakeWordRearm('Chat WS reconnected');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [wsConnected]);
+
+  // Wake-from-suspend recovery: a backgrounded tab or a dropped network can
+  // stall the wake-word engine (suspended AudioContext / ended mic track). When
+  // the tab becomes visible again or the network returns, re-arm it. These do
+  // NOT clear the activation latch (unlike reconnect, the current turn is not
+  // necessarily dead), so the latch guard keeps a live turn from being double-
+  // armed.
+  useEffect(() => {
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') attemptWakeWordRearm('Tab visible');
+    };
+    const onOnline = () => attemptWakeWordRearm('Network online');
+    document.addEventListener('visibilitychange', onVisible);
+    window.addEventListener('online', onOnline);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisible);
+      window.removeEventListener('online', onOnline);
+    };
+  }, [attemptWakeWordRearm]);
+
   // Streaming-aware speakText. Resolves when the TTS request is dispatched
   // (streaming) or playback completes (legacy). Existing callers see the
   // same Promise<void> shape.
@@ -1284,6 +1391,8 @@ export function ChatProvider({ children }: ChatProviderProps) {
     sentenceStreamRef.current.dispatchedIdx = 0;
     sentenceStreamRef.current.active = false;
     sentenceStreamRef.current.streamDone = false;
+    // New turn — not streaming over the WS until a wsSendMessage succeeds below.
+    wsStreamingTurnRef.current = false;
 
     lastUserQueryRef.current = text;
     lastIntentInfoRef.current = null;
@@ -1349,6 +1458,9 @@ export function ChatProvider({ children }: ChatProviderProps) {
     // if the socket isn't OPEN, so we close the race between whenReady()
     // resolving true and the actual transmit.
     if (isReady() && wsSendMessage(wsMessage)) {
+      // The turn is now streaming over the WS; a mid-stream socket drop makes it
+      // recoverable (the reconnect effect clears the spinner + notifies).
+      wsStreamingTurnRef.current = true;
       setRagSources([]);
     } else {
       try {

--- a/src/frontend/src/pages/ChatPage/context/wakeWordRecovery.ts
+++ b/src/frontend/src/pages/ChatPage/context/wakeWordRecovery.ts
@@ -1,0 +1,60 @@
+/**
+ * Wake-word reconnect / wake-from-suspend recovery — decision logic.
+ *
+ * The browser wake-word engine is local (mic + onnxruntime) and survives a
+ * chat-WS blip on its own. It gets stranded (isEnabled:true, isListening:false,
+ * nothing detecting, until a manual page reload) in a few ways:
+ *
+ *  - A WS drop that lands *mid-turn*: on detection the engine is paused
+ *    (handleRecordingStart) and only resumed when the backend's `done` frame
+ *    arrives (handleStreamDone). A backend `Recreate` rollout (deploy /
+ *    ConfigMap reload) drops the WS; if it dropped between that pause and the
+ *    `done`, the frame never comes — "doesn't listen any longer after a deploy".
+ *  - The engine emitting an `error` (audio pipeline disruption): useWakeWord
+ *    flips isListening:false so the state is honest, but does not self-restart.
+ *  - Tab suspend / laptop sleep / network loss interrupting the engine.
+ *
+ * ChatContext re-arms the engine on three recovery triggers — chat-WS reconnect,
+ * tab becoming visible, and network coming back online. This pure predicate
+ * isolates the "should we resume?" decision so it can be unit-tested without
+ * rendering the whole provider.
+ */
+export interface WakeWordRecoveryState {
+  /**
+   * This is a genuine recovery moment (a chat-WS RECONNECT — not the initial
+   * connect — or a tab-visible / network-online event), not a spurious call.
+   */
+  isRecoveryTrigger: boolean;
+  /** The user has wake word switched on (engine should be listening). */
+  wakeWordEnabled: boolean;
+  /** The engine is already actively listening — nothing to recover. */
+  isListening: boolean;
+  /** A capture is in progress — don't interrupt it (a later edge recovers). */
+  recording: boolean;
+  /**
+   * A wake-word-triggered turn is mid-flight (detected → recording/processing/
+   * TTS, awaiting its resume). Resuming now would double-arm the engine and
+   * fight the turn's own resume — skip. The WS-reconnect path clears this latch
+   * first (that turn is dead once the socket dropped), so only it can proceed.
+   */
+  wakeWordActivated: boolean;
+}
+
+/**
+ * Whether a recovery trigger should resume the (stranded, paused) wake-word
+ * engine.
+ *
+ * True only when: it's a genuine recovery moment, the user wants wake word on,
+ * the engine is NOT already listening (so the happy "WS blipped outside a turn"
+ * case is skipped — the local engine kept running there), no capture is active,
+ * and no wake-word turn is mid-flight.
+ */
+export function shouldRearmWakeWord(state: WakeWordRecoveryState): boolean {
+  return (
+    state.isRecoveryTrigger &&
+    state.wakeWordEnabled &&
+    !state.isListening &&
+    !state.recording &&
+    !state.wakeWordActivated
+  );
+}

--- a/tests/frontend/react/context/wakeWordRecovery.test.ts
+++ b/tests/frontend/react/context/wakeWordRecovery.test.ts
@@ -1,0 +1,52 @@
+/**
+ * shouldRearmWakeWord — wake-word recovery decision.
+ *
+ * The local wake-word engine gets stranded (isEnabled:true, isListening:false,
+ * nothing detecting) by a mid-turn WS drop (backend Recreate rollout), an
+ * engine error, or a tab/network suspend. ChatContext re-arms it on three
+ * recovery triggers (WS reconnect, tab-visible, network-online); this predicate
+ * gates that resume. The tests lock the five guards so a future edit can't
+ * resume during the happy path (engine still listening), interrupt an active
+ * capture, or double-arm in the middle of a wake-word turn.
+ */
+import { describe, it, expect } from 'vitest';
+import { shouldRearmWakeWord } from '../../../../src/frontend/src/pages/ChatPage/context/wakeWordRecovery';
+
+const base = {
+  isRecoveryTrigger: true,
+  wakeWordEnabled: true,
+  isListening: false,
+  recording: false,
+  wakeWordActivated: false,
+};
+
+describe('shouldRearmWakeWord', () => {
+  it('re-arms a stranded engine on a recovery trigger (enabled, idle, not in a turn)', () => {
+    expect(shouldRearmWakeWord(base)).toBe(true);
+  });
+
+  it('does NOT fire when it is not a recovery moment (e.g. the initial WS connect)', () => {
+    expect(shouldRearmWakeWord({ ...base, isRecoveryTrigger: false })).toBe(false);
+  });
+
+  it('does nothing when wake word is switched off', () => {
+    expect(shouldRearmWakeWord({ ...base, wakeWordEnabled: false })).toBe(false);
+  });
+
+  it('skips the happy path: engine already listening (WS blipped outside a turn)', () => {
+    // The local engine keeps running through a WS blip that is not mid-turn,
+    // so isListening stays true — resuming would be a redundant restart.
+    expect(shouldRearmWakeWord({ ...base, isListening: true })).toBe(false);
+  });
+
+  it('does not interrupt an active capture (a later edge recovers it)', () => {
+    expect(shouldRearmWakeWord({ ...base, recording: true })).toBe(false);
+  });
+
+  it('does not double-arm during a wake-word-triggered turn (latch still set)', () => {
+    // tab-visible / online fire without clearing the latch, so this guard
+    // stops a resume during the processing/TTS phase of a live turn. The
+    // WS-reconnect path clears the latch first (dead turn), so it still passes.
+    expect(shouldRearmWakeWord({ ...base, wakeWordActivated: true })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem
The browser wake-word engine (local mic + onnxruntime) gets stranded paused (`isEnabled:true`, `isListening:false`, nothing detecting, until a manual reload) when a backend `Recreate` rollout drops the chat WS mid-turn — the engine pauses on detection and only resumes on the backend's `done` frame, which never arrives once the socket is gone. Engine errors and tab/network suspend strand it the same way. This is the "doesn't listen any longer after a deploy" report.

## Fix
- Re-arm the engine on three recovery triggers: chat-WS **reconnect** (edge-triggered on `wsConnected`), **tab-visible**, **network-online**. A pure `shouldRearmWakeWord` predicate gates the resume (skips already-listening, active capture, live turn).
- On reconnect, a dead WS turn: clear the stuck spinner, finalize the half-streamed bubble, surface `errors.connectionInterrupted` — guarded on a `wsStreamingTurnRef` so a REST-fallback turn isn't falsely interrupted.
- `useWakeWord` error handler flips `isListening:false` (was stale-true) so the status dot is honest and recovery can fire; plus an in-flight start latch so simultaneous triggers can't double-start the engine.

## Tests
6 `shouldRearmWakeWord` predicate tests; existing useWakeWord (15) + ChatPage render (15) suites green. Passed `/review` (4 adversarial findings auto-fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)