### PR TITLE
chore(worker): raise document-worker memory limit 6Gi → 10Gi

### DIFF
--- a/k8s/document-worker.yaml
+++ b/k8s/document-worker.yaml
@@ -119,10 +119,13 @@ spec:
           # need the `procps` package in the runtime image, which we don't
           # ship to keep the image lean.
           resources:
-            requests: {cpu: 500m, memory: 1Gi}
-            # 6Gi owns the Docling/EasyOCR peak alone. Backend can drop to
-            # ~5Gi post-cutover (PR C1) since it no longer runs this pipeline.
-            limits:   {cpu: "2",  memory: 6Gi}
+            requests: {cpu: 500m, memory: 2Gi}
+            # 10Gi limit: a large scanned PDF under Docling/EasyOCR force-full-page
+            # OCR can peak past 6Gi and OOMKill the worker mid-run (doc 241, a 5.6MB
+            # scan, blew >6Gi 2026-07-02 → orphaned in the PEL). Request stays low
+            # (2Gi) so scheduling isn't starved; the pod bursts to 10Gi only during
+            # a heavy OCR. Node k8s-gpu-3 has ~15Gi allocatable.
+            limits:   {cpu: "2",  memory: 10Gi}
       volumes:
         - name: uploads
           persistentVolumeClaim:


### PR DESCRIPTION
Prevents the OOMKill-mid-OCR that orphaned doc 241 (5.6MB scan blew >6Gi). Limit 6Gi→10Gi, request 1Gi→2Gi (low request keeps scheduling healthy; node k8s-gpu-3 has ~15Gi allocatable). Already applied live via `kubectl patch`; this persists it in `k8s/document-worker.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)