### PR TITLE
fix(voice): noise read as speech — mic noise suppression + raise VAD floor

### DIFF
--- a/src/frontend/src/pages/ChatPage/hooks/useAudioRecording.ts
+++ b/src/frontend/src/pages/ChatPage/hooks/useAudioRecording.ts
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import type { AxiosError } from 'axios';
 import apiClient from '../../../utils/axios';
 import { debug } from '../../../utils/debug';
+import { VOICE_MIC_CONSTRAINTS } from './voiceAudioUtils';
 
 // VAD Configuration Constants
 const VAD_CONFIG = {
@@ -145,7 +146,10 @@ export function useAudioRecording({
 
     try {
       debug.log('Starting recording with Voice Activity Detection...');
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      // Shared VOICE_MIC_CONSTRAINTS: noiseSuppression + AGC-off keep the ambient
+      // noise floor below speech level so the VAD can detect end-of-utterance
+      // silence (raw {audio:true} let AGC push a quiet room's floor to speech level).
+      const stream = await navigator.mediaDevices.getUserMedia(VOICE_MIC_CONSTRAINTS);
       streamRef.current = stream;
       debug.log('Microphone access granted');
       debug.log('Stream Tracks:', stream.getTracks().map(t => ({

--- a/src/frontend/src/pages/ChatPage/hooks/useVoiceStream.ts
+++ b/src/frontend/src/pages/ChatPage/hooks/useVoiceStream.ts
@@ -31,7 +31,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { getWebSocketUrl } from '../../../utils/env';
 import { debug } from '../../../utils/debug';
-import { computeRms, detectBargeIn } from './voiceAudioUtils';
+import { computeRms, detectBargeIn, VOICE_MIC_CONSTRAINTS } from './voiceAudioUtils';
 
 const RFWA_MAGIC = new Uint8Array([0x52, 0x46, 0x57, 0x41]); // "RFWA"
 const HEADER_LEN = 24; // 4 magic + 16 uuid + 4 sequence
@@ -82,9 +82,22 @@ function vlog(stage: string, extra?: Record<string, unknown>): void {
 // streaming path's end-of-utterance UX matches what users learned with
 // the legacy hook. Server-side VAD also runs as a safety net (C.2).
 const VAD = {
-  SILENCE_THRESHOLD: 10,      // RMS below this counts as silence
+  // RMS below this counts as silence. Set above the measured ambient noise
+  // floor so steady background noise doesn't read as speech (which kept the
+  // recording open forever and fed Whisper garbage). Measured in a real noisy
+  // room WITH VOICE_MIC_CONSTRAINTS: suppressed floor median 12, p95 15, max 19
+  // — so 22 clears the floor with margin while staying well under speech
+  // (median ~40-54 on this scale). Sits just above BARGE_IN_RMS_THRESHOLD (20),
+  // the codebase's other "voiced" gate. Raising it further risks clipping soft
+  // speakers — MAX_RECORDING_MS is the backstop for a never-voiced session.
+  SILENCE_THRESHOLD: 22,
   SILENCE_DURATION_MS: 1500,  // total silence before auto-stop
   MIN_RECORDING_MS: 800,      // ignore silence in the first ~800 ms
+  // Hard cap so the recorder always stops client-side, even if the user is so
+  // soft/distant they never cross SILENCE_THRESHOLD (so `speechSeen` never
+  // flips and the silence branch can't fire) or the mic wedges. Server VAD
+  // also finalizes, but this keeps the client from streaming indefinitely.
+  MAX_RECORDING_MS: 20000,
   FFT_SIZE: 512,
   SMOOTHING: 0.3,
 };
@@ -539,6 +552,14 @@ export function useVoiceStream({
     ws: WebSocket,
   ): Promise<void> => {
     streamRef.current = stream;
+    // Surface whether the mic constraints actually applied — some Android/WebView
+    // builds silently ignore `autoGainControl:false`, which lets AGC push the
+    // noise floor back to speech level and revives the noise-as-speech bug on
+    // exactly those devices. Logged so it's diagnosable instead of invisible.
+    try {
+      const s = stream.getAudioTracks()[0]?.getSettings?.();
+      if (s) debug.log('voice mic settings:', { autoGainControl: s.autoGainControl, noiseSuppression: s.noiseSuppression, echoCancellation: s.echoCancellation });
+    } catch { /* getSettings unsupported — ignore */ }
     const recorder = new MediaRecorder(stream, { mimeType: VOICE_CODEC });
     recorderRef.current = recorder;
 
@@ -576,6 +597,16 @@ export function useVoiceStream({
         const rms = computeRms(a, dataArray);
         const now = Date.now();
         const recordingTime = now - recordingStart;
+
+        // Hard backstop: stop after MAX_RECORDING_MS regardless of VAD state.
+        // Covers a never-voiced session (soft/distant speaker who never crosses
+        // SILENCE_THRESHOLD, so `speechSeen` never flips and the silence branch
+        // can't fire) and a wedged mic, so the client never streams forever.
+        if (recordingTime > VAD.MAX_RECORDING_MS) {
+          try { rec.stop(); } catch { /* ignore */ }
+          vadFrameRef.current = null;
+          return;
+        }
 
         // Compute the silence-auto-stop decision every frame (cheap,
         // VAD timing precision matters), but throttle React state
@@ -680,7 +711,7 @@ export function useVoiceStream({
 
     let stream: MediaStream;
     try {
-      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      stream = await navigator.mediaDevices.getUserMedia(VOICE_MIC_CONSTRAINTS);
     } catch (e) {
       onError?.('mic_denied', e instanceof Error ? e.message : String(e));
       return;
@@ -832,9 +863,7 @@ export function useVoiceStream({
     const open = async (): Promise<void> => {
       let stream: MediaStream;
       try {
-        stream = await navigator.mediaDevices.getUserMedia({
-          audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: false },
-        });
+        stream = await navigator.mediaDevices.getUserMedia(VOICE_MIC_CONSTRAINTS);
       } catch (e) {
         // Mic permission revoked between turns — degrade silently to
         // no-barge-in for this reply (finding 3B). Mic button + wake

--- a/src/frontend/src/pages/ChatPage/hooks/voiceAudioUtils.ts
+++ b/src/frontend/src/pages/ChatPage/hooks/voiceAudioUtils.ts
@@ -8,6 +8,22 @@
  */
 
 /**
+ * Mic constraints for EVERY voice-capture path (recording, barge-in listener,
+ * speaker enrollment). Without these the raw `{audio:true}` stream runs with
+ * browser auto-gain ON, which cranks the gain on a quiet room and pushes the
+ * ambient noise floor up to speech level (measured RMS median 53 in a real
+ * room) — so the VAD never sees silence and the streamed noise is transcribed
+ * as garbage. `noiseSuppression` removes stationary background noise;
+ * `autoGainControl:false` keeps the floor down so the VAD stays meaningful.
+ * Centralized so recording, verification, and enrollment share identical
+ * acoustic preprocessing (the ECAPA speaker embedding is sensitive to a
+ * train/test mismatch between enroll and verify).
+ */
+export const VOICE_MIC_CONSTRAINTS: MediaStreamConstraints = {
+  audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: false },
+};
+
+/**
  * RMS of the analyser's current frequency-domain frame, on the 0..255
  * byte scale.
  *

--- a/src/frontend/src/pages/SpeakersPage.tsx
+++ b/src/frontend/src/pages/SpeakersPage.tsx
@@ -7,6 +7,7 @@ import {
 } from 'lucide-react';
 import { extractApiError } from '../utils/axios';
 import { useConfirmDialog } from '../components/ConfirmDialog';
+import { VOICE_MIC_CONSTRAINTS } from './ChatPage/hooks/voiceAudioUtils';
 import Modal from '../components/Modal';
 import PageHeader from '../components/PageHeader';
 import Alert from '../components/Alert';
@@ -208,7 +209,11 @@ export default function SpeakersPage() {
 
   const startRecording = async () => {
     try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      // Share VOICE_MIC_CONSTRAINTS with the recording/verify path so the ECAPA
+      // speaker embedding is enrolled on the SAME acoustic preprocessing it will
+      // be verified against (noiseSuppression + AGC-off). A raw-vs-suppressed
+      // enroll/verify mismatch widens the embedding gap and raises false rejects.
+      const stream = await navigator.mediaDevices.getUserMedia(VOICE_MIC_CONSTRAINTS);
       streamRef.current = stream;
 
       const mediaRecorder = new MediaRecorder(stream);


### PR DESCRIPTION
## Problem
Browser voice treated background noise as speech: the recording never auto-stopped and Whisper transcribed noise as garbage. Measured live in the user's noisy room.

## Root cause (two, both measured)
1. The **primary** record path opened the mic **raw** (`{audio:true}`) — no noise suppression, browser auto-gain ON. AGC cranked the room's floor to **speech level** (ambient RMS median **53**; speech median ~54). The barge-in listener already used the right constraints; the record path didn't.
2. After suppression the residual floor still measured p95 15 / max 19 — above the old `SILENCE_THRESHOLD: 10`.

## Fix
- Shared `VOICE_MIC_CONSTRAINTS` (`echoCancellation` + `noiseSuppression` + `autoGainControl:false`) on the record path, barge-in, legacy recorder, **and speaker enrollment**. Measured: floor **53 → 12**.
- `SILENCE_THRESHOLD` **10 → 22** (data-driven: above measured suppressed noise max 19, below speech ~40-54).
- Review hardening: `MAX_RECORDING_MS` (20s) client backstop for never-voiced sessions; enrollment/verify share preprocessing (ECAPA); log applied mic settings (catch WebViews that ignore AGC-off).

## Tests
48 voice/audio/speaker frontend tests green; tsc clean. Floor drop validated live (53→12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)