### PR TITLE
feat(frontend): flip baseline CSP to enforcing (PR 1b)

### DIFF
--- a/src/frontend/nginx.conf
+++ b/src/frontend/nginx.conf
@@ -19,8 +19,9 @@
 #       'sha256-...'      — the ONE static inline <script> in index.html (the
 #                           FOUC theme-flash guard). Hashed instead of
 #                           'unsafe-inline' so no inline-script injection
-#                           surface is opened. SEE the build-stability caveat
-#                           below — this is why v1 ships Report-Only.
+#                           surface is opened. Verified against the MINIFIED
+#                           dist/index.html (Vite's html-minify did NOT alter
+#                           the bytes) before enforcing — see note below.
 #
 #   style-src 'self' 'unsafe-inline'
 #       'self'            — the hashed Tailwind v4 stylesheet + bundled
@@ -72,18 +73,20 @@
 #   form-action 'self'    — forms may only POST same-origin.
 #
 # ---------------------------------------------------------------------------
-# REPORT-ONLY FIRST (v1). The header name is Content-Security-Policy-Report-Only
-# so a wrong directive REPORTS instead of BREAKING. This is deliberate: a rich
-# PWA where a missed directive silently kills wakeword/voice/TTS is exactly the
-# case for observe-then-enforce. Flip to `Content-Security-Policy` (the enforcing
-# name) in a follow-up PR after a clean browser-verification pass. The two trap
-# directives to watch in the browser console are:
-#   * the inline-script HASH — Vite's html-minify step CAN alter the inline
-#     script's bytes at build, invalidating 'sha256-...'. If the console reports
-#     the theme script blocked, EITHER recompute the hash from the built
-#     dist/index.html, OR fall back to 'unsafe-inline' on script-src.
-#   * 'wasm-unsafe-eval' — if absent, the wake-word WASM compile is reported.
-# Because v1 is Report-Only, neither can brick the app before it is observed.
+# ENFORCING (v2, frontend v2.15.16). The header name is `Content-Security-Policy`
+# — violations are BLOCKED, not just reported. v1 (frontend v2.15.15) shipped the
+# Report-Only variant and was browser-verified clean (zero securitypolicyviolation
+# events across load + /chat + /wissen + /settings + a live WS open) before this
+# flip. The two trap directives were both confirmed against the real build:
+#   * the inline-script HASH — hashing the MINIFIED served dist/index.html's
+#     inline <script> reproduced 'sha256-...' exactly (Vite's html-minify did
+#     not alter the bytes). If a future build changes that inline script, the
+#     theme guard will be BLOCKED — recompute the hash from the built
+#     dist/index.html, or fall back to 'unsafe-inline' on script-src.
+#   * 'wasm-unsafe-eval' — confirmed: the onnxruntime wake-word WASM compiled
+#     and ran. Removing it would now BLOCK wakeword, not just report it.
+# To revert to observe-mode, rename the header back to
+# `Content-Security-Policy-Report-Only` in every location below.
 #
 # nginx `add_header` does NOT inherit once a location declares its own — so the
 # CSP (like the other security headers) is re-declared in EVERY location that
@@ -112,8 +115,8 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
-    # Baseline CSP — Report-Only for v1 (observe, then flip to enforcing).
-    add_header Content-Security-Policy-Report-Only $csp always;
+    # Baseline CSP — ENFORCING (v1 shipped Report-Only, verified clean, then flipped).
+    add_header Content-Security-Policy $csp always;
 
     # Service worker + its registration script have STABLE names (sw.js,
     # registerSW.js), so the immutable rule below would HTTP-cache them for a
@@ -130,7 +133,7 @@ server {
         default_type application/javascript;
         add_header Cache-Control "no-cache, no-store, must-revalidate" always;
         add_header X-Content-Type-Options "nosniff" always;
-        add_header Content-Security-Policy-Report-Only $csp always;
+        add_header Content-Security-Policy $csp always;
         expires off;
     }
 
@@ -143,13 +146,13 @@ server {
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
-        add_header Content-Security-Policy-Report-Only $csp always;
+        add_header Content-Security-Policy $csp always;
         expires off;
     }
     location = /manifest.webmanifest {
         add_header Cache-Control "no-cache, must-revalidate" always;
         add_header X-Content-Type-Options "nosniff" always;
-        add_header Content-Security-Policy-Report-Only $csp always;
+        add_header Content-Security-Policy $csp always;
         expires off;
     }
 
@@ -185,7 +188,7 @@ server {
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
-        add_header Content-Security-Policy-Report-Only $csp always;
+        add_header Content-Security-Policy $csp always;
         expires off;
     }
 

--- a/src/frontend/test_csp_headers.sh
+++ b/src/frontend/test_csp_headers.sh
@@ -19,9 +19,9 @@ set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 CONF="$HERE/nginx.conf"
 IMG="nginx:1.28-alpine"
-HEADER="Content-Security-Policy-Report-Only"   # v1 ships Report-Only; flip to
-                                               # "Content-Security-Policy" here
-                                               # when the policy is enforced.
+HEADER="Content-Security-Policy"               # ENFORCING (v2). v1 shipped the
+                                               # "-Report-Only" variant; flipped
+                                               # after a clean browser-verify pass.
 
 # 0. nginx syntax must be valid.
 echo "[csp-test] nginx -t ..."


### PR DESCRIPTION
PR 1b of the chat-artifacts plan — flips the baseline CSP from observe-mode to enforcing now that v1 (Report-Only, frontend v2.15.15, #799) is deployed and verified clean.

## What
- `src/frontend/nginx.conf`: header name `Content-Security-Policy-Report-Only` → `Content-Security-Policy` in all 5 header-setting `location` blocks (server-level covers `/` + SPA fallback). Comment block updated to record the verification + a one-line revert note.
- `src/frontend/test_csp_headers.sh`: assert the enforcing header name.

## Why now (verified clean in Report-Only)
v1 was browser-verified live (Playwright on renfield.local), all green:
- inline theme-script `sha256` matches the **minified** served `dist/index.html` exactly (Vite's html-minify didn't alter the bytes — the #1 risk);
- `wasm-unsafe-eval` works — onnxruntime wakeword WASM compiled and ran;
- `connect-src 'self'` → `wss://renfield.local/ws` reached `OPEN`;
- **zero** `securitypolicyviolation` events across load + `/chat` + `/wissen/dokumente` + `/settings` + the WS open.

`nginx -t` passes (validated in `nginx:1.28-alpine`). Frontend/nginx-only, no backend, no env knob. To revert to observe-mode, rename the header back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)