### PR TITLE
feat(plugins): support multiple startup plugin modules (PLUGIN_MODULES)

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -1457,20 +1457,27 @@ EVOLUTION_API_URL=http://evolution-api:8080
 
 ## Hook / Extension System
 
-Das Hook-System ermöglicht externen Paketen (z.B. `renfield-twin`) sich an definierten Lifecycle-Stellen einzuhängen, ohne dass renfield eine Abhängigkeit zum Plugin hat.
+Das Hook-System ermöglicht externen Paketen, sich an definierten Lifecycle-Stellen einzuhängen, ohne dass renfield eine Abhängigkeit zum Plugin hat.
 
 ```bash
-# Entry-Point für Hook-basierte Extensions
-# Format: "package.module:callable" — wird beim Startup aufgerufen
-# Leer = deaktiviert (Standard)
+# Entry-Point für eine Hook-basierte Extension.
+# Format: "package.module:callable" — wird beim Startup aufgerufen.
+# Leer = deaktiviert (Standard).
 PLUGIN_MODULE=
 
-# Beispiel: renfield-twin Extension
-PLUGIN_MODULE=renfield_twin.hooks:register
+# Mehrere Extensions: komma-separierte Liste von "package.module:callable".
+# Wird nach PLUGIN_MODULE geladen und dedupliziert; ein fehlerhaftes Plugin
+# wird geloggt und übersprungen, bricht den Startup also nicht ab.
+PLUGIN_MODULES=
+
+# Beispiele
+PLUGIN_MODULE=example_pkg.plugin:register
+PLUGIN_MODULES=pkg_a.plugin:register,pkg_b.plugin:register
 ```
 
 **Defaults:**
 - `PLUGIN_MODULE`: `""` (deaktiviert)
+- `PLUGIN_MODULES`: `""` (deaktiviert)
 
 **Hook Events:** `startup`, `shutdown`, `register_routes`, `register_tools`, `post_message`, `retrieve_context`
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -841,7 +841,10 @@ Async Hook-System für die Open-Core-Architektur. Externe Pakete registrieren Ca
 
 **Aktivierung:**
 ```bash
-PLUGIN_MODULE=renfield_twin.hooks:register
+# Ein Plugin:
+PLUGIN_MODULE=example_pkg.plugin:register
+# Mehrere (komma-separiert, dedupliziert, fehlertolerant):
+PLUGIN_MODULES=pkg_a.plugin:register,pkg_b.plugin:register
 ```
 
 **Verfügbare Hook Events:**

--- a/src/backend/api/lifecycle.py
+++ b/src/backend/api/lifecycle.py
@@ -836,16 +836,13 @@ async def _cancel_startup_tasks():
 # to connected devices.
 
 
-async def _load_plugin_module():
-    """Load the plugin module specified in settings.plugin_module.
+async def _load_one_plugin(spec: str):
+    """Load and invoke a single plugin spec.
 
     Format: "package.module:callable" — the callable receives no args
     and is expected to call register_hook() for the events it cares about.
