### PR TITLE
chore(satellite): v1.4.5 — prove OTA steady-state

### DIFF
--- a/src/satellite/renfield_satellite/__init__.py
+++ b/src/satellite/renfield_satellite/__init__.py
@@ -5,7 +5,7 @@ A headless voice assistant satellite for the Renfield ecosystem.
 Designed for Raspberry Pi Zero 2 W with ReSpeaker 2-Mics Pi HAT.
 """
 
-__version__ = "1.4.4"
+__version__ = "1.4.5"
 __author__ = "Renfield Team"
 
 # Lazy imports to allow CLI tools to run without all dependencies


### PR DESCRIPTION
OTA target above 1.4.4 to demonstrate a satellite with the package-delivered fixed installer OTAs cleanly and the backup-path fix survives the update. 🤖 Generated with [Claude Code](https://claude.com/claude-code)