### PR TITLE
feat: UI pairing flow for BLE IRK capture ("pair my phone for presence")

### DIFF
--- a/src/backend/ha_glue/api/routes/presence.py
+++ b/src/backend/ha_glue/api/routes/presence.py
@@ -355,6 +355,57 @@ async def create_irk(
     )
 
 
+class BLEIrkCaptureRequest(BaseModel):
+    satellite_id: str
+    user_id: int
+    label: str = Field(..., min_length=1, max_length=100)
+    window_seconds: int = Field(default=60, ge=10, le=180)
+
+
+@router.post("/irks/capture", response_model=BLEIrkResponse, status_code=201)
+async def capture_irk(
+    body: BLEIrkCaptureRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_permission(Permission.ADMIN)),
+):
+    """Drive the UI pairing flow: open a one-time pairing window on a satellite,
+    capture the phone's IRK when it bonds, and store it (encrypted) for `user_id`.
+    The caller shows the user the 'pair to Renfield <room>' prompt meanwhile."""
+    from models.database import User as DBUser, UserBleIrk
+    from services.secret_encryption import encrypt_secret
+    from ha_glue.services.satellite_manager import get_satellite_manager
+
+    if not (await db.execute(select(DBUser).where(DBUser.id == body.user_id))).scalar_one_or_none():
+        raise HTTPException(status_code=404, detail="User not found")
+    if (await db.execute(select(UserBleIrk).where(UserBleIrk.label == body.label))).scalar_one_or_none():
+        raise HTTPException(status_code=409, detail="Label already exists")
+
+    manager = get_satellite_manager()
+    res = await manager.request_irk_capture(body.satellite_id, body.label, body.window_seconds)
+    if res.get("error"):
+        raise HTTPException(status_code=502, detail=f"Capture failed: {res['error']}")
+    irk = (res.get("irk") or "").lower()
+    if len(irk) != 32 or any(c not in "0123456789abcdef" for c in irk):
+        raise HTTPException(status_code=408, detail="No phone paired during the capture window")
+
+    row = UserBleIrk(
+        user_id=body.user_id, label=body.label,
+        irk_encrypted=encrypt_secret(irk), is_enabled=True,
+    )
+    db.add(row)
+    await db.commit()
+    await db.refresh(row)
+
+    presence = get_presence_service()
+    await presence.load_device_registry(db)
+    await presence.push_macs_to_satellites()
+
+    return BLEIrkResponse(
+        id=row.id, user_id=row.user_id, label=row.label, is_enabled=row.is_enabled,
+        created_at=row.created_at.isoformat() if row.created_at else None,
+    )
+
+
 class BLEIrkUpdate(BaseModel):
     is_enabled: bool
 

--- a/src/backend/ha_glue/api/websocket/satellite_handler.py
+++ b/src/backend/ha_glue/api/websocket/satellite_handler.py
@@ -718,6 +718,14 @@ Gib eine kurze, natürliche Antwort. KEIN JSON, nur Text."""
                     data.get("error"),
                 )
 
+            # Reply to an on-demand IRK pairing capture request
+            elif msg_type == "irk_capture_result":
+                satellite_manager.resolve_irk_capture(
+                    data.get("request_id"),
+                    data.get("result"),
+                    data.get("error"),
+                )
+
             # Handle BLE presence scan results
             elif msg_type == "ble_presence":
                 if satellite_id and ha_glue_settings.presence_enabled:

--- a/src/backend/ha_glue/services/satellite_manager.py
+++ b/src/backend/ha_glue/services/satellite_manager.py
@@ -137,6 +137,7 @@ class SatelliteManager:
         # On-demand camera snapshot requests: request_id → Future[image_b64|None].
         self._pending_snapshots: dict[str, asyncio.Future] = {}
         self._pending_bt_scans: dict[str, asyncio.Future] = {}
+        self._pending_irk_captures: dict[str, asyncio.Future] = {}
 
         # Configuration - use settings from config
         from utils.config import settings
@@ -762,6 +763,44 @@ class SatelliteManager:
         fut = self._pending_bt_scans.get(request_id)
         if fut is not None and not fut.done():
             fut.set_result([] if error else (devices or []))
+
+    async def request_irk_capture(
+        self, satellite_id: str, label: str, window_seconds: int = 60,
+        timeout: float | None = None,
+    ) -> dict:
+        """Ask a satellite to open a one-time pairing window and capture a phone's
+        IRK. Returns {'irk','mac','name'} on success, {} on no-bond-in-window, or
+        {'error': ...} on failure/timeout. Mirrors request_bt_scan; the reply
+        arrives as an 'irk_capture_result' message (resolved via resolve_irk_capture)."""
+        sat = self.satellites.get(satellite_id)
+        if sat is None:
+            return {"error": "satellite not connected"}
+        if timeout is None:
+            timeout = window_seconds + 15.0
+        request_id = uuid.uuid4().hex
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        self._pending_irk_captures[request_id] = fut
+        try:
+            await sat.websocket.send_json({
+                "type": "irk_capture_request",
+                "request_id": request_id,
+                "params": {"label": label, "window_seconds": window_seconds},
+            })
+            return await asyncio.wait_for(fut, timeout=timeout)
+        except asyncio.TimeoutError:
+            return {"error": "timed out waiting for the satellite"}
+        except Exception as e:  # noqa: BLE001
+            return {"error": str(e)}
+        finally:
+            self._pending_irk_captures.pop(request_id, None)
+
+    def resolve_irk_capture(
+        self, request_id: str, result: dict | None, error: str | None
+    ) -> None:
+        """Resolve a pending request_irk_capture() future with the satellite's reply."""
+        fut = self._pending_irk_captures.get(request_id)
+        if fut is not None and not fut.done():
+            fut.set_result({"error": error} if error else (result or {}))
 
     async def cleanup_stale(self):
         """Remove stale satellites and timed-out sessions"""

