### PR TITLE
fix(chat): device toggle resolves new state from action, not a stale re-read

### DIFF
--- a/src/backend/ha_glue/services/internal_tools.py
+++ b/src/backend/ha_glue/services/internal_tools.py
@@ -469,10 +469,12 @@ class InternalToolService:
             from ha_glue.integrations.homeassistant import HomeAssistantClient
             ha = HomeAssistantClient()
             # Existence probe — a non-existent entity_id (or a state read failure)
-            # must not actuate. None → reject.
+            # must not actuate. None → reject. Also yields the PRIOR state so we
+            # can resolve the new state deterministically (below).
             state = await ha.get_state(entity_id)
             if not state:
                 return {"success": False, "message": f"Gerät {entity_id} nicht gefunden", "action_taken": False}
+            prior = (state or {}).get("state", "unknown")
 
             if domain == "scene":
                 ok = await ha.call_service("scene", "turn_on", entity_id)
@@ -481,10 +483,18 @@ class InternalToolService:
             if not ok:
                 return {"success": False, "message": f"Schalten von {entity_id} fehlgeschlagen", "action_taken": False}
 
-            # Re-read so the widget reconciles to the real new state. A scene has
-            # no on/off state — report 'on' transiently for UI feedback.
-            new_state = await ha.get_state(entity_id)
-            resolved = (new_state or {}).get("state", "unknown") if domain != "scene" else "on"
+            # Resolve the new state from the ACTION, not a re-read: HA's state
+            # store lags the service call, so an immediate get_state returns the
+            # PRE-change value and the widget would snap back. The action makes
+            # the new state deterministic (toggle inverts the prior state).
+            if domain == "scene" or action == "turn_on":
+                resolved = "on"
+            elif action == "turn_off":
+                resolved = "off"
+            elif action == "toggle":
+                resolved = "off" if prior == "on" else "on"
+            else:
+                resolved = prior
             return {
                 "success": True,
                 "action_taken": True,

--- a/tests/backend/test_device_widget_tools.py
+++ b/tests/backend/test_device_widget_tools.py
@@ -56,16 +56,30 @@ async def test_device_action_rejects_nonexistent_entity():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_device_action_toggle_calls_ha_and_returns_state():
+async def test_device_action_toggle_inverts_prior_state_deterministically():
     svc = InternalToolService()
     ha = _ha_mock()
-    ha.get_state = AsyncMock(side_effect=[{"state": "off"}, {"state": "on"}])  # probe, then re-read
+    # Single probe (prior=off); the new state is computed from the action (toggle
+    # → on), NOT a re-read (HA's state store lags the service call).
+    ha.get_state = AsyncMock(return_value={"state": "off"})
     with patch("ha_glue.integrations.homeassistant.HomeAssistantClient", return_value=ha):
         out = await svc._device_action({"entity_id": "light.wz", "action": "toggle"})
     assert out["success"] is True
     ha.call_service.assert_awaited_once_with("light", "toggle", "light.wz")
+    assert ha.get_state.await_count == 1  # no second re-read
     assert out["data"]["state"] == "on"
     assert out["data"]["entity_id"] == "light.wz"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_device_action_turn_off_resolves_off():
+    svc = InternalToolService()
+    ha = _ha_mock()
+    ha.get_state = AsyncMock(return_value={"state": "on"})
+    with patch("ha_glue.integrations.homeassistant.HomeAssistantClient", return_value=ha):
+        out = await svc._device_action({"entity_id": "switch.x", "action": "turn_off"})
+    assert out["data"]["state"] == "off"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Live-verification fix for #837: a toggle actuated correctly but the widget reverted because the immediate `get_state` re-read returned HA's pre-change value (state-store lag). Resolve the new state from the action deterministically (toggle inverts the probed prior). 10 device tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)