### PR TITLE
feat(satellite): connectivity watchdog + effective HW-watchdog drop-in

### DIFF
--- a/docs/SATELLITE_CONNECTIVITY.md
+++ b/docs/SATELLITE_CONNECTIVITY.md
@@ -103,19 +103,33 @@ Client behavior fixes (shipped in the satellite package):
 > The watchdog uses a **clean `os._exit`**, never a SIGKILL-mid-restart — so it
 > does not risk the SD-card corruption that bricked a satellite before.
 
-### Hardware watchdog (SoC-level, complements the app watchdog)
+### Watchdogs beyond the app-level disconnect exit
 
 The `max_disconnected_seconds` watchdog only fires while the **process is still
-running** — it can't recover a *total* system hang (kernel / Wi-Fi-stack lockup)
-where the board goes fully unreachable for minutes. For that, provisioning
-enables the **SoC hardware watchdog** via systemd: `RuntimeWatchdogSec`
-(`satellite_hw_watchdog_sec`, default **14 s**) in `/etc/systemd/system.conf`.
-systemd opens `/dev/watchdog` and pets it every cycle; if PID 1 or the kernel
-wedges, the SoC watchdog hard-resets the board. Keep the value **≤ the SoC max**
-(BCM2835 ~15 s, sunxi/Allwinner ~16 s) or the timer won't arm. Applied via the
-`watchdog` tag; a `reexec systemd` handler re-arms it without a reboot
-(`daemon-reload` alone does **not** activate the watchdog device). Set to `0` to
-disable.
+running**, so it can't recover a *total* hang where the board goes unreachable
+for minutes. Two lower layers cover that (both under the `watchdog` tag):
+
+**1. SoC hardware watchdog — kernel / PID-1 hangs.** systemd opens
+`/dev/watchdog` and pets it every cycle; if PID 1 or the kernel wedges, the SoC
+watchdog hard-resets the board. Raspberry Pi OS **already ships this enabled at
+1 min** (`/usr/lib/systemd/system.conf.d/40-rpi-enable-watchdog.conf`), so a bare
+edit to `/etc/systemd/system.conf` is **inert** — that OS drop-in outranks it.
+We instead write a **higher-precedence drop-in**
+`/etc/systemd/system.conf.d/50-renfield-watchdog.conf` with
+`RuntimeWatchdogSec={{ satellite_hw_watchdog_sec }}s` (default **14 s**). Keep it
+**≤ the SoC max** (BCM2835 ~15 s, sunxi/Allwinner ~16 s) or the timer won't arm.
+A `reexec systemd` handler re-arms it live (verified: `RuntimeWatchdogUSec`
+drops to 14 s without a reboot — `daemon-reload` alone does **not** re-arm it).
+
+**2. Network watchdog — wedged Wi-Fi / IP stack.** The HW watchdog can *not*
+catch the most common drop-off: the kernel stays healthy (so it keeps petting
+`/dev/watchdog`) but Wi-Fi/IP is dead and the satellite can't reach the backend.
+`renfield-net-watchdog.timer` runs `renfield-net-watchdog.sh` every ~60 s; if the
+Pi can't reach its **default gateway** for `net_watchdog_fail_threshold`
+consecutive checks (default **5** ≈ 5 min) it `systemctl reboot`s. It keys on the
+*gateway*, not the backend, so a backend redeploy never triggers a reboot; a
+**10-min post-boot grace** (read from `/proc/uptime`) prevents reboot loops.
+Disable with `net_watchdog_enabled: false`.
 
 ## Diagnosing "X won't connect"
 

--- a/src/satellite/provisioning/group_vars/satellites.yml
+++ b/src/satellite/provisioning/group_vars/satellites.yml
@@ -29,8 +29,17 @@ server_max_disconnected_seconds: 300  # exit→systemd restart if unreconnectabl
 
 # Hardware watchdog: systemd pets /dev/watchdog every cycle; if PID 1 / the kernel
 # hangs, the SoC watchdog hard-resets the board. Keep <= the SoC max (BCM2835 ~15s,
