### PR TITLE
chore(satellite): v1.4.2 — cryptography in OTA whitelist + version bump

### DIFF
--- a/src/satellite/renfield_satellite/__init__.py
+++ b/src/satellite/renfield_satellite/__init__.py
@@ -5,7 +5,7 @@ A headless voice assistant satellite for the Renfield ecosystem.
 Designed for Raspberry Pi Zero 2 W with ReSpeaker 2-Mics Pi HAT.
 """
 
-__version__ = "1.4.1"
+__version__ = "1.4.2"
 __author__ = "Renfield Team"
 
 # Lazy imports to allow CLI tools to run without all dependencies

--- a/src/satellite/renfield_satellite/update/update_manager.py
+++ b/src/satellite/renfield_satellite/update/update_manager.py
@@ -488,6 +488,7 @@ class UpdateManager:
         "webrtcvad", "noisereduce", "spidev", "soundcard", "bleak",
         "lgpio", "python-mpv", "psutil", "pyyaml", "zeroconf",
         "sounddevice", "pyaudio", "scipy", "librosa", "RPi.GPIO",
+        "cryptography",
     })
 
     @staticmethod


### PR DESCRIPTION
## What
- Bump satellite `__version__` → **1.4.2** (publishes #840 IRK byte-order + #843 crypto-missing warning as an OTA-retrievable version).
- **Add `cryptography` to the OTA installer `SAFE_PACKAGES` whitelist.**

## Why the whitelist fix is required
#843 added `cryptography` to `src/satellite/requirements.txt` but not to `SAFE_PACKAGES`. The OTA installer validates the incoming requirements against that whitelist and **rejects + rolls back** anything unknown — so an OTA to 1.4.2 would fail with "Unknown packages: cryptography". The `test_shipped_requirements_pass_validation` regression test was also silently failing (tests run on .159, not CI). Now in sync (verified: every requirements package ∈ SAFE_PACKAGES).

## Rollout note (catch-22)
The deployed sats run the **1.4.1** installer, whose `SAFE_PACKAGES` doesn't include cryptography. Since the *current* installer validates the *incoming* requirements, they can't OTA to 1.4.2 cleanly until they have this installer — so they get 1.4.2 via **ansible `--tags app`** this once. From 1.4.2 onward, OTA works normally. (Thanks to #775's non-destructive rollback, a rejected OTA fails safe, not bricks.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)