### PR TITLE
feat(frontend): baseline Content-Security-Policy (Report-Only v1)

### DIFF
--- a/.claude/skills/deploy-production/SKILL.md
+++ b/.claude/skills/deploy-production/SKILL.md
@@ -395,6 +395,18 @@ until the SW re-fetches and detects a new build. The propagation rule lives in
   (`X-Frame-Options`/`X-Content-Type-Options`/`X-XSS-Protection`) for that
   response — re-declare them in every such location. Always `nginx -t` the config
   (run it in a `nginx:1.28-alpine` container) before building the image.
+- **Baseline CSP ships Report-Only first (`Content-Security-Policy-Report-Only`).**
+  The policy lives in the same `nginx.conf` (`map $host $csp`, re-declared per
+  `location` — same inheritance trap above). It is intentionally Report-Only so a
+  wrong directive **reports** to the browser console instead of breaking the PWA.
+  **Do NOT flip the header name to enforcing `Content-Security-Policy` blind** —
+  gate the flip on a clean browser-verification pass with DevTools console open:
+  exercise wakeword (the `'wasm-unsafe-eval'` onnxruntime path), voice, chat-WS,
+  TTS, and an SW update, and confirm **zero CSP violation reports**. The two
+  fragile directives to watch: the inline theme-script `sha256` hash (Vite's
+  html-minify can alter the bytes at build → recompute from the built
+  `dist/index.html` or fall back to `'unsafe-inline'` on `script-src`) and
+  `'wasm-unsafe-eval'` (absent → wakeword WASM compile is reported/blocked).
 
 Verify the live headers from inside the cluster (renfield.local mDNS is flaky
 from the laptop):

