### PR TITLE
fix(satellite): make OTA-via-UI work — bundle source + source-derived version

### DIFF
--- a/.claude/skills/deploy-production/SKILL.md
+++ b/.claude/skills/deploy-production/SKILL.md
@@ -70,6 +70,18 @@ rsync -avz --delete \
 # Rsync wakeword models INTO the backend build context (Dockerfile COPYs ./wakeword-models)
 rsync -avz \
   data/wakeword-models/ evdb@192.168.1.159:/tmp/renfield-build-vX.Y.Z/src/backend/wakeword-models/
+
+# Rsync the satellite source INTO the backend build context (Dockerfile COPYs ./satellite).
+# Bundled so the OTA update service can build /api/satellites/update-package AND so
+# get_latest_version reads __version__ from it (the advertised version can't drift from
+# the shipped package). Without this the OTA UI 503s — see references/satellite-deploy.md.
+# Exclude provisioning/ (gitignored ansible inventory with real household IPs — must not
+# be baked into the image) and tests/ — only renfield_satellite/ + requirements.txt +
+# setup.py are packaged by build_update_package anyway.
+rsync -avz --delete \
+  --exclude='__pycache__' --exclude='*.pyc' --exclude='.pytest_cache' \
+  --exclude='provisioning' --exclude='tests' \
+  src/satellite/ evdb@192.168.1.159:/tmp/renfield-build-vX.Y.Z/src/backend/satellite/
 ```
 
 ### Step 2 — On .159, build + push
@@ -361,8 +373,8 @@ curl -sI http://renfield.local/          # 308 → https
 
 1. ✅ Merge release commits into `main` (PR review done).
 2. ✅ Tag `vX.Y.Z` locally + push tag + create GitHub release.
-3. ✅ rsync `src/backend`, `src/frontend`, `data/wakeword-models` to `/tmp/renfield-build-vX.Y.Z` on .159 (the model dir lands INSIDE the backend build context as `wakeword-models/`).
-4. ✅ Verify staging — `Dockerfile`, `.dockerignore`, `wakeword-models/` (~9 files) all present; `config/mcp_servers.yaml` etc. NOT present (else the configmap mount breaks).
+3. ✅ rsync `src/backend`, `src/frontend`, `data/wakeword-models`, `src/satellite` to `/tmp/renfield-build-vX.Y.Z` on .159 (the model dir lands INSIDE the backend build context as `wakeword-models/`; the satellite source as `satellite/` — bundled for the OTA update package).
+4. ✅ Verify staging — `Dockerfile`, `.dockerignore`, `wakeword-models/` (~9 files), `satellite/renfield_satellite/__init__.py` all present; `config/mcp_servers.yaml` etc. NOT present (else the configmap mount breaks).
 5. ✅ Build backend (long if requirements.txt changed) and frontend (fast); build voice-server ONLY if `voice-server/` changed (its own `v0.1.x` tag).
 6. ✅ Push `:latest` + the pinned tag for each image built — verify each `digest:` line in the push output.
 7. ✅ Roll out: `rollout restart` backend, dlna-mcp, document-worker; `kubectl set image` for frontend (and voice-server if rebuilt) — both run pinned tags, so `rollout restart` is a no-op for them.

--- a/docs/SATELLITE_OTA_UPDATES.md
+++ b/docs/SATELLITE_OTA_UPDATES.md
@@ -43,12 +43,25 @@ Over-the-Air (OTA) Updates für Renfield Satellites ermöglichen die Aktualisier
 
 ### Backend
 
-In `.env` die neueste verfügbare Version setzen:
+Die "neueste verfügbare Version" wird **aus der gebündelten Satellite-Quelle gelesen**
+(`__version__` in `renfield_satellite/__init__.py`) — nicht aus einer separaten
+Variable. Das Backend-Image bündelt die Satellite-Quelle nach `/app/satellite`
+(Dockerfile `COPY satellite /app/satellite`; die Quelle wird beim Build aus
+`src/satellite/` in den Build-Context gesynct — siehe `deploy-production` Skill),
+und `SatelliteUpdateService.get_latest_version()` liest die Version daraus. Dadurch
+kann die angebotene Version nie von dem tatsächlich ausgelieferten Paket abweichen.
+Ein neues Satellite-Release = `__version__` im Satellite-Repo erhöhen, Backend neu
+bauen — kein Env-Bump nötig.
 
 ```bash
