### PR TITLE
fix(satellite): OTA backup Permission denied — writable backup path (v1.4.4)

### DIFF
--- a/src/satellite/renfield_satellite/__init__.py
+++ b/src/satellite/renfield_satellite/__init__.py
@@ -5,7 +5,7 @@ A headless voice assistant satellite for the Renfield ecosystem.
 Designed for Raspberry Pi Zero 2 W with ReSpeaker 2-Mics Pi HAT.
 """
 
-__version__ = "1.4.3"
+__version__ = "1.4.4"
 __author__ = "Renfield Team"
 
 # Lazy imports to allow CLI tools to run without all dependencies

--- a/src/satellite/renfield_satellite/update/update_manager.py
+++ b/src/satellite/renfield_satellite/update/update_manager.py
@@ -91,16 +91,18 @@ class UpdateManager:
             # Try to detect install path
             self.install_path = self._detect_install_path()
 
-        # Backup path — a SIBLING of the install dir, never inside it. A backup
-        # under install_path/.backup gets deleted by the rollback's own
-        # rmtree(install_path), so the restore then finds nothing and the whole
-        # install (venv included) is lost — this bricked a satellite in prod.
+        # Backup path — must be (1) OUTSIDE install_path, so the rollback's own
+        # rmtree(install_path) can't delete it (a backup under install_path/.backup
+        # bricked a satellite in prod — #775), AND (2) writable by the service user.
+        # The earlier "sibling of install_path" choice broke #2: install_path.parent
+        # is typically /opt, which is root-owned, so a non-root satellite (runs as
+        # `evdb`) hit `[Errno 13] Permission denied` at the backup step and every OTA
+        # failed there. Use the running user's home (writable + external), falling
+        # back to the temp dir.
         if backup_path:
             self.backup_path = Path(backup_path)
         else:
-            self.backup_path = self.install_path.parent / (
-                self.install_path.name + ".update-backup"
-            )
+            self.backup_path = self._default_backup_path()
         self.service_name = service_name
 
         # State
@@ -109,6 +111,23 @@ class UpdateManager:
         self._progress = 0
         self._on_progress: Optional[Callable[[UpdateStage, int, str], None]] = None
         self._backup_created = False
+
+    def _default_backup_path(self) -> Path:
+        """A backup dir that is OUTSIDE install_path and writable by this process.
+
+        Prefers the running user's home (writable, external to the typically
+        root-owned /opt where install_path lives); falls back to the temp dir if
+        home is missing or not writable. Never a child of install_path.
+        """
+        name = ".renfield-update-backup-" + self.install_path.name
+        try:
+            import pwd
+            home = Path(pwd.getpwuid(os.getuid()).pw_dir)
+            if home and home != self.install_path and os.access(home, os.W_OK):
+                return home / name
+        except (KeyError, OSError, ImportError):
+            pass
+        return Path(tempfile.gettempdir()) / name
 
     def _detect_install_path(self) -> Path:
         """Detect the satellite installation path"""

--- a/tests/satellite/test_update_security.py
+++ b/tests/satellite/test_update_security.py
@@ -356,3 +356,31 @@ class TestBackupRollback:
         mgr._rollback()
         assert (install / "venv" / "bin" / "python").exists()
         assert (install / "renfield_satellite" / "__init__.py").exists()
+
+
+@pytest.mark.satellite
+@pytest.mark.unit
+class TestDefaultBackupPathWritable:
+    """Regression for the OTA-backup permission bug: the default backup path must
+    be writable by the (non-root) service user AND live outside install_path.
+
+    The previous default — a sibling of install_path — failed with
+    `[Errno 13] Permission denied` in prod: install_path is /opt/renfield-satellite
+    (evdb-owned) but /opt is root-owned, so the evdb service could not create the
+    sibling /opt/renfield-satellite.update-backup, and every OTA died at backup.
+    """
+
+    def test_default_backup_is_external_and_writable(self, tmp_path):
+        import os
+        install_path = tmp_path / "install"
+        install_path.mkdir()
+        (install_path / "renfield_satellite").mkdir()
+
+        mgr = UpdateManager(install_path=str(install_path))  # no explicit backup_path
+
+        bp = mgr.backup_path
+        # Outside install_path so the rollback's rmtree(install_path) can't delete it.
+        assert bp != install_path and install_path not in bp.parents
+        # Parent must exist and be writable by THIS process (the bug was a
+        # non-writable parent), not assumed-writable.
+        assert bp.parent.exists() and os.access(bp.parent, os.W_OK)


### PR DESCRIPTION
A **real end-to-end OTA** (not just the validation) surfaced the next bug: the update died at the backup step with `[Errno 13] Permission denied: '/opt/renfield-satellite.update-backup'`. #775's external-sibling backup is unwritable because `/opt` is root-owned and the satellite runs as non-root `evdb`. Fix: backup goes to the running user's home (writable + external to install_path), temp-dir fallback. **Verified live**: kinderbad OTA'd 1.4.2→1.4.3 successfully with this installer (backup created at `/home/evdb/.renfield-update-backup-…`). Adds a regression test. Bumps to v1.4.4 so the fix ships in the OTA package (else it doesn't persist across updates). 🤖 Generated with [Claude Code](https://claude.com/claude-code)