### PR TITLE
feat: day/night awareness, night LED dimming, presence history, BT scan from chat

### DIFF
--- a/src/backend/alembic/versions/pc20260616_presence_event_satellite_id.py
+++ b/src/backend/alembic/versions/pc20260616_presence_event_satellite_id.py
@@ -1,0 +1,45 @@
+"""presence_events.satellite_id + history index — persistent presence history
+
+Revision ID: pc20260616_sat_id
+Revises: pc20260614_email_ingest
+Create Date: 2026-06-14
+
+Persistent presence history is mostly ADDITIVE on top of the already-persisted
+``presence_events`` table (written on every room enter/leave by
+``presence_analytics._persist_event``). This migration adds:
+
+  * ``satellite_id`` (nullable String(100)) — which satellite produced the
+    detection on an ``enter`` event (NULL for ``leave``/voice/web events).
+  * ``ix_presence_events_history`` (user_id, created_at) — backs the timeline
+    + last-seen queries that read a single user's events chronologically (the
+    existing ``ix_presence_events_analytics`` leads with room_id and is a poor
+    match for that access pattern).
+
+A nullable ADD COLUMN is metadata-only on Postgres and the index build is
+ordinary DDL, so this migration is fully transactional.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "pc20260616_sat_id"
+down_revision = "pc20260614_email_ingest"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "presence_events",
+        sa.Column("satellite_id", sa.String(100), nullable=True),
+    )
+    op.create_index(
+        "ix_presence_events_history",
+        "presence_events",
+        ["user_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_presence_events_history", table_name="presence_events")
+    op.drop_column("presence_events", "satellite_id")

--- a/src/backend/api/lifecycle.py
+++ b/src/backend/api/lifecycle.py
@@ -155,6 +155,51 @@ def _schedule_whisper_preload():
         logger.warning(f"⚠️  Whisper-Preloading fehlgeschlagen: {e}")
 
 
+# Last-seen daypart for the watcher loop. Module-level so the loop closure
+# carries state across ticks; `None` until the first tick (which always fires
+# the hook because there is no prior value to compare against).
+_daypart_watcher_state: dict[str, str | None] = {"last": None}
+
+
+def _schedule_daypart_watcher():
+    """Watch for day/evening/night transitions and fire the `daypart_changed`
+    hook so features (e.g. satellite LED dimming) can react.
+
+    Runs at boot (so the first tick establishes the current daypart) and then
+    every 5 minutes. Stateless apart from the module-level last-seen daypart.
+    """
+
+    async def _tick():
+        from services.daypart_service import get_daypart_info
+        from utils.hooks import run_hooks
+
+        info = get_daypart_info()
+        current = info["daypart"]
+        local_time = info["local_time"]
+        previous = _daypart_watcher_state["last"]
+
+        if current != previous:
+            # run_hooks never raises — handler exceptions are logged inside.
+            await run_hooks(
+                "daypart_changed",
+                previous=previous,
+                current=current,
+                local_time=local_time,
+            )
+            _daypart_watcher_state["last"] = current
+            logger.info(
+                f"🌓 Daypart transition: {previous} → {current} (local {local_time})"
+            )
+
+    _spawn_periodic_task(
+        name="Daypart watcher",
+        interval=300,
+        work=_tick,
+        started_msg="✅ Daypart Watcher gestartet (alle 5 Minuten)",
+        run_at_boot=True,
+    )
+
+
 def _schedule_notification_cleanup():
     """Schedule periodic cleanup of expired notifications."""
     if not settings.proactive_enabled:
@@ -971,6 +1016,7 @@ async def lifespan(app: "FastAPI"):
     if settings.features["voice"]:
         _schedule_whisper_preload()
         _schedule_speaker_vocab_rebuild()
+    _schedule_daypart_watcher()
     _schedule_notification_cleanup()
     _schedule_reminder_checker()
     _schedule_notification_poller(app)

--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -1093,6 +1093,12 @@ async def websocket_endpoint(
                     user_personality_style, user_personality_prompt, ollama.default_lang
                 )
 
+            # Build time-of-day context for agent prompts (day/evening/night).
+            # build_time_context wraps everything in try/except and returns ""
+            # on any error, so this can never break the agent path.
+            from services.daypart_service import build_time_context
+            time_context = build_time_context(lang=ollama.default_lang)
+
             # Get router from app state (initialized at startup if agent_enabled)
             agent_router = getattr(app.state, 'agent_router', None)
 
@@ -1400,6 +1406,7 @@ async def websocket_endpoint(
                             memory_context=memory_context,
                             document_context=document_context,
                             personality_context=personality_context,
+                            time_context=time_context,
                             user_permissions=user_permissions,
                             user_id=user_id,
                             context_vars_text=_context_vars_text,
@@ -1619,6 +1626,7 @@ async def websocket_endpoint(
                         memory_context=memory_context,
                         document_context=document_context,
                         personality_context=personality_context,
+                        time_context=time_context,
                         user_permissions=user_permissions,
                         user_id=user_id,
                         context_vars_text=_context_vars_text,

--- a/src/backend/ha_glue/api/routes/presence.py
+++ b/src/backend/ha_glue/api/routes/presence.py
@@ -5,6 +5,8 @@ Endpoints for room occupancy, user presence, BLE device management,
 and presence analytics (heatmap, predictions).
 """
 
+from datetime import UTC, datetime, timedelta
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 from sqlalchemy import select
@@ -306,6 +308,18 @@ class DailySummary(BaseModel):
     leave_count: int
 
 
+class PresenceEventResponse(BaseModel):
+    id: int
+    user_id: int
+    room_id: int
+    room_name: str | None = None
+    event_type: str
+    source: str | None = None
+    confidence: float | None = None
+    satellite_id: str | None = None
+    created_at: datetime
+
+
 @router.get("/analytics/heatmap", response_model=list[HeatmapCell])
 async def get_heatmap(
     days: int = Query(default=30, ge=1, le=365),
@@ -342,3 +356,114 @@ async def get_daily_summary(
 
     service = PresenceAnalyticsService(db)
     return await service.get_daily_summary(days=days)
+
+
+# --- Persistent presence history (timeline / last-seen / room-window) ---
+
+
+def _resolve_history_target(user_id: int | None, current_user: "User | None") -> int:
+    """Resolve whose presence history to read, guarding against IDOR.
+
+    Self-lookups and single-user mode (``current_user`` None, AUTH off) are
+    unrestricted. Reading ANOTHER user's location history requires ROOMS_MANAGE
+    — otherwise any ROOMS_READ user could enumerate where anyone in the
+    household has been.
+    """
+    target = user_id if user_id is not None else (current_user.id if current_user else None)
+    if target is None:
+        raise HTTPException(status_code=400, detail="user_id is required")
+    if (
+        current_user is not None
+        and target != current_user.id
+        and not current_user.has_permission(Permission.ROOMS_MANAGE.value)
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail="Reading another user's presence history requires ROOMS_MANAGE",
+        )
+    return target
+
+
+@router.get("/analytics/timeline", response_model=list[PresenceEventResponse])
+async def get_presence_timeline(
+    user_id: int | None = Query(default=None),
+    since: datetime | None = Query(default=None),
+    until: datetime | None = Query(default=None),
+    room_id: int | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=1000),
+    offset: int = Query(default=0, ge=0),
+    db: AsyncSession = Depends(get_db),
+    current_user: User | None = Depends(require_permission(Permission.ROOMS_READ)),
+):
+    """Chronological presence-event timeline for a user.
+
+    Defaults to the authenticated user when ``user_id`` is omitted. In
+    single-user mode (AUTH_ENABLED=false) ``current_user`` is None.
+    """
+    if not ha_glue_settings.presence_history_enabled:
+        raise HTTPException(status_code=404, detail="Presence history is disabled")
+
+    target_user_id = _resolve_history_target(user_id, current_user)
+
+    from ha_glue.services.presence_analytics import PresenceAnalyticsService
+
+    service = PresenceAnalyticsService(db)
+    return await service.get_timeline(
+        user_id=target_user_id,
+        since=since,
+        until=until,
+        room_id=room_id,
+        limit=limit,
+        offset=offset,
+    )
+
+
+class LastSeenByRoomEntry(BaseModel):
+    room_id: int
+    room_name: str | None = None
+    last_seen: datetime
+
+
+@router.get("/analytics/last-seen-by-room", response_model=list[LastSeenByRoomEntry])
+async def get_last_seen_by_room(
+    user_id: int | None = Query(default=None),
+    db: AsyncSession = Depends(get_db),
+    current_user: User | None = Depends(require_permission(Permission.ROOMS_READ)),
+):
+    """Per-room most-recent 'enter' time for a user."""
+    if not ha_glue_settings.presence_history_enabled:
+        raise HTTPException(status_code=404, detail="Presence history is disabled")
+
+    target_user_id = _resolve_history_target(user_id, current_user)
+
+    from ha_glue.services.presence_analytics import PresenceAnalyticsService
+
+    service = PresenceAnalyticsService(db)
+    return await service.get_last_seen_by_room(user_id=target_user_id)
+
+
+@router.get("/analytics/room-window", response_model=list[PresenceEventResponse])
+async def get_room_window(
+    room_id: int = Query(...),
+    since: datetime | None = Query(default=None),
+    until: datetime | None = Query(default=None),
+    db: AsyncSession = Depends(get_db),
+    current_user: User | None = Depends(require_permission(Permission.ROOMS_MANAGE)),
+):
+    """All users' enter/leave events for a room within a window (admin).
+
+    ``since``/``until`` default to the last 24 hours when omitted.
+    """
+    if not ha_glue_settings.presence_history_enabled:
+        raise HTTPException(status_code=404, detail="Presence history is disabled")
+
+    now = datetime.now(UTC).replace(tzinfo=None)
+    if until is None:
+        until = now
+    if since is None:
+        since = until - timedelta(hours=24)
+
+    from ha_glue.services.presence_analytics import PresenceAnalyticsService
+
+    service = PresenceAnalyticsService(db)
+    return await service.get_room_occupancy_window(room_id=room_id, since=since, until=until)

--- a/src/backend/ha_glue/api/websocket/satellite_handler.py
+++ b/src/backend/ha_glue/api/websocket/satellite_handler.py
@@ -702,6 +702,14 @@ Gib eine kurze, natürliche Antwort. KEIN JSON, nur Text."""
                     data.get("request_id"), data.get("image")
                 )
 
+            # Reply to an on-demand Bluetooth discovery scan request
+            elif msg_type == "bt_scan_result":
+                satellite_manager.resolve_bt_scan(
+                    data.get("request_id"),
+                    data.get("devices", []),
+                    data.get("error"),
+                )
+
             # Handle BLE presence scan results
             elif msg_type == "ble_presence":
                 if satellite_id and ha_glue_settings.presence_enabled:

--- a/src/backend/ha_glue/api/websocket/satellite_handler.py
+++ b/src/backend/ha_glue/api/websocket/satellite_handler.py
@@ -232,6 +232,10 @@ async def satellite_websocket(
                     device_type="satellite"
                 )
 
+                # Ride the current target LED brightness in the ack so a
+                # satellite reconnecting mid-night comes up already dimmed.
+                from ha_glue.services.led_dimming_service import get_led_dimming_service
+
                 await websocket.send_json({
                     "type": "register_ack",
                     "success": success,
@@ -239,6 +243,7 @@ async def satellite_websocket(
                     "room_id": room_id,
                     "protocol_version": settings.ws_protocol_version,
                     "model_download_url": "/api/settings/wakeword/models",
+                    "led_brightness": get_led_dimming_service().get_current_led_brightness(),
                 })
                 logger.info(f"📡 Satellite {satellite_id} registered from {room}")
 

--- a/src/backend/ha_glue/bootstrap.py
+++ b/src/backend/ha_glue/bootstrap.py
@@ -220,6 +220,18 @@ async def ha_glue_on_startup(*, app: Any) -> None:
             "ha_glue.bootstrap: Zeroconf init failed"
         )
 
+    # --- Satellite LED night-dimming (backend-driven brightness push) ---
+    # Seeds the current daypart brightness and registers the `daypart_changed`
+    # hook so night transitions push a dimmed LED brightness to all satellites.
+    try:
+        from ha_glue.services.led_dimming_service import get_led_dimming_service
+
+        await get_led_dimming_service().initialize()
+    except Exception:  # noqa: BLE001
+        logger.opt(exception=True).warning(
+            "ha_glue.bootstrap: LED dimming init failed"
+        )
+
 
 async def _init_zeroconf(app: Any) -> None:
     """Start the Zeroconf mDNS service for satellite auto-discovery.

--- a/src/backend/ha_glue/models/database.py
+++ b/src/backend/ha_glue/models/database.py
@@ -409,10 +409,12 @@ class PresenceEvent(Base):
     event_type = Column(String(20), nullable=False)  # "enter" | "leave"
     source = Column(String(20), default="ble")        # "ble" | "voice" | "web"
     confidence = Column(Float, nullable=True)
+    satellite_id = Column(String(100), nullable=True)  # satellite producing the enter detection (NULL on leave/voice/web)
     created_at = Column(DateTime, default=_utcnow, index=True)
 
     __table_args__ = (
         Index("ix_presence_events_analytics", "user_id", "room_id", "created_at"),
+        Index("ix_presence_events_history", "user_id", "created_at"),
     )
 
 

--- a/src/backend/ha_glue/services/bt_scan_service.py
+++ b/src/backend/ha_glue/services/bt_scan_service.py
@@ -1,0 +1,184 @@
+"""
+Bluetooth Scan Service — aggregate a fan-out discovery scan across satellites.
+
+The backend has NO Bluetooth hardware: a "scan all bluetooth devices" chat
+request is fanned out to every connected satellite (each runs a BLE + Classic
+discovery via `BTDiscoveryScanner`), and this service merges the per-satellite
+device lists into one deduplicated view:
+
+- dedup by MAC (case-insensitive, upper),
+- keep the strongest RSSI seen across all satellites,
+- record which room/satellite saw the device (and at what RSSI),
+- annotate an OUI vendor from the MAC prefix.
+
+The LLM formats the returned dict for the user; this service does no
+presentation. It never raises out of scan_all_satellites — a satellite that
+times out or errors is simply counted as not-responded.
+"""
+
+from loguru import logger
+
+# Common OUI (first 3 octets) → vendor. Not exhaustive — a best-effort label so
+# the chat answer is more useful than a bare MAC. Unknown prefixes => "Unknown".
+_OUI: dict[str, str] = {
+    # Apple
+    "A4:C3:F0": "Apple",
+    "AC:DE:48": "Apple",
+    "F0:18:98": "Apple",
+    "3C:15:C2": "Apple",
+    "D0:81:7A": "Apple",
+    "B8:E8:56": "Apple",
+    # Samsung
+    "00:12:FB": "Samsung",
+    "5C:0A:5B": "Samsung",
+    "8C:77:12": "Samsung",
+    "C8:19:F7": "Samsung",
+    # Google
+    "F4:F5:D8": "Google",
+    "94:EB:2C": "Google",
+    "3C:5A:B4": "Google",
+    # Xiaomi
+    "28:6C:07": "Xiaomi",
+    "64:09:80": "Xiaomi",
+    "F8:A4:5F": "Xiaomi",
+    # Sony
+    "00:13:A9": "Sony",
+    "FC:F1:52": "Sony",
+    # Intel
+    "00:1B:77": "Intel",
+    "3C:A9:F4": "Intel",
+    "A0:88:69": "Intel",
+    # Realtek
+    "00:E0:4C": "Realtek",
+    "52:54:00": "Realtek",
+    # Espressif (ESP32 / ESP8266)
+    "24:0A:C4": "Espressif",
+    "30:AE:A4": "Espressif",
+    "A4:CF:12": "Espressif",
+    # Raspberry Pi
+    "B8:27:EB": "Raspberry Pi",
+    "DC:A6:32": "Raspberry Pi",
+    "E4:5F:01": "Raspberry Pi",
+    # Nordic Semiconductor (BLE beacons / dev kits)
+    "C0:98:E5": "Nordic",
+    "EB:30:1E": "Nordic",
+    # Bose
+    "04:52:C7": "Bose",
+    # Microsoft
+    "00:50:F2": "Microsoft",
+}
+
+
+def _oui_lookup(mac: str) -> str:
+    """Map a MAC's first 3 octets to a vendor name ("Unknown" if not in _OUI)."""
+    if not mac:
+        return "Unknown"
+    prefix = ":".join(mac.upper().split(":")[:3])
+    return _OUI.get(prefix, "Unknown")
+
+
+def _rssi_of(dev: dict):
+    """RSSI as int or None (treat malformed values as missing)."""
+    v = dev.get("rssi")
+    if v is None:
+        return None
+    try:
+        return int(v)
+    except (ValueError, TypeError):
+        return None
+
+
+class BtScanService:
+    """Fan-out + aggregate a Bluetooth discovery scan across all satellites."""
+
+    async def scan_all_satellites(
+        self,
+        satellite_manager,
+        ble_duration: float = 10.0,
+        classic_timeout: float = 12.0,
+        per_sat_timeout: float = 30.0,
+    ) -> dict:
+        """
+        Request a discovery scan from every connected satellite, in parallel, and
+        merge the results.
+
+        Returns:
+            {
+              "total_devices": int,
+              "satellites_queried": int,
+              "satellites_responded": int,
+              "devices": [
+                {"mac", "name", "rssi_best", "transport", "vendor", "rooms": [
+                    {"satellite_id", "room", "rssi"}, ...
+                ]}, ...  # sorted by rssi_best desc (None last)
+              ],
+            }
+        """
+        import asyncio
+
+        sats = list(satellite_manager.satellites.values())
+        params = {"ble_duration": ble_duration, "classic_timeout": classic_timeout}
+
+        async def _scan(sat):
+            return await satellite_manager.request_bt_scan(
+                sat.satellite_id, params, timeout=per_sat_timeout
+            )
+
+        results = await asyncio.gather(
+            *[_scan(sat) for sat in sats], return_exceptions=True
+        )
+
+        # MAC -> aggregate record.
+        agg: dict[str, dict] = {}
+        responded = 0
+        for sat, result in zip(sats, results):
+            if isinstance(result, Exception) or result is None:
+                # Timed out / raised / unknown satellite => not responded.
+                continue
+            responded += 1
+            for dev in result:
+                mac = (dev.get("mac") or "").upper()
+                if not mac:
+                    continue
+                rssi = _rssi_of(dev)
+                entry = agg.get(mac)
+                if entry is None:
+                    entry = {
+                        "mac": mac,
+                        "name": dev.get("name") or None,
+                        "rssi_best": rssi,
+                        "transport": dev.get("transport") or None,
+                        "vendor": _oui_lookup(mac),
+                        "rooms": [],
+                    }
+                    agg[mac] = entry
+                else:
+                    # Fill a missing name / keep the strongest RSSI across rooms.
+                    if not entry["name"] and dev.get("name"):
+                        entry["name"] = dev.get("name")
+                    if rssi is not None and (
+                        entry["rssi_best"] is None or rssi > entry["rssi_best"]
+                    ):
+                        entry["rssi_best"] = rssi
+                entry["rooms"].append({
+                    "satellite_id": sat.satellite_id,
+                    "room": sat.room,
+                    "rssi": rssi,
+                })
+
+        # Strongest signal first; devices with no RSSI (e.g. Classic) sort last.
+        devices = sorted(
+            agg.values(),
+            key=lambda d: (d["rssi_best"] is not None, d["rssi_best"] or -9999),
+            reverse=True,
+        )
+
+        logger.info(
+            f"BT scan: {len(devices)} devices from {responded}/{len(sats)} satellites"
+        )
+        return {
+            "total_devices": len(devices),
+            "satellites_queried": len(sats),
+            "satellites_responded": responded,
+            "devices": devices,
+        }

--- a/src/backend/ha_glue/services/internal_tools.py
+++ b/src/backend/ha_glue/services/internal_tools.py
@@ -136,6 +136,13 @@ class InternalToolService:
                 "station_id": "TuneIn station ID to remove (required)",
             },
         },
