### PR TITLE
feat(routing): audio-quality tiebreak within equal priority (DLNA > HA > tablet)

### DIFF
--- a/docs/OUTPUT_ROUTING.md
+++ b/docs/OUTPUT_ROUTING.md
@@ -61,13 +61,18 @@ ADVERTISE_PORT=80
 
 ### Prioritätsreihenfolge
 
-Geräte werden in der konfigurierten Reihenfolge geprüft. Verwende die Pfeil-Buttons um die Priorität zu ändern. Das erste verfügbare Gerät wird verwendet.
+Geräte werden in der konfigurierten Reihenfolge geprüft. Verwende die Pfeil-Buttons um die Priorität zu ändern — **Position 1 = primäres Gerät**. Das erste verfügbare Gerät wird verwendet.
+
+**Qualitäts-Tiebreak:** Haben mehrere Geräte dieselbe Priorität (z. B. keines wurde geordnet — alle auf dem Default-Wert), entscheidet die **Audio-Qualität der Geräteklasse**: externer AV-Renderer (DLNA / Samsung / Sonos) > HA-`media_player` (Smart Speaker) > Renfield-Tablet/Satellit (interner Lautsprecher). So landet die Antwort in einem ungeordneten Raum automatisch auf dem hochwertigsten Gerät (z. B. der HiFiBerry statt dem Tablet). Die manuell gesetzte Priorität gewinnt immer zuerst; Qualität bricht nur Gleichstände (danach `id` für Determinismus).
 
 ## Routing-Algorithmus
 
 ```
-1. Hole alle konfigurierten Output-Geräte für Raum, sortiert nach Priorität
-2. Für jedes Gerät (in Prioritätsreihenfolge):
+1. Hole alle konfigurierten Output-Geräte für Raum, sortiert nach
+   (Priorität ASC, Audio-Qualität DESC, id ASC)
+   — Priorität = manuelle Primär-Reihenfolge; Qualität bricht Gleichstände
+     (externer Renderer > HA-Speaker > Renfield-Tablet)
+2. Für jedes Gerät (in dieser Reihenfolge):
    a. Prüfe Verfügbarkeit via HA API / DeviceManager
    b. Wenn verfügbar (idle/paused) → verwenden
    c. Wenn beschäftigt UND allow_interruption=True → verwenden
@@ -77,6 +82,8 @@ Geräte werden in der konfigurierten Reihenfolge geprüft. Verwende die Pfeil-Bu
    → Fallback auf Eingabegerät (wenn es Speaker hat)
 4. Wenn nichts verfügbar → Keine Audio-Ausgabe
 ```
+
+**Stationär vs. mobil:** Der Raumkontext wird per **IP des registrierten Raumgeräts** aufgelöst (`resolve_room_context_by_ip`). Ein nicht registriertes, mobiles Gerät (Handy/Laptop) trifft keinen Raum → kein Routing → die Antwort spielt im **Browser**. „Stationär" ≡ „als Raumgerät registriert". Chat-TTS wird serverseitig an `homeassistant`- **und** `dlna`-Ziele zugestellt (der Renderer bekommt die volle Antwort als einen Clip); `renfield`-Ziele = das Eingabegerät selbst → der Browser spielt.
 
 ### Verfügbarkeitsstatus
 

--- a/src/backend/ha_glue/services/output_routing_service.py
+++ b/src/backend/ha_glue/services/output_routing_service.py
@@ -140,6 +140,30 @@ class OutputDecision:
     reason: str
 
 
