### PR TITLE
feat(agent): agent_system_prompt hook for plugin role-specific system prompts

### DIFF
--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -415,6 +415,35 @@ def _llm_options_or_default(prompt_key: str, fallback: dict) -> dict:
     return cfg if cfg is not None else fallback
 
 
+async def _apply_agent_system_prompt_hook(
+    json_system_message: str, role: Any, lang: str | None
+) -> str:
+    """Let a plugin prepend a role-specific system prompt to the agent's system message.
+
+    Fires the ``agent_system_prompt`` hook (``role``, ``lang``). The first
+    handler returning a non-empty string has it PREPENDED to ``json_system_message``
+    (which carries the "respond only with JSON" format directive); the full ReAct
+    format + tools live in the user-message ``agent_prompt``, so prepending adds
+    role identity without disturbing the format contract.
+
+    Fail-open by contract: with 0 handlers (e.g. standalone Renfield) the input is
+    returned unchanged — byte-identical — and any handler error is swallowed so a
+    misbehaving plugin can never break the agent loop.
+    """
+    try:
+        from utils.hooks import run_hooks
+
+        results = await run_hooks("agent_system_prompt", role=role, lang=lang)
+        role_sys = next(
+            (r for r in (results or []) if isinstance(r, str) and r.strip()), None
+        )
+        if role_sys:
+            return role_sys + "\n\n" + json_system_message
+    except Exception as e:  # pragma: no cover - defensive
+        logger.debug(f"agent_system_prompt hook skipped: {e}")
+    return json_system_message
+
+
 # Fields that contain large binary data (base64-encoded)
 _BLOB_FIELDS = {"content_base64"}
 
@@ -642,6 +671,7 @@ class AgentService:
         self.step_timeout = step_timeout or settings.agent_step_timeout
         self.total_timeout = total_timeout or settings.agent_total_timeout
         self._prompt_key = (role.prompt_key if role else None) or "agent_prompt"
+        self._role = role  # exposed to the agent_system_prompt hook (plugin role prompts)
         self._preselected_tools: dict | None = None
 
     def _should_use_native_fc(self, agent_client) -> bool:
@@ -1390,6 +1420,11 @@ class AgentService:
         llm_options = _llm_options_or_default("llm_options", _DEFAULT_LLM_OPTIONS)
         llm_options_retry = _llm_options_or_default("llm_options_retry", _DEFAULT_LLM_OPTIONS_RETRY)
         json_system_message = prompt_manager.get("agent", "json_system_message", lang=lang)
+        # Let a plugin (e.g. an edition's role-specific prompts) prepend a role
+        # system prompt. Computed once — reused at every LLM call site below.
+        json_system_message = await _apply_agent_system_prompt_hook(
+            json_system_message, getattr(self, "_role", None), lang
+        )
 
         # Native function calling — opt-in per role AND requires the agent client
         # to advertise `supports_native_tools`. Default path stays on ReAct.