-# sunxi ~16s) or the timer won't arm. 0 disables.
+# sunxi ~16s) or the timer won't arm. 0 disables. Set via a 50- drop-in that
+# overrides the Raspberry Pi OS default (40-rpi-enable-watchdog.conf = 1 min).
 satellite_hw_watchdog_sec: 14
+
+# Network watchdog: reboots the Pi if its default gateway is unreachable for
+# net_watchdog_fail_threshold consecutive ~1-min checks — recovers a wedged
+# Wi-Fi/IP stack that the HW watchdog can't (kernel stays healthy). Empty target
+# = auto-derive the gateway. A 10-min post-boot grace prevents reboot loops.
+net_watchdog_enabled: true
+net_watchdog_target: ""
+net_watchdog_fail_threshold: 5
 
 # Wake word
 wakeword_model: "hey_renfield"

--- a/src/satellite/provisioning/group_vars/satellites.yml
+++ b/src/satellite/provisioning/group_vars/satellites.yml
@@ -40,6 +40,8 @@ satellite_hw_watchdog_sec: 14
 net_watchdog_enabled: true
 net_watchdog_target: ""
 net_watchdog_fail_threshold: 5
+net_watchdog_max_reboots: 3        # stop rebooting after this many — a gateway down
+                                   # for hours won't be fixed by it; a good ping refills
 
 # Wake word
 wakeword_model: "hey_renfield"

--- a/src/satellite/provisioning/provision.yml
+++ b/src/satellite/provisioning/provision.yml
@@ -74,22 +74,82 @@
         - "{{ satellite_code_dir }}"
 
     # =========================================================================
-    # WATCHDOG — Hardware watchdog: auto-reboot on a total system/kernel hang
-    # (the failure mode where the Pi goes fully unreachable for minutes). systemd
-    # opens /dev/watchdog and pets it; if PID 1 or the kernel wedges, the SoC
-    # watchdog hard-resets the board. Does NOT catch an app-only hang (the
-    # satellite process self-exits via server.max_disconnected_seconds for that).
+    # WATCHDOG — two complementary layers:
+    #   1. SoC hardware watchdog (RuntimeWatchdogSec): auto-reboots on a kernel /
+    #      PID-1 hang. Raspberry Pi OS already ships this at 1 min via
+    #      /usr/lib/systemd/system.conf.d/40-rpi-enable-watchdog.conf; we tighten
+    #      it with a 50- drop-in (higher precedence) so it actually takes effect.
+    #   2. Network watchdog (renfield-net-watchdog.timer): reboots if the Pi can't
+    #      reach its default gateway for N minutes — the wedged-Wi-Fi/IP failure
+    #      the HW watchdog can't catch (kernel stays healthy and keeps petting it).
     # =========================================================================
 
-    - name: Enable systemd hardware watchdog (RuntimeWatchdogSec)
+    - name: Ensure systemd manager drop-in dir exists
+      tags: [watchdog, system]
+      ansible.builtin.file:
+        path: /etc/systemd/system.conf.d
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    # Drop a 50- override above the OS 40-rpi-enable-watchdog.conf default.
+    - name: Tighten SoC hardware watchdog (RuntimeWatchdogSec drop-in)
+      tags: [watchdog, system]
+      ansible.builtin.copy:
+        dest: /etc/systemd/system.conf.d/50-renfield-watchdog.conf
+        content: |
+          # Managed by Ansible — overrides 40-rpi-enable-watchdog.conf.
+          [Manager]
+          RuntimeWatchdogSec={{ satellite_hw_watchdog_sec }}s
+        owner: root
+        group: root
+        mode: "0644"
+      when: satellite_hw_watchdog_sec | int > 0
+      notify: reexec systemd
+
+    # A previous revision wrote RuntimeWatchdogSec into the main system.conf
+    # (inert — the OS drop-in outranks it). Restore the shipped default there.
+    - name: Restore system.conf RuntimeWatchdogSec default (now set via drop-in)
       tags: [watchdog, system]
       ansible.builtin.lineinfile:
         path: /etc/systemd/system.conf
-        regexp: '^#?RuntimeWatchdogSec='
-        line: "RuntimeWatchdogSec={{ satellite_hw_watchdog_sec }}s"
+        regexp: '^RuntimeWatchdogSec='
+        line: "#RuntimeWatchdogSec=off"
         state: present
