### PR TITLE
docs: BLE phone presence (IRK) + Esszimmer k8s satellite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Renfield is a fully offline-capable, self-hosted **digital assistant** — a personal AI hub for knowledge retrieval, tool access, and smart home control. Serves multiple household users in parallel.
 
-**Tech Stack:** Python 3.11 + FastAPI + SQLAlchemy | React 18 + TypeScript + Vite + Tailwind CSS + PWA | Docker Compose, PostgreSQL 16, Redis 7, Ollama | Satellites: Pi Zero 2 W + ReSpeaker + OpenWakeWord
+**Tech Stack:** Python 3.11 + FastAPI + SQLAlchemy | React 18 + TypeScript + Vite + Tailwind CSS + PWA | Docker Compose, PostgreSQL 16, Redis 7, Ollama | Satellites: Pi Zero 2 W + ReSpeaker + OpenWakeWord (bare-metal via Ansible). The Esszimmer satellite is the first **arm64 / k8s-pod** satellite — an Orange Pi Zero 3W (Allwinner A733) with a USB ReSpeaker XVF3800, run as a node-pinned privileged pod (`k8s/satellite-esszimmer.yaml`); see the **BLE phone presence** note below.
 
 **LLM:** Local models via Ollama (multi-model: chat, intent, RAG, agent, vision, embeddings).
 
@@ -77,6 +77,17 @@ docker exec -it renfield-backend alembic downgrade -1
 **Key config:** All via `.env` loaded by `utils/config.py` (Pydantic Settings). Full list: `docs/ENVIRONMENT_VARIABLES.md`.
 
 For architecture questions, use the `architecture-guide` agent.
+
+### BLE phone presence via IRK resolution + the k8s satellite
+
+Modern phones advertise a **rotating** BLE Resolvable Private Address (RPA), so a static MAC whitelist can't track them. Renfield resolves the rotating address back to a stable identity using the device's **Identity Resolving Key (IRK)** — the same mechanism as Home Assistant's *Private BLE Device* / Bermuda. No app, no extra hardware. Design + status: [`docs/design/ble-presence-improvement.md`](docs/design/ble-presence-improvement.md) (SHIPPED + DEPLOYED).
+
+- **Resolver** (`src/satellite/renfield_satellite/ble/rpa.py`): the BLE-spec `ah` hash (AES-128, validated against the spec vector); pure software on scanned adverts → works on any adapter (no raw HCI / Classic-BT / bonding). The continuous scanner (`ble/scanner.py`, `ble.continuous`) keeps one `BleakScanner` running with EWMA-smoothed RSSI; default stays periodic.
+- **Backend IRK store** (`user_ble_irks`, migration `pc20260619`): per-person IRK **encrypted at rest** via `services/secret_encryption.py` (Fernet from `SECRET_KEY` — rotating `SECRET_KEY` is destructive to these secrets). Admin API `GET/POST/PATCH/DELETE /api/presence/irks` (the IRK is **never returned**). Pushed to satellites via the `ble_known_irks` WS message; `presence_service.process_ble_report` maps a resolved `identity` back to the user (`irk:<label>` key, survives rotation).
+- **UI pairing flow** ("pair my phone for presence", `components/presence/IrkPairing.tsx`): `POST /api/presence/irks/capture` → `satellite_manager.request_irk_capture` → the satellite opens a bounded BlueZ pairing window (`_capture_irk_for_request`: discoverable + `bt-agent`), reads the bonded phone's IRK from `/var/lib/bluetooth` (BlueZ doesn't expose IRKs over D-Bus), re-secures, replies `irk_capture_result`; the backend stores it encrypted. Mirrors the `capture_snapshot`/`bt_scan_request` request-response pattern.
+- **The Esszimmer k8s satellite** (`k8s/satellite-esszimmer.yaml`): node-pinned privileged pod, `hostNetwork`, `hostAliases renfield.local→Traefik LB`, hostPath `/dev/snd` + `/dev/bus/usb` (USB audio + XVF3800 LED via `xvf_host`) + `/run/dbus` (BLE via host BlueZ) + **`/var/lib/bluetooth` RO** (IRK capture). Image built on the Pi, imported into the node containerd (`ctr -n k8s.io images import`), `imagePullPolicy: Never`. The custom `hey_renfield.onnx` wakeword model + personal device MACs/IRKs live in the image build context / backend DB, never in git.
+- **Bonded vs resolver:** a satellite that has *bonded* the phone (Esszimmer did) lets BlueZ resolve the RPA to the identity MAC natively → it's tracked as a normal `ble` known-device. Non-bonded satellites use the pushed IRK + the software resolver. Device identities live in the **backend known-devices DB** (`UserBleDevice`) — not in the manifest. With the BLE stack on multiple satellites, the backend's `_assign_room` does multi-satellite RSSI arbitration (mean RSSI + per-extra-satellite bonus + hysteresis).
+- Deploy note: the satellite image needs `bluez`/`bluez-tools` + `cryptography`; bare-metal Pis need the `cryptography` dep (in the Ansible `satellite_python_packages`) and `sudo` for the `/var/lib/bluetooth` read.
 
 ### Platform-owned internal agent tools
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -446,6 +446,7 @@ RAG_CONTEXT_WINDOW=1              # Benachbarte Chunks (0=deaktiviert)
 - **Hardware-Button** — Manuelle Aktivierung
 - **Auto-Discovery** — Backend-Erkennung via Zeroconf/mDNS
 - **OTA-Updates** — Version-Tracking und Update-Pakete