+        "internal.bluetooth_scan": {
+            "description": "Scan for ALL nearby Bluetooth devices (broad discovery, NOT the known-presence whitelist). Use for 'scan all bluetooth devices' / 'welche Bluetooth-Geräte sind in der Nähe?'. The scan is fanned out to every satellite and runs a BLE + Classic discovery in each room. It is SLOW — 15-30 seconds — so call it ONCE and WAIT for the result; do NOT retry or call it repeatedly. Only devices that are actively advertising/discoverable appear (most phones are not discoverable over Classic and won't show up). Returns each device's MAC, name (if any), best RSSI, transport, OUI vendor, and which rooms saw it.",
+            "parameters": {
+                "ble_duration": "BLE listen time in seconds per satellite (default 10, max 20)",
+                "classic_timeout": "Classic inquiry time in seconds per satellite (default 12, max 20)",
+            },
+        },
         "internal.presence_history": {
             "description": "Query a user's PERSISTED presence history (survives restarts, unlike the live current-location tools). Use for 'where was X earlier/yesterday', 'when was X last in the kitchen', or 'who was in the living room this morning'. Accepts username or first/last name.",
             "parameters": {
@@ -163,6 +170,7 @@ class InternalToolService:
         "internal.list_radio_favorites": "_list_radio_favorites",
         "internal.remove_radio_favorite": "_remove_radio_favorite",
         "internal.presence_history": "_presence_history",
+        "internal.bluetooth_scan": "_bluetooth_scan",
     }
 
     async def execute(self, intent: str, parameters: dict) -> dict:
@@ -2676,5 +2684,75 @@ class InternalToolService:
             return {
                 "success": False,
                 "message": f"Error removing favorite: {e!s}",
+                "action_taken": False,
+            }
+
+    async def _bluetooth_scan(self, params: dict) -> dict:
+        """Fan a broad Bluetooth discovery scan out to every satellite and return
+        the aggregated device list. Gated on bt_scan_enabled. Slow (15-30s)."""
+        from ha_glue.utils.config import ha_glue_settings
+
+        if not ha_glue_settings.bt_scan_enabled:
+            return {
+                "success": False,
+                "message": "Bluetooth scanning is disabled",
+                "action_taken": False,
+            }
+
+        # Clamp the durations so a runaway value can't pin the BT controllers.
+        def _clamp(value, default: float) -> float:
+            try:
+                return max(1.0, min(20.0, float(value)))
+            except (ValueError, TypeError):
+                return default
+
+        ble_duration = _clamp(params.get("ble_duration"), 10.0)
+        classic_timeout = _clamp(params.get("classic_timeout"), 12.0)
+
+        try:
+            from ha_glue.services.bt_scan_service import BtScanService
+            from ha_glue.services.satellite_manager import get_satellite_manager
+
+            sat_mgr = get_satellite_manager()
+            data = await BtScanService().scan_all_satellites(
+                sat_mgr,
+                ble_duration=ble_duration,
+                classic_timeout=classic_timeout,
+                # Allow the satellite enough time for the sequential BLE+Classic scan.
+                per_sat_timeout=ble_duration + classic_timeout + 15.0,
+            )
+
+            if data["satellites_queried"] == 0:
+                return {
+                    "success": False,
+                    "message": "No satellites are connected to scan from",
+                    "action_taken": False,
+                    "data": data,
+                }
+            if data["satellites_responded"] == 0:
+                return {
+                    "success": False,
+                    "message": (
+                        f"None of the {data['satellites_queried']} satellite(s) responded "
+                        f"to the Bluetooth scan"
+                    ),
+                    "action_taken": False,
+                    "data": data,
+                }
+
+            return {
+                "success": True,
+                "message": (
+                    f"Found {data['total_devices']} Bluetooth device(s) across "
+                    f"{data['satellites_responded']}/{data['satellites_queried']} satellite(s)"
+                ),
+                "action_taken": True,
+                "data": data,
+            }
+        except Exception as e:  # noqa: BLE001
+            logger.error(f"Error running Bluetooth scan: {e}")
+            return {
+                "success": False,
+                "message": f"Error running Bluetooth scan: {e!s}",
                 "action_taken": False,
             }

--- a/src/backend/ha_glue/services/internal_tools.py
+++ b/src/backend/ha_glue/services/internal_tools.py
@@ -136,6 +136,16 @@ class InternalToolService:
                 "station_id": "TuneIn station ID to remove (required)",
             },
         },
+        "internal.presence_history": {
+            "description": "Query a user's PERSISTED presence history (survives restarts, unlike the live current-location tools). Use for 'where was X earlier/yesterday', 'when was X last in the kitchen', or 'who was in the living room this morning'. Accepts username or first/last name.",
+            "parameters": {
+                "user_name": "Name of the user (username, first or last name). Required for 'timeline' and 'last_seen_by_room'.",
+                "room_name": "Room name to focus on. Required for 'who_was_in_room'; optional filter for 'timeline'.",
+                "since": "Start of the window as ISO8601 (e.g. 2026-06-14T08:00:00). Default: 24h ago.",
+                "until": "End of the window as ISO8601. Default: now.",
+                "query_type": "'timeline' (a user's room enter/leave events, default), 'last_seen_by_room' (per-room last seen for a user), or 'who_was_in_room' (everyone's events in a room over the window).",
+            },
+        },
     }
 
     _HANDLERS = {
@@ -152,6 +162,7 @@ class InternalToolService:
         "internal.save_radio_favorite": "_save_radio_favorite",
         "internal.list_radio_favorites": "_list_radio_favorites",
         "internal.remove_radio_favorite": "_remove_radio_favorite",
+        "internal.presence_history": "_presence_history",
     }
 
     async def execute(self, intent: str, parameters: dict) -> dict:
@@ -2140,6 +2151,183 @@ class InternalToolService:
             "message": f"{len(users)} user(s) detected at home",
             "action_taken": True,
             "data": {"users": users},
+        }
+
+    async def _presence_history(self, params: dict) -> dict:
+        """Query a user's PERSISTED presence history (timeline / last-seen /
+        who-was-in-room) — survives restarts, unlike the live presence tools."""
+        from datetime import UTC, datetime, timedelta
+
+        from ha_glue.utils.config import ha_glue_settings
+
+        if not ha_glue_settings.presence_history_enabled:
+            return {
+                "success": False,
+                "message": "Presence history is disabled",
+                "action_taken": False,
+            }
+
+        from ha_glue.services.presence_analytics import _analytics_tz, _to_local
+        from ha_glue.services.presence_service import get_presence_service
+
+        query_type = (params.get("query_type") or "timeline").strip().lower()
+        user_name = (params.get("user_name") or "").strip()
+        room_name = (params.get("room_name") or "").strip()
+
+        # Parse the ISO8601 window (default: last 24h, naive UTC to match storage).
+        def _parse_iso(value: str | None) -> datetime | None:
+            if not value:
+                return None
+            try:
+                dt = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+            except ValueError:
+                return None
+            if dt.tzinfo is not None:
+                dt = dt.astimezone(UTC).replace(tzinfo=None)
+            return dt
+
+        now = datetime.now(UTC).replace(tzinfo=None)
+        until = _parse_iso(params.get("until")) or now
+        since = _parse_iso(params.get("since")) or (until - timedelta(hours=24))
+
+        tz = _analytics_tz()
+
+        def _fmt(dt: datetime | None) -> str:
+            if dt is None:
+                return "unknown"
+            return _to_local(dt, tz).strftime("%Y-%m-%d %H:%M")
+
+        presence_service = get_presence_service()
+
+        # Resolve the room filter (ILIKE) when given.
+        room_id = None
+        if room_name:
+            from sqlalchemy import select
+
+            from models.database import Room
+            from services.database import AsyncSessionLocal
+
+            async with AsyncSessionLocal() as db:
+                result = await db.execute(
+                    select(Room).where(Room.name.ilike(f"%{room_name}%"))
+                )
+                room = result.scalars().first()
+            if room is None:
+                return {
+                    "success": False,
+                    "message": f"Room '{room_name}' not found",
+                    "action_taken": False,
+                }
+            room_id = room.id
+
+        from ha_glue.services.presence_analytics import PresenceAnalyticsService
+        from services.database import AsyncSessionLocal
+
+        if query_type == "who_was_in_room":
+            if room_id is None:
+                return {
+                    "success": False,
+                    "message": "Parameter 'room_name' is required for 'who_was_in_room'",
+                    "action_taken": False,
+                }
+            async with AsyncSessionLocal() as db:
+                service = PresenceAnalyticsService(db)
+                events = await service.get_room_occupancy_window(
+                    room_id=room_id, since=since, until=until
+                )
+            names = []
+            for ev in events:
+                name = presence_service.get_display_name(ev["user_id"])
+                ev["user_name"] = name
+                if ev["event_type"] == "enter" and name not in names:
+                    names.append(name)
+            who = ", ".join(names) if names else "nobody"
+            summary = (
+                f"Between {_fmt(since)} and {_fmt(until)}, {room_name} was entered by: {who}."
+                if names
+                else f"No presence events for {room_name} between {_fmt(since)} and {_fmt(until)}."
+            )
+            return {
+                "success": True,
+                "message": f"{len(events)} event(s) in {room_name}",
+                "action_taken": True,
+                "data": {"room_name": room_name, "events": events},
+                "summary": summary,
+            }
+
+        # timeline / last_seen_by_room both need a resolved user.
+        if not user_name:
+            return {
+                "success": False,
+                "message": "Parameter 'user_name' is required",
+                "action_taken": False,
+            }
+        user_id = presence_service.find_user_by_name(user_name)
+        if user_id is None:
+            return {
+                "success": False,
+                "message": f"User '{user_name}' not found",
+                "action_taken": False,
+            }
+        display_name = presence_service.get_display_name(user_id)
+
+        if query_type == "last_seen_by_room":
+            async with AsyncSessionLocal() as db:
+                service = PresenceAnalyticsService(db)
+                rows = await service.get_last_seen_by_room(user_id=user_id)
+            if not rows:
+                return {
+                    "success": True,
+                    "message": f"No presence history for {display_name}",
+                    "action_taken": True,
+                    "data": {"user_name": display_name, "rooms": []},
+                    "summary": f"There is no recorded presence history for {display_name}.",
+                }
+            parts = [f"{r['room_name']} ({_fmt(r['last_seen'])})" for r in rows]
+            summary = f"{display_name} was last seen in: " + "; ".join(parts) + "."
+            return {
+                "success": True,
+                "message": f"{len(rows)} room(s) for {display_name}",
+                "action_taken": True,
+                "data": {"user_name": display_name, "rooms": rows},
+                "summary": summary,
+            }
+
+        # Default: timeline.
+        async with AsyncSessionLocal() as db:
+            service = PresenceAnalyticsService(db)
+            events = await service.get_timeline(
+                user_id=user_id,
+                since=since,
+                until=until,
+                room_id=room_id,
+                limit=100,
+            )
+        if not events:
+            return {
+                "success": True,
+                "message": f"No presence events for {display_name} in that window",
+                "action_taken": True,
+                "data": {"user_name": display_name, "events": events},
+                "summary": (
+                    f"{display_name} has no recorded presence events between "
+                    f"{_fmt(since)} and {_fmt(until)}."
+                ),
+            }
+        lines = [
+            f"{_fmt(ev['created_at'])}: {ev['event_type']} {ev['room_name'] or 'unknown room'}"
+            for ev in events
+        ]
+        summary = (
+            f"{display_name}'s presence between {_fmt(since)} and {_fmt(until)}:\n"
+            + "\n".join(lines)
+        )
+        return {
+            "success": True,
+            "message": f"{len(events)} event(s) for {display_name}",
+            "action_taken": True,
+            "data": {"user_name": display_name, "events": events},
+            "summary": summary,
         }
 
     # ── Radio tools ──────────────────────────────────────────────────────────

