### PR TITLE
feat(presence): backend per-person BLE IRK store (encrypted) + push to satellites

### DIFF
--- a/src/backend/alembic/versions/pc20260619_ble_irk_store.py
+++ b/src/backend/alembic/versions/pc20260619_ble_irk_store.py
@@ -1,0 +1,38 @@
+"""per-person BLE IRK store (user_ble_irks)
+
+Revision ID: pc20260619_ble_irk_store
+Revises: pc20260618_message_branching
+Create Date: 2026-06-19
+
+Stores per-person BLE Identity Resolving Keys (encrypted at rest) used to
+resolve rotating RPAs to a stable identity for presence. See
+docs/design/ble-presence-improvement.md.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "pc20260619_ble_irk_store"
+down_revision = "pc20260618_message_branching"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_ble_irks",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("label", sa.String(length=100), nullable=False),
+        sa.Column("irk_encrypted", sa.String(length=255), nullable=False),
+        sa.Column("is_enabled", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+    )
+    op.create_index("ix_user_ble_irks_user_id", "user_ble_irks", ["user_id"])
+    op.create_index("ix_user_ble_irks_label", "user_ble_irks", ["label"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_user_ble_irks_label", table_name="user_ble_irks")
+    op.drop_index("ix_user_ble_irks_user_id", table_name="user_ble_irks")
+    op.drop_table("user_ble_irks")

--- a/src/backend/ha_glue/api/routes/presence.py
+++ b/src/backend/ha_glue/api/routes/presence.py
@@ -355,6 +355,37 @@ async def create_irk(
     )
 
 
+class BLEIrkUpdate(BaseModel):
+    is_enabled: bool
+
+
+@router.patch("/irks/{irk_id}", response_model=BLEIrkResponse)
+async def update_irk(
+    irk_id: int,
+    body: BLEIrkUpdate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_permission(Permission.ADMIN)),
+):
+    """Enable/disable an IRK without deleting it (disabling stops resolution +
+    re-pushes the reduced set to satellites)."""
+    from models.database import UserBleIrk
+    row = (await db.execute(select(UserBleIrk).where(UserBleIrk.id == irk_id))).scalar_one_or_none()
+    if not row:
+        raise HTTPException(status_code=404, detail="IRK not found")
+    row.is_enabled = body.is_enabled
+    await db.commit()
+    await db.refresh(row)
+
+    presence = get_presence_service()
+    await presence.load_device_registry(db)
+    await presence.push_macs_to_satellites()
+
+    return BLEIrkResponse(
+        id=row.id, user_id=row.user_id, label=row.label, is_enabled=row.is_enabled,
+        created_at=row.created_at.isoformat() if row.created_at else None,
+    )
+
+
 @router.delete("/irks/{irk_id}", status_code=204)
 async def delete_irk(
     irk_id: int,

--- a/src/backend/ha_glue/api/routes/presence.py
+++ b/src/backend/ha_glue/api/routes/presence.py
@@ -285,6 +285,95 @@ async def delete_device(
         raise HTTPException(status_code=404, detail="Device not found")
 
 
+# --- Per-person BLE IRK store (resolve rotating RPAs → stable identity) ---
+
+class BLEIrkCreate(BaseModel):
+    user_id: int
+    label: str = Field(..., min_length=1, max_length=100,
+                       description="Globally-unique stable identity (e.g. 'eduard-iphone')")
+    irk: str = Field(..., pattern=r"^[0-9A-Fa-f]{32}$",
+                     description="16-byte IRK as 32 hex chars, MSO-first")
+
+
+class BLEIrkResponse(BaseModel):
+    id: int
+    user_id: int
+    label: str
+    is_enabled: bool
+    created_at: str | None = None
+
+
+@router.get("/irks", response_model=list[BLEIrkResponse])
+async def list_irks(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_permission(Permission.ADMIN)),
+):
+    """List registered BLE IRKs (metadata only — the key itself is never returned)."""
+    from models.database import UserBleIrk
+    rows = (await db.execute(select(UserBleIrk))).scalars().all()
+    return [
+        BLEIrkResponse(
+            id=r.id, user_id=r.user_id, label=r.label, is_enabled=r.is_enabled,
+            created_at=r.created_at.isoformat() if r.created_at else None,
+        )
+        for r in rows
+    ]
+
+
+@router.post("/irks", response_model=BLEIrkResponse, status_code=201)
+async def create_irk(
+    body: BLEIrkCreate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_permission(Permission.ADMIN)),
+):
+    """Register a per-person IRK (stored encrypted, pushed to satellites)."""
+    from models.database import User as DBUser, UserBleIrk
+    from services.secret_encryption import encrypt_secret
+
+    if not (await db.execute(select(DBUser).where(DBUser.id == body.user_id))).scalar_one_or_none():
+        raise HTTPException(status_code=404, detail="User not found")
+    if (await db.execute(select(UserBleIrk).where(UserBleIrk.label == body.label))).scalar_one_or_none():
+        raise HTTPException(status_code=409, detail="Label already exists")
+
+    row = UserBleIrk(
+        user_id=body.user_id,
+        label=body.label,
+        irk_encrypted=encrypt_secret(body.irk.lower()),
+        is_enabled=True,
+    )
+    db.add(row)
+    await db.commit()
+    await db.refresh(row)
+
+    presence = get_presence_service()
+    await presence.load_device_registry(db)   # reloads MAC + IRK caches
+    await presence.push_macs_to_satellites()
+
+    return BLEIrkResponse(
+        id=row.id, user_id=row.user_id, label=row.label, is_enabled=row.is_enabled,
+        created_at=row.created_at.isoformat() if row.created_at else None,
+    )
+
+
+@router.delete("/irks/{irk_id}", status_code=204)
+async def delete_irk(
+    irk_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_permission(Permission.ADMIN)),
+):
+    """Revoke a BLE IRK (deletes it + re-pushes the reduced set to satellites)."""
+    from models.database import UserBleIrk
+    row = (await db.execute(select(UserBleIrk).where(UserBleIrk.id == irk_id))).scalar_one_or_none()
+    if not row:
+        raise HTTPException(status_code=404, detail="IRK not found")
+    await db.delete(row)
+    await db.commit()
+
+    presence = get_presence_service()
+    await presence.load_device_registry(db)
+    await presence.push_macs_to_satellites()
+
+
 # --- Analytics ---
 
 class HeatmapCell(BaseModel):

--- a/src/backend/ha_glue/api/websocket/satellite_handler.py
+++ b/src/backend/ha_glue/api/websocket/satellite_handler.py
@@ -264,11 +264,19 @@ async def satellite_websocket(
                                 "type": "classic_bt_known_devices",
                                 "devices": list(classic_macs),
                             })
+                        # Per-person IRKs for resolving rotating RPAs (iPhones)
+                        irks = presence_svc.get_ble_irks()
+                        if irks:
+                            await websocket.send_json({
+                                "type": "ble_known_irks",
+                                "irks": irks,
+                            })
                         total = len(ble_macs) + len(classic_macs)
-                        if total:
-                            logger.debug(f"Pushed {len(ble_macs)} BLE + {len(classic_macs)} Classic BT MACs to {satellite_id}")
+                        if total or irks:
+                            logger.debug(f"Pushed {len(ble_macs)} BLE + {len(classic_macs)} Classic BT MACs "
+                                         f"+ {len(irks)} IRK(s) to {satellite_id}")
                     except Exception as e:
-                        logger.warning(f"Failed to push MACs: {e}")
+                        logger.warning(f"Failed to push MACs/IRKs: {e}")
 
             # Handle config acknowledgment from satellite
             elif msg_type == "config_ack":

--- a/src/backend/ha_glue/models/database.py
+++ b/src/backend/ha_glue/models/database.py
@@ -381,6 +381,36 @@ class UserBleDevice(Base):
     user = relationship("User", backref="ble_devices")
 
 
+class UserBleIrk(Base):
+    """Per-person BLE Identity Resolving Key for presence.
+
+    Modern phones (iPhone/Android) advertise with rotating Resolvable Private
+    Addresses, so a static MAC whitelist can't track them. The IRK — obtained
+    out-of-band once (iPhone: Mac/iCloud keychain or a one-time bond to a
+    satellite; Android: bonded-device info) — lets a satellite resolve the
+    rotating address back to this stable `label`. See
+    docs/design/ble-presence-improvement.md.
+
+    The IRK is a device-tracking secret: stored ENCRYPTED at rest
+    (services/secret_encryption) and pushed to satellites over the WS link only.
+    """
+
+    __tablename__ = "user_ble_irks"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    # Globally-unique stable identity the satellite reports on a resolved match;
+    # the backend maps it back to this user for presence attribution.
+    label = Column(String(100), unique=True, nullable=False, index=True)
+    # Fernet token of the 32-hex-char IRK — never stored or logged in plaintext.
+    irk_encrypted = Column(String(255), nullable=False)
+    is_enabled = Column(Boolean, default=True)
+    created_at = Column(DateTime, default=_utcnow)
+    updated_at = Column(DateTime, default=_utcnow, onupdate=_utcnow)
+
+    user = relationship("User", backref="ble_irks")
+
+
 class PresenceEvent(Base):
     """Persisted presence event for analytics (heatmap, predictions)."""
 

--- a/src/backend/ha_glue/services/presence_service.py
+++ b/src/backend/ha_glue/services/presence_service.py
@@ -198,7 +198,7 @@ class PresenceService:
             # `mac` would never match a whitelist); key it by the identity so a
             # phone is tracked across RPA rotation. Otherwise key by MAC.
             identity = device.get("identity")
-            if identity and identity in self._irk_label_to_user:
+            if identity and identity in getattr(self, "_irk_label_to_user", {}):
                 key = "irk:" + identity
             else:
                 key = device.get("mac", "").upper()
@@ -234,7 +234,7 @@ class PresenceService:
         user_id. Keeps IRK identities out of the MAC caches used for the
         satellite known-MAC push."""
         if key.startswith("irk:"):
