### PR TITLE
test: fix pre-existing test rot (12 drifted tests) + checkin-listener hardening

### DIFF
--- a/src/backend/services/database.py
+++ b/src/backend/services/database.py
@@ -38,16 +38,28 @@ engine = create_async_engine(
 # hook must be revisited.
 @event.listens_for(engine.sync_engine, "checkin")
 def _release_leaked_advisory_locks_on_checkin(dbapi_connection, connection_record):
-    """Release any held advisory locks when a connection returns to the pool."""
-    cursor = dbapi_connection.cursor()
+    """Release any held advisory locks when a connection returns to the pool.
+
+    Best-effort and MUST NEVER raise — a checkin hook that throws breaks pool
+    return for every caller. A connection checked in after its event loop has
+    closed (e.g. across async-test boundaries) can have a None/dead
+    ``dbapi_connection``, so cursor creation itself is inside the guard.
+    """
+    if dbapi_connection is None:
+        return
+    cursor = None
     try:
+        cursor = dbapi_connection.cursor()
         cursor.execute("SELECT pg_advisory_unlock_all();")
     except Exception as e:
-        # Best-effort: never block checkin on cleanup failure. Worst case
-        # is the original leak symptom comes back, which we'll see in logs.
+        # Worst case is the original leak symptom comes back, visible in logs.
         logger.warning(f"checkin: pg_advisory_unlock_all failed (swallowed): {type(e).__name__}: {e}")
     finally:
-        cursor.close()
+        if cursor is not None:
+            try:
+                cursor.close()
+            except Exception:
+                pass
 
 
 # Session Factory

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -861,16 +861,31 @@ def _ensure_ha_glue_routes(app):
 
 
 @pytest.fixture
-async def app_with_test_db(override_get_db, mock_ha_client):
+async def app_with_test_db(override_get_db, mock_ha_client, async_engine, monkeypatch):
     """FastAPI app with test database and mocked services"""
+    import services.database as _db_mod
     from main import app
     from services.database import get_db
 
     # Mount the ha_glue routers that the lifespan would normally register.
     _ensure_ha_glue_routes(app)
 
-    # Override database
+    # Override the request-scoped DB dependency (Depends(get_db)).
     app.dependency_overrides[get_db] = override_get_db
+
+    # Some routes deliberately open their OWN session via AsyncSessionLocal
+    # instead of Depends(get_db) — e.g. streaming exports that must outlive the
+    # request-scoped session (api/routes/trajectories.export_jsonl). Those bypass
+    # the dependency override and would hit the REAL Postgres engine; under
+    # full-suite ordering that engine's pooled connection is bound to a prior
+    # test's already-closed event loop → "attached to a different loop". Point
+    # AsyncSessionLocal at the StaticPool test engine so these paths use the same
+    # hermetic in-memory DB as the rest of the suite. (Routes import it lazily
+    # in-function, so patching the module attribute takes effect at call time.)
+    test_sessionmaker = async_sessionmaker(
+        async_engine, class_=AsyncSession, expire_on_commit=False
+    )
+    monkeypatch.setattr(_db_mod, "AsyncSessionLocal", test_sessionmaker)
 
     yield app
 

--- a/tests/backend/test_agent_router.py
+++ b/tests/backend/test_agent_router.py
@@ -852,6 +852,11 @@ class TestLoadRolesConfig:
             )
 
         config = load_roles_config(config_path)
+        if not config.get("roles"):
+            pytest.skip(
+                "agent_roles.yaml present but empty in this environment "
+                "(ConfigMap-served at deploy; a 0-byte stub in the test image)"
+            )
         assert "roles" in config
         assert "smart_home" in config["roles"]
         assert "conversation" in config["roles"]
@@ -1130,6 +1135,11 @@ class TestRoutineRole:
             )
 
         config = load_roles_config(config_path)
+        if not config.get("roles"):
+            pytest.skip(
+                "agent_roles.yaml present but empty in this environment "
+                "(ConfigMap-served at deploy; a 0-byte stub in the test image)"
+            )
         assert "routine" in config["roles"]
         role_cfg = config["roles"]["routine"]
         assert "homeassistant" in role_cfg["mcp_servers"]

