### PR TITLE
feat(chat): follow-up suggestion chips (opt-in, dark)

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -262,6 +262,28 @@ Der Agent Loop ermöglicht komplexe, mehrstufige Anfragen mit bedingter Logik un
 
 Einfache Anfragen ("Schalte das Licht ein") nutzen weiterhin den schnellen Single-Intent-Pfad.
 
+### Folgefragen-Chips (Follow-up Chips)
+
+```bash
+FOLLOWUP_CHIPS_ENABLED=false
+FOLLOWUP_CHIPS_MODEL=            # leer → OLLAMA_INTENT_MODEL (kleines/schnelles Modell)
+FOLLOWUP_CHIPS_COUNT=3           # 1-5
+FOLLOWUP_CHIPS_TIMEOUT_SECONDS=5.0  # 1-30; Best-Effort-Obergrenze
+```
+
+**Defaults:**
+- `FOLLOWUP_CHIPS_ENABLED`: `false` (Opt-in/dark)
+- `FOLLOWUP_CHIPS_MODEL`: `""` (fällt auf `OLLAMA_INTENT_MODEL` zurück)
+- `FOLLOWUP_CHIPS_COUNT`: `3`
+- `FOLLOWUP_CHIPS_TIMEOUT_SECONDS`: `5.0`
+
+**Wann aktivieren:** Schlägt nach jeder substanziellen Chat-Antwort 2-4 anklickbare
+Folgefragen vor (Tipp füllt das Eingabefeld, kein Auto-Senden). Erzeugt einen
+**zusätzlichen kleinen LLM-Aufruf pro Turn** — läuft im Hintergrund nach dem
+`done`-Frame, verzögert also Antwort/TTS/Wakeword nicht. Bei gesprochenen
+(TTS-)Antworten übersprungen (Chips sind nur visuell). Auf einer ausgelasteten
+gemeinsamen GPU die zusätzliche Inferenzlast bedenken.
+
 ---
 
 ### Proaktive Benachrichtigungen

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -20,6 +20,7 @@ Renfield ist ein vollständig offline-fähiger, selbst-gehosteter **digitaler As
 - **Album Art**: Jellyfin-Bild-URLs und gängige Bildformate (`.jpg`, `.png`, `.gif`, `.webp`) werden als Inline-Bilder gerendert statt als Klartext
 - **Collapsible Agent Steps**: Agent-Schritte (Tool-Calls + Ergebnisse) sind einklappbar — offen während der Verarbeitung, eingeklappt nach Abschluss
 - **Quellen-Chips**: Stützt sich eine Antwort auf die Wissensdatenbank (RAG), erscheinen unter der Antwort anklickbare Quellen-Chips — Dokumentname + Zugriffs-Tier (`TierBadge`), je verlinkt auf `/knowledge?doc={id}`. Nur die im Zug tatsächlich abgerufenen, bereits circle-gefilterten Dokumente erscheinen (keine zweite Berechtigungs-Prüfung); ohne KB-Treffer wird nichts gezeigt. Live über den `done`-Frame, persistiert in `message_metadata.sources` (rehydriert beim Laden der Historie).
+- **Folgefragen-Chips** (`FOLLOWUP_CHIPS_ENABLED`, opt-in/dark): Nach einer Antwort schlägt ein kleiner Best-Effort-LLM-Aufruf 2-4 kurze Folgefragen vor, die unter der letzten Assistenten-Antwort als anklickbare Chips erscheinen; ein Tipp füllt das Eingabefeld (kein Auto-Senden). Im **Hintergrund nach dem `done`-Frame** erzeugt (verzögert die Antwort/TTS/Wakeword nie) und über einen separaten `followups`-Frame nachgereicht; bei gesprochenen (TTS-)Antworten, Fehler-Turns und sehr kurzen Antworten übersprungen. Ephemer (nicht persistiert).
 - **Credential Sanitization**: API-Keys und Tokens in MCP-Antworten werden automatisch aus der Chat-Anzeige redacted
 
 ### Chat-Historie

