### PR TITLE
feat(satellite): Esszimmer satellite on Orange Pi (k8s) + fix silent-mic capture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,6 @@ voice-server/tests/b5/corpus_production.txt
 
 # Schicht A golden set — REAL household docs + labels, NEVER commit (privacy)
 tests/eval/schicht_a_fixtures_local/
+
+# Custom wakeword models are fetched into the build context, not committed
+src/satellite/models/

--- a/k8s/satellite-esszimmer.yaml
+++ b/k8s/satellite-esszimmer.yaml
@@ -1,0 +1,164 @@
+# Renfield Satellite — Esszimmer (Orange Pi Zero 3W, ReSpeaker XVF3800 USB)
+#
+# The FIRST satellite run as a k8s workload (the rest of the fleet is bare-metal
+# Ansible). Pinned to the single arm64 node `orangepizero3w` because it is a
+# physical, room-attached device (USB mic+speaker, BLE). Replaces the old
+# bare-metal Esszimmer satellite (Pi + 2-Mic-V2 HAT) — same satellite_id.
+#
+# Why the unusual pod settings:
+#  - hostNetwork: zeroconf/mDNS + the WS link to renfield.local need host net
+#    (Calico does not forward multicast pod-net <-> host-net).
+#  - privileged + /dev/snd + /dev/bus/usb: USB audio (ALSA) and the xvf_host
+#    USB LED-control binary need raw device access (pragmatic for a pinned
+#    singleton; not a device-plugin).
+#  - /run/dbus: BLE presence via bleak talks to the HOST BlueZ over D-Bus.
+#  - nodeSelector + toleration: only this satellite lands on the tainted board.
+#  - image imported directly into the node containerd (k8s.io ns); pullPolicy
+#    Never — no registry round-trip for a node-local single-arch image.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: satellite-esszimmer-config
+  namespace: renfield
+  labels:
+    app.kubernetes.io/name: satellite-esszimmer
+    app.kubernetes.io/part-of: renfield
+data:
+  satellite.yaml: |
+    satellite:
+      id: "sat-esszimmer"
+      room: "Esszimmer"
+      language: "de"
+    server:
+      url: "wss://renfield.local/ws/satellite"
+      auto_discover: false
+      auth_enabled: false
+      verify_tls: false           # ingress uses a self-signed cert
+      max_disconnected_seconds: 300
+    audio:
+      sample_rate: 16000
+      chunk_size: 1280
+      channels: 1                 # XVF3800 delivers a single post-DSP stream
+      physical_mics: 4            # reported as array-size capability
+      use_arecord: false          # USB UAC device; no AC108 in-process crash
+      device: "default"           # /etc/asound.conf maps default → XVF3800 (dsnoop)
+      playback_device: "default"  # → XVF3800 out jack (dmix); needs a speaker plugged in
+      beamforming:
+        enabled: false            # XVF3800 does beamforming + AEC in hardware
+    wakeword:
+      model: "hey_renfield"       # custom model baked into the image (from wohnzimmer)
+      threshold: 0.5
+      models_path: "/opt/renfield-satellite/models"
+    vad:
+      backend: "silero"
+      silero_threshold: 0.5
+      silero_model_path: "/opt/renfield-satellite/models/silero_vad.onnx"
+    led:
+      type: "xvf3800"             # LED ring driven via xvf_host over USB
+      brightness: 20
+      idle_color: "yellow"        # Esszimmer identity colour (continuity w/ old sat)
+      xvf_host_path: "/opt/renfield-satellite/bin/xvf_host"
+    button:
+      gpio_pin: 17                # no button wired; degrades to no-op without GPIO libs
+    ble:
+      enabled: true               # board has strong BT; real advertisement RSSI
+      scan_interval: 3            # near-continuous (BT5.4, mains power) — was 30
+      scan_duration: 7.0          # scan 7s of every ~10s → sub-~10s presence latency
+      rssi_threshold: -80
+      classic_rssi: false         # AIC8800 raw-HCI (hcitool cc/rssi) is broken here;
+                                  # the bleak advertisement scanner provides real RSSI
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: satellite-esszimmer
+  namespace: renfield
+  labels:
+    app.kubernetes.io/name: satellite-esszimmer
+    app.kubernetes.io/part-of: renfield
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate              # singleton bound to one piece of hardware
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: satellite-esszimmer
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: satellite-esszimmer
+        app.kubernetes.io/part-of: renfield
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      # Deterministic resolution of the backend (Traefik LB) — the pod's DNS
+      # (CoreDNS) otherwise may not see the LAN's renfield.local record.
+      hostAliases:
+        - ip: "192.168.1.230"
+          hostnames: ["renfield.local"]
+      # Pin to the Orange Pi; tolerate its dedicated taint.
+      nodeSelector:
+        renfield.io/satellite-room: esszimmer
+      tolerations:
+        - key: renfield.io/satellite
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values: ["arm64"]
+      containers:
+        - name: satellite
+          image: renfield/satellite:esszimmer-v3
+          imagePullPolicy: Never   # imported into node containerd (k8s.io ns)
+          securityContext:
+            privileged: true        # raw /dev access for USB audio + xvf_host
+          env:
+            - name: RENFIELD_SERVER_URL
+              value: "wss://renfield.local/ws/satellite"
+            - name: RENFIELD_SATELLITE_ID
+              value: "sat-esszimmer"
+            - name: RENFIELD_SATELLITE_ROOM
+              value: "Esszimmer"
+            - name: RENFIELD_BLE_ENABLED
+              value: "true"
+            - name: RENFIELD_VERIFY_TLS
+              value: "false"
+            - name: RENFIELD_AUTO_DISCOVER
+              value: "false"
+          volumeMounts:
+            - name: config
+              mountPath: /opt/renfield-satellite/config
+            - name: snd
+              mountPath: /dev/snd
+            - name: usb
+              mountPath: /dev/bus/usb
+            - name: dbus
+              mountPath: /run/dbus
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+            limits:
+              cpu: "2"
+              memory: "1Gi"
+      volumes:
+        - name: config
+          configMap:
+            name: satellite-esszimmer-config
+        - name: snd
+          hostPath:
+            path: /dev/snd
+        - name: usb
+          hostPath:
+            path: /dev/bus/usb
+        - name: dbus
+          hostPath:
+            path: /run/dbus