-            return self._irk_label_to_user.get(key[4:])
+            return getattr(self, "_irk_label_to_user", {}).get(key[4:])
         return self._mac_to_user.get(key)
 
     def _assign_room(self, mac: str):
@@ -547,7 +547,7 @@ class PresenceService:
     def get_ble_irks(self) -> list[dict]:
         """Per-person IRKs to push to satellites: [{'name': label, 'irk': hex}].
         IRK hex is decrypted in memory; only ever leaves over the WS link."""
-        return [{"name": label, "irk": irk} for label, irk in self._irks_hex.items()]
+        return [{"name": label, "irk": irk} for label, irk in getattr(self, "_irks_hex", {}).items()]
 
     async def push_macs_to_satellites(self):
         """Push current known MACs + IRKs to all connected satellites."""

--- a/src/backend/ha_glue/services/presence_service.py
+++ b/src/backend/ha_glue/services/presence_service.py
@@ -66,6 +66,10 @@ class PresenceService:
         self._user_first_names: dict[int, str] = {}      # user_id → first_name
         self._user_last_names: dict[int, str] = {}       # user_id → last_name
         self._pending_events: list[tuple[str, dict]] = []  # (event_name, kwargs)
+        # Per-person IRK store (for resolving rotating RPAs on non-bonded
+        # satellites). label → user_id, and label → decrypted IRK hex.
+        self._irk_label_to_user: dict[str, int] = {}
+        self._irks_hex: dict[str, str] = {}
 
     async def load_device_registry(self, db: AsyncSession):
         """Load UserBleDevice table into MAC → user_id cache."""
