### PR TITLE
fix(db): raise connection-pool headroom 30→45/process (folder-ingest flood)

### DIFF
--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -73,8 +73,15 @@ class Settings(BaseSettings):
     postgres_host: str = "postgres"
     postgres_port: int = Field(default=5432, ge=1, le=65535)
     postgres_db: str = "renfield"
-    db_pool_size: int = Field(default=10, ge=1, le=100)
-    db_max_overflow: int = Field(default=20, ge=0, le=200)
+    # 15 + 30 = 45 connections/process. backend + document-worker each get their
+    # own pool → 2 × 45 = 90 max, safely under Postgres max_connections=100. Bumped
+    # from 10+20 after a folder-ingest backlog flood exhausted the 30/process pool
+    # (QueuePool timeout → docs failed with create_error). Env-overridable if the
+    # DB's max_connections is raised. Do NOT push per-process total past ~45 while
+    # max_connections=100 and two processes share it, or you trade pool timeouts
+    # for "too many connections".
+    db_pool_size: int = Field(default=15, ge=1, le=100)
+    db_max_overflow: int = Field(default=30, ge=0, le=200)
     db_pool_recycle: int = Field(default=3600, ge=60, le=86400)
 
     # Redis


### PR DESCRIPTION
## Summary

A folder-ingest **backlog flood** (dozens of documents pushed at once after a 403 token outage was fixed) exhausted the backend's DB connection pool:

```
QueuePool limit of size 10 overflow 20 reached, connection timed out, timeout 30.00
```

→ real documents failed to ingest (`create_error`) and were moved to `failed/`.

## Change

Bump the pool defaults **10+20 → 15+30 = 45 connections/process**.

- backend + document-worker each get their own pool → **2 × 45 = 90 max**, safely under **Postgres `max_connections=100`** (verified live; 19 in use at check time).
- Env-overridable (`DB_POOL_SIZE` / `DB_MAX_OVERFLOW`) if `max_connections` is raised later.
- Deliberately **not** larger: 60/process × 2 = 120 would exceed `max_connections` and trade pool timeouts for the worse "too many connections" error.

Config-only; no migration. Takes effect on backend rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)