### PR TITLE
fix(voice): serialize WS sends — fixes tts_failed concurrent-drain crash

### DIFF
--- a/voice-server/tests/test_send_serialization.py
+++ b/voice-server/tests/test_send_serialization.py
@@ -1,0 +1,99 @@
+"""Regression test: concurrent websocket sends are serialized.
+
+TTS streams audio frames from a background asyncio.Task (`_run_tts`) while the
+receive loop concurrently emits `partial_transcript` / `final_transcript` frames
+via `_send_json`. Two coroutines doing `await ws.send_*` on the SAME websocket at
+once tripped the `websockets` legacy-protocol drain assert
+(`_drain_helper: assert waiter is None or waiter.cancelled()`), which surfaced as
+an empty-message `AssertionError` reported to the client as `tts_failed:` (no
+detail). The fix is a per-connection send lock guarding the two raw send sites
+(`_send_json` send_text + `_run_tts` send_bytes).
+
+This test reproduces the overlap window: a FakeWebSocket whose sends yield to the
+event loop and flag any second send that begins while one is still in flight.
+Without the lock the gather() below interleaves a TTS send_bytes with a
+_send_json send_text → overlap flagged. With the lock they serialize.
+
+Environment: like test_cancel_ack, importing `voice_server.api.ws_voice` pulls in
+the service modules, so run where the voice-server deps are installed (the
+voice-server image / the .159 build box). No Piper / Whisper / GPU is exercised.
+
+    cd voice-server && pip install -r requirements.txt -r requirements-dev.txt
+    pytest tests/test_send_serialization.py
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+
+from voice_server.api.ws_voice import SessionState, _send_json, _spawn_tts
+
+
+class OverlapDetectingWebSocket:
+    """Records frames AND flags any two sends that overlap in flight.
+
+    Each send sets an `_active` flag, yields to the loop (so a concurrent send
+    can interleave if it isn't serialized), then clears the flag. A send that
+    finds `_active` already set on entry means two drains overlapped — exactly
+    what the websockets assert guards against.
+    """
+
+    def __init__(self) -> None:
+        self.text_frames: list[dict] = []
+        self.bytes_frames: list[bytes] = []
+        self._active = False
+        self.overlap_detected = False
+
+    async def _guarded(self, record) -> None:
+        if self._active:
+            self.overlap_detected = True
+        self._active = True
+        await asyncio.sleep(0)  # yield — an unserialized concurrent send slips in here
+        record()
+        await asyncio.sleep(0)
+        self._active = False
+
+    async def send_text(self, text: str) -> None:
+        await self._guarded(lambda: self.text_frames.append(json.loads(text)))
+
+    async def send_bytes(self, data: bytes) -> None:
+        await self._guarded(lambda: self.bytes_frames.append(data))
+
+    def frames_of_type(self, frame_type: str) -> list[dict]:
+        return [f for f in self.text_frames if f.get("type") == frame_type]
+
+
+class MultiFrameTTS:
+    """Fake TTSService that streams several frames, yielding between each so a
+    concurrent _send_json has a window to interleave."""
+
+    async def stream_sentences(self, text, request_id, language=None):
+        for i in range(6):
+            await asyncio.sleep(0)
+            yield f"frame-{i}".encode()
+
+
+async def test_concurrent_tts_and_transcript_sends_are_serialized() -> None:
+    ws = OverlapDetectingWebSocket()
+    state = SessionState(user_id="u1")
+    rid = str(uuid.uuid4())
+
+    await _spawn_tts(ws, state, {"request_id": rid, "text": "hallo welt"}, MultiFrameTTS())
+    tts_task = state.tts_tasks[rid]
+
+    async def spam_partials() -> None:
+        # Mirror the receive loop emitting partial transcripts WHILE TTS streams.
+        for i in range(12):
+            await _send_json(ws, {"type": "partial_transcript", "text": f"p{i}", "confidence": 0.9})
+            await asyncio.sleep(0)
+
+    await asyncio.gather(tts_task, spam_partials())
+
+    # The whole point: no two sends overlapped.
+    assert ws.overlap_detected is False
+    # And both streams actually delivered (the lock didn't drop/deadlock anything).
+    assert ws.bytes_frames == [f"frame-{i}".encode() for i in range(6)]
+    assert ws.frames_of_type("tts_done") == [{"type": "tts_done", "request_id": rid}]
+    assert len(ws.frames_of_type("partial_transcript")) == 12
+    assert rid not in state.tts_tasks  # _wrapped finally cleaned up

--- a/voice-server/voice_server/api/ws_voice.py
+++ b/voice-server/voice_server/api/ws_voice.py
@@ -36,6 +36,7 @@ import json
 import logging
 import time
 import uuid
+import weakref
 from dataclasses import dataclass, field
 
 import numpy as np
@@ -107,8 +108,34 @@ def _accumulated_seconds(state: SessionState) -> float:
     return total / 16000.0
 
 
+# Per-connection send serialization. TTS streams frames from a background
+# asyncio.Task (_run_tts) while the receive loop concurrently emits
+# partial_transcript / final_transcript / error frames. Two coroutines doing
+# `await ws.send_*` on the SAME websocket at once trips the `websockets` legacy
+# protocol drain assert (`_drain_helper: assert waiter is None or
+# waiter.cancelled()`) — surfaced as an empty-message AssertionError that the
+# generic handler reported to the client as `tts_failed:` (with no detail).
+# EVERY send funnels through exactly two raw sites — _send_json (send_text) and
+# _run_tts (send_bytes) — so guarding both with one per-ws lock serializes the
+# whole send surface. Keyed weakly by the WebSocket so the lock is per-connection
+# and is GC'd with it (no need to thread state through ~17 call sites; guarding
+# the two choke points is provably complete). Interleaving a text frame between
+# TTS audio frames is fine — the client demuxes by type; the lock only prevents
+# two *concurrent* drains.
+_ws_send_locks: "weakref.WeakKeyDictionary[WebSocket, asyncio.Lock]" = weakref.WeakKeyDictionary()
+
+
+def _send_lock_for(ws: WebSocket) -> asyncio.Lock:
+    lock = _ws_send_locks.get(ws)
+    if lock is None:
+        lock = asyncio.Lock()
+        _ws_send_locks[ws] = lock
+    return lock
+
+
 async def _send_json(ws: WebSocket, payload: dict) -> None:
-    await ws.send_text(json.dumps(payload, separators=(",", ":")))
+    async with _send_lock_for(ws):
+        await ws.send_text(json.dumps(payload, separators=(",", ":")))
 
 
 async def _send_error(ws: WebSocket, code: str, message: str, request_id: str | None = None) -> None:
@@ -260,7 +287,11 @@ async def _run_tts(
     rid = str(request_id)
     try:
         async for frame in tts.stream_sentences(text, request_id, language=language):
-            await ws.send_bytes(frame)
+            # Serialized against the receive loop's concurrent text sends
+            # (partial/final transcript) via the per-ws send lock — otherwise
+            # two simultaneous drains trip the websockets assert → tts_failed.
+            async with _send_lock_for(ws):
+                await ws.send_bytes(frame)
         await _send_json(ws, {"type": "tts_done", "request_id": rid})
     except asyncio.CancelledError:
         # CancelledError reaches here from two sources: a client `cancel`


### PR DESCRIPTION
**User-reported bug:** `tts_failed:` (empty message) on a voice answer. Root cause: `_run_tts` streams TTS frames from a background task while the receive loop concurrently emits `partial_transcript`/`final_transcript` — two `await ws.send_*` on the same socket trip the `websockets` `_drain_helper` assert (empty `AssertionError` → reported as `tts_failed:`). Hit when the user keeps talking while TTS plays.

Fix: one per-connection `asyncio.Lock` (weak-keyed by the WebSocket) guarding the only two raw send sites (`_send_json` send_text + `_run_tts` send_bytes) — provably serializes the whole send surface. Regression test (overlap-detecting fake WS) + 5 existing cancel tests = **6/6 green**. Built voice-server **v0.1.7**, deployed to the GPU node (healthy, CUDA init OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)