--- a/src/backend/ha_glue/services/led_dimming_service.py
+++ b/src/backend/ha_glue/services/led_dimming_service.py
@@ -1,0 +1,127 @@
+"""Satellite LED night-dimming service.
+
+Backend-driven push (Approach A): on the platform `daypart_changed` hook the
+backend computes a target LED brightness (night → ``settings.led_night_brightness``,
+otherwise ``settings.led_day_brightness``) and pushes it to every connected
+satellite over the existing WebSocket as a ``{"type": "led_config",
+"brightness": N}`` message. The satellite scales all its LED animations to that
+brightness — animations are never disabled.
+
+The current target brightness is held in process so the satellite WebSocket
+handler can ride it in ``register_ack``; a satellite that reconnects mid-night
+therefore comes up already dimmed.
+
+Everything here is best-effort: a per-satellite send failure is logged and
+swallowed, never raised, so one dead link can't break the push to the others or
+the hook chain.
+"""
+
+from __future__ import annotations
+
+from loguru import logger
+
+from utils.config import settings
+
+
+class LedDimmingService:
+    """Holds the current satellite LED brightness and pushes it on daypart change.
+
+    Singleton — access via :func:`get_led_dimming_service`. ``initialize`` seeds
+    the current brightness from the live daypart and registers the
+    ``daypart_changed`` hook handler.
+    """
+
+    def __init__(self) -> None:
+        # Default to the day level until initialize() reads the real daypart.
+        self._current_brightness: int = settings.led_day_brightness
+        self._initialized: bool = False
+
+    @staticmethod
+    def _brightness_for_daypart(daypart: str) -> int:
+        """Resolve the target brightness for a daypart string."""
+        if daypart == "night":
+            return settings.led_night_brightness
+        return settings.led_day_brightness
+
+    async def initialize(self) -> None:
+        """Seed current brightness from the live daypart + register the hook.
+
+        Idempotent: registering twice is avoided so a double startup call does
+        not push twice per transition.
+        """
+        from services.daypart_service import is_night
+
+        try:
+            night = is_night()
+        except Exception:  # noqa: BLE001 — never break startup on a clock error
+            logger.opt(exception=True).warning(
+                "LedDimmingService: is_night() failed, assuming day"
+            )
+            night = False
+
+        self._current_brightness = (
+            settings.led_night_brightness if night else settings.led_day_brightness
+        )
+
+        if not self._initialized:
+            from utils.hooks import is_hook_registered, register_hook
+
+            if not is_hook_registered("daypart_changed", self._on_daypart_changed):
+                register_hook("daypart_changed", self._on_daypart_changed)
+            self._initialized = True
+
+        logger.info(
+            f"💡 LedDimmingService initialized: night={night}, "
+            f"brightness={self._current_brightness}"
+        )
+
+    async def _on_daypart_changed(
+        self, *, previous: str | None = None, current: str, local_time: str = "",
+    ) -> None:
+        """`daypart_changed` hook handler — recompute + push the new brightness."""
+        self._current_brightness = self._brightness_for_daypart(current)
+        logger.info(
+            f"💡 Daypart {previous} → {current} (local {local_time}): "
+            f"LED brightness → {self._current_brightness}"
+        )
+        await self.push_brightness_to_all_satellites(self._current_brightness)
+
+    async def push_brightness_to_all_satellites(self, brightness: int) -> None:
+        """Send a ``led_config`` message to every connected satellite.
+
+        Per-satellite send failures are caught and logged; this never raises.
+        """
+        from ha_glue.services.satellite_manager import get_satellite_manager
+
+        manager = get_satellite_manager()
+        message = {"type": "led_config", "brightness": int(brightness)}
+
+        sent = 0
+        for sat in list(manager.satellites.values()):
+            try:
+                await sat.websocket.send_json(message)
+                sent += 1
+            except Exception as e:  # noqa: BLE001 — one dead link must not break the rest
+                logger.warning(
+                    f"💡 Failed to push LED brightness to {sat.satellite_id}: {e}"
+                )
+
+        logger.info(
+            f"💡 Pushed LED brightness {brightness} to {sent} satellite(s)"
+        )
+
+    def get_current_led_brightness(self) -> int:
+        """Return the current target LED brightness (for register_ack)."""
+        return self._current_brightness
+
+
+# Global singleton instance
+_led_dimming_service: LedDimmingService | None = None
+
+
+def get_led_dimming_service() -> LedDimmingService:
+    """Get or create the global LedDimmingService instance."""
+    global _led_dimming_service
+    if _led_dimming_service is None:
+        _led_dimming_service = LedDimmingService()
+    return _led_dimming_service

--- a/src/backend/ha_glue/services/presence_analytics.py
+++ b/src/backend/ha_glue/services/presence_analytics.py
@@ -74,6 +74,7 @@ async def _persist_event(event_type: str, **kwargs):
                 event_type=event_type,
                 source=kwargs.get("source", "ble"),
                 confidence=kwargs.get("confidence"),
+                satellite_id=kwargs.get("satellite_id"),
             )
             db.add(event)
             await db.commit()
@@ -236,6 +237,150 @@ class PresenceAnalyticsService:
         return [
             {"date": day, "enter_count": enter, "leave_count": leave}
             for day, (enter, leave) in sorted(by_date.items())
+        ]
+
+    async def get_timeline(
+        self,
+        user_id: int,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        room_id: int | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict]:
+        """
+        Chronological presence-event timeline for a single user.
+
+        Returns rows oldest-first as dicts with all event fields plus the joined
+        room_name. ``since``/``until`` bound created_at (naive UTC); ``room_id``
+        restricts to one room. ``limit``/``offset`` page the result.
+        """
+        stmt = (
+            select(
+                PresenceEvent.id,
+                PresenceEvent.user_id,
+                PresenceEvent.room_id,
+                Room.name.label("room_name"),
+                PresenceEvent.event_type,
+                PresenceEvent.source,
+                PresenceEvent.confidence,
+                PresenceEvent.satellite_id,
+                PresenceEvent.created_at,
+            )
+            .join(Room, Room.id == PresenceEvent.room_id)
+            .where(PresenceEvent.user_id == user_id)
+        )
+
+        if since is not None:
+            stmt = stmt.where(PresenceEvent.created_at >= since)
+        if until is not None:
+            stmt = stmt.where(PresenceEvent.created_at <= until)
+        if room_id is not None:
+            stmt = stmt.where(PresenceEvent.room_id == room_id)
+
+        stmt = (
+            stmt.order_by(PresenceEvent.created_at.asc(), PresenceEvent.id.asc())
+            .limit(limit)
+            .offset(offset)
+        )
+
+        rows = (await self.db.execute(stmt)).all()
+        return [
+            {
+                "id": r.id,
+                "user_id": r.user_id,
+                "room_id": r.room_id,
+                "room_name": r.room_name,
+                "event_type": r.event_type,
+                "source": r.source,
+                "confidence": r.confidence,
+                "satellite_id": r.satellite_id,
+                "created_at": r.created_at,
+            }
+            for r in rows
+        ]
+
+    async def get_last_seen_by_room(self, user_id: int) -> list[dict]:
+        """
+        Most recent 'enter' time for the user in each room.
+
+        Returns list of {room_id, room_name, last_seen} ordered most-recent
+        first. 'leave' events are ignored. Empty list when the user has no
+        enter events.
+        """
+        from sqlalchemy import func
+
+        stmt = (
+            select(
+                PresenceEvent.room_id,
+                Room.name.label("room_name"),
+                func.max(PresenceEvent.created_at).label("last_seen"),
+            )
+            .join(Room, Room.id == PresenceEvent.room_id)
+            .where(
+                PresenceEvent.user_id == user_id,
+                PresenceEvent.event_type == "enter",
+            )
+            .group_by(PresenceEvent.room_id, Room.name)
+        )
+
+        rows = (await self.db.execute(stmt)).all()
+        out = [
+            {
+                "room_id": r.room_id,
+                "room_name": r.room_name,
+                "last_seen": r.last_seen,
+            }
+            for r in rows
+            if r.last_seen is not None
+        ]
+        out.sort(key=lambda d: d["last_seen"], reverse=True)
+        return out
+
+    async def get_room_occupancy_window(
+        self, room_id: int, since: datetime, until: datetime
+    ) -> list[dict]:
+        """
+        All users' enter/leave events for one room within a time window.
+
+        Returns rows chronological (oldest-first) so a caller can reconstruct
+        who was in the room and when over the window.
+        """
+        stmt = (
+            select(
+                PresenceEvent.id,
+                PresenceEvent.user_id,
+                PresenceEvent.room_id,
+                Room.name.label("room_name"),
+                PresenceEvent.event_type,
+                PresenceEvent.source,
+                PresenceEvent.confidence,
+                PresenceEvent.satellite_id,
+                PresenceEvent.created_at,
+            )
+            .join(Room, Room.id == PresenceEvent.room_id)
+            .where(
+                PresenceEvent.room_id == room_id,
+                PresenceEvent.created_at >= since,
+                PresenceEvent.created_at <= until,
+            )
+            .order_by(PresenceEvent.created_at.asc(), PresenceEvent.id.asc())
+        )
+
+        rows = (await self.db.execute(stmt)).all()
+        return [
+            {
+                "id": r.id,
+                "user_id": r.user_id,
+                "room_id": r.room_id,
+                "room_name": r.room_name,
+                "event_type": r.event_type,
+                "source": r.source,
+                "confidence": r.confidence,
+                "satellite_id": r.satellite_id,
+                "created_at": r.created_at,
+            }
+            for r in rows
         ]
 
     async def cleanup_old_events(self, retention_days: int | None = None) -> int:

--- a/src/backend/ha_glue/services/presence_service.py
+++ b/src/backend/ha_glue/services/presence_service.py
@@ -320,6 +320,7 @@ class PresenceService:
                         "room_name": self._room_names.get(best_room_id),
                         "confidence": confidence,
                         "source": "ble",