+    A failing plugin is logged and swallowed so it cannot crash startup.
     """
-    spec = settings.plugin_module
-    if not spec:
-        return
-
     try:
         import importlib
 
@@ -866,6 +863,27 @@ async def _load_plugin_module():
         logger.info(f"Plugin module loaded: {spec}")
     except Exception:
         logger.opt(exception=True).error(f"Failed to load plugin module: {spec}")
+
+
+async def _load_plugin_module():
+    """Load all configured startup plugins.
+
+    Sources, in order: settings.plugin_module (singular, backward-compat) then
+    settings.plugin_modules (a comma-separated list of "module:callable"
+    entries). Entries are deduped so the same spec is invoked only once even if
+    it appears in both. Each is loaded independently — one failing plugin is
+    logged and skipped, never crashing startup.
+    """
+    specs: list[str] = []
+    seen: set[str] = set()
+    for raw in [settings.plugin_module, *settings.plugin_modules.split(",")]:
+        spec = raw.strip()
+        if spec and spec not in seen:
+            seen.add(spec)
+            specs.append(spec)
+
+    for spec in specs:
+        await _load_one_plugin(spec)
 
 
 @asynccontextmanager

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -619,6 +619,10 @@ class Settings(BaseSettings):
 
     # === Plugin / Extension System ===
     plugin_module: str = ""  # e.g. "renfield_twin.hooks:register"
+    # Comma-separated list of additional "module:callable" startup plugins,
+    # e.g. "renfield_twin.hooks:register,other_pkg.mod:init". Loaded in order
+    # after plugin_module; duplicates across both are deduped.
+    plugin_modules: str = ""
 
     # === Authentication ===
     # Set to True to enable authentication (default: False for development)

--- a/tests/backend/test_plugin_modules_loader.py
+++ b/tests/backend/test_plugin_modules_loader.py
@@ -1,0 +1,130 @@
+"""Unit tests for the multi-plugin startup loader (``api.lifecycle._load_plugin_module``).
+
+Renfield supports a single startup plugin via ``PLUGIN_MODULE`` and a
+comma-separated list via ``PLUGIN_MODULES``. The loader must invoke each
+configured ``module:callable`` exactly once, dedupe entries that appear in
+both settings, and swallow a failing plugin so it never crashes startup.
+
+The import mechanism is monkeypatched so the test is hermetic — no real
+plugin modules are needed.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from api import lifecycle
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+@pytest.fixture
+def fake_modules(monkeypatch):
+    """Patch ``importlib.import_module`` to resolve named fake modules.
+
+    Returns a dict ``{module_path: SimpleNamespace}`` whose attributes are the
+    callables the loader will invoke. Tests register callables onto these.
+    """
+    registry: dict[str, SimpleNamespace] = {}
+
+    def fake_import(module_path: str):
+        if module_path not in registry:
+            raise ImportError(f"no fake module {module_path}")
+        return registry[module_path]
+
+    import importlib
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    return registry
+
+
+def _set_settings(monkeypatch, *, plugin_module: str = "", plugin_modules: str = ""):
+    monkeypatch.setattr(
+        lifecycle.settings, "plugin_module", plugin_module, raising=False
+    )
+    monkeypatch.setattr(
+        lifecycle.settings, "plugin_modules", plugin_modules, raising=False
+    )
+
+
+async def test_plugin_modules_invokes_each_once(fake_modules, monkeypatch):
+    reg1, reg2 = MagicMock(), MagicMock()
+    fake_modules["a.b"] = SimpleNamespace(reg1=reg1)
+    fake_modules["c.d"] = SimpleNamespace(reg2=reg2)
+
+    _set_settings(monkeypatch, plugin_modules="a.b:reg1,c.d:reg2")
+
+    await lifecycle._load_plugin_module()
+
+    reg1.assert_called_once_with()
+    reg2.assert_called_once_with()
+
+
+async def test_plugin_module_singular_still_works(fake_modules, monkeypatch):
+    register = MagicMock()
+    fake_modules["only.one"] = SimpleNamespace(register=register)
+
+    _set_settings(monkeypatch, plugin_module="only.one:register")
+
+    await lifecycle._load_plugin_module()
+
+    register.assert_called_once_with()
+
+
+async def test_both_set_dedupes(fake_modules, monkeypatch):
+    shared = MagicMock()
+    extra = MagicMock()
+    fake_modules["dup.mod"] = SimpleNamespace(reg=shared)
+    fake_modules["other.mod"] = SimpleNamespace(init=extra)
+
+    # Same spec in both singular and the list — must run once.
+    _set_settings(
+        monkeypatch,
+        plugin_module="dup.mod:reg",
+        plugin_modules="dup.mod:reg,other.mod:init",
+    )
+
+    await lifecycle._load_plugin_module()
+
+    shared.assert_called_once_with()
+    extra.assert_called_once_with()
+
+
+async def test_failing_plugin_does_not_crash_and_others_load(fake_modules, monkeypatch):
+    good = MagicMock()
+    boom = MagicMock(side_effect=RuntimeError("kaboom"))
+    fake_modules["good.mod"] = SimpleNamespace(reg=good)
+    fake_modules["bad.mod"] = SimpleNamespace(reg=boom)
+    # "missing.mod" is intentionally NOT registered → ImportError.
+
+    _set_settings(
+        monkeypatch,
+        plugin_modules="bad.mod:reg,missing.mod:reg,good.mod:reg",
+    )
+
+    # Must not raise despite a raising callable and an unimportable module.
+    await lifecycle._load_plugin_module()
+
+    boom.assert_called_once_with()
+    good.assert_called_once_with()
+
+
+async def test_async_register_callable_is_awaited(fake_modules, monkeypatch):
+    from unittest.mock import AsyncMock
+
+    areg = AsyncMock()
+    fake_modules["async.mod"] = SimpleNamespace(register=areg)
+
+    _set_settings(monkeypatch, plugin_modules="async.mod:register")
+
+    await lifecycle._load_plugin_module()
+
+    areg.assert_awaited_once_with()
+
+
+async def test_empty_settings_is_noop(fake_modules, monkeypatch):
+    _set_settings(monkeypatch, plugin_module="", plugin_modules="")
+    # No modules registered; should simply do nothing without error.
+    await lifecycle._load_plugin_module()


### PR DESCRIPTION
## What
Extends the single `PLUGIN_MODULE` startup loader to also accept **`PLUGIN_MODULES`** — a comma-separated list of `module:callable` specs.

- Loaded in order, after `PLUGIN_MODULE`.
- Deduped against `PLUGIN_MODULE` (an entry in both is invoked once).
- Each plugin is isolated: one failing/​unimportable plugin logs and continues — it never crashes startup (same failure behavior as the existing single loader).

## Why
Lets more than one in-process plugin run side by side (today the loader is single-slot). No behavior change when only `PLUGIN_MODULE` is set.

## Tests
`tests/backend/test_plugin_modules_loader.py` (6, `@pytest.mark.unit`, hermetic — monkeypatches `importlib`): both list entries invoked once; singular still works; both-set dedupes; a raising callable + an unimportable module don't crash and later plugins still load; async register awaited; empty settings is a no-op. Green on the `.159` runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)