### PR TITLE
feat(satellite/ble): continuous scanning + smoothed RSSI; codify BlueZ Experimental

### DIFF
--- a/docs/design/ble-presence-improvement.md
+++ b/docs/design/ble-presence-improvement.md
@@ -1,0 +1,78 @@
+# BLE Presence Improvement
+
+Improve household BLE presence (accuracy, latency, reliability), prompted by the
+Esszimmer Orange Pi Zero 3W (Allwinner A733, **Bluetooth 5.4**) being a much
+stronger BT radio than the Pi-Zero fleet — and a good primary anchor.
+
+## Current state (before this work)
+- Satellite `ble/scanner.py`: a periodic `BleakScanner.discover()` burst every
+  `scan_interval` (30 s) for `scan_duration` (5 s); reports `{mac, rssi}` for
+  devices in a `known_devices` MAC whitelist above `rssi_threshold`. Backend
+  aggregates per-room RSSI for arbitration.
+- `classic_rssi: false` on the A733 board (AIC8800 raw-HCI `hcitool cc/rssi` is
+  broken; advertisement RSSI is real and used).
+
+## Problems (what limits accuracy)
+1. **MAC randomization (root limiter).** Modern phones/watches rotate their BLE
+   address (RPA), so a static MAC whitelist drifts. **Not fixed by any BT version.**
+2. **Scan latency / coverage.** 5 s scan every 30 s → up to ~30 s latency; a
+   device advertising in the gap is missed.
+3. **RSSI jitter.** Single-shot advertisement RSSI is noisy → room arbitration
+   flip-flops (cf. the Kinderbad synthetic-−50 hijack incident).
+
+## What the BT 5.4 controller offers (probed on the A733)
+- ✅ LE **2M** + **Coded (Long Range)** PHY (`LECODEDTX/RX`), Extended
+  Advertising, address privacy.
+- ❌ **No usable AoA/AoD direction-finding** (no CTE exposed; needs a multi-antenna
+  array). No angle-based positioning.
+
+## Plan (phased)
+
+### Phase 1 — Continuous, smoothed scanning  ✅ IMPLEMENTED (this change)
+- **BlueZ `Experimental = true`** codified in the satellite Ansible
+  (`provision.yml` → `ini_file` on `/etc/bluetooth/main.conf`, restarts
+  bluetoothd). Unlocks the AdvertisementMonitor/passive APIs and survives a
+  re-image. *(Already set live on the Esszimmer host.)*
+- **Continuous scanning** in `ble/scanner.py` (`continuous: true`): one
+  long-running `BleakScanner` with a detection callback instead of discover()
+  bursts; per-device **EWMA-smoothed RSSI** with a freshness window
+  (`smoothing_alpha`, `freshness_seconds`). The scan loop polls
+  `get_readings()` each `scan_interval`. Falls back to the periodic discover()
+  path when `continuous: false` (default → fleet byte-identical).
+- Config plumbed through `BLEConfig`, `load_config`, the Ansible template +
+  group_vars (`ble_continuous` etc.).
+- **Latency** also reduced independently by `scan_interval 30→3` on the A733.
+
+### Phase 1b — AdvertisementMonitor passive offload  ⏳ DEFERRED
+Use BlueZ passive scanning (`scanning_mode="passive"` + `or_patterns`, kernel
+RSSI-threshold offload) rather than active continuous scan. Lower power/CPU;
+needs Experimental (now enabled). Follow-on to the continuous callback above.
+
+### Phase 1c — Backend RSSI smoothing + hysteresis  ⏳ DEFERRED (shared backend)
+Median/EWMA + hand-off hysteresis in the room-arbitration logic to kill
+flip-flop. Touches the production backend → its own reviewed change.
+
+### Phase 2 — Defeat MAC randomization via IRK/bonding  ⏳ DEFERRED (the real win)
+Bond household devices so BlueZ resolves rotating RPAs to a stable identity via
+the IRK; presence keys on resolved identity, not raw MAC. Largest surface:
+satellite (bonding/resolution) + backend (identity store, IRK distribution,
+presence model) + a small enroll UX + privacy review (storing IRKs).
+
+### Phase 3 — Optional reach  ⏳ DEFERRED
+Coded-PHY (Long Range) scanning for compatible tags/beacons; connection-based
+RSSI for bonded devices.
+
+## Non-goals
+Direction finding / angle positioning (hardware can't); UWB.
+
+## Rollout & metrics
+Designed fleet-wide; validated on the Esszimmer A733 as the strongest anchor,
+then rolled to the Pi fleet via Ansible (`--tags app`). Older radios still gain
+continuous scan + smoothing (and later IRK). Metrics: presence-detection
+latency, room-arbitration flip rate, % time known devices resolved after MAC
+rotation.
+
+## Open questions
+- Bond per-satellite vs central IRK distribution?
+- Audit: which household devices use stable vs randomized addresses today?
+- Privacy/consent model for storing IRKs (ties into household privacy posture).

--- a/src/satellite/provisioning/group_vars/satellites.yml
+++ b/src/satellite/provisioning/group_vars/satellites.yml
@@ -107,6 +107,12 @@ ble_enabled: true
 ble_scan_interval: 30
 ble_scan_duration: 5
 ble_rssi_threshold: -80
+# Continuous BLE scanning (one long-running BleakScanner + smoothed EWMA RSSI)
+# instead of periodic discover() bursts. Off by default (Pi Zero 2 W keeps the
+# simple periodic path); opt in per-host (e.g. BT 5.x / mains-powered nodes).
+ble_continuous: false
+ble_smoothing_alpha: 0.4
+ble_freshness_seconds: 20.0
 
 # openwakeword installed separately with --no-deps for Python 3.13+ compat
 openwakeword_package: "openwakeword"

--- a/src/satellite/provisioning/provision.yml
+++ b/src/satellite/provisioning/provision.yml
@@ -30,6 +30,11 @@
       ansible.builtin.systemd:
         daemon_reload: true
 
+    - name: restart bluetooth
+      ansible.builtin.systemd:
+        name: bluetooth
+        state: restarted
+
   tasks:
     # =========================================================================
     # SYSTEM — System preparation
@@ -524,6 +529,21 @@
         name: renfield-bt
         enabled: true
         state: started
+
+    # Enable BlueZ experimental features — required for the AdvertisementMonitor
+    # API (continuous, kernel-offloaded, threshold-based per-device RSSI used by
+    # the continuous BLE presence scanner). Without this, BlueZ rejects the
+    # passive/monitor APIs. Survives re-image; restarts bluetoothd on change.
+    - name: Enable BlueZ Experimental (AdvertisementMonitor API)
+      tags: [bluetooth, config]
+      ansible.builtin.ini_file:
+        path: /etc/bluetooth/main.conf
+        section: General
+        option: Experimental
+        value: "true"
+        no_extra_spaces: true
+        mode: "0644"
+      notify: restart bluetooth
 
     # =========================================================================
     # SERVICE — Systemd service

--- a/src/satellite/provisioning/templates/satellite.yaml.j2
+++ b/src/satellite/provisioning/templates/satellite.yaml.j2
@@ -94,6 +94,9 @@ ble:
   scan_interval: {{ ble_scan_interval }}
   scan_duration: {{ ble_scan_duration }}
   rssi_threshold: {{ ble_rssi_threshold }}
+  continuous: {{ ble_continuous | default(false) | lower }}
+  smoothing_alpha: {{ ble_smoothing_alpha | default(0.4) }}
+  freshness_seconds: {{ ble_freshness_seconds | default(20.0) }}
 {% if enviro_phat_enabled | default(false) %}
 
 enviro:

--- a/src/satellite/renfield_satellite/ble/scanner.py
+++ b/src/satellite/renfield_satellite/ble/scanner.py
@@ -3,8 +3,18 @@ BLE Scanner for Renfield Satellite
 
 Scans for known BLE devices (phones, watches) and reports RSSI values.
 Uses bleak library for cross-platform BLE scanning.
-Pi Zero 2 W has Bluetooth 4.2 built-in.
+
+Two modes:
+  - Periodic (default, legacy): a discover() burst every scan_interval. Simple,
+    works on any adapter (Pi Zero 2 W, BT 4.2).
+  - Continuous (continuous=True, BT 5.x / mains-powered nodes): a single
+    BleakScanner stays running with a detection callback; per-device RSSI is
+    smoothed (EWMA) and reported with a freshness window. Lower presence latency
+    and steadier RSSI for room arbitration. Requires no extra adapter features,
+    but benefits from BlueZ Experimental (AdvertisementMonitor) being enabled.
 """
+
+import time
 
 try:
     from bleak import BleakScanner as _BleakScanner
@@ -22,9 +32,23 @@ class BLEScanner:
     ensuring privacy and efficiency.
     """
 
-    def __init__(self, scan_duration: float = 5.0, rssi_threshold: int = -80):
+    def __init__(
+        self,
+        scan_duration: float = 5.0,
+        rssi_threshold: int = -80,
+        smoothing_alpha: float = 0.4,
+        freshness_seconds: float = 20.0,
+    ):
         self.scan_duration = scan_duration
         self.rssi_threshold = rssi_threshold
+        self.smoothing_alpha = smoothing_alpha
+        self.freshness_seconds = freshness_seconds
+
+        # Continuous-mode state
+        self._scanner = None
+        self._known_macs: set[str] = set()
+        # mac -> [ewma_rssi, last_seen_monotonic]
+        self._readings: dict[str, list] = {}
 
         if not BLEAK_AVAILABLE:
             print("Warning: bleak not installed. BLE scanning disabled.")
@@ -33,9 +57,11 @@ class BLEScanner:
     def available(self) -> bool:
         return BLEAK_AVAILABLE
 
+    # ---- Periodic mode (legacy) -------------------------------------------
+
     async def scan(self, known_macs: set[str]) -> list[dict]:
         """
-        Scan for known BLE devices.
+        One discover() burst for known BLE devices.
 
         Args:
             known_macs: Set of MAC addresses (uppercase, colon-separated) to look for.
@@ -64,4 +90,75 @@ class BLEScanner:
                 if rssi is not None and rssi >= self.rssi_threshold:
                     results.append({"mac": mac, "rssi": rssi})
 
+        return results
+
+    # ---- Continuous mode --------------------------------------------------
+
+    def update_known(self, known_macs: set[str]) -> None:
+        """Update the known-MAC whitelist the detection callback filters on
+        (the backend pushes updates while the continuous scanner keeps running)."""
+        self._known_macs = {m.upper() for m in known_macs}
+        # Drop readings for devices no longer tracked
+        for mac in list(self._readings):
+            if mac not in self._known_macs:
+                self._readings.pop(mac, None)
+
+    def _on_detection(self, device, adv_data) -> None:
+        """bleak detection callback: fold each advertisement into a per-device
+        EWMA RSSI. Cheap and runs on the event loop."""
+        mac = (device.address or "").upper()
+        if mac not in self._known_macs:
+            return
+        rssi = getattr(adv_data, "rssi", None)
+        if rssi is None:
+            return
+        now = time.monotonic()
+        entry = self._readings.get(mac)
+        if entry is None:
+            self._readings[mac] = [float(rssi), now]
+        else:
+            a = self.smoothing_alpha
+            entry[0] = a * float(rssi) + (1.0 - a) * entry[0]
+            entry[1] = now
+
+    async def start_continuous(self, known_macs: set[str]) -> bool:
+        """Start a single long-running scanner with the detection callback.
+        Returns True if started (or already running), False if unavailable."""
+        if not BLEAK_AVAILABLE:
+            return False
+        self.update_known(known_macs)
+        if self._scanner is not None:
+            return True
+        try:
+            self._scanner = _BleakScanner(detection_callback=self._on_detection)
+            await self._scanner.start()
+            print("BLE continuous scanner started")
+            return True
+        except Exception as e:
+            print(f"BLE continuous start error: {e}")
+            self._scanner = None
+            return False
+
+    async def stop_continuous(self) -> None:
+        if self._scanner is not None:
+            try:
+                await self._scanner.stop()
+            except Exception as e:
+                print(f"BLE continuous stop error: {e}")
+            self._scanner = None
+        self._readings.clear()
+
+    def get_readings(self) -> list[dict]:
+        """Snapshot of fresh, above-threshold devices with smoothed RSSI.
+        Prunes stale entries (unseen > freshness_seconds)."""
+        now = time.monotonic()
+        results = []
+        for mac in list(self._readings):
+            rssi, last_seen = self._readings[mac]
+            if now - last_seen > self.freshness_seconds:
+                self._readings.pop(mac, None)
+                continue
+            rssi_i = int(round(rssi))
+            if rssi_i >= self.rssi_threshold:
+                results.append({"mac": mac, "rssi": rssi_i})
         return results

--- a/src/satellite/renfield_satellite/config.py
+++ b/src/satellite/renfield_satellite/config.py
@@ -160,6 +160,13 @@ class BLEConfig:
     known_devices: List[str] = field(default_factory=list)  # MAC whitelist, pushed from backend
     classic_rssi: bool = True     # read real Classic-BT RSSI (hcitool cc/rssi); off => synthetic -50
     classic_rssi_interval: float = 300.0  # seconds between real RSSI reads per device (throttle connect churn)
+    # Continuous scanning (BT 5.x / mains-powered nodes): keep a single BleakScanner
+    # running with a detection callback instead of periodic discover() bursts, and
+    # report a smoothed (EWMA) per-device RSSI. Lower latency + steadier RSSI for
+    # room arbitration. Falls back to the discover() loop when False.
+    continuous: bool = False
+    smoothing_alpha: float = 0.4      # EWMA weight for each new RSSI sample (0..1)
+    freshness_seconds: float = 20.0   # drop a device from presence if unseen this long
 
 
 @dataclass
@@ -322,6 +329,9 @@ def load_config(config_path: Optional[str] = None) -> Config:
         config.ble.rssi_threshold = ble.get("rssi_threshold", config.ble.rssi_threshold)
         config.ble.classic_rssi = ble.get("classic_rssi", config.ble.classic_rssi)
         config.ble.classic_rssi_interval = ble.get("classic_rssi_interval", config.ble.classic_rssi_interval)
+        config.ble.continuous = ble.get("continuous", config.ble.continuous)
+        config.ble.smoothing_alpha = ble.get("smoothing_alpha", config.ble.smoothing_alpha)
+        config.ble.freshness_seconds = ble.get("freshness_seconds", config.ble.freshness_seconds)
         if "known_devices" in ble:
             config.ble.known_devices = ble["known_devices"]
 

--- a/src/satellite/renfield_satellite/satellite.py
+++ b/src/satellite/renfield_satellite/satellite.py
@@ -248,6 +248,8 @@ class Satellite:
             self.ble_scanner = BLEScanner(
                 scan_duration=self.config.ble.scan_duration,
                 rssi_threshold=self.config.ble.rssi_threshold,
+                smoothing_alpha=self.config.ble.smoothing_alpha,
+                freshness_seconds=self.config.ble.freshness_seconds,
             )
             # Pre-populate from config (backend will push updates)
             self._ble_known_macs = {mac.upper() for mac in self.config.ble.known_devices}
@@ -1130,8 +1132,15 @@ class Satellite:
         self._ble_task = asyncio.create_task(self._ble_scan_loop())
 
     async def _ble_scan_loop(self):
-        """Background loop that periodically scans for BLE devices"""
-        print("BLE scan loop started")
+        """Background loop reporting BLE presence.
+
+        Continuous mode (config.ble.continuous): keep ONE BleakScanner running
+        with a detection callback and poll its smoothed per-device RSSI every
+        scan_interval — lower latency + steadier RSSI. Periodic mode (default):
+        a discover() burst each scan_interval (works on any adapter).
+        """
+        continuous = self.config.ble.continuous
+        print(f"BLE scan loop started ({'continuous' if continuous else 'periodic'})")
         try:
             while self._running:
                 await asyncio.sleep(self.config.ble.scan_interval)
@@ -1141,7 +1150,13 @@ class Satellite:
                     continue
 
                 try:
-                    devices = await self.ble_scanner.scan(self._ble_known_macs)
+                    if continuous:
+                        # idempotent: starts once, then just refreshes the
+                        # known-MAC whitelist the callback filters on
+                        await self.ble_scanner.start_continuous(self._ble_known_macs)
+                        devices = self.ble_scanner.get_readings()
+                    else:
+                        devices = await self.ble_scanner.scan(self._ble_known_macs)
                     if devices:
                         await self.ws_client.send_ble_presence(devices)
                         print(f"BLE scan: {len(devices)} known devices detected")
@@ -1149,6 +1164,9 @@ class Satellite:
                     print(f"BLE scan error: {e}")
         except asyncio.CancelledError:
             pass
+        finally:
+            if continuous and self.ble_scanner is not None:
+                await self.ble_scanner.stop_continuous()
         print("BLE scan loop stopped")
 
     async def _start_classic_bt_scan_loop(self):

--- a/tests/satellite/test_ble_scanner_continuous.py
+++ b/tests/satellite/test_ble_scanner_continuous.py
@@ -1,0 +1,71 @@
+"""
+Unit tests for the continuous BLE presence scanner (BLEScanner continuous mode).
+
+Pure logic — exercises the detection-callback EWMA smoothing, known-MAC
+filtering, threshold gating and freshness pruning without any BLE hardware.
+"""
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from renfield_satellite.ble.scanner import BLEScanner
+
+
+def _det(scanner, mac, rssi):
+    """Feed one advertisement into the detection callback."""
+    scanner._on_detection(SimpleNamespace(address=mac), SimpleNamespace(rssi=rssi))
+
+
+@pytest.mark.satellite
+@pytest.mark.unit
+class TestBLEScannerContinuous:
+    def test_only_known_macs_tracked(self):
+        s = BLEScanner(rssi_threshold=-80)
+        s.update_known({"AA:BB:CC:DD:EE:FF"})
+        _det(s, "AA:BB:CC:DD:EE:FF", -50)
+        _det(s, "11:22:33:44:55:66", -40)  # not in whitelist
+        macs = {r["mac"] for r in s.get_readings()}
+        assert macs == {"AA:BB:CC:DD:EE:FF"}
+
+    def test_case_insensitive_match(self):
+        s = BLEScanner(rssi_threshold=-80)
+        s.update_known({"aa:bb:cc:dd:ee:ff"})
+        _det(s, "AA:BB:CC:DD:EE:FF", -55)
+        assert len(s.get_readings()) == 1
+
+    def test_ewma_smoothing(self):
+        s = BLEScanner(rssi_threshold=-100, smoothing_alpha=0.5)
+        s.update_known({"AA:BB:CC:DD:EE:FF"})
+        _det(s, "AA:BB:CC:DD:EE:FF", -60)
+        _det(s, "AA:BB:CC:DD:EE:FF", -70)  # 0.5*-70 + 0.5*-60 = -65
+        assert s.get_readings()[0]["rssi"] == -65
+
+    def test_threshold_gates_weak_signal(self):
+        s = BLEScanner(rssi_threshold=-70)
+        s.update_known({"AA:BB:CC:DD:EE:FF"})
+        _det(s, "AA:BB:CC:DD:EE:FF", -85)  # below threshold
+        assert s.get_readings() == []
+
+    def test_freshness_prune(self):
+        s = BLEScanner(rssi_threshold=-100, freshness_seconds=5.0)
+        s.update_known({"AA:BB:CC:DD:EE:FF"})
+        _det(s, "AA:BB:CC:DD:EE:FF", -50)
+        assert len(s.get_readings()) == 1
+        # Age the last-seen timestamp beyond the freshness window
+        s._readings["AA:BB:CC:DD:EE:FF"][1] = time.monotonic() - 10.0
+        assert s.get_readings() == []
+
+    def test_update_known_drops_removed_device(self):
+        s = BLEScanner(rssi_threshold=-100)
+        s.update_known({"AA:BB:CC:DD:EE:FF"})
+        _det(s, "AA:BB:CC:DD:EE:FF", -50)
+        assert len(s.get_readings()) == 1
+        s.update_known(set())  # device no longer tracked
+        assert s.get_readings() == []
+
+    def test_none_rssi_ignored(self):
+        s = BLEScanner(rssi_threshold=-100)
+        s.update_known({"AA:BB:CC:DD:EE:FF"})
+        _det(s, "AA:BB:CC:DD:EE:FF", None)
+        assert s.get_readings() == []


### PR DESCRIPTION
BLE presence improvement Phase 1 (design: docs/design/ble-presence-improvement.md).

- Continuous scanning mode in scanner.py (one long-running BleakScanner + detection callback + EWMA-smoothed per-device RSSI + freshness window), gated by `continuous: true` (default off → fleet byte-identical).
- Config plumbed through BLEConfig/load_config/satellite.py scan loop + Ansible template/group_vars.
- Codify BlueZ `Experimental = true` in provision.yml (survives re-image; unlocks AdvertisementMonitor API).
- 7 unit tests for the continuous logic (no hardware needed).

Deferred (documented): AdvertisementMonitor passive offload, backend RSSI smoothing, and IRK/bonding (the MAC-randomization fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)