-      when: satellite_hw_watchdog_sec | int > 0
       notify: reexec systemd
+
+    - name: Deploy network watchdog script
+      tags: [watchdog, system]
+      ansible.builtin.template:
+        src: renfield-net-watchdog.sh.j2
+        dest: "{{ satellite_base_dir }}/bin/renfield-net-watchdog.sh"
+        owner: root
+        group: root
+        mode: "0755"
+      when: net_watchdog_enabled | default(true)
+
+    - name: Deploy network watchdog systemd units
+      tags: [watchdog, system]
+      ansible.builtin.template:
+        src: "{{ item }}.j2"
+        dest: "/etc/systemd/system/{{ item }}"
+        owner: root
+        group: root
+        mode: "0644"
+      loop:
+        - renfield-net-watchdog.service
+        - renfield-net-watchdog.timer
+      when: net_watchdog_enabled | default(true)
+      notify: reload systemd
+
+    - name: Enable + start the network watchdog timer
+      tags: [watchdog, system]
+      ansible.builtin.systemd:
+        name: renfield-net-watchdog.timer
+        enabled: "{{ net_watchdog_enabled | default(true) }}"
+        state: "{{ 'started' if (net_watchdog_enabled | default(true)) else 'stopped' }}"
+        daemon_reload: true
 
     # =========================================================================
     # BOOT — Boot configuration (config.txt)

--- a/src/satellite/provisioning/provision.yml
+++ b/src/satellite/provisioning/provision.yml
@@ -109,14 +109,14 @@
       notify: reexec systemd
 
     # A previous revision wrote RuntimeWatchdogSec into the main system.conf
-    # (inert — the OS drop-in outranks it). Restore the shipped default there.
-    - name: Restore system.conf RuntimeWatchdogSec default (now set via drop-in)
+    # (inert — the OS drop-in outranks it). Remove it; idempotent on a clean
+    # system (no match → no change → no reexec).
+    - name: Remove inert RuntimeWatchdogSec from system.conf (now set via drop-in)
       tags: [watchdog, system]
       ansible.builtin.lineinfile:
         path: /etc/systemd/system.conf
         regexp: '^RuntimeWatchdogSec='
-        line: "#RuntimeWatchdogSec=off"
-        state: present
+        state: absent
       notify: reexec systemd
 
     - name: Deploy network watchdog script

--- a/src/satellite/provisioning/templates/renfield-net-watchdog.service.j2
+++ b/src/satellite/provisioning/templates/renfield-net-watchdog.service.j2
@@ -1,11 +1,11 @@
 [Unit]
 Description=Renfield satellite network watchdog (reboot if local network is wedged)
-# Don't run while shutting down/rebooting.
-DefaultDependencies=no
-After=network.target
-Conflicts=shutdown.target
-Before=shutdown.target
+After=network-online.target
+Wants=network-online.target
+# Default dependencies are kept on purpose: they give the implicit
+# Conflicts=shutdown.target / Before=shutdown.target so this never runs (or
+# triggers a reboot) while the system is already shutting down.
 
 [Service]
 Type=oneshot
-ExecStart={{ satellite_base_dir }}/bin/renfield-net-watchdog.sh "{{ net_watchdog_target | default('') }}" {{ net_watchdog_fail_threshold | default(5) }}
+ExecStart={{ satellite_base_dir }}/bin/renfield-net-watchdog.sh "{{ net_watchdog_target | default('') }}" {{ net_watchdog_fail_threshold | default(5) }} {{ net_watchdog_max_reboots | default(3) }}

--- a/src/satellite/provisioning/templates/renfield-net-watchdog.service.j2
+++ b/src/satellite/provisioning/templates/renfield-net-watchdog.service.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=Renfield satellite network watchdog (reboot if local network is wedged)
+# Don't run while shutting down/rebooting.
+DefaultDependencies=no
+After=network.target
+Conflicts=shutdown.target
+Before=shutdown.target
+
+[Service]
+Type=oneshot
+ExecStart={{ satellite_base_dir }}/bin/renfield-net-watchdog.sh "{{ net_watchdog_target | default('') }}" {{ net_watchdog_fail_threshold | default(5) }}

