### PR TITLE
fix(voice): chat TTS to DLNA room renderers + speaker_info hook crash

### DIFF
--- a/src/backend/ha_glue/services/chat_voice_handlers.py
+++ b/src/backend/ha_glue/services/chat_voice_handlers.py
@@ -83,14 +83,26 @@ async def ha_route_chat_tts_to_device_output(
                 f"{decision.target_type}:{decision.target_id}"
             )
 
-            # Only handle server-side if we have a configured HA output device
-            # (Renfield devices would be the input device itself in this case)
+            # Deliver server-side to any configured ROOM output device that
+            # audio_output_service.play_audio can drive — both HA media players
+            # AND DLNA renderers (HiFiBerry / Samsung / Sonos via the dlna MCP).
+            # `target_type == "renfield"` is deliberately NOT here: a renfield
+            # device IS the input device (the browser/satellite that asked), so
+            # it plays locally — returning False lets the frontend handle it.
+            # (Bug fix: this used to gate on `== "homeassistant"` only, so a room
+            # whose output device is a DLNA renderer fell through to False and the
+            # answer played in the BROWSER instead of the room speaker — and the
+            # browser's sentence-chunked stream then cut off after sentence 1 when
+            # the open mic heard it and barge-in cancelled the rest. play_audio
+            # already dispatches DLNA vs HA by output_device type.)
             if (
                 decision.output_device
                 and not decision.fallback_to_input
-                and decision.target_type == "homeassistant"
+                and decision.target_type in ("homeassistant", "dlna")
             ):
-                # Generate TTS via the platform Piper service
+                # Generate TTS via the platform Piper service — the FULL answer
+                # as one clip (not sentence-chunked), so it plays through to the
+                # end on the renderer.
                 from services.piper_service import get_piper_service
                 piper = get_piper_service()
                 tts_audio = await piper.synthesize_to_bytes(response_text)
@@ -104,7 +116,9 @@ async def ha_route_chat_tts_to_device_output(
                     )
 
                     if success:
