### PR TITLE
fix(csp): allow blob: in script-src for the wake-word AudioWorklet

### DIFF
--- a/src/frontend/nginx.conf
+++ b/src/frontend/nginx.conf
@@ -6,7 +6,7 @@
 #   default-src 'self'
 #       Fallback for any directive not listed. Same-origin only.
 #
-#   script-src 'self' 'wasm-unsafe-eval' 'sha256-...'
+#   script-src 'self' 'wasm-unsafe-eval' blob: 'sha256-...'
 #       'self'            — the hashed Vite bundles + the external
 #                           /registerSW.js the PWA plugin injects.
 #       'wasm-unsafe-eval'— onnxruntime-web compiles the wake-word .onnx/.ort
@@ -16,6 +16,20 @@
 #                           WITHOUT permitting JS eval(). Omit it → wake word
 #                           silently dies. (numThreads=1 + proxy=false, so NO
 #                           onnxruntime web-worker is spawned.)
+#       blob:             — the wake-word lib (openwakeword-wasm-browser) loads
+#                           its AudioWorklet processor from a blob: URL
+#                           (`new Blob([src]) → createObjectURL → audioWorklet
+#                           .addModule(blobURL)`). AudioWorklet modules are
+#                           governed by script-src (NOT worker-src), so without
+#                           blob: here the worklet load is blocked with
+#                           `AbortError: Unable to load a worklet's module` and
+#                           wake word is unavailable. blob: URLs are same-origin-
+#                           created and there is no HTML-injection sink (Lane A
+#                           artifacts are React-escaped), so this opens no
+#                           practical hole — the standard cost of a blob-worklet
+#                           PWA. (Regression fix: enforcing CSP without blob:
+#                           broke wake word; verified the onnxruntime WASM path
+#                           but not the separate AudioWorklet path.)
 #       'sha256-...'      — the ONE static inline <script> in index.html (the
 #                           FOUC theme-flash guard). Hashed instead of
 #                           'unsafe-inline' so no inline-script injection
@@ -96,7 +110,7 @@
 
 # Single source of truth for the policy string (avoids per-location drift).
 map $host $csp {
-    default "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'sha256-punQmGiNS8da81PCRuSsjEAS5CzAnZcWK/ykEF4Wg4A='; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; media-src 'self' blob: data:; worker-src 'self' blob:; manifest-src 'self'; frame-src 'self'; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; form-action 'self'";
+    default "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' blob: 'sha256-punQmGiNS8da81PCRuSsjEAS5CzAnZcWK/ykEF4Wg4A='; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; media-src 'self' blob: data:; worker-src 'self' blob:; manifest-src 'self'; frame-src 'self'; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; form-action 'self'";
 }
 
 server {


### PR DESCRIPTION
**Regression hotfix.** The enforcing baseline CSP (#800, frontend v2.15.16) broke wake word in prod: `openwakeword-wasm-browser` loads its AudioWorklet processor from a `blob:` URL (`new Blob([src]) → URL.createObjectURL → audioWorklet.addModule(blobURL)`). AudioWorklet module scripts are governed by **`script-src`** (NOT `worker-src`, which already had `blob:`), so `script-src 'self' 'wasm-unsafe-eval'` without `blob:` blocked the load → `AbortError: Unable to load a worklet's module` ("Wake Word nicht verfügbar").

The Report-Only verification checked the onnxruntime WASM path (a different CSP surface) but never triggered wake-word-*enable*, and Chrome reports worklet CSP rejections as an `AbortError` rather than a clean violation event — so it slipped through.

Fix: add `blob:` to `script-src`. blob: URLs are same-origin-created and there's no HTML-injection sink (Lane A artifacts are React-escaped), so this opens no practical hole — the standard cost of a blob-worklet/WASM PWA. `nginx -t` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)