### PR TITLE
satellite(watchdog): Tier-2 backend-link recovery (fixes 27h-dark wedge)

### DIFF
--- a/src/satellite/provisioning/group_vars/satellites.yml
+++ b/src/satellite/provisioning/group_vars/satellites.yml
@@ -56,6 +56,18 @@ net_watchdog_fail_threshold: 5
 net_watchdog_max_reboots: 3        # stop rebooting after this many — a gateway down
                                    # for hours won't be fixed by it; a good ping refills
 
+# Tier-2 backend-link watchdog (same timer/script): when the gateway IS reachable
+# but the satellite process is running yet holds NO connection to the backend
+# ingress for backend_watchdog_fail_threshold consecutive ~1-min checks, restart
+# the satellite service (NOT a reboot — a down backend isn't the Pi's fault).
+# Recovers the "service up but wedged, stayed dark for hours until power-cycled"
+# failure that neither the HW nor the gateway watchdog catches. Threshold is kept
+# above server.max_disconnected_seconds so the app's own reconnect tries first.
+backend_watchdog_service: "renfield-satellite.service"
+backend_watchdog_port: 443                # wss ingress port the satellite connects to
+backend_watchdog_fail_threshold: 10       # ~10 min wedged → restart the service
+backend_watchdog_max_restarts: 3          # stop after this many — a restored link refills
+
 # Wake word
 wakeword_model: "hey_renfield"
 wakeword_threshold: 0.5

--- a/src/satellite/provisioning/templates/renfield-net-watchdog.service.j2
+++ b/src/satellite/provisioning/templates/renfield-net-watchdog.service.j2
@@ -8,4 +8,6 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart={{ satellite_base_dir }}/bin/renfield-net-watchdog.sh "{{ net_watchdog_target | default('') }}" {{ net_watchdog_fail_threshold | default(5) }} {{ net_watchdog_max_reboots | default(3) }}
+# Args: <gateway-target> <fail-threshold> <max-reboots> (Tier 1) then
+#       <service-unit> <backend-port> <backend-threshold> <max-restarts> (Tier 2)
+ExecStart={{ satellite_base_dir }}/bin/renfield-net-watchdog.sh "{{ net_watchdog_target | default('') }}" {{ net_watchdog_fail_threshold | default(5) }} {{ net_watchdog_max_reboots | default(3) }} "{{ backend_watchdog_service | default('renfield-satellite.service') }}" {{ backend_watchdog_port | default(443) }} {{ backend_watchdog_fail_threshold | default(10) }} {{ backend_watchdog_max_restarts | default(3) }}

--- a/src/satellite/provisioning/templates/renfield-net-watchdog.sh.j2
+++ b/src/satellite/provisioning/templates/renfield-net-watchdog.sh.j2
@@ -1,25 +1,92 @@
 #!/bin/bash
 # Renfield satellite network watchdog (managed by Ansible — do not edit on host).
 #
-# Recovers a *wedged network stack* — the failure the SoC hardware watchdog
-# CANNOT catch: the kernel + systemd stay healthy (so /dev/watchdog keeps being
-# pet) but Wi-Fi/IP is dead and the satellite can't reach the backend. The
-# app-level reconnect (server.max_disconnected_seconds) only restarts the
-# process; if the whole stack is wedged that doesn't help, so as a last resort
-# we reboot the board.
+# Two independent recovery tiers, each for a failure the SoC hardware watchdog
+# CANNOT catch (the kernel + systemd stay healthy, so /dev/watchdog keeps being
+# pet):
 #