--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -289,6 +289,37 @@ async def _route_chat_tts_output(
     return False
 
 
+async def _followup_chips_background(
+    websocket,
+    user_message: str,
+    assistant_response: str,
+    lang: str,
+    model: str,
+    count: int,
+    timeout: float,
+) -> None:
+    """Background task: generate follow-up suggestion chips AFTER `done`, then
+    push them as a separate `followups` frame.
+
+    Off the turn's critical path on purpose — a synchronous pre-`done` call would
+    delay the spinner-off / TTS-resume / wakeword re-arm that the frontend gates
+    on `done` (harmful especially for voice turns, which can't use the chips).
+    Best-effort + bounded: no chips on any failure/timeout, never raises.
+    """
+    try:
+        from services.followup_service import generate_followups
+        chips = await asyncio.wait_for(
+            generate_followups(
+                user_message, assistant_response, lang=lang, model=model, count=count
+            ),
+            timeout=timeout,
+        )
+        if chips:
+            await websocket.send_json({"type": "followups", "suggested_followups": chips})
+    except Exception as e:  # noqa: BLE001 — best-effort; chips are optional
+        logger.debug(f"follow-up chips skipped: {e}")
+
+
 async def _extract_memories_background(
     user_message: str,
     assistant_response: str,
@@ -1992,6 +2023,31 @@ WICHTIG: Nutze die ECHTEN Daten aus dem Ergebnis! Gib NUR die Antwort, KEIN JSON
                 )
                 _background_tasks.add(task)
                 task.add_done_callback(_background_tasks.discard)
+
+            # Background: follow-up suggestion chips (opt-in/dark). Dispatched
+            # AFTER `done` so it never delays the turn (see _followup_chips_background).
+            # Skipped on error turns, trivially short answers, and spoken (TTS)
+            # turns — chips are a visual/tap affordance, useless + wasteful there.
+            if (
+                settings.followup_chips_enabled
+                and full_response
+                and len(full_response.strip()) >= 16
+                and not tts_handled_by_server
+                and (action_result is None or action_result.get("success") is not False)
+            ):
+                fu_task = asyncio.create_task(
+                    _followup_chips_background(
+                        websocket,
+                        content,
+                        full_response,
+                        lang=ollama.default_lang,
+                        model=settings.followup_chips_model or settings.ollama_intent_model,
+                        count=settings.followup_chips_count,
+                        timeout=settings.followup_chips_timeout_seconds,
+                    )
+                )
+                _background_tasks.add(fu_task)
+                fu_task.add_done_callback(_background_tasks.discard)
             else:
                 # WARN-level so the absence of extraction is auditable.
                 # The conversation/knowledge route can silently bypass this

--- a/src/backend/services/followup_service.py
+++ b/src/backend/services/followup_service.py
@@ -1,0 +1,131 @@
+"""
+Follow-up suggestion chips — platform service.
+
+After an assistant answer, propose 2-4 short follow-up questions the user might
+ask next, shown as tappable chips under the turn (chat-ui roadmap item 2).
+
+Design (decided in /plan-eng-review): a SINGLE small best-effort LLM call in the
+shared chat-handler seam — NOT a same-generation trailing block. Rationale: a
+dedicated call's failure is harmless (no chips), whereas a trailing JSON block
+rides on the agent's critical output and a bad parse could corrupt the answer.
+The codebase already distrusts local-model structured output (radio/KG guards);
+here that distrust is absorbed by returning `[]` on ANY failure.
+
+Gated by `followup_chips_enabled` (dark by default). Bounded by the caller via
+`asyncio.wait_for` so it can never block the turn's `done` frame.
+"""
+
+from __future__ import annotations
+
+import json
+
+from loguru import logger
+
+
+# Keep chips short + scannable; drop anything that's really a sentence/paragraph.
+_MAX_CHIP_CHARS = 80
+
+
+def _parse_followups(raw: str, count: int) -> list[str]:
+    """Tolerantly parse the model output into ≤count clean chip strings.
+
+    Accepts a JSON array of strings (the requested format) OR, as a fallback,
+    newline/bullet/numbered lines. Trims, de-dupes (case-insensitive), drops
+    empties and overlong entries. Never raises.
+    """
+    if not raw or not raw.strip():
+        return []
+
+    candidates: list[str] = []
+
+    # Preferred: a JSON array (possibly wrapped in prose / a ```json fence).
+    text = raw.strip()
+    start, end = text.find("["), text.rfind("]")
+    if start != -1 and end > start:
+        try:
+            arr = json.loads(text[start : end + 1])
+            if isinstance(arr, list):
+                # Keep only string items — a malformed array of objects/lists
+                # ([{"q":"…"}], [["a"]]) must not render Python-repr garbage as
+                # tappable chips.
+                candidates = [x for x in arr if isinstance(x, str)]
+        except (ValueError, TypeError):
+            candidates = []
+
+    # Fallback: line-based (strip bullets / numbering / quotes).
+    if not candidates:
+        for line in text.splitlines():
+            s = line.strip().lstrip("-*•0123456789.)• ").strip().strip('"').strip()
+            if s:
+                candidates.append(s)
+
+    out: list[str] = []
+    seen: set[str] = set()
+    for c in candidates:
+        s = c.strip().strip('"').strip()
+        if not s or len(s) > _MAX_CHIP_CHARS:
+            continue
+        # Drop pure-punctuation noise ("{}", "[]", "---") — a real chip has words.
+        if not any(ch.isalnum() for ch in s):
+            continue
+        key = s.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(s)
+        if len(out) >= count:
+            break
+    return out
+
+
+async def generate_followups(
+    user_message: str,
+    answer: str,
+    lang: str = "de",
+    *,
+    model: str,
+    count: int = 3,
+) -> list[str]:
+    """Best-effort: propose up to `count` short follow-up questions.
+
+    Returns `[]` on ANY failure (model error, bad output, empty) — the caller
+    treats no-chips as the normal degraded state. The caller is responsible for
+    the timeout (`asyncio.wait_for`); this function does not block on its own.
+    """
+    user_message = (user_message or "").strip()
+    answer = (answer or "").strip()
+    if not answer:
+        return []
+
+    try:
+        from utils.llm_client import extract_response_content, get_default_client
+
+        lang_name = "Deutsch" if (lang or "de").startswith("de") else "English"
+        system = (
+            f"You suggest follow-up questions for a chat assistant. Given the user's "
+            f"message and the assistant's answer, propose up to {count} SHORT, distinct "
+            f"questions the user would plausibly ask NEXT. Write them in {lang_name}, "
+            f"phrased as the user (first person), each under {_MAX_CHIP_CHARS} characters. "
+            f'Return ONLY a JSON array of strings, e.g. ["...", "..."]. No prose, no keys.'
+        )
+        prompt = (
+            f"User message:\n{user_message[:1000]}\n\n"
+            f"Assistant answer:\n{answer[:2000]}\n\n"
+            f"Up to {count} follow-up questions as a JSON array:"
+        )
+
+        client = get_default_client()
+        response = await client.chat(
+            model=model,
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": prompt},
+            ],
+            format="json",
+            options={"temperature": 0.4},
+        )
+        raw = extract_response_content(response) or ""
+        return _parse_followups(raw, count)
+    except Exception as e:  # noqa: BLE001 — best-effort; no chips on any failure
+        logger.debug(f"follow-up chip generation skipped: {e}")
+        return []

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -188,6 +188,15 @@ class Settings(BaseSettings):
     agent_model: str | None = None     # Optional: separate model for agent (default: ollama_model)
     agent_ollama_url: str | None = None # Optional: separate Ollama instance for agent (default: ollama_url)
 
