### PR TITLE
fix(satellite): ensure bin dir exists for net-watchdog deploy

### DIFF
--- a/src/satellite/provisioning/provision.yml
+++ b/src/satellite/provisioning/provision.yml
@@ -119,6 +119,16 @@
         state: absent
       notify: reexec systemd
 
+    - name: Ensure satellite bin dir exists (not all HAT profiles create it)
+      tags: [watchdog, system]
+      ansible.builtin.file:
+        path: "{{ satellite_base_dir }}/bin"
+        state: directory
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: "0755"
+      when: net_watchdog_enabled | default(true)
+
     - name: Deploy network watchdog script
       tags: [watchdog, system]
       ansible.builtin.template:


### PR DESCRIPTION
Hotfix for #841: the net-watchdog script deploy assumed `/opt/renfield-satellite/bin` exists, but only the XVF3800 HAT profile creates it. The 2-mic/whisplay satellites (wohnzimmer, arbeitszimmer) failed the deploy. Adds an explicit dir-ensure task under the `watchdog` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)