-# Decision signal = reachability of the DEFAULT GATEWAY, not the backend: a
-# down backend (e.g. a rolling redeploy) is not the Pi's fault and must NOT
-# trigger a reboot. Only when the Pi can't reach its own gateway is the local
-# network genuinely dead.
+#   Tier 1 — wedged network stack.  Wi-Fi/IP is dead and the Pi can't even reach
+#   its own default gateway.  Last resort: reboot the board.  The decision
+#   signal is the GATEWAY, not the backend: a down backend (e.g. a rolling
+#   redeploy) is not the Pi's fault and must NOT trigger a reboot.
+#
+#   Tier 2 — wedged satellite link.  The OS + Wi-Fi are healthy (gateway
+#   reachable) but the satellite *process* is running yet has NO connection to
+#   the backend and isn't recovering on its own (the app-level reconnect /
+#   server.max_disconnected_seconds failed to clear a stuck socket / DNS / async
+#   strand).  This is the "stayed dark for hours until someone power-cycled it"
+#   case.  We do NOT reboot for it (still not the Pi's fault if the backend is
+#   genuinely down) — we just restart the satellite service, which is cheap and
+#   clears a wedged process.  A long threshold means a normal redeploy +
+#   reconnect never trips it; only a sustained wedge does.
 set -u
 
 TARGET="${1:-}"
 THRESHOLD="${2:-5}"               # consecutive failures (timer cadence ≈ 1/min) → reboot
 MAX_REBOOTS="${3:-3}"             # give up after this many reboots — a gateway that's
                                   # been down for hours won't be fixed by rebooting
-STATE=/run/renfield-net-watchdog.fails             # fail counter (tmpfs, clears on reboot)
-BUDGET=/var/lib/renfield/net-watchdog-reboots      # reboot budget (persists across reboots)
+# Tier-2 (backend-link) parameters:
+SVC="${4:-renfield-satellite.service}"   # unit whose backend link we watch / restart
+BACKEND_PORT="${5:-443}"                 # wss ingress port the satellite connects to
+BACKEND_THRESHOLD="${6:-10}"             # consecutive checks (~1/min) with the service
+                                         # UP but no backend link → restart it. Keep
+                                         # comfortably above server.max_disconnected_seconds
+                                         # so the app's own reconnect gets first crack.
+MAX_RESTARTS="${7:-3}"                   # restart budget before giving up until it returns
+
+# State/budget paths (env-overridable for tests; production defaults below).
+# *.fails live on tmpfs (clear on reboot); *budget paths persist across reboots.
+STATE="${RENFIELD_WD_STATE:-/run/renfield-net-watchdog.fails}"
+BUDGET="${RENFIELD_WD_BUDGET:-/var/lib/renfield/net-watchdog-reboots}"
+BSTATE="${RENFIELD_WD_BSTATE:-/run/renfield-net-watchdog.backend-fails}"
+BBUDGET="${RENFIELD_WD_BBUDGET:-/var/lib/renfield/net-watchdog-restarts}"
+UPTIME_FILE="${RENFIELD_WD_UPTIME_FILE:-/proc/uptime}"
+
+# --- Tier 2 helper: is the satellite actually talking to the backend? ---------
+# True iff the service's MAIN process holds an ESTABLISHED connection to the
+# backend ingress on $BACKEND_PORT. Matching the service PID (not just any
+# :443 socket) avoids a false-healthy from unrelated TLS traffic (apt, etc.).
+backend_link_ok() {
+    command -v ss >/dev/null 2>&1 || return 0   # no ss → can't judge; assume OK (never act)
+    local pid
+    pid=$(systemctl show -p MainPID --value "$SVC" 2>/dev/null || echo 0)
+    { [ -z "$pid" ] || [ "$pid" = "0" ]; } && return 1
+    ss -tnp state established "( dport = :$BACKEND_PORT )" 2>/dev/null \
+        | grep -q "pid=$pid,"
+}
+
+# Runs only when the gateway is reachable (Tier 1 passed). Restarts a wedged
+# satellite service; never reboots.
+check_backend_link() {
+    # Service not supposed to be running (stopped/disabled) → nothing to watch.
+    systemctl is-active --quiet "$SVC" 2>/dev/null || { rm -f "$BSTATE"; return; }
+
+    if backend_link_ok; then
+        rm -f "$BSTATE" "$BBUDGET"          # connected → clear counter + refill budget
+        return
+    fi
+
+    local bfails
+    bfails=$(( $(cat "$BSTATE" 2>/dev/null || echo 0) + 1 ))
+    echo "$bfails" > "$BSTATE"
+    logger -t renfield-net-watchdog "satellite up but no backend link ($bfails/$BACKEND_THRESHOLD)"
+    [ "$bfails" -lt "$BACKEND_THRESHOLD" ] && return
+
+    # Threshold reached. Spend from the persistent restart budget so a backend
+    # that stays down for hours can't restart-loop the service forever; a
+    # restored link refills it.
+    local restarts
+    restarts=$(( $(cat "$BBUDGET" 2>/dev/null || echo 0) + 1 ))
+    if [ "$restarts" -gt "$MAX_RESTARTS" ]; then
+        logger -t renfield-net-watchdog "no backend link after $MAX_RESTARTS restarts — giving up until it returns"
+        return
+    fi
+    mkdir -p "$(dirname "$BBUDGET")"
+    echo "$restarts" > "$BBUDGET"
+    rm -f "$BSTATE"                          # reset the per-attempt counter
+    logger -t renfield-net-watchdog "restarting $SVC — wedged with no backend link ($restarts/$MAX_RESTARTS)"
+    systemctl restart "$SVC"
+}
 
 # Derive the IPv4 default gateway if no explicit target was given.
 if [ -z "$TARGET" ]; then
