### PR TITLE
feat(chat): provenance source chips on knowledge-backed answers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ The agent loop sees a mix of MCP tools (`mcp.<server>.<tool>`) and `internal.*` 
 
 | Tool | Purpose | Source |
 |---|---|---|
-| `internal.knowledge_search` | Semantic RAG search over the user's knowledge base | `services/knowledge_tool.py` |
+| `internal.knowledge_search` | Semantic RAG search over the user's knowledge base; also returns structured `data.sources` (deduped per document) that `chat_handler._extract_agent_sources` surfaces as chat **provenance chips** | `services/knowledge_tool.py` |
 | `internal.list_my_memories` | Enumerate the asker's own conversation memories (preferences/facts/instructions) WITHOUT the per-turn `{memory_context}` vector threshold — backs broad self-knowledge queries ("Was weißt du über mich?") the small auto-injected snapshot can't answer. Reads only the authenticated user's own memories. | `services/memory_list_tool.py` |
 | `internal.forward_attachment_to_paperless` | Forward a chat-attached file to Paperless using real server-stored bytes — prevents the LLM from handling base64 payloads it can't actually see | `services/chat_upload_tool.py` |
 | `internal.ingest_file` | Interactive folder-ingest: the agent points at a file `path` on a watched share; pulls the bytes through the filesystem MCP (`mcp.files.read_file`, `truncate=False` — no 128 KB cap corruption) and runs them through the same `folder_ingest.ingest_document` bridge as the REST push (dedup / owner+tier / Paperless leg identical). Gated by `FOLDER_INGEST_ENABLED`. See `docs/FOLDER_INGEST.md`. | `services/folder_ingest_tool.py` |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -19,6 +19,7 @@ Renfield ist ein vollständig offline-fähiger, selbst-gehosteter **digitaler As
 ### Rich Content in Chat-Nachrichten
 - **Album Art**: Jellyfin-Bild-URLs und gängige Bildformate (`.jpg`, `.png`, `.gif`, `.webp`) werden als Inline-Bilder gerendert statt als Klartext
 - **Collapsible Agent Steps**: Agent-Schritte (Tool-Calls + Ergebnisse) sind einklappbar — offen während der Verarbeitung, eingeklappt nach Abschluss
+- **Quellen-Chips**: Stützt sich eine Antwort auf die Wissensdatenbank (RAG), erscheinen unter der Antwort anklickbare Quellen-Chips — Dokumentname + Zugriffs-Tier (`TierBadge`), je verlinkt auf `/knowledge?doc={id}`. Nur die im Zug tatsächlich abgerufenen, bereits circle-gefilterten Dokumente erscheinen (keine zweite Berechtigungs-Prüfung); ohne KB-Treffer wird nichts gezeigt. Live über den `done`-Frame, persistiert in `message_metadata.sources` (rehydriert beim Laden der Historie).
 - **Credential Sanitization**: API-Keys und Tokens in MCP-Antworten werden automatisch aus der Chat-Anzeige redacted
 
 ### Chat-Historie
@@ -389,7 +390,7 @@ PDF, DOCX, PPTX, XLSX, HTML, Markdown, TXT — verarbeitet mit IBM Docling.
 - **Knowledge Bases** — Organisiere Dokumente in thematischen Sammlungen
 - **KB-Sharing** — Teile Wissensdatenbanken mit anderen Nutzern (RPBAC)
 - **Follow-up-Fragen** — RAG-Kontext bleibt für Nachfragen erhalten