--- a/src/frontend/src/api/resources/presence.ts
+++ b/src/frontend/src/api/resources/presence.ts
@@ -216,3 +216,78 @@ export function useDeletePresenceDevice() {
     'common.error',
   );
 }
+
+// --- Per-person BLE IRK store (resolve rotating phone addresses) ---
+
+export interface BleIrk {
+  id: number;
+  user_id: number;
+  label: string;
+  is_enabled: boolean;
+  created_at?: string | null;
+}
+
+export interface IrkCapturePayload {
+  satellite_id: string;
+  user_id: number;
+  label: string;
+  window_seconds?: number;
+}
+
+async function fetchIrks(): Promise<BleIrk[]> {
+  try {
+    const response = await apiClient.get<BleIrk[]>('/api/presence/irks');
+    return Array.isArray(response.data) ? response.data : [];
+  } catch {
+    return [];
+  }
+}
+
+async function captureIrkRequest(input: IrkCapturePayload): Promise<BleIrk> {
+  // Long-poll: the backend holds the request open for the pairing window.
+  const response = await apiClient.post<BleIrk>('/api/presence/irks/capture', input, {
+    timeout: ((input.window_seconds ?? 60) + 30) * 1000,
+  });
+  return response.data;
+}
+
+async function deleteIrkRequest(id: number): Promise<void> {
+  await apiClient.delete(`/api/presence/irks/${id}`);
+}
+
+export function usePresenceIrksQuery() {
+  return useApiQuery(
+    {
+      queryKey: [...keys.presence.all, 'irks'] as const,
+      queryFn: fetchIrks,
+      staleTime: STALE.DEFAULT,
+    },
+    'common.error',
+  );
+}
+
+export function useCaptureIrk() {
+  const queryClient = useQueryClient();
+  return useApiMutation(
+    {
+      mutationFn: captureIrkRequest,
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: [...keys.presence.all, 'irks'] });
+      },
+    },
+    'common.error',
+  );
+}
+
+export function useDeletePresenceIrk() {
+  const queryClient = useQueryClient();
+  return useApiMutation(
+    {
+      mutationFn: deleteIrkRequest,
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: [...keys.presence.all, 'irks'] });
+      },
+    },
+    'common.error',
+  );
+}

