### PR TITLE
fix(satellite): boot-time reconnect loop was GC'd, stranding satellite in idle

### DIFF
--- a/docs/SATELLITE_CONNECTIVITY.md
+++ b/docs/SATELLITE_CONNECTIVITY.md
@@ -30,7 +30,11 @@ each time; the room row is created on first connect (`ROOMS_AUTO_CREATE_FROM_SAT
 2. **mDNS / boot-window race.** `renfield.local` depends on Avahi + the cluster
    `mdns-responder`. At boot (before NTP/mDNS are ready) the handshake can time
    out — these failures appear only in the *satellite* journal, never in backend
-   logs (they never reach FastAPI).
+   logs (they never reach FastAPI). Concretely, the first 1–2
+   `getaddrinfo("renfield.local")` calls fail with `[Errno -2] Name or service
+   not known` for ~2-3s until Avahi's multicast cache warms, then resolve fine.
+   The reconnect loop recovers from this (≥ v1.4.1) — see *In-process wedges*
+   below for the strand bug where it didn't.
 3. **Device offline.** A powered-off / crashed / WiFi-disassociated Pi shows
    nothing in backend logs. Check it physically: `ping <ip>`, ARP, the LED. A
    4-mic-HAT unit can hit the AC108 + onnxruntime same-process kernel crash —
@@ -82,6 +86,16 @@ Client behavior fixes (shipped in the satellite package):
 - `_register()` recv is bounded by `register_timeout` (was unbounded).
 - A failed **heartbeat send now triggers reconnect immediately** (was swallowed,
   leaving a zombie connection until the WS ping timeout ~30 s later).
+- **Boot-time reconnect strand (≥ v1.4.1).** When the *first* connect failed at
+  boot (the cold-mDNS race above), the recovery loop was scheduled with a bare
+  `asyncio.create_task()` whose result was discarded; the event loop holds only
+  a weak reference, so it was garbage-collected before it ran. "will retry"
+  printed but the loop never executed (no `Reconnecting in Xs` line in the
+  journal) — the satellite was stranded in `idle` forever, while still showing
+  the blue idle LED (so it *looked* connected). Fixed by keeping a strong
+  reference (`_reconnect_task`) + the `_reconnecting` guard, and by making each
+  reconnect attempt exception-safe so a transient error can't kill the loop or
+  bypass the watchdog.
 - The disconnect watchdog (`max_disconnected_seconds`) exits → systemd
   `Restart=always` brings up a clean process. `StartLimitIntervalSec=0` in the
   unit ensures these legitimate restarts never trip systemd's burst limit.

--- a/src/satellite/renfield_satellite/__init__.py
+++ b/src/satellite/renfield_satellite/__init__.py
@@ -5,7 +5,7 @@ A headless voice assistant satellite for the Renfield ecosystem.
 Designed for Raspberry Pi Zero 2 W with ReSpeaker 2-Mics Pi HAT.
 """
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 __author__ = "Renfield Team"
 
 # Lazy imports to allow CLI tools to run without all dependencies

--- a/src/satellite/renfield_satellite/satellite.py
+++ b/src/satellite/renfield_satellite/satellite.py
@@ -83,6 +83,7 @@ class Satellite:
         self._reconnecting: bool = False  # Prevent duplicate reconnection attempts
         self._wakeword_pending: bool = False  # Prevent duplicate wakeword processing
         self._pending_snapshot: Optional[asyncio.Task] = None  # Background camera capture
+        self._reconnect_task: Optional[asyncio.Task] = None  # Startup-failure reconnect loop (kept referenced so asyncio doesn't GC it)
 
         # Metrics tracking
         self._last_wakeword: Optional[Dict[str, Any]] = None
@@ -374,7 +375,7 @@ class Satellite:
             self._set_state(SatelliteState.ERROR)
             self.leds.set_pattern(LEDPattern.ERROR)
             await asyncio.sleep(2)
-            asyncio.create_task(self._reconnect_with_discovery())
+            self._start_reconnect_loop()
 
         # Go to idle state
         self._set_state(SatelliteState.IDLE)
@@ -436,6 +437,27 @@ class Satellite:
         else:
             print("No Renfield server found on network")
             return None
+
+    def _start_reconnect_loop(self):
+        """Schedule the reconnect loop from the async run() context.
+
+        The first connect commonly fails at boot because mDNS resolution of the
+        server host (e.g. renfield.local) is cold for the first ~2-3s until
+        avahi's multicast cache warms — getaddrinfo raises
+        "[Errno -2] Name or service not known", then resolves fine seconds later.
+        The reconnect loop recovers from that, BUT it must actually run: a bare
+        asyncio.create_task() whose result is discarded is held only weakly by
+        the event loop and can be garbage-collected before it is ever scheduled,
+        which silently strands the satellite in idle forever ("will retry" never
+        happens). Keep a strong reference on self, and honor the _reconnecting
+        guard so a concurrent _on_disconnected does not spawn a duplicate loop.
+        """
+        if self._reconnecting:
+            return
+        self._reconnecting = True
+        self._reconnect_task = asyncio.create_task(
+            self._reconnect_with_discovery_wrapper()
+        )
 
     async def _reconnect_with_discovery_wrapper(self):
         """Wrapper for reconnection that resets the reconnecting flag"""
@@ -501,20 +523,30 @@ class Satellite:
             if not self._running:
                 break
 
-            # Re-discover server if auto-discovery is enabled and no URL set
-            if self.config.server.auto_discover and not self.config.server.url:
-                print("Re-discovering server...")
-                server_url = await self._discover_server()
-                if server_url:
-                    self.ws_client.set_server_url(server_url)
+            # Guard the whole attempt: a transient exception in discovery, token
+            # fetch, or connect must NOT escape the loop. If it did, the wrapper's
+            # finally would reset _reconnecting=False and the task would die — and
+            # on the startup-failure path there is no live receive loop left to
+            # re-fire _on_disconnected, so reconnection would never restart AND the
+            # disconnect watchdog above (which only runs inside this loop) would be
+            # bypassed. Swallow, log, and let the next iteration retry with backoff.
+            try:
+                # Re-discover server if auto-discovery is enabled and no URL set
+                if self.config.server.auto_discover and not self.config.server.url:
+                    print("Re-discovering server...")
+                    server_url = await self._discover_server()
+                    if server_url:
+                        self.ws_client.set_server_url(server_url)
 
-                    # Fetch new auth token if authentication is enabled
-                    if self.config.server.auth_enabled:
-                        await self._fetch_and_set_token(server_url)
+                        # Fetch new auth token if authentication is enabled
+                        if self.config.server.auth_enabled:
+                            await self._fetch_and_set_token(server_url)
 
-            # Try to connect
-            if await self.ws_client.connect():
-                return True
+                # Try to connect
+                if await self.ws_client.connect():
+                    return True
+            except Exception as e:
+                print(f"Reconnect attempt {attempts} errored: {e} - will retry")
 
         return False
 

--- a/tests/satellite/test_startup_reconnect.py
+++ b/tests/satellite/test_startup_reconnect.py
@@ -1,0 +1,117 @@
+"""
+Regression tests for the boot-time reconnect scheduling.
+
+Bug (2026-06-14): a satellite whose FIRST connect failed at boot was stranded
+in idle forever and never retried. Root cause: cold mDNS resolution of the
+server host (renfield.local) raises "[Errno -2] Name or service not known" for
+the first ~2-3s after boot until avahi's multicast cache warms; the startup
+path scheduled the recovery loop with a BARE asyncio.create_task() whose result
+was discarded. The event loop only holds a weak reference to such a task, so it
+was garbage-collected before it ever ran — "Failed to connect - will retry" was
+printed but the reconnect loop never executed (confirmed in the journal: no
+"Reconnecting in Xs" line ever appeared across three boots).
+
+The fix routes startup reconnection through `_start_reconnect_loop()`, which
+keeps a strong reference on `self._reconnect_task` and honors the
+`_reconnecting` guard (mirroring the disconnect path).
+"""
+
+import asyncio
+
+import pytest
+
+from renfield_satellite.satellite import Satellite
+
+
+def _bare_satellite():
+    """A Satellite with only the attributes the reconnect-scheduling seam needs,
+    bypassing __init__ (which constructs real hardware controllers)."""
+    sat = Satellite.__new__(Satellite)
+    sat._reconnecting = False
+    sat._reconnect_task = None
+    sat._running = True
+    return sat
+
+
+@pytest.mark.asyncio
+async def test_startup_reconnect_task_is_stored_and_runs():
+    """The scheduled reconnect loop must be stored on self (so asyncio's weak
+    task reference can't GC it before it runs) AND must actually execute.
+
+    Regression guard: reverting to a bare, discarded asyncio.create_task() leaves
+    _reconnect_task None — the isinstance assert fails. (A deterministic "GC
+    reaps an unreferenced task" reproduction isn't possible in a unit test, so we
+    assert the contract the fix establishes: the task is retained and the loop
+    body runs to its first statement.)"""
+    sat = _bare_satellite()
+
+    ran = asyncio.Event()
+
+    async def fake_loop():
+        ran.set()
+
+    sat._reconnect_with_discovery_wrapper = fake_loop
+
+    sat._start_reconnect_loop()
+
+    assert sat._reconnecting is True
+    assert isinstance(sat._reconnect_task, asyncio.Task)
+
+    # The scheduled coroutine actually runs (would never fire if it were dropped).
+    await asyncio.wait_for(ran.wait(), timeout=1.0)
+    await sat._reconnect_task
+
+
+@pytest.mark.asyncio
+async def test_start_reconnect_loop_guard_prevents_duplicate():
+    """A second schedule while already reconnecting is a no-op (no duplicate loop
+    racing a concurrent _on_disconnected)."""
+    sat = _bare_satellite()
+
+    calls = {"n": 0}
+
+    async def fake_loop():
+        calls["n"] += 1
+        await asyncio.sleep(0.01)
+
+    sat._reconnect_with_discovery_wrapper = fake_loop
+
+    sat._start_reconnect_loop()
+    first = sat._reconnect_task
+    sat._start_reconnect_loop()  # guarded — must not spawn a second task
+
+    assert sat._reconnect_task is first
+    await first
+    assert calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_reconnect_loop_survives_transient_exception():
+    """A transient exception during an attempt (discovery/token/connect) must NOT
+    escape the loop. If it did, the wrapper's finally would reset _reconnecting
+    and the task would die with no live receive loop to re-trigger it — re-
+    stranding the boot path and bypassing the disconnect watchdog. The loop must
+    swallow it and retry the next attempt."""
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+
+    sat = _bare_satellite()
+    sat.config = SimpleNamespace(
+        server=SimpleNamespace(
+            max_disconnected_seconds=0,  # watchdog off for the test
+            reconnect_interval=0,  # no real sleep
+            auto_discover=False,
+            url="wss://renfield.local/ws/satellite",
+            auth_enabled=False,
+        )
+    )
+
+    # First attempt raises (e.g. cold-mDNS getaddrinfo), second connects.
+    sat.ws_client = SimpleNamespace(
+        connect=AsyncMock(side_effect=[OSError("[Errno -2] Name or service not known"), True])
+    )
+
+    result = await asyncio.wait_for(sat._reconnect_with_discovery(), timeout=2.0)
+
+    assert result is True
+    assert sat.ws_client.connect.await_count == 2  # retried after the exception


### PR DESCRIPTION
## Problem

A satellite whose **first** WebSocket connect fails at boot was stranded in `idle` **forever** and never retried.

Root cause confirmed on `satellite-fitnessraum` (.72) by journal inspection across three boots:

```
Connecting to wss://renfield.local/ws/satellite...
Connection failed: [Errno -2] Name or service not known
Failed to connect to server - will retry
State: error -> idle
```

…and then **never a single `Reconnecting in Xs (attempt N)` line.** "will retry" was a lie.

Two distinct defects:

1. **Trigger** — cold mDNS: the first `getaddrinfo("renfield.local")` calls fail with `[Errno -2]` for ~2-3s after boot until avahi's multicast cache warms (measured: calls 1-2 fail, 3+ succeed), then resolves fine forever. Inherent to mDNS, not host-specific.
2. **Root cause (load-bearing)** — the startup-failure path scheduled the recovery loop with a bare `asyncio.create_task(...)` whose result was discarded. The event loop holds only a **weak reference** to such a task, so it was garbage-collected before it ever ran. The satellite was permanently stranded, even though DNS resolved 3s later.

The disconnect path worked (it routes through `run_coroutine_threadsafe`, which is tracked) — line 377 was the only discarded-ref `create_task` in the file. Already-connected satellites never re-resolve, so only a *fresh boot* hit the strand.

This also explains a UX confusion: a stranded satellite shows the **blue idle LED** (ERROR LED at boot is immediately overwritten by IDLE while still disconnected), so it *looks* connected when it isn't.

## Fix

- Route startup reconnection through `_start_reconnect_loop()`, which keeps a strong reference on `self._reconnect_task` and honors the `_reconnecting` guard (mirrors the disconnect path). A transient boot DNS failure now always recovers (~5s).
- Make `_reconnect_with_discovery`'s per-attempt body exception-safe. A transient error in discovery/token-fetch/connect must not escape the loop — otherwise the wrapper's `finally` resets `_reconnecting` and the task dies with no live receive loop to re-trigger it (re-stranding the boot path), and the `os._exit` disconnect watchdog (which only runs inside the loop) is bypassed. Now swallowed, logged, retried with backoff. *(Found by adversarial review.)*

## Tests

`tests/satellite/test_startup_reconnect.py` — task-retention, duplicate-guard, transient-exception resilience. Full satellite suite **50 passed** on the .159 py3.11 runner.

Bumps satellite `1.4.0 -> 1.4.1` (ships via ansible / OTA).

## Deploy note

Ship to satellites via `ansible --tags app` + restart (a stranded satellite can't be reached over OTA). `satellite-fitnessraum` (.72) is the currently-stranded one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)