### PR TITLE
fix(satellite): IRK byte-order resolution + hardware watchdog + Wohnzimmer continuous BLE

### DIFF
--- a/docs/SATELLITE_CONNECTIVITY.md
+++ b/docs/SATELLITE_CONNECTIVITY.md
@@ -103,6 +103,20 @@ Client behavior fixes (shipped in the satellite package):
 > The watchdog uses a **clean `os._exit`**, never a SIGKILL-mid-restart — so it
 > does not risk the SD-card corruption that bricked a satellite before.
 
+### Hardware watchdog (SoC-level, complements the app watchdog)
+
+The `max_disconnected_seconds` watchdog only fires while the **process is still
+running** — it can't recover a *total* system hang (kernel / Wi-Fi-stack lockup)
+where the board goes fully unreachable for minutes. For that, provisioning
+enables the **SoC hardware watchdog** via systemd: `RuntimeWatchdogSec`
+(`satellite_hw_watchdog_sec`, default **14 s**) in `/etc/systemd/system.conf`.
+systemd opens `/dev/watchdog` and pets it every cycle; if PID 1 or the kernel
+wedges, the SoC watchdog hard-resets the board. Keep the value **≤ the SoC max**
+(BCM2835 ~15 s, sunxi/Allwinner ~16 s) or the timer won't arm. Applied via the
+`watchdog` tag; a `reexec systemd` handler re-arms it without a reboot
+(`daemon-reload` alone does **not** activate the watchdog device). Set to `0` to
+disable.
+
 ## Diagnosing "X won't connect"
 
 ```bash

--- a/docs/design/ble-presence-improvement.md
+++ b/docs/design/ble-presence-improvement.md
@@ -82,6 +82,18 @@ name→hex), `cryptography` dep, unit tests (incl. the BT spec vector).
 (like the known-devices list); enrollment flow + documented Mac-export step;
 privacy review for storing IRKs; live end-to-end proof with one real IRK.
 
+> **Byte-order gotcha (fixed #840, 2026-06-22).** BlueZ stores the
+> `IdentityResolvingKey` in `/var/lib/bluetooth/.../info` **least-significant-octet
+> first**, but `ble/rpa.py` and the backend IRK store expect it **MSO-first** (the
+> BLE-spec `ah` order). The UI pairing-capture reader (`_read_bonded_irks`) read
+> the key as-is, so a captured IRK was stored byte-swapped and **silently never
+> resolved** a rotating address — masked because a *bonded* satellite resolves the
+> phone natively via BlueZ, and because the first captured IRK never persisted to
+> the backend until the bug was hit live. `_read_bonded_irks` now reverses at that
+> single boundary (the manual `POST /api/presence/irks` path already takes
+> MSO-first hex, so both converge). Proven: the device's real advertised RPA
+> resolves only against the reversed bytes.
+
 > Classic-BT (BlueZ connection-RSSI) was evaluated and rejected for iPhones —
 > no API to poll an iPhone over BR/EDR and iPhones aren't Classic-discoverable.
 

--- a/src/satellite/provisioning/group_vars/satellites.yml
+++ b/src/satellite/provisioning/group_vars/satellites.yml
@@ -27,6 +27,11 @@ server_ping_timeout: 8            # drop the link if no pong within (s)
 server_register_timeout: 15       # cap the post-connect register handshake (s)
 server_max_disconnected_seconds: 300  # exit→systemd restart if unreconnectable this long (0=off)
 
+# Hardware watchdog: systemd pets /dev/watchdog every cycle; if PID 1 / the kernel
+# hangs, the SoC watchdog hard-resets the board. Keep <= the SoC max (BCM2835 ~15s,
+# sunxi ~16s) or the timer won't arm. 0 disables.
+satellite_hw_watchdog_sec: 14
+
 # Wake word
 wakeword_model: "hey_renfield"
 wakeword_threshold: 0.5

--- a/src/satellite/provisioning/host_vars/satellite-wohnzimmer.yml
+++ b/src/satellite/provisioning/host_vars/satellite-wohnzimmer.yml
@@ -22,3 +22,8 @@ led_idle_color: "green"
 
 # 2-mic overlay variant: "simple" or "full"
 overlay_variant: "simple"
+
+# BLE presence: keep one scanner running continuously (vs 30 s bursts) so the
+# weak Pi Zero radio is more likely to catch a phone's intermittent adverts.
+# Enabled here because this room sits at the edge of phone BLE range.
+ble_continuous: true

--- a/src/satellite/provisioning/provision.yml
+++ b/src/satellite/provisioning/provision.yml
@@ -35,6 +35,10 @@
         name: bluetooth
         state: restarted
 
+    - name: reexec systemd
+      ansible.builtin.systemd:
+        daemon_reexec: true
+
   tasks:
     # =========================================================================
     # SYSTEM — System preparation
@@ -68,6 +72,24 @@
         - "{{ satellite_config_dir }}"
         - "{{ satellite_models_dir }}"
         - "{{ satellite_code_dir }}"
+
+    # =========================================================================
+    # WATCHDOG — Hardware watchdog: auto-reboot on a total system/kernel hang
+    # (the failure mode where the Pi goes fully unreachable for minutes). systemd
+    # opens /dev/watchdog and pets it; if PID 1 or the kernel wedges, the SoC
+    # watchdog hard-resets the board. Does NOT catch an app-only hang (the
+    # satellite process self-exits via server.max_disconnected_seconds for that).
+    # =========================================================================
+
+    - name: Enable systemd hardware watchdog (RuntimeWatchdogSec)
+      tags: [watchdog, system]
+      ansible.builtin.lineinfile:
+        path: /etc/systemd/system.conf
+        regexp: '^#?RuntimeWatchdogSec='
+        line: "RuntimeWatchdogSec={{ satellite_hw_watchdog_sec }}s"
+        state: present
+      when: satellite_hw_watchdog_sec | int > 0
+      notify: reexec systemd
 
     # =========================================================================
     # BOOT — Boot configuration (config.txt)

--- a/src/satellite/renfield_satellite/satellite.py
+++ b/src/satellite/renfield_satellite/satellite.py
@@ -493,9 +493,17 @@ class Satellite:
 
     @staticmethod
     def _read_bonded_irks(bt_root: str = "/var/lib/bluetooth") -> dict:
-        """Map bonded-device MAC -> IRK hex from BlueZ's store. BlueZ does not
-        expose bonding keys over D-Bus, so we read the on-disk info files
-        (requires root / a hostPath mount in the k8s pod)."""
+        """Map bonded-device MAC -> IRK hex (most-significant-octet first) from
+        BlueZ's store. BlueZ does not expose bonding keys over D-Bus, so we read
+        the on-disk info files (requires root / a hostPath mount in the k8s pod).
+
+        BlueZ writes the IdentityResolvingKey *least*-significant-octet first,
+        but the RPA resolver and the backend store expect it MSO-first (see
+        ble/rpa.py — "reverse them at the config boundary, not here"). This
+        reader IS that boundary, so it reverses the bytes; without this, a
+        captured IRK is stored byte-swapped and silently never resolves a
+        rotating address (a bonded satellite still resolves natively via BlueZ,
+        which masked the bug)."""
         import glob
         import os
         found = {}
@@ -521,7 +529,12 @@ class Satellite:
                     irk = line.split("=", 1)[1].strip()
                     break
             if irk:
-                found[mac] = irk
+                try:
+                    # BlueZ stores the IRK LSO-first; convert to the MSO-first
+                    # form the resolver + backend expect.
+                    found[mac] = bytes.fromhex(irk)[::-1].hex().upper()
+                except ValueError:
+                    continue
         return found
 
     async def _capture_irk_for_request(self, params: dict) -> dict:

--- a/tests/satellite/test_irk_capture_parse.py
+++ b/tests/satellite/test_irk_capture_parse.py
@@ -1,7 +1,9 @@
 """
 Unit test for the BlueZ info-file IRK parser used by the UI pairing-capture flow
-(Satellite._read_bonded_irks). Verifies it extracts the IdentityResolvingKey and
-ignores devices/sections without one.
+(Satellite._read_bonded_irks). Verifies it extracts the IdentityResolvingKey,
+reverses BlueZ's least-significant-octet-first byte order to the most-significant-
+octet-first form the resolver/backend expect, and ignores devices/sections
+without an IRK.
 """
 import os
 
@@ -42,7 +44,26 @@ def test_read_bonded_irks_extracts_only_irk(tmp_path):
 
     result = Satellite._read_bonded_irks(str(tmp_path))
 
-    assert result == {"4C:E6:C0:27:52:93": "3A66FE43118690229991659536EF9A4B"}
+    # BlueZ stores the key LSO-first (3A66…9A4B); the reader returns it
+    # MSO-first (4B9A…663A) so the software RPA resolver actually matches.
+    assert result == {"4C:E6:C0:27:52:93": "4B9AEF36956591992290861143FE663A"}
+
+
+@pytest.mark.satellite
+@pytest.mark.unit
+def test_read_bonded_irks_reverses_byte_order(tmp_path):
+    """The returned IRK is BlueZ's stored key with the bytes reversed."""
+    adapter = tmp_path / "10:11:12:13:14:15"
+    dev = adapter / "4C:E6:C0:27:52:93"
+    dev.mkdir(parents=True)
+    (dev / "info").write_text(_WITH_IRK)
+
+    bluez_stored = "3A66FE43118690229991659536EF9A4B"
+    expected = bytes.fromhex(bluez_stored)[::-1].hex().upper()
+
+    result = Satellite._read_bonded_irks(str(tmp_path))
+
+    assert result["4C:E6:C0:27:52:93"] == expected
 
 
 @pytest.mark.satellite


### PR DESCRIPTION
## Context

Investigating "Wohnzimmer satellite doesn't see me" (presence reported nobody home). Root cause was a chain — captured below — plus reliability gaps surfaced along the way.

## Root cause: IRK never resolved
- The user's phone was registered only as a **static BLE RPA snapshot** (rotates every ~15 min → dead within minutes).
- The per-person **IRK never persisted** to the backend (capture 2 days ago failed to store) — so no satellite could resolve the rotating address.
- Even once recovered, the IRK was **byte-swapped**: BlueZ stores the key LSO-first, but the RPA resolver + backend store expect MSO-first. Proven empirically — the phone's real advertised address `6B:30:E2:…` resolves **only** with the reversed bytes.

The IRK is already corrected + registered in production (so presence works now). This PR fixes the **code** so future pairings don't hit the same trap.

## Changes
1. **`fix(satellite)`** — `_read_bonded_irks` reverses BlueZ's LSO-first key to MSO-first at the read boundary (as `ble/rpa.py`'s docstring prescribes). Updated + added tests.
2. **`chore(satellite)`** — systemd `RuntimeWatchdogSec=14s` hardware watchdog (auto-reboot on total kernel/system hang — the "unreachable for minutes" failure mode), under the BCM2835/sunxi SoC max.
3. **`chore(satellite)`** — `ble_continuous: true` for the Wohnzimmer (edge of phone BLE range → continuous scan catches intermittent adverts the 30s bursts miss).

## Testing
- Satellite unit test asserts the reversal (uses the real device's data); transform verified to produce the value that resolves the phone's RPA.
- `ansible-playbook --syntax-check` passes.
- Backend tests run on the .159 box (CI is non-functional by design).

## Deploy
Ansible `--tags watchdog,config,app` against reachable satellites + a careful Wohnzimmer restart. No image-breaking changes; the production IRK is already fixed so there's no urgency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)