--- a/src/frontend/src/components/presence/IrkPairing.tsx
+++ b/src/frontend/src/components/presence/IrkPairing.tsx
@@ -1,0 +1,143 @@
+/**
+ * IRK pairing flow — "pair my phone for presence".
+ *
+ * Lets an admin open a one-time pairing window on a satellite; the user pairs
+ * their phone from its Bluetooth settings, and the satellite captures the IRK
+ * (encrypted server-side) so the phone's rotating BLE address resolves to a
+ * stable identity for room presence. No app, no hardware.
+ */
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import {
+  usePresenceIrksQuery,
+  useCaptureIrk,
+  useDeletePresenceIrk,
+  usePresenceUsersQuery,
+} from '../../api/resources/presence';
+import { useSatellitesQuery } from '../../api/resources/satellites';
+
+export default function IrkPairing() {
+  const { t } = useTranslation();
+  const irksQuery = usePresenceIrksQuery();
+  const usersQuery = usePresenceUsersQuery();
+  const satellitesQuery = useSatellitesQuery(false);
+  const capture = useCaptureIrk();
+  const deleteIrk = useDeletePresenceIrk();
+
+  const irks = irksQuery.data ?? [];
+  const users = usersQuery.data ?? [];
+  const satellites = satellitesQuery.data?.satellites ?? [];
+
+  const [userId, setUserId] = useState<string>('');
+  const [satelliteId, setSatelliteId] = useState<string>('');
+  const [label, setLabel] = useState<string>('');
+  const [message, setMessage] = useState<string | null>(null);
+
+  const room = satellites.find((s) => s.satellite_id === satelliteId)?.room ?? '';
+  const canStart = userId && satelliteId && label.trim().length > 0 && !capture.isPending;
+
+  const handlePair = async () => {
+    setMessage(null);
+    try {
+      await capture.mutateAsync({
+        satellite_id: satelliteId,
+        user_id: Number(userId),
+        label: label.trim(),
+        window_seconds: 60,
+      });
+      setMessage(t('presence.irk.captured'));
+      setLabel('');
+    } catch {
+      setMessage(t('presence.irk.failed'));
+    }
+  };
+
+  return (
+    <section className="card mt-6">
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+        {t('presence.irk.title')}
+      </h2>
+      <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        {t('presence.irk.description')}
+      </p>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-3">
+        <select
+          className="input"
+          value={userId}
+          onChange={(e) => setUserId(e.target.value)}
+          aria-label={t('presence.irk.user')}
+        >
+          <option value="">{t('presence.irk.selectUser')}</option>
+          {users.map((u) => (
+            <option key={u.id} value={u.id}>{u.username}</option>
+          ))}
+        </select>
+
+        <select
+          className="input"
+          value={satelliteId}
+          onChange={(e) => setSatelliteId(e.target.value)}
+          aria-label={t('presence.irk.satellite')}
+        >
+          <option value="">{t('presence.irk.selectSatellite')}</option>
+          {satellites.map((s) => (
+            <option key={s.satellite_id} value={s.satellite_id}>
+              {s.room || s.satellite_id}
+            </option>
+          ))}
+        </select>
+
+        <input
+          className="input"
+          type="text"
+          value={label}
+          placeholder={t('presence.irk.labelPlaceholder')}
+          onChange={(e) => setLabel(e.target.value)}
+          aria-label={t('presence.irk.label')}
+        />
+      </div>
+
+      <div className="mt-4 flex items-center gap-3">
+        <button className="btn-primary" disabled={!canStart} onClick={handlePair}>
+          {capture.isPending ? t('presence.irk.waiting') : t('presence.irk.startPairing')}
+        </button>
+        {capture.isPending && (
+          <span className="text-sm text-amber-600 dark:text-amber-400">
+            {t('presence.irk.instructions', { room: room || t('presence.irk.theSatellite') })}
+          </span>
+        )}
+      </div>
+
+      {message && (
+        <p className="mt-2 text-sm text-gray-700 dark:text-gray-300">{message}</p>
+      )}
+
+      {irks.length > 0 && (
+        <ul className="mt-5 divide-y divide-gray-200 dark:divide-gray-700">
+          {irks.map((irk) => {
+            const owner = users.find((u) => u.id === irk.user_id)?.username ?? `#${irk.user_id}`;
+            return (
+              <li key={irk.id} className="flex items-center justify-between py-2">
+                <span className="text-sm text-gray-800 dark:text-gray-200">
+                  {irk.label} <span className="text-gray-400">· {owner}</span>
+                  {!irk.is_enabled && (
+                    <span className="ml-2 text-xs text-gray-400">({t('presence.irk.disabled')})</span>
+                  )}
+                </span>
+                <button
+                  className="btn-secondary text-sm"
+                  onClick={() => deleteIrk.mutate(irk.id)}
+                  disabled={deleteIrk.isPending}
+                >
+                  {t('presence.irk.revoke')}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -926,6 +926,24 @@
     }
   },
   "presence": {
+    "irk": {
+      "title": "Telefon-Präsenz (BLE-Kopplung)",
+      "description": "Koppeln Sie ein Telefon einmalig, damit seine wechselnde Bluetooth-Adresse einer festen Identität für die Raumpräsenz zugeordnet wird. Keine App nötig.",
+      "user": "Benutzer",
+      "selectUser": "Benutzer wählen…",
+      "satellite": "Satellit",
+      "selectSatellite": "Satellit wählen…",
+      "label": "Bezeichnung",
+      "labelPlaceholder": "z. B. eduard-iphone",
+      "startPairing": "Kopplung starten",
+      "waiting": "Warte auf Telefon…",
+      "instructions": "Am Telefon: Einstellungen → Bluetooth → „Renfield {{room}}“ antippen.",
+      "theSatellite": "den Satelliten",
+      "captured": "Gekoppelt — Telefon-Präsenz wird jetzt erfasst.",
+      "failed": "Kein Telefon rechtzeitig gekoppelt. Bitte erneut versuchen.",
+      "disabled": "deaktiviert",
+      "revoke": "Entfernen"
+    },
     "title": "Anwesenheit",
     "subtitle": "Wer ist wo — Raumpräsenz via BLE, Sprache und Web",
     "roomOccupancy": "Raumbelegung",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -926,6 +926,24 @@
     }
   },
   "presence": {
+    "irk": {
+      "title": "Phone presence (BLE pairing)",
+      "description": "Pair a phone once so its rotating Bluetooth address resolves to a stable identity for room presence. No app required.",
+      "user": "User",
+      "selectUser": "Select user…",
+      "satellite": "Satellite",
+      "selectSatellite": "Select satellite…",
+      "label": "Label",
+      "labelPlaceholder": "e.g. eduard-iphone",
+      "startPairing": "Start pairing",
+      "waiting": "Waiting for phone…",
+      "instructions": "On the phone: Settings → Bluetooth → tap “Renfield {{room}}”.",
+      "theSatellite": "the satellite",
+      "captured": "Paired — phone presence is now tracked.",
+      "failed": "No phone paired in time. Try again.",
+      "disabled": "disabled",
+      "revoke": "Revoke"
+    },
     "title": "Presence",
     "subtitle": "Who is where — room presence via BLE, voice, and web",
     "roomOccupancy": "Room Occupancy",

--- a/src/frontend/src/pages/PresencePage.tsx
+++ b/src/frontend/src/pages/PresencePage.tsx
@@ -19,6 +19,7 @@ import PageHeader from '../components/PageHeader';
 import Alert from '../components/Alert';
 import Badge from '../components/Badge';
 import AnalyticsTab from '../components/presence/AnalyticsTab';
+import IrkPairing from '../components/presence/IrkPairing';
 import {
   usePresenceRoomsQuery,
   usePresenceDevicesQuery,
@@ -564,6 +565,8 @@ export default function PresencePage() {
           </div>
         </div>
       )}
+
+      <IrkPairing />
 
       <AddDeviceModal
         isOpen={showAddDevice}

--- a/src/satellite/Dockerfile
+++ b/src/satellite/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         mpv libmpv2 \
         libsamplerate0 libopenblas0 \
         libusb-1.0-0 \
+        bluez bluez-tools \
         ca-certificates curl \
     && rm -rf /var/lib/apt/lists/*
 

--- a/src/satellite/renfield_satellite/network/websocket_client.py
+++ b/src/satellite/renfield_satellite/network/websocket_client.py
@@ -137,6 +137,8 @@ class WebSocketClient:
         self._capture_snapshot: Optional[Callable[[], Any]] = None
         # Async callback(params) -> list[dict] for an on-demand BT discovery scan.
         self._on_bt_scan_request: Optional[Callable[[Dict[str, Any]], Any]] = None
+        # Async callback(params) -> dict for a backend-requested IRK pairing capture.
+        self._on_irk_capture: Optional[Callable[[Dict[str, Any]], Any]] = None
 
         # Tasks
         self._heartbeat_task: Optional[asyncio.Task] = None
@@ -240,6 +242,11 @@ class WebSocketClient:
         """Register async callback(params)->list[dict] for a backend-requested
         Bluetooth discovery scan. Returns the discovered device list."""
         self._on_bt_scan_request = callback
+
+    def on_irk_capture(self, callback: Callable[[Dict[str, Any]], Any]):
+        """Register async callback(params)->dict for a backend-requested IRK
+        pairing capture. Returns {'irk': hex, 'mac': str, 'name': str} or {}."""
+        self._on_irk_capture = callback
 
     def set_metrics_callback(self, callback: Callable[[], Dict[str, Any]]):
         """Register callback to get current metrics for heartbeat"""
@@ -625,6 +632,36 @@ class WebSocketClient:
             asyncio.create_task(
                 self._handle_bt_scan(data.get("request_id"), data.get("params", {}))
             )
+
+        elif msg_type == "irk_capture_request":
+            # Backend asked us to open a one-time pairing window and capture a
+            # phone's IRK. Async so the capture window never blocks receive.
+            asyncio.create_task(
+                self._handle_irk_capture(data.get("request_id"), data.get("params", {}))
+            )
+
+    async def _handle_irk_capture(self, request_id, params):
+        """Run the IRK pairing capture and send back an irk_capture_result.
+        Always replies (result=None + error on failure) so the backend never hangs."""
+        result = None
+        error = None
+        try:
+            if self._on_irk_capture is not None:
+                result = await self._on_irk_capture(params or {})
+            else:
+                error = "irk_capture not supported on this satellite"
+        except Exception as e:  # noqa: BLE001
+            error = str(e)
+            print(f"IRK capture failed: {e}")
+        try:
+            await self._send({
+                "type": "irk_capture_result",
+                "request_id": request_id,
+                "result": result,
+                "error": error,
+            })
+        except Exception as e:  # noqa: BLE001
+            print(f"Failed to send irk_capture_result: {e}")
 
     async def _handle_bt_scan(self, request_id, params):
         """Run the BT discovery scan and send back a bt_scan_result. Always

--- a/src/satellite/renfield_satellite/satellite.py
+++ b/src/satellite/renfield_satellite/satellite.py
@@ -306,6 +306,8 @@ class Satellite:
         self.ws_client._capture_snapshot = self._capture_snapshot_for_request
         # On-demand Bluetooth discovery scan ("scan all bluetooth devices")
         self.ws_client.on_bt_scan_request(self._handle_bt_scan_for_request)
+        # On-demand IRK pairing capture (UI "pair my phone for presence")
+        self.ws_client.on_irk_capture(self._capture_irk_for_request)
 
         # Update manager progress callback
         self.update_manager.on_progress(self._on_update_progress)
@@ -488,6 +490,92 @@ class Satellite:
             params.get("ble_duration", 10.0),
             params.get("classic_timeout", 12.0),
         )
+
+    @staticmethod
+    def _read_bonded_irks(bt_root: str = "/var/lib/bluetooth") -> dict:
+        """Map bonded-device MAC -> IRK hex from BlueZ's store. BlueZ does not
+        expose bonding keys over D-Bus, so we read the on-disk info files
+        (requires root / a hostPath mount in the k8s pod)."""
+        import glob
+        import os
+        found = {}
+        for info_path in glob.glob(f"{bt_root}/*/*/info"):
+            try:
+                with open(info_path) as fh:
+                    txt = fh.read()
+            except OSError:
+                continue
+            if "[IdentityResolvingKey]" not in txt:
+                continue
+            mac = os.path.basename(os.path.dirname(info_path)).upper()
+            irk = None
+            in_section = False
+            for raw in txt.splitlines():
+                line = raw.strip()
+                if line == "[IdentityResolvingKey]":
+                    in_section = True
+                    continue
+                if in_section and line.startswith("["):
+                    break
+                if in_section and line.startswith("Key="):
+                    irk = line.split("=", 1)[1].strip()
+                    break
+            if irk:
+                found[mac] = irk
+        return found
+
+    async def _capture_irk_for_request(self, params: dict) -> dict:
+        """Open a one-time pairing window, let a phone bond, and capture its IRK
+        from BlueZ; re-secure the adapter afterward. Returns
+        {'irk': hex, 'mac': str, 'name': label} or {} (no new bond in time).
+        Raises (→ surfaced as error) if the BlueZ store isn't readable."""
+        import asyncio as _aio
+        import os
+
+        label = params.get("label") or "device"
+        window = int(params.get("window_seconds", 60))
+        bt_root = "/var/lib/bluetooth"
+
+        if not os.path.isdir(bt_root) or not os.access(bt_root, os.R_OK):
+            raise RuntimeError(
+                f"{bt_root} not readable — IRK capture needs root / a hostPath mount"
+            )
+
+        async def _bctl(*args):
+            proc = await _aio.create_subprocess_exec(
+                "bluetoothctl", *args,
+                stdout=_aio.subprocess.DEVNULL, stderr=_aio.subprocess.DEVNULL,
+            )
+            await proc.wait()
+
+        before = set(self._read_bonded_irks(bt_root).keys())
+        await _bctl("system-alias", f"Renfield {self.config.satellite.room}")
+        await _bctl("power", "on")
+        await _bctl("pairable", "on")
+        await _bctl("discoverable-timeout", "0")
+        await _bctl("discoverable", "on")
+        agent = await _aio.create_subprocess_exec(
+            "bt-agent", "-c", "NoInputNoOutput",
+            stdout=_aio.subprocess.DEVNULL, stderr=_aio.subprocess.DEVNULL,
+        )
+        print(f"IRK capture window open ({window}s) — pair the phone now")
+        try:
+            for _ in range(window):
+                await _aio.sleep(1)
+                current = self._read_bonded_irks(bt_root)
+                new_macs = set(current.keys()) - before
+                if new_macs:
+                    mac = sorted(new_macs)[0]
+                    print(f"IRK captured for newly-bonded {mac}")
+                    return {"irk": current[mac], "mac": mac, "name": label}
+            return {}
+        finally:
+            await _bctl("discoverable", "off")
+            await _bctl("pairable", "off")
+            try:
+                agent.terminate()
+            except ProcessLookupError:
+                pass
 
     async def _reconnect_with_discovery(self):
         """

--- a/tests/satellite/test_irk_capture_parse.py
+++ b/tests/satellite/test_irk_capture_parse.py
@@ -1,0 +1,51 @@
+"""
+Unit test for the BlueZ info-file IRK parser used by the UI pairing-capture flow
+(Satellite._read_bonded_irks). Verifies it extracts the IdentityResolvingKey and
+ignores devices/sections without one.
+"""
+import os
+
+import pytest
+
+from renfield_satellite.satellite import Satellite
+
+_WITH_IRK = """[General]
+Name=Karnak
+
+[IdentityResolvingKey]
+Key=3A66FE43118690229991659536EF9A4B
+
+[LinkKey]
+Key=0123456789ABCDEF0123456789ABCDEF
+"""
+
+_NO_IRK = """[General]
+Name=Speaker
+
+[LinkKey]
+Key=FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+"""
+
+
+@pytest.mark.satellite
+@pytest.mark.unit
+def test_read_bonded_irks_extracts_only_irk(tmp_path):
+    adapter = tmp_path / "10:11:12:13:14:15"
+    # device with an IRK
+    d1 = adapter / "4C:E6:C0:27:52:93"
+    d1.mkdir(parents=True)
+    (d1 / "info").write_text(_WITH_IRK)
+    # device without an IRK (e.g. a Classic speaker) — must be ignored
+    d2 = adapter / "AA:BB:CC:DD:EE:FF"
+    d2.mkdir(parents=True)
+    (d2 / "info").write_text(_NO_IRK)
+
+    result = Satellite._read_bonded_irks(str(tmp_path))
+
+    assert result == {"4C:E6:C0:27:52:93": "3A66FE43118690229991659536EF9A4B"}
+
+
+@pytest.mark.satellite
+@pytest.mark.unit
+def test_read_bonded_irks_missing_root(tmp_path):
+    assert Satellite._read_bonded_irks(str(tmp_path / "nope")) == {}


### PR DESCRIPTION
Full-stack 'pair my phone for presence' flow on top of the IRK store (#826).

**Mechanism** (12d0120): backend→satellite `irk_capture_request`/`irk_capture_result` (mirrors capture_snapshot/bt_scan); satellite opens a bounded BlueZ pairing window (discoverable + bt-agent), reads the bonded phone's IRK from /var/lib/bluetooth, re-secures; `POST /api/presence/irks/capture` stores it encrypted. Dockerfile gains bluez/bluez-tools. Parser unit-test.

**Frontend**: IrkPairing card in PresencePage (user/satellite/label → long-poll capture with on-phone instructions → store/list/revoke); de+en i18n; typechecks clean.

⚠️ Deploy: backend IRK store (#826) + satellite image rebuild with a **/var/lib/bluetooth RO hostPath mount** on the pod (BlueZ keys aren't on D-Bus); bare-metal Pis need sudo for the read. Follow-ups: Vitest component test, HTTP route tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)