+                        "satellite_id": best_satellite_id,
                     }))
                     if was_first:
                         self._pending_events.append(("presence_first_arrived", {

--- a/src/backend/ha_glue/services/satellite_manager.py
+++ b/src/backend/ha_glue/services/satellite_manager.py
@@ -136,6 +136,7 @@ class SatelliteManager:
         self._lock = asyncio.Lock()
         # On-demand camera snapshot requests: request_id → Future[image_b64|None].
         self._pending_snapshots: dict[str, asyncio.Future] = {}
+        self._pending_bt_scans: dict[str, asyncio.Future] = {}
 
         # Configuration - use settings from config
         from utils.config import settings
@@ -726,6 +727,41 @@ class SatelliteManager:
         fut = self._pending_snapshots.get(request_id)
         if fut is not None and not fut.done():
             fut.set_result(image_b64)
+
+    async def request_bt_scan(
+        self, satellite_id: str, params: dict | None = None, timeout: float = 30.0
+    ) -> list | None:
+        """Ask a satellite to run a broad Bluetooth discovery scan NOW and return
+        the discovered device list, or None on unknown-satellite/timeout/error.
+        Backend→satellite request over the WS; the reply arrives as a
+        'bt_scan_result' message (resolved via resolve_bt_scan). Mirrors
+        request_snapshot."""
+        sat = self.satellites.get(satellite_id)
+        if sat is None:
+            return None
+        request_id = uuid.uuid4().hex
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        self._pending_bt_scans[request_id] = fut
+        try:
+            await sat.websocket.send_json({
+                "type": "bt_scan_request",
+                "request_id": request_id,
+                "params": params or {},
+            })
+            return await asyncio.wait_for(fut, timeout=timeout)
+        except (asyncio.TimeoutError, Exception):  # noqa: BLE001
+            return None
+        finally:
+            self._pending_bt_scans.pop(request_id, None)
+
+    def resolve_bt_scan(
+        self, request_id: str, devices: list | None, error: str | None
+    ) -> None:
+        """Resolve a pending request_bt_scan() future with the satellite's reply.
+        On a satellite-side error the device list is treated as empty."""
+        fut = self._pending_bt_scans.get(request_id)
+        if fut is not None and not fut.done():
+            fut.set_result([] if error else (devices or []))
 
     async def cleanup_stale(self):
         """Remove stale satellites and timed-out sessions"""

--- a/src/backend/ha_glue/utils/config.py
+++ b/src/backend/ha_glue/utils/config.py
@@ -98,6 +98,7 @@ class HaGlueSettings(BaseSettings):
     presence_analytics_retention_days: int = 90         # Days to keep presence events for analytics
     presence_analytics_timezone: str = "Europe/Berlin"  # Local TZ for heatmap/forecast hour+day bucketing (events stored UTC)
     presence_history_enabled: bool = True               # Persistent presence-history timeline routes + agent tool (gate; events are always persisted)
+    bt_scan_enabled: bool = False                       # On-demand Bluetooth discovery scan ("scan all bluetooth devices") fanned out to satellites
 
     # === Announce / message-relay camera occupancy check ===
     # For a personal announcement, after the BLE gate passes, optionally take a

--- a/src/backend/ha_glue/utils/config.py
+++ b/src/backend/ha_glue/utils/config.py
@@ -97,6 +97,7 @@ class HaGlueSettings(BaseSettings):
     presence_webhook_secret: SecretStr | None = None    # Shared secret for webhook auth (X-Webhook-Secret header)
     presence_analytics_retention_days: int = 90         # Days to keep presence events for analytics
     presence_analytics_timezone: str = "Europe/Berlin"  # Local TZ for heatmap/forecast hour+day bucketing (events stored UTC)
+    presence_history_enabled: bool = True               # Persistent presence-history timeline routes + agent tool (gate; events are always persisted)
 
     # === Announce / message-relay camera occupancy check ===
     # For a personal announcement, after the BLE gate passes, optionally take a

--- a/src/backend/prompts/agent.yaml
+++ b/src/backend/prompts/agent.yaml
@@ -4,7 +4,7 @@
 
 de:
   # Main agent prompt template
-  # Available variables: {message}, {conv_context}, {memory_context}, {document_context}, {personality_context}, {tools_prompt}, {self_learning_blocks}, {history_prompt}, {step_directive}
+  # Available variables: {message}, {conv_context}, {memory_context}, {document_context}, {time_context}, {personality_context}, {tools_prompt}, {self_learning_blocks}, {history_prompt}, {step_directive}
   agent_prompt: |
     Du bist ein Agent, der komplexe Aufgaben Schritt für Schritt löst.
 
@@ -27,6 +27,7 @@ de:
 
     {document_context}
 
+    {time_context}
     {personality_context}
 
     ANTWORT-FORMAT: Antworte mit GENAU EINEM JSON-Objekt.
@@ -93,6 +94,7 @@ de:
 
     {document_context}
 
+    {time_context}
     {personality_context}
 
     ANTWORT-FORMAT: Antworte mit GENAU EINEM JSON-Objekt.
@@ -152,6 +154,7 @@ de:
 
     {document_context}
 
+    {time_context}
     {personality_context}
 
     ANTWORT-FORMAT: Antworte mit GENAU EINEM JSON-Objekt.
@@ -201,6 +204,7 @@ de:
 
     {document_context}
 
+    {time_context}
     {personality_context}
 
     ANTWORT-FORMAT: Antworte mit GENAU EINEM JSON-Objekt.
@@ -258,6 +262,7 @@ de:
 
     {document_context}
 
+    {time_context}
     {personality_context}
 
     ANTWORT-FORMAT: Antworte mit GENAU EINEM JSON-Objekt.
@@ -338,6 +343,7 @@ de:
 
     {document_context}
 
+    {time_context}
     {personality_context}
 
     ANTWORT-FORMAT: Antworte mit GENAU EINEM JSON-Objekt.
@@ -441,6 +447,7 @@ de:
 
     {document_context}
 
+    {time_context}
     {personality_context}
 
     ANTWORT-FORMAT: Antworte mit GENAU EINEM JSON-Objekt.
@@ -595,7 +602,7 @@ de:
 
 en:
   # Main agent prompt template
-  # Available variables: {message}, {conv_context}, {memory_context}, {document_context}, {personality_context}, {tools_prompt}, {self_learning_blocks}, {history_prompt}, {step_directive}
+  # Available variables: {message}, {conv_context}, {memory_context}, {document_context}, {time_context}, {personality_context}, {tools_prompt}, {self_learning_blocks}, {history_prompt}, {step_directive}
   agent_prompt: |
     You are an agent that solves complex tasks step by step.
 
@@ -618,6 +625,7 @@ en:
 
     {document_context}
 
+    {time_context}
     {personality_context}
 
     RESPONSE FORMAT: Reply with EXACTLY ONE JSON object.
@@ -680,6 +688,7 @@ en:
 
     {document_context}
 
+    {time_context}
     {personality_context}
 
     RESPONSE FORMAT: Reply with EXACTLY ONE JSON object.
@@ -736,6 +745,7 @@ en:
 
     {document_context}
 
+    {time_context}
     {personality_context}
 
     RESPONSE FORMAT: Reply with EXACTLY ONE JSON object.
@@ -782,6 +792,7 @@ en:
 
     {document_context}
 
+    {time_context}
     {personality_context}
 
     RESPONSE FORMAT: Reply with EXACTLY ONE JSON object.
@@ -836,6 +847,7 @@ en:
 
     {document_context}
 
+    {time_context}
     {personality_context}
 
     RESPONSE FORMAT: Reply with EXACTLY ONE JSON object.
@@ -913,6 +925,7 @@ en:
 
     {document_context}
 
+    {time_context}
     {personality_context}
 
     RESPONSE FORMAT: Reply with EXACTLY ONE JSON object.
@@ -1013,6 +1026,7 @@ en:
 
     {document_context}
 
+    {time_context}
     {personality_context}
 
     RESPONSE FORMAT: Reply with EXACTLY ONE JSON object.

--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -1032,6 +1032,7 @@ class AgentService:
         memory_context: str = "",
         document_context: str = "",
         personality_context: str = "",
+        time_context: str = "",
         context_vars_text: str = "",
         summary_text: str = "",
         user_id: int | None = None,
@@ -1221,6 +1222,7 @@ class AgentService:
             memory_context=memory_context,
             document_context=document_context,
             personality_context=personality_context,
+            time_context=time_context,
             tools_prompt=tools_prompt,
             self_learning_blocks=self_learning_blocks,
             history_prompt=history_prompt,
@@ -1238,6 +1240,7 @@ class AgentService:
                 memory_context=memory_context,
                 document_context=document_context,
                 personality_context=personality_context,
+                time_context=time_context,
                 tools_prompt=tools_prompt,
                 self_learning_blocks=self_learning_blocks,
                 history_prompt=history_prompt,
@@ -1257,6 +1260,7 @@ class AgentService:
         memory_context: str = "",
         document_context: str = "",
         personality_context: str = "",
+        time_context: str = "",
         user_permissions: list[str] | None = None,
         user_id: int | None = None,
         context_vars_text: str = "",
@@ -1298,6 +1302,7 @@ class AgentService:
                 memory_context=memory_context,
                 document_context=document_context,
                 personality_context=personality_context,
+                time_context=time_context,
                 user_permissions=user_permissions,
                 user_id=user_id,
                 context_vars_text=context_vars_text,
@@ -1390,6 +1395,7 @@ class AgentService:
         memory_context: str = "",
         document_context: str = "",
         personality_context: str = "",
+        time_context: str = "",
         user_permissions: list[str] | None = None,
         user_id: int | None = None,
         context_vars_text: str = "",
@@ -1411,6 +1417,7 @@ class AgentService:
             memory_context: Formatted memory section for the agent prompt
             document_context: Formatted document section for the agent prompt
             personality_context: Formatted personality section for the agent prompt
+            time_context: Formatted time-of-day section for the agent prompt
             user_permissions: User's permission strings for MCP access control.
                 None means no auth / allow all (backwards-compatible).
             user_id: Authenticated user ID for per-user tool filtering.
@@ -1484,11 +1491,12 @@ class AgentService:
             # (tool-health warnings, procedural skill injection) and to
             # _enforce_token_budget which re-invokes _build_agent_prompt up
             # to 5 times during reduction passes.
-            prompt = await self._build_agent_prompt(message, context, conversation_history, room_context=room_context, lang=lang, memory_context=memory_context, document_context=document_context, personality_context=personality_context, context_vars_text=context_vars_text, summary_text=summary_text, user_id=user_id)
+            prompt = await self._build_agent_prompt(message, context, conversation_history, room_context=room_context, lang=lang, memory_context=memory_context, document_context=document_context, personality_context=personality_context, time_context=time_context, context_vars_text=context_vars_text, summary_text=summary_text, user_id=user_id)
             prompt, memory_context, document_context, conversation_history = await self._enforce_token_budget(
                 prompt, context, message, conversation_history,
                 memory_context=memory_context, document_context=document_context, lang=lang,
                 room_context=room_context, personality_context=personality_context,
+                time_context=time_context,
                 context_vars_text=context_vars_text, summary_text=summary_text,
                 user_id=user_id,
             )

--- a/src/backend/services/daypart_service.py
+++ b/src/backend/services/daypart_service.py
@@ -1,0 +1,171 @@
+"""
+Day/night awareness — compute the current time-of-day ("daypart") so the agent
+LLM can see it in its prompt and features can react to day/evening/night
+transitions via the `daypart_changed` hook.
+
+Everything here is best-effort and must NEVER break the agent path:
+``build_time_context`` wraps all work in try/except and returns "" on any error.
+
+Daypart windows are configurable HH:MM strings in the local timezone
+(``settings.daypart_*``). The timezone is resolved from
+``settings.daypart_timezone`` (if set), else ha_glue's
+``presence_analytics_timezone`` (import-guarded — ha_glue may be absent), else
+UTC.
+"""
+
+from datetime import datetime, time as dt_time
+from typing import Literal
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from loguru import logger
+
+from utils.config import settings
+
+Daypart = Literal["day", "evening", "night"]
+
+# Safe fallback windows — used only if a configured HH:MM string is malformed.
+_DEFAULT_NIGHT_START = dt_time(22, 0)
+_DEFAULT_NIGHT_END = dt_time(7, 0)
+_DEFAULT_EVENING_START = dt_time(18, 0)
+
+# Localized weekday names (Mon=0 .. Sun=6), keyed by language.
+_WEEKDAYS = {
+    "de": ["Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag", "Sonntag"],
+    "en": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"],
+}
+
+# Localized daypart labels.
+_DAYPART_LABELS = {
+    "de": {"day": "Tag", "evening": "Abend", "night": "Nacht"},
+    "en": {"day": "Day", "evening": "Evening", "night": "Night"},
+}
+
+
+def _resolve_tz() -> ZoneInfo:
+    """Resolve the local timezone for daypart computation.
+
+    Order: ``settings.daypart_timezone`` (if non-empty) → ha_glue's
+    ``presence_analytics_timezone`` (import-guarded) → ``"UTC"``. An invalid
+    name falls back to UTC without raising.
+    """
+    name = (settings.daypart_timezone or "").strip()
+    if not name:
+        try:
+            from ha_glue.utils.config import ha_glue_settings
+
+            name = (ha_glue_settings.presence_analytics_timezone or "").strip()
+        except Exception:  # noqa: BLE001 — ha_glue may be absent
+            name = ""
+    if not name:
+        name = "UTC"
+    try:
+        return ZoneInfo(name)
+    except (ZoneInfoNotFoundError, ValueError):
+        logger.warning(f"Invalid daypart timezone {name!r}; falling back to UTC")
+        return ZoneInfo("UTC")
+
+
+def _parse_hhmm(value: str, fallback: dt_time) -> dt_time:
+    """Parse an ``HH:MM`` string into a ``time``; return ``fallback`` on bad input."""
+    try:
+        parts = str(value).strip().split(":")
+        hour = int(parts[0])
+        minute = int(parts[1]) if len(parts) > 1 else 0
+        if not (0 <= hour <= 23 and 0 <= minute <= 59):
+            raise ValueError(f"out of range: {value!r}")
+        return dt_time(hour, minute)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"Invalid daypart time {value!r}; using fallback {fallback}: {e}")
+        return fallback
+
+
+def _now_local(_now: datetime | None = None) -> datetime:
+    """Return the current local wall-clock time in the resolved timezone.
+
+    ``_now`` (test seam) may be naive (treated as already-local) or aware
+    (converted into the resolved tz).
+    """
+    tz = _resolve_tz()
+    if _now is not None:
+        if _now.tzinfo is None:
+            return _now
+        return _now.astimezone(tz)
+    return datetime.now(tz)
+
+
+def get_current_daypart(_now: datetime | None = None) -> Daypart:
+    """Compute the current daypart from the configured clock windows.
+
+    - night: if ``night_start > night_end`` (the usual 22:00→07:00 wrap),
+      night = ``t >= night_start or t < night_end``; otherwise (no wrap)
+      night = ``night_start <= t < night_end``.
+    - evening: ``evening_start <= t < night_start``.
+    - day: everything else.
+    """
+    night_start = _parse_hhmm(settings.daypart_night_start, _DEFAULT_NIGHT_START)
+    night_end = _parse_hhmm(settings.daypart_night_end, _DEFAULT_NIGHT_END)
+    evening_start = _parse_hhmm(settings.daypart_evening_start, _DEFAULT_EVENING_START)
+
+    t = _now_local(_now).time()
+
+    if night_start > night_end:
+        is_night = t >= night_start or t < night_end
+    else:
+        is_night = night_start <= t < night_end
+    if is_night:
+        return "night"
+
+    # Evening runs from evening_start until night begins. Like night, it can wrap
+    # midnight — e.g. an early-morning night window (night_start < evening_start)
+    # means evening spans evening_start → midnight → night_start.
+    if evening_start <= night_start:
+        is_evening = evening_start <= t < night_start
+    else:
+        is_evening = t >= evening_start or t < night_start
+    if is_evening:
+        return "evening"
+
+    return "day"
+
+
+def is_night(_now: datetime | None = None) -> bool:
+    """True if the current daypart is night."""
+    return get_current_daypart(_now) == "night"
+
+
+def get_daypart_info(_now: datetime | None = None) -> dict:
+    """Return a small dict for the ``daypart_changed`` hook payload.
+
+    Keys: ``daypart`` (day/evening/night), ``local_time`` (HH:MM), ``local_date``
+    (YYYY-MM-DD), all in the resolved local timezone.
+    """
+    now = _now_local(_now)
+    return {
+        "daypart": get_current_daypart(_now),
+        "local_time": now.strftime("%H:%M"),
+        "local_date": now.strftime("%Y-%m-%d"),
+    }
+
+
+def build_time_context(lang: str = "de") -> str:
+    """Build a short prompt string describing the current time-of-day.
+
+    Example (de): ``"ZEITKONTEXT: Aktuelle Zeit: 22:14 Uhr (Nacht, Donnerstag)"``
+    Example (en): ``"TIME CONTEXT: Current time: 22:14 (Night, Thursday)"``
+
+    Wraps everything in try/except and returns "" on ANY error so the agent
+    path can never be broken by this helper.
+    """
+    try:
+        lang_key = "en" if str(lang).lower().startswith("en") else "de"
+        now = _now_local()
+        daypart = get_current_daypart()
+        label = _DAYPART_LABELS[lang_key][daypart]
+        weekday = _WEEKDAYS[lang_key][now.weekday()]
+        hhmm = now.strftime("%H:%M")
+        if lang_key == "en":
+            return f"TIME CONTEXT: Current time: {hhmm} ({label}, {weekday})"
+        return f"ZEITKONTEXT: Aktuelle Zeit: {hhmm} Uhr ({label}, {weekday})"
+    except Exception as e:  # noqa: BLE001 — must never break the agent
+        logger.warning(f"build_time_context failed, returning empty: {e}")
+        return ""

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -58,6 +58,13 @@ class Settings(BaseSettings):
     daypart_night_start: str = "22:00"
     daypart_night_end: str = "07:00"
     daypart_evening_start: str = "18:00"
+    # Satellite LED brightness (0-31, APA102/XVF3800 scale) per daypart. The
+    # backend pushes the night level to all connected satellites on the
+    # `daypart_changed` → night transition (and rides it in register_ack so a
+    # mid-night reconnect comes up dimmed). Animations are never disabled — only
+    # their brightness is scaled. See ha_glue/services/led_dimming_service.py.
+    led_day_brightness: int = 20
+    led_night_brightness: int = 5
 
     # Datenbank - Einzelfelder für dynamischen DATABASE_URL-Aufbau
     database_url: str | None = None

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -51,6 +51,14 @@ class Settings(BaseSettings):
     feature_knowledge: bool | None = None        # None = use edition default
     feature_knowledge_graph: bool | None = None  # None = use edition default
 
+    # Day/night awareness — time-of-day windows used by services/daypart_service.py
+    # to compute the current daypart (day/evening/night) for the agent prompt and
+    # the `daypart_changed` hook. Windows are HH:MM in the local timezone.
+    daypart_timezone: str = ""  # empty => reuse ha_glue presence_analytics_timezone, else UTC
+    daypart_night_start: str = "22:00"
+    daypart_night_end: str = "07:00"
+    daypart_evening_start: str = "18:00"
+
     # Datenbank - Einzelfelder für dynamischen DATABASE_URL-Aufbau
     database_url: str | None = None
     postgres_user: str = "renfield"

--- a/src/backend/utils/hooks.py
+++ b/src/backend/utils/hooks.py
@@ -60,6 +60,13 @@ HOOK_EVENTS: frozenset[str] = frozenset({
     "presence_leave_room",
     "presence_first_arrived",
     "presence_last_left",
+    # Time-of-day transition — fired by the lifecycle daypart watcher when the
+    # computed daypart changes (or on the first tick after boot). Lets features
+    # react to day/evening/night boundaries (e.g. satellite LED dimming).
+    # Kwargs: `previous: str` (the prior daypart, or None on first tick),
+    # `current: str` (the new daypart), `local_time: str` (HH:MM in the
+    # configured local timezone).
+    "daypart_changed",
     "compact_mcp_result",
     "authenticate",
     # Pluggable-auth identity resolution — fired ONCE by /auth/login after

--- a/src/satellite/provisioning/group_vars/satellites.yml
+++ b/src/satellite/provisioning/group_vars/satellites.yml
@@ -39,6 +39,7 @@ vad_silero_threshold: 0.5
 
 # LED
 led_brightness: 20
+led_night_brightness: 5
 led_type: "apa102"
 
 # Display

--- a/src/satellite/provisioning/templates/satellite.yaml.j2
+++ b/src/satellite/provisioning/templates/satellite.yaml.j2
@@ -53,6 +53,9 @@ vad:
 led:
   type: "{{ led_type | default('apa102') }}"
   brightness: {{ led_brightness }}
+  # Local default only — the live night brightness is pushed by the backend
+  # (led_night_brightness) over the WebSocket; this just documents the fallback.
+  night_brightness: {{ led_night_brightness | default(5) }}
   idle_color: "{{ led_idle_color | default('blue') }}"
   # num_leds is emitted for EVERY led_type so the satellite's capability
   # report (sent to the fleet page) reflects this device. Pre-fix the

--- a/src/satellite/renfield_satellite/ble/discovery_scanner.py
+++ b/src/satellite/renfield_satellite/ble/discovery_scanner.py
@@ -1,0 +1,137 @@
+"""
+Bluetooth Discovery Scanner for Renfield Satellite.
+
+Unlike the presence scanners (`BLEScanner` / `ClassicBTScanner`), which probe a
+KNOWN whitelist of MACs to decide who is home, this scanner answers the chat
+question "scan all bluetooth devices": it does a broad, no-filter DISCOVERY of
+every advertising/discoverable device in radio range, for both transports:
+
+- BLE: `BleakScanner.discover` (passive advertisement listen).
+- Classic BR/EDR: an `hcitool scan` inquiry (only finds DISCOVERABLE devices —
+  most phones are not discoverable, so Classic results are usually sparse).
+
+The Pi has a SINGLE Bluetooth controller, so the two sub-scans are run
+SEQUENTIALLY — a BLE scan and a Classic inquiry at the same time fight over the
+one radio and both come back empty/garbled. discover() NEVER raises: a failing
+sub-scan logs and contributes whatever it managed to collect, so the backend
+always gets a (possibly partial) list rather than an error.
+
+Each result dict: {"mac": <UPPER>, "name": str|None, "rssi": int|None,
+"transport": "BLE"|"Classic"}. RSSI is None for Classic (an inquiry carries no
+per-device signal strength on this path).
+"""
+
+import asyncio
+import re
+import shutil
+
+try:
+    from bleak import BleakScanner
+    BLEAK_AVAILABLE = True
+except ImportError:  # pragma: no cover - bleak missing only on non-Pi dev boxes
+    BleakScanner = None  # type: ignore
+    BLEAK_AVAILABLE = False
+
+# A discoverable device line from `hcitool scan`:  "\t<MAC>\t<Name>".
+# The first output line is the "Scanning ..." header, which has no MAC.
+_HCITOOL_LINE_RE = re.compile(
+    r"^\s*([0-9A-Fa-f]{2}(?::[0-9A-Fa-f]{2}){5})\s+(.*)$"
+)
+
+
+class BTDiscoveryScanner:
+    """Broad, no-filter Bluetooth discovery across BLE + Classic transports."""
+
+    @property
+    def classic_available(self) -> bool:
+        """Classic inquiry needs hcitool; absent on a controller-less dev box."""
+        return shutil.which("hcitool") is not None
+
+    async def discover(
+        self, ble_duration: float = 10.0, classic_timeout: float = 12.0
+    ) -> list[dict]:
+        """
+        Discover all advertising/discoverable BT devices in range.
+
+        Runs Classic inquiry first, then BLE — sequentially, since the Pi has a
+        single BT controller. Never raises: a sub-scan error logs and returns
+        what it has.
+
+        Args:
+            ble_duration: Seconds to listen for BLE advertisements.
+            classic_timeout: Inquiry length hint for `hcitool scan`. The actual
+                subprocess wait is classic_timeout + 3 (hcitool overhead).
+
+        Returns:
+            List of {"mac", "name", "rssi", "transport"} dicts.
+        """
+        results: list[dict] = []
+        # Classic first, then BLE (one controller — must not overlap).
+        results.extend(await self._discover_classic(classic_timeout))
+        results.extend(await self._discover_ble(ble_duration))
+        return results
+
+    async def _discover_ble(self, ble_duration: float) -> list[dict]:
+        """BLE advertisement scan via bleak. No MAC filter — every device."""
+        if not BLEAK_AVAILABLE:
+            print("BT discovery: bleak not available, skipping BLE scan")
+            return []
+        out: list[dict] = []
+        try:
+            # return_adv=True yields {address: (BLEDevice, AdvertisementData)} so
+            # we can read the per-advertisement RSSI (device.rssi is deprecated).
+            discovered = await BleakScanner.discover(
+                timeout=ble_duration, return_adv=True
+            )
+            for device, adv in discovered.values():
+                addr = getattr(device, "address", None)
+                if not addr:
+                    continue
+                out.append({
+                    "mac": str(addr).upper(),
+                    "name": getattr(device, "name", None) or None,
+                    "rssi": getattr(adv, "rssi", None),
+                    "transport": "BLE",
+                })
+        except Exception as e:  # noqa: BLE001 - never propagate out of discover()
+            print(f"BT discovery: BLE scan failed: {e}")
+        return out
+
+    async def _discover_classic(self, classic_timeout: float) -> list[dict]:
+        """Classic BR/EDR inquiry via `hcitool scan`. BLE-only if hcitool absent."""
+        if not self.classic_available:
+            return []
+        out: list[dict] = []
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "hcitool", "scan", "--length", "8",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                stdout, _ = await asyncio.wait_for(
+                    proc.communicate(), timeout=classic_timeout + 3
+                )
+            except asyncio.TimeoutError:
+                try:
+                    proc.kill()
+                    await proc.wait()
+                except ProcessLookupError:
+                    pass
+                print("BT discovery: Classic inquiry timed out")
+                return out
+            for line in stdout.decode(errors="replace").splitlines():
+                m = _HCITOOL_LINE_RE.match(line)
+                if not m:
+                    # The "Scanning ..." header and blank lines fall here.
+                    continue
+                mac, name = m.group(1).upper(), m.group(2).strip()
+                out.append({
+                    "mac": mac,
+                    "name": name or None,
+                    "rssi": None,
+                    "transport": "Classic",
+                })
+        except Exception as e:  # noqa: BLE001 - never propagate out of discover()
+            print(f"BT discovery: Classic inquiry failed: {e}")
+        return out

--- a/src/satellite/renfield_satellite/config.py
+++ b/src/satellite/renfield_satellite/config.py
@@ -108,7 +108,12 @@ class VADConfig:
 class LEDConfig:
     """LED control settings"""
     type: str = "apa102"  # "apa102", "gpio_rgb", "xvf3800", or "none"
-    brightness: int = 20  # 0-255
+    brightness: int = 20  # 0-31 (APA102/XVF3800 scale)
+    # Documentation/default only — the LIVE night brightness is pushed by the
+    # backend over the WebSocket (`led_config` / register_ack led_brightness).
+    # This is the local fallback default the backend's led_night_brightness
+    # mirrors; the satellite does not apply it on its own.
+    night_brightness: int = 5
     spi_bus: int = 0
     spi_device: int = 0
     num_leds: int = 3
@@ -282,6 +287,7 @@ def load_config(config_path: Optional[str] = None) -> Config:
         led = config_data["led"]
         config.led.type = led.get("type", config.led.type)
         config.led.brightness = led.get("brightness", config.led.brightness)
+        config.led.night_brightness = led.get("night_brightness", config.led.night_brightness)
         config.led.num_leds = led.get("num_leds", config.led.num_leds)
         config.led.spi_bus = led.get("spi_bus", config.led.spi_bus)
         config.led.spi_device = led.get("spi_device", config.led.spi_device)

--- a/src/satellite/renfield_satellite/network/websocket_client.py
+++ b/src/satellite/renfield_satellite/network/websocket_client.py
@@ -134,6 +134,8 @@ class WebSocketClient:
         self._on_led_config: Optional[Callable[[int], None]] = None
         # Async callback returning JPEG bytes (or None) for an on-demand snapshot.
         self._capture_snapshot: Optional[Callable[[], Any]] = None
+        # Async callback(params) -> list[dict] for an on-demand BT discovery scan.
+        self._on_bt_scan_request: Optional[Callable[[Dict[str, Any]], Any]] = None
 
         # Tasks
         self._heartbeat_task: Optional[asyncio.Task] = None
@@ -228,6 +230,11 @@ class WebSocketClient:
     def on_led_config(self, callback: Callable[[int], None]):
         """Register callback for backend-pushed LED brightness (0-31)"""
         self._on_led_config = callback
+
+    def on_bt_scan_request(self, callback: Callable[[Dict[str, Any]], Any]):
+        """Register async callback(params)->list[dict] for a backend-requested
+        Bluetooth discovery scan. Returns the discovered device list."""
+        self._on_bt_scan_request = callback
 
     def set_metrics_callback(self, callback: Callable[[], Dict[str, Any]]):
         """Register callback to get current metrics for heartbeat"""
@@ -597,6 +604,35 @@ class WebSocketClient:
             # check before a private announcement). Reply asynchronously so we
             # never block the receive loop on camera capture.
             asyncio.create_task(self._handle_capture_snapshot(data.get("request_id")))
+
+        elif msg_type == "bt_scan_request":
+            # Backend asked for an on-demand Bluetooth discovery scan ("scan all
+            # bluetooth devices"). Reply asynchronously so the long BLE+Classic
+            # scan never blocks the receive loop.
+            asyncio.create_task(
+                self._handle_bt_scan(data.get("request_id"), data.get("params", {}))
+            )
+
+    async def _handle_bt_scan(self, request_id, params):
+        """Run the BT discovery scan and send back a bt_scan_result. Always
+        replies (devices=[] + error on failure) so the backend never hangs."""
+        devices: list = []
+        error = None
+        try:
+            if self._on_bt_scan_request is not None:
+                devices = await self._on_bt_scan_request(params or {})
+        except Exception as e:  # noqa: BLE001
+            error = str(e)
+            print(f"BT discovery scan failed: {e}")
+        try:
+            await self._send({
+                "type": "bt_scan_result",
+                "request_id": request_id,
+                "devices": devices,
+                "error": error,
+            })
+        except Exception as e:  # noqa: BLE001
+            print(f"Failed to send bt_scan_result: {e}")
 
     async def _handle_capture_snapshot(self, request_id):
         """Capture a snapshot and send it back as a snapshot_result. Always sends

--- a/src/satellite/renfield_satellite/network/websocket_client.py
+++ b/src/satellite/renfield_satellite/network/websocket_client.py
@@ -129,6 +129,9 @@ class WebSocketClient:
         self._on_update_request: Optional[Callable[[str, str, str, int], None]] = None  # version, url, checksum, size
         self._on_ble_known_devices: Optional[Callable[[List[str]], None]] = None
         self._on_classic_bt_known_devices: Optional[Callable[[List[str]], None]] = None
+        # Backend-pushed LED brightness (night-dimming). Carried both as a live
+        # `led_config` message and inside register_ack (mid-night reconnect).
+        self._on_led_config: Optional[Callable[[int], None]] = None
         # Async callback returning JPEG bytes (or None) for an on-demand snapshot.
         self._capture_snapshot: Optional[Callable[[], Any]] = None
 
@@ -221,6 +224,10 @@ class WebSocketClient:
     def on_classic_bt_known_devices(self, callback: Callable[[List[str]], None]):
         """Register callback for Classic BT known devices list from server"""
         self._on_classic_bt_known_devices = callback
+
+    def on_led_config(self, callback: Callable[[int], None]):
+        """Register callback for backend-pushed LED brightness (0-31)"""
+        self._on_led_config = callback
 
     def set_metrics_callback(self, callback: Callable[[], Dict[str, Any]]):
         """Register callback to get current metrics for heartbeat"""
@@ -381,6 +388,14 @@ class WebSocketClient:
                 )
                 print(f"Registered successfully. Server protocol: {server_protocol}")
                 print(f"Config: wake_words={self._server_config.wake_words}, threshold={self._server_config.threshold}")
+
+                # Apply the backend's current LED brightness immediately so a
+                # satellite reconnecting mid-night comes up already dimmed.
+                if self._on_led_config and "led_brightness" in data:
+                    try:
+                        self._on_led_config(int(data["led_brightness"]))
+                    except (TypeError, ValueError) as e:
+                        print(f"Invalid register_ack led_brightness: {e}")
 
                 if self._on_connected:
                     self._on_connected(self._server_config)
@@ -567,6 +582,15 @@ class WebSocketClient:
             print(f"Classic BT known devices received: {len(devices)} MACs")
             if self._on_classic_bt_known_devices:
                 self._on_classic_bt_known_devices(devices)
+
+        elif msg_type == "led_config":
+            # Backend pushed a new LED brightness (night-dimming). Guard a
+            # missing/garbage value so a malformed push can't crash the loop.
+            if self._on_led_config and "brightness" in data:
+                try:
+                    self._on_led_config(int(data["brightness"]))
+                except (TypeError, ValueError) as e:
+                    print(f"Invalid led_config brightness: {e}")
 
         elif msg_type == "capture_snapshot":
             # Backend asked for an on-demand camera snapshot (e.g. occupancy

--- a/src/satellite/renfield_satellite/satellite.py
+++ b/src/satellite/renfield_satellite/satellite.py
@@ -35,6 +35,7 @@ from .network.model_downloader import get_model_downloader, ModelDownloader
 from .wakeword.detector import MICRO_BUILTIN_MODELS
 from .ble.scanner import BLEScanner, BLEAK_AVAILABLE
 from .ble.classic_scanner import ClassicBTScanner
+from .ble.discovery_scanner import BTDiscoveryScanner
 from .update import UpdateManager, UpdateStage
 
 
@@ -265,6 +266,10 @@ class Satellite:
         elif self.config.ble.enabled:
             print("Warning: hcitool not found. Classic BT scanning disabled.")
 
+        # On-demand broad BT discovery scanner (backend "scan all bluetooth
+        # devices" request). Independent of the known-MAC presence scanners.
+        self.bt_discovery_scanner = BTDiscoveryScanner()
+
         # Wire up callbacks
         self._setup_callbacks()
 
@@ -290,6 +295,8 @@ class Satellite:
         self.ws_client.on_led_config(self._on_led_config_update)
         # On-demand camera snapshot (backend occupancy check for private announcements)
         self.ws_client._capture_snapshot = self._capture_snapshot_for_request
+        # On-demand Bluetooth discovery scan ("scan all bluetooth devices")
+        self.ws_client.on_bt_scan_request(self._handle_bt_scan_for_request)
 
         # Update manager progress callback
         self.update_manager.on_progress(self._on_update_progress)
@@ -443,6 +450,14 @@ class Satellite:
         if self.camera and self.camera.available:
             return await self.camera.capture()
         return None
+
+    async def _handle_bt_scan_for_request(self, params: dict) -> list[dict]:
+        """Run a broad BT discovery scan for a backend "scan all bluetooth
+        devices" request, returning the discovered device list (BLE + Classic)."""
+        return await self.bt_discovery_scanner.discover(
+            params.get("ble_duration", 10.0),
+            params.get("classic_timeout", 12.0),
+        )
 
     async def _reconnect_with_discovery(self):
         """

--- a/src/satellite/renfield_satellite/satellite.py
+++ b/src/satellite/renfield_satellite/satellite.py
@@ -286,6 +286,8 @@ class Satellite:
         self.ws_client.on_ble_known_devices(self._on_ble_known_devices)
         # Classic BT known devices callback
         self.ws_client.on_classic_bt_known_devices(self._on_classic_bt_known_devices)
+        # Backend-pushed LED brightness (night-dimming)
+        self.ws_client.on_led_config(self._on_led_config_update)
         # On-demand camera snapshot (backend occupancy check for private announcements)
         self.ws_client._capture_snapshot = self._capture_snapshot_for_request
 
@@ -1050,6 +1052,28 @@ class Satellite:
         """Handle Classic BT known devices list pushed from server"""
         self._classic_bt_known_macs = {mac.upper() for mac in devices}
         print(f"Classic BT known devices updated: {len(self._classic_bt_known_macs)} MACs")
+
+    def _on_led_config_update(self, brightness: int):
+        """Apply a backend-pushed LED brightness (night-dimming).
+
+        Only scales animation brightness — never stops/restarts the running
+        pattern. Brightness is clamped to the APA102/XVF3800 0-31 range. For the
+        XVF3800 (XMOS renders effects in hardware) an explicit LED_BRIGHTNESS
+        command is needed; APA102/GPIO read ``self.leds.brightness`` live per
+        frame so setting the attribute is enough.
+        """
+        clamped = min(31, max(0, int(brightness)))
+        old = getattr(self.leds, "brightness", None)
+        self.leds.brightness = clamped
+
+        # XVF3800: push the brightness to the XMOS chip at runtime.
+        if hasattr(self.leds, "_run"):
+            try:
+                self.leds._run("LED_BRIGHTNESS", str(clamped))
+            except Exception as e:
+                print(f"Failed to set XVF3800 LED brightness: {e}")
+
+        print(f"LED brightness updated: {old} -> {clamped}")
 
     async def _start_ble_scan_loop(self):
         """Start the BLE scanning background loop"""

--- a/tests/backend/test_bt_scan_service.py
+++ b/tests/backend/test_bt_scan_service.py
@@ -1,0 +1,160 @@
+"""
+Tests for BtScanService — fan-out + aggregate a Bluetooth discovery scan.
+
+Covers:
+- MAC dedup keeping the strongest RSSI across satellites,
+- the same MAC seen by two satellites collapsing to one device with two rooms,
+- OUI vendor lookup from the MAC prefix,
+- a raising / timed-out satellite being skipped (satellites_responded reflects it),
+- sorting by best RSSI (strongest first).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ha_glue.services.bt_scan_service import BtScanService, _oui_lookup
+
+
+def _sat(sat_id, room):
+    return SimpleNamespace(satellite_id=sat_id, room=room)
+
+
+def _make_manager(sats, scan_results):
+    """Fake satellite_manager: .satellites dict + request_bt_scan returning a
+    preset per-satellite-id result (a list, None, or an Exception to raise)."""
+    mgr = SimpleNamespace()
+    mgr.satellites = {s.satellite_id: s for s in sats}
+
+    async def _request_bt_scan(satellite_id, params, timeout=30.0):
+        result = scan_results.get(satellite_id)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    mgr.request_bt_scan = AsyncMock(side_effect=_request_bt_scan)
+    return mgr
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dedup_keeps_strongest_rssi_and_merges_rooms():
+    """Same MAC from two satellites -> one device, two rooms, best RSSI kept."""
+    sats = [_sat("sat-a", "Kitchen"), _sat("sat-b", "Office")]
+    scan_results = {
+        "sat-a": [{"mac": "11:22:33:44:55:66", "name": "Phone", "rssi": -70, "transport": "BLE"}],
+        "sat-b": [{"mac": "11:22:33:44:55:66", "name": "Phone", "rssi": -40, "transport": "BLE"}],
+    }
+    mgr = _make_manager(sats, scan_results)
+
+    out = await BtScanService().scan_all_satellites(mgr)
+
+    assert out["total_devices"] == 1
+    assert out["satellites_queried"] == 2
+    assert out["satellites_responded"] == 2
+    dev = out["devices"][0]
+    assert dev["mac"] == "11:22:33:44:55:66"
+    assert dev["rssi_best"] == -40  # strongest wins
+    rooms = {r["room"] for r in dev["rooms"]}
+    assert rooms == {"Kitchen", "Office"}
+    assert len(dev["rooms"]) == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_oui_vendor_lookup():
+    """An Apple OUI prefix resolves to the Apple vendor label."""
+    sats = [_sat("sat-a", "Kitchen")]
+    scan_results = {
+        "sat-a": [{"mac": "A4:C3:F0:11:22:33", "name": "iPhone", "rssi": -55, "transport": "BLE"}],
+    }
+    mgr = _make_manager(sats, scan_results)
+
+    out = await BtScanService().scan_all_satellites(mgr)
+
+    assert out["devices"][0]["vendor"] == "Apple"
+    # Sanity-check the helper directly too.
+    assert _oui_lookup("A4:C3:F0:00:00:00") == "Apple"
+    assert _oui_lookup("DE:AD:BE:EF:00:00") == "Unknown"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_raising_and_timed_out_satellites_are_skipped():
+    """A satellite that raises (gather exception) or returns None (timeout) is
+    not counted as responded, but the rest still aggregate."""
+    sats = [
+        _sat("sat-good", "Kitchen"),
+        _sat("sat-raises", "Office"),
+        _sat("sat-timeout", "Bedroom"),
+    ]
+    scan_results = {
+        "sat-good": [{"mac": "AA:BB:CC:DD:EE:FF", "name": "Speaker", "rssi": -60, "transport": "Classic"}],
+        "sat-raises": RuntimeError("ws send failed"),
+        "sat-timeout": None,  # request_bt_scan returns None on timeout
+    }
+    mgr = _make_manager(sats, scan_results)
+
+    out = await BtScanService().scan_all_satellites(mgr)
+
+    assert out["satellites_queried"] == 3
+    assert out["satellites_responded"] == 1  # only sat-good
+    assert out["total_devices"] == 1
+    assert out["devices"][0]["mac"] == "AA:BB:CC:DD:EE:FF"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sorted_by_rssi_desc_none_last():
+    """Devices sort strongest-RSSI first; a Classic (None RSSI) device sorts last."""
+    sats = [_sat("sat-a", "Kitchen")]
+    scan_results = {
+        "sat-a": [
+            {"mac": "00:00:00:00:00:01", "name": "weak", "rssi": -90, "transport": "BLE"},
+            {"mac": "00:00:00:00:00:02", "name": "strong", "rssi": -30, "transport": "BLE"},
+            {"mac": "00:00:00:00:00:03", "name": "classic", "rssi": None, "transport": "Classic"},
+        ],
+    }
+    mgr = _make_manager(sats, scan_results)
+
+    out = await BtScanService().scan_all_satellites(mgr)
+
+    macs = [d["mac"] for d in out["devices"]]
+    assert macs[0] == "00:00:00:00:00:02"  # strongest first
+    assert macs[1] == "00:00:00:00:00:01"
+    assert macs[2] == "00:00:00:00:00:03"  # None RSSI last
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_no_satellites_returns_empty():
+    """Zero satellites -> empty aggregate, queried/responded 0."""
+    mgr = _make_manager([], {})
+
+    out = await BtScanService().scan_all_satellites(mgr)
+
+    assert out == {
+        "total_devices": 0,
+        "satellites_queried": 0,
+        "satellites_responded": 0,
+        "devices": [],
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_missing_name_filled_from_other_satellite():
+    """A device seen nameless by one satellite and named by another keeps the name."""
+    sats = [_sat("sat-a", "Kitchen"), _sat("sat-b", "Office")]
+    scan_results = {
+        "sat-a": [{"mac": "12:34:56:78:9A:BC", "name": None, "rssi": -80, "transport": "BLE"}],
+        "sat-b": [{"mac": "12:34:56:78:9A:BC", "name": "Headphones", "rssi": -85, "transport": "BLE"}],
+    }
+    mgr = _make_manager(sats, scan_results)
+
+    out = await BtScanService().scan_all_satellites(mgr)
+
+    assert out["total_devices"] == 1
+    assert out["devices"][0]["name"] == "Headphones"
+    assert out["devices"][0]["rssi_best"] == -80

--- a/tests/backend/test_bt_scan_tool.py
+++ b/tests/backend/test_bt_scan_tool.py
@@ -1,0 +1,149 @@
+"""
+Tests for the internal.bluetooth_scan agent tool (_bluetooth_scan handler).
+
+Covers:
+- bt_scan_enabled=False => early disabled message (no scan run),
+- enabled + 0 satellites responded => success False,
+- happy path => success True + aggregated data,
+- the tool is registered in TOOLS + _HANDLERS.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ha_glue.services.internal_tools import InternalToolService
+
+
+@pytest.fixture
+def internal_tools():
+    return InternalToolService()
+
+
+def test_tool_registered():
+    """internal.bluetooth_scan is exposed in TOOLS and dispatched in _HANDLERS."""
+    assert "internal.bluetooth_scan" in InternalToolService.TOOLS
+    assert InternalToolService._HANDLERS["internal.bluetooth_scan"] == "_bluetooth_scan"
+    desc = InternalToolService.TOOLS["internal.bluetooth_scan"]["description"]
+    # The description must warn it's slow and not to retry.
+    assert "15-30" in desc
+    assert "retry" in desc.lower()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_disabled_returns_early(internal_tools):
+    """Flag off => disabled message, BtScanService never constructed."""
+    with patch("ha_glue.utils.config.ha_glue_settings") as mock_settings, \
+         patch("ha_glue.services.bt_scan_service.BtScanService") as mock_svc:
+        mock_settings.bt_scan_enabled = False
+        result = await internal_tools._bluetooth_scan({})
+
+    assert result["success"] is False
+    assert "disabled" in result["message"].lower()
+    mock_svc.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_no_satellites_responded_is_failure(internal_tools):
+    """Enabled but 0 satellites responded => success False (with data echoed)."""
+    scan_data = {
+        "total_devices": 0,
+        "satellites_queried": 2,
+        "satellites_responded": 0,
+        "devices": [],
+    }
+    with patch("ha_glue.utils.config.ha_glue_settings") as mock_settings, \
+         patch("ha_glue.services.satellite_manager.get_satellite_manager"), \
+         patch("ha_glue.services.bt_scan_service.BtScanService") as mock_svc:
+        mock_settings.bt_scan_enabled = True
+        mock_svc.return_value.scan_all_satellites = AsyncMock(return_value=scan_data)
+        result = await internal_tools._bluetooth_scan({})
+
+    assert result["success"] is False
+    assert result["data"]["satellites_responded"] == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_happy_path_returns_devices(internal_tools):
+    """Enabled + responding satellites => success True + aggregated data."""
+    scan_data = {
+        "total_devices": 1,
+        "satellites_queried": 2,
+        "satellites_responded": 2,
+        "devices": [{
+            "mac": "A4:C3:F0:11:22:33",
+            "name": "iPhone",
+            "rssi_best": -40,
+            "transport": "BLE",
+            "vendor": "Apple",
+            "rooms": [{"satellite_id": "sat-a", "room": "Kitchen", "rssi": -40}],
+        }],
+    }
+    with patch("ha_glue.utils.config.ha_glue_settings") as mock_settings, \
+         patch("ha_glue.services.satellite_manager.get_satellite_manager") as mock_mgr, \
+         patch("ha_glue.services.bt_scan_service.BtScanService") as mock_svc:
+        mock_settings.bt_scan_enabled = True
+        mock_svc.return_value.scan_all_satellites = AsyncMock(return_value=scan_data)
+        result = await internal_tools._bluetooth_scan(
+            {"ble_duration": 8, "classic_timeout": 10}
+        )
+
+    assert result["success"] is True
+    assert result["action_taken"] is True
+    assert result["data"]["total_devices"] == 1
+    assert result["data"]["devices"][0]["vendor"] == "Apple"
+    # The satellite manager was resolved and the service invoked.
+    mock_mgr.assert_called_once()
+    mock_svc.return_value.scan_all_satellites.assert_awaited_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_no_satellites_connected_is_failure(internal_tools):
+    """0 satellites queried (none connected) => success False."""
+    scan_data = {
+        "total_devices": 0,
+        "satellites_queried": 0,
+        "satellites_responded": 0,
+        "devices": [],
+    }
+    with patch("ha_glue.utils.config.ha_glue_settings") as mock_settings, \
+         patch("ha_glue.services.satellite_manager.get_satellite_manager"), \
+         patch("ha_glue.services.bt_scan_service.BtScanService") as mock_svc:
+        mock_settings.bt_scan_enabled = True
+        mock_svc.return_value.scan_all_satellites = AsyncMock(return_value=scan_data)
+        result = await internal_tools._bluetooth_scan({})
+
+    assert result["success"] is False
+    assert "no satellites" in result["message"].lower()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_durations_clamped_to_20(internal_tools):
+    """ble_duration / classic_timeout are clamped to a 20s ceiling."""
+    captured = {}
+
+    async def _capture(satellite_manager, **kwargs):
+        captured.update(kwargs)
+        return {
+            "total_devices": 0,
+            "satellites_queried": 1,
+            "satellites_responded": 1,
+            "devices": [],
+        }
+
+    with patch("ha_glue.utils.config.ha_glue_settings") as mock_settings, \
+         patch("ha_glue.services.satellite_manager.get_satellite_manager"), \
+         patch("ha_glue.services.bt_scan_service.BtScanService") as mock_svc:
+        mock_settings.bt_scan_enabled = True
+        mock_svc.return_value.scan_all_satellites = _capture
+        await internal_tools._bluetooth_scan(
+            {"ble_duration": 999, "classic_timeout": 999}
+        )
+
+    assert captured["ble_duration"] == 20.0
+    assert captured["classic_timeout"] == 20.0

--- a/tests/backend/test_daypart_service.py
+++ b/tests/backend/test_daypart_service.py
@@ -1,0 +1,208 @@
+"""
+Unit tests for services/daypart_service.py — day/night awareness.
+
+Pure (no DB, no async). Deterministic times are injected via the ``_now``
+seam; settings windows are patched via ``patch.object`` on the module's
+``settings`` instance.
+"""
+
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+import services.daypart_service as ds
+from services.daypart_service import (
+    build_time_context,
+    get_current_daypart,
+    get_daypart_info,
+    is_night,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _at(hour: int, minute: int = 0, *, year=2026, month=6, day=11) -> datetime:
+    """A naive (treated-as-local) datetime at the given wall-clock time.
+
+    2026-06-11 is a Thursday — used by the build_time_context weekday tests.
+    """
+    return datetime(year, month, day, hour, minute)
+
+
+# ---------------------------------------------------------------------------
+# Night window — midnight wrap (the default 22:00 → 07:00)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "hour,minute,expected",
+    [
+        (23, 0, "night"),    # late evening, after night_start
+        (0, 1, "night"),     # just after midnight
+        (3, 0, "night"),     # deep night
+        (6, 59, "night"),    # last minute before night_end
+        (7, 0, "day"),       # exactly night_end → no longer night
+        (12, 0, "day"),      # midday
+        (17, 59, "day"),     # last minute before evening
+        (18, 0, "evening"),  # exactly evening_start
+        (20, 0, "evening"),  # mid-evening
+        (21, 59, "evening"), # last minute before night_start
+        (22, 0, "night"),    # exactly night_start → night
+    ],
+)
+def test_night_wrap_default_windows(hour, minute, expected):
+    with patch.object(ds.settings, "daypart_night_start", "22:00"), \
+         patch.object(ds.settings, "daypart_night_end", "07:00"), \
+         patch.object(ds.settings, "daypart_evening_start", "18:00"), \
+         patch.object(ds.settings, "daypart_timezone", "UTC"):
+        assert get_current_daypart(_at(hour, minute)) == expected
+
+
+# ---------------------------------------------------------------------------
+# Night window — no wrap (night_start < night_end)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "hour,minute,expected",
+    [
+        # Degenerate config: an early-morning night (02:00-04:00) with evening
+        # starting at 18:00. Evening then wraps midnight (evening_start >
+        # night_start), i.e. 18:00 → 02:00 is evening, 02:00-04:00 night,
+        # 04:00-18:00 day. (The realistic wrap config is covered above.)
+        (1, 0, "evening"),   # 01:00 is still in the wrapped evening (< night_start)
+        (2, 0, "night"),     # exactly night_start
+        (3, 0, "night"),     # inside no-wrap night
+        (3, 59, "night"),    # last minute before night_end
+        (4, 0, "day"),       # exactly night_end → day
+        (12, 0, "day"),      # midday — outside both evening and night
+        (18, 0, "evening"),  # exactly evening_start
+        (23, 0, "evening"),  # after evening_start, before the wrapped night_start
+    ],
+)
+def test_night_no_wrap(hour, minute, expected):
+    with patch.object(ds.settings, "daypart_night_start", "02:00"), \
+         patch.object(ds.settings, "daypart_night_end", "04:00"), \
+         patch.object(ds.settings, "daypart_evening_start", "18:00"), \
+         patch.object(ds.settings, "daypart_timezone", "UTC"):
+        assert get_current_daypart(_at(hour, minute)) == expected
+
+
+# ---------------------------------------------------------------------------
+# is_night delegates to get_current_daypart
+# ---------------------------------------------------------------------------
+
+def test_is_night_delegates():
+    with patch.object(ds.settings, "daypart_night_start", "22:00"), \
+         patch.object(ds.settings, "daypart_night_end", "07:00"), \
+         patch.object(ds.settings, "daypart_evening_start", "18:00"), \
+         patch.object(ds.settings, "daypart_timezone", "UTC"):
+        assert is_night(_at(23, 0)) is True
+        assert is_night(_at(6, 59)) is True
+        assert is_night(_at(12, 0)) is False
+        assert is_night(_at(20, 0)) is False  # evening, not night
+
+
+# ---------------------------------------------------------------------------
+# get_daypart_info shape
+# ---------------------------------------------------------------------------
+
+def test_get_daypart_info():
+    with patch.object(ds.settings, "daypart_night_start", "22:00"), \
+         patch.object(ds.settings, "daypart_night_end", "07:00"), \
+         patch.object(ds.settings, "daypart_evening_start", "18:00"), \
+         patch.object(ds.settings, "daypart_timezone", "UTC"):
+        info = get_daypart_info(_at(22, 14))
+        assert info["daypart"] == "night"
+        assert info["local_time"] == "22:14"
+        assert info["local_date"] == "2026-06-11"
+
+
+# ---------------------------------------------------------------------------
+# build_time_context — non-empty + carries the daypart label (de + en)
+# ---------------------------------------------------------------------------
+
+def test_build_time_context_de_contains_label():
+    # 2026-06-11 22:14 is a Thursday night.
+    with patch.object(ds.settings, "daypart_night_start", "22:00"), \
+         patch.object(ds.settings, "daypart_night_end", "07:00"), \
+         patch.object(ds.settings, "daypart_evening_start", "18:00"), \
+         patch.object(ds.settings, "daypart_timezone", "UTC"), \
+         patch.object(ds, "_now_local", return_value=_at(22, 14)):
+        out = build_time_context(lang="de")
+        assert out  # non-empty
+        assert "ZEITKONTEXT" in out
+        assert "Nacht" in out
+        assert "Donnerstag" in out
+        assert "22:14" in out
+
+
+def test_build_time_context_en_contains_label():
+    with patch.object(ds.settings, "daypart_night_start", "22:00"), \
+         patch.object(ds.settings, "daypart_night_end", "07:00"), \
+         patch.object(ds.settings, "daypart_evening_start", "18:00"), \
+         patch.object(ds.settings, "daypart_timezone", "UTC"), \
+         patch.object(ds, "_now_local", return_value=_at(22, 14)):
+        out = build_time_context(lang="en")
+        assert out
+        assert "TIME CONTEXT" in out
+        assert "Night" in out
+        assert "Thursday" in out
+        assert "22:14" in out
+
+
+def test_build_time_context_day_label_de():
+    with patch.object(ds.settings, "daypart_night_start", "22:00"), \
+         patch.object(ds.settings, "daypart_night_end", "07:00"), \
+         patch.object(ds.settings, "daypart_evening_start", "18:00"), \
+         patch.object(ds.settings, "daypart_timezone", "UTC"), \
+         patch.object(ds, "_now_local", return_value=_at(12, 0)):
+        out = build_time_context(lang="de")
+        assert "Tag" in out
+        assert "12:00" in out
+
+
+# ---------------------------------------------------------------------------
+# build_time_context never raises — returns "" on error
+# ---------------------------------------------------------------------------
+
+def test_build_time_context_empty_on_error():
+    # datetime.now (via _now_local) raising must degrade to "".
+    with patch.object(ds, "_now_local", side_effect=RuntimeError("boom")):
+        assert build_time_context(lang="de") == ""
+        assert build_time_context(lang="en") == ""
+
+
+# ---------------------------------------------------------------------------
+# TZ fallback chain — invalid TZ degrades to UTC without crashing
+# ---------------------------------------------------------------------------
+
+def test_invalid_tz_falls_back_to_utc():
+    with patch.object(ds.settings, "daypart_timezone", "Not/AReal_Zone"):
+        tz = ds._resolve_tz()
+        assert str(tz) == "UTC"
+
+
+def test_empty_tz_falls_back_without_crashing():
+    # Empty daypart_timezone → ha_glue presence_analytics_timezone (or UTC).
+    # Either way we must get a usable ZoneInfo and no exception.
+    with patch.object(ds.settings, "daypart_timezone", ""):
+        tz = ds._resolve_tz()
+        assert tz is not None
+        # daypart computation still works under the resolved tz.
+        with patch.object(ds.settings, "daypart_night_start", "22:00"), \
+             patch.object(ds.settings, "daypart_night_end", "07:00"), \
+             patch.object(ds.settings, "daypart_evening_start", "18:00"):
+            assert get_current_daypart(_at(23, 0)) == "night"
+
+
+# ---------------------------------------------------------------------------
+# Malformed HH:MM config falls back to safe defaults (no crash)
+# ---------------------------------------------------------------------------
+
+def test_malformed_hhmm_uses_default():
+    with patch.object(ds.settings, "daypart_night_start", "not-a-time"), \
+         patch.object(ds.settings, "daypart_night_end", "07:00"), \
+         patch.object(ds.settings, "daypart_evening_start", "18:00"), \
+         patch.object(ds.settings, "daypart_timezone", "UTC"):
+        # Default night_start (22:00) is used → 23:00 is still night.
+        assert get_current_daypart(_at(23, 0)) == "night"

--- a/tests/backend/test_led_dimming_service.py
+++ b/tests/backend/test_led_dimming_service.py
@@ -1,0 +1,139 @@
+"""Unit tests for ha_glue.services.led_dimming_service.LedDimmingService.
+
+Covers:
+- initialize() seeds night brightness when is_night() True, day when False
+- _on_daypart_changed("night") pushes led_config to all connected satellites
+- push skips/handles a satellite whose send_json raises (no propagation)
+- get_current_led_brightness reflects state
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ha_glue.services.led_dimming_service import LedDimmingService
+from utils.config import settings
+
+
+@pytest.fixture
+def patched_brightness(monkeypatch):
+    """Pin the day/night brightness levels to known values."""
+    monkeypatch.setattr(settings, "led_day_brightness", 20, raising=False)
+    monkeypatch.setattr(settings, "led_night_brightness", 5, raising=False)
+    return settings
+
+
+def _fake_satellite(satellite_id: str):
+    """Build a satellite stub with an AsyncMock send_json websocket."""
+    ws = SimpleNamespace(send_json=AsyncMock())
+    return SimpleNamespace(satellite_id=satellite_id, websocket=ws)
+
+
+def _patch_manager(monkeypatch, satellites: dict):
+    """Patch get_satellite_manager() to return a manager with these satellites."""
+    manager = SimpleNamespace(satellites=satellites)
+    monkeypatch.setattr(
+        "ha_glue.services.satellite_manager.get_satellite_manager",
+        lambda: manager,
+    )
+    return manager
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_initialize_night_sets_night_brightness(patched_brightness, monkeypatch):
+    monkeypatch.setattr(
+        "services.daypart_service.is_night", lambda *a, **k: True
+    )
+    svc = LedDimmingService()
+    # Avoid registering a real hook in the global registry.
+    monkeypatch.setattr(
+        "utils.hooks.is_hook_registered", lambda *a, **k: True
+    )
+    await svc.initialize()
+    assert svc.get_current_led_brightness() == 5
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_initialize_day_sets_day_brightness(patched_brightness, monkeypatch):
+    monkeypatch.setattr(
+        "services.daypart_service.is_night", lambda *a, **k: False
+    )
+    svc = LedDimmingService()
+    monkeypatch.setattr(
+        "utils.hooks.is_hook_registered", lambda *a, **k: True
+    )
+    await svc.initialize()
+    assert svc.get_current_led_brightness() == 20
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_on_daypart_changed_night_pushes_to_all_satellites(
+    patched_brightness, monkeypatch
+):
+    sat_a = _fake_satellite("sat-a")
+    sat_b = _fake_satellite("sat-b")
+    _patch_manager(monkeypatch, {"sat-a": sat_a, "sat-b": sat_b})
+
+    svc = LedDimmingService()
+    await svc._on_daypart_changed(previous="day", current="night", local_time="22:00")
+
+    assert svc.get_current_led_brightness() == 5
+    expected = {"type": "led_config", "brightness": 5}
+    sat_a.websocket.send_json.assert_awaited_once_with(expected)
+    sat_b.websocket.send_json.assert_awaited_once_with(expected)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_on_daypart_changed_day_pushes_day_brightness(
+    patched_brightness, monkeypatch
+):
+    sat_a = _fake_satellite("sat-a")
+    _patch_manager(monkeypatch, {"sat-a": sat_a})
+
+    svc = LedDimmingService()
+    await svc._on_daypart_changed(previous="night", current="day", local_time="07:00")
+
+    assert svc.get_current_led_brightness() == 20
+    sat_a.websocket.send_json.assert_awaited_once_with(
+        {"type": "led_config", "brightness": 20}
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_push_handles_send_failure_without_propagation(
+    patched_brightness, monkeypatch
+):
+    failing = _fake_satellite("sat-bad")
+    failing.websocket.send_json.side_effect = RuntimeError("dead link")
+    good = _fake_satellite("sat-good")
+    _patch_manager(monkeypatch, {"sat-bad": failing, "sat-good": good})
+
+    svc = LedDimmingService()
+    # Must NOT raise even though one satellite's send fails.
+    await svc.push_brightness_to_all_satellites(5)
+
+    # The healthy satellite still received its push.
+    good.websocket.send_json.assert_awaited_once_with(
+        {"type": "led_config", "brightness": 5}
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_push_with_no_satellites_is_noop(patched_brightness, monkeypatch):
+    _patch_manager(monkeypatch, {})
+    svc = LedDimmingService()
+    # No satellites → must not raise.
+    await svc.push_brightness_to_all_satellites(5)
+
+
+@pytest.mark.unit
+def test_get_current_led_brightness_defaults_to_day(patched_brightness):
+    svc = LedDimmingService()
+    assert svc.get_current_led_brightness() == 20

--- a/tests/backend/test_presence_history.py
+++ b/tests/backend/test_presence_history.py
@@ -1,0 +1,353 @@
+"""
+Tests for Persistent Presence History — satellite_id persistence, timeline /
+last-seen / room-window query methods, and the internal.presence_history tool.
+
+Mirrors the fixture + seeding pattern in test_presence_analytics.py.
+"""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from models.database import PresenceEvent, Role, Room, User
+from ha_glue.services.presence_analytics import PresenceAnalyticsService
+
+# ---------------------------------------------------------------------------
+# Helpers (same shape as test_presence_analytics.py)
+# ---------------------------------------------------------------------------
+
+async def _seed_role(db, role_id=1):
+    from sqlalchemy import select
+    result = await db.execute(select(Role).where(Role.id == role_id))
+    if result.scalar_one_or_none():
+        return
+    role = Role(id=role_id, name="TestRole", permissions="{}")
+    db.add(role)
+    await db.commit()
+
+
+async def _seed_user(db, user_id=1, username=None):
+    await _seed_role(db)
+    user = User(
+        id=user_id,
+        username=username or f"user{user_id}",
+        password_hash="x",
+        role_id=1,
+    )
+    db.add(user)
+    await db.commit()
+    return user
+
+
+async def _seed_room(db, room_id=10, room_name="Kitchen"):
+    room = Room(id=room_id, name=room_name)
+    db.add(room)
+    await db.commit()
+    return room
+
+
+async def _insert_event(db, user_id, room_id, event_type="enter", source="ble",
+                        confidence=None, satellite_id=None, created_at=None):
+    ev = PresenceEvent(
+        user_id=user_id,
+        room_id=room_id,
+        event_type=event_type,
+        source=source,
+        confidence=confidence,
+        satellite_id=satellite_id,
+    )
+    if created_at:
+        ev.created_at = created_at
+    db.add(ev)
+    await db.commit()
+    return ev
+
+
+@pytest.fixture(autouse=True)
+def _utc_analytics_tz(monkeypatch):
+    """Pin analytics bucketing/formatting to UTC for deterministic assertions."""
+    monkeypatch.setattr(
+        "ha_glue.services.presence_analytics.ha_glue_settings.presence_analytics_timezone",
+        "UTC",
+        raising=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# satellite_id persistence
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@pytest.mark.database
+class TestSatelliteIdPersistence:
+    async def test_enter_stores_satellite_id(self, db_session):
+        """_persist_event writes satellite_id onto an enter row."""
+        from ha_glue.services.presence_analytics import _persist_event
+
+        await _seed_user(db_session, user_id=1)
+        await _seed_room(db_session, room_id=10)
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=db_session)
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        import sys
+        mock_db_mod = type(sys)("services.database")
+        mock_db_mod.AsyncSessionLocal = lambda: mock_ctx
+        with patch.dict(sys.modules, {"services.database": mock_db_mod}):
+            await _persist_event(
+                "enter",
+                user_id=1, room_id=10, source="ble", confidence=0.9,
+                satellite_id="arbeitszimmer",
+            )
+
+        from sqlalchemy import select
+        events = (await db_session.execute(select(PresenceEvent))).scalars().all()
+        assert len(events) == 1
+        assert events[0].event_type == "enter"
+        assert events[0].satellite_id == "arbeitszimmer"
+
+    async def test_leave_has_null_satellite_id(self, db_session):
+        """A leave event (no satellite_id kwarg) stores NULL."""
+        from ha_glue.services.presence_analytics import _persist_event
+
+        await _seed_user(db_session, user_id=1)
+        await _seed_room(db_session, room_id=10)
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=db_session)
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        import sys
+        mock_db_mod = type(sys)("services.database")
+        mock_db_mod.AsyncSessionLocal = lambda: mock_ctx
+        with patch.dict(sys.modules, {"services.database": mock_db_mod}):
+            await _persist_event("leave", user_id=1, room_id=10, source="ble")
+
+        from sqlalchemy import select
+        events = (await db_session.execute(select(PresenceEvent))).scalars().all()
+        assert len(events) == 1
+        assert events[0].event_type == "leave"
+        assert events[0].satellite_id is None
+
+
+# ---------------------------------------------------------------------------
+# get_timeline
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@pytest.mark.database
+class TestTimeline:
+    async def test_empty_returns_empty(self, db_session):
+        service = PresenceAnalyticsService(db_session)
+        assert await service.get_timeline(user_id=1) == []
+
+    async def test_chronological_order_and_fields(self, db_session):
+        await _seed_user(db_session, user_id=1)
+        await _seed_room(db_session, room_id=10, room_name="Kitchen")
+
+        base = datetime.now(UTC).replace(tzinfo=None, microsecond=0)
+        # Insert out of order; expect oldest-first out.
+        await _insert_event(db_session, 1, 10, "leave", created_at=base + timedelta(minutes=10))
+        await _insert_event(db_session, 1, 10, "enter", satellite_id="sat-a",
+                            created_at=base)
+
+        service = PresenceAnalyticsService(db_session)
+        rows = await service.get_timeline(user_id=1)
+        assert [r["event_type"] for r in rows] == ["enter", "leave"]
+        assert rows[0]["room_name"] == "Kitchen"
+        assert rows[0]["satellite_id"] == "sat-a"
+        assert rows[1]["satellite_id"] is None
+
+    async def test_since_filter(self, db_session):
+        await _seed_user(db_session, user_id=1)
+        await _seed_room(db_session, room_id=10)
+
+        now = datetime.now(UTC).replace(tzinfo=None, microsecond=0)
+        await _insert_event(db_session, 1, 10, "enter", created_at=now - timedelta(days=5))
+        await _insert_event(db_session, 1, 10, "enter", created_at=now - timedelta(hours=1))
+
+        service = PresenceAnalyticsService(db_session)
+        rows = await service.get_timeline(user_id=1, since=now - timedelta(hours=2))
+        assert len(rows) == 1
+
+    async def test_room_id_filter(self, db_session):
+        await _seed_user(db_session, user_id=1)
+        await _seed_room(db_session, room_id=10, room_name="Kitchen")
+        await _seed_room(db_session, room_id=11, room_name="Office")
+
+        now = datetime.now(UTC).replace(tzinfo=None, microsecond=0)
+        await _insert_event(db_session, 1, 10, "enter", created_at=now)
+        await _insert_event(db_session, 1, 11, "enter", created_at=now + timedelta(minutes=1))
+
+        service = PresenceAnalyticsService(db_session)
+        rows = await service.get_timeline(user_id=1, room_id=11)
+        assert len(rows) == 1
+        assert rows[0]["room_name"] == "Office"
+
+    async def test_pagination(self, db_session):
+        await _seed_user(db_session, user_id=1)
+        await _seed_room(db_session, room_id=10)
+
+        now = datetime.now(UTC).replace(tzinfo=None, microsecond=0)
+        for i in range(5):
+            await _insert_event(db_session, 1, 10, "enter",
+                                created_at=now + timedelta(minutes=i))
+
+        service = PresenceAnalyticsService(db_session)
+        page1 = await service.get_timeline(user_id=1, limit=2, offset=0)
+        page2 = await service.get_timeline(user_id=1, limit=2, offset=2)
+        assert len(page1) == 2
+        assert len(page2) == 2
+        assert page1[0]["id"] != page2[0]["id"]
+        # Continues chronologically across pages.
+        assert page1[-1]["created_at"] <= page2[0]["created_at"]
+
+
+# ---------------------------------------------------------------------------
+# get_last_seen_by_room
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@pytest.mark.database
+class TestLastSeenByRoom:
+    async def test_empty_returns_empty(self, db_session):
+        service = PresenceAnalyticsService(db_session)
+        assert await service.get_last_seen_by_room(user_id=1) == []
+
+    async def test_max_enter_per_room_ignores_leave(self, db_session):
+        await _seed_user(db_session, user_id=1)
+        await _seed_room(db_session, room_id=10, room_name="Kitchen")
+        await _seed_room(db_session, room_id=11, room_name="Office")
+
+        now = datetime.now(UTC).replace(tzinfo=None, microsecond=0)
+        # Kitchen: two enters, latest wins.
+        await _insert_event(db_session, 1, 10, "enter", created_at=now - timedelta(hours=3))
+        latest_kitchen = now - timedelta(hours=1)
+        await _insert_event(db_session, 1, 10, "enter", created_at=latest_kitchen)
+        # A later LEAVE must not be reported as last-seen.
+        await _insert_event(db_session, 1, 10, "leave", created_at=now)
+        # Office: one enter.
+        await _insert_event(db_session, 1, 11, "enter", created_at=now - timedelta(hours=2))
+
+        service = PresenceAnalyticsService(db_session)
+        rows = await service.get_last_seen_by_room(user_id=1)
+        by_room = {r["room_name"]: r["last_seen"] for r in rows}
+        assert by_room["Kitchen"] == latest_kitchen
+        assert "Office" in by_room
+        # Ordered most-recent first.
+        assert rows[0]["room_name"] == "Kitchen"
+
+
+# ---------------------------------------------------------------------------
+# get_room_occupancy_window
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@pytest.mark.database
+class TestRoomOccupancyWindow:
+    async def test_only_target_room_and_time_bounds(self, db_session):
+        await _seed_user(db_session, user_id=1)
+        await _seed_user(db_session, user_id=2)
+        await _seed_room(db_session, room_id=10, room_name="Kitchen")
+        await _seed_room(db_session, room_id=11, room_name="Office")
+
+        now = datetime.now(UTC).replace(tzinfo=None, microsecond=0)
+        since = now - timedelta(hours=2)
+        until = now
+
+        # In window, target room, two users.
+        await _insert_event(db_session, 1, 10, "enter", created_at=now - timedelta(hours=1))
+        await _insert_event(db_session, 2, 10, "enter", created_at=now - timedelta(minutes=30))
+        # Other room — excluded.
+        await _insert_event(db_session, 1, 11, "enter", created_at=now - timedelta(hours=1))
+        # Out of window — excluded.
+        await _insert_event(db_session, 1, 10, "enter", created_at=now - timedelta(hours=5))
+
+        service = PresenceAnalyticsService(db_session)
+        rows = await service.get_room_occupancy_window(room_id=10, since=since, until=until)
+        assert len(rows) == 2
+        assert {r["user_id"] for r in rows} == {1, 2}
+        assert all(r["room_id"] == 10 for r in rows)
+        # Chronological.
+        assert rows[0]["created_at"] <= rows[1]["created_at"]
+
+
+# ---------------------------------------------------------------------------
+# internal.presence_history tool
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@pytest.mark.database
+class TestPresenceHistoryTool:
+    def _patch_session(self, db_session):
+        """Return a patch.dict context binding services.database.AsyncSessionLocal
+        to the test session so the tool's lazy imports use it."""
+        import sys
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=db_session)
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_db_mod = type(sys)("services.database")
+        mock_db_mod.AsyncSessionLocal = lambda: mock_ctx
+        return patch.dict(sys.modules, {"services.database": mock_db_mod})
+
+    async def test_missing_user_name_timeline(self, db_session):
+        from ha_glue.services.internal_tools import InternalToolService
+
+        svc = InternalToolService()
+        res = await svc._presence_history({"query_type": "timeline"})
+        assert res["success"] is False
+        assert "user_name" in res["message"]
+
+    async def test_unknown_user_informative(self, db_session):
+        from ha_glue.services.internal_tools import InternalToolService
+        from ha_glue.services.presence_service import get_presence_service
+
+        with patch.object(get_presence_service(), "find_user_by_name", return_value=None):
+            svc = InternalToolService()
+            res = await svc._presence_history(
+                {"query_type": "timeline", "user_name": "Nobody"}
+            )
+        assert res["success"] is False
+        assert "not found" in res["message"].lower()
+
+    async def test_timeline_returns_summary(self, db_session):
+        from ha_glue.services.internal_tools import InternalToolService
+        from ha_glue.services.presence_service import get_presence_service
+
+        await _seed_user(db_session, user_id=1, username="alice")
+        await _seed_room(db_session, room_id=10, room_name="Kitchen")
+        base = datetime.now(UTC).replace(tzinfo=None, microsecond=0)
+        await _insert_event(db_session, 1, 10, "enter", satellite_id="sat-a", created_at=base)
+
+        ps = get_presence_service()
+        with patch.object(ps, "find_user_by_name", return_value=1), \
+             patch.object(ps, "get_display_name", return_value="Alice"), \
+             self._patch_session(db_session):
+            svc = InternalToolService()
+            res = await svc._presence_history({
+                "query_type": "timeline",
+                "user_name": "Alice",
+                "since": (base - timedelta(hours=1)).isoformat(),
+                "until": (base + timedelta(hours=1)).isoformat(),
+            })
+
+        assert res["success"] is True
+        assert res["data"]["events"]
+        assert "Alice" in res["summary"]
+        assert "Kitchen" in res["summary"]
+
+    async def test_gate_off_returns_disabled(self, db_session, monkeypatch):
+        from ha_glue.services.internal_tools import InternalToolService
+
+        monkeypatch.setattr(
+            "ha_glue.utils.config.ha_glue_settings.presence_history_enabled",
+            False,
+            raising=False,
+        )
+        svc = InternalToolService()
+        res = await svc._presence_history({"query_type": "timeline", "user_name": "Alice"})
+        assert res["success"] is False
+        assert "disabled" in res["message"].lower()

--- a/tests/satellite/test_discovery_scanner.py
+++ b/tests/satellite/test_discovery_scanner.py
@@ -1,0 +1,191 @@
+"""
+Unit tests for the broad Bluetooth discovery scanner (BTDiscoveryScanner).
+
+Covers the no-filter BLE scan (every advertising device returned), the Classic
+`hcitool scan` inquiry parsing, and the never-raise guarantees:
+- a BLE bleak error contributes nothing but doesn't crash discover(),
+- an hcitool error / timeout yields an empty Classic list (no raise),
+- a missing hcitool (shutil.which None) falls back to BLE-only.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from renfield_satellite.ble import discovery_scanner
+from renfield_satellite.ble.discovery_scanner import BTDiscoveryScanner
+
+
+def _ble_pair(address, name, rssi):
+    """Build a (BLEDevice, AdvertisementData)-shaped pair for BleakScanner."""
+    device = SimpleNamespace(address=address, name=name)
+    adv = SimpleNamespace(rssi=rssi)
+    return device, adv
+
+
+def _fake_discover(pairs):
+    """Replacement for BleakScanner.discover(return_adv=True): {addr: (dev, adv)}."""
+    async def _discover(*args, **kwargs):
+        return {p[0].address: p for p in pairs}
+    return _discover
+
+
+def _hcitool_proc(stdout: bytes = b"", returncode: int = 0, raise_timeout: bool = False):
+    """A fake asyncio subprocess for `hcitool scan`."""
+    class _FakeProc:
+        def __init__(self):
+            self.returncode = returncode
+
+        async def communicate(self):
+            if raise_timeout:
+                raise asyncio.TimeoutError()
+            return stdout, b""
+
+        async def wait(self):
+            return self.returncode
+
+        def kill(self):
+            pass
+
+    async def _create(*args, **kwargs):
+        return _FakeProc()
+
+    return _create
+
+
+_HCITOOL_OUTPUT = (
+    b"Scanning ...\n"
+    b"\t4C:E6:C0:27:52:93\tPixel 7\n"
+    b"\tAA:BB:CC:DD:EE:FF\tLiving Room Speaker\n"
+)
+
+
+@pytest.mark.satellite
+@pytest.mark.asyncio
+async def test_ble_returns_all_devices_no_filter():
+    """Every advertising BLE device is returned (no whitelist), transport=BLE."""
+    pairs = [
+        _ble_pair("11:22:33:44:55:66", "Watch", -40),
+        _ble_pair("77:88:99:AA:BB:CC", None, -90),
+    ]
+    scanner = BTDiscoveryScanner()
+    with patch("renfield_satellite.ble.discovery_scanner.shutil.which", return_value=None), \
+         patch.object(discovery_scanner, "BLEAK_AVAILABLE", True), \
+         patch.object(discovery_scanner, "BleakScanner",
+                      SimpleNamespace(discover=_fake_discover(pairs))):
+        result = await scanner.discover(ble_duration=1.0, classic_timeout=1.0)
+
+    macs = {d["mac"] for d in result}
+    assert macs == {"11:22:33:44:55:66", "77:88:99:AA:BB:CC"}
+    assert all(d["transport"] == "BLE" for d in result)
+    by_mac = {d["mac"]: d for d in result}
+    assert by_mac["11:22:33:44:55:66"]["rssi"] == -40
+    assert by_mac["11:22:33:44:55:66"]["name"] == "Watch"
+    assert by_mac["77:88:99:AA:BB:CC"]["name"] is None
+
+
+@pytest.mark.satellite
+@pytest.mark.asyncio
+async def test_classic_lines_parsed():
+    """`hcitool scan` lines parse into Classic devices; the header is skipped."""
+    scanner = BTDiscoveryScanner()
+    with patch("renfield_satellite.ble.discovery_scanner.shutil.which",
+               return_value="/usr/bin/hcitool"), \
+         patch.object(discovery_scanner, "BLEAK_AVAILABLE", False), \
+         patch("asyncio.create_subprocess_exec",
+               side_effect=_hcitool_proc(stdout=_HCITOOL_OUTPUT)):
+        result = await scanner.discover(ble_duration=1.0, classic_timeout=1.0)
+
+    classic = [d for d in result if d["transport"] == "Classic"]
+    assert {d["mac"] for d in classic} == {
+        "4C:E6:C0:27:52:93", "AA:BB:CC:DD:EE:FF"
+    }
+    # RSSI is None for Classic; the "Scanning ..." header produced no row.
+    assert all(d["rssi"] is None for d in classic)
+    by_mac = {d["mac"]: d for d in classic}
+    assert by_mac["4C:E6:C0:27:52:93"]["name"] == "Pixel 7"
+
+
+@pytest.mark.satellite
+@pytest.mark.asyncio
+async def test_classic_error_yields_empty_no_raise():
+    """An hcitool error returns an empty Classic list without raising."""
+    async def _boom(*args, **kwargs):
+        raise OSError("hcitool exploded")
+
+    scanner = BTDiscoveryScanner()
+    with patch("renfield_satellite.ble.discovery_scanner.shutil.which",
+               return_value="/usr/bin/hcitool"), \
+         patch.object(discovery_scanner, "BLEAK_AVAILABLE", False), \
+         patch("asyncio.create_subprocess_exec", side_effect=_boom):
+        result = await scanner.discover(ble_duration=1.0, classic_timeout=1.0)
+
+    assert result == []  # BLE off + Classic errored -> empty, no exception
+
+
+@pytest.mark.satellite
+@pytest.mark.asyncio
+async def test_classic_timeout_yields_empty_no_raise():
+    """A Classic inquiry timeout returns empty (the subprocess is killed)."""
+    scanner = BTDiscoveryScanner()
+    with patch("renfield_satellite.ble.discovery_scanner.shutil.which",
+               return_value="/usr/bin/hcitool"), \
+         patch.object(discovery_scanner, "BLEAK_AVAILABLE", False), \
+         patch("asyncio.create_subprocess_exec",
+               side_effect=_hcitool_proc(raise_timeout=True)):
+        result = await scanner.discover(ble_duration=1.0, classic_timeout=1.0)
+
+    assert result == []
+
+
+@pytest.mark.satellite
+@pytest.mark.asyncio
+async def test_missing_hcitool_is_ble_only():
+    """No hcitool installed -> Classic skipped, only BLE devices returned."""
+    pairs = [_ble_pair("11:22:33:44:55:66", "Watch", -40)]
+    scanner = BTDiscoveryScanner()
+    assert scanner.classic_available is False  # shutil.which patched below
+
+    with patch("renfield_satellite.ble.discovery_scanner.shutil.which", return_value=None), \
+         patch.object(discovery_scanner, "BLEAK_AVAILABLE", True), \
+         patch.object(discovery_scanner, "BleakScanner",
+                      SimpleNamespace(discover=_fake_discover(pairs))):
+        result = await scanner.discover(ble_duration=1.0, classic_timeout=1.0)
+
+    assert len(result) == 1
+    assert result[0]["transport"] == "BLE"
+    assert result[0]["mac"] == "11:22:33:44:55:66"
+
+
+@pytest.mark.satellite
+@pytest.mark.asyncio
+async def test_ble_error_does_not_raise():
+    """A bleak discover() error is swallowed; discover() still returns a list."""
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("bluez busy")
+
+    scanner = BTDiscoveryScanner()
+    with patch("renfield_satellite.ble.discovery_scanner.shutil.which", return_value=None), \
+         patch.object(discovery_scanner, "BLEAK_AVAILABLE", True), \
+         patch.object(discovery_scanner, "BleakScanner",
+                      SimpleNamespace(discover=_boom)):
+        result = await scanner.discover(ble_duration=1.0, classic_timeout=1.0)
+
+    assert result == []
+
+
+@pytest.mark.satellite
+@pytest.mark.asyncio
+async def test_lowercase_mac_uppercased():
+    """BLE device addresses are normalized to upper-case MACs."""
+    pairs = [_ble_pair("aa:bb:cc:dd:ee:ff", "x", -50)]
+    scanner = BTDiscoveryScanner()
+    with patch("renfield_satellite.ble.discovery_scanner.shutil.which", return_value=None), \
+         patch.object(discovery_scanner, "BLEAK_AVAILABLE", True), \
+         patch.object(discovery_scanner, "BleakScanner",
+                      SimpleNamespace(discover=_fake_discover(pairs))):
+        result = await scanner.discover(ble_duration=1.0, classic_timeout=1.0)
+
+    assert result[0]["mac"] == "AA:BB:CC:DD:EE:FF"

--- a/tests/satellite/test_led_dimming.py
+++ b/tests/satellite/test_led_dimming.py
@@ -1,0 +1,149 @@
+"""
+Satellite LED night-dimming tests.
+
+Tests for Satellite._on_led_config_update (the backend-pushed brightness
+handler) and the WebSocketClient led_config dispatch:
+- sets leds.brightness
+- clamps >31 to 31 and <0 to 0
+- does NOT change the running animation pattern (only scales brightness)
+- XVF3800 path calls _run("LED_BRIGHTNESS", ...)
+- ws_client dispatches a led_config message / register_ack led_brightness
+
+The Satellite class is heavy to fully construct, so _on_led_config_update is
+exercised as an unbound method against a lightweight fake `self` holding only
+a fake LED controller (duck-typing matches the real attribute access).
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+
+class FakeAPA102LEDs:
+    """Minimal stand-in for LEDController/GPIOLEDController.
+
+    Reads ``self.brightness`` live per animation frame, so changing the
+    attribute is the whole runtime mechanism (no _run). Tracks a pattern
+    attribute so the test can assert the animation is left untouched.
+    """
+
+    def __init__(self, brightness=20):
+        self.brightness = brightness
+        self.current_pattern = "idle"  # must stay unchanged by a brightness push
+
+
+class FakeXVF3800LEDs:
+    """Minimal stand-in for XVF3800LEDController.
+
+    The XMOS chip renders effects in hardware, so a runtime brightness change
+    needs an explicit ``_run("LED_BRIGHTNESS", n)`` call.
+    """
+
+    def __init__(self, brightness=20):
+        self.brightness = brightness
+        self.current_pattern = "speaking"
+        self._run = MagicMock()
+
+
+def _call_update(leds, brightness):
+    """Invoke Satellite._on_led_config_update against a fake self holding leds."""
+    from renfield_satellite.satellite import Satellite
+
+    fake_self = MagicMock()
+    fake_self.leds = leds
+    Satellite._on_led_config_update(fake_self, brightness)
+
+
+class TestOnLedConfigUpdate:
+
+    @pytest.mark.satellite
+    def test_sets_brightness(self):
+        leds = FakeAPA102LEDs(brightness=20)
+        _call_update(leds, 5)
+        assert leds.brightness == 5
+
+    @pytest.mark.satellite
+    def test_clamps_above_31(self):
+        leds = FakeAPA102LEDs(brightness=20)
+        _call_update(leds, 99)
+        assert leds.brightness == 31
+
+    @pytest.mark.satellite
+    def test_clamps_below_0(self):
+        leds = FakeAPA102LEDs(brightness=20)
+        _call_update(leds, -10)
+        assert leds.brightness == 0
+
+    @pytest.mark.satellite
+    def test_does_not_change_pattern(self):
+        leds = FakeAPA102LEDs(brightness=20)
+        before = leds.current_pattern
+        _call_update(leds, 3)
+        # Only brightness scaled — animation pattern untouched.
+        assert leds.current_pattern == before
+        assert leds.brightness == 3
+
+    @pytest.mark.satellite
+    def test_xvf3800_calls_run_led_brightness(self):
+        leds = FakeXVF3800LEDs(brightness=20)
+        _call_update(leds, 7)
+        assert leds.brightness == 7
+        leds._run.assert_called_once_with("LED_BRIGHTNESS", "7")
+        # Pattern still untouched.
+        assert leds.current_pattern == "speaking"
+
+    @pytest.mark.satellite
+    def test_xvf3800_clamps_before_run(self):
+        leds = FakeXVF3800LEDs(brightness=20)
+        _call_update(leds, 50)
+        assert leds.brightness == 31
+        leds._run.assert_called_once_with("LED_BRIGHTNESS", "31")
+
+
+class TestWebSocketClientLedConfigDispatch:
+
+    def _make_client(self):
+        from renfield_satellite.network.websocket_client import WebSocketClient
+
+        return WebSocketClient(satellite_id="sat-test", room="Test Room")
+
+    @pytest.mark.satellite
+    @pytest.mark.asyncio
+    async def test_led_config_message_invokes_callback(self):
+        client = self._make_client()
+        received = []
+        client.on_led_config(lambda b: received.append(b))
+
+        await client._handle_message({"type": "led_config", "brightness": 5})
+        assert received == [5]
+
+    @pytest.mark.satellite
+    @pytest.mark.asyncio
+    async def test_led_config_missing_brightness_is_safe(self):
+        client = self._make_client()
+        received = []
+        client.on_led_config(lambda b: received.append(b))
+
+        # No "brightness" key — must not raise and must not invoke the callback.
+        await client._handle_message({"type": "led_config"})
+        assert received == []
+
+    @pytest.mark.satellite
+    @pytest.mark.asyncio
+    async def test_led_config_invalid_brightness_is_safe(self):
+        client = self._make_client()
+        received = []
+        client.on_led_config(lambda b: received.append(b))
+
+        # Non-int garbage — guarded, no raise, no callback.
+        await client._handle_message({"type": "led_config", "brightness": "nope"})
+        assert received == []
+
+    @pytest.mark.satellite
+    @pytest.mark.asyncio
+    async def test_led_config_coerces_string_int(self):
+        client = self._make_client()
+        received = []
+        client.on_led_config(lambda b: received.append(b))
+
+        await client._handle_message({"type": "led_config", "brightness": "8"})
+        assert received == [8]


### PR DESCRIPTION
Four features, implemented autonomously and tested thoroughly (per /goal).

## 1. Day/night awareness (`daypart`)
`services/daypart_service.py` computes day/evening/night from configurable clock windows in the local TZ. Injects `{time_context}` into every agent prompt variant; a 5-min lifecycle watcher fires a new `daypart_changed` hook on transitions. Fail-open. 28 unit tests.

## 2. Night LED dimming (`leds`, depends on #1)
`LedDimmingService` consumes `daypart_changed` → pushes `led_config {brightness}` to all satellites over WS; `register_ack` carries current brightness (mid-night reconnect comes up dimmed). Satellite scales `leds.brightness` (animations keep running). Config `led_day_brightness`/`led_night_brightness`. 17 tests.

## 3. Persistent presence history (`presence`)
Adds `satellite_id` to `presence_events` (migration `pc20260616`), three timeline query methods + `/api/presence/analytics/` routes, an `internal.presence_history` chat tool ("where was X", "who was in room Y"), `PRESENCE_HISTORY_ENABLED` flag. In-memory live presence untouched. **IDOR guard**: cross-user history reads require ROOMS_MANAGE (caught by the automated security review). Tests.

## 4. Fuller BT scan from chat (`bluetooth`)
`internal.bluetooth_scan` fans a discovery scan out to all satellites over a new `bt_scan_request`/`bt_scan_result` WS protocol (mirrors `capture_snapshot`). Satellites run Classic-BT inquiry + BLE discovery; backend dedups by MAC, keeps strongest RSSI, per-room, OUI→vendor. Gated dark behind `BT_SCAN_ENABLED`. 19 tests.

## Safety
All ship safely: BT scan flag-off, LED/daypart config-driven, presence history additive (nullable column). Regression sweep: 311 passed, 0 new failures (pre-existing `wissensbasis` async_client + heatmap-TZ issues excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)