### PR TITLE
fix(pwa): propagate the blob-worklet CSP fix to existing clients (build-stamp bump)

### DIFF
--- a/.claude/skills/deploy-production/SKILL.md
+++ b/.claude/skills/deploy-production/SKILL.md
@@ -407,6 +407,27 @@ until the SW re-fetches and detects a new build. The propagation rule lives in
   html-minify can alter the bytes at build → recompute from the built
   `dist/index.html` or fall back to `'unsafe-inline'` on `script-src`) and
   `'wasm-unsafe-eval'` (absent → wakeword WASM compile is reported/blocked).
+  **A THIRD fragile surface, learned painfully (2026-06-16):** the wake-word
+  **AudioWorklet** is loaded from a `blob:` URL (`new Blob → createObjectURL →
+  audioWorklet.addModule`) and is governed by **`script-src`, NOT `worker-src`** —
+  so `script-src` needs **`blob:`** or wake word dies with `AbortError: Unable to
+  load a worklet's module`. This is a DISTINCT surface from the onnxruntime WASM
+  (`'wasm-unsafe-eval'`); verifying "WASM loaded" does NOT cover it. Always trigger
+  wake-word **enable** (the `addModule`), not just page load, when validating CSP —
+  Chrome reports a worklet CSP rejection as an `AbortError`, not always a clean
+  `securitypolicyviolation` event, so a violation-listener check can miss it.
+- **A header-only change (CSP etc.) does NOT propagate to existing PWA clients on its own.**
+  The SW precaches `index.html` (`globPatterns` includes `html`) **with its response headers**
+  (the CSP is captured at fetch time). A change touching only `nginx.conf` leaves every *built*
+  file byte-identical → the workbox precache manifest and `sw.js` are unchanged → `autoUpdate`
+  never fires → existing clients keep serving the **stale-CSP precached shell** (a fresh `nginx`
+  curl shows the new header, but the browser enforces the cached one — wake word stayed broken
+  after the blob-worklet CSP fix until this was understood). **Fix: pair any served-header change
+  with a frontend build bump** — bump `__BUILD_STAMP__` in `src/frontend/src/main.tsx` (its whole
+  purpose). That changes the JS bundle hash → rewrites index.html's `<script src>` → index.html's
+  revision changes → the SW re-precaches it (re-fetching the current header) and `autoUpdate`
+  propagates on the next visit. Verify the served `/assets/index-<hash>.js` filename actually
+  CHANGED after the build.
 
 Verify the live headers from inside the cluster (renfield.local mDNS is flaky
 from the laptop):

--- a/src/frontend/src/main.tsx
+++ b/src/frontend/src/main.tsx
@@ -7,6 +7,20 @@ import App from './App';
 import './index.css';
 import './i18n';
 
+// Build stamp — also the PWA service-worker propagation lever.
+// The SW (vite-plugin-pwa, registerType:autoUpdate) PRECACHES index.html via
+// globPatterns, storing its response INCLUDING the CSP header captured at fetch
+// time. A change that touches only a non-bundled asset (e.g. the nginx CSP
+// header) leaves every built file byte-identical → the precache manifest and
+// sw.js don't change → autoUpdate never fires → existing clients keep serving
+// the stale-CSP shell. Bumping this string changes the JS bundle hash → rewrites
+// index.html's <script src> → index.html's revision changes → the SW re-precaches
+// it (re-fetching the current CSP) and propagates. So: when you change a served
+// HTTP header (CSP etc.) without any other frontend change, BUMP THIS so the fix
+// reaches existing PWA clients. See reference_pwa_sw_nocache_nginx.
+const __BUILD_STAMP__ = '2026-06-16.csp-blob-worklet';
+console.info(`Renfield frontend build ${__BUILD_STAMP__}`);
+
 // Edition selector for theme tokens. When VITE_APP_EDITION=pro, the
 // CSS attribute selector [data-edition="pro"] in index.css re-points
 // the gray-* palette to slate-* for a cooler enterprise feel —


### PR DESCRIPTION
Follow-up to #803. The CSP fix was nginx-only, so the JS bundle/sw.js were byte-identical → the PWA service worker never updated and kept serving the precached index.html with the **old CSP header** (captured at precache time). Wake word stayed broken for existing clients despite the live nginx header being correct.

Fix: a real `__BUILD_STAMP__` in `main.tsx` bumps the bundle hash → index.html revision changes → SW re-precaches it (re-fetching the `blob:` CSP) → `autoUpdate` propagates. Documents the rule in the deploy skill: **pair any served-header change with a build-stamp bump.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)