### PR TITLE
chore(satellite): Esszimmer v5 + /var/lib/bluetooth mount

### DIFF
--- a/k8s/satellite-esszimmer.yaml
+++ b/k8s/satellite-esszimmer.yaml
@@ -119,7 +119,7 @@ spec:
                     values: ["arm64"]
       containers:
         - name: satellite
-          image: renfield/satellite:esszimmer-v4
+          image: renfield/satellite:esszimmer-v5
           imagePullPolicy: Never   # imported into node containerd (k8s.io ns)
           securityContext:
             privileged: true        # raw /dev access for USB audio + xvf_host
@@ -145,6 +145,9 @@ spec:
               mountPath: /dev/bus/usb
             - name: dbus
               mountPath: /run/dbus
+            - name: bluetooth
+              mountPath: /var/lib/bluetooth
+              readOnly: true
           resources:
             requests:
               cpu: "250m"
@@ -165,3 +168,8 @@ spec:
         - name: dbus
           hostPath:
             path: /run/dbus
+        # RO read of BlueZ bonding keys — needed to capture an IRK during the UI
+        # pairing flow (BlueZ does not expose IRKs over D-Bus).
+        - name: bluetooth
+          hostPath:
+            path: /var/lib/bluetooth


### PR DESCRIPTION
Sync the deployed Esszimmer manifest: v5 image + the approved /var/lib/bluetooth RO mount for UI IRK capture. Deployed + verified (iPhone resolves via BLE on v5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)