+# Audio-quality rank by device class, used ONLY as a tiebreak between devices of
+# equal `priority` (the user-set primary ordering always wins first). Higher =
+# better. External AV renderers (DLNA / Samsung / Sonos / any generic provider)
+# are dedicated audio/AV hardware → highest; an HA media_player (smart speaker)
+# is mid; a Renfield tablet/satellite built-in speaker is lowest. So when a room
+# has several audio devices and the user hasn't ordered them (all default
+# priority), the answer goes to the best-quality device automatically.
+# (Within the same rank, `priority` then `id` keep it deterministic.)
+_AUDIO_QUALITY_RANK: dict[str, int] = {
+    "renfield": 1,
+    "homeassistant": 2,
+    "dlna": 3,
+    "samsung": 3,
+    "sonos": 3,
+}
+# Unknown / future providers are assumed to be dedicated external renderers
+# (the only known lower-quality classes are renfield + homeassistant).
+_DEFAULT_QUALITY_RANK = 3
+
+
+def _audio_quality_rank(device: RoomOutputDevice) -> int:
+    return _AUDIO_QUALITY_RANK.get(device.target_type, _DEFAULT_QUALITY_RANK)
+
+
 class OutputRoutingService:
     """
     Service for routing TTS/visual output to the best available device.
@@ -270,15 +294,22 @@ class OutputRoutingService:
         room_id: int,
         output_type: str
     ) -> list[RoomOutputDevice]:
-        """Get all configured output devices for a room, sorted by priority."""
+        """Configured output devices for a room, ordered by selection precedence.
+
+        Precedence: `priority` ASC (the user-set primary ordering — position #1
+        wins) THEN audio quality DESC as the tiebreak when devices share a
+        priority (e.g. all at the default), THEN `id` ASC for determinism. So a
+        room with an unordered HiFiBerry + a tablet auto-prefers the HiFiBerry.
+        """
         stmt = (
             select(RoomOutputDevice)
             .where(RoomOutputDevice.room_id == room_id)
             .where(RoomOutputDevice.output_type == output_type)
-            .order_by(RoomOutputDevice.priority)
         )
         result = await self.db.execute(stmt)
-        return list(result.scalars().all())
+        devices = list(result.scalars().all())
+        devices.sort(key=lambda d: (d.priority, -_audio_quality_rank(d), d.id))
+        return devices
 
     async def _check_device_availability(
         self,

--- a/tests/backend/test_output_routing_quality_tiebreak.py
+++ b/tests/backend/test_output_routing_quality_tiebreak.py
@@ -1,0 +1,100 @@
+"""OutputRoutingService: audio-quality tiebreak within equal priority.
+
+Policy: `priority` (the user-set primary ordering) wins first; when devices
+share a priority (e.g. all at the default — the user never ordered them), the
+higher-audio-quality device class wins: external AV renderer (DLNA / Samsung /
+Sonos) > HA media_player > Renfield tablet/satellite. So an unordered room with
+a HiFiBerry + a tablet auto-prefers the HiFiBerry.
+"""
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Pre-mock heavy/optional modules pulled in transitively (mirror the sibling
+# routing test's guarded stubbing).
+for _mod in ("asyncpg", "whisper", "piper", "piper.voice", "speechbrain",
+             "speechbrain.inference", "speechbrain.inference.speaker",
+             "openwakeword", "openwakeword.model"):
+    if _mod in sys.modules:
+        continue
+    try:
+        __import__(_mod)
+    except Exception:  # noqa: BLE001
+        sys.modules[_mod] = MagicMock()
+
+import pytest
+
+from ha_glue.services.output_routing_service import (
+    OutputRoutingService,
+    _audio_quality_rank,
+)
+
+
+def _dev(*, target_type, priority=1, dev_id=0):
+    d = MagicMock()
+    d.target_type = target_type
+    d.priority = priority
+    d.id = dev_id
+    return d
+
+
+def _svc():
+    with patch("ha_glue.services.output_routing_service.HomeAssistantClient", return_value=AsyncMock()):
+        return OutputRoutingService(AsyncMock())
+
+
+def _mock_query_result(svc, devices):
+    """Make svc._get_output_devices's DB query return `devices` (unsorted)."""
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = devices
+    svc.db.execute = AsyncMock(return_value=result)
+
+
+@pytest.mark.unit
+def test_quality_rank_by_class() -> None:
+    assert _audio_quality_rank(_dev(target_type="dlna")) == 3
+    assert _audio_quality_rank(_dev(target_type="samsung")) == 3
+    assert _audio_quality_rank(_dev(target_type="sonos")) == 3
+    assert _audio_quality_rank(_dev(target_type="homeassistant")) == 2
+    assert _audio_quality_rank(_dev(target_type="renfield")) == 1
+    # Unknown / future provider → treated as an external renderer (high).
+    assert _audio_quality_rank(_dev(target_type="future_brand")) == 3
+
+
+@pytest.mark.unit
+async def test_tiebreak_prefers_highest_quality_when_unordered() -> None:
+    """All default priority → DLNA > HA > renfield, regardless of DB order."""
+    svc = _svc()
+    tablet = _dev(target_type="renfield", priority=1, dev_id=1)
+    speaker = _dev(target_type="homeassistant", priority=1, dev_id=2)
+    hifi = _dev(target_type="dlna", priority=1, dev_id=3)
+    _mock_query_result(svc, [tablet, speaker, hifi])  # arbitrary insertion order
+
+    ordered = await svc._get_output_devices(room_id=1, output_type="audio")
+
+    assert [d.target_type for d in ordered] == ["dlna", "homeassistant", "renfield"]
+
+
+@pytest.mark.unit
+async def test_explicit_priority_beats_quality() -> None:
+    """A tablet the user ordered first (priority 1) beats a HiFiBerry at 2."""
+    svc = _svc()
+    tablet = _dev(target_type="renfield", priority=1, dev_id=1)
+    hifi = _dev(target_type="dlna", priority=2, dev_id=2)
+    _mock_query_result(svc, [hifi, tablet])
+
+    ordered = await svc._get_output_devices(room_id=1, output_type="audio")
+
+    assert [d.target_type for d in ordered] == ["renfield", "dlna"]  # priority wins
+
+
+@pytest.mark.unit
+async def test_same_class_same_priority_is_deterministic_by_id() -> None:
+    """Two externals tied on priority + quality → stable by id."""
+    svc = _svc()
+    a = _dev(target_type="dlna", priority=1, dev_id=7)
+    b = _dev(target_type="samsung", priority=1, dev_id=3)
+    _mock_query_result(svc, [a, b])
+
+    ordered = await svc._get_output_devices(room_id=1, output_type="audio")
+
+    assert [d.id for d in ordered] == [3, 7]


### PR DESCRIPTION
Completes the room TTS-output routing policy. The full policy now: mobile/non-stationary → browser (no room registration); tablet-only room → tablet (fallback-to-input); room audio device → used (DLNA fix #806); **multiple → manual priority order, position 1 = primary**; **none ordered → highest audio quality** ← this PR.

Quality is inferred from device class (external AV renderer dlna/samsung/sonos > HA media_player > Renfield tablet/satellite) and used ONLY as a tiebreak within equal priority; `id` is the final deterministic tiebreak. `_get_output_devices` sorts `(priority ASC, quality DESC, id ASC)`.

Tests: 4 new + 35 existing routing tests = 39 green on .159. Doc: OUTPUT_ROUTING.md updated (tiebreak + stationary-vs-mobile mechanism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)