--- a/src/satellite/Dockerfile
+++ b/src/satellite/Dockerfile
@@ -1,0 +1,105 @@
+# Renfield Satellite — container image (aarch64)
+#
+# Built for the Orange Pi Zero 3W satellite running as a node-pinned pod in the
+# private k8s cluster. Hardware config = ReSpeaker XVF3800 4-Mic Array (USB):
+#   - audio capture/playback via ALSA over USB  (needs /dev/snd)
+#   - LED ring via the xvf_host subprocess over USB (needs /dev/bus/usb + libusb)
+#   - BLE presence via bleak → host BlueZ over D-Bus (needs /run/dbus mounted)
+#   - GPIO button/SPI LEDs are NOT used (import-guarded, degrade to no-op)
+#
+# Build natively on the Orange Pi (arm64), then import into the node containerd:
+#   docker build -t renfield/satellite:esszimmer-v1 .
+#   docker save renfield/satellite:esszimmer-v1 | ctr -n k8s.io images import -
+FROM debian:bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    SATELLITE_HOME=/opt/renfield-satellite
+
+# --- System deps ---
+#  build: gcc + portaudio19-dev (pyaudio), python3-dev
+#  audio runtime: libasound2(+plugins), libportaudio2, mpv/libmpv2, libsamplerate0
+#  numeric: libopenblas0 (numpy/onnxruntime)
+#  xvf_host: libusb-1.0-0
+#  ble: bluez tooling not needed in-container (uses host BlueZ via D-Bus), but
+#       dbus client libs come with python deps
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 python3-pip python3-venv python3-dev \
+        gcc g++ \
+        portaudio19-dev libportaudio2 \
+        libasound2 libasound2-plugins alsa-utils \
+        mpv libmpv2 \
+        libsamplerate0 libopenblas0 \
+        libusb-1.0-0 \
+        ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR ${SATELLITE_HOME}
+
+# --- Python deps (mirrors provisioning group_vars, minus Pi-only GPIO/SPI libs) ---
+# GPIO libs (RPi.GPIO/lgpio/gpiozero/spidev) intentionally omitted: the xvf3800
+# LED path is subprocess-only and the button degrades to a no-op without them.
+RUN pip3 install --break-system-packages \
+        "setuptools<81" \
+        numpy \
+        websockets \
+        aiohttp \
+        requests \
+        pyyaml \
+        zeroconf \
+        psutil \
+        pyaudio \
+        python-mpv \
+        webrtcvad \
+        onnxruntime \
+        tflite-runtime \
+        pymicro-wakeword \
+        pyopen-wakeword \
+        noisereduce \
+        scikit-learn \
+        bleak \
+        Pillow \
+    && pip3 install --break-system-packages --no-deps openwakeword
+
+# --- Wake word + VAD models (baked) ---
+# openWakeWord base feature models + a builtin keyword, plus Silero VAD.
+# NOTE: the household's custom "hey_renfield.onnx" is NOT bundled here (not in
+# the repo); mount or add it before go-live to match the rest of the fleet.
+RUN mkdir -p ${SATELLITE_HOME}/models \
+    && OWW=https://github.com/dscripka/openWakeWord/releases/download/v0.5.1 \
+    && curl -fsSL -o ${SATELLITE_HOME}/models/melspectrogram.onnx   $OWW/melspectrogram.onnx \
+    && curl -fsSL -o ${SATELLITE_HOME}/models/embedding_model.onnx  $OWW/embedding_model.onnx \
+    && curl -fsSL -o ${SATELLITE_HOME}/models/alexa_v0.1.onnx       $OWW/alexa_v0.1.onnx \
+    && curl -fsSL -o ${SATELLITE_HOME}/models/silero_vad.onnx \
+        https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad.onnx
+
+# Household custom wake word "hey_renfield" (not in the repo — fetched from an
+# existing satellite into the build context at models/hey_renfield.onnx).
+COPY models/hey_renfield.onnx ${SATELLITE_HOME}/models/hey_renfield.onnx
+
+# openWakeWord loads its base feature models (melspectrogram/embedding) from its
+# OWN package resources/models dir — not models_path. Mirror the Ansible step.
+RUN OWW_DIR=$(python3 -c "import openwakeword,os;print(os.path.join(os.path.dirname(openwakeword.__file__),'resources','models'))") \
+    && mkdir -p "$OWW_DIR" \
+    && cp ${SATELLITE_HOME}/models/melspectrogram.onnx ${SATELLITE_HOME}/models/embedding_model.onnx \
+          ${SATELLITE_HOME}/models/alexa_v0.1.onnx "$OWW_DIR/"
+
+# ALSA: make the PortAudio "default" device resolve to the XVF3800 (USB), since
+# the container has no per-user ~/.asoundrc like the bare-metal satellites.
+COPY config/asound.conf /etc/asound.conf
+
+# --- XVF3800 LED control binary + libs ---
+COPY hardware/xvf3800/ ${SATELLITE_HOME}/bin/
+RUN chmod +x ${SATELLITE_HOME}/bin/xvf_host
+
+# --- Application code ---
+COPY renfield_satellite/ ${SATELLITE_HOME}/renfield_satellite/
+
+# Config is provided at runtime via the mounted ConfigMap at
+# ${SATELLITE_HOME}/config/satellite.yaml
+# Entrypoint takes the config path POSITIONALLY (main.run reads sys.argv[1]).
+# Per-deployment values (id/room/server url/ble) can also be overridden via
+# RENFIELD_* env vars in the pod spec (see config.py).
+ENV PYTHONPATH=${SATELLITE_HOME}
+CMD ["python3", "-m", "renfield_satellite", "/opt/renfield-satellite/config/satellite.yaml"]

