### PR TITLE
i18n: wire up hardcoded UI strings + Italian intent descriptions

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -137,7 +137,7 @@ Siehe [SATELLITE_CAMERA.md](SATELLITE_CAMERA.md) für Setup und Modellvergleich.
 DEFAULT_LANGUAGE=de
 
 # Unterstützte Sprachen (kommasepariert)
-SUPPORTED_LANGUAGES=de,en
+SUPPORTED_LANGUAGES=de,en,it
 
 # Whisper STT Modell
 WHISPER_MODEL=base
@@ -151,7 +151,7 @@ PIPER_DEFAULT_VOICE=de_DE-thorsten-high
 
 **Defaults:**
 - `DEFAULT_LANGUAGE`: `de`
-- `SUPPORTED_LANGUAGES`: `de,en`
+- `SUPPORTED_LANGUAGES`: `de,en,it`
 - `WHISPER_MODEL`: `base`
 - `PIPER_VOICES`: `de:de_DE-thorsten-high,en:en_US-amy-medium`
 - `PIPER_DEFAULT_VOICE`: `de_DE-thorsten-high` (Fallback, wenn die Sprache nicht in `PIPER_VOICES` ist)
@@ -1882,7 +1882,7 @@ OLLAMA_MODEL=qwen3:14b
 # Sprache & Voice
 # -----------------------------------------------------------------------------
 DEFAULT_LANGUAGE=de
-SUPPORTED_LANGUAGES=de,en
+SUPPORTED_LANGUAGES=de,en,it
 WHISPER_MODEL=base
 PIPER_VOICES=de:de_DE-thorsten-high,en:en_US-amy-medium
 PIPER_DEFAULT_VOICE=de_DE-thorsten-high  # Fallback for languages not in PIPER_VOICES

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -106,6 +106,9 @@ data:
 
   # Feature flags
   DEFAULT_LANGUAGE: "de"
+  # UI languages selectable + persistable (backend validates the language
+  # preference against this list). 'it' added with the Italian locale (#628).
+  SUPPORTED_LANGUAGES: "de,en,it"
   AGENT_ENABLED: "true"
   MCP_ENABLED: "true"
   MEMORY_ENABLED: "true"

--- a/src/backend/api/routes/intents.py
+++ b/src/backend/api/routes/intents.py
@@ -74,7 +74,7 @@ class IntentPromptResponse(BaseModel):
 
 @router.get("/status", response_model=IntentRegistryStatusResponse)
 async def get_intent_status(
-    lang: str = Query("de", description="Language for descriptions (de/en)"),
+    lang: str = Query("de", description="Language for descriptions (de/en/it)"),
     _user: User = Depends(require_permission(Permission.ADMIN)),
 ):
     """
@@ -148,7 +148,7 @@ async def get_intent_status(
 
 @router.get("/prompt", response_model=IntentPromptResponse)
 async def get_intent_prompt(
-    lang: str = Query("de", description="Language for prompt (de/en)"),
+    lang: str = Query("de", description="Language for prompt (de/en/it)"),
     _user: User = Depends(require_permission(Permission.ADMIN)),
 ):
     """

--- a/src/backend/services/intent_registry.py
+++ b/src/backend/services/intent_registry.py
@@ -39,13 +39,20 @@ class IntentDef:
     parameters: list[IntentParam] = field(default_factory=list)
     examples_de: list[str] = field(default_factory=list)
     examples_en: list[str] = field(default_factory=list)
+    # Optional Italian; falls back to German when not provided.
+    description_it: str | None = None
+    examples_it: list[str] = field(default_factory=list)
 
     def get_description(self, lang: str = "de") -> str:
-        """Get description in specified language."""
+        """Get description in specified language (falls back to German)."""
+        if lang == "it" and self.description_it:
+            return self.description_it
         return self.description_en if lang == "en" else self.description_de
 
     def get_examples(self, lang: str = "de") -> list[str]:
-        """Get examples in specified language."""
+        """Get examples in specified language (falls back to German)."""
+        if lang == "it" and self.examples_it:
+            return self.examples_it
         return self.examples_en if lang == "en" else self.examples_de
 
 
