### PR TITLE
feat(chat): show branch switcher immediately after a fork

### DIFF
--- a/src/frontend/src/main.tsx
+++ b/src/frontend/src/main.tsx
@@ -18,7 +18,7 @@ import './i18n';
 // it (re-fetching the current CSP) and propagates. So: when you change a served
 // HTTP header (CSP etc.) without any other frontend change, BUMP THIS so the fix
 // reaches existing PWA clients. See reference_pwa_sw_nocache_nginx.
-const __BUILD_STAMP__ = '2026-06-19.chat-branching-phase2';
+const __BUILD_STAMP__ = '2026-06-20.branch-switcher-fork-reload';
 console.info(`Renfield frontend build ${__BUILD_STAMP__}`);
 
 // Edition selector for theme tokens. When VITE_APP_EDITION=pro, the

--- a/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
+++ b/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
@@ -593,6 +593,15 @@ export function ChatProvider({ children }: ChatProviderProps) {
   // to a no-op; assigned after speakText is declared below.
   const speakTextRef = useRef<(text: string) => Promise<void>>(async () => undefined);
 
+  // Chat branching (Phase 2): when the in-flight turn is a FORK (edit/regenerate),
+  // its `done` frame has created a new sibling — but the WS stream carries no
+  // branch metadata, so the ‹n/m› switcher only appears once history is reloaded.
+  // `sendMessageInternal` arms this flag for a forked turn; `handleStreamDone`
+  // reloads history once when it sees it set (via reloadHistoryRef — reloadHistory
+  // is declared further below, same forward-reference pattern as speakTextRef).
+  const pendingForkReloadRef = useRef(false);
+  const reloadHistoryRef = useRef<() => Promise<void>>(async () => undefined);
+
   // Sentence-streaming auto-TTS (option A). Tracks accumulated chat
   // content so we can dispatch each completed sentence as its own
   // tts_request as the LLM streams. The voice-server's tts handler
@@ -845,6 +854,14 @@ export function ChatProvider({ children }: ChatProviderProps) {
     // Turn finished cleanly — no longer a live WS stream for reconnect to interrupt.
     wsStreamingTurnRef.current = false;
     setLoading(false);
+
+    // Chat branching (Phase 2): a forked turn just landed — reload history so the
+    // new sibling's ‹n/m› switcher renders immediately (the WS stream carries no
+    // branch metadata). One-shot; ignored on a normal append.
+    if (pendingForkReloadRef.current) {
+      pendingForkReloadRef.current = false;
+      void reloadHistoryRef.current();
+    }
   }, [resumeWakeWord]);
 
   // Sentence boundary regex for streaming TTS dispatch. Matches a
@@ -1727,6 +1744,12 @@ export function ChatProvider({ children }: ChatProviderProps) {
       // The turn is now streaming over the WS; a mid-stream socket drop makes it
       // recoverable (the reconnect effect clears the spinner + notifies).
       wsStreamingTurnRef.current = true;
+      // Chat branching (Phase 2): a forked turn → reload history on `done` so the
+      // new sibling's ‹n/m› switcher renders immediately. Armed only on a
+      // confirmed WS send (the REST fallback doesn't carry the fork).
+      if (typeof opts?.forkFromMessageId === 'number') {
+        pendingForkReloadRef.current = true;
+      }
       setRagSources([]);
     } else {
       try {
@@ -1811,6 +1834,8 @@ export function ChatProvider({ children }: ChatProviderProps) {
       console.error('Failed to reload history after branch change:', err);
     }
   }, [sessionId, loadConversationHistory]);
+  // Expose to handleStreamDone (declared earlier) via the forward-ref.
+  reloadHistoryRef.current = reloadHistory;
 
   // Switch the active branch to the sibling identified by `messageId` (the ◂/▸
   // switcher). The backend repoints the active leaf to that sibling's subtree


### PR DESCRIPTION
## Summary
Phase 2 UX polish (follow-up to #832). Edit/regenerate stream the new sibling over WS, which carries no branch metadata, so the `‹n/m›` switcher only appeared after a manual history reload. Now a forked turn reloads history once on the `done` frame so the switcher renders immediately.

- `sendMessageInternal` arms a one-shot `pendingForkReloadRef` on a confirmed WS send when `forkFromMessageId` is set.
- `handleStreamDone` consumes it after the turn finalizes → `reloadHistory()` (reached via a forward-ref `reloadHistoryRef`, same pattern as `speakTextRef`, since `reloadHistory` is declared later).
- No-op on a normal append.

## Test plan
- `tsc` clean for ChatContext; eslint clean (no new warnings; refs need no deps).
- Frontend-only; no backend / migration.
- Will browser-verify live: regenerate a turn → switcher appears without a manual reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)