--- a/src/frontend/nginx.conf
+++ b/src/frontend/nginx.conf
@@ -1,3 +1,101 @@
+# Baseline Content-Security-Policy for the Renfield PWA.
+#
+# Derived from THIS app's actual needs (not a generic template) — every
+# directive below is tied to a real, grepped usage:
+#
+#   default-src 'self'
+#       Fallback for any directive not listed. Same-origin only.
+#
+#   script-src 'self' 'wasm-unsafe-eval' 'sha256-...'
+#       'self'            — the hashed Vite bundles + the external
+#                           /registerSW.js the PWA plugin injects.
+#       'wasm-unsafe-eval'— onnxruntime-web compiles the wake-word .onnx/.ort
+#                           models via WebAssembly (src/hooks/useWakeWord.ts:
+#                           `import('onnxruntime-web')`, wasmPaths '/ort/').
+#                           WASM compilation is CSP-gated; this token permits it
+#                           WITHOUT permitting JS eval(). Omit it → wake word
+#                           silently dies. (numThreads=1 + proxy=false, so NO
+#                           onnxruntime web-worker is spawned.)
+#       'sha256-...'      — the ONE static inline <script> in index.html (the
+#                           FOUC theme-flash guard). Hashed instead of
+#                           'unsafe-inline' so no inline-script injection
+#                           surface is opened. SEE the build-stability caveat
+#                           below — this is why v1 ships Report-Only.
+#
+#   style-src 'self' 'unsafe-inline'
+#       'self'            — the hashed Tailwind v4 stylesheet + bundled
+#                           @fontsource CSS.
+#       'unsafe-inline'   — REQUIRED, not avoidable by hashing:
+#                           (a) 14 components use React `style={{...}}` for
+#                               dynamic widths/heights/CSS-vars
+#                               (e.g. PaperlessAuditPage progress bars,
+#                               GraphView height, BestaetigtToast --toast-duration);
+#                           (b) recharts / react-force-graph / three.js inject
+#                               runtime <style> elements with computed values.
+#                           These are dynamic → no stable hash exists. CSP has no
+#                           way to allow attribute styles via hash in practice,
+#                           so 'unsafe-inline' on style-src stays. Low risk:
+#                           style injection ≠ script execution.
+#
+#   img-src 'self' data: blob:
+#       'self'  — /logo-icon.svg etc., same-origin Paperless thumbnails.
+#       data:   — inline data:image/svg+xml noise backgrounds on Login/Register.
+#       blob:   — object-URL chat images / generated previews.
+#
+#   font-src 'self'
+#       @fontsource-variable/{dm-sans,cormorant} are BUNDLED (imported in
+#       main.tsx) → served same-origin as .woff2. No CDN. (data: kept off here;
+#       @fontsource emits url(...woff2) references, not data: URIs.)
+#
+#   connect-src 'self'
+#       Chat / device / wakeword WebSockets + /api fetches are ALL same-origin
+#       in prod (getWebSocketUrl/getApiBaseUrl derive from window.location →
+#       wss://<host>/ws). 'self' covers same-origin wss:. SearXNG/Ollama are
+#       server-side, never reached from the browser. NOTE: if a deploy ever sets
+#       VITE_WS_URL/VITE_API_URL to a CROSS-origin host, add that origin here.
+#
+#   media-src 'self' blob: data:
+#       TTS audio playback (new Audio / AudioContext) plays same-origin or
+#       object-URL/data: blobs (src/pages/ChatPage/hooks/useAudioRecording.ts).
+#
+#   worker-src 'self' blob:
+#       The vite-plugin-pwa service worker (sw.js, same-origin). blob: kept for
+#       any future blob-URL worker (Workbox can register workers via blob).
+#
+#   manifest-src 'self'   — the PWA web manifest.
+#   frame-src 'self'      — no iframes today; reserved for the Lane B chat-
+#                           artifact sandbox (srcdoc frames) — harmless now.
+#   frame-ancestors 'none'— clickjacking defence; supersedes X-Frame-Options
+#                           (kept for old-browser belt-and-suspenders).
+#   base-uri 'self'       — block <base> tag hijack of relative URLs.
+#   object-src 'none'     — no <object>/<embed>/<applet> plugins, ever.
+#   form-action 'self'    — forms may only POST same-origin.
+#
+# ---------------------------------------------------------------------------
+# REPORT-ONLY FIRST (v1). The header name is Content-Security-Policy-Report-Only
+# so a wrong directive REPORTS instead of BREAKING. This is deliberate: a rich
+# PWA where a missed directive silently kills wakeword/voice/TTS is exactly the
+# case for observe-then-enforce. Flip to `Content-Security-Policy` (the enforcing
+# name) in a follow-up PR after a clean browser-verification pass. The two trap
+# directives to watch in the browser console are:
+#   * the inline-script HASH — Vite's html-minify step CAN alter the inline
+#     script's bytes at build, invalidating 'sha256-...'. If the console reports
+#     the theme script blocked, EITHER recompute the hash from the built
+#     dist/index.html, OR fall back to 'unsafe-inline' on script-src.
+#   * 'wasm-unsafe-eval' — if absent, the wake-word WASM compile is reported.
+# Because v1 is Report-Only, neither can brick the app before it is observed.
+#
+# nginx `add_header` does NOT inherit once a location declares its own — so the
+# CSP (like the other security headers) is re-declared in EVERY location that
+# sets headers. The $csp variable below is the single source of truth to avoid
+# per-location drift. (Documented trap: reference_pwa_sw_nocache_nginx.)
+# ---------------------------------------------------------------------------
+
+# Single source of truth for the policy string (avoids per-location drift).
+map $host $csp {
+    default "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'sha256-punQmGiNS8da81PCRuSsjEAS5CzAnZcWK/ykEF4Wg4A='; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; media-src 'self' blob: data:; worker-src 'self' blob:; manifest-src 'self'; frame-src 'self'; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; form-action 'self'";
+}
+
 server {
     listen 80;
     server_name localhost;
@@ -14,6 +112,8 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
+    # Baseline CSP — Report-Only for v1 (observe, then flip to enforcing).
+    add_header Content-Security-Policy-Report-Only $csp always;
 
     # Service worker + its registration script have STABLE names (sw.js,
     # registerSW.js), so the immutable rule below would HTTP-cache them for a
@@ -25,11 +125,12 @@ server {
     # (workbox-*.js is content-hashed, so it stays in the immutable block.)
     # NOTE: nginx `add_header` does NOT inherit from the server block once a
     # location declares its own — so every location with a Cache-Control header
-    # must re-declare the security headers, or it silently drops them.
+    # must re-declare the security headers AND the CSP, or it silently drops them.
     location ~* ^/(sw\.js|registerSW\.js)$ {
         default_type application/javascript;
         add_header Cache-Control "no-cache, no-store, must-revalidate" always;
         add_header X-Content-Type-Options "nosniff" always;
+        add_header Content-Security-Policy-Report-Only $csp always;
         expires off;
     }
 
@@ -42,11 +143,13 @@ server {
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
+        add_header Content-Security-Policy-Report-Only $csp always;
         expires off;
     }
     location = /manifest.webmanifest {
         add_header Cache-Control "no-cache, must-revalidate" always;
         add_header X-Content-Type-Options "nosniff" always;
+        add_header Content-Security-Policy-Report-Only $csp always;
         expires off;
     }
 
@@ -82,6 +185,7 @@ server {
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
+        add_header Content-Security-Policy-Report-Only $csp always;
         expires off;
     }
 

--- a/src/frontend/test_csp_headers.sh
+++ b/src/frontend/test_csp_headers.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# test_csp_headers.sh — verifies the baseline Content-Security-Policy in
+# nginx.conf is present on every document/worker/SW response (design §6 CSP
+# test), and that it survives the nginx `add_header` inheritance trap on the
+# locations that re-declare their own headers (`/`, `= /index.html`, the
+# SPA fallback, `sw.js`/`registerSW.js`, `manifest.webmanifest`).
+#
+# There is no nginx test harness in this repo; this mirrors how the PWA
+# no-cache headers were verified (a throwaway nginx:1.28-alpine container +
+# header inspection — see memory reference_pwa_sw_nocache_nginx). It uses ONLY
+# docker + the container's busybox wget, so it needs no host curl/node.
+#
+# Usage:  ./test_csp_headers.sh
+# Exit:   0 = all assertions pass, non-zero = a header was missing/wrong.
+#
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CONF="$HERE/nginx.conf"
+IMG="nginx:1.28-alpine"
+HEADER="Content-Security-Policy-Report-Only"   # v1 ships Report-Only; flip to
+                                               # "Content-Security-Policy" here
+                                               # when the policy is enforced.
+
+# 0. nginx syntax must be valid.
+echo "[csp-test] nginx -t ..."
+docker run --rm -v "$CONF:/etc/nginx/conf.d/default.conf:ro" "$IMG" nginx -t
+
+# 1. Minimal docroot so try_files / index resolve.
+TMP="$(mktemp -d)"
+trap 'docker rm -f "$CID" >/dev/null 2>&1 || true; docker network rm "$NET" >/dev/null 2>&1 || true; rm -rf "$TMP"' EXIT
+printf '<!doctype html><title>t</title>' > "$TMP/index.html"
+printf '{}'        > "$TMP/manifest.webmanifest"
+printf '/*sw*/'    > "$TMP/sw.js"
+printf '/*reg*/'   > "$TMP/registerSW.js"
+printf 'body{}'    > "$TMP/app-abc123.css"
+
+NET="csptest_$$"
+docker network create "$NET" >/dev/null
+CID="$(docker run -d --rm --network "$NET" --name "cspnginx_$$" \
+  -v "$CONF:/etc/nginx/conf.d/default.conf:ro" \
+  -v "$TMP:/usr/share/nginx/html:ro" "$IMG")"
+sleep 2
+
+fail=0
+hdrs() {  # fetch response headers for a path via a sibling busybox container
+  docker run --rm --network "$NET" "$IMG" \
+    sh -c "wget -S -q -O /dev/null http://cspnginx_$$:80$1 2>&1"
+}
+
+# Paths that MUST carry the CSP (document + worker contexts).
+for path in "/" "/index.html" "/deep/spa/route" "/sw.js" "/registerSW.js" "/manifest.webmanifest"; do
+  if hdrs "$path" | grep -qi "^[[:space:]]*${HEADER}:"; then
+    echo "[csp-test] OK   $path  -> $HEADER present"
+  else
+    echo "[csp-test] FAIL $path  -> $HEADER MISSING"
+    fail=1
+  fi
+done
+
+# Spot-check a required directive made it through (catches an empty/truncated map).
+if hdrs "/" | grep -qi "wasm-unsafe-eval"; then
+  echo "[csp-test] OK   /  -> wasm-unsafe-eval present (wakeword WASM)"
+else
+  echo "[csp-test] FAIL /  -> wasm-unsafe-eval MISSING (wakeword would break when enforced)"
+  fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "[csp-test] FAILED"
+  exit 1
+fi
+echo "[csp-test] all CSP header assertions passed"


### PR DESCRIPTION
PR 1 of the chat-artifacts plan (`docs/design/chat-artifacts-sandbox.md` §3.4/§8) — the standalone, sequenced-first baseline CSP. The repo ships **no CSP today**; this closes that gap and is the Lane-B prerequisite.

## What
- `src/frontend/nginx.conf`: baseline CSP via a single `map $host $csp` source-of-truth, re-declared in all 6 header-setting `location` blocks (the `add_header` inheritance trap). Every directive is tied to a grepped usage — `'wasm-unsafe-eval'` for the onnxruntime wakeword, `style-src 'unsafe-inline'` for dynamic React inline styles + chart-lib runtime `<style>`, same-origin `connect-src`/`media-src`/`worker-src` for the WS/TTS/SW, an inline-script `sha256` hash for the FOUC theme guard, plus `frame-ancestors 'none'`/`base-uri 'self'`/`object-src 'none'`/`form-action 'self'` hardening.
- `src/frontend/test_csp_headers.sh`: container test asserting the header on all 6 locations (+ `wasm-unsafe-eval` spot-check, absent on hashed subresources). `nginx -t` passes.
- `.claude/skills/deploy-production/SKILL.md`: doc note gating the enforcing flip on a clean browser pass.

## Why Report-Only for v1
Header name is `Content-Security-Policy-Report-Only` → a wrong directive **reports** instead of breaking. The two fragile directives (the inline-script hash, computed from source but unverified against the minified build; and `'wasm-unsafe-eval'`) would each silently kill a feature if enforced and slightly wrong. Observe-then-enforce.

## Follow-up (PR 1b, one-line)
After deploy + a clean DevTools-console pass (wakeword/voice/chat-WS/TTS/SW → zero CSP reports), flip the header name to enforcing `Content-Security-Policy`. That unblocks Lane A artifacts (PR 2).

Frontend/nginx-only, no backend, no env knob, zero blast radius (Report-Only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)