-                        logger.info(f"🔊 TTS sent to HA media player: {decision.target_id}")
+                        logger.info(
+                            f"🔊 TTS sent to {decision.target_type} output: {decision.target_id}"
+                        )
                         return True
                     logger.warning(
                         f"Failed to send TTS to {decision.target_id}, "

--- a/src/backend/ha_glue/services/sweep_handlers.py
+++ b/src/backend/ha_glue/services/sweep_handlers.py
@@ -30,6 +30,8 @@ async def ha_chat_context_established(
     room_id: int,
     room_name: str | None = None,
     lang: str = "de",
+    speaker_info: dict | None = None,
+    **_: object,
 ) -> None:
     """Register BLE voice-auth presence when a user speaks from a known room.
 

--- a/tests/backend/test_chat_tts_routing.py
+++ b/tests/backend/test_chat_tts_routing.py
@@ -1,0 +1,97 @@
+"""Chat-TTS output routing: a room with a DLNA renderer must get the answer
+delivered to the renderer (server-side), not punted to the browser.
+
+Regression: `ha_route_chat_tts_to_device_output` used to gate server-side
+delivery on `target_type == "homeassistant"` only, so a room whose output device
+is a DLNA renderer (e.g. a HiFiBerry) fell through to `return False` → the
+answer played in the BROWSER instead of the room speaker, and the browser's
+sentence-chunked voice stream then cut off after sentence 1 (open mic → barge-in
+cancelled the rest). `audio_output_service.play_audio` already dispatches DLNA vs
+HA by device type; the fix lets `target_type == "dlna"` through too.
+"""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ha_glue.services.chat_voice_handlers import ha_route_chat_tts_to_device_output
+
+
+def _decision(target_type: str, *, fallback: bool = False, has_device: bool = True):
+    d = MagicMock()
+    d.target_type = target_type
+    d.fallback_to_input = fallback
+    d.output_device = MagicMock() if has_device else None
+    d.target_id = f"{target_type}-dev"
+    d.reason = "device_available"
+    return d
+
+
+@asynccontextmanager
+async def _fake_session():
+    yield MagicMock()
+
+
+async def _run(decision, *, play_success: bool = True, tts_bytes: bytes = b"RIFFxxxxWAVE"):
+    routing = MagicMock()
+    routing.get_audio_output_for_room = AsyncMock(return_value=decision)
+    piper = MagicMock()
+    piper.synthesize_to_bytes = AsyncMock(return_value=tts_bytes)
+    audio_out = MagicMock()
+    audio_out.play_audio = AsyncMock(return_value=play_success)
+    with patch("services.database.AsyncSessionLocal", _fake_session), \
+         patch("ha_glue.services.output_routing_service.OutputRoutingService", return_value=routing), \
+         patch("services.piper_service.get_piper_service", return_value=piper), \
+         patch("ha_glue.services.audio_output_service.get_audio_output_service", return_value=audio_out):
+        result = await ha_route_chat_tts_to_device_output(
+            room_context={"room_id": 5, "device_id": 1},
+            response_text="Satz eins. Satz zwei. Satz drei.",
+        )
+    return result, audio_out, piper
+
+
+@pytest.mark.unit
+async def test_dlna_target_delivers_server_side() -> None:
+    """The core fix: a DLNA renderer gets the full clip + tts_handled=True."""
+    result, audio_out, piper = await _run(_decision("dlna"))
+    assert result is True
+    audio_out.play_audio.assert_awaited_once()
+    # full answer synthesized as one clip (not sentence-chunked)
+    piper.synthesize_to_bytes.assert_awaited_once_with("Satz eins. Satz zwei. Satz drei.")
+
+
+@pytest.mark.unit
+async def test_homeassistant_target_still_delivers() -> None:
+    result, audio_out, _ = await _run(_decision("homeassistant"))
+    assert result is True
+    audio_out.play_audio.assert_awaited_once()
+
+
+@pytest.mark.unit
+async def test_renfield_target_falls_back_to_browser() -> None:
+    """A renfield device IS the input device → browser plays (return False)."""
+    result, audio_out, _ = await _run(_decision("renfield"))
+    assert result is False
+    audio_out.play_audio.assert_not_awaited()
+
+
+@pytest.mark.unit
+async def test_dlna_play_failure_falls_back_to_browser() -> None:
+    result, audio_out, _ = await _run(_decision("dlna"), play_success=False)
+    assert result is False
+    audio_out.play_audio.assert_awaited_once()
+
+
+@pytest.mark.unit
+async def test_fallback_to_input_does_not_deliver() -> None:
+    result, audio_out, _ = await _run(_decision("dlna", fallback=True))
+    assert result is False
+    audio_out.play_audio.assert_not_awaited()
+
+
+@pytest.mark.unit
+async def test_no_room_returns_none() -> None:
+    result = await ha_route_chat_tts_to_device_output(room_context={}, response_text="x")
+    assert result is None


### PR DESCRIPTION
**User-reported:** voice answer "cuts off after the first sentence, and plays via browser instead of the HiFiBerry in the Arbeitszimmer." Both symptoms, one root cause.

`ha_route_chat_tts_to_device_output` gated server-side delivery on `target_type == "homeassistant"` only. The Arbeitszimmer's output device is a **DLNA** renderer, so the decision (`device_available → dlna:HiFiBerry Arbeitszimmer`) fell through to `return False` → the frontend played it. That's (a) why it played in the browser not the HiFiBerry, and (b) why it cut off after sentence 1 — the browser's sentence-chunked voice stream gets cancelled by barge-in when the open mic hears sentence 1.

Fix: let `target_type == "dlna"` through too. `audio_output_service.play_audio` already dispatches DLNA (`_play_on_dlna_renderer` → `mcp.dlna.play_tracks`) vs HA by device type. The full answer is synthesized as one clip and played on the renderer; `tts_handled=True` so the browser doesn't play (no cutoff). Verified server-side: the renderer path is the established TTS-to-DLNA delivery (HiFiBerry validated in prior work).

Also: `ha_chat_context_established` crashed every voice turn (`unexpected keyword argument 'speaker_info'`) — added `speaker_info` + `**_`. Only broke voice-presence (caught by run_hooks), not TTS, but fixed.

Tests: `test_chat_tts_routing.py` 6/6 green on .159 (dlna delivers+True · ha delivers · renfield/fallback/play-fail → browser · no-room → None).

🤖 Generated with [Claude Code](https://claude.com/claude-code)