### PR TITLE
chore(satellite): bump Esszimmer pod image to esszimmer-v6 (satellite v1.4.6)

### DIFF
--- a/k8s/satellite-esszimmer.yaml
+++ b/k8s/satellite-esszimmer.yaml
@@ -119,7 +119,7 @@ spec:
                     values: ["arm64"]
       containers:
         - name: satellite
-          image: renfield/satellite:esszimmer-v5
+          image: renfield/satellite:esszimmer-v6
           imagePullPolicy: Never   # imported into node containerd (k8s.io ns)
           securityContext:
             privileged: true        # raw /dev access for USB audio + xvf_host


### PR DESCRIPTION
## Summary

Records the Esszimmer k8s-pod satellite image bump in the manifest to match the live cluster.

**Context:** Esszimmer (the first k8s-pod satellite) was stuck on satellite **v1.4.1** while the rest of the fleet is on v1.4.6. OTA can't update a pod satellite — its code lives on the ephemeral container layer and is wiped back to the baked image version on every pod restart. The fix was to rebuild the image natively on the Orange Pi (arm64) at v1.4.6 and `ctr -n k8s.io images import` it into the node containerd, then repoint the deployment.

This PR just updates the committed manifest (`esszimmer-v5` → `esszimmer-v6`) so it matches the live cluster — `kubectl diff -f k8s/satellite-esszimmer.yaml` now shows no drift.

## Verification (live)

- Backend reports `sat-esszimmer` version **1.4.6**, `update_available=false` (whole fleet now on 1.4.6).
- `error_count_1h` dropped 49 → 0 after the update.
- Pod healthy, connected, and authenticated (enrollment PSK provisioned separately via the `satellite-esszimmer-secret`).

No code change — manifest only. The image itself is node-local (`imagePullPolicy: Never`), already imported on `orangepizero3w`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)