### PR TITLE
docs(command-center): design doc + on-brand radial prototype

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -272,6 +272,15 @@ The hybrid extractor (deterministic Steuernummer/IBAN with whitespace normalizat
 
 ## P3 — Conditional / on signal
 
+### Command Center — live constellation of the running system
+Origin: 2026-06-27, sparked by the "Apex" (Reznikov Engineering) radial mission-control UI. Design doc + on-brand React prototype landed on `docs/command-center`; cinematic video mockups in `renfield-video/`. **Primary source: `docs/design/command-center.md`.**
+- **WHAT:** A single read-first "mission control" page (`/admin/command-center`) that unifies what's today scattered across six admin pages (`/admin/routing`, `tool-health`, `trajectories`, `satellites`, `presence`, `integrations`) into one live radial board: a core (active agent role, live off the chat WS `done` frame) → ring of agent roles → ring of MCP tools coloured by health → ring of satellites/rooms coloured by presence → federation peers. Read-only, every node drills into its existing admin page.
+- **WHY:** All the data already exists and is emitted; nothing surfaces it together or *live*. Replaces "open six tabs to understand the system" with one at-a-glance board; reuses role-surfacing's `agent_role` for the live pulse + `presence_map` data for the rooms ring.
+- **PROS:** Mostly frontend composition over existing endpoints + the WS pulse — no new inference, no new endpoints, no schema change. Phase-3 payoff (a circle-aware household **kiosk**, "what's the house doing") is genuinely Renfield-unique — no other chat UI has satellites/rooms to show.
+- **CONS:** Ring crowding at mobile widths (needs a collapsed/list fallback); the kiosk projection needs real circle-aware authz (a non-admin, content-free view) — that's the costly part, deliberately out of v1. The "stunning"/glowing-orb video aesthetic deliberately BREAKS DESIGN.md and must NOT bleed into the product component (`AgentConstellation.tsx` stays restrained, motion only where motivated — see the cinematic mockups for the marketing-only look).
+- **CONTEXT:** Prototype = `src/frontend/src/components/command-center/AgentConstellation.tsx` (+ `types.ts`/`demoData.ts`, `commandCenter.*` i18n), not yet routed. Phase 1 = assemble the live `CommandCenterModel` from the six endpoints + wire the WS pulse + add the `<AdminRoute>` page.
+- **DEPENDS ON:** strategic green-light (same premise gate as the chat-UI roadmap — is an ops board / kiosk worth the build for a voice-first household?). Standalone otherwise.
+
 ### Self-Learning — gated on burn-in data
 Both items below were surfaced by outside voice during the 2026-05-26 `/plan-eng-review` of the admin console PR. Build only when the gate fires.
 

--- a/docs/design/command-center.md
+++ b/docs/design/command-center.md
@@ -1,0 +1,201 @@
+# Command Center — live constellation of the running system
+
+Status: **Design / prototype.** A frontend prototype of the centerpiece radial
+component ships alongside this doc (`src/frontend/src/components/command-center/`,
+demo-data, not yet routed). Backend wiring + the page shell are Phase 1 below.
+
+Scope: a single **read-first "mission control"** surface that shows, at a glance,
+what the running Renfield is *doing right now* — which agent role is answering,
+which MCP tools/integrations are healthy, which satellites/rooms are live and
+occupied, and which federation peers are reachable. It does **not** add control
+logic; it composes data Renfield already emits and drills down into the existing
+admin pages.
+
+## Why this doc exists
+
+The trigger was a reference UI ("Apex" by Reznikov Engineering): a radial
+"mission control" with a glowing central core surrounded by labelled agents
+(Strategist, Researcher, Chief of staff, …) and tools (Calendar, Email, Memory,
+Drive). The pattern is compelling because it answers one question instantly:
+**"what is my agent system, and what is it doing?"**
+
+Renfield already produces every datum such a view needs — but the data is
+scattered across six separate admin pages (`/admin/routing`,
+`/admin/tool-health`, `/admin/trajectories`, `/admin/satellites`,
+`/admin/presence`, `/admin/integrations`). No surface unifies them, and none is
+*alive* (reflecting the current turn as it happens). The Command Center is that
+unifying, live surface.
+
+## The reference, and what to borrow vs reject
+
+**Borrow** (the interaction concept):
+
+- A **central core** = the orchestrator/assistant, with the **currently-active
+  agent role** surfaced on it live.
+- **Concentric rings of labelled nodes** = the system's capabilities, grouped by
+  kind (roles, tools, rooms, peers).
+- **Node state encodes live status** (health / presence / online) by colour +
+  a non-colour channel.
+- An **ambient, at-a-glance** read — legible from across the room, good on a
+  wall tablet / kiosk.
+
+**Reject** (the aesthetic): the Apex look is a glowing sci-fi orb with energy
+blooms and radial gradients. **This directly violates `DESIGN.md`**, which is
+locked and explicit:
+
+> Decoration level: INTENTIONAL — light grain on cream surfaces, **no decorative
+> blobs / gradients / icons-in-circles**.
+
+and the AI-slop blacklist forbids *"purple/violet/indigo gradients"* and
+*"icon-in-circle decoration"*. Renfield's identity is **warm, restrained,
+serif** — crimson + turquoise + cream + Cormorant, "for HOME, not work." So the
+Command Center must be a **structural constellation**, not a light show:
+
+| Apex (reject) | Renfield Command Center (adopt) |
+|---|---|
+| Glowing energy orb, radial gradient core | Solid crimson core disc, thin ring, Cormorant wordmark |
+| Bloom/particle connectors | Thin 1–2px connectors; only the **active** edge animates (a subtle dash), `prefers-reduced-motion` honoured |
+| Sci-fi neon palette | DESIGN.md tier/brand tokens only (`--color-primary-*`, `--color-accent-*`, cream) |
+| Decorative; impressionistic | Legible; every node is a real entity that drills down |
+
+This is the central design decision: **the *layout* is borrowed, the *vibe* is
+Renfield's.** Calibrate every pixel against `DESIGN.md` at build time.
+
+## The constellation: rings and what feeds them
+
+```
+                    ◦ peers (federation, outer arc)
+              ○────────────────────────────────○
+           ○        rooms / satellites            ○
+        ○        ◇──────────────────────◇           ○
+      ◇       tools / MCP integrations      ◇         ◦
+     ◇     ●──────────────────────────●       ◇
+    ◇     ●      agent roles            ●      ◇
+    ◇    ●         ┌─────────┐          ●     ◇
+         ●         │ RENFIELD│  ← active role surfaced here
+    ◇    ●         │  core   │          ●     ◇
+    ◇     ●        └─────────┘         ●      ◇
+     ◇     ●──────────────────────────●      ◇
+      ◇        ◇──────────────────────◇     ◦
+        ○         (rooms ring)            ○
+           ○                            ○
+              ○────────────────────────○
+```
+
+| Ring | Nodes | Live state shown | Backend source (already exists) |
+|---|---|---|---|
+| **Core** | Renfield orchestrator | the **currently active agent role** | WS `done` frame `agent_role` + `role_hint` (role-surfacing item 6, already on the wire) |
+| **Roles** | `agent_roles.yaml` roles (smart_home, knowledge, media, presence, general, conversation, …) | which role just answered (pulse), idle vs active | `GET /api/roles`; live highlight from the chat WS `done` frame |
+| **Tools / MCP** | Home Assistant, Paperless, Jellyfin, Calendar, Email, Search, n8n, DLNA, Weather, News, Radio | health: healthy / degraded / down / unknown | `GET /api/tool-health`, `GET /api/intents/integrations/summary` |
+| **Rooms / satellites** | each satellite/room | online/offline + occupant count (presence) | `GET /api/satellites`, `GET /api/presence/rooms` |
+| **Peers** (optional outer arc) | federation instances | reachable / unreachable | federation status endpoint (Federation Audit already lists peers) |
+
+Node colour encoding (DESIGN.md tokens, **always paired with a non-colour
+channel** per WCAG 1.4.1 — a ring style, icon, or label, never colour alone):
+
+- **Healthy / online / occupied** → `--color-accent-500` turquoise.
+- **Degraded / warn** → `--color-primary-300` light crimson.
+- **Down / offline** → `--color-primary-700` deep crimson, **plus** a dashed/hollow ring.
+- **Unknown / idle** → `--color-gray-400`, hollow.
+- **Active role** (this turn) → turquoise fill + the only animated connector.
+
+## Live data
+
+Two channels, no new inference, no new polling burden:
+
+1. **Push (the "alive" part):** the Command Center subscribes to the same chat WS
+   stream the app already maintains. On each `done` frame it reads `agent_role`
+   and lights that role node + pulses its connector for ~2s. This is the cheap,
+   high-impact signal — it makes the board *breathe* with real household activity
+   without any extra backend work (role-surfacing already plumbed it).
+2. **Poll (the "status" part):** tool-health, satellites, presence, and peers
+   poll on the existing React-Query cadence (`refetchInterval`, e.g. 5s for
+   presence/satellites which already auto-refresh, 30s for tool-health). No new
+   endpoints — all six already exist and are admin-gated.
+
+## Interaction model
+
+**Read-first.** Every node is a **drill-down**, not a control:
+
+- Click a **role** → `/admin/routing` (+ optional pin-role-for-next-turn, reusing
+  the existing routing-only `role_hint`; *display* and *pin* are both already
+  permission-safe — pinning never escalates, every tool stays gated at execute).
+- Click a **tool/MCP** → `/admin/tool-health` (or `/admin/integrations`) filtered
+  to that tool.
+- Click a **satellite/room** → `/admin/satellites/{id}` or `/admin/presence`.
+- Click a **peer** → `/brain/audit` (Federation Audit).
+
+No write actions in v1. (The interactive device widgets already own the
+artifact→action write-back channel inside chat; the Command Center stays an
+**awareness** surface, which keeps its security surface trivial.)
+
+## Permissions & circles
+
+- **v1 is `Permission.ADMIN`-gated** (route `/admin/command-center`, same
+  `<AdminRoute>` + backend `require_permission(ADMIN)` as the six pages it
+  composes). No new authz.
+- **A future household/kiosk "ambient" mode** (Phase 3) would need a non-admin,
+  **circle-aware** projection: a household member sees rooms/presence they're
+  permitted to and *never* sees another member's private activity. That is a real
+  authz design (reuse the presence service's existing per-user room visibility +
+  `circle_sql` rules for anything atom-bearing) — explicitly **out of v1**.
+- The live role pulse must **not** leak *content* (no message text, no who-asked
+  on a shared display) — it shows only the *role* and *node status*. Keep it that
+  way for the kiosk story.
+
+## Interaction states (not designed until these are)
+
+Per the DESIGN.md / chat-roadmap discipline, every node has all four:
+
+| Node | loading | empty | error | live |
+|---|---|---|---|---|
+| Core | skeleton disc | n/a (always present) | "backend unreachable" banner | active-role label |
+| Role | dim outline | role list empty → hide ring | role fetch failed → grey ring + retry | turquoise + pulse |
+| Tool | dim outline | no tools configured → hide ring | health fetch failed → all `unknown` | health colour |
+| Room/sat | dim outline | **no satellites → warm empty state, not blank** | presence fetch failed → `unknown` | online + occupant dot |
+| Peer | hidden until loaded | no peers → omit the outer arc entirely | unreachable → hollow dashed | turquoise |
+
+Global: **offline / GPU-saturated** state (a first-class Renfield condition) must
+render as a calm "system busy" core treatment, not an error — it's routine for a
+shared-GPU household.
+
+## Where it fits
+
+1. **Phase 1 — admin page** `/admin/command-center`: the unified ops view. Pure
+   composition of the six existing endpoints + the chat WS pulse. This is the
+   high-value, low-risk slice; it replaces "open six tabs to understand the
+   system" with one board.
+2. **Phase 2 — live pulse + drill-downs** wired to the real WS stream and the
+   admin pages.
+3. **Phase 3 — household/kiosk ambient mode** (circle-aware, non-admin,
+   content-free): a wall-tablet "what's the house doing" display. This is the
+   Renfield-unique payoff — no survey chat UI has satellites/rooms to show — but
+   it carries the authz work above and should follow only if the kiosk use case
+   is real.
+
+## Relationship to the chat-UI modernization roadmap
+
+The Command Center is **not** a chat-UI roadmap item — it's an **ops/awareness**
+surface, a sibling to the admin pages, not part of `/chat`. But it **reuses two
+roadmap outputs directly**: role-surfacing (item 6, the `agent_role` on the wire)
+for the live pulse, and the `presence_map` data (item 10) for the rooms ring. It
+ships independently of the roadmap's open items.
+
+## Open questions (resolve when scheduling Phase 1)
+
+1. **Ring crowding.** 11+ MCP tools on one ring at 375px is unreadable. Mobile
+   likely needs a collapsed/list fallback (the constellation is a
+   desktop/kiosk-first layout). Define the responsive breakpoint behaviour.
+2. **Role↔tool edges.** Apex draws every node to the core. Showing *which tools a
+   role can use* (the `agent_roles.yaml` `mcp_tools`/`internal_tools` lists) as
+   on-hover edges is richer but risks spaghetti — decide hover-only vs always-on.
+3. **Pulse history.** Should the board show only the *current* turn, or a short
+   decaying trail of the last N role activations (a heartbeat)? Trail is prettier
+   but needs a small client-side ring buffer.
+4. **Federation arc.** Include peers in v1 or defer? (Federation is itself
+   relatively new; the data exists but the visual adds an outer ring.)
+5. **Premise.** Same caveat as the chat roadmap: is an ops board worth building,
+   or is the value really the **Phase 3 kiosk**? If the kiosk is the goal, design
+   the circle-aware projection first so Phase 1 doesn't bake in admin-only
+   assumptions.
+```

--- a/src/frontend/src/components/command-center/AgentConstellation.tsx
+++ b/src/frontend/src/components/command-center/AgentConstellation.tsx
@@ -1,0 +1,288 @@
+// Command Center centerpiece — a live, structural constellation of the running
+// system. PROTOTYPE: renders standalone with demo data; not yet routed. See
+// docs/design/command-center.md for the full spec and the deliberate departure
+// from the "glowing orb" reference (DESIGN.md forbids decorative gradients/blobs).
+//
+// On-brand by construction: DESIGN.md tier/brand tokens only, thin connectors,
+// only the *active* edge animates, prefers-reduced-motion honoured, a11y summary.
+import { useTranslation } from 'react-i18next';
+
+import type { CommandCenterModel, NodeHealth } from './types';
+import { demoModel } from './demoData';
+
+const C = 430; // svg centre (viewBox 860×860)
+const R_ROLES = 150;
+const R_TOOLS = 255;
+const R_ROOMS = 345;
+const R_CORE = 70;
+
+const TOKEN = {
+  core: 'var(--color-primary-600)',
+  coreRing: 'var(--color-primary-700)',
+  active: 'var(--color-accent-500)', // turquoise
+  cream: 'var(--color-cream)',
+  healthy: 'var(--color-accent-500)',
+  degraded: 'var(--color-primary-300)',
+  down: 'var(--color-primary-700)',
+  unknown: 'var(--color-gray-400)',
+} as const;
+
+function polar(r: number, deg: number): [number, number] {
+  const a = ((deg - 90) * Math.PI) / 180;
+  return [C + r * Math.cos(a), C + r * Math.sin(a)];
+}
+
+function healthColor(h: NodeHealth): string {
+  return TOKEN[h];
+}
+
+function anchorFor(x: number): 'start' | 'middle' | 'end' {
+  const dx = x - C;
+  if (dx > 2) return 'start';
+  if (dx < -2) return 'end';
+  return 'middle';
+}
+
+interface Props {
+  model?: CommandCenterModel;
+  className?: string;
+}
+
+/** Read-only live constellation. Feed it a CommandCenterModel (Phase 1 assembles
+ *  one from the six admin endpoints + the chat WS `done` frame); defaults to demo. */
+export default function AgentConstellation({ model = demoModel, className }: Props) {
+  const { t } = useTranslation();
+  const { core, roles, tools, rooms, peers = [] } = model;
+  const activeRole = roles.find((r) => r.id === core.activeRoleId);
+
+  // even angular spread per ring (0° = top, clockwise)
+  const at = (i: number, n: number) => (n > 0 ? (360 / n) * i : 0);
+  // peers occupy a top arc (-55°..55°) so they read as an outer cluster, not a ring
+  const peerAngle = (i: number, n: number) => (n > 1 ? -55 + (110 / (n - 1)) * i : 0);
+
+  return (
+    <div className={className}>
+      <svg
+        viewBox="0 0 860 860"
+        className="w-full h-auto max-h-[70vh]"
+        role="img"
+        aria-labelledby="cc-title cc-desc"
+      >
+        <title id="cc-title">{t('commandCenter.title', { defaultValue: 'Command Center' })}</title>
+        <desc id="cc-desc">
+          {t('commandCenter.srSummary', {
+            defaultValue:
+              '{{roles}} agent roles, {{tools}} tools, {{rooms}} rooms. Active role: {{active}}.',
+            roles: roles.length,
+            tools: tools.length,
+            rooms: rooms.length,
+            active: activeRole?.label ?? t('commandCenter.idle', { defaultValue: 'idle' }),
+          })}
+        </desc>
+
+        <style>{`
+          .cc-core { transform-box: fill-box; transform-origin: center; animation: ccBreathe 5.5s ease-in-out infinite; }
+          .cc-active-edge { stroke-dasharray: 6 8; animation: ccDash 1.1s linear infinite; }
+          .cc-occupied { animation: ccPulse 2.8s ease-in-out infinite; }
+          @keyframes ccBreathe { 0%,100% { transform: scale(1); } 50% { transform: scale(1.025); } }
+          @keyframes ccDash { to { stroke-dashoffset: -28; } }
+          @keyframes ccPulse { 0%,100% { opacity: .55; } 50% { opacity: 1; } }
+          @media (prefers-reduced-motion: reduce) {
+            .cc-core, .cc-active-edge, .cc-occupied { animation: none; }
+          }
+        `}</style>
+
+        {/* faint ring guides — structure, not decoration */}
+        {[R_ROLES, R_TOOLS, R_ROOMS].map((r) => (
+          <circle
+            key={r}
+            cx={C}
+            cy={C}
+            r={r}
+            fill="none"
+            stroke="var(--color-gray-300)"
+            strokeOpacity={0.25}
+            strokeWidth={1}
+          />
+        ))}
+
+        {/* core → role connectors (only the active one animates) */}
+        {roles.map((role, i) => {
+          const [x, y] = polar(R_ROLES, at(i, roles.length));
+          const [cx, cy] = polar(R_CORE + 2, at(i, roles.length));
+          const isActive = role.id === core.activeRoleId;
+          return (
+            <line
+              key={`edge-${role.id}`}
+              x1={cx}
+              y1={cy}
+              x2={x}
+              y2={y}
+              stroke={isActive ? TOKEN.active : 'var(--color-gray-400)'}
+              strokeOpacity={isActive ? 0.9 : 0.22}
+              strokeWidth={isActive ? 2.5 : 1.5}
+              className={isActive ? 'cc-active-edge' : undefined}
+            />
+          );
+        })}
+
+        {/* ROOMS / SATELLITES ring (outermost full ring) */}
+        {rooms.map((room, i) => {
+          const deg = at(i, rooms.length);
+          const [x, y] = polar(R_ROOMS, deg);
+          const [lx, ly] = polar(R_ROOMS + 20, deg);
+          const occupied = room.online && room.occupants > 0;
+          const color = !room.online ? TOKEN.down : occupied ? TOKEN.active : TOKEN.unknown;
+          return (
+            <g key={`room-${room.id}`}>
+              <circle
+                cx={x}
+                cy={y}
+                r={9}
+                fill={room.online ? color : 'none'}
+                stroke={color}
+                strokeWidth={2}
+                strokeDasharray={room.online ? undefined : '3 3'}
+                className={occupied ? 'cc-occupied' : undefined}
+              />
+              {occupied && (
+                <text x={x} y={y + 3.5} textAnchor="middle" fontSize={10} fill={TOKEN.cream}>
+                  {room.occupants}
+                </text>
+              )}
+              <text
+                x={lx}
+                y={ly + 3}
+                textAnchor={anchorFor(lx)}
+                fontSize={13}
+                fill="currentColor"
+                className="text-gray-600 dark:text-gray-300"
+              >
+                {room.label}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* TOOLS / MCP ring */}
+        {tools.map((tool, i) => {
+          const deg = at(i, tools.length);
+          const [x, y] = polar(R_TOOLS, deg);
+          const [lx, ly] = polar(R_TOOLS + 18, deg);
+          const color = healthColor(tool.health);
+          return (
+            <g key={`tool-${tool.id}`}>
+              <rect
+                x={x - 7}
+                y={y - 7}
+                width={14}
+                height={14}
+                rx={3}
+                transform={`rotate(45 ${x} ${y})`}
+                fill={tool.health === 'unknown' ? 'none' : color}
+                stroke={color}
+                strokeWidth={2}
+              />
+              <text
+                x={lx}
+                y={ly + 3}
+                textAnchor={anchorFor(lx)}
+                fontSize={12}
+                fill="currentColor"
+                className="text-gray-500 dark:text-gray-400"
+              >
+                {tool.label}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* ROLES ring */}
+        {roles.map((role, i) => {
+          const deg = at(i, roles.length);
+          const [x, y] = polar(R_ROLES, deg);
+          const [lx, ly] = polar(R_ROLES - 22, deg);
+          const isActive = role.id === core.activeRoleId;
+          return (
+            <g key={`role-${role.id}`}>
+              {isActive && (
+                <circle cx={x} cy={y} r={16} fill={TOKEN.active} opacity={0.18} />
+              )}
+              <circle
+                cx={x}
+                cy={y}
+                r={10}
+                fill={isActive ? TOKEN.active : TOKEN.cream}
+                stroke={isActive ? TOKEN.active : 'var(--color-gray-400)'}
+                strokeWidth={2}
+              />
+              <text
+                x={lx}
+                y={ly + 3}
+                textAnchor={anchorFor(lx)}
+                fontSize={13}
+                fontWeight={isActive ? 600 : 400}
+                fill="currentColor"
+                className={isActive ? 'text-gray-900 dark:text-white' : 'text-gray-600 dark:text-gray-300'}
+              >
+                {role.label}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* PEERS — outer top arc, only when present */}
+        {peers.map((peer, i) => {
+          const deg = peerAngle(i, peers.length);
+          const [x, y] = polar(R_ROOMS + 55, deg);
+          return (
+            <g key={`peer-${peer.id}`}>
+              <circle
+                cx={x}
+                cy={y}
+                r={7}
+                fill="none"
+                stroke={peer.online ? TOKEN.active : TOKEN.unknown}
+                strokeWidth={2}
+                strokeDasharray="2 3"
+              />
+              <text x={x} y={y - 12} textAnchor="middle" fontSize={11} fill="currentColor" className="text-gray-500 dark:text-gray-400">
+                {peer.label}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* CORE */}
+        <g className="cc-core">
+          <circle cx={C} cy={C} r={R_CORE} fill={TOKEN.core} stroke={TOKEN.coreRing} strokeWidth={2} />
+          <text
+            x={C}
+            y={C - 4}
+            textAnchor="middle"
+            fontSize={26}
+            fill={TOKEN.cream}
+            className="font-display"
+          >
+            {core.label}
+          </text>
+          {activeRole && (
+            <text x={C} y={C + 20} textAnchor="middle" fontSize={12} fill={TOKEN.active}>
+              {activeRole.label}
+            </text>
+          )}
+        </g>
+      </svg>
+
+      {/* legend + sr-only enumeration (Tier-0 a11y: status not by colour alone) */}
+      <div className="mt-3 flex flex-wrap items-center justify-center gap-x-5 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
+        {(['healthy', 'degraded', 'down', 'unknown'] as NodeHealth[]).map((h) => (
+          <span key={h} className="inline-flex items-center gap-1.5">
+            <span className="inline-block w-2.5 h-2.5 rounded-sm" style={{ background: healthColor(h) }} />
+            {t(`commandCenter.legend.${h}`, { defaultValue: h })}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/components/command-center/demoData.ts
+++ b/src/frontend/src/components/command-center/demoData.ts
@@ -1,0 +1,37 @@
+// Demo model so <AgentConstellation /> renders standalone (prototype / Storybook /
+// design review) without backend wiring. Mirrors a realistic Renfield household:
+// roles from agent_roles.yaml, the live MCP integrations, the real satellites.
+import type { CommandCenterModel } from './types';
+
+export const demoModel: CommandCenterModel = {
+  core: { label: 'Renfield', activeRoleId: 'smart_home' },
+  roles: [
+    { id: 'smart_home', label: 'Smart Home' },
+    { id: 'knowledge', label: 'Knowledge' },
+    { id: 'media', label: 'Media' },
+    { id: 'presence', label: 'Presence' },
+    { id: 'conversation', label: 'Conversation' },
+    { id: 'general', label: 'General' },
+  ],
+  tools: [
+    { id: 'homeassistant', label: 'Home Assistant', health: 'healthy' },
+    { id: 'paperless', label: 'Paperless', health: 'healthy' },
+    { id: 'jellyfin', label: 'Jellyfin', health: 'healthy' },
+    { id: 'calendar', label: 'Calendar', health: 'healthy' },
+    { id: 'email', label: 'Email', health: 'degraded' },
+    { id: 'search', label: 'Search', health: 'healthy' },
+    { id: 'n8n', label: 'n8n', health: 'healthy' },
+    { id: 'dlna', label: 'DLNA', health: 'healthy' },
+    { id: 'weather', label: 'Weather', health: 'healthy' },
+    { id: 'news', label: 'News', health: 'unknown' },
+    { id: 'radio', label: 'Radio', health: 'down' },
+  ],
+  rooms: [
+    { id: 'wohnzimmer', label: 'Wohnzimmer', online: true, occupants: 2 },
+    { id: 'esszimmer', label: 'Esszimmer', online: true, occupants: 1 },
+    { id: 'arbeitszimmer', label: 'Arbeitszimmer', online: true, occupants: 0 },
+    { id: 'kinderbad', label: 'Kinderbad', online: true, occupants: 0 },
+    { id: 'fitnessraum', label: 'Fitnessraum', online: false, occupants: 0 },
+  ],
+  peers: [{ id: 'reva', label: 'Reva', online: true }],
+};

--- a/src/frontend/src/components/command-center/types.ts
+++ b/src/frontend/src/components/command-center/types.ts
@@ -1,0 +1,47 @@
+// Command Center — typed model for the live constellation.
+// See docs/design/command-center.md. The component is fed this shape; Phase 1
+// assembles it from the six existing admin endpoints + the chat WS `done` frame.
+
+export type NodeHealth = 'healthy' | 'degraded' | 'down' | 'unknown';
+
+export interface CoreNode {
+  /** Display name of the orchestrator, e.g. "Renfield". */
+  label: string;
+  /** id of the agent role answering the current turn, if any (live pulse). */
+  activeRoleId?: string;
+}
+
+export interface RoleNode {
+  id: string;
+  /** Human label, already localized by the caller (roles come from agent_roles.yaml). */
+  label: string;
+}
+
+export interface ToolNode {
+  id: string;
+  label: string;
+  health: NodeHealth;
+}
+
+export interface RoomNode {
+  id: string;
+  label: string;
+  online: boolean;
+  /** Number of people the presence service currently places in this room. */
+  occupants: number;
+}
+
+export interface PeerNode {
+  id: string;
+  label: string;
+  online: boolean;
+}
+
+export interface CommandCenterModel {
+  core: CoreNode;
+  roles: RoleNode[];
+  tools: ToolNode[];
+  rooms: RoomNode[];
+  /** Federation instances — optional; the outer arc is omitted when empty. */
+  peers?: PeerNode[];
+}

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -1783,5 +1783,23 @@
       "openInDocs": "In Dokumenten öffnen",
       "openInGraph": "Im Graph öffnen"
     }
+  },
+  "commandCenter": {
+    "title": "Kommandozentrale",
+    "subtitle": "Live-Konstellation des laufenden Systems",
+    "idle": "inaktiv",
+    "srSummary": "{{roles}} Agenten-Rollen, {{tools}} Werkzeuge, {{rooms}} Räume. Aktive Rolle: {{active}}.",
+    "ring": {
+      "roles": "Agenten-Rollen",
+      "tools": "Werkzeuge & Integrationen",
+      "rooms": "Räume & Satelliten",
+      "peers": "Föderations-Instanzen"
+    },
+    "legend": {
+      "healthy": "Gesund",
+      "degraded": "Eingeschränkt",
+      "down": "Ausgefallen",
+      "unknown": "Unbekannt"
+    }
   }
 }

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -1783,5 +1783,23 @@
       "openInDocs": "Open in Documents",
       "openInGraph": "Open in Graph"
     }
+  },
+  "commandCenter": {
+    "title": "Command Center",
+    "subtitle": "Live constellation of the running system",
+    "idle": "idle",
+    "srSummary": "{{roles}} agent roles, {{tools}} tools, {{rooms}} rooms. Active role: {{active}}.",
+    "ring": {
+      "roles": "Agent roles",
+      "tools": "Tools & integrations",
+      "rooms": "Rooms & satellites",
+      "peers": "Federation peers"
+    },
+    "legend": {
+      "healthy": "Healthy",
+      "degraded": "Degraded",
+      "down": "Down",
+      "unknown": "Unknown"
+    }
   }
 }


### PR DESCRIPTION
## What

A read-first **Command Center** surface that unifies what's today scattered across six admin pages (`/admin/routing`, `tool-health`, `trajectories`, `satellites`, `presence`, `integrations`) into one **live radial board**: a core (the active agent role, live off the chat WS `done` frame) → ring of agent roles → ring of MCP tools coloured by health → ring of satellites/rooms coloured by presence → federation peers. Read-only; every node drills into its existing admin page.

Sparked by the "Apex" (Reznikov Engineering) radial mission-control UI.

## Contents

- **`docs/design/command-center.md`** — design doc: concept, ring→endpoint mapping, the live-pulse mechanism (reuses role-surfacing's `agent_role`), interaction states, permissions/circles, phasing (Phase 3 = circle-aware household **kiosk**), open questions.
- **`src/frontend/src/components/command-center/`** — on-brand React prototype (`AgentConstellation.tsx` + `types.ts` + `demoData.ts`). SVG, DESIGN.md tokens only, only the active edge animates, `prefers-reduced-motion`, a11y summary. **Not yet routed.**
- **`commandCenter.*` i18n keys** in `de.json` + `en.json`.
- **`TODOS.md`** — P3 entry tracking the build, pointing at the design doc as primary source.

## Key design decision

Borrow Apex's **layout**, reject its glowing-orb **aesthetic** — `DESIGN.md` is locked ("no decorative blobs/gradients/icons-in-circles"; purple/neon blacklisted). The product component stays restrained and warm; the cinematic "stunning" version exists only as **marketing mockups** (kept local, deliberately not committed — 41 MB of video).

## Scope / not included

- No backend changes, no schema change, no new endpoints — Phase 1 (assembling the live model + routing the page) is follow-up work tracked in TODOS.
- Premise-gated (same as the chat-UI roadmap): is an ops board / kiosk worth building for a voice-first household? Filed P3 pending green-light.

🤖 Generated with [Claude Code](https://claude.com/claude-code)