@@ -28,14 +95,17 @@ fi
 # No gateway known (boot race / no route) — can't decide, stay hands-off.
 [ -z "$TARGET" ] && exit 0
 
-# Don't reboot during the first 10 min of uptime: let the network settle after a
-# boot and bound how fast a reboot loop could cycle.
-up=$(cut -d. -f1 /proc/uptime 2>/dev/null || echo 0)
+# Don't act during the first 10 min of uptime: let the network settle after a
+# boot (and the satellite get its first backend connection) and bound how fast a
+# reboot loop could cycle. Applies to BOTH tiers.
+up=$(cut -d. -f1 "$UPTIME_FILE" 2>/dev/null || echo 0)
 [ "$up" -lt 600 ] && exit 0
 
 if ping -c 2 -W 3 "$TARGET" >/dev/null 2>&1; then
-    # Network healthy → clear the fail counter AND refill the reboot budget.
+    # Network healthy → clear the gateway fail counter AND refill the reboot
+    # budget, then check the higher-level backend link (Tier 2).
     rm -f "$STATE" "$BUDGET"
+    check_backend_link
     exit 0
 fi
 

--- a/tests/satellite/test_net_watchdog.py
+++ b/tests/satellite/test_net_watchdog.py
@@ -1,0 +1,164 @@
+"""Tests for the satellite network watchdog script (Tier 1 reboot + Tier 2
+backend-link restart).
+
+The script is `provisioning/templates/renfield-net-watchdog.sh.j2` — pure bash
+(no Jinja substitutions in the body), so we run it directly with stubbed
+`ping`/`ss`/`systemctl`/`logger`/`ip` on PATH and assert on the side effects
+(did it reboot? restart the service? how did the counters move?).
+
+Tier 2 is the fix for the "satellite process up but wedged with no backend
+connection, stayed dark for hours until power-cycled" failure: when the gateway
+is reachable but the service has no ESTABLISHED link to the backend ingress for
+N consecutive checks, restart the service (never reboot).
+"""
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.satellite
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "src/satellite/provisioning/templates/renfield-net-watchdog.sh.j2"
+)
+
+SVC = "renfield-satellite.service"
+SAT_PID = "1068"
+BACKEND_PORT = "443"
+GW_THRESHOLD = "5"
+MAX_REBOOTS = "3"
+BACKEND_THRESHOLD = "10"
+MAX_RESTARTS = "3"
+
+
+def _write(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+@pytest.fixture
+def env(tmp_path):
+    """A sandbox: stub commands on PATH + temp state paths. Behaviour of the
+    stubs is driven by env vars the test sets per-scenario."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    calls = tmp_path / "systemctl.calls"
+
+    # ping: exit 0 (reachable) iff GATEWAY_UP=1
+    _write(bindir / "ping", '#!/bin/bash\n[ "${GATEWAY_UP:-1}" = "1" ] && exit 0 || exit 1\n')
+    # logger: no-op
+    _write(bindir / "logger", "#!/bin/bash\nexit 0\n")
+    # ip: print a default route so the gateway auto-derives if no target given
+    _write(bindir / "ip", '#!/bin/bash\necho "default via 10.0.0.1 dev wlan0"\n')
+    # ss: emit a line containing pid=<SAT_PID>, iff SS_HAS_LINK=1 (the satellite
+    # holds an ESTABLISHED backend connection)
+    _write(
+        bindir / "ss",
+        '#!/bin/bash\n'
+        'if [ "${SS_HAS_LINK:-0}" = "1" ]; then\n'
+        '  echo "ESTAB 0 0 192.168.1.225:50052 192.168.1.230:443 users:((\\"python\\",pid=${SAT_PID},fd=18))"\n'
+        'fi\n'
+        'exit 0\n',
+    )
+    # systemctl: record restart/reboot; answer is-active / show MainPID from env
+    _write(
+        bindir / "systemctl",
+        '#!/bin/bash\n'
+        f'echo "$@" >> "{calls}"\n'
+        'case "$1" in\n'
+        '  is-active) [ "${SVC_ACTIVE:-1}" = "1" ] && exit 0 || exit 3 ;;\n'
+        '  show) echo "${SAT_PID}" ;;\n'  # -p MainPID --value
+        '  restart|reboot) exit 0 ;;\n'
+        'esac\n'
+        'exit 0\n',
+    )
+
+    uptime = tmp_path / "uptime"
+    uptime.write_text("9999.0 9000.0\n")  # well past the 10-min boot grace
+
+    base = {
+        **os.environ,
+        "PATH": f"{bindir}:{os.environ['PATH']}",
+        "SAT_PID": SAT_PID,
+        "RENFIELD_WD_STATE": str(tmp_path / "fails"),
+        "RENFIELD_WD_BUDGET": str(tmp_path / "reboots"),
+        "RENFIELD_WD_BSTATE": str(tmp_path / "bfails"),
+        "RENFIELD_WD_BBUDGET": str(tmp_path / "restarts"),
+        "RENFIELD_WD_UPTIME_FILE": str(uptime),
+    }
+    return {"tmp": tmp_path, "calls": calls, "base": base, "uptime": uptime}
+
+
+def run(env, *, target="10.0.0.1", **overrides):
+    e = {**env["base"], **{k: str(v) for k, v in overrides.items()}}
+    args = [
+        "bash", str(SCRIPT), target, GW_THRESHOLD, MAX_REBOOTS,
+        SVC, BACKEND_PORT, BACKEND_THRESHOLD, MAX_RESTARTS,
+    ]
+    subprocess.run(args, env=e, check=True, capture_output=True, timeout=30)
+
+
+def calls(env) -> str:
+    return env["calls"].read_text() if env["calls"].exists() else ""
+
+
+# --- Tier 2: backend-link restart ------------------------------------------
+
+def test_connected_does_nothing_and_clears_counter(env):
+    (env["tmp"] / "bfails").write_text("4")
+    run(env, GATEWAY_UP=1, SVC_ACTIVE=1, SS_HAS_LINK=1)
+    assert "restart" not in calls(env)
+    assert "reboot" not in calls(env)
+    assert not (env["tmp"] / "bfails").exists()  # cleared on a healthy link
+
+
+def test_no_link_below_threshold_increments_only(env):
+    run(env, GATEWAY_UP=1, SVC_ACTIVE=1, SS_HAS_LINK=0)
+    assert "restart" not in calls(env)
+    assert (env["tmp"] / "bfails").read_text().strip() == "1"
+
+
+def test_no_link_at_threshold_restarts_service(env):
+    (env["tmp"] / "bfails").write_text(str(int(BACKEND_THRESHOLD) - 1))  # 9 → 10
+    run(env, GATEWAY_UP=1, SVC_ACTIVE=1, SS_HAS_LINK=0)
+    assert f"restart {SVC}" in calls(env)
+    assert "reboot" not in calls(env)  # NEVER reboot for a backend issue
+    assert (env["tmp"] / "restarts").read_text().strip() == "1"  # budget spent
+
+
+def test_restart_budget_exhausted_gives_up(env):
+    (env["tmp"] / "bfails").write_text(str(int(BACKEND_THRESHOLD) - 1))
+    (env["tmp"] / "restarts").write_text(MAX_RESTARTS)  # already at the cap
+    run(env, GATEWAY_UP=1, SVC_ACTIVE=1, SS_HAS_LINK=0)
+    assert "restart" not in calls(env)
+
+
+def test_inactive_service_is_not_restarted(env):
+    (env["tmp"] / "bfails").write_text(str(int(BACKEND_THRESHOLD) - 1))
+    run(env, GATEWAY_UP=1, SVC_ACTIVE=0, SS_HAS_LINK=0)
+    assert "restart" not in calls(env)
+    assert not (env["tmp"] / "bfails").exists()  # counter reset when not running
+
+
+# --- Tier 1 regression + grace ---------------------------------------------
+
+def test_gateway_down_at_threshold_reboots(env):
+    (env["tmp"] / "fails").write_text(str(int(GW_THRESHOLD) - 1))  # 4 → 5
+    run(env, GATEWAY_UP=0)
+    assert "reboot" in calls(env)
+
+
+def test_gateway_down_below_threshold_no_reboot(env):
+    run(env, GATEWAY_UP=0)
+    assert "reboot" not in calls(env)
+    assert (env["tmp"] / "fails").read_text().strip() == "1"
+
+
+def test_boot_grace_suppresses_all_action(env):
+    env["uptime"].write_text("120.0 60.0\n")  # < 600s grace
+    (env["tmp"] / "bfails").write_text(str(int(BACKEND_THRESHOLD) - 1))
+    run(env, GATEWAY_UP=1, SVC_ACTIVE=1, SS_HAS_LINK=0)
+    assert calls(env) == ""  # neither tier acts during the boot grace


### PR DESCRIPTION
## Summary

Closes the watchdog blind spot that left **arbeitszimmer dark for ~27 hours**: the OS + Wi-Fi were healthy (gateway reachable) but the satellite *process* was running yet had **no connection to the backend** and never recovered. Neither existing watchdog catches this — the SoC HW watchdog only fires on a kernel/PID-1 hang, and the net-watchdog only reboots on **gateway** unreachable. It sat dark until power-cycled by hand.

## Design

A **Tier 2** added to the same net-watchdog timer/script, runs only when the gateway IS reachable (Tier 1 passed):

- **Trigger:** the satellite service is active but its **MAIN process holds no `ESTABLISHED` connection to the backend ingress** (`:443`) for `backend_watchdog_fail_threshold` (~10) consecutive ~1-min checks.
- **Action:** `systemctl restart renfield-satellite` — **never a reboot**. A down backend (e.g. a rolling redeploy) is not the Pi's fault, so the gateway-only reboot rule is unchanged.
- **Safety:** matches the *service PID* (not any `:443` socket → no false-healthy from apt/TLS noise); a **restart budget** (3) prevents restart-looping during a long backend outage and refills when the link returns; the **10-min boot grace** + a threshold above `server.max_disconnected_seconds` ensure the app's own reconnect gets first crack and a normal redeploy never trips it.

## Changes
- `templates/renfield-net-watchdog.sh.j2` — Tier-2 logic + env-overridable state paths/uptime file for unit-testing (production defaults unchanged).
- `templates/renfield-net-watchdog.service.j2` — passes the 4 Tier-2 args.
- `group_vars/satellites.yml` — `backend_watchdog_{service,port,fail_threshold,max_restarts}`.
- `tests/satellite/test_net_watchdog.py` — 8 scenarios.

## Test Plan
- [x] **8/8 pass**: connected/healthy, below-threshold increment, at-threshold restart, budget-exhausted give-up, inactive-service skip, **Tier-1 reboot regression**, boot-grace suppression. Pure bash + `ss`/`ping`/`systemctl` stubs.
- [x] `bash -n` syntax clean.
- [x] Ground-truthed against the live arbeitszimmer connection (`python` PID → `192.168.1.230:443`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)