### PR TITLE
fix: media/presence/radio reliability (follow-me, handoff import, tool-preselect prereqs)

### DIFF
--- a/src/backend/ha_glue/services/internal_tools.py
+++ b/src/backend/ha_glue/services/internal_tools.py
@@ -581,11 +581,17 @@ class InternalToolService:
             rid = await self._get_room_id(room_name)
             if rid is None:
                 return
-            # Session owner = the authenticated chat caller when present;
-            # otherwise derive it from presence (whoever is in the playback
-            # room). Without this fallback, AUTH-disabled playback has
-            # user_id=None → no session is registered → leaving never stops the
-            # music, even though presence_leave_room fires with the real user.
+            # Session owner: in practice always the presence-resolved occupant of
+            # the playback room. `params` never carries a user_id today (the
+            # dispatcher passes it as a kwarg, not in params, and the LLM tool
+            # schema has no user_id arg), so the `or` first operand is currently
+            # inert — kept only for a future authenticated-caller path. Without
+            # the presence fallback, AUTH-disabled playback has user_id=None → no
+            # session registered → leaving never stops the music, even though
+            # presence_leave_room fires with that same presence-resolved user.
+            # Caveat: presence is BLE-cadence (~30-60s), so "play then walk away
+            # immediately" may register no session if the scan hasn't yet placed
+            # the user in the room; >1 occupants → None (no follow, by design).
             user_id = params.get("user_id") or self._presence_room_user(rid)
             if not user_id:
                 return

--- a/src/backend/ha_glue/services/internal_tools.py
+++ b/src/backend/ha_glue/services/internal_tools.py
@@ -549,6 +549,26 @@ class InternalToolService:
             logger.error(f"Error announcing in room '{room_name}': {e}")
             return {"success": False, "message": f"Error announcing: {e!s}", "action_taken": False}
 
+    def _presence_room_user(self, room_id: int) -> int | None:
+        """The single user presence currently places in ``room_id``, else None.
+
+        Used to attribute a media session when there is no authenticated chat
+        user (AUTH disabled / single-user mode) — Media Follow Me keys sessions
+        on user_id and presence_leave_room fires with the presence-resolved
+        user_id, so the playback side must agree. Returns None when the room has
+        zero or ambiguous (>1) occupants, so we never attribute (and later stop)
+        the wrong person's music.
+        """
+        try:
+            from ha_glue.services.presence_service import get_presence_service
+
+            occupants = get_presence_service().get_room_occupants(room_id)
+            if len(occupants) == 1:
+                return occupants[0].user_id
+            return None
+        except Exception:
+            return None
+
     async def _register_media_follow(
         self, params: dict, room_name: str, media_type, **kwargs
     ) -> None:
@@ -557,25 +577,32 @@ class InternalToolService:
 
         if not _settings.media_follow_enabled:
             return
-        user_id = params.get("user_id")
-        if not user_id:
-            return
         try:
+            rid = await self._get_room_id(room_name)
+            if rid is None:
+                return
+            # Session owner = the authenticated chat caller when present;
+            # otherwise derive it from presence (whoever is in the playback
+            # room). Without this fallback, AUTH-disabled playback has
+            # user_id=None → no session is registered → leaving never stops the
+            # music, even though presence_leave_room fires with the real user.
+            user_id = params.get("user_id") or self._presence_room_user(rid)
+            if not user_id:
+                return
+
             from ha_glue.services.media_follow_service import MediaType, get_media_follow_service
 
             mf = get_media_follow_service()
             # Convert string to enum if needed
             if isinstance(media_type, str):
                 media_type = MediaType(media_type)
-            rid = await self._get_room_id(room_name)
-            if rid is not None:
-                mf.register_playback(
-                    user_id=int(user_id),
-                    room_id=rid,
-                    room_name=room_name,
-                    media_type=media_type,
-                    **kwargs,
-                )
+            mf.register_playback(
+                user_id=int(user_id),
+                room_id=rid,
+                room_name=room_name,
+                media_type=media_type,
+                **kwargs,
+            )
         except Exception as e:
             logger.debug(f"Media follow registration failed: {e}")
 

--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -402,6 +402,32 @@ _DEFAULT_LLM_OPTIONS_TOOL_PRESELECT = {
     "temperature": 0, "num_predict": 120, "num_ctx": 4096,
 }
 
