### PR TITLE
fix(media-follow): music now actually follows — resume-ordering + suspend-clears-own-session

### DIFF
--- a/src/backend/ha_glue/services/internal_tools.py
+++ b/src/backend/ha_glue/services/internal_tools.py
@@ -1225,8 +1225,10 @@ class InternalToolService:
         else:
             result = await self._media_control_ha(action, device_data, resolved_room_name, params)
 
-        # Clear media follow session on explicit stop
-        if action == "stop" and result.get("success"):
+        # Clear media follow session on explicit USER stop — but NOT when the stop
+        # is Media Follow's own suspend (_stop_playback sets _media_follow_internal),
+        # which would delete the session we're about to resume in the next room.
+        if action == "stop" and result.get("success") and not params.get("_media_follow_internal"):
             from ha_glue.utils.config import ha_glue_settings as _settings
             if _settings.media_follow_enabled:
                 try:

--- a/src/backend/ha_glue/services/media_follow_service.py
+++ b/src/backend/ha_glue/services/media_follow_service.py
@@ -149,15 +149,29 @@ class MediaFollowService:
         self, user_id: int, room_id: int, room_name: str, **kw
     ) -> None:
         """Called when a user enters a room (presence hook)."""
+        # Drop expired suspended sessions first, then look up the live one.
+        self._cleanup_expired_sessions()
         session = self._sessions.get(user_id)
-        if not session or session.state != SessionState.SUSPENDED:
+        if not session:
             return
 
-        # Cleanup expired sessions
-        self._cleanup_expired_sessions()
-        # Re-check after cleanup
-        session = self._sessions.get(user_id)
-        if not session or session.state != SessionState.SUSPENDED:
+        # Decide whether this enter should (re)start playback here:
+        #  - SUSPENDED: the user left elsewhere first (the leave fired) and is now
+        #    arriving — resume.
+        #  - PLAYING in a DIFFERENT room: the user moved but the matching 'leave'
+        #    has NOT fired yet. presence_stale_timeout (120s) means the old room's
+        #    satellite keeps seeing the device long after the move, so the enter
+        #    routinely arrives while the session is still PLAYING. Treat it as a
+        #    move: stop the old room, then resume here. Without this branch the
+        #    late leave suspends the session AFTER this enter already bailed, and
+        #    the music never follows (the live-test bug, 2026-06-14).
+        if session.state == SessionState.PLAYING:
+            if session.room_id == room_id:
+                return  # already playing in this room — nothing to do
+            await self._stop_playback(session)
+            session.state = SessionState.SUSPENDED
+            session.suspended_at = time.time()
+        elif session.state != SessionState.SUSPENDED:
             return
 
         # Check for conflict: another user playing in this room

--- a/src/backend/ha_glue/services/media_follow_service.py
+++ b/src/backend/ha_glue/services/media_follow_service.py
@@ -237,6 +237,12 @@ class MediaFollowService:
                 "action": "stop",
                 "room_name": session.room_name,
                 "force": "true",
