### PR TITLE
fix(deploy): prune step quoting — awk 'NR>3' → tail -n +4

### DIFF
--- a/bin/deploy-production.sh
+++ b/bin/deploy-production.sh
@@ -153,7 +153,7 @@ fi
 log "cleanup + image prune on $BUILD_HOST"
 on_build "rm -rf $STAGING; \
   for repo in backend frontend; do \
-    docker images \"$REGISTRY/\$repo\" --format '{{.Repository}}:{{.Tag}}' | awk 'NR>3' | xargs -r -n1 docker rmi 2>/dev/null || true; \
+    docker images \"$REGISTRY/\$repo\" --format '{{.Repository}}:{{.Tag}}' | tail -n +4 | xargs -r -n1 docker rmi 2>/dev/null || true; \
   done; \
   docker image prune -f >/dev/null 2>&1; docker builder prune -f --keep-storage 10GB >/dev/null 2>&1; \
   df -h / | tail -1"


### PR DESCRIPTION
## Problem

`bin/deploy-production.sh` exits **1 on its final cleanup/prune step** even when the build + push + rollout + smoke all succeeded — observed live shipping the room-handoff feature (`2026-06-27-roomhandoff`):

```
bin/deploy-production.sh: line 64: 3 | xargs -r -n1 docker rmi ...: No such file or directory
```

## Root cause

The image-retention command pipes `awk 'NR>3'`, passed through `on_build()` → `run()` → `eval "$@"` → `ssh "$BUILD_HOST '$*'"`. The inner single quotes around `NR>3` **prematurely close the `ssh '…'` single-quote wrapper**, so `eval` then parses `>3` as a redirect to a file named `3`. (The adjacent `--format '{{…}}'` single quotes break out too, but survive because their content has no eval-active characters.)

## Fix

`awk 'NR>3'` → `tail -n +4`. `docker images` lists newest-first, so `tail -n +4` keeps the newest 3 tags — identical behavior — and is **quote-free**, immune to the nesting.

## Verification

Replicated `on_build`'s exact `eval`→ssh path against `.159`: **exit 0**, prune runs clean. `bash -n` syntax-checks.

## Impact

Cosmetic-only bug (deploys themselves succeeded; only the `.159` disk-prune housekeeping was skipped, leaving the exit-1). This makes every future deploy's cleanup step complete cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)