+# Hard workflow prerequisites: a tool the pre-selection LLM may pick cannot
+# function without its companion(s), so they are re-added even when the LLM
+# prunes them. STRUCTURAL dependencies, not preferences: internal.play_radio
+# plays a TuneIn station_id that ONLY mcp.radio.search_stations can resolve —
+# drop the search tool and the agent guesses an id and loops.
+_REQUIRED_TOOL_COMPANIONS: dict[str, tuple[str, ...]] = {
+    "internal.play_radio": ("mcp.radio.search_stations",),
+}
+
+
+def _with_required_companions(selected_names: list[str]) -> list[str]:
+    """Expand a selected-tool-name list with the structural prerequisites of any
+    selected tool (see ``_REQUIRED_TOOL_COMPANIONS``). Pure, order-stable, and
+    dedup-safe — unknown tools are untouched. Filtering to actually-available
+    tools happens at the call site, so naming a companion that the current role
+    lacks is harmless.
+    """
+    out = list(selected_names)
+    seen = set(out)
+    for name in selected_names:
+        for companion in _REQUIRED_TOOL_COMPANIONS.get(name, ()):
+            if companion not in seen:
+                out.append(companion)
+                seen.add(companion)
+    return out
+
 
 def _llm_options_or_default(prompt_key: str, fallback: dict) -> dict:
     """Resolve LLM options from prompts/agent.yaml, falling back to a default.
@@ -817,6 +843,11 @@ class AgentService:
             if not isinstance(selected, list) or not selected:
                 logger.warning(f"Tool pre-selection returned non-list: {response_text[:100]}")
                 return None
+
+            # Re-add any structural prerequisites the LLM pruned (e.g. it picked
+            # internal.play_radio but dropped mcp.radio.search_stations, which it
+            # needs to resolve the station_id). Filtered against the registry below.
+            selected = _with_required_companions(selected)
 
             # Filter to valid tool names
             filtered = {

--- a/src/backend/services/conversation_handoff.py
+++ b/src/backend/services/conversation_handoff.py
@@ -141,7 +141,11 @@ async def on_presence_enter_room(**kwargs) -> None:
     """Hook listener for presence_enter_room — triggers handoff when speaker moves rooms."""
     from datetime import date
 
-    from models.database import AsyncSessionLocal
+    # AsyncSessionLocal lives in services.database. The old
+    # `from models.database import AsyncSessionLocal` raised ImportError on EVERY
+    # room change — and it sits OUTSIDE the try below, so it escaped the handler
+    # and surfaced as "Hook on_presence_enter_room failed" in run_hooks.
+    from services.database import AsyncSessionLocal
 
     user_id = kwargs.get("user_id")
     satellite_id = kwargs.get("satellite_id")

--- a/tests/backend/test_agent_service.py
+++ b/tests/backend/test_agent_service.py
@@ -2388,3 +2388,31 @@ class TestTrajectoryStepRecording:
                       tool="x", success=True),
         ]
         assert outcome_from_steps(steps) == TRAJECTORY_OUTCOME_ABORT
+
+
+# ---------------------------------------------------------------------------
+# Tool pre-selection: structural companion re-inclusion
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_with_required_companions_readds_radio_search():
+    """play_radio's station_id is unknowable without search_stations, so the
+    pre-selection must never end up with play_radio but no search tool."""
+    from services.agent_service import _with_required_companions
+
+    out = _with_required_companions(["internal.resolve_room_player", "internal.play_radio"])
+    assert "mcp.radio.search_stations" in out
+    # order-stable: companion appended, originals kept in order
+    assert out[:2] == ["internal.resolve_room_player", "internal.play_radio"]
+
+
+@pytest.mark.unit
+def test_with_required_companions_is_dedup_safe_and_inert():
+    from services.agent_service import _with_required_companions
+
+    # already present → no duplicate
+    out = _with_required_companions(["internal.play_radio", "mcp.radio.search_stations"])
+    assert out.count("mcp.radio.search_stations") == 1
+    # unrelated tools untouched
+    assert _with_required_companions(["internal.media_control"]) == ["internal.media_control"]
+    assert _with_required_companions([]) == []

--- a/tests/backend/test_conversation_handoff.py
+++ b/tests/backend/test_conversation_handoff.py
@@ -274,3 +274,15 @@ async def test_handoff_auth_disabled_speaker_only(db_session):
     assert target.speaker_id == 5
     assert target.user_id is None
     assert target.context_vars == {"topic": "no-auth"}
+
+
+@pytest.mark.unit
+async def test_on_presence_enter_room_session_import_resolves():
+    """Regression: on_presence_enter_room imported AsyncSessionLocal from
+    models.database (wrong → ImportError on EVERY room change, escaping the
+    handler to run_hooks). The import sits above the satellite_id guard, so a
+    call with no satellite_id still executes it — returning without raising
+    proves it now resolves from services.database."""
+    from services.conversation_handoff import on_presence_enter_room
+    # no satellite_id → early return, but only AFTER the import line has run
+    await on_presence_enter_room(user_id=2, room_name="Arbeitszimmer")

--- a/tests/backend/test_internal_tools.py
+++ b/tests/backend/test_internal_tools.py
@@ -3672,3 +3672,68 @@ class TestAnnounceInRoom:
             })
         assert result["success"] is True
         deps.audio.play_audio.assert_awaited_once()
+
+
+# ============================================================================
+# Media Follow Me — presence-derived session owner (option A)
+# ============================================================================
+
+class TestRegisterMediaFollowPresenceFallback:
+    """When playback has no authenticated chat user (AUTH disabled), the follow
+    session must be attributed to the user presence places in the playback room
+    — the SAME user_id that presence_leave_room later fires with — so leaving
+    actually stops the music."""
+
+    @pytest.mark.unit
+    def test_presence_room_user_single_vs_ambiguous(self, internal_tools, monkeypatch):
+        from types import SimpleNamespace
+        import ha_glue.services.presence_service as ps
+
+        class _PS:
+            def __init__(self, occ): self._occ = occ
+            def get_room_occupants(self, _rid): return self._occ
+
+        monkeypatch.setattr(ps, "get_presence_service", lambda: _PS([SimpleNamespace(user_id=7)]))
+        assert internal_tools._presence_room_user(2) == 7
+        # >1 occupant → ambiguous → None (never attribute the wrong person)
+        monkeypatch.setattr(ps, "get_presence_service",
+                            lambda: _PS([SimpleNamespace(user_id=7), SimpleNamespace(user_id=8)]))
+        assert internal_tools._presence_room_user(2) is None
+        # empty room → None
+        monkeypatch.setattr(ps, "get_presence_service", lambda: _PS([]))
+        assert internal_tools._presence_room_user(2) is None
+
+    def _wire(self, internal_tools, monkeypatch, presence_user, captured):
+        from ha_glue.utils.config import ha_glue_settings
+        import ha_glue.services.media_follow_service as mfs
+        monkeypatch.setattr(ha_glue_settings, "media_follow_enabled", True)
+        monkeypatch.setattr(internal_tools, "_get_room_id", AsyncMock(return_value=2))
+        monkeypatch.setattr(internal_tools, "_presence_room_user", lambda rid: presence_user)
+
+        class _MF:
+            def register_playback(self, **kw): captured.update(kw)
+
+        monkeypatch.setattr(mfs, "get_media_follow_service", lambda: _MF())
+
+    @pytest.mark.unit
+    async def test_falls_back_to_presence_room_user(self, internal_tools, monkeypatch):
+        captured: dict = {}
+        self._wire(internal_tools, monkeypatch, presence_user=7, captured=captured)
+        await internal_tools._register_media_follow({"user_id": None}, "Arbeitszimmer", "radio")
+        assert captured.get("user_id") == 7
+        assert captured.get("room_id") == 2
+        assert captured.get("room_name") == "Arbeitszimmer"
+
+    @pytest.mark.unit
+    async def test_chat_user_id_wins_over_presence(self, internal_tools, monkeypatch):
+        captured: dict = {}
+        self._wire(internal_tools, monkeypatch, presence_user=99, captured=captured)
+        await internal_tools._register_media_follow({"user_id": 5}, "Arbeitszimmer", "radio")
+        assert captured.get("user_id") == 5  # authenticated caller wins
+
+    @pytest.mark.unit
+    async def test_skips_when_no_user_resolvable(self, internal_tools, monkeypatch):
+        captured: dict = {}
+        self._wire(internal_tools, monkeypatch, presence_user=None, captured=captured)
+        await internal_tools._register_media_follow({"user_id": None}, "Arbeitszimmer", "radio")
+        assert captured == {}  # nothing registered (empty/ambiguous room)


### PR DESCRIPTION
Three related media/presence reliability fixes.

### 1. Media Follow Me never stopped music on leave (AUTH_ENABLED=false)
Chat playback runs `user_id=None` in single-user mode → `_register_media_follow` bailed, no follow session created, while `presence_leave_room` fires with the real device-mapped user. Now the session is attributed to the single user **presence places in the playback room** (`_presence_room_user`), matching the leave event. Ambiguous/empty rooms register nothing.

### 2. conversation_handoff hook error on every room change
`on_presence_enter_room` imported `AsyncSessionLocal` from `models.database` (moved to `services.database`) → `ImportError` above the try → `Hook ... failed` every room change. Fixed the import (live-verified: 0 since deploy).

### 3. Radio looped on a guessed station id ("ich habe keine Such-Tools")
The LLM tool pre-selection sometimes pruned `mcp.radio.search_stations` while keeping `internal.play_radio`, so the agent couldn't resolve the station_id and looped. Added `_REQUIRED_TOOL_COMPANIONS` + a pure `_with_required_companions()` that re-adds a tool's **structural prerequisites** after pre-selection (filtered against the registry).

## Tests
4 media-follow presence-fallback + 1 handoff import regression + 2 companion-expansion — green on .159. Deployed: media-follow/handoff in v2.17.9; radio fix in v2.17.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)