+                # Mark this as Media Follow's OWN suspend-stop, not a user "stop".
+                # _media_control clears the follow session on a stop; without this
+                # marker the suspend would delete the very session we're about to
+                # resume in the next room, so the music never follows (live-test
+                # 2026-06-14).
+                "_media_follow_internal": True,
             })
             if not result.get("success"):
                 logger.warning(

--- a/tests/backend/test_media_follow_service.py
+++ b/tests/backend/test_media_follow_service.py
@@ -199,13 +199,47 @@ class TestOnUserEnterRoom:
         mock_resume.assert_called_once_with(session, 20, "Wohnzimmer")
 
     @pytest.mark.asyncio
-    async def test_enter_no_suspended_session_no_action(self, playing_session):
-        """Playing session (not suspended) should not trigger resume."""
+    async def test_enter_different_room_while_playing_follows(self, playing_session):
+        """Playing in room A, enter room B with NO prior leave (the presence
+        stale-timeout ordering: the 'left A' event lags up to 120s behind the
+        real move, so the enter arrives while the session is still PLAYING).
+        Must treat it as a move — stop A and resume in B. Regression for the
+        2026-06-14 live-test bug where the lagging leave left the music stuck
+        SUSPENDED and it never followed."""
+        session = playing_session.get_session(1)  # PLAYING in room 10
+        mock_stop = AsyncMock()
         mock_resume = AsyncMock()
-        with patch.object(playing_session, "_resume_playback", mock_resume):
+        with patch.object(playing_session, "_stop_playback", mock_stop), \
+             patch.object(playing_session, "_resume_playback", mock_resume), \
+             patch("ha_glue.services.media_follow_service.ha_glue_settings") as s:
+            s.media_follow_resume_delay = 0
+            s.media_follow_suspend_timeout = 600.0
             await playing_session.on_user_enter_room(
                 user_id=1, room_id=20, room_name="Wohnzimmer"
             )
+        mock_stop.assert_called_once()  # old room stopped
+        mock_resume.assert_called_once_with(session, 20, "Wohnzimmer")
+
+    @pytest.mark.asyncio
+    async def test_enter_same_room_while_playing_no_action(self, playing_session):
+        """Entering the SAME room the session is already playing in is a no-op."""
+        mock_stop = AsyncMock()
+        mock_resume = AsyncMock()
+        with patch.object(playing_session, "_stop_playback", mock_stop), \
+             patch.object(playing_session, "_resume_playback", mock_resume):
+            await playing_session.on_user_enter_room(
+                user_id=1, room_id=10, room_name="Arbeitszimmer"
+            )
+        mock_stop.assert_not_called()
+        mock_resume.assert_not_called()
+        assert playing_session.get_session(1).state == SessionState.PLAYING
+
+    @pytest.mark.asyncio
+    async def test_enter_no_session_no_action(self, service):
+        """Entering a room with no media session does nothing."""
+        mock_resume = AsyncMock()
+        with patch.object(service, "_resume_playback", mock_resume):
+            await service.on_user_enter_room(user_id=99, room_id=20, room_name="X")
         mock_resume.assert_not_called()
 
     @pytest.mark.asyncio

--- a/tests/backend/test_media_follow_service.py
+++ b/tests/backend/test_media_follow_service.py
@@ -136,6 +136,32 @@ class TestOnUserLeaveRoom:
         assert session.suspended_at is not None
 
     @pytest.mark.asyncio
+    async def test_suspend_does_not_clear_session(self, playing_session):
+        """on_user_leave_room's internal stop must NOT clear the session — it
+        must survive as SUSPENDED so the next room can resume it. Regression for
+        the live-test 2026-06-14: _stop_playback -> _media_control(action=stop)
+        was clearing the very session being suspended, so the music never
+        followed. The stop must carry the _media_follow_internal marker."""
+        captured = {}
+
+        async def fake_media_control(params):
+            captured.update(params)
+            return {"success": True}
+
+        with patch(
+            "ha_glue.services.internal_tools.InternalToolService._media_control",
+            side_effect=fake_media_control,
+        ), patch.object(playing_session, "_is_user_opted_in", return_value=True):
+            await playing_session.on_user_leave_room(
+                user_id=1, room_id=10, room_name="Arbeitszimmer"
+            )
+
+        s = playing_session.get_session(1)
+        assert s is not None, "session was cleared during suspend — nothing to follow"
+        assert s.state == SessionState.SUSPENDED
+        assert captured.get("_media_follow_internal") is True
+
+    @pytest.mark.asyncio
     async def test_leave_stops_playback(self, playing_session):
         mock_stop = AsyncMock()
         with patch.object(playing_session, "_is_user_opted_in", return_value=True), \


### PR DESCRIPTION
## Why
Live-tested Media Follow Me: music stopped when leaving a room but never resumed in the next one. Two stacked bugs, both found by walking the house and reading the logs + the durable presence-event log.

## Bug 1 — resume bailed on enter-before-leave ordering
`on_user_enter_room` only resumed a session already in `SUSPENDED` state, assuming events arrive leave-then-enter. But `presence_stale_timeout=120s` means the old room's satellite keeps seeing the device long after the move, so the `enter(new room)` routinely fires while the session is still `PLAYING` → the handler bailed; then the lagging `leave` suspended it with nothing left to re-trigger a resume.

**Fix:** on enter, if the session is `PLAYING` in a *different* room, treat it as a move (stop old → resume here) instead of requiring it to already be suspended. Same-room enter stays a no-op.

## Bug 2 — the suspend cleared its own session
`on_user_leave_room` suspends by calling `_stop_playback` → `InternalToolService._media_control(action="stop")`, which has a "clear the follow session on stop" step (meant for a *user's* stop). It couldn't tell the follow's internal suspend-stop from a user stop, so **the suspend deleted the very session it was suspending**. By the time `enter` fired, there was no session to resume.

**Fix:** `_stop_playback` tags its stop with `_media_follow_internal=True`; `_media_control` skips the session-clear when that marker is present. A genuine user "stop" (no marker) still clears.

## Validated live
With both fixes (deployed as v2.17.14), the full chain fires and the music followed across rooms and back:
`suspending` → session survives → `entered <room> — resuming` → `Resumed playback`.

## Tests
37/37 media-follow tests pass, incl. the enter-different-room-while-playing follow, the same-room no-op, the no-session no-op, and the suspend-must-not-clear-session regression.

> Note: live testing also surfaced a separate **presence** flip-flop bug (broken room-change hysteresis) that makes presence itself unreliable for adjacent rooms — fixed in a follow-up PR. This PR fixes the media-follow *mechanism*; presence accuracy is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)