--- a/src/backend/utils/hooks.py
+++ b/src/backend/utils/hooks.py
@@ -271,6 +271,13 @@ HOOK_EVENTS: frozenset[str] = frozenset({
     # Return value is ignored; exceptions are caught (run_hooks) so a faulty
     # filter degrades to the unfiltered registry rather than breaking the turn.
     "filter_agent_tools",
+    # Role-specific system prompt for the MAIN agent loop — fired by
+    # AgentService once per request (where the JSON system message is built),
+    # with the classified `role` and `lang` in scope. A handler returns a
+    # string to PREPEND to the system message (e.g. an edition's role-specific
+    # prompt), or None. Renfield does not ship a handler; the default is
+    # byte-identical. Symmetric, for the system prompt, to filter_agent_tools.
+    "agent_system_prompt",
     "check_output",
     "extract_context_vars",
     "build_synthesis_context",

--- a/tests/backend/test_agent_system_prompt_hook.py
+++ b/tests/backend/test_agent_system_prompt_hook.py
@@ -1,0 +1,81 @@
+"""Tests for the `agent_system_prompt` hook seam (services.agent_service).
+
+Lets a plugin (e.g. an edition's role-specific prompts) prepend a role system
+prompt to the agent's JSON system message. Contract:
+  - 0 handlers  → byte-identical (standalone Renfield unchanged)
+  - 1st non-empty string handler result → prepended ("<role>\\n\\n<base>")
+  - None / blank / raising handlers → ignored (fail-open)
+"""
+
+import asyncio
+
+import pytest
+
+from utils.hooks import clear_hooks, register_hook
+from services.agent_service import _apply_agent_system_prompt_hook
+
+_BASE = "Antworte nur mit JSON."
+
+
+@pytest.fixture(autouse=True)
+def _isolate_hooks():
+    clear_hooks()
+    yield
+    clear_hooks()
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_no_handler_is_byte_identical():
+    out = _run(_apply_agent_system_prompt_hook(_BASE, role="release", lang="de"))
+    assert out == _BASE
+
+
+def test_handler_prepends_and_preserves_json_directive():
+    async def handler(role=None, lang=None, **kw):
+        return f"ROLE-SYS::{role}::{lang}"
+
+    register_hook("agent_system_prompt", handler)
+    out = _run(_apply_agent_system_prompt_hook(_BASE, role="advisor", lang="en"))
+    assert out == "ROLE-SYS::advisor::en\n\n" + _BASE
+    assert out.endswith(_BASE)  # the JSON format directive survives
+
+
+def test_none_result_keeps_base():
+    async def handler(**kw):
+        return None
+
+    register_hook("agent_system_prompt", handler)
+    assert _run(_apply_agent_system_prompt_hook(_BASE, role="release", lang="de")) == _BASE
+
+
+def test_blank_result_keeps_base():
+    async def handler(**kw):
+        return "   "
+
+    register_hook("agent_system_prompt", handler)
+    assert _run(_apply_agent_system_prompt_hook(_BASE, role="release", lang="de")) == _BASE
+
+
+def test_raising_handler_is_fail_open():
+    async def handler(**kw):
+        raise RuntimeError("boom")
+
+    register_hook("agent_system_prompt", handler)
+    # run_hooks swallows handler errors → no result → base returned unchanged.
+    assert _run(_apply_agent_system_prompt_hook(_BASE, role="release", lang="de")) == _BASE
+
+
+def test_first_nonempty_result_wins():
+    async def h_none(**kw):
+        return None
+
+    async def h_str(**kw):
+        return "FIRST"
+
+    register_hook("agent_system_prompt", h_none)
+    register_hook("agent_system_prompt", h_str)
+    out = _run(_apply_agent_system_prompt_hook(_BASE, role="x", lang="de"))
+    assert out == "FIRST\n\n" + _BASE

--- a/tests/backend/test_hooks.py
+++ b/tests/backend/test_hooks.py
@@ -50,6 +50,7 @@ def test_uplift_events_are_registerable():
         "post_sub_agent",
         "check_output",
         "filter_agent_tools",
+        "agent_system_prompt",
     }
     missing = uplift_events - HOOK_EVENTS
     assert not missing, (


### PR DESCRIPTION
## What

Adds an `agent_system_prompt` hook to `AgentService` so a plugin (e.g. an edition layer) can supply a **role-specific system prompt** to the main web agent loop. Without it, every role uses the generic `agent_prompt`.

Fired **once per request** where the JSON system message is built (`agent_service.py`), with the classified `role` + `lang`. A handler returns a string that is **prepended** to `json_system_message`; the full ReAct format + tools stay in the user-message `agent_prompt`, so prepending adds role identity without disturbing the format contract. This is the system-prompt twin of the existing `filter_agent_tools` seam.

## Why

An edition plugin (Reva) needs web-chat to use its role-specific prompts (identity, GDPR framing, tool hints) instead of the generic prompt — closing a Teams/web "path divergence" gap where web silently behaved differently from the Teams loop.

## Contract / safety

- **Fail-open:** 0 handlers (standalone Renfield) → input returned unchanged, **byte-identical**. Any handler error is swallowed (`run_hooks` already never raises) so a misbehaving plugin can't break the agent loop.
- **First non-empty string wins;** `None`/blank results are ignored.
- `agent_system_prompt` is **forward-declared in `HOOK_EVENTS`** (like `check_output`/`filter_agent_tools`) so plugins can register the handler even though Renfield ships none — without this, a plugin's `register_hook` would `ValueError` at bootstrap.

## Changes
- `utils/hooks.py`: declare `agent_system_prompt` in `HOOK_EVENTS`.
- `services/agent_service.py`: `_apply_agent_system_prompt_hook()` helper (unit-testable) + `self._role` stash + one call at the `json_system_message` build site (reused by both LLM call sites).
- `tests/backend/test_agent_system_prompt_hook.py`: 6 contract tests (prepend, None/blank/raising → unchanged, first-non-empty-wins, 0-handlers byte-identical).
- `tests/backend/test_hooks.py`: `agent_system_prompt` added to the uplift-registerability guard.

## Test evidence
Full backend suite run on the `.159` test box against this branch vs. a clean `f7063cf` baseline (same env): **identical failing-node-ID sets (1412 each), zero regressions**, branch has **+6 passed** (the new tests). The pre-existing failures/errors are environment skew (no Ollama/MCP services + older DB migration), identical on both sides. CI on `.159` will run the suite in a properly-migrated env as the final gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)