@@ -57,9 +64,13 @@ class IntegrationIntents:
     title_en: str
     intents: list[IntentDef]
     is_enabled_func: callable  # Function that returns True if integration is enabled
+    # Optional Italian; falls back to German when not provided.
+    title_it: str | None = None
 
     def get_title(self, lang: str = "de") -> str:
-        """Get section title in specified language."""
+        """Get section title in specified language (falls back to German)."""
+        if lang == "it" and self.title_it:
+            return self.title_it
         return self.title_en if lang == "en" else self.title_de
 
 
@@ -71,23 +82,28 @@ KNOWLEDGE_INTENTS = IntegrationIntents(
     integration_name="knowledge",
     title_de="WISSENSDATENBANK (RAG)",
     title_en="KNOWLEDGE BASE (RAG)",
+    title_it="BASE DI CONOSCENZA (RAG)",
     is_enabled_func=lambda: settings.rag_enabled,
     intents=[
         IntentDef(
             name="knowledge.search",
             description_de="Suche in der Wissensdatenbank",
             description_en="Search knowledge base",
+            description_it="Cerca nella conoscenza di base",
             parameters=[IntentParam("query", "Suchanfrage", required=True)],
             examples_de=["Suche nach Rezepten", "Finde Informationen über Python"],
             examples_en=["Search for recipes", "Find information about Python"],
+            examples_it=["Cerca ricette", "Trova informazioni su Python"],
         ),
         IntentDef(
             name="knowledge.ask",
             description_de="Frage an die Wissensdatenbank",
             description_en="Ask knowledge base",
+            description_it="Chiedi alla conoscenza di base",
             parameters=[IntentParam("question", "Die Frage", required=True)],
             examples_de=["Was steht in meinen Notizen über Docker?"],
             examples_en=["What do my notes say about Docker?"],
+            examples_it=["Cosa dicono i miei appunti su Docker?"],
         ),
     ],
 )
@@ -96,14 +112,17 @@ GENERAL_INTENTS = IntegrationIntents(
     integration_name="general",
     title_de="ALLGEMEIN",
     title_en="GENERAL",
+    title_it="GENERALE",
     is_enabled_func=lambda: True,  # Always enabled
     intents=[
         IntentDef(
             name="general.conversation",
             description_de="Normale Konversation (kein spezifischer Intent)",
             description_en="Normal conversation (no specific intent)",
+            description_it="Conversazione normale (nessun intento)",
             examples_de=["Wie geht es dir?", "Erzähl mir einen Witz"],
             examples_en=["How are you?", "Tell me a joke"],
+            examples_it=["Come stai?", "Raccontami una barzelletta"],
         ),
     ],
 )

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -28,7 +28,8 @@
     "continue": "Weiter",
     "back": "Zurück",
     "done": "Fertig",