-- **Quellen-Zitation** — Antworten verweisen auf Quelldokumente
+- **Quellen-Zitation** — wissensgestützte Chat-Antworten zeigen die verwendeten Dokumente als anklickbare **Quellen-Chips** (siehe „Rich Content in Chat-Nachrichten")
 - **Re-Embedding** — `POST /admin/reembed` nach Modellwechsel
 - **knowledge_search Agent Tool** — Internes Tool im Agent Loop für kombinierte Suche über RAG-Dokumente und MCP-Quellen (Paperless)
 - **EasyOCR Fallback** — Garbled PDFs werden automatisch mit EasyOCR nachverarbeitet für bessere Text-Extraktion

--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -145,6 +145,32 @@ def _parse_mcp_raw_data(data: list) -> any:
         return None
 
 
+def _extract_agent_sources(tool_results: list) -> list[dict]:
+    """Collect provenance sources from this turn's knowledge_search tool results.
+
+    Returns a deduped (by document_id) list of {document_id, filename, title, tier}
+    for the chat "source chips" UI. The sources are already circle-filtered at
+    retrieval time (rag.search pins to the asker's user_id), so surfacing them is
+    pure display — no second permission path. Empty list when the turn used no
+    knowledge_search (the UI renders nothing for an empty list).
+    """
+    sources: list[dict] = []
+    seen: set = set()
+    for tool_name, data in tool_results:
+        if tool_name != "internal.knowledge_search" or not isinstance(data, dict):
+            continue
+        # `data` is the tool's INNER result dict (AgentStep.data = result["data"],
+        # set in agent_service), so `sources` lives at the top level here — NOT
+        # nested under another "data" key.
+        for src in data.get("sources") or []:
+            doc_id = src.get("document_id") if isinstance(src, dict) else None
+            if doc_id is None or doc_id in seen:
+                continue
+            seen.add(doc_id)
+            sources.append(src)
+    return sources
+
+
 def _build_agent_action_result(tool_results: list) -> dict:
     """Build a synthetic action_result from agent tool results for conversation history.
 
@@ -976,6 +1002,10 @@ async def websocket_endpoint(
             intent = None
             action_result = None
             agent_steps_count = 0
+            # Provenance sources (knowledge_search) for the chat source-chips UI.
+            # Shared init so the persist/done block can reference it on every path
+            # (the legacy non-agent path never touches agent_tool_results).
+            agent_tool_results: list = []
             media_shortcut_handled = False
             paperless_confirm_handled = False
             pending_confirm_token = None
@@ -1796,6 +1826,12 @@ WICHTIG: Nutze die ECHTEN Daten aus dem Ergebnis! Gib NUR die Antwort, KEIN JSON
             }
             if action_summary:
                 assistant_metadata["action_summary"] = action_summary
+            # Provenance: which documents this answer drew on (circle-filtered at
+            # retrieval). Persisted so chips rehydrate on history load; also sent
+            # on the `done` frame below for the live turn. Empty → key omitted.
+            agent_sources = _extract_agent_sources(agent_tool_results)
+            if agent_sources:
+                assistant_metadata["sources"] = agent_sources
 
             session_state.add_to_history("user", content)
             if full_response:
@@ -1902,6 +1938,8 @@ WICHTIG: Nutze die ECHTEN Daten aus dem Ergebnis! Gib NUR die Antwort, KEIN JSON
             }
             if agent_used:
                 done_msg["agent_steps"] = agent_steps_count
+            if agent_sources:
+                done_msg["sources"] = agent_sources
             # Include intent info for frontend feedback UI
             if intent:
                 done_msg["intent"] = {

--- a/src/backend/services/knowledge_tool.py
+++ b/src/backend/services/knowledge_tool.py
@@ -77,19 +77,32 @@ async def knowledge_search(params: dict) -> dict:
 
         if results:
             context_parts = []
+            # Structured per-document provenance for the chat "source chips" UI.
+            # rag.search already circle-filtered by user_id, so these only contain
+            # documents the asker may see — no extra permission check needed.
+            # Deduped by document_id (one chip per source document, not per chunk).
+            sources: list[dict] = []
+            seen_doc_ids: set = set()
             for r in results:
+                doc = r.get("document") if isinstance(r.get("document"), dict) else {}
                 content = (
                     r.get("chunk", {}).get("content", "")
                     if isinstance(r.get("chunk"), dict)
                     else r.get("content", "")
                 )
-                source = (
-                    r.get("document", {}).get("filename", "")
-                    if isinstance(r.get("document"), dict)
-                    else r.get("filename", "")
-                )
+                source = doc.get("filename", "") or r.get("filename", "")
                 if content:
                     context_parts.append(f"[{source}] {content[:500]}")
+
+                doc_id = doc.get("id")
+                if doc_id is not None and doc_id not in seen_doc_ids:
+                    seen_doc_ids.add(doc_id)
+                    sources.append({
+                        "document_id": doc_id,
+                        "filename": source,
+                        "title": doc.get("title") or source or f"Dokument {doc_id}",
+                        "tier": doc.get("circle_tier"),
+                    })
 
             return {
                 "success": True,
@@ -99,6 +112,7 @@ async def knowledge_search(params: dict) -> dict:
                     "query": query,
                     "results_count": len(results),
                     "context": "\n\n".join(context_parts),
+                    "sources": sources,
                 },
             }
         return {

--- a/src/frontend/src/components/chat/SourceChips.tsx
+++ b/src/frontend/src/components/chat/SourceChips.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { Link } from 'react-router';
+import { useTranslation } from 'react-i18next';
+import { FileText } from 'lucide-react';
+import TierBadge from '../TierBadge';
+import type { MessageSource } from '../../types/chat';
+
+/**
+ * Provenance "source chips" under a knowledge-backed assistant turn.
+ *
+ * Shows which KB documents the answer drew on (filename + access-tier), each a
+ * link into the document view (`/knowledge?doc={id}`). The sources are already
+ * circle-filtered at retrieval time, so this is pure display.
+ *
+ * Design rules (per /plan-design-review):
+ *  - Empty/undefined → render NOTHING (not an empty container).
+ *  - Cap at MAX_VISIBLE; overflow collapses behind a "+N more" toggle.
+ *  - Tier is never color-only — TierBadge pairs the color with a symbol+label.
+ *  - Chips are real links: keyboard-focusable, visible focus ring.
+ */
+
+const MAX_VISIBLE = 6;
+
+export default function SourceChips({ sources }: { sources?: MessageSource[] }) {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+
+  if (!sources || sources.length === 0) return null;
+
+  const visible = expanded ? sources : sources.slice(0, MAX_VISIBLE);
+  const hidden = sources.length - visible.length;
+
+  return (
+    <div className="mt-2 flex flex-wrap items-center gap-1.5" aria-label={t('chat.sources.label')}>
+      <span className="text-xs text-gray-500 dark:text-gray-400 mr-0.5">
+        {t('chat.sources.label')}:
+      </span>
+      {visible.map((src) => {
+        const label = src.title || src.filename || String(src.document_id);
+        return (
+          <Link
+            key={src.document_id}
+            to={`/knowledge?doc=${encodeURIComponent(String(src.document_id))}`}
+            title={label}
+            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-gray-200 text-gray-700 hover:bg-gray-300 dark:bg-gray-600 dark:text-gray-200 dark:hover:bg-gray-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+          >
+            <FileText className="w-3 h-3 flex-shrink-0" aria-hidden="true" />
+            <span className="truncate max-w-[160px]">{label}</span>
+            {typeof src.tier === 'number' && src.tier >= 0 && src.tier <= 4 && (
+              <TierBadge tier={src.tier} className="text-[10px]" />
+            )}
+          </Link>
+        );
+      })}
+      {hidden > 0 && (
+        <button
+          type="button"
+          onClick={() => setExpanded(true)}
+          className="text-xs text-primary-600 dark:text-primary-400 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 rounded"
+        >
+          {t('chat.sources.more', { count: hidden })}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -128,6 +128,10 @@
     "assistantResponse": "Antwort von {{appName}}",
     "readAloud": "Vorlesen",
     "albumArt": "Albumcover",
+    "sources": {
+      "label": "Quellen",
+      "more": "+{{count}} weitere"
+    },
     "intent": "Intent",
     "startConversation": "Starte ein Gespräch mit {{appName}}",
     "useTextOrMic": "Du kannst Text eingeben oder das Mikrofon nutzen",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -128,6 +128,10 @@
     "assistantResponse": "Response from {{appName}}",
     "readAloud": "Read aloud",
     "albumArt": "Album art",
+    "sources": {
+      "label": "Sources",
+      "more": "+{{count}} more"
+    },
     "intent": "Intent",
     "startConversation": "Start a conversation with {{appName}}",
     "useTextOrMic": "You can type text or use the microphone",

--- a/src/frontend/src/pages/ChatPage/ChatMessages.tsx
+++ b/src/frontend/src/pages/ChatPage/ChatMessages.tsx
@@ -7,6 +7,7 @@ import IntentCorrectionButton from '../../components/IntentCorrectionButton';
 import AttachmentQuickActions from './AttachmentQuickActions';
 import EmailForwardDialog from './EmailForwardDialog';
 import PaperlessConfirmCard from './PaperlessConfirmCard';
+import SourceChips from '../../components/chat/SourceChips';
 import { useChatContext } from './context/ChatContext';
 import { CitationChip } from '../../components/wissensbasis/CitationChip';
 import { useTraceQuery, type TraceEntity } from '../../api/resources/wissensbasis';
@@ -312,6 +313,12 @@ export default function ChatMessages() {
             )}
 
             {message.role === 'assistant' ? renderMessageContent(message.content, t('chat.albumArt'), message.entities ?? chipEntities, `msg-${index}`) : <p className="whitespace-pre-wrap">{message.content}</p>}
+
+            {/* Provenance source chips — KB documents a knowledge-backed answer
+                used. Renders nothing when the turn had no sources. */}
+            {message.role === 'assistant' && !message.streaming && (
+              <SourceChips sources={message.sources} />
+            )}
 
             {/* Adaptive Card (from WebSocket card message) */}
             {message.card && (

--- a/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
+++ b/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
@@ -44,7 +44,7 @@ import type {
   UploadProcessedMessage,
 } from '../hooks/useChatWebSocket';
 import type { UploadStates, UploadedDocument } from '../hooks/useDocumentUpload';
-import type { Conversation } from '../../../types/chat';
+import type { Conversation, MessageSource } from '../../../types/chat';
 import type { TraceEntity } from '../../../api/resources/wissensbasis';
 import { useConfirmDialog } from '../../../components/ConfirmDialog';
 import { drainSentenceTts, type SentenceStreamState } from './sentenceStream';
@@ -114,6 +114,9 @@ export interface ChatUiMessage {
   // on_pre_save_message. Lets the chip renderer wrap mentions per bubble
   // instead of smearing the session-last reasoning trace across all of them.
   entities?: TraceEntity[];
+  // Provenance source chips — the KB documents a knowledge-backed answer drew
+  // on. Arrives on the `done` frame live; rehydrates from `metadata.sources`.
+  sources?: MessageSource[];
 }
 
 /** Map a persisted history message to the in-memory UI shape. */
@@ -123,13 +126,14 @@ export function historyToUiMessage(m: {
   metadata?: unknown;
 }): ChatUiMessage {
   const meta = m.metadata as
-    | { attachments?: MessageAttachment[]; wb_entities?: TraceEntity[] }
+    | { attachments?: MessageAttachment[]; wb_entities?: TraceEntity[]; sources?: MessageSource[] }
     | undefined;
   return {
     role: m.role === 'system' ? 'assistant' : (m.role as 'user' | 'assistant'),
     content: m.content,
     ...(meta?.attachments && meta.attachments.length > 0 && { attachments: meta.attachments }),
     ...(meta?.wb_entities && meta.wb_entities.length > 0 && { entities: meta.wb_entities }),
+    ...(meta?.sources && meta.sources.length > 0 && { sources: meta.sources }),
   };
 }
 
@@ -592,6 +596,8 @@ export function ChatProvider({ children }: ChatProviderProps) {
           // F4c — any lingering per-peer progress lines belong only to
           // the live streaming phase; drop them when the message finalizes.
           federationProgress: undefined,
+          // Provenance source chips for this turn (knowledge-backed answers).
+          ...(data.sources && data.sources.length > 0 && { sources: data.sources }),
         };
         lastIntentInfoRef.current = null;
 

--- a/src/frontend/src/pages/ChatPage/hooks/useChatWebSocket.ts
+++ b/src/frontend/src/pages/ChatPage/hooks/useChatWebSocket.ts
@@ -1,6 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { debug } from '../../../utils/debug';
 import { getWebSocketUrl } from '../../../utils/env';
+import type { MessageSource } from '../../../types/chat';
 
 export interface BaseWsMessage {
   type: string;
@@ -16,6 +17,7 @@ export interface DoneMessage extends BaseWsMessage {
   type: 'done';
   tts_handled?: boolean;
   intent?: { intent: string; confidence?: number };
+  sources?: MessageSource[];
 }
 
 export interface ActionWsMessage extends BaseWsMessage {

--- a/src/frontend/src/types/chat.ts
+++ b/src/frontend/src/types/chat.ts
@@ -5,6 +5,16 @@
 // Message role
 export type MessageRole = 'user' | 'assistant' | 'system';
 
+// Provenance source — a knowledge-base document a knowledge-backed answer drew
+// on. Surfaced as a "source chip" under the assistant turn. `tier` is the
+// circle access-tier (0=self … 4=public); null when the row carried no tier.
+export interface MessageSource {
+  document_id: number | string;
+  filename: string;
+  title: string;
+  tier?: number | null;
+}
+
 // Chat message
 export interface ChatMessage {
   id?: number;
@@ -13,6 +23,9 @@ export interface ChatMessage {
   content: string;
   created_at: string;
   metadata?: Record<string, unknown>;
+  // Provenance chips. On the live turn these arrive on the `done` frame; on
+  // history load they rehydrate from `metadata.sources`.
+  sources?: MessageSource[];
 }
 
 // Conversation summary
@@ -77,6 +90,8 @@ export interface ChatActionMessage {
 export interface ChatDoneMessage {
   type: 'done';
   tts_handled: boolean;
+  agent_steps?: number;
+  sources?: MessageSource[];
 }
 
 export interface ChatErrorMessage {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,68 +1,62 @@
-# Generic Output Providers — implementation plan
+# Plan — Provenance chips in chat (roadmap item 7)
 
-Branch: `feat/output-providers`. Source of truth: `docs/design/output-providers.md`
-(eng-reviewed 2026-06-07). Big-bang feature PR, phases 1-4, all behind
-`OUTPUT_PROVIDERS_ENABLED` (additive schema only; destructive cleanup is a P2
-follow-up). Flag OFF = byte-identical to today.
+Source: `docs/design/chat-ui-modernization.md` Tier 1 item 7. First-slice build.
+Goal: show **which sources** a knowledge-backed chat answer used, as chips under
+the assistant turn (filename + access-tier), so the answer's provenance is visible.
 
-## Phase 1 — Foundation (config + Protocol + MCP registry)  ✅ DONE (20/20 tests green on .159)
-- [x] P1.1 `config.py`: `output_providers_enabled: bool = False`
-- [x] P1.2 `mcp_client.py`: `MCPServerConfig.output_provider: dict | None = None` + parse in `load_config`
-- [x] P1.3 new `ha_glue/services/output_providers.py`:
-      - dataclasses: `OutputTarget`, `MediaRef`, `PlayResult`, `ControlResult`, `TargetStatus`
-      - capability constants (audio/video/power/transport/queue) + `OutputProvider` Protocol
-      - `McpOutputProvider` (maps the 4 contract methods onto `mcp.<server>.<tool>`, envelope+shape normalize)
-      - `build_mcp_output_providers(mcp_manager)` → {key: McpOutputProvider} from stanzas
-      - NOTE: built-in renfield/HA adapters deferred to Phase 4 (aggregation), where their
-        discover() is consumed + dispatch wiring exists — not shipping half-baked stubs.
-- [x] P1.4 unit tests (`tests/backend/test_output_providers.py`): 20 tests — registry build,
-      capability parsing (known + unknown-kept), stanza validation (malformed/no-discover skipped),
-      McpOutputProvider discover/play/control/status normalization, tool-failure + transport-error
-      → OutputProviderError, payload extraction, target-shape normalization (contract + legacy).
+## Reality check (verified, corrects the roadmap doc)
+- `FactProvenance` is NOT reusable here — it renders deterministic(✓)/advisory(~),
+  not document-source chips. Source chips are a NEW small component reusing `TierBadge`.
+- NOT pure-frontend: `knowledge_tool.py` flattens `rag.search` results into a
+  `context` string and discards per-source structure; the chat stream/`Message`
+  carries no sources today. Needs backend capture + stream + persist.
+- Circle-safety: `rag.search(user_id=...)` already circle-filters retrieval, so
+  sources only contain rows the asker could already see — no `circle_sql` change,
+  no second read path.
 
-## Phase 2 — Additive model migration + dual-read  ✅ DONE (11 PG + 35 routing tests green on .159)
-- [x] P2.1 `RoomOutputDevice`: add `output_provider` + `output_target_id` columns (nullable)
-- [x] P2.2 migration `pc20260610_output_target` (additive add cols + CASE/COALESCE backfill; NO drop)
-- [x] P2.3 `target_id`/`target_type` props prefer new cols, fall back to old (dual-read)
-- [x] P2.4 `add_output_device` dual-writes the pair from a legacy arg + accepts an explicit
-      `(provider, target_id)` path (samsung, no legacy col); CRUD create/response schemas + route gain the pair
-- [x] P2.5 real-PG tests (`test_output_providers_phase2_pg.py`): backfill SQL across all 3 legacy
-      types + idempotent skip-already-paired, dual-read (prefer/fallback/both/empty), add_output_device
-      dual-write + explicit-pair + 3 validation paths. Full plugin-aware `alembic upgrade` verified at
-      deploy time (repo convention: ha_glue room tables live in a separate plugin migration tree, so a
-      core-only from-scratch upgrade can't build them — backfill LOGIC tested via create_all'd PG instead).
+## Backend
+- [x] `services/knowledge_tool.py` — returns `data.sources`: deduped
+  `[{document_id, filename, title, tier}]` from `rag.search` results (tier IS on
+  the result: `document.circle_tier`). `context` text unchanged.
+- [x] `api/websocket/chat_handler.py` — added `_extract_agent_sources()` helper +
+  shared `agent_tool_results` init; on the shared persist/done path, derives
+  sources from the turn's `internal.knowledge_search` tool results (deduped),
+  attaches to `assistant_metadata["sources"]` (persist) + `done_msg["sources"]`
+  (live). NOTE: agent loop runs in chat_handler, NOT agent_service — corrected
+  from the plan. Scope v1 = knowledge_search only.
 
-## Phase 3 — config-driven adapter + generic dispatch + power-on  ✅ DONE (58 tests; 0 regressions)
-- [x] P3a config-driven MCP adapter (bridge in renfield, not in MCP servers) — McpOutputProvider
-      maps contract↔native tools via per-method arg-templates; control per-action; 25 tests
-- [x] P3.1 `_resolve_room_player` + `_play_in_room` route via registry when flag on (samsung);
-      dlna/HA/renfield keep their legacy branches. `_check_device_availability` uses dual-read
-      target_type so generic-provider rows resolve as available.
-- [x] P3.2 power-on: status off/unreachable → control('on') → `_poll_provider_ready` (bounded by
-      boot_timeout, iteration-based) → play; never-wakes → honest "could not wake" error
-- [x] P3.4 samsung `output_provider` stanza (quoted "on"/"off" keys — YAML-bool footgun; parser
-      also coerces bool keys defensively). dlna stays legacy (gapless capability preserved).
-- [x] P3.5 tests: 9 dispatch (already-on / power-on / never-wakes / control-fail / play-fail /
-      non-power / poll bounds) + 25 adapter; existing internal_tools = same 6 pre-existing
-      stale-tree failures with AND without my change (proven zero regression).
-- N/A P3.3 shims: `internal.play_*_on_dlna` unchanged (dlna stays legacy this phase); they delegate
-      to the generic resolver only when dlna itself moves onto the contract (deferred w/ dlna).
+## Frontend
+- [x] `types/chat.ts` — added `MessageSource` + `sources?` on `ChatMessage` and
+  `ChatDoneMessage`.
+- [x] `components/chat/SourceChips.tsx` — NEW. Chip per source: filename +
+  `<TierBadge>` (when tier 0-4), links to `/knowledge?doc={id}`. Empty/undefined
+  → renders nothing. Dark mode + i18n (de+en `chat.sources.*`). Caps at 6 with
+  "+N weitere" expand. Clickable (chosen over labels-only).
+- [x] `pages/ChatPage/ChatMessages.tsx` — renders `<SourceChips>` under finished
+  assistant turns.
+- [x] `context/ChatContext.tsx` — `ChatUiMessage.sources`; `done` handler attaches
+  `data.sources`; `historyToUiMessage` rehydrates from `metadata.sources`.
+- [x] `hooks/useChatWebSocket.ts` — `DoneMessage.sources`.
 
-## Phase 4 — Aggregation + frontend  ✅ DONE (5 aggregation + 4 RTL tests; typecheck clean)
-- [x] P4.1 `get_aggregated_outputs` (built-ins via existing methods + registry providers via
-      parallel `asyncio.gather` discover, per-provider `output_provider_discover_timeout`,
-      **degraded-not-dropped**); `available-outputs` returns `output_targets` when flag on (None off).
-- [x] P4.2 `RoomOutputSettings.tsx` data-driven: generic mode (output_targets present) → one unified
-      picker over all providers + capability badges + unreachable-disabled + submits (provider,
-      target_id) pair; flag off → byte-identical legacy type-buttons. `roomOutputs.ts` types extended.
-- [x] P4.3 RTL (`RoomOutputSettings.test.tsx`, 4 tests): unified picker / no type-buttons / unreachable
-      disabled / submits the pair / legacy fallback when output_targets absent.
+## Tests
+- [x] Backend: `test_knowledge_tool.py` (structured deduped sources; no-results →
+  no key) + `test_chat_handler_provenance.py` (`_extract_agent_sources` dedupe,
+  ignores non-knowledge_search, empty/malformed). 11 passed on .159.
+- [x] Frontend RTL: `SourceChips.test.tsx` — renders/links, empty → nothing,
+  cap+overflow, tier-absent. 4 passed.
 
-## Gate
-- Flag OFF byte-identical ✅ (verified: dual-read identical, dispatch/aggregation gated, frontend legacy path).
-- Real-PG for migration ✅ (backfill logic + dual-read on real PG; full plugin-aware upgrade at deploy).
-- Totals: 85 backend + 4 RTL tests green; existing internal_tools = same 6 pre-existing stale-tree fails.
-- NEXT: /review + adversarial → docs sweep → one big-bang PR.
+## Out of scope (v1)
+- Clickable deep-link into `/wissen` (can be a fast-follow; v1 may ship labels).
+- document_fact / KG-edge provenance (knowledge_search only for v1).
+- Items 2/4/6 of the first slice (separate PRs).
 
-## Review (filled at the end)
-_(pending — run /review on the full branch diff)_
+## Review
+- Verified the "data exists / pure-frontend" roadmap claim was WRONG before coding:
+  `knowledge_search` discarded per-source structure; chat stream carried no sources;
+  `FactProvenance` is a deterministic/advisory glyph, not a document-source chip.
+- Circle-safety: sources come only from `rag.search(user_id=...)` which is already
+  circle-filtered — no `circle_sql` change, no second read path.
+- Tests green: backend 11/11 (.159), frontend 4/4 (isolated). `tsc` clean on the 5
+  changed files (2 pre-existing errors in untouched skills.ts/trajectories.ts).
+- Pending before deploy: `npm run build` (prod Tailwind pass — per the frontend
+  prod-build gate), and `/review`.

--- a/tests/backend/test_chat_handler_provenance.py
+++ b/tests/backend/test_chat_handler_provenance.py
@@ -1,0 +1,59 @@
+"""
+Tests for `api.websocket.chat_handler._extract_agent_sources`.
+
+Provenance "source chips": after a turn, the chat handler collects the KB
+documents the answer drew on from this turn's `knowledge_search` tool results,
+deduped by document_id, and attaches them to the assistant message
+(`message_metadata.sources`) + the `done` stream frame.
+"""
+
+import pytest
+
+from api.websocket.chat_handler import _extract_agent_sources
+
+
+def _ks(sources):
+    """The knowledge_search `step.data` as chat_handler actually receives it.
+
+    chat_handler appends `(step.tool, step.data)` and agent_service sets
+    `AgentStep.data = result["data"]` — i.e. the tool's INNER result dict. So
+    `sources` sits at the top level here, NOT nested under another "data" key.
+    (Encoding the wrong outer-envelope shape here once let a dead-on-arrival
+    extractor bug pass review — the fixture MUST mirror the runtime payload.)
+    """
+    return {"results_count": len(sources), "sources": sources}
+
+
+@pytest.mark.unit
+def test_collects_and_dedupes_knowledge_search_sources():
+    tool_results = [
+        ("internal.knowledge_search", _ks([
+            {"document_id": 7, "filename": "a.pdf", "title": "A", "tier": 2},
+            {"document_id": 9, "filename": "b.pdf", "title": "B", "tier": 0},
+        ])),
+        # a second knowledge_search in the same turn repeating doc 7 → deduped
+        ("internal.knowledge_search", _ks([
+            {"document_id": 7, "filename": "a.pdf", "title": "A", "tier": 2},
+            {"document_id": 12, "filename": "c.pdf", "title": "C", "tier": 4},
+        ])),
+    ]
+    out = _extract_agent_sources(tool_results)
+    assert [s["document_id"] for s in out] == [7, 9, 12]
+
+
+@pytest.mark.unit
+def test_ignores_non_knowledge_search_tools():
+    tool_results = [
+        ("internal.play_in_room", {"success": True, "data": {"sources": [{"document_id": 1}]}}),
+        ("mcp.paperless.search_documents", {"data": {"sources": [{"document_id": 2}]}}),
+    ]
+    assert _extract_agent_sources(tool_results) == []
+
+
+@pytest.mark.unit
+def test_empty_and_malformed_yield_no_sources():
+    assert _extract_agent_sources([]) == []
+    # knowledge_search with no sources key, or a missing document_id
+    assert _extract_agent_sources([("internal.knowledge_search", {"data": {}})]) == []
+    assert _extract_agent_sources([("internal.knowledge_search", _ks([{"filename": "x.pdf"}]))]) == []
+    assert _extract_agent_sources([("internal.knowledge_search", None)]) == []

--- a/tests/backend/test_knowledge_tool.py
+++ b/tests/backend/test_knowledge_tool.py
@@ -92,6 +92,68 @@ class TestKnowledgeSearch:
         )
 
     @pytest.mark.unit
+    async def test_returns_structured_sources(self):
+        """Results carry a deduped, document-keyed `sources` list for the chat
+        provenance-chips UI (filename, title, tier)."""
+        mock_rag = MagicMock()
+        mock_rag.search = AsyncMock(return_value=[
+            {
+                "chunk": {"content": "chunk A1"},
+                "document": {"id": 7, "filename": "rechnung.pdf", "title": "Rechnung März", "circle_tier": 2},
+            },
+            {  # second chunk of the SAME document → must dedupe to one source
+                "chunk": {"content": "chunk A2"},
+                "document": {"id": 7, "filename": "rechnung.pdf", "title": "Rechnung März", "circle_tier": 2},
+            },
+            {
+                "chunk": {"content": "chunk B1"},
+                "document": {"id": 9, "filename": "vertrag.pdf", "title": "Vertrag", "circle_tier": 0},
+            },
+        ])
+
+        mock_db = AsyncMock()
+
+        @asynccontextmanager
+        async def mock_session():
+            yield mock_db
+
+        stubs = _stub_db_and_rag_modules()
+        try:
+            with patch("services.database.AsyncSessionLocal", mock_session, create=True), \
+                 patch("services.rag_service.RAGService", return_value=mock_rag, create=True):
+                result = await knowledge_search({"query": "x"})
+        finally:
+            _teardown_stubs(stubs)
+
+        sources = result["data"]["sources"]
+        assert [s["document_id"] for s in sources] == [7, 9]  # deduped, order-preserved
+        assert sources[0] == {
+            "document_id": 7, "filename": "rechnung.pdf", "title": "Rechnung März", "tier": 2,
+        }
+        assert sources[1]["tier"] == 0
+
+    @pytest.mark.unit
+    async def test_no_results_has_no_sources(self):
+        """Empty search → no `sources` key (UI renders nothing)."""
+        mock_rag = MagicMock()
+        mock_rag.search = AsyncMock(return_value=[])
+        mock_db = AsyncMock()
+
+        @asynccontextmanager
+        async def mock_session():
+            yield mock_db
+
+        stubs = _stub_db_and_rag_modules()
+        try:
+            with patch("services.database.AsyncSessionLocal", mock_session, create=True), \
+                 patch("services.rag_service.RAGService", return_value=mock_rag, create=True):
+                result = await knowledge_search({"query": "nope"})
+        finally:
+            _teardown_stubs(stubs)
+
+        assert "sources" not in result["data"]
+
+    @pytest.mark.unit
     async def test_custom_top_k(self):
         """Custom top_k is forwarded to RAG search."""
         mock_rag = MagicMock()

--- a/tests/frontend/react/components/SourceChips.test.tsx
+++ b/tests/frontend/react/components/SourceChips.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * SourceChips — provenance chips under a knowledge-backed assistant turn.
+ * German is the test default.
+ */
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SourceChips from '../../../../src/frontend/src/components/chat/SourceChips';
+import type { MessageSource } from '../../../../src/frontend/src/types/chat';
+import { renderWithRouter } from '../test-utils';
+
+const src = (id: number, title: string, tier?: number): MessageSource => ({
+  document_id: id,
+  filename: `${title}.pdf`,
+  title,
+  tier,
+});
+
+describe('SourceChips', () => {
+  it('renders nothing for empty or undefined sources', () => {
+    const { container, rerender } = renderWithRouter(<SourceChips sources={[]} />);
+    expect(container).toBeEmptyDOMElement();
+    rerender(<SourceChips sources={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders one chip per source, linking into the document view', () => {
+    renderWithRouter(<SourceChips sources={[src(7, 'Rechnung', 2), src(9, 'Vertrag', 0)]} />);
+    const rechnung = screen.getByRole('link', { name: /Rechnung/ });
+    expect(rechnung).toHaveAttribute('href', '/knowledge?doc=7');
+    expect(screen.getByRole('link', { name: /Vertrag/ })).toHaveAttribute('href', '/knowledge?doc=9');
+    // tier is surfaced (TierBadge is not color-only — it carries an aria-label)
+    expect(screen.getAllByLabelText(/./).length).toBeGreaterThan(0);
+  });
+
+  it('caps at 6 sources and reveals the rest on "+N weitere"', async () => {
+    const many = Array.from({ length: 9 }, (_, i) => src(i + 1, `Doc${i + 1}`, 2));
+    renderWithRouter(<SourceChips sources={many} />);
+    expect(screen.getAllByRole('link')).toHaveLength(6);
+    const more = screen.getByText('+3 weitere');
+    await userEvent.click(more);
+    expect(screen.getAllByRole('link')).toHaveLength(9);
+  });
+
+  it('omits the tier badge when tier is absent but still renders the chip', () => {
+    renderWithRouter(<SourceChips sources={[src(5, 'Notiz')]} />);
+    expect(screen.getByRole('link', { name: /Notiz/ })).toHaveAttribute('href', '/knowledge?doc=5');
+  });
+});


### PR DESCRIPTION
## What

First slice of the chat-UI modernization roadmap (`docs/design/chat-ui-modernization.md`, item 7). When a chat answer draws on the knowledge base, show **which documents it used** as chips under the assistant turn — filename + access-tier (`TierBadge`), each linking to `/knowledge?doc={id}`.

## Why this isn't "pure frontend" (verified before building)

The roadmap assumed "data exists, surfacing only." It didn't:
- `knowledge_search` flattened `rag.search` results into a `context` string and **discarded** the per-source structure.
- The chat stream / `Message` carried **no** sources.
- `FactProvenance` is a deterministic(✓)/advisory(~) glyph, **not** a document-source chip.

So this adds real (small, migration-free) backend plumbing plus a new frontend component.

## How

**Backend**
- `knowledge_tool.py`: return structured `data.sources` (deduped by `document_id`: `document_id`, `filename`, `title`, `tier`) alongside the unchanged `context` text.
- `chat_handler.py`: `_extract_agent_sources()` collects this turn's `knowledge_search` sources (deduped), attaches them to the assistant `message_metadata` (persisted) and the `done` WS frame (live).
- **Circle-safe for free:** sources come only from `rag.search(user_id=...)`, which is already circle-filtered — no `circle_sql` change, no second read path. (Messages aren't atoms, so this correctly does *not* route through the atom filter.)

**Frontend**
- New `components/chat/SourceChips.tsx`: chip per source + `TierBadge` (tier never color-only), caps at 6 with "+N weitere", **empty → renders nothing**, dark mode + i18n (de+en).
- Wired into `ChatMessages.tsx`; live via the `done` frame, rehydrated from `metadata.sources` on history load.

## Reviews

- **/plan-eng-review + /plan-design-review** on the roadmap doc first (premise-gate, Tier 0 cross-cutting, per-item design decisions).
- **/review** on this diff. The adversarial pass caught a **P0 dead-on-arrival bug**: `_extract_agent_sources` read `data["data"]["sources"]`, but `AgentStep.data` is the tool's *inner* dict (`agent_service` sets `data=result["data"]`), so it returned `[]` every turn — and a wrong-shaped test fixture had masked it. Fixed the extractor + rewrote the fixture to mirror the runtime payload.

## Tests

- Backend **11** (`test_knowledge_tool.py` structured/deduped sources + no-results→no-key; `test_chat_handler_provenance.py` dedupe / ignores non-knowledge-search / empty+malformed).
- Frontend RTL **4** (`SourceChips.test.tsx`: render+link, empty→nothing, cap+overflow, tier-absent).

## Notes / follow-ups

- "Retrieved provenance," not "cited provenance" — chips show documents the turn *retrieved*, even if the LLM didn't end up quoting them. Honest, acceptable for v1.
- Run `npm run build` (prod Tailwind pass) before deploy, per the frontend prod-build gate.
- v1 = `knowledge_search` only; document-fact / KG-edge provenance is a fast-follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)