--- a/tests/backend/test_agent_tools.py
+++ b/tests/backend/test_agent_tools.py
@@ -11,16 +11,20 @@ import pytest
 from services.agent_tools import AgentToolRegistry, ToolDefinition
 
 # The registry always registers the platform-owned internal tools in
-# __init__ via _register_internal_tools(). There are three of them:
-#   internal.knowledge_search
-#   internal.forward_attachment_to_paperless
-#   internal.paperless_commit_upload
-# Tests that count tools or assert an "empty" registry must account for
-# these baseline entries.
+# __init__ via _register_internal_tools() — the union of KNOWLEDGE_TOOL,
+# MEMORY_LIST_TOOL, CHAT_UPLOAD_TOOLS and WIDGET_TOOLS. Tests that count
+# tools or assert an "empty" registry must account for these baseline
+# entries. Keep this set in sync when a platform internal.* tool is added
+# (ha_glue-registered tools come via the register_tools hook and are NOT
+# in this baseline).
 INTERNAL_TOOL_NAMES = {
-    "internal.knowledge_search",
-    "internal.forward_attachment_to_paperless",
-    "internal.paperless_commit_upload",
+    "internal.knowledge_search",          # KNOWLEDGE_TOOL
+    "internal.list_my_memories",          # MEMORY_LIST_TOOL
+    "internal.forward_attachment_to_paperless",  # CHAT_UPLOAD_TOOLS
+    "internal.paperless_commit_upload",   # CHAT_UPLOAD_TOOLS
+    "internal.render_table",              # WIDGET_TOOLS
+    "internal.render_list",               # WIDGET_TOOLS
+    "internal.weather_widget",            # WIDGET_TOOLS
 }
 NUM_INTERNAL_TOOLS = len(INTERNAL_TOOL_NAMES)
 

--- a/tests/backend/test_ha_glue_boundary.py
+++ b/tests/backend/test_ha_glue_boundary.py
@@ -72,6 +72,13 @@ ALLOWED_IMPORTERS = frozenset({
     # lazy-pattern rule as the compat shim above. Surfaced once the boundary
     # test's BACKEND_ROOT was fixed to resolve the real source tree.
     "services/whisper_prompt_builder.py",
+    # (2) Lazy, exception-guarded fallback — daypart_service._resolve_tz() does a
+    # function-body `from ha_glue.utils.config import ha_glue_settings` inside a
+    # try/except solely to source a timezone when `settings.daypart_timezone` is
+    # empty. Deferred + guarded ("ha_glue may be absent" → falls back to UTC), so
+    # a platform-only deploy never reaches it. Same lazy-pattern rule as the shims
+    # above.
+    "services/daypart_service.py",
 })
 
 

--- a/tests/backend/test_memory_retrieval_lane_c.py
+++ b/tests/backend/test_memory_retrieval_lane_c.py
@@ -64,6 +64,11 @@ class TestRetrieveRankerRouting:
     async def test_default_ranker_uses_single_stage_sql(self, mr, captured_db):
         with patch("services.memory_retrieval.settings") as s:
             s.auth_enabled = False
+            # Phase 3c Memory→KG bridge is dark by default; without this the
+            # patched MagicMock settings make it truthy, so retrieve() issues a
+            # trailing kg_entities resolve query and _Capture (last-write) holds
+            # THAT instead of the ranker query under test. Pin it off.
+            s.memory_kg_bridge_enabled = False
             s.memory_retrieval_limit = 5
             s.memory_retrieval_threshold = 0.0
             await mr.retrieve("hello", user_id=None)
@@ -78,6 +83,11 @@ class TestRetrieveRankerRouting:
     async def test_recency_aware_uses_two_stage_cte(self, mr, captured_db):
         with patch("services.memory_retrieval.settings") as s:
             s.auth_enabled = False
+            # Phase 3c Memory→KG bridge is dark by default; without this the
+            # patched MagicMock settings make it truthy, so retrieve() issues a
+            # trailing kg_entities resolve query and _Capture (last-write) holds
+            # THAT instead of the ranker query under test. Pin it off.
+            s.memory_kg_bridge_enabled = False
             s.memory_retrieval_limit = 5
             s.memory_retrieval_threshold = 0.0
             s.memory_retrieval_recall_k = 50