--- a/src/satellite/provisioning/templates/renfield-net-watchdog.sh.j2
+++ b/src/satellite/provisioning/templates/renfield-net-watchdog.sh.j2
@@ -15,32 +15,46 @@
 set -u
 
 TARGET="${1:-}"
-THRESHOLD="${2:-5}"            # consecutive failures (timer cadence ≈ 1/min) → reboot
-STATE=/run/renfield-net-watchdog.fails
+THRESHOLD="${2:-5}"               # consecutive failures (timer cadence ≈ 1/min) → reboot
+MAX_REBOOTS="${3:-3}"             # give up after this many reboots — a gateway that's
+                                  # been down for hours won't be fixed by rebooting
+STATE=/run/renfield-net-watchdog.fails             # fail counter (tmpfs, clears on reboot)
+BUDGET=/var/lib/renfield/net-watchdog-reboots      # reboot budget (persists across reboots)
 
-# Derive the default gateway if no explicit target was given.
+# Derive the IPv4 default gateway if no explicit target was given.
 if [ -z "$TARGET" ]; then
-    TARGET=$(ip route 2>/dev/null | awk '/^default/{print $3; exit}')
+    TARGET=$(ip -4 route 2>/dev/null | awk '/^default/{print $3; exit}')
 fi
 # No gateway known (boot race / no route) — can't decide, stay hands-off.
 [ -z "$TARGET" ] && exit 0
 
 # Don't reboot during the first 10 min of uptime: let the network settle after a
-# boot and avoid a tight reboot loop if the gateway is persistently unreachable.
+# boot and bound how fast a reboot loop could cycle.
 up=$(cut -d. -f1 /proc/uptime 2>/dev/null || echo 0)
 [ "$up" -lt 600 ] && exit 0
 
 if ping -c 2 -W 3 "$TARGET" >/dev/null 2>&1; then
-    rm -f "$STATE"
+    # Network healthy → clear the fail counter AND refill the reboot budget.
+    rm -f "$STATE" "$BUDGET"
     exit 0
 fi
 
 fails=$(( $(cat "$STATE" 2>/dev/null || echo 0) + 1 ))
 echo "$fails" > "$STATE"
 logger -t renfield-net-watchdog "gateway $TARGET unreachable ($fails/$THRESHOLD)"
+[ "$fails" -lt "$THRESHOLD" ] && exit 0
 
-if [ "$fails" -ge "$THRESHOLD" ]; then
-    logger -t renfield-net-watchdog "threshold reached after ${fails} checks — rebooting"
-    rm -f "$STATE"
-    systemctl reboot
+# Threshold reached. Spend from the persistent reboot budget so a gateway that
+# stays down for hours can't reboot-loop the board indefinitely; once exhausted
+# we stay up and keep checking (a successful ping refills the budget).
+reboots=$(( $(cat "$BUDGET" 2>/dev/null || echo 0) + 1 ))
+if [ "$reboots" -gt "$MAX_REBOOTS" ]; then
+    logger -t renfield-net-watchdog "gateway still down after $MAX_REBOOTS reboots — giving up until it returns"
+    exit 0
 fi
+mkdir -p "$(dirname "$BUDGET")"
+echo "$reboots" > "$BUDGET"
+logger -t renfield-net-watchdog "gateway down past threshold — rebooting ($reboots/$MAX_REBOOTS)"
+# Leave $STATE in place: the real reboot wipes /run; if the reboot call fails the
+# budget already advanced, so we still can't loop.
+systemctl reboot