@@ -93,6 +97,31 @@ class PresenceService:
         logger.info(f"Presence: loaded {len(self._mac_to_user)} devices "
                      f"(BLE: {sum(1 for m in self._mac_to_method.values() if m == 'ble')}, "
                      f"Classic BT: {sum(1 for m in self._mac_to_method.values() if m == 'classic_bt')})")
+
+        await self._load_irks(db)
+
+    async def _load_irks(self, db: AsyncSession):
+        """Load UserBleIrk into the label → user_id and label → IRK-hex caches,
+        decrypting each IRK. A row that fails to decrypt is skipped (logged)."""
+        from models.database import UserBleIrk
+        from services.secret_encryption import decrypt_secret
+
+        result = await db.execute(
+            select(UserBleIrk).where(UserBleIrk.is_enabled == True)  # noqa: E712
+        )
+        rows = result.scalars().all()
+        label_to_user: dict[str, int] = {}
+        irks_hex: dict[str, str] = {}
+        for row in rows:
+            try:
+                irks_hex[row.label] = decrypt_secret(row.irk_encrypted)
+            except Exception:
+                logger.warning(f"Presence: could not decrypt IRK for label '{row.label}' (skipped)")
+                continue
+            label_to_user[row.label] = row.user_id
+        self._irk_label_to_user = label_to_user
+        self._irks_hex = irks_hex
+        logger.info(f"Presence: loaded {len(irks_hex)} BLE IRK(s)")
 
     def set_room_name(self, room_id: int, name: str):
         """Cache a room name for display."""