--- a/src/satellite/config/asound.conf
+++ b/src/satellite/config/asound.conf
@@ -1,0 +1,35 @@
+# Renfield Satellite — ALSA config for ReSpeaker XVF3800 USB (container /etc/asound.conf)
+# Mirrors provisioning/templates/asoundrc-xvf3800-usb.j2 so the PortAudio
+# "default" device resolves to the XVF3800 (capture via dsnoop, playback via dmix).
+defaults.pcm.rate_converter "samplerate"
+
+pcm.!default {
+    type asym
+    playback.pcm "xvf_play"
+    capture.pcm "xvf_cap"
+}
+
+pcm.xvf_play {
+    type plug
+    slave.pcm "dmixed"
+}
+
+pcm.xvf_cap {
+    type plug
+    slave.pcm "dsnooped"
+}
+
+pcm.dmixed {
+    type dmix
+    slave.pcm "hw:Array"
+    ipc_key 555555
+}
+
+pcm.dsnooped {
+    type dsnoop
+    slave {
+        pcm "hw:Array"
+        channels 1
+    }
+    ipc_key 666666
+}

--- a/src/satellite/renfield_satellite/audio/capture.py
+++ b/src/satellite/renfield_satellite/audio/capture.py
@@ -201,14 +201,25 @@ class AudioCapture:
         if not self._pyaudio:
             return None
 
-        # If device specified, try to find it
+        # If device specified, try to find it. Prefer an EXACT name match before
+        # falling back to substring: the configured device "default" must resolve
+        # to the ALSA "default" PCM (our /etc/asound.conf → XVF3800 dsnoop), NOT
+        # "sysdefault" (raw card, opened exclusively, silent on this hardware) —
+        # a plain substring match picks "sysdefault" because it *contains*
+        # "default", which captured pure silence and broke wake-word detection.
         if self.device_name:
-            for i in range(self._pyaudio.get_device_count()):
+            name = self.device_name.lower()
+            count = self._pyaudio.get_device_count()
+            for i in range(count):
                 info = self._pyaudio.get_device_info_by_index(i)
-                if info['maxInputChannels'] > 0:
-                    if self.device_name.lower() in info['name'].lower():
-                        print(f"Found microphone: {info['name']} (index {i})")
-                        return i
+                if info['maxInputChannels'] > 0 and info['name'].lower() == name:
+                    print(f"Found microphone (exact): {info['name']} (index {i})")
+                    return i
+            for i in range(count):
+                info = self._pyaudio.get_device_info_by_index(i)
+                if info['maxInputChannels'] > 0 and name in info['name'].lower():
+                    print(f"Found microphone (substring): {info['name']} (index {i})")
+                    return i
 
         # Use default input device
         try:


### PR DESCRIPTION
First Renfield satellite as a k8s workload (Orange Pi Zero 3W / A733 / XVF3800 USB), joined as the first arm64 node.

Root-cause fix: wake-word never fired because PyAudio's default input resolved to the silent on-board HDMI card and the device matcher preferred `sysdefault` over `default`; capture.py now does exact-match-first device selection so `default` → ALSA default PCM (asound.conf → XVF3800). Verified end-to-end (hey_renfield @ 0.70).

Includes the arm64 Dockerfile, /etc/asound.conf, and the node-pinned privileged k8s manifest. Custom wakeword model is gitignored (fetched into the build context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)