--- a/src/satellite/provisioning/templates/renfield-net-watchdog.sh.j2
+++ b/src/satellite/provisioning/templates/renfield-net-watchdog.sh.j2
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Renfield satellite network watchdog (managed by Ansible — do not edit on host).
+#
+# Recovers a *wedged network stack* — the failure the SoC hardware watchdog
+# CANNOT catch: the kernel + systemd stay healthy (so /dev/watchdog keeps being
+# pet) but Wi-Fi/IP is dead and the satellite can't reach the backend. The
+# app-level reconnect (server.max_disconnected_seconds) only restarts the
+# process; if the whole stack is wedged that doesn't help, so as a last resort
+# we reboot the board.
+#
+# Decision signal = reachability of the DEFAULT GATEWAY, not the backend: a
+# down backend (e.g. a rolling redeploy) is not the Pi's fault and must NOT
+# trigger a reboot. Only when the Pi can't reach its own gateway is the local
+# network genuinely dead.
+set -u
+
+TARGET="${1:-}"
+THRESHOLD="${2:-5}"            # consecutive failures (timer cadence ≈ 1/min) → reboot
+STATE=/run/renfield-net-watchdog.fails
+
+# Derive the default gateway if no explicit target was given.
+if [ -z "$TARGET" ]; then
+    TARGET=$(ip route 2>/dev/null | awk '/^default/{print $3; exit}')
+fi
+# No gateway known (boot race / no route) — can't decide, stay hands-off.
+[ -z "$TARGET" ] && exit 0
+
+# Don't reboot during the first 10 min of uptime: let the network settle after a
+# boot and avoid a tight reboot loop if the gateway is persistently unreachable.
+up=$(cut -d. -f1 /proc/uptime 2>/dev/null || echo 0)
+[ "$up" -lt 600 ] && exit 0
+
+if ping -c 2 -W 3 "$TARGET" >/dev/null 2>&1; then
+    rm -f "$STATE"
+    exit 0
+fi
+
+fails=$(( $(cat "$STATE" 2>/dev/null || echo 0) + 1 ))
+echo "$fails" > "$STATE"
+logger -t renfield-net-watchdog "gateway $TARGET unreachable ($fails/$THRESHOLD)"
+
+if [ "$fails" -ge "$THRESHOLD" ]; then
+    logger -t renfield-net-watchdog "threshold reached after ${fails} checks — rebooting"
+    rm -f "$STATE"
+    systemctl reboot
+fi

--- a/src/satellite/provisioning/templates/renfield-net-watchdog.timer.j2
+++ b/src/satellite/provisioning/templates/renfield-net-watchdog.timer.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run the Renfield network watchdog periodically
+
+[Timer]
+OnBootSec=3min
+OnUnitActiveSec=60s
+AccuracySec=10s
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Why

Follow-up to #840. Deploying that PR's HW watchdog surfaced two facts:

1. **The HW watchdog was inert.** Raspberry Pi OS already ships `RuntimeWatchdogSec=1m` via `/usr/lib/systemd/system.conf.d/40-rpi-enable-watchdog.conf`, which **outranks** an edit to `/etc/systemd/system.conf`. So #840's change did nothing.
2. **The observed failure isn't a kernel hang.** A 1-min HW watchdog was *already running* during the multi-minute satellite outages — a kernel/PID-1 hang would have rebooted the board within a minute. The drop-offs are **wedged Wi-Fi/IP stacks**: the kernel stays healthy (keeps petting `/dev/watchdog`) but the Pi can't reach the network. The HW watchdog structurally cannot catch this.

## What

Two complementary layers (both `--tags watchdog`):

- **HW watchdog, now effective** — written via a higher-precedence `50-renfield-watchdog.conf` drop-in so `RuntimeWatchdogSec=14s` actually applies (verified live: `RuntimeWatchdogUSec=14s` after `daemon-reexec`, no reboot). The old inert `system.conf` line is restored to default.
- **Network watchdog** — `renfield-net-watchdog.timer` runs every ~60s; reboots the Pi if its **default gateway** is unreachable for `net_watchdog_fail_threshold` (default 5 ≈ 5 min) consecutive checks. Keys on the *gateway*, not the backend, so a backend redeploy never triggers a reboot. A **10-min post-boot grace** (`/proc/uptime`) prevents reboot loops.

## Safeguards on the reboot path
- Gateway-based signal (Pi's own network dead, not a backend outage).
- 5-check (~5 min) threshold absorbs transient blips.
- 10-min uptime grace → no tight reboot loops.
- Fail-counter in `/run` (clears on reboot).

## Testing
- `ansible-playbook --syntax-check` + `bash -n` pass.
- **Real run verified end-to-end on satellite-kinderbad**: drop-in applied (`RuntimeWatchdogUSec=14s`), timer active + firing every 60s, gateway-derivation + reset-on-reachable confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)