-    "clear": "Leeren"
+    "clear": "Leeren",
+    "daysShort": "{{days}}d"
   },
   "nav": {
     "chat": "Chat",
@@ -771,7 +772,57 @@
     "selectAll": "Alle auswählen",
     "clear": "Leeren",
     "systemRole": "Systemrolle",
-    "systemRoleInfo": "Dies ist eine Systemrolle. Du kannst Berechtigungen ändern, aber nicht umbenennen oder löschen."
+    "systemRoleInfo": "Dies ist eine Systemrolle. Du kannst Berechtigungen ändern, aber nicht umbenennen oder löschen.",
+    "categories": {
+      "knowledgeBases": {
+        "name": "Wissensdatenbanken",
+        "description": "Zugriff auf Dokumente der Wissensdatenbank"
+      },
+      "homeAssistant": {
+        "name": "Home Assistant",
+        "description": "Steuerung von Smart-Home-Geräten"
+      },
+      "cameras": {
+        "name": "Kameras",
+        "description": "Kamera- und Videozugriff"
+      },
+      "conversations": {
+        "name": "Unterhaltungen",
+        "description": "Zugriff auf den Chatverlauf"
+      },
+      "roomsDevices": {
+        "name": "Räume & Geräte",
+        "description": "Verwaltung von Räumen und Geräten"
+      },
+      "speakers": {
+        "name": "Sprecher",
+        "description": "Verwaltung von Sprachprofilen"
+      },
+      "administration": {
+        "name": "Administration",
+        "description": "Systemadministration"
+      }
+    },
+    "permDesc": {
+      "kb_none": "Kein Zugriff auf Wissensdatenbanken",
+      "kb_own": "Nur Zugriff auf eigene Wissensdatenbanken",
+      "kb_shared": "Zugriff auf eigene und geteilte Wissensdatenbanken",
+      "kb_all": "Voller Zugriff auf alle Wissensdatenbanken",
+      "ha_none": "Kein Zugriff auf Home Assistant",
+      "ha_read": "Nur Gerätezustände ansehen",
+      "ha_control": "Geräte steuern (an/aus)",
+      "ha_full": "Volle Kontrolle inklusive Diensten",
+      "cam_none": "Kein Kamerazugriff",
+      "cam_view": "Kameraereignisse ansehen",
+      "cam_full": "Voller Kamerazugriff inklusive Schnappschüssen",
+      "chat_own": "Nur Zugriff auf eigene Unterhaltungen",
+      "chat_all": "Zugriff auf alle Unterhaltungen",
+      "rooms_read": "Räume und Geräte ansehen",
+      "rooms_manage": "Räume und Geräte verwalten",
+      "speakers_own": "Eigenes Sprachprofil verwalten",
+      "speakers_all": "Alle Sprachprofile verwalten",
+      "admin": "Vollständige Systemadministration"
+    }
   },
   "integrations": {
     "title": "Integrationen",
@@ -1800,6 +1851,21 @@
       "degraded": "Eingeschränkt",
       "down": "Ausgefallen",
       "unknown": "Unbekannt"
+    }
+  },
+  "routing": {
+    "title": "Routing-Dashboard",
+    "subtitle": "Aktuelle Routing-Entscheidungen über alle Kanäle",
+    "classificationLayers": "Klassifizierungs-Ebenen",
+    "empty": "Keine Routing-Einträge gefunden",
+    "col": {
+      "time": "Zeit",
+      "message": "Nachricht",
+      "domain": "Domäne",
+      "layer": "Ebene",
+      "confidence": "Konfidenz",
+      "entities": "Entitäten",
+      "feedback": "Feedback"
     }
   }
 }

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -28,7 +28,8 @@
     "continue": "Continue",
     "back": "Back",
     "done": "Done",
-    "clear": "Clear"
+    "clear": "Clear",
+    "daysShort": "{{days}}d"
   },
   "nav": {
     "chat": "Chat",
@@ -771,7 +772,57 @@
     "selectAll": "Select all",
     "clear": "Clear",
     "systemRole": "System Role",
-    "systemRoleInfo": "This is a system role. You can modify its permissions but cannot rename or delete it."
+    "systemRoleInfo": "This is a system role. You can modify its permissions but cannot rename or delete it.",
+    "categories": {
+      "knowledgeBases": {
+        "name": "Knowledge Bases",
+        "description": "Access to knowledge base documents"
+      },
+      "homeAssistant": {
+        "name": "Home Assistant",
+        "description": "Smart home device control"
+      },
+      "cameras": {
+        "name": "Cameras",
+        "description": "Camera and video access"
+      },
+      "conversations": {
+        "name": "Conversations",
+        "description": "Chat history access"
+      },
+      "roomsDevices": {
+        "name": "Rooms & Devices",
+        "description": "Room and device management"
+      },
+      "speakers": {
+        "name": "Speakers",
+        "description": "Voice profile management"
+      },
+      "administration": {
+        "name": "Administration",
+        "description": "System administration"
+      }
+    },
+    "permDesc": {
+      "kb_none": "No access to knowledge bases",
+      "kb_own": "Access only own knowledge bases",
+      "kb_shared": "Access own and shared knowledge bases",
+      "kb_all": "Full access to all knowledge bases",
+      "ha_none": "No access to Home Assistant",
+      "ha_read": "View device states only",
+      "ha_control": "Control devices (on/off)",
+      "ha_full": "Full control including services",
+      "cam_none": "No camera access",
+      "cam_view": "View camera events",
+      "cam_full": "Full camera access including snapshots",
+      "chat_own": "Access only own conversations",
+      "chat_all": "Access all conversations",
+      "rooms_read": "View rooms and devices",
+      "rooms_manage": "Manage rooms and devices",
+      "speakers_own": "Manage own speaker profile",
+      "speakers_all": "Manage all speaker profiles",
+      "admin": "Full system administration"
+    }
   },
   "integrations": {
     "title": "Integrations",
@@ -1800,6 +1851,21 @@
       "degraded": "Degraded",
       "down": "Down",
       "unknown": "Unknown"
+    }
+  },
+  "routing": {
+    "title": "Routing Dashboard",
+    "subtitle": "Recent routing decisions across all channels",
+    "classificationLayers": "Classification Layers",
+    "empty": "No routing traces found",
+    "col": {
+      "time": "Time",
+      "message": "Message",
+      "domain": "Domain",
+      "layer": "Layer",
+      "confidence": "Confidence",
+      "entities": "Entities",
+      "feedback": "Feedback"
     }
   }
 }

