### PR TITLE
chore(satellite): enable continuous BLE on Esszimmer (image v4)

### DIFF
--- a/k8s/satellite-esszimmer.yaml
+++ b/k8s/satellite-esszimmer.yaml
@@ -68,6 +68,9 @@ data:
       rssi_threshold: -80
       classic_rssi: false         # AIC8800 raw-HCI (hcitool cc/rssi) is broken here;
                                   # the bleak advertisement scanner provides real RSSI
+      continuous: true            # one long-running scanner + EWMA-smoothed RSSI (BT5.4)
+      smoothing_alpha: 0.4
+      freshness_seconds: 20.0
 
 ---
 apiVersion: apps/v1
@@ -116,7 +119,7 @@ spec:
                     values: ["arm64"]
       containers:
         - name: satellite
-          image: renfield/satellite:esszimmer-v3
+          image: renfield/satellite:esszimmer-v4
           imagePullPolicy: Never   # imported into node containerd (k8s.io ns)
           securityContext:
             privileged: true        # raw /dev access for USB audio + xvf_host


### PR DESCRIPTION
Deploy-sync: flip `ble.continuous: true` (+ smoothing/freshness) on the Esszimmer ConfigMap and bump the image to v4 (built from main). Deployed + verified live (`BLE scan loop started (continuous)`). Idle until BLE known-device MACs are registered for the room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)