### PR TITLE
fix(router): route list/table requests to the tool-capable general role

### DIFF
--- a/config/agent_roles.yaml
+++ b/config/agent_roles.yaml
@@ -135,8 +135,8 @@ roles:
 
   general:
     description:
-      de: "Allgemein: Komplexe oder domainuebergreifende Anfragen"
-      en: "General: complex or cross-domain queries"
+      de: "Allgemein: Komplexe oder domainuebergreifende Anfragen; AUCH wenn der Nutzer Daten oder Fakten ausdruecklich als LISTE oder TABELLE dargestellt haben moechte (z.B. 'liste ... auf', 'zeig mir eine Liste/Tabelle von ...', 'erstelle eine Tabelle mit/der ...', 'vergleiche ... als Tabelle')"
+      en: "General: complex or cross-domain queries; ALSO when the user explicitly wants data or facts shown as a LIST or TABLE (e.g. 'list ...', 'show me a list/table of ...', 'create a table of ...', 'compare ... as a table')"
     mcp_servers: null
     internal_tools: null
     max_steps: 12
@@ -144,6 +144,6 @@ roles:
 
   conversation:
     description:
-      de: "Konversation & Texterstellung: Smalltalk, Allgemeinwissen, Meinungen, sowie das Verfassen/Erstellen von Texten, Dokumenten, Fragebögen, Checklisten, Konzepten, Plänen, Vorlagen — KEINE Aktion und KEINE Weitergabe einer Nachricht an eine Person (eine Nachricht ausrichten gehoert zu 'presence')"
-      en: "Conversation & writing: smalltalk, general knowledge, opinions, and writing/creating text, documents, questionnaires, checklists, concepts, plans, templates — NO action and NOT relaying a message to a person (relaying a message belongs to 'presence')"
+      de: "Konversation & Texterstellung: Smalltalk, Allgemeinwissen, Meinungen, sowie das Verfassen/Erstellen von Texten, Dokumenten, Fragebögen, Checklisten, Konzepten, Plänen, Vorlagen — KEINE Aktion und KEINE Weitergabe einer Nachricht an eine Person (eine Nachricht ausrichten gehoert zu 'presence'). NICHT hierher, wenn der Nutzer Daten/Fakten ausdruecklich als LISTE oder TABELLE dargestellt haben moechte (das gehoert zu 'general')"
+      en: "Conversation & writing: smalltalk, general knowledge, opinions, and writing/creating text, documents, questionnaires, checklists, concepts, plans, templates — NO action and NOT relaying a message to a person (relaying a message belongs to 'presence'). NOT here when the user explicitly wants data/facts shown as a LIST or TABLE (that belongs to 'general')"
     # No agent loop - direct LLM response


### PR DESCRIPTION
Gen-UI follow-up (#835). Live verification showed a general-knowledge "list/table on request" classified as `conversation` (no agent loop / no tools) → markdown prose, never the `render_list`/`render_table` widget. Tightens the `general` + `conversation` role descriptions so explicit "show data as a LIST or TABLE" requests route to `general` (which has the render tools).

Live-verified after the ConfigMap patch: weather, list ("fünf größten Länder"), and table ("vier Himmelsrichtungen") all render as widgets. ConfigMap-served — already patched live; this syncs the repo source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)