+    # Follow-up suggestion chips (chat-ui roadmap item 2). Opt-in/dark. After an
+    # assistant answer, a small best-effort LLM call proposes 2-4 tappable
+    # follow-up questions, attached to the `done` frame (ephemeral, not persisted).
+    # Failure/timeout silently yields no chips — never blocks the turn.
+    followup_chips_enabled: bool = False
+    followup_chips_model: str = ""              # "" → ollama_intent_model (small/fast tier)
+    followup_chips_count: int = Field(default=3, ge=1, le=5)
+    followup_chips_timeout_seconds: float = Field(default=5.0, ge=1.0, le=30.0)
+
     # OpenAI-compatible LLM endpoint (e.g. llama-server). When set, the agent
     # tier (and optionally chat/RAG/intent via per-tier overrides below) routes
     # through this endpoint instead of Ollama. The URL must include the

--- a/src/frontend/src/components/chat/FollowupChips.tsx
+++ b/src/frontend/src/components/chat/FollowupChips.tsx
@@ -1,0 +1,35 @@
+import { useTranslation } from 'react-i18next';
+import { CornerDownLeft } from 'lucide-react';
+import { useChatContext } from '../../pages/ChatPage/context/ChatContext';
+
+/**
+ * Follow-up suggestion chips under the last assistant turn (chat-ui roadmap
+ * item 2). Tapping a chip fills the composer with that text — the user reviews
+ * and sends (no auto-send: safer for a shared household, no accidental sends).
+ *
+ * Ephemeral by design — only the live last assistant turn carries these, so they
+ * don't reappear on history reload. Empty/undefined → renders nothing.
+ */
+export default function FollowupChips({ followups }: { followups?: string[] }) {
+  const { t } = useTranslation();
+  const { setInput } = useChatContext();
+
+  if (!followups || followups.length === 0) return null;
+
+  return (
+    <div className="mt-2 flex flex-wrap gap-1.5" aria-label={t('chat.followups.label')}>
+      {followups.map((text, i) => (
+        <button
+          key={`${i}-${text}`}
+          type="button"
+          onClick={() => setInput?.(text)}
+          title={text}
+          className="inline-flex items-center gap-1 min-h-[44px] sm:min-h-0 px-3 py-1.5 rounded-full text-sm bg-primary-50 text-primary-700 hover:bg-primary-100 dark:bg-primary-900/30 dark:text-primary-200 dark:hover:bg-primary-900/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+        >
+          <CornerDownLeft className="w-3.5 h-3.5 flex-shrink-0 opacity-70" aria-hidden="true" />
+          <span className="truncate max-w-[260px]">{text}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -132,6 +132,9 @@
       "label": "Quellen",
       "more": "+{{count}} weitere"
     },
+    "followups": {
+      "label": "Vorschläge für Folgefragen"
+    },
     "intent": "Intent",
     "startConversation": "Starte ein Gespräch mit {{appName}}",
     "useTextOrMic": "Du kannst Text eingeben oder das Mikrofon nutzen",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -132,6 +132,9 @@
       "label": "Sources",
       "more": "+{{count}} more"
     },
+    "followups": {
+      "label": "Follow-up suggestions"
+    },
     "intent": "Intent",
     "startConversation": "Start a conversation with {{appName}}",
     "useTextOrMic": "You can type text or use the microphone",

--- a/src/frontend/src/pages/ChatPage/ChatMessages.tsx
+++ b/src/frontend/src/pages/ChatPage/ChatMessages.tsx
@@ -8,6 +8,7 @@ import AttachmentQuickActions from './AttachmentQuickActions';
 import EmailForwardDialog from './EmailForwardDialog';
 import PaperlessConfirmCard from './PaperlessConfirmCard';
 import SourceChips from '../../components/chat/SourceChips';
+import FollowupChips from '../../components/chat/FollowupChips';
 import { useChatContext } from './context/ChatContext';
 import { CitationChip } from '../../components/wissensbasis/CitationChip';
 import { useTraceQuery, type TraceEntity } from '../../api/resources/wissensbasis';
@@ -318,6 +319,12 @@ export default function ChatMessages() {
                 used. Renders nothing when the turn had no sources. */}
             {message.role === 'assistant' && !message.streaming && (
               <SourceChips sources={message.sources} />
+            )}
+
+            {/* Follow-up suggestion chips — only under the LAST finished
+                assistant turn (ephemeral; tapping fills the composer). */}
+            {message.role === 'assistant' && !message.streaming && index === messages.length - 1 && (
+              <FollowupChips followups={message.suggestedFollowups} />
             )}
 
             {/* Adaptive Card (from WebSocket card message) */}

--- a/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
+++ b/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
@@ -36,6 +36,7 @@ import type {
   DocumentProcessingMessage,
   DocumentReadyMessage,
   DoneMessage,
+  FollowupsMessage,
   IntentFeedbackRequestMessage,
   PaperlessCommittedMessage,
   PaperlessConfirmField,
@@ -117,6 +118,9 @@ export interface ChatUiMessage {
   // Provenance source chips — the KB documents a knowledge-backed answer drew
   // on. Arrives on the `done` frame live; rehydrates from `metadata.sources`.
   sources?: MessageSource[];
+  // Ephemeral follow-up suggestion chips for this turn (NOT persisted — only
+  // the live last assistant turn carries them).
+  suggestedFollowups?: string[];
 }
 
 /** Map a persisted history message to the in-memory UI shape. */
@@ -598,6 +602,7 @@ export function ChatProvider({ children }: ChatProviderProps) {
           federationProgress: undefined,
           // Provenance source chips for this turn (knowledge-backed answers).
           ...(data.sources && data.sources.length > 0 && { sources: data.sources }),
+          // Follow-up chips arrive separately, AFTER `done`, via handleFollowups.
         };
         lastIntentInfoRef.current = null;
 
@@ -918,6 +923,23 @@ export function ChatProvider({ children }: ChatProviderProps) {
   }, []);
 
   // Adaptive Card from server (sent after orchestrated/single-role response)
+  // Follow-up suggestion chips arrive AFTER `done` (generated in the background
+  // so they never delay the turn). Attach to the most recent assistant message;
+  // ephemeral, so they're gone on reload.
+  const handleFollowups = useCallback((data: FollowupsMessage) => {
+    if (!data.suggested_followups || data.suggested_followups.length === 0) return;
+    setMessages((prev) => {
+      const updated = [...prev];
+      for (let i = updated.length - 1; i >= 0; i--) {
+        if (updated[i].role === 'assistant') {
+          updated[i] = { ...updated[i], suggestedFollowups: data.suggested_followups };
+          break;
+        }
+      }
+      return updated;
+    });
+  }, []);
+
   const handleCard = useCallback((data: CardMessage) => {
     if (!data.card) return;
     setMessages((prev) => {
@@ -985,6 +1007,7 @@ export function ChatProvider({ children }: ChatProviderProps) {
     onAgentToolResult: handleAgentToolResult,
     onAgentFederationProgress: handleAgentFederationProgress,
     onCard: handleCard,
+    onFollowups: handleFollowups,
     onPaperlessConfirmRequest: handlePaperlessConfirmRequest,
   });
 

--- a/src/frontend/src/pages/ChatPage/hooks/useChatWebSocket.ts
+++ b/src/frontend/src/pages/ChatPage/hooks/useChatWebSocket.ts
@@ -20,6 +20,11 @@ export interface DoneMessage extends BaseWsMessage {
   sources?: MessageSource[];
 }
 
+export interface FollowupsMessage extends BaseWsMessage {
+  type: 'followups';
+  suggested_followups: string[];
+}
+
 export interface ActionWsMessage extends BaseWsMessage {
   type: 'action';
   intent: { intent?: string; confidence?: number; parameters?: Record<string, unknown> } | string;
@@ -164,6 +169,7 @@ interface UseChatWebSocketOptions {
   onAgentToolResult?: (data: AgentToolResultMessage) => void;
   onAgentFederationProgress?: (data: AgentFederationProgressMessage) => void;
   onCard?: (data: CardMessage) => void;
+  onFollowups?: (data: FollowupsMessage) => void;
 }
 
 /**
@@ -187,6 +193,7 @@ export function useChatWebSocket({
   onAgentToolResult,
   onAgentFederationProgress,
   onCard,
+  onFollowups,
 }: UseChatWebSocketOptions = {}) {
   const [wsConnected, setWsConnected] = useState(false);
   const wsRef = useRef<WebSocket | null>(null);
@@ -272,6 +279,8 @@ export function useChatWebSocket({
         const msg = data as AgentFederationProgressMessage;
         debug.log('Federation progress:', msg.peer_display_name, msg.label, `seq=${msg.sequence}`);
         onAgentFederationProgress?.(msg);
+      } else if (data.type === 'followups') {
+        onFollowups?.(data as FollowupsMessage);
       } else if (data.type === 'card') {
         debug.log('Card received');
         onCard?.(data as CardMessage);
@@ -297,7 +306,7 @@ export function useChatWebSocket({
     };
 
     wsRef.current = ws;
-  }, [onStreamChunk, onStreamDone, onAction, onRagContext, onIntentFeedbackRequest, onDocumentProcessing, onDocumentReady, onDocumentError, onUploadProcessed, onPaperlessCommitted, onPaperlessConfirmRequest, onAgentThinking, onAgentToolCall, onAgentToolResult, onAgentFederationProgress, onCard]);
+  }, [onStreamChunk, onStreamDone, onAction, onRagContext, onIntentFeedbackRequest, onDocumentProcessing, onDocumentReady, onDocumentError, onUploadProcessed, onPaperlessCommitted, onPaperlessConfirmRequest, onAgentThinking, onAgentToolCall, onAgentToolResult, onAgentFederationProgress, onCard, onFollowups]);
 
   useEffect(() => {
     connectWebSocket();

--- a/src/frontend/src/types/chat.ts
+++ b/src/frontend/src/types/chat.ts
@@ -94,6 +94,13 @@ export interface ChatDoneMessage {
   sources?: MessageSource[];
 }
 
+// Ephemeral follow-up suggestion chips, pushed AFTER `done` (generated in the
+// background so it never delays the turn). Attaches to the last assistant turn.
+export interface ChatFollowupsMessage {
+  type: 'followups';
+  suggested_followups: string[];
+}
+
 export interface ChatErrorMessage {
   type: 'error';
   message: string;
@@ -121,5 +128,6 @@ export type ChatWebSocketMessage =
   | ChatStreamMessage
   | ChatActionMessage
   | ChatDoneMessage
+  | ChatFollowupsMessage
   | ChatErrorMessage
   | ChatFederationProgressMessage;

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,62 +1,79 @@
-# Plan — Provenance chips in chat (roadmap item 7)
+# Plan — Follow-up suggestion chips (chat-ui roadmap item 2)
 
-Source: `docs/design/chat-ui-modernization.md` Tier 1 item 7. First-slice build.
-Goal: show **which sources** a knowledge-backed chat answer used, as chips under
-the assistant turn (filename + access-tier), so the answer's provenance is visible.
+Source: `docs/design/chat-ui-modernization.md` Tier 1 item 2. After an assistant
+answer, show 2-4 tappable follow-up suggestions under the turn.
 
-## Reality check (verified, corrects the roadmap doc)
-- `FactProvenance` is NOT reusable here — it renders deterministic(✓)/advisory(~),
-  not document-source chips. Source chips are a NEW small component reusing `TierBadge`.
-- NOT pure-frontend: `knowledge_tool.py` flattens `rag.search` results into a
-  `context` string and discards per-source structure; the chat stream/`Message`
-  carries no sources today. Needs backend capture + stream + persist.
-- Circle-safety: `rag.search(user_id=...)` already circle-filters retrieval, so
-  sources only contain rows the asker could already see — no `circle_sql` change,
-  no second read path.
+## Approach (decided with user, reverses the roadmap's "same generation" line)
+Generate in the **single shared seam** in `chat_handler` (after `full_response`,
+where every path — conversation / agent / RAG — converges), via ONE small
+best-effort call. NO agent-output-contract change. A parse/timeout failure just
+drops the chips (answer untouched). Gated + dark by default.
+
+Why not same-generation: a trailing-JSON-in-the-answer block touches every
+prompt, is fragile on local models the codebase already distrusts, and a bad
+parse could corrupt the visible answer. A dedicated call fails gracefully.
+
+## Decisions
+- **Ephemeral, NOT persisted.** Chips are next-step suggestions for the *live*
+  turn only → attach to the `done` frame, shown under the LAST assistant turn,
+  cleared on the next user send. (Unlike provenance chips, which persist.)
+  No `message_metadata`, no history rehydration.
+- **Tap = fill the composer + focus** (NOT auto-send) — safer for a household
+  (no accidental sends); user reviews/sends. (Speakable-for-voice = follow-up.)
+- **Best-effort + bounded** — `asyncio.wait_for(timeout)`, try/except; `done` is
+  never blocked beyond the timeout; empty list on any failure. Prose already
+  streamed, so only `done`+chips lag by ~one small-model inference.
 
 ## Backend
-- [x] `services/knowledge_tool.py` — returns `data.sources`: deduped
-  `[{document_id, filename, title, tier}]` from `rag.search` results (tier IS on
-  the result: `document.circle_tier`). `context` text unchanged.
-- [x] `api/websocket/chat_handler.py` — added `_extract_agent_sources()` helper +
-  shared `agent_tool_results` init; on the shared persist/done path, derives
-  sources from the turn's `internal.knowledge_search` tool results (deduped),
-  attaches to `assistant_metadata["sources"]` (persist) + `done_msg["sources"]`
-  (live). NOTE: agent loop runs in chat_handler, NOT agent_service — corrected
-  from the plan. Scope v1 = knowledge_search only.
+- [ ] `utils/config.py` — `followup_chips_enabled` (False/dark), `followup_chips_model`
+  (""→ `ollama_intent_model`), `followup_chips_count` (3), `followup_chips_timeout_seconds` (5).
+- [ ] `services/followup_service.py` (NEW) — `generate_followups(user_message, answer,
+  lang, *, model, count, timeout) -> list[str]`. Tight prompt → 2-4 short questions
+  in the user's language; tolerant parse (JSON array OR newline/bullet lines);
+  trims to `count`, drops empties/dupes/overlong; returns `[]` on ANY failure.
+- [ ] `chat_handler.py` — in the shared block (after `full_response`, near `done_msg`):
+  if `followup_chips_enabled` AND substantive non-error turn (full_response present,
+  `action_success` not False, len ≥ small floor), best-effort
+  `await asyncio.wait_for(generate_followups(...), timeout)` → `done_msg["suggested_followups"]`.
+  Wrapped try/except — never block `done`. (v1: all substantive turns; gate-by-intent = follow-up.)
 
 ## Frontend
-- [x] `types/chat.ts` — added `MessageSource` + `sources?` on `ChatMessage` and
-  `ChatDoneMessage`.
-- [x] `components/chat/SourceChips.tsx` — NEW. Chip per source: filename +
-  `<TierBadge>` (when tier 0-4), links to `/knowledge?doc={id}`. Empty/undefined
-  → renders nothing. Dark mode + i18n (de+en `chat.sources.*`). Caps at 6 with
-  "+N weitere" expand. Clickable (chosen over labels-only).
-- [x] `pages/ChatPage/ChatMessages.tsx` — renders `<SourceChips>` under finished
-  assistant turns.
-- [x] `context/ChatContext.tsx` — `ChatUiMessage.sources`; `done` handler attaches
-  `data.sources`; `historyToUiMessage` rehydrates from `metadata.sources`.
-- [x] `hooks/useChatWebSocket.ts` — `DoneMessage.sources`.
+- [ ] `types/chat.ts` — `ChatDoneMessage.suggested_followups?: string[]`.
+- [ ] `hooks/useChatWebSocket.ts` — `DoneMessage.suggested_followups?: string[]`.
+- [ ] `context/ChatContext.tsx` — `ChatUiMessage.suggestedFollowups?: string[]`; `done`
+  handler attaches `suggested_followups` to the completed msg; ensure only the LAST
+  assistant msg carries them (clear/none on older turns is automatic since not persisted).
+- [ ] `components/chat/FollowupChips.tsx` (NEW) — tappable chips; tap → `setInput(text)`
+  + focus composer (via context). Empty/undefined → renders nothing. 44px targets,
+  keyboard-focusable, dark mode + i18n.
+- [ ] `pages/ChatPage/ChatMessages.tsx` — render `<FollowupChips>` under the LAST
+  finished assistant turn only (index === last && !streaming).
 
 ## Tests
-- [x] Backend: `test_knowledge_tool.py` (structured deduped sources; no-results →
-  no key) + `test_chat_handler_provenance.py` (`_extract_agent_sources` dedupe,
-  ignores non-knowledge_search, empty/malformed). 11 passed on .159.
-- [x] Frontend RTL: `SourceChips.test.tsx` — renders/links, empty → nothing,
-  cap+overflow, tier-absent. 4 passed.
+- [ ] Backend: `followup_service` parses JSON + line formats → N chips; returns []
+  on garbage / timeout / empty; respects `count`. chat_handler attaches when flag on,
+  none when off / error turn (mock the service).
+- [ ] Frontend RTL: FollowupChips renders chips, empty → nothing, tap calls setInput.
 
 ## Out of scope (v1)
-- Clickable deep-link into `/wissen` (can be a fast-follow; v1 may ship labels).
-- document_fact / KG-edge provenance (knowledge_search only for v1).
-- Items 2/4/6 of the first slice (separate PRs).
+- Persistence / history rehydration (ephemeral by design).
+- Voice-speakable chips (roadmap noted; follow-up).
+- Auto-send on tap; gate-by-intent (generate-for-all is fine behind the flag).
+
+## Status: IMPLEMENTED
+- Backend: `config` flags + `services/followup_service.py` (NEW) + `chat_handler`
+  shared-seam best-effort call (bounded by `asyncio.wait_for`, try/except, gated).
+- Frontend: `types`/`useChatWebSocket` `suggested_followups`; `ChatContext`
+  `suggestedFollowups` + done-handler attach; `FollowupChips.tsx` (NEW, tap→setInput);
+  `ChatMessages` renders under the LAST finished assistant turn; i18n de+en.
+- Parser hardened: requires word content (drops "{}"/"[]"/"---" noise).
+- Tests: backend 8 (parse JSON/lines/dedupe/overlong/garbage + generate
+  success/empty/best-effort-fail), frontend 7 (FollowupChips 3 + SourceChips 4
+  still green). tsc clean on changed files.
 
 ## Review
-- Verified the "data exists / pure-frontend" roadmap claim was WRONG before coding:
-  `knowledge_search` discarded per-source structure; chat stream carried no sources;
-  `FactProvenance` is a deterministic/advisory glyph, not a document-source chip.
-- Circle-safety: sources come only from `rag.search(user_id=...)` which is already
-  circle-filtered — no `circle_sql` change, no second read path.
-- Tests green: backend 11/11 (.159), frontend 4/4 (isolated). `tsc` clean on the 5
-  changed files (2 pre-existing errors in untouched skills.ts/trajectories.ts).
-- Pending before deploy: `npm run build` (prod Tailwind pass — per the frontend
-  prod-build gate), and `/review`.
+- Reversed the roadmap's "same generation" line with the user — dedicated
+  best-effort call fails gracefully (no chips) vs a trailing block that could
+  corrupt the answer. Single seam covers all paths, no agent-contract change.
+- Ephemeral (done-frame only, last turn) — no persistence/rehydration.
+- Pending before deploy: `npm run build` (prod Tailwind) + `/review`.

--- a/tests/backend/test_followup_service.py
+++ b/tests/backend/test_followup_service.py
@@ -1,0 +1,74 @@
+"""
+Tests for `services.followup_service` — follow-up suggestion chips.
+
+The parser is the load-bearing part (local models emit JSON *or* loose lines);
+`generate_followups` must be best-effort — `[]` on any failure, never raising.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.followup_service import _parse_followups, generate_followups
+
+
+# ---- _parse_followups (pure) -------------------------------------------------
+
+@pytest.mark.unit
+def test_parses_json_array():
+    raw = '["Wie viel kostet das?", "Wann ist es fällig?"]'
+    assert _parse_followups(raw, 3) == ["Wie viel kostet das?", "Wann ist es fällig?"]
+
+
+@pytest.mark.unit
+def test_parses_json_wrapped_in_prose_or_fence():
+    raw = 'Here you go:\n```json\n["A?", "B?"]\n```'
+    assert _parse_followups(raw, 3) == ["A?", "B?"]
+
+
+@pytest.mark.unit
+def test_line_fallback_strips_bullets_and_numbering():
+    raw = "- Frage eins?\n2. Frage zwei?\n• Frage drei?"
+    assert _parse_followups(raw, 3) == ["Frage eins?", "Frage zwei?", "Frage drei?"]
+
+
+@pytest.mark.unit
+def test_trims_to_count_dedupes_and_drops_overlong():
+    raw = '["A?", "a?", "B?", "' + ("x" * 100) + '", "C?", "D?"]'
+    # "a?" dedupes "A?" (casefold); the 100-char entry is dropped; capped at 2
+    assert _parse_followups(raw, 2) == ["A?", "B?"]
+
+
+@pytest.mark.unit
+def test_empty_or_garbage_yields_empty():
+    assert _parse_followups("", 3) == []
+    assert _parse_followups("   ", 3) == []
+    assert _parse_followups("{}", 3) == []  # object, not array, no lines
+
+
+# ---- generate_followups (best-effort) ----------------------------------------
+
+@pytest.mark.unit
+async def test_generate_returns_parsed_chips():
+    mock_client = MagicMock()
+    mock_client.chat = AsyncMock(return_value={"message": {"content": '["X?", "Y?"]'}})
+    with patch("utils.llm_client.get_default_client", return_value=mock_client), \
+         patch("utils.llm_client.extract_response_content", return_value='["X?", "Y?"]'):
+        out = await generate_followups("q", "an answer long enough", lang="de", model="m", count=3)
+    assert out == ["X?", "Y?"]
+
+
+@pytest.mark.unit
+async def test_generate_empty_answer_short_circuits():
+    # No client call when there's no answer to follow up on.
+    with patch("utils.llm_client.get_default_client", side_effect=AssertionError("should not be called")):
+        assert await generate_followups("q", "   ", model="m") == []
+
+
+@pytest.mark.unit
+async def test_generate_is_best_effort_on_failure():
+    mock_client = MagicMock()
+    mock_client.chat = AsyncMock(side_effect=RuntimeError("ollama down"))
+    with patch("utils.llm_client.get_default_client", return_value=mock_client), \
+         patch("utils.llm_client.extract_response_content", return_value=""):
+        assert await generate_followups("q", "an answer", model="m") == []

--- a/tests/frontend/react/components/FollowupChips.test.tsx
+++ b/tests/frontend/react/components/FollowupChips.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * FollowupChips — ephemeral follow-up suggestion chips. Tapping fills the
+ * composer (setInput), never auto-sends. German is the test default.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import FollowupChips from '../../../../src/frontend/src/components/chat/FollowupChips';
+import {
+  type ChatContextValue,
+} from '../../../../src/frontend/src/pages/ChatPage/context/ChatContext';
+import { chatContextWithSpies } from '../test-chat-mock';
+import { renderWithRouter } from '../test-utils';
+
+const ctx = chatContextWithSpies();
+
+vi.mock('../../../../src/frontend/src/pages/ChatPage/context/ChatContext', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../../../src/frontend/src/pages/ChatPage/context/ChatContext')
+  >('../../../../src/frontend/src/pages/ChatPage/context/ChatContext');
+  return { ...actual, useChatContext: (): ChatContextValue => ctx };
+});
+
+describe('FollowupChips', () => {
+  it('renders nothing for empty or undefined', () => {
+    const { container, rerender } = renderWithRouter(<FollowupChips followups={[]} />);
+    expect(container).toBeEmptyDOMElement();
+    rerender(<FollowupChips followups={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders a button per suggestion', () => {
+    renderWithRouter(<FollowupChips followups={['Wie viel kostet das?', 'Wann ist es fällig?']} />);
+    expect(screen.getByRole('button', { name: /Wie viel kostet das\?/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Wann ist es fällig\?/ })).toBeInTheDocument();
+  });
+
+  it('tapping a chip fills the composer (setInput) and does NOT send', async () => {
+    renderWithRouter(<FollowupChips followups={['Und morgen?']} />);
+    await userEvent.click(screen.getByRole('button', { name: /Und morgen\?/ }));
+    expect(ctx.setInput).toHaveBeenCalledWith('Und morgen?');
+    expect(ctx.sendMessage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Chat-UI roadmap **item 2**. After an assistant answer, show 2-4 tappable follow-up suggestions under the last turn. Tapping **fills the composer** (`setInput`) — never auto-sends (safer for a shared household). Gated by `followup_chips_enabled` (dark by default).

## How (decided in planning + hardened in review)

**Generation:** a single small best-effort LLM call (intent-tier model) where every response path converges — NOT a same-generation trailing block. Rationale: a dedicated call's failure is harmless (no chips); a trailing block rides on the agent's critical output and a bad parse could corrupt the answer, and the codebase already distrusts local-model structured output.

**Off the critical path (review fix):** dispatched as a **background task AFTER the `done` frame**, pushing a separate `followups` WS frame. A synchronous pre-`done` call would delay spinner-off / TTS-resume / wakeword re-arm by up to the timeout — harmful especially for voice turns that can't use chips. Tracked in `_background_tasks` (strong ref, no GC). Skipped on error turns, trivially short answers, and spoken (TTS) turns. Ephemeral (not persisted).

Backend: `config` flags · `services/followup_service.py` (`generate_followups` best-effort, `format=json`, tolerant parse, keeps only string items, dedupe/drop-overlong) · `chat_handler._followup_chips_background`.
Frontend: new `followups` frame + `onFollowups` · `ChatContext.handleFollowups` (attaches to last assistant turn) · `FollowupChips.tsx` (tap→setInput, empty→nothing, 44px, i18n de+en) · `ChatMessages` renders under the last finished turn only.

## Review

`/review` adversarial pass caught two real issues, both fixed in this PR:
1. **Synchronous-before-`done` latency** → moved to background + post-`done` frame.
2. **`str(x)` on JSON array items** leaking Python-repr garbage (`{'q':'…'}`) as chips → `isinstance(x, str)` filter.
Confirmed clean: no XSS/auto-send, gate has no NameError, no stale-chip/duplicate-key, parser doesn't hang/raise.

## Tests

Backend **8** (`test_followup_service.py`: parse JSON/lines/dedupe/overlong/garbage/non-string + generate success/empty/best-effort-fail). Frontend RTL **3** (`FollowupChips`: render, empty→nothing, tap→setInput no-send) + SourceChips 4 still green.

## Notes / follow-ups

- LLM-text chips are untrusted but safe: React-escaped, tap only fills the composer.
- v1 generates for text turns (skips spoken); voice-speakable chips + gate-by-intent = follow-ups.
- Run `npm run build` (prod Tailwind) before deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)