@@ -103,6 +113,11 @@ class TestRetrieveRankerRouting:
         Otherwise Stage-1 would return fewer rows than the LIMIT clause asks for."""
         with patch("services.memory_retrieval.settings") as s:
             s.auth_enabled = False
+            # Phase 3c Memory→KG bridge is dark by default; without this the
+            # patched MagicMock settings make it truthy, so retrieve() issues a
+            # trailing kg_entities resolve query and _Capture (last-write) holds
+            # THAT instead of the ranker query under test. Pin it off.
+            s.memory_kg_bridge_enabled = False
             s.memory_retrieval_limit = 5
             s.memory_retrieval_threshold = 0.0
             s.memory_retrieval_recall_k = 10  # smaller than limit
@@ -120,6 +135,11 @@ class TestRetrieveRankerRouting:
         similarity*importance*confidence rerank over the bigger recall window."""
         with patch("services.memory_retrieval.settings") as s:
             s.auth_enabled = False
+            # Phase 3c Memory→KG bridge is dark by default; without this the
+            # patched MagicMock settings make it truthy, so retrieve() issues a
+            # trailing kg_entities resolve query and _Capture (last-write) holds
+            # THAT instead of the ranker query under test. Pin it off.
+            s.memory_kg_bridge_enabled = False
             s.memory_retrieval_limit = 5
             s.memory_retrieval_threshold = 0.0
             s.memory_retrieval_recall_k = 50
@@ -139,6 +159,11 @@ class TestRetrieveRankerRouting:
         two-stage SQL. Strict equality on the string spelling."""
         with patch("services.memory_retrieval.settings") as s:
             s.auth_enabled = False
+            # Phase 3c Memory→KG bridge is dark by default; without this the
+            # patched MagicMock settings make it truthy, so retrieve() issues a
+            # trailing kg_entities resolve query and _Capture (last-write) holds
+            # THAT instead of the ranker query under test. Pin it off.
+            s.memory_kg_bridge_enabled = False
             s.memory_retrieval_limit = 5
             s.memory_retrieval_threshold = 0.0
             await mr.retrieve("hello", user_id=None, ranker="garbage")

--- a/tests/backend/test_rag_hybrid_search.py
+++ b/tests/backend/test_rag_hybrid_search.py
@@ -320,37 +320,52 @@ class TestFTSReindex:
         db = AsyncMock()
         return RAGService(db)
 
+    @staticmethod
+    def _mock_engine():
+        """Mock async engine for reindex_fts: `async with engine.connect() as conn:
+        conn = await conn.execution_options(...); await conn.execute(text(...))`.
+        Returns (engine, conn) so tests can assert on conn.execute."""
+        conn = AsyncMock()
+        conn.execution_options = AsyncMock(return_value=conn)
+        conn.execute = AsyncMock()
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=conn)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        engine = MagicMock()
+        engine.connect = MagicMock(return_value=cm)
+        return engine, conn
+
     @pytest.mark.unit
-    async def test_reindex_fts_returns_count(self, rag_service):
-        """reindex_fts returns the count of updated chunks."""
-        mock_result = MagicMock()
-        mock_result.rowcount = 42
-        rag_service.db.execute = AsyncMock(return_value=mock_result)
+    async def test_reindex_fts_rebuilds_gin_index(self, rag_service):
+        """reindex_fts issues REINDEX INDEX CONCURRENTLY on the GIN index.
 
