### PR TITLE
chore(satellite): v1.4.3 — validate the OTA path end-to-end

### DIFF
--- a/src/satellite/renfield_satellite/__init__.py
+++ b/src/satellite/renfield_satellite/__init__.py
@@ -5,7 +5,7 @@ A headless voice assistant satellite for the Renfield ecosystem.
 Designed for Raspberry Pi Zero 2 W with ReSpeaker 2-Mics Pi HAT.
 """
 
-__version__ = "1.4.2"
+__version__ = "1.4.3"
 __author__ = "Renfield Team"
 
 # Lazy imports to allow CLI tools to run without all dependencies


### PR DESCRIPTION
Bumps the satellite version to 1.4.3 to run a real OTA (1.4.2→1.4.3) on a satellite that has the fixed 1.4.2 installer (cryptography in SAFE_PACKAGES), proving #845's catch-22 is resolved and the full OTA path completes. 🤖 Generated with [Claude Code](https://claude.com/claude-code)