+- **Orange Pi / k8s-Variante** — der Esszimmer-Satellit ist der erste **arm64-/k8s-Pod**-Satellit: ein Orange Pi Zero 3W (Allwinner A733) mit USB-ReSpeaker XVF3800, als node-fixierter privilegierter Pod im privaten Cluster (`k8s/satellite-esszimmer.yaml`) statt bare-metal. Stärkeres Bluetooth (BT 5.4) → gut geeignet als BLE-Präsenz-Anker.
 
 ### Zentrale Wake-Word-Verwaltung
 - Admin-UI für zentrale Konfiguration
@@ -867,6 +868,14 @@ Jeder Raumwechsel (`enter`/`leave`) wird dauerhaft in `presence_events` protokol
 "Scanne die Bluetooth-Geräte" → das Tool `internal.bluetooth_scan` fächert eine Discovery an alle Satelliten aus (Backend hat keine BT-Hardware). Jeder Satellit führt eine Classic-BT-Inquiry (`hcitool scan`) **und** eine BLE-Discovery (`BleakScanner`) aus; das Backend dedupliziert per MAC, behält das stärkste RSSI, sammelt pro Raum und löst die Herstellerkennung (OUI→Vendor) auf. Ergebnis: Adresse, Name (oft leer), Raum/Satellit, RSSI, Hersteller.
 
 Hinweise: nur **sichtbare/advertisende** Geräte erscheinen (die meisten Handys sind standardmäßig nicht auffindbar); ein Scan dauert ~15-30 s. Opt-in via `BT_SCAN_ENABLED` (zählt alle Geräte im Haus auf → Privatsphäre).
+
+### Telefon-Präsenz per IRK (rotierende BLE-Adressen auflösen)
+
+Moderne Telefone senden eine **rotierende** BLE-Adresse (Resolvable Private Address), daher kann eine feste MAC-Whitelist sie nicht verfolgen. Renfield löst die wechselnde Adresse über den **Identity Resolving Key (IRK)** des Geräts auf eine stabile Identität auf — dasselbe Verfahren wie Home Assistants *Private BLE Device* / Bermuda. **Keine App, keine Zusatz-Hardware.** Reines Software-Matching (AES-128, BLE-Spec `ah`-Hash) auf den gescannten Advertisements → funktioniert auf jedem Adapter (kein rohes HCI, kein Classic-BT, kein Pairing nötig zur Auflösung).
+
+**IRK-Erfassung über die UI** ("Telefon für Präsenz koppeln", auf der Anwesenheits-Seite): Admin wählt Nutzer + Satellit + Bezeichnung → der gewählte Satellit öffnet ein einmaliges, zeitlich begrenztes Kopplungsfenster (auto-akzeptierender BlueZ-Agent). Der Nutzer koppelt das Telefon über **Einstellungen → Bluetooth → „Renfield \<Raum\>"**; der Satellit liest den dabei ausgetauschten IRK aus BlueZ, sichert den Adapter wieder ab und meldet ihn zurück. Der IRK wird **verschlüsselt at rest** gespeichert (Fernet aus `SECRET_KEY`) und über die WS-Verbindung an die Satelliten verteilt; er wird **nie** in einer API-Antwort oder im Log im Klartext zurückgegeben. Verwaltung: `GET/POST/PATCH/DELETE /api/presence/irks` (Admin). Entkoppeln/Widerrufen am Telefon **oder** über „Entfernen" in der UI.
+
+**Kontinuierliches Scannen** (`ble.continuous`, opt-in pro Satellit): ein dauerhaft laufender Scanner mit EWMA-geglättetem RSSI statt periodischer Bursts → geringere Latenz + ruhigere Raumzuordnung; Standard bleibt periodisch. Bei mehreren Satelliten mit aktivem BLE-Stack führt das Backend eine **Multi-Satelliten-Raumzuordnung** durch (mittleres RSSI + Bonus je zusätzlichem Satelliten + Hysterese). Design + Status: `docs/design/ble-presence-improvement.md`.
 
 ## Tageszeit-Bewusstsein & LED-Nachtdimmung
 

--- a/docs/design/ble-presence-improvement.md
+++ b/docs/design/ble-presence-improvement.md
@@ -52,7 +52,14 @@ needs Experimental (now enabled). Follow-on to the continuous callback above.
 Median/EWMA + hand-off hysteresis in the room-arbitration logic to kill
 flip-flop. Touches the production backend → its own reviewed change.
 
-### Phase 2 — Defeat MAC randomization via IRK-based RPA resolution  🔶 IN PROGRESS (the real win)
+> **STATUS 2026-06-19: SHIPPED + DEPLOYED.** Phase 1 (continuous scan + BlueZ
+> Experimental) and Phase 2 (IRK store + RPA resolution + UI pairing flow) are
+> merged (#825/#826/#828/#829) and live: backend IRK store deployed, the
+> Esszimmer Orange Pi satellite resolves an iPhone via BLE, and the BLE stack is
+> rolled out to the Pi fleet (multi-satellite room arbitration active). Phases
+> 1b/1c/3 remain deferred.
+
+### Phase 2 — Defeat MAC randomization via IRK-based RPA resolution  ✅ SHIPPED + DEPLOYED (the real win)
 **Corrected mechanism** (the original "bond the phone to the satellite" is
 infeasible — iOS/Android won't expose themselves for passive bonding). Instead,
 the same approach Home Assistant's *Private BLE Device* / Bermuda use, which is


### PR DESCRIPTION
Documents the shipped IRK BLE presence feature + the first arm64/k8s satellite (CLAUDE.md subsystem note + subsection, FEATURES.md entries, design-doc status → shipped). Per the doc-update gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)