-        with patch("services.rag_service.settings") as mock_settings:
-            mock_settings.rag_hybrid_fts_config = "simple"
-
+        Post-pc20260529 the search_vector is a GENERATED STORED column, so
+        there is no app-side row repopulation — reindex_fts just rebuilds the
+        GIN index via a fresh AUTOCOMMIT engine connection (REINDEX CONCURRENTLY
+        cannot run inside a transaction)."""
+        engine, conn = self._mock_engine()
+        with patch("services.database.engine", engine):
             result = await rag_service.reindex_fts()
 
-        assert result["updated_count"] == 42
-        assert result["fts_config"] == "simple"
+        assert result["status"] == "ok"
+        assert result["index"] == "idx_document_chunks_search_vector_gin"
+        assert "duration_ms" in result
+        # AUTOCOMMIT isolation + a REINDEX CONCURRENTLY statement were issued.
+        conn.execution_options.assert_awaited_once_with(isolation_level="AUTOCOMMIT")
+        sql = str(conn.execute.await_args[0][0])
+        assert "REINDEX INDEX CONCURRENTLY" in sql
+        assert "idx_document_chunks_search_vector_gin" in sql
 
     @pytest.mark.unit
-    async def test_reindex_fts_uses_config(self, rag_service):
-        """reindex_fts uses the configured FTS config."""
-        mock_result = MagicMock()
-        mock_result.rowcount = 0
-        rag_service.db.execute = AsyncMock(return_value=mock_result)
+    async def test_reindex_fts_runs_outside_transaction(self, rag_service):
+        """The rebuild must use a dedicated AUTOCOMMIT connection, not self.db
+        (whose request-scoped session is in an autobegun transaction)."""
+        engine, conn = self._mock_engine()
+        with patch("services.database.engine", engine):
+            await rag_service.reindex_fts()
 
-        with patch("services.rag_service.settings") as mock_settings:
-            mock_settings.rag_hybrid_fts_config = "german"
-
-            result = await rag_service.reindex_fts()
-
-        assert result["fts_config"] == "german"
-        # Verify SQL was called with german config
-        call_args = rag_service.db.execute.call_args
-        assert call_args[0][1]["fts_config"] == "german"
+        engine.connect.assert_called_once()
+        conn.execution_options.assert_awaited_once_with(isolation_level="AUTOCOMMIT")
 
 
 # =============================================================================
@@ -380,7 +395,9 @@ class TestBM25OrQuery:
         call_args = rag_retrieval.db.execute.call_args
         params = call_args[0][1]
         assert params["or_query"] == "Rechnungen OR 2022 OR Stirkenbend"
-        assert params["fts_config"] == "german"
+        # NOTE: `fts_config` is no longer a bound param — search now runs against
+        # the GENERATED STORED `search_vector` column (fixed config baked in at
+        # the column definition), so the query doesn't parameterize the config.
 
     @pytest.mark.unit
     async def test_bm25_single_word_query(self, rag_retrieval):


### PR DESCRIPTION
Twelve tests on `main` were failing due to drift from since-merged feature changes (none security-related). Full backend suite went **13 failed → 1 failed (4777 passed)** on the .159 build box.

**Test-rot fixes** (`test:` commit)
- `test_ha_glue_boundary` — allowlist `daypart_service.py` (deferred, exception-guarded `ha_glue` TZ-fallback import; same lazy pattern already allowlisted for `whisper_prompt_builder`).
- `test_memory_retrieval_lane_c` (4) — the `patch(settings)` MagicMock left `memory_kg_bridge_enabled` (dark by default) truthy, so `retrieve()` issued a trailing kg_entities query and the last-write capture asserted on the wrong SQL. Pin the bridge off.
- `test_agent_tools` (2) — refresh the platform internal-tool baseline (now also `list_my_memories` + Gen-UI `render_table`/`render_list`/`weather_widget` + `paperless_commit_upload`).
- `test_agent_router` (2) — skip cleanly when `agent_roles.yaml` is present but EMPTY (ConfigMap-served at deploy; a 0-byte stub in the test image) — skip previously only covered an absent file.
- `test_rag_hybrid_search` (3) — FTS moved to a GENERATED `search_vector` column + `REINDEX CONCURRENTLY`; drop the removed `fts_config` bound-param assertion and rewrite the reindex tests to the new `status/index/duration_ms` contract.

**Robustness fix** (`fix(db):` commit)
- The advisory-lock `checkin` listener built its cursor outside the try/except, so a connection checked in after its event loop closed could crash the hook (breaking pool checkin) — contrary to its own "never block checkin" contract. Now guarded.

**Known remaining:** `test_trajectory_routes::test_require_redacted...409` passes in isolation but fails under full-suite ordering (the `async_client` fixture shares the module engine pool across per-test event loops). Addressed separately as a test-infra fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)