### PR TITLE
fix(satellite): add cryptography dep for IRK resolution on the Pi fleet

### DIFF
--- a/src/satellite/provisioning/group_vars/satellites.yml
+++ b/src/satellite/provisioning/group_vars/satellites.yml
@@ -94,6 +94,7 @@ satellite_python_packages:
   - aiohttp
   - requests
   - bleak
+  - cryptography   # IRK-based RPA resolution (ble/rpa.py) — resolve rotating phone addresses
   - Pillow
 
 # XVF3800 LED control


### PR DESCRIPTION
ble/rpa.py needs cryptography (AES) for RPA resolution; it was in the Orange Pi Dockerfile but missing from the Ansible deps, so bare-metal Pis would silently no-op. Adds it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)