@@ -156,12 +185,18 @@ class PresenceService:
         now = time.time()
 
         for device in devices:
-            mac = device.get("mac", "").upper()
             rssi = device.get("rssi", -100)
 
-            # Only track known devices
-            if mac not in self._mac_to_user:
-                continue
+            # An IRK-resolved reading carries a stable `identity` (the rotating
+            # `mac` would never match a whitelist); key it by the identity so a
+            # phone is tracked across RPA rotation. Otherwise key by MAC.
+            identity = device.get("identity")
+            if identity and identity in self._irk_label_to_user:
+                key = "irk:" + identity
+            else:
+                key = device.get("mac", "").upper()
+                if self._user_for_key(key) is None:
+                    continue  # not a known device
 
             sighting = DeviceSighting(
                 satellite_id=satellite_id,
@@ -171,15 +206,15 @@ class PresenceService:
             )
 
             # Keep only recent sightings (last 2 minutes)
-            if mac not in self._sightings:
-                self._sightings[mac] = []
-            self._sightings[mac] = [
-                s for s in self._sightings[mac]
+            if key not in self._sightings:
+                self._sightings[key] = []
+            self._sightings[key] = [
+                s for s in self._sightings[key]
                 if now - s.timestamp < self._stale_timeout
             ]
-            self._sightings[mac].append(sighting)
+            self._sightings[key].append(sighting)
 
-            self._assign_room(mac)
+            self._assign_room(key)
 
         # Clean up stale presence
         self._cleanup_stale(now)
@@ -187,9 +222,17 @@ class PresenceService:
         # Fire collected presence events
         await self._fire_pending_events()
 
+    def _user_for_key(self, key: str) -> int | None:
+        """Resolve a sighting key (a MAC, or an "irk:<label>" identity) to a
+        user_id. Keeps IRK identities out of the MAC caches used for the
+        satellite known-MAC push."""
+        if key.startswith("irk:"):
+            return self._irk_label_to_user.get(key[4:])
+        return self._mac_to_user.get(key)
+
     def _assign_room(self, mac: str):
         """Assign a user to a room based on multi-satellite RSSI aggregation with hysteresis."""
-        user_id = self._mac_to_user.get(mac)
+        user_id = self._user_for_key(mac)
         if user_id is None:
             return
 
@@ -494,15 +537,21 @@ class PresenceService:
         """Get MAC addresses of Classic BT devices only."""
         return {mac for mac, method in self._mac_to_method.items() if method == "classic_bt"}
 
+    def get_ble_irks(self) -> list[dict]:
+        """Per-person IRKs to push to satellites: [{'name': label, 'irk': hex}].
+        IRK hex is decrypted in memory; only ever leaves over the WS link."""
+        return [{"name": label, "irk": irk} for label, irk in self._irks_hex.items()]
+
     async def push_macs_to_satellites(self):
-        """Push current known MACs to all connected satellites."""
+        """Push current known MACs + IRKs to all connected satellites."""
         from ha_glue.services.satellite_manager import get_satellite_manager
 
         manager = get_satellite_manager()
         ble_macs = list(self.get_ble_macs())
         classic_macs = list(self.get_classic_bt_macs())
+        irks = self.get_ble_irks()
 
-        if not ble_macs and not classic_macs:
+        if not ble_macs and not classic_macs and not irks:
             return
 
         for sat_id, sat_info in manager.satellites.items():
@@ -517,9 +566,15 @@ class PresenceService:
                         "type": "classic_bt_known_devices",
                         "devices": classic_macs,
                     })
-                logger.debug(f"Pushed {len(ble_macs)} BLE + {len(classic_macs)} Classic BT MACs to {sat_id}")
+                if irks:
+                    await sat_info.websocket.send_json({
+                        "type": "ble_known_irks",
+                        "irks": irks,
+                    })
+                logger.debug(f"Pushed {len(ble_macs)} BLE + {len(classic_macs)} Classic BT MACs "
+                             f"+ {len(irks)} IRK(s) to {sat_id}")
             except Exception as e:
-                logger.warning(f"Failed to push MACs to {sat_id}: {e}")
+                logger.warning(f"Failed to push MACs/IRKs to {sat_id}: {e}")
 
     async def add_device(
         self,

--- a/src/backend/ha_glue/services/presence_service.py
+++ b/src/backend/ha_glue/services/presence_service.py
@@ -121,6 +121,13 @@ class PresenceService:
             label_to_user[row.label] = row.user_id
         self._irk_label_to_user = label_to_user
         self._irks_hex = irks_hex
+        if rows and not irks_hex:
+            # All IRKs failed to decrypt — almost certainly a SECRET_KEY change.
+            # Surface a single aggregate signal, not just scattered per-row warns.
+            logger.error(
+                f"Presence: {len(rows)} BLE IRK(s) present but 0 decryptable — "
+                "SECRET_KEY may have rotated; phone presence will not resolve."
+            )
         logger.info(f"Presence: loaded {len(irks_hex)} BLE IRK(s)")
 
     def set_room_name(self, room_id: int, name: str):

--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -2594,6 +2594,7 @@ _HA_GLUE_REEXPORT_NAMES = frozenset({
     "RoomOutputDevice",
     "RoomSatellite",
     "UserBleDevice",
+    "UserBleIrk",
 })
 
 

--- a/src/backend/services/secret_encryption.py
+++ b/src/backend/services/secret_encryption.py
@@ -2,13 +2,17 @@
 Symmetric encryption for sensitive values stored at rest (e.g. BLE IRKs).
 
 Keys derived deterministically from `settings.secret_key` (the same secret used
-for JWT signing), so no extra key management is needed and rotating SECRET_KEY
-rotates the encryption key. Uses Fernet (AES-128-CBC + HMAC-SHA256, authenticated).
+for JWT signing). Uses Fernet (AES-128-CBC + HMAC-SHA256, authenticated).
 
 IRKs are device-tracking secrets — never store or log them in plaintext.