--- a/src/frontend/src/pages/BrainReviewPage.tsx
+++ b/src/frontend/src/pages/BrainReviewPage.tsx
@@ -115,7 +115,7 @@ export default function BrainReviewPage() {
               }`}
               aria-pressed={days === d}
             >
-              {d}d
+              {t('common.daysShort', { days: d })}
             </button>
           ))}
         </div>

--- a/src/frontend/src/pages/KnowledgePage.tsx
+++ b/src/frontend/src/pages/KnowledgePage.tsx
@@ -520,7 +520,7 @@ export default function KnowledgePage() {
               </div>
               <div>
                 <div className="text-2xl font-bold text-gray-900 dark:text-white">{stats.knowledge_base_count}</div>
-                <div className="text-sm text-gray-500 dark:text-gray-400">Knowledge Bases</div>
+                <div className="text-sm text-gray-500 dark:text-gray-400">{t('knowledge.knowledgeBases')}</div>
               </div>
             </div>
           </div>
@@ -532,7 +532,7 @@ export default function KnowledgePage() {
         <div className="card">
           <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
             <FolderOpen className="w-5 h-5 text-primary-400" />
-            Knowledge Bases
+            {t('knowledge.knowledgeBases')}
           </h2>
           <div className="flex flex-wrap gap-2">
             <button

--- a/src/frontend/src/pages/RolesPage.tsx
+++ b/src/frontend/src/pages/RolesPage.tsx
@@ -26,6 +26,9 @@ import {
 } from '../api/resources/roles';
 
 interface PermissionCategoryDef {
+  // i18n slug → roles.categories.<slug>.{name,description}. The English
+  // strings below stay as the t() fallback (defaultValue).
+  slug: string;
   description: string;
   permissions: string[];
   feature?: string;
@@ -41,36 +44,53 @@ interface RoleFormData {
 // Categories with a 'feature' key are only shown when that feature is enabled
 const PERMISSION_CATEGORIES: Record<string, PermissionCategoryDef> = {
   'Knowledge Bases': {
+    slug: 'knowledgeBases',
     description: 'Access to knowledge base documents',
     permissions: ['kb.none', 'kb.own', 'kb.shared', 'kb.all']
   },
   'Home Assistant': {
+    slug: 'homeAssistant',
     description: 'Smart home device control',
     permissions: ['ha.none', 'ha.read', 'ha.control', 'ha.full'],
     feature: 'smart_home'
   },
   'Cameras': {
+    slug: 'cameras',
     description: 'Camera and video access',
     permissions: ['cam.none', 'cam.view', 'cam.full'],
     feature: 'cameras'
   },
   'Conversations': {
+    slug: 'conversations',
     description: 'Chat history access',
     permissions: ['chat.own', 'chat.all']
   },
   'Rooms & Devices': {
+    slug: 'roomsDevices',
     description: 'Room and device management',
     permissions: ['rooms.read', 'rooms.manage']
   },
   'Speakers': {
+    slug: 'speakers',
     description: 'Voice profile management',
     permissions: ['speakers.own', 'speakers.all']
   },
   'Administration': {
+    slug: 'administration',
     description: 'System administration',
     permissions: ['admin']
   }
 };
+
+// Map a permission code ('kb.none') to its i18n description key, with the
+// English PERMISSION_DESCRIPTIONS entry as the t() fallback.
+const permDescription = (
+  t: (key: string, opts?: Record<string, unknown>) => string,
+  perm: string,
+): string =>
+  t(`roles.permDesc.${perm.replace(/\./g, '_')}`, {
+    defaultValue: PERMISSION_DESCRIPTIONS[perm] ?? perm,
+  });
 
 // Permission descriptions
 const PERMISSION_DESCRIPTIONS: Record<string, string> = {
@@ -335,7 +355,7 @@ export default function RolesPage() {
                     )}
                     <div className="flex flex-wrap gap-1 mt-2">
                       {role.permissions.slice(0, 5).map((perm) => (
-                        <span key={perm} title={PERMISSION_DESCRIPTIONS[perm]}>
+                        <span key={perm} title={permDescription(t, perm)}>
                           <Badge color="gray">{perm}</Badge>
                         </span>
                       ))}
@@ -424,7 +444,7 @@ export default function RolesPage() {
             <div className="space-y-2 max-h-96 overflow-y-auto pr-2">
               {Object.entries(PERMISSION_CATEGORIES).filter(([, { feature }]) =>
                 !feature || isFeatureEnabled(feature)
-              ).map(([category, { description, permissions }]) => {
+              ).map(([category, { slug, description, permissions }]) => {
                 const isExpanded = expandedCategories[category];
                 const selectedCount = getCategoryPermissionCount(category, formData.permissions);
 
@@ -443,8 +463,8 @@ export default function RolesPage() {
                           <ChevronRight className="w-4 h-4 text-gray-500 dark:text-gray-400" />
                         )}
                         <div className="text-left">
-                          <p className="text-gray-900 dark:text-white font-medium">{category}</p>
-                          <p className="text-gray-400 dark:text-gray-500 text-xs">{description}</p>
+                          <p className="text-gray-900 dark:text-white font-medium">{t(`roles.categories.${slug}.name`, { defaultValue: category })}</p>
+                          <p className="text-gray-400 dark:text-gray-500 text-xs">{t(`roles.categories.${slug}.description`, { defaultValue: description })}</p>
                         </div>
                       </div>
                       <span className={`text-sm px-2 py-0.5 rounded ${
@@ -493,7 +513,7 @@ export default function RolesPage() {
                               <div>
                                 <p className="text-gray-900 dark:text-white text-sm font-medium">{perm}</p>
                                 <p className="text-gray-400 dark:text-gray-500 text-xs">
-                                  {PERMISSION_DESCRIPTIONS[perm]}
+                                  {permDescription(t, perm)}
                                 </p>
                               </div>
                             </label>

--- a/src/frontend/src/pages/RoutingDashboardPage.tsx
+++ b/src/frontend/src/pages/RoutingDashboardPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { RefreshCw, CheckCircle2, XCircle } from 'lucide-react';
 import {
   useRoutingTracesQuery,
@@ -15,6 +16,7 @@ const LAYER_COLORS: Record<Layer, string> = {
 };
 
 export default function RoutingDashboardPage() {
+  const { t } = useTranslation();
   const [domainFilter, setDomainFilter] = useState('');
 
   const tracesQuery = useRoutingTracesQuery(domainFilter);
@@ -34,10 +36,10 @@ export default function RoutingDashboardPage() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
-            Routing Dashboard
+            {t('routing.title')}
           </h1>
           <p className="text-sm text-gray-500 dark:text-gray-400">
-            Recent routing decisions across all channels
+            {t('routing.subtitle')}
           </p>
         </div>
         <button
@@ -46,7 +48,7 @@ export default function RoutingDashboardPage() {
           className="btn-secondary flex items-center gap-2"
         >
           <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
-          Refresh
+          {t('common.refresh')}
         </button>
       </div>
 
@@ -69,7 +71,7 @@ export default function RoutingDashboardPage() {
 
       {stats?.by_layer && (
         <div className="card">
-          <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">Classification Layers</h2>
+          <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">{t('routing.classificationLayers')}</h2>
           <div className="flex flex-wrap gap-2">
             {Object.entries(stats.by_layer).map(([layer, count]) => (
               <span
@@ -87,13 +89,13 @@ export default function RoutingDashboardPage() {
         <table className="w-full text-sm">
           <thead>
             <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
-              <th className="pb-2 pr-4">Time</th>
-              <th className="pb-2 pr-4">Message</th>
-              <th className="pb-2 pr-4">Domain</th>
-              <th className="pb-2 pr-4">Layer</th>
-              <th className="pb-2 pr-4">Confidence</th>
-              <th className="pb-2 pr-4">Entities</th>
-              <th className="pb-2">Feedback</th>
+              <th className="pb-2 pr-4">{t('routing.col.time')}</th>
+              <th className="pb-2 pr-4">{t('routing.col.message')}</th>
+              <th className="pb-2 pr-4">{t('routing.col.domain')}</th>
+              <th className="pb-2 pr-4">{t('routing.col.layer')}</th>
+              <th className="pb-2 pr-4">{t('routing.col.confidence')}</th>
+              <th className="pb-2 pr-4">{t('routing.col.entities')}</th>
+              <th className="pb-2">{t('routing.col.feedback')}</th>
             </tr>
           </thead>
           <tbody>
@@ -134,7 +136,7 @@ export default function RoutingDashboardPage() {
             {traces.length === 0 && (
               <tr>
                 <td colSpan={7} className="py-8 text-center text-gray-400">
-                  {loading ? 'Loading...' : 'No routing traces found'}
+                  {loading ? t('common.loading') : t('routing.empty')}
                 </td>
               </tr>
             )}

--- a/tests/backend/test_intent_registry.py
+++ b/tests/backend/test_intent_registry.py
@@ -59,6 +59,46 @@ class TestIntentDef:
         assert intent.get_examples("de") == ["Beispiel 1", "Beispiel 2"]
         assert intent.get_examples("en") == ["Example 1", "Example 2"]
 
+    def test_get_description_italian(self):
+        """Italian description is returned when provided (#628)."""
+        intent = IntentDef(
+            name="test.intent",
+            description_de="Deutsche Beschreibung",
+            description_en="English description",
+            description_it="Descrizione italiana",
+        )
+        assert intent.get_description("it") == "Descrizione italiana"
+
+    def test_get_description_italian_falls_back_to_german(self):
+        """Italian falls back to German when no Italian string is set (#628)."""
+        intent = IntentDef(
+            name="test.intent",
+            description_de="Deutsche Beschreibung",
+            description_en="English description",
+        )
+        assert intent.get_description("it") == "Deutsche Beschreibung"
+
+    def test_get_examples_italian(self):
+        """Italian examples returned when set, else fall back to German (#628)."""
+        with_it = IntentDef(
+            name="test.intent",
+            description_de="Test",
+            description_en="Test",
+            examples_de=["Beispiel"],
+            examples_en=["Example"],
+            examples_it=["Esempio"],
+        )
+        assert with_it.get_examples("it") == ["Esempio"]
+
+        without_it = IntentDef(
+            name="test.intent",
+            description_de="Test",
+            description_en="Test",
+            examples_de=["Beispiel"],
+            examples_en=["Example"],
+        )
+        assert without_it.get_examples("it") == ["Beispiel"]
+
 
 class TestIntegrationIntents:
     """Tests for IntegrationIntents dataclass."""
@@ -85,6 +125,27 @@ class TestIntegrationIntents:
         )
         assert integration.get_title("en") == "Test Integration EN"
 
+    def test_get_title_italian(self):
+        """Italian title returned when set, else fall back to German (#628)."""
+        with_it = IntegrationIntents(
+            integration_name="test",
+            title_de="Test Integration",
+            title_en="Test Integration EN",
+            intents=[],
+            is_enabled_func=lambda: True,
+            title_it="Integrazione Test",
+        )
+        assert with_it.get_title("it") == "Integrazione Test"
+
+        without_it = IntegrationIntents(
+            integration_name="test",
+            title_de="Test Integration",
+            title_en="Test Integration EN",
+            intents=[],
+            is_enabled_func=lambda: True,
+        )
+        assert without_it.get_title("it") == "Test Integration"
+
 
 class TestCoreIntegrationDefinitions:
     """Tests for core integration definitions."""
@@ -96,6 +157,16 @@ class TestCoreIntegrationDefinitions:
         intent_names = [i.name for i in KNOWLEDGE_INTENTS.intents]
         assert "knowledge.search" in intent_names
         assert "knowledge.ask" in intent_names
+
+    def test_core_intents_have_italian(self):
+        """Core knowledge + general intents carry Italian descriptions (#628)."""
+        assert KNOWLEDGE_INTENTS.get_title("it") == "BASE DI CONOSCENZA (RAG)"
+        by_name = {i.name: i for i in KNOWLEDGE_INTENTS.intents}
+        assert by_name["knowledge.search"].get_description("it") == "Cerca nella conoscenza di base"
+        assert by_name["knowledge.ask"].get_description("it") == "Chiedi alla conoscenza di base"
+
+        general = GENERAL_INTENTS.intents[0]
+        assert general.get_description("it") == "Conversazione normale (nessun intento)"
 
     def test_general_intents_always_enabled(self):
         """Test general intents are always enabled."""


### PR DESCRIPTION
## Summary

Closes the untranslated-text gaps @Alfyus flagged on #628. These were **pre-existing de/en gaps too** — the strings were hardcoded (never wired to `t()`) or, for the intent registry, only carried `de`/`en`. Adding Italian (#628) just made them visible.

## Changes

**Frontend (new `de`+`en` keys + wiring):**
- **KnowledgePage** — "Knowledge Bases" heading/label → `t('knowledge.knowledgeBases')` (the key already existed; the component never used it).
- **BrainReviewPage** — bare `{d}d` day-filter suffix → `t('common.daysShort')` (Italian renders "g" for *giorni*).
- **RoutingDashboardPage** — was 100% hardcoded with no `useTranslation`; added the hook + a new `routing.*` namespace (title, subtitle, classification layers, table headers, empty state; reuses `common.refresh`/`common.loading`).
- **RolesPage** — permission category names/descriptions + the 18 permission descriptions were hardcoded English consts → `roles.categories.*` + `roles.permDesc.*`, with the English strings kept as the `t()` `defaultValue` fallback.

**Backend (gap #3 — registry was already language-aware, only `de`/`en` populated):**
- `intent_registry` gains optional `description_it`/`examples_it`/`title_it` with a **German fallback** in the getters; the 3 core intents (`knowledge.search`/`ask`, `general.conversation`) populated using @Alfyus's suggested wording.
- `intents` route `lang` Query doc: `de/en` → `de/en/it`.

**Config:**
- `k8s/configmap.yaml`: `SUPPORTED_LANGUAGES: "de,en,it"` (declarative — lets authenticated users persist the Italian preference; the backend validates against this list).

~44 new keys added to `de.json` + `en.json` (full parity preserved, **1609 each**). Italian for these keys ships as a follow-up commit on the #628 branch (`it.json` lives there, not on `main`).

## Test Plan
- [x] Backend: **48 intent tests pass on .159** incl. new Italian-fallback + core-intent coverage (`test_intent_registry.py`).
- [x] Frontend: `tsc --noEmit` clean (only 2 pre-existing unrelated errors), `eslint` clean on touched files.
- [x] de/en locale parity verified (1609/1609).

## Related
Follow-up to #628 (Italian translation by @Alfyus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)