-# Satellite OTA Updates
-SATELLITE_LATEST_VERSION=1.1.0
+# Optionaler Fallback NUR falls die Quelle nicht gebündelt ist (lokale Dev /
+# abgespecktes Image). Wird ignoriert, sobald /app/satellite vorhanden ist.
+SATELLITE_LATEST_VERSION=1.4.0
 ```
+
+> **Wichtig:** Ohne die gebündelte Quelle liefert `GET /api/satellites/update-package`
+> einen 503 (kein Paket baubar). Der Build bricht laut ab, wenn `src/satellite/`
+> nicht in den Build-Context gesynct wurde (Dockerfile-Assertion).
 
 ### Satellite
 

--- a/src/backend/.dockerignore
+++ b/src/backend/.dockerignore
@@ -28,3 +28,11 @@ htmlcov
 # Virtualenvs shouldn't leak into the image.
 .venv
 venv
+
+# The satellite source is synced into the build context as satellite/ and COPY'd
+# into the image for the OTA update package (build_update_package only needs
+# renfield_satellite/ + requirements.txt + setup.py). Keep the gitignored ansible
+# inventory (real household IPs/hostnames) and the satellite test suite OUT of the
+# image regardless of what the rsync left in the context.
+satellite/provisioning
+satellite/tests

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -180,6 +180,22 @@ COPY . .
 # the backend sources (synced from the repo's data/wakeword-models/ at build time).
 COPY wakeword-models /app/wakeword-models
 
+# Satellite source — bundled so the OTA update service can build update packages
+# (SatelliteUpdateService.build_update_package reads /app/satellite, and
+# get_latest_version reads its __version__). Without this the
+# /api/satellites/update-package endpoint 503s and the UI can't push updates.
+# Synced into the backend build context from the repo's src/satellite/ at build
+# time (the build context is src/backend/, like wakeword-models above).
+COPY satellite /app/satellite
+
+# Fail the build LOUDLY if the bundled source is missing or truncated (a partial
+# rsync would otherwise let COPY succeed, then silently degrade: get_latest_version
+# falls back to config and build_update_package would tar a corrupt tree). Assert
+# the package entrypoint exists and carries a parseable __version__.
+RUN test -f /app/satellite/renfield_satellite/__init__.py \
+    && grep -Eq '^__version__\s*=\s*["'"'"'][0-9]+(\.[0-9]+)*["'"'"']' /app/satellite/renfield_satellite/__init__.py \
+    || (echo "ERROR: /app/satellite missing or has no parseable __version__ — was src/satellite/ rsynced into the build context?" && exit 1)
+
 # Create non-root user for security
 RUN useradd --create-home --shell /bin/bash appuser \
     && chown -R appuser:appuser /app

--- a/src/backend/ha_glue/api/routes/satellites.py
+++ b/src/backend/ha_glue/api/routes/satellites.py
@@ -15,6 +15,7 @@ from models.database import User
 from models.permissions import Permission
 from services.auth_service import require_permission
 from ha_glue.services.satellite_manager import get_satellite_manager
+from ha_glue.services.satellite_update_service import get_satellite_update_service
 from utils.config import settings
 from ha_glue.utils.config import ha_glue_settings
 
@@ -168,9 +169,10 @@ def _satellite_to_response(sat_id: str, sat_data: dict[str, Any]) -> SatelliteRe
                 transcription=session.transcription
             )
 
-    # Get version info
+    # Get version info. Single source of truth = the update service (reads the
+    # bundled satellite source), so this list view and /versions never disagree.
     version = sat_data.get("version", "unknown")
-    update_available = _is_update_available(version, ha_glue_settings.satellite_latest_version)
+    update_available = _is_update_available(version, get_satellite_update_service().get_latest_version())
 
     return SatelliteResponse(
         satellite_id=sat_id,
@@ -225,7 +227,7 @@ async def list_satellites(_user: User = Depends(require_permission(Permission.AD
         total_count=len(responses),
         online_count=len(responses),  # All returned are online
         active_sessions=active_sessions,
-        latest_version=ha_glue_settings.satellite_latest_version
+        latest_version=get_satellite_update_service().get_latest_version()
     )
 
 

--- a/src/backend/ha_glue/services/satellite_update_service.py
+++ b/src/backend/ha_glue/services/satellite_update_service.py
@@ -6,11 +6,20 @@ Manages update initiation and tracks update progress.
 """
 
 import hashlib
+import re
 import tarfile
 import tempfile
 import time
 from pathlib import Path
 from typing import Any
+
+# Match `__version__ = "1.4.0"` (single or double quotes), tolerating an inline
+# comment / trailing whitespace. Anchored at line start so __version_info__ or a
+# commented-out line can't match.
+_VERSION_RE = re.compile(r'^__version__\s*=\s*["\']([^"\']+)["\']')
+# A valid version is dotted digits — reject anything else so a malformed source
+# can't poison version comparison (int() parse) or the tarball filename.
+_VERSION_VALUE_RE = re.compile(r"^\d+(\.\d+)*$")
 
 from loguru import logger
 
@@ -41,8 +50,41 @@ class SatelliteUpdateService:
         logger.info("📦 SatelliteUpdateService initialized")
 
     def get_latest_version(self) -> str:
-        """Get the latest available satellite version from config"""
-        return ha_glue_settings.satellite_latest_version
+        """Latest available satellite version.
+
+        Read from the bundled satellite source (``__version__`` in
+        ``renfield_satellite/__init__.py``) so the advertised version is ALWAYS
+        exactly the package the OTA endpoint would actually serve. This kills the
+        drift class of bug where the source shipped a new version but the
+        ``satellite_latest_version`` env was never bumped (the UI then offered a
+        stale version, or — once it pointed below the deployed code — offered
+        nothing). Falls back to the configured value when the source isn't
+        bundled (local dev / a stripped image).
+        """
+        return self._read_source_version() or ha_glue_settings.satellite_latest_version
+
+    def _read_source_version(self) -> str | None:
+        """Parse ``__version__`` from the bundled satellite source, or None.
+
+        A plain line scan rather than an import — the satellite package pulls in
+        hardware deps (pyaudio, gpiozero, …) the backend image doesn't have.
+        """
+        init_file = self.satellite_source_path / "renfield_satellite" / "__init__.py"
+        try:
+            for line in init_file.read_text().splitlines():
+                m = _VERSION_RE.match(line)
+                if m:
+                    value = m.group(1).strip()
+                    # Reject a malformed value rather than let it disable OTA
+                    # (non-numeric breaks is_update_available's int() compare) or
+                    # flow unsanitized into the package filename.
+                    return value if _VERSION_VALUE_RE.match(value) else None
+        except (OSError, ValueError):
+            # OSError: missing/unreadable. ValueError (incl. UnicodeDecodeError):
+            # a corrupt/non-UTF8 file. Either way fall back to the config value
+            # rather than crash version resolution.
+            return None
+        return None
 
     def is_update_available(self, current_version: str) -> bool:
         """

--- a/src/backend/ha_glue/utils/config.py
+++ b/src/backend/ha_glue/utils/config.py
@@ -124,7 +124,12 @@ class HaGlueSettings(BaseSettings):
     jellyfin_user_id: str | None = None
 
     # === Satellite OTA Updates ===
-    satellite_latest_version: str = "1.0.0"  # Latest available satellite version
+    # FALLBACK only. The authoritative latest version is read at runtime from the
+    # bundled satellite source (__version__ in renfield_satellite/__init__.py) by
+    # SatelliteUpdateService.get_latest_version — so the advertised version can't
+    # drift from the package actually served. This value (or the
+    # SATELLITE_LATEST_VERSION env) is used only when the source isn't bundled.
+    satellite_latest_version: str = "1.4.0"  # Fallback latest satellite version
     satellite_package_cache_ttl: int = Field(default=300, ge=10, le=86400)
 
     # === Rooms ===

--- a/tests/backend/test_satellite_updates.py
+++ b/tests/backend/test_satellite_updates.py
@@ -8,10 +8,16 @@ Tests cover:
 - WebSocket message handling for updates
 """
 
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import AsyncClient
+
+# A source path guaranteed not to exist, so get_latest_version() falls back to
+# the configured value (these tests assert the config-fallback behavior, not the
+# bundled-source read which is covered separately below).
+_NO_SOURCE = Path("/nonexistent/satellite-source")
 
 # =============================================================================
 # SatelliteManager Version Tracking Tests
@@ -179,14 +185,91 @@ class TestSatelliteUpdateService:
     """Tests for SatelliteUpdateService"""
 
     @pytest.mark.unit
-    def test_get_latest_version(self):
-        """get_latest_version should return config value"""
+    def test_get_latest_version_falls_back_to_config(self):
+        """get_latest_version falls back to the config value when no source is bundled"""
         from ha_glue.services.satellite_update_service import SatelliteUpdateService
 
         with patch('ha_glue.services.satellite_update_service.ha_glue_settings') as mock_settings:
             mock_settings.satellite_latest_version = "2.0.0"
             service = SatelliteUpdateService()
+            service.satellite_source_path = _NO_SOURCE
             assert service.get_latest_version() == "2.0.0"
+
+    @pytest.mark.unit
+    def test_get_latest_version_reads_bundled_source(self, tmp_path):
+        """get_latest_version reads __version__ from the bundled source, ignoring config drift"""
+        from ha_glue.services.satellite_update_service import SatelliteUpdateService
+
+        # Lay out a fake bundled source: <root>/renfield_satellite/__init__.py
+        pkg = tmp_path / "renfield_satellite"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text('"""doc"""\n__version__ = "9.9.9"\n')
+
+        with patch('ha_glue.services.satellite_update_service.ha_glue_settings') as mock_settings:
+            # Config says something stale — the source must win.
+            mock_settings.satellite_latest_version = "1.0.0"
+            service = SatelliteUpdateService()
+            service.satellite_source_path = tmp_path
+            assert service.get_latest_version() == "9.9.9"
+
+    @pytest.mark.unit
+    def test_read_source_version_handles_missing_marker(self, tmp_path):
+        """_read_source_version returns None when __version__ is absent"""
+        from ha_glue.services.satellite_update_service import SatelliteUpdateService
+
+        pkg = tmp_path / "renfield_satellite"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("# no version here\n")
+
+        service = SatelliteUpdateService()
+        service.satellite_source_path = tmp_path
+        assert service._read_source_version() is None
+
+    @pytest.mark.unit
+    def test_read_source_version_tolerates_inline_comment(self, tmp_path):
+        """An inline comment / extra whitespace must not corrupt the parsed version.
+
+        Regression guard: the old end-strip parser turned `__version__ = "1.4.0"  # x`
+        into `1.4.0"  # x`, which silently disabled OTA (non-numeric -> int() fails ->
+        is_update_available False for every satellite).
+        """
+        from ha_glue.services.satellite_update_service import SatelliteUpdateService
+
+        pkg = tmp_path / "renfield_satellite"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text('__version__ = "1.4.0"   # noqa: E501\n')
+
+        service = SatelliteUpdateService()
+        service.satellite_source_path = tmp_path
+        assert service._read_source_version() == "1.4.0"
+
+    @pytest.mark.unit
+    def test_read_source_version_rejects_non_numeric(self, tmp_path):
+        """A non-dotted-digit version is rejected (None) rather than poisoning compare."""
+        from ha_glue.services.satellite_update_service import SatelliteUpdateService
+
+        pkg = tmp_path / "renfield_satellite"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text('__version__ = "1.4.0-dev/oops"\n')
+
+        service = SatelliteUpdateService()
+        service.satellite_source_path = tmp_path
+        assert service._read_source_version() is None
+
+    @pytest.mark.unit
+    def test_read_source_version_ignores_version_info_sibling(self, tmp_path):
+        """__version_info__ must not be mistaken for __version__."""
+        from ha_glue.services.satellite_update_service import SatelliteUpdateService
+
+        pkg = tmp_path / "renfield_satellite"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text(
+            '__version_info__ = (1, 4, 0)\n__version__ = "1.4.0"\n'
+        )
+
+        service = SatelliteUpdateService()
+        service.satellite_source_path = tmp_path
+        assert service._read_source_version() == "1.4.0"
 
     @pytest.mark.unit
     def test_is_update_available_newer(self):
@@ -196,6 +279,7 @@ class TestSatelliteUpdateService:
         with patch('ha_glue.services.satellite_update_service.ha_glue_settings') as mock_settings:
             mock_settings.satellite_latest_version = "2.0.0"
             service = SatelliteUpdateService()
+            service.satellite_source_path = _NO_SOURCE
 
             assert service.is_update_available("1.0.0") is True
             assert service.is_update_available("1.9.9") is True
@@ -208,6 +292,7 @@ class TestSatelliteUpdateService:
         with patch('ha_glue.services.satellite_update_service.ha_glue_settings') as mock_settings:
             mock_settings.satellite_latest_version = "1.0.0"
             service = SatelliteUpdateService()
+            service.satellite_source_path = _NO_SOURCE
 
             assert service.is_update_available("1.0.0") is False
 
@@ -219,6 +304,7 @@ class TestSatelliteUpdateService:
         with patch('ha_glue.services.satellite_update_service.ha_glue_settings') as mock_settings:
             mock_settings.satellite_latest_version = "1.0.0"
             service = SatelliteUpdateService()
+            service.satellite_source_path = _NO_SOURCE
 
             assert service.is_update_available("2.0.0") is False
 
@@ -230,6 +316,7 @@ class TestSatelliteUpdateService:
         with patch('ha_glue.services.satellite_update_service.ha_glue_settings') as mock_settings:
             mock_settings.satellite_latest_version = "1.0.0"
             service = SatelliteUpdateService()
+            service.satellite_source_path = _NO_SOURCE
 
             assert service.is_update_available("unknown") is False
 

--- a/tests/backend/test_satellite_updates_integration.py
+++ b/tests/backend/test_satellite_updates_integration.py
@@ -142,8 +142,15 @@ class TestSatelliteUpdateAPIFlow:
         )
 
         try:
-            # Step 1: Check versions - should show update available
-            with patch('ha_glue.services.satellite_update_service.ha_glue_settings') as mock_settings:
+            # Step 1: Check versions - should show update available.
+            # Force the bundled-source read off so the configured value drives
+            # the assertion (the deployed image bundles a real source whose
+            # __version__ would otherwise win — that path is covered separately).
+            with patch('ha_glue.services.satellite_update_service.ha_glue_settings') as mock_settings, \
+                 patch(
+                     'ha_glue.services.satellite_update_service.SatelliteUpdateService._read_source_version',
+                     return_value=None,
+                 ):
                 mock_settings.satellite_latest_version = "2.0.0"
 
                 response = await async_client.get("/api/satellites/versions")
@@ -304,7 +311,11 @@ class TestVersionComparisonIntegration:
 
         try:
             with patch('ha_glue.api.routes.satellites.ha_glue_settings') as mock_route_settings, \
-                 patch('ha_glue.services.satellite_update_service.ha_glue_settings') as mock_svc_settings:
+                 patch('ha_glue.services.satellite_update_service.ha_glue_settings') as mock_svc_settings, \
+                 patch(
+                     'ha_glue.services.satellite_update_service.SatelliteUpdateService._read_source_version',
+                     return_value=None,
+                 ):
                 mock_route_settings.satellite_latest_version = "2.0.0"
                 mock_svc_settings.satellite_latest_version = "2.0.0"
 
@@ -392,6 +403,47 @@ class TestUpdatePackageIntegration:
 
             response = await async_client.get("/api/satellites/update-package")
             assert response.status_code == 503
+
+    @pytest.mark.unit
+    def test_build_package_from_real_source(self, tmp_path):
+        """With a bundled source on disk, build a real tarball and read its version.
+
+        Regression guard for the OTA outage: the backend image shipped WITHOUT
+        the satellite source, so build_update_package returned None and
+        /update-package 503'd. This proves a present source yields a package
+        whose version matches the source __version__ (not a config value).
+        """
+        import tarfile
+
+        from ha_glue.services.satellite_update_service import SatelliteUpdateService
+
+        # Minimal but realistic bundled layout.
+        pkg = tmp_path / "renfield_satellite"
+        (pkg / "ble").mkdir(parents=True)
+        (pkg / "__init__.py").write_text('__version__ = "3.2.1"\n')
+        (pkg / "ble" / "classic_scanner.py").write_text("# scanner\n")
+        (tmp_path / "requirements.txt").write_text("loguru\n")
+
+        with patch('ha_glue.services.satellite_update_service.ha_glue_settings') as mock_settings:
+            mock_settings.satellite_latest_version = "0.0.1"  # stale config — must be ignored
+            mock_settings.satellite_package_cache_ttl = 300
+            service = SatelliteUpdateService()
+            service.satellite_source_path = tmp_path
+
+            # Version comes from the bundled source, not config.
+            assert service.get_latest_version() == "3.2.1"
+
+            # A real tarball is produced and contains the satellite package.
+            package_path = service.build_update_package()
+            assert package_path is not None and package_path.exists()
+            with tarfile.open(package_path, "r:gz") as tar:
+                names = tar.getnames()
+            assert "renfield_satellite/__init__.py" in names
+            assert "renfield_satellite/ble/classic_scanner.py" in names
+
+            info = service.get_package_info()
+            assert info["version"] == "3.2.1"
+            assert info["checksum"].startswith("sha256:")
 
 
 # =============================================================================


### PR DESCRIPTION
## Problem

The satellite OTA-via-UI update path was **non-functional**, surfaced while trying to update the Kinderbad satellite (running 4-month-old code that reports a flat synthetic −50, hijacking presence room-arbitration). Two compounding bugs:

1. **No package to serve.** The backend image never bundled the satellite source (no `COPY` in the Dockerfile), so `SatelliteUpdateService.build_update_package()` found no `/app/satellite` and returned `None` → `GET /api/satellites/update-package` **503'd**. The UI could advertise an update but never deliver one.
2. **Stale advertised version.** "Latest version" came from `SATELLITE_LATEST_VERSION` env, which drifted: source shipped `1.4.0` (deployed to satellites via the ansible rsync flow) but the env stayed `1.3.0`, so the UI showed a lower version than the code.

## Fix

- **Dockerfile** bundles the satellite source into `/app/satellite` (synced into the backend build context at build time, like `wakeword-models`) + a build-time assertion that fails the build loudly if the source is missing/truncated (instead of silently degrading to the config fallback + serving a corrupt tarball).
- **`get_latest_version()`** reads `__version__` from the bundled source, falling back to config — the advertised version is **always** exactly the package served, so it can't drift again. The list + detail routes now use the service as the single source of truth (were reading `ha_glue_settings` directly, diverging from `/versions`).
- **`.dockerignore` + deploy rsync excludes** keep `provisioning/` (gitignored inventory with real household IPs) and `tests/` out of the image.
- Config default bumped to `1.4.0` (fallback only; bundled source is authoritative).

## Review hardening

`/review` adversarial pass caught a latent foot-gun: the version parser used end-strip, so a stray inline comment in `__init__.py` (`__version__ = "1.4.0"  # noqa`) would parse to garbage and **silently disable OTA cluster-wide** + feed an unsanitized string into the tarball filename. Hardened to an anchored regex + numeric validation, with regression tests.

## Tests

New unit coverage for source-version read + fallback + malformed/inline-comment/`__version_info__` guards, and a real-source package-build regression guard (real source on disk → real tarball, version from source not config). 18 satellite-update unit tests green on the .159 build box. Existing config-fallback tests pinned to a no-source path.

## Deploy note

Requires the new build step (rsync `src/satellite/` into the backend build context) — documented in `deploy-production` skill + `docs/SATELLITE_OTA_UPDATES.md`. **OTA-via-UI for Kinderbad only works once this ships in a new backend image.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)