+
+WARNING: this couples the data key to SECRET_KEY. Rotating SECRET_KEY is a
+DESTRUCTIVE operation for these secrets — every stored value becomes
+permanently undecryptable and must be re-entered. It is not a clean re-key.
 """
 import base64
 import hashlib
+import logging
 from functools import lru_cache
 
 from cryptography.fernet import Fernet, InvalidToken
@@ -17,12 +21,24 @@ from utils.config import settings
 
 __all__ = ["encrypt_secret", "decrypt_secret", "InvalidToken"]
 
+logger = logging.getLogger(__name__)
+
+_DEFAULT_SECRET = "changeme-in-production-use-strong-random-key"
+
 
 @lru_cache(maxsize=1)
 def _fernet() -> Fernet:
     raw = settings.secret_key
     # SecretStr in pydantic; tolerate a plain str too.
     secret = raw.get_secret_value() if hasattr(raw, "get_secret_value") else str(raw)
+    if secret == _DEFAULT_SECRET:
+        # Encrypting a tracking secret under the publicly-known default key is
+        # effectively plaintext — flag loudly (logged once via the cache).
+        logger.warning(
+            "secret_encryption: SECRET_KEY is the insecure default — "
+            "encrypted-at-rest secrets (e.g. BLE IRKs) are NOT protected. "
+            "Set a strong SECRET_KEY."
+        )
     # Derive a stable 32-byte urlsafe-base64 Fernet key from the app secret.
     key = base64.urlsafe_b64encode(hashlib.sha256(secret.encode()).digest())
     return Fernet(key)

--- a/src/backend/services/secret_encryption.py
+++ b/src/backend/services/secret_encryption.py
@@ -1,0 +1,39 @@
+"""
+Symmetric encryption for sensitive values stored at rest (e.g. BLE IRKs).
+
+Keys derived deterministically from `settings.secret_key` (the same secret used
+for JWT signing), so no extra key management is needed and rotating SECRET_KEY
+rotates the encryption key. Uses Fernet (AES-128-CBC + HMAC-SHA256, authenticated).
+
+IRKs are device-tracking secrets — never store or log them in plaintext.
+"""
+import base64
+import hashlib
+from functools import lru_cache
+
+from cryptography.fernet import Fernet, InvalidToken
+
+from utils.config import settings
+
+__all__ = ["encrypt_secret", "decrypt_secret", "InvalidToken"]
+
+
+@lru_cache(maxsize=1)
+def _fernet() -> Fernet:
+    raw = settings.secret_key
+    # SecretStr in pydantic; tolerate a plain str too.
+    secret = raw.get_secret_value() if hasattr(raw, "get_secret_value") else str(raw)
+    # Derive a stable 32-byte urlsafe-base64 Fernet key from the app secret.
+    key = base64.urlsafe_b64encode(hashlib.sha256(secret.encode()).digest())
+    return Fernet(key)
+
+
+def encrypt_secret(plaintext: str) -> str:
+    """Encrypt a string for storage at rest. Returns a Fernet token (str)."""
+    return _fernet().encrypt(plaintext.encode()).decode()
+
+
+def decrypt_secret(token: str) -> str:
+    """Decrypt a Fernet token produced by encrypt_secret(). Raises InvalidToken
+    if the data is corrupt or the key changed."""
+    return _fernet().decrypt(token.encode()).decode()

--- a/src/satellite/renfield_satellite/network/websocket_client.py
+++ b/src/satellite/renfield_satellite/network/websocket_client.py
@@ -129,6 +129,7 @@ class WebSocketClient:
         self._on_update_request: Optional[Callable[[str, str, str, int], None]] = None  # version, url, checksum, size
         self._on_ble_known_devices: Optional[Callable[[List[str]], None]] = None
         self._on_classic_bt_known_devices: Optional[Callable[[List[str]], None]] = None
+        self._on_ble_irks: Optional[Callable[[List[Dict[str, Any]]], None]] = None
         # Backend-pushed LED brightness (night-dimming). Carried both as a live
         # `led_config` message and inside register_ack (mid-night reconnect).
         self._on_led_config: Optional[Callable[[int], None]] = None
@@ -222,6 +223,10 @@ class WebSocketClient:
     def on_ble_known_devices(self, callback: Callable[[List[str]], None]):
         """Register callback for BLE known devices list from server"""
         self._on_ble_known_devices = callback
+
+    def on_ble_irks(self, callback: Callable[[List[Dict[str, Any]]], None]):
+        """Register callback for backend-pushed per-person IRKs."""
+        self._on_ble_irks = callback
 
     def on_classic_bt_known_devices(self, callback: Callable[[List[str]], None]):
         """Register callback for Classic BT known devices list from server"""
@@ -589,6 +594,14 @@ class WebSocketClient:
             print(f"Classic BT known devices received: {len(devices)} MACs")
             if self._on_classic_bt_known_devices:
                 self._on_classic_bt_known_devices(devices)
+
+        elif msg_type == "ble_known_irks":
+            # Server pushed per-person IRKs ([{"name","irk"(hex)}]) for resolving
+            # rotating RPAs to a stable identity.
+            irks = data.get("irks", [])
+            print(f"BLE known IRKs received: {len(irks)}")
+            if self._on_ble_irks:
+                self._on_ble_irks(irks)
 
         elif msg_type == "led_config":
             # Backend pushed a new LED brightness (night-dimming). Guard a

--- a/src/satellite/renfield_satellite/satellite.py
+++ b/src/satellite/renfield_satellite/satellite.py
@@ -298,6 +298,8 @@ class Satellite:
         self.ws_client.on_ble_known_devices(self._on_ble_known_devices)
         # Classic BT known devices callback
         self.ws_client.on_classic_bt_known_devices(self._on_classic_bt_known_devices)
+        # Backend-pushed per-person IRKs (resolve rotating RPAs)
+        self.ws_client.on_ble_irks(self._on_ble_irks_received)
         # Backend-pushed LED brightness (night-dimming)
         self.ws_client.on_led_config(self._on_led_config_update)
         # On-demand camera snapshot (backend occupancy check for private announcements)
@@ -1105,6 +1107,16 @@ class Satellite:
         """Handle Classic BT known devices list pushed from server"""
         self._classic_bt_known_macs = {mac.upper() for mac in devices}
         print(f"Classic BT known devices updated: {len(self._classic_bt_known_macs)} MACs")
+
+    def _on_ble_irks_received(self, irks: list):
+        """Handle per-person IRKs pushed from the backend ([{name, irk(hex)}]).
+        Parses hex → 16 bytes and feeds the scanner's RPA resolver."""
+        parsed = self._parse_irks({item.get("name"): item.get("irk")
+                                   for item in irks if item.get("name") and item.get("irk")})
+        self._ble_irks = parsed
+        if self.ble_scanner is not None:
+            self.ble_scanner.update_irks(parsed)
+        print(f"BLE IRKs updated: {len(parsed)}")
 
     def _on_led_config_update(self, brightness: int):
         """Apply a backend-pushed LED brightness (night-dimming).

--- a/tests/backend/test_ble_irk_store.py
+++ b/tests/backend/test_ble_irk_store.py
@@ -1,0 +1,88 @@
+"""
+Tests for the per-person BLE IRK store: encryption-at-rest, the presence
+service IRK helpers, and identity-based presence routing.
+"""
+import pytest
+
+from services.secret_encryption import decrypt_secret, encrypt_secret, InvalidToken
+
+IRK_HEX = "3a66fe43118690229991659536ef9a4b"
+
+
+def _svc():
+    """A fresh PresenceService without running __init__ (mirrors the suite's
+    existing fixture style), with the IRK caches populated."""
+    from ha_glue.services.presence_service import PresenceService
+    svc = PresenceService.__new__(PresenceService)
+    svc._mac_to_user = {}
+    svc._mac_to_method = {}
+    svc._presence = {}
+    svc._sightings = {}
+    svc._hysteresis_threshold = 2
+    svc._stale_timeout = 120.0
+    svc._rssi_threshold = -80
+    svc._room_names = {}
+    svc._user_names = {}
+    svc._user_first_names = {}
+    svc._user_last_names = {}
+    svc._pending_events = []
+    svc._irk_label_to_user = {}
+    svc._irks_hex = {}
+    return svc
+
+
+@pytest.mark.backend
+@pytest.mark.unit
+class TestSecretEncryption:
+    def test_roundtrip(self):
+        token = encrypt_secret(IRK_HEX)
+        assert token != IRK_HEX          # not stored in plaintext
+        assert decrypt_secret(token) == IRK_HEX
+
+    def test_tampered_token_raises(self):
+        with pytest.raises(InvalidToken):
+            decrypt_secret("not-a-valid-fernet-token")
+
+
+@pytest.mark.backend
+@pytest.mark.unit
+class TestPresenceIRKHelpers:
+    def test_get_ble_irks_shape(self):
+        svc = _svc()
+        svc._irks_hex = {"alice-iphone": IRK_HEX}
+        assert svc.get_ble_irks() == [{"name": "alice-iphone", "irk": IRK_HEX}]
+
+    def test_user_for_key_resolves_irk_and_mac(self):
+        svc = _svc()
+        svc._irk_label_to_user = {"alice-iphone": 7}
+        svc._mac_to_user = {"AA:BB:CC:DD:EE:FF": 3}
+        assert svc._user_for_key("irk:alice-iphone") == 7
+        assert svc._user_for_key("irk:unknown") is None
+        assert svc._user_for_key("AA:BB:CC:DD:EE:FF") == 3
+        assert svc._user_for_key("00:00:00:00:00:00") is None
+
+    @pytest.mark.asyncio
+    async def test_process_ble_report_routes_identity_to_user(self):
+        svc = _svc()
+        svc._irk_label_to_user = {"alice-iphone": 7}
+        # A rotating RPA the satellite resolved to "alice-iphone"
+        await svc.process_ble_report(
+            satellite_id="sat-kitchen",
+            room_id=5,
+            devices=[{"mac": "7E:3C:54:25:17:3E", "rssi": -50, "identity": "alice-iphone"}],
+            room_name="Kitchen",
+        )
+        # Tracked under the stable identity key, not the rotating MAC
+        assert "irk:alice-iphone" in svc._sightings
+        assert "7E:3C:54:25:17:3E" not in svc._sightings
+
+    @pytest.mark.asyncio
+    async def test_process_ble_report_ignores_unknown_identity(self):
+        svc = _svc()  # no IRKs registered
+        await svc.process_ble_report(
+            satellite_id="sat-kitchen",
+            room_id=5,
+            devices=[{"mac": "7E:3C:54:25:17:3E", "rssi": -50, "identity": "ghost"}],
+            room_name="Kitchen",
+        )
+        assert svc._sightings == {}

--- a/tests/backend/test_ble_irk_store.py
+++ b/tests/backend/test_ble_irk_store.py
@@ -86,3 +86,29 @@ class TestPresenceIRKHelpers:
             room_name="Kitchen",
         )
         assert svc._sightings == {}
+
+    @pytest.mark.asyncio
+    async def test_load_irks_skips_undecryptable_rows(self):
+        """A row that fails to decrypt (e.g. SECRET_KEY changed) is skipped while
+        good rows still load — the decrypt-skip silent-failure branch."""
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        svc = _svc()
+        good = SimpleNamespace(label="alice-iphone", irk_encrypted="good-token", user_id=7, is_enabled=True)
+        bad = SimpleNamespace(label="bob-iphone", irk_encrypted="stale-token", user_id=8, is_enabled=True)
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = [good, bad]
+        db = MagicMock()
+        db.execute = AsyncMock(return_value=result)
+
+        def fake_decrypt(token):
+            if token == "good-token":
+                return IRK_HEX
+            raise InvalidToken()
+
+        with patch("services.secret_encryption.decrypt_secret", side_effect=fake_decrypt):
+            await svc._load_irks(db)
+
+        assert svc._irks_hex == {"alice-iphone": IRK_HEX}
+        assert svc._irk_label_to_user == {"alice-iphone": 7}


### PR DESCRIPTION
Backend half of the IRK presence approach (engine: #825). Stores each person's BLE IRK **encrypted at rest** (Fernet via SECRET_KEY), admin API to manage them, and pushes them to satellites (`ble_known_irks` WS) to resolve rotating RPAs → stable identity.

- `user_ble_irks` table + migration pc20260619 (additive).
- services/secret_encryption.py (Fernet); IRK never returned/logged in plaintext.
- presence_service: load/decrypt, push, identity→user routing in process_ble_report.
- API: GET/POST/PATCH/DELETE /api/presence/irks (ADMIN).
- satellite: receive ble_known_irks → RPA resolver.
- tests: encryption, helpers, identity routing, _load_irks decrypt-skip.

**Independent review: safe to merge, no P0/P1**; P2 hardening applied (aggregate decrypt-fail signal, default-SECRET_KEY warning, PATCH enable/disable, decrypt-skip test).

⚠️ Deploy: run migration TARGETED (`alembic upgrade pc20260619_ble_irk_store`) — repo has a 2nd alembic head. Follow-up: HTTP route tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)