### PR TITLE
feat(command-center): fullscreen kiosk wall-display (Phase 3)

### DIFF
--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -50,6 +50,7 @@ const AdminToolHealthPage = lazy(() => import('./pages/AdminToolHealthPage'));
 const AdminTrajectoriesPage = lazy(() => import('./pages/AdminTrajectoriesPage'));
 const AdminCuratorPage = lazy(() => import('./pages/AdminCuratorPage'));
 const CommandCenterPage = lazy(() => import('./pages/CommandCenterPage'));
+const KioskPage = lazy(() => import('./pages/KioskPage'));
 const WissenLayout = lazy(() => import('./pages/wissen/WissenLayout'));
 const OverviewLens = lazy(() => import('./pages/wissen/OverviewLens'));
 
@@ -66,6 +67,14 @@ function AppRoutes() {
       {/* Public routes without layout */}
       <Route path="/login" element={<LoginPage />} />
       <Route path="/register" element={<RegisterPage />} />
+
+      {/* Fullscreen wall-display kiosk — deliberately OUTSIDE the app Layout
+          (no sidebar/header). Admin-gated (auth-off = open, like the board). */}
+      <Route path="/kiosk" element={
+        <AdminRoute>
+          <KioskPage />
+        </AdminRoute>
+      } />
 
       {/* Routes with layout */}
       <Route path="/*" element={

--- a/src/frontend/src/components/command-center/KioskConstellation.tsx
+++ b/src/frontend/src/components/command-center/KioskConstellation.tsx
@@ -340,13 +340,21 @@ function Telem({ label, value, alert }: { label: string; value: string; alert?: 
 }
 
 function usePrefersReducedMotion(): boolean {
-  const [reduced, setReduced] = useState(false);
+  const [reduced, setReduced] = useState(
+    () => window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false,
+  );
   useEffect(() => {
     const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
     const on = () => setReduced(mq.matches);
     on();
-    mq.addEventListener('change', on);
-    return () => mq.removeEventListener('change', on);
+    // Older WebKit (some wall-display browsers) only has the legacy add/remove
+    // Listener API — fall back so the effect never throws and blanks the kiosk.
+    if (mq.addEventListener) {
+      mq.addEventListener('change', on);
+      return () => mq.removeEventListener('change', on);
+    }
+    mq.addListener(on);
+    return () => mq.removeListener(on);
   }, []);
   return reduced;
 }

--- a/src/frontend/src/components/command-center/KioskConstellation.tsx
+++ b/src/frontend/src/components/command-center/KioskConstellation.tsx
@@ -1,0 +1,366 @@
+// KioskConstellation — the FULLSCREEN, cinematic "stunning" command-center for
+// a wall display. Deliberately breaks DESIGN.md (glow, bloom, radial gradients)
+// per TODOS.md line 315 — the marketing/kiosk aesthetic that must stay OUT of
+// the restrained admin `AgentConstellation`. This is a separate component so
+// that boundary holds.
+//
+// It renders full-bleed on a dark cosmic field: a glowing core that reacts to
+// real household voice activity (idle / listening / processing / speaking, from
+// the satellites' own state), concentric rings of roles / tools / rooms / peers,
+// and an ambient telemetry corner. Content-free by design (counts, role names,
+// room names only) so it is safe on a shared screen.
+import { useEffect, useMemo, useState } from 'react';
+import type { TFunction } from 'i18next';
+import { useTranslation } from 'react-i18next';
+
+import type { NodeHealth } from './types';
+import type { CoreState, KioskState } from './useKioskModel';
+
+const VW = 1920;
+const VH = 1080;
+const CX = VW / 2;
+const CY = VH / 2;
+const R_ROLES = 210;
+const R_TOOLS = 340;
+const R_ROOMS = 452;
+const R_PEERS = 520;
+const R_CORE = 96;
+
+const C = {
+  active: '#00e4b8', // turquoise
+  healthy: '#00e4b8',
+  degraded: '#f7a4ae',
+  down: '#e63e54',
+  unknown: '#5b6472',
+  crimson: '#e63e54',
+  cream: '#f0e6d3',
+  dim: '#7d8794',
+} as const;
+
+const CORE_COLOR: Record<CoreState, string> = {
+  idle: C.crimson,
+  listening: C.active,
+  processing: C.cream,
+  speaking: C.active,
+  busy: C.unknown,
+};
+
+function polar(r: number, deg: number): [number, number] {
+  const a = ((deg - 90) * Math.PI) / 180;
+  return [CX + r * Math.cos(a), CY + r * Math.sin(a)];
+}
+/** Like polar but around the origin (0,0) — for groups translated to the core. */
+function ray(r: number, deg: number): [number, number] {
+  const a = ((deg - 90) * Math.PI) / 180;
+  return [r * Math.cos(a), r * Math.sin(a)];
+}
+function healthColor(h: NodeHealth): string {
+  return h === 'healthy' ? C.healthy : h === 'degraded' ? C.degraded : h === 'down' ? C.down : C.unknown;
+}
+function anchorFor(x: number): 'start' | 'middle' | 'end' {
+  const dx = x - CX;
+  if (dx > 4) return 'start';
+  if (dx < -4) return 'end';
+  return 'middle';
+}
+
+// Deterministic star field (no Math.random — SSR/rebuild-stable).
+const STARS = Array.from({ length: 140 }, (_, i) => {
+  const a = (i * 2654435761) % 2147483647;
+  const b = (i * 40503 + 12345) % 2147483647;
+  return { x: (a % VW), y: (b % VH), r: 0.5 + ((a >> 8) % 10) / 8, o: 0.06 + ((b >> 6) % 30) / 120 };
+});
+
+interface Props {
+  kiosk: KioskState;
+}
+
+export default function KioskConstellation({ kiosk }: Props) {
+  const { t } = useTranslation();
+  const { model, core, activeRoom, activeRoleLabel, telemetry } = kiosk;
+  const { roles, tools, rooms, peers = [] } = model;
+
+  const reduced = usePrefersReducedMotion();
+  const clock = useClock();
+
+  const at = (i: number, n: number, offset = 0) => (n > 0 ? (360 / n) * i + offset : 0);
+  const toolOffset = tools.length > 0 ? 180 / tools.length : 0;
+  const peerAngle = (i: number, n: number) => (n > 1 ? -50 + (100 / (n - 1)) * i : 0);
+  const coreColor = CORE_COLOR[core];
+
+  // Radiating "voice" spikes when listening/speaking.
+  const voiceActive = core === 'listening' || core === 'speaking';
+  const spikes = useMemo(
+    () => Array.from({ length: 48 }, (_, i) => (360 / 48) * i),
+    [],
+  );
+
+  return (
+    <div className="relative w-full h-full overflow-hidden bg-black select-none">
+      <svg viewBox={`0 0 ${VW} ${VH}`} className="w-full h-full" preserveAspectRatio="xMidYMid slice" role="img"
+        aria-label={t('kiosk.srSummary', {
+          defaultValue: 'Renfield command center. {{present}} people present, {{online}} of {{total}} satellites online.',
+          present: telemetry.peoplePresent, online: telemetry.satellitesOnline, total: telemetry.satellitesTotal,
+        })}>
+        <defs>
+          <radialGradient id="k-bg" cx="50%" cy="46%" r="75%">
+            <stop offset="0%" stopColor="#0d1524" />
+            <stop offset="55%" stopColor="#080d18" />
+            <stop offset="100%" stopColor="#03050a" />
+          </radialGradient>
+          <radialGradient id="k-core" cx="42%" cy="38%" r="70%">
+            <stop offset="0%" stopColor="#ffffff" stopOpacity={0.95} />
+            <stop offset="30%" stopColor={coreColor} stopOpacity={0.95} />
+            <stop offset="100%" stopColor={coreColor} stopOpacity={0.65} />
+          </radialGradient>
+          <radialGradient id="k-bloom" cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stopColor={coreColor} stopOpacity={0.5} />
+            <stop offset="100%" stopColor={coreColor} stopOpacity={0} />
+          </radialGradient>
+          <filter id="k-glow" x="-120%" y="-120%" width="340%" height="340%">
+            <feGaussianBlur stdDeviation="6" result="b" />
+            <feMerge><feMergeNode in="b" /><feMergeNode in="SourceGraphic" /></feMerge>
+          </filter>
+          <filter id="k-soft" x="-60%" y="-60%" width="220%" height="220%">
+            <feGaussianBlur stdDeviation="2.4" />
+          </filter>
+        </defs>
+
+        <style>{`
+          .k-breathe { transform-box: fill-box; transform-origin: center; animation: kBreathe 6s ease-in-out infinite; }
+          .k-bloom  { transform-box: fill-box; transform-origin: center; animation: kBloom 4.5s ease-in-out infinite; }
+          .k-occ    { animation: kPulse 3s ease-in-out infinite; }
+          .k-active-edge { stroke-dasharray: 7 10; animation: kDash 1s linear infinite; }
+          .k-spike  { transform-box: fill-box; transform-origin: center; animation: kSpin 22s linear infinite; }
+          .k-spike2 { transform-box: fill-box; transform-origin: center; animation: kSpin 30s linear infinite reverse; }
+          @keyframes kBreathe { 0%,100% { transform: scale(1); } 50% { transform: scale(1.03); } }
+          @keyframes kBloom { 0%,100% { opacity: .55; transform: scale(1); } 50% { opacity: .85; transform: scale(1.08); } }
+          @keyframes kPulse { 0%,100% { opacity: .5; } 50% { opacity: 1; } }
+          @keyframes kDash { to { stroke-dashoffset: -34; } }
+          @keyframes kSpin { to { transform: rotate(360deg); } }
+          @media (prefers-reduced-motion: reduce) {
+            .k-breathe, .k-bloom, .k-occ, .k-active-edge, .k-spike, .k-spike2 { animation: none; }
+          }
+        `}</style>
+
+        <rect x={0} y={0} width={VW} height={VH} fill="url(#k-bg)" />
+        {STARS.map((s, i) => (
+          <circle key={i} cx={s.x} cy={s.y} r={s.r} fill="#cfe6ff" opacity={s.o} />
+        ))}
+
+        {/* faint ring guides */}
+        {[R_ROLES, R_TOOLS, R_ROOMS].map((r) => (
+          <circle key={r} cx={CX} cy={CY} r={r} fill="none" stroke="#2a3550" strokeOpacity={0.35} strokeWidth={1} />
+        ))}
+
+        {/* core → role connectors, active one animates */}
+        {roles.map((role, i) => {
+          const [x, y] = polar(R_ROLES - 14, at(i, roles.length));
+          const [cx, cy] = polar(R_CORE + 4, at(i, roles.length));
+          const isActive = role.id === model.core.activeRoleId;
+          return (
+            <line key={`e-${role.id}`} x1={cx} y1={cy} x2={x} y2={y}
+              stroke={isActive ? C.active : '#2f3a55'} strokeOpacity={isActive ? 0.9 : 0.28}
+              strokeWidth={isActive ? 3 : 1.5} className={isActive && !reduced ? 'k-active-edge' : undefined} />
+          );
+        })}
+
+        {/* ROOMS ring */}
+        {rooms.map((room, i) => {
+          const deg = at(i, rooms.length, toolOffset / 2);
+          const [x, y] = polar(R_ROOMS, deg);
+          const [lx, ly] = polar(R_ROOMS + 30, deg);
+          const occupied = room.online && room.occupants > 0;
+          const col = !room.online ? C.down : occupied ? C.active : C.unknown;
+          return (
+            <g key={`room-${room.id}`}>
+              {occupied && <circle cx={x} cy={y} r={30} fill={col} opacity={0.16} filter="url(#k-soft)" className={reduced ? undefined : 'k-occ'} />}
+              <circle cx={x} cy={y} r={13} fill={room.online ? col : 'none'} stroke={col} strokeWidth={2.5}
+                strokeDasharray={room.online ? undefined : '4 4'} filter={room.online ? 'url(#k-glow)' : undefined} />
+              {occupied && <text x={x} y={y + 5} textAnchor="middle" fontSize={15} fontWeight={700} fill="#05121a">{room.occupants}</text>}
+              <text x={lx} y={ly + 6} textAnchor={anchorFor(lx)} fontSize={19} fontWeight={600} fill={occupied ? '#eaf2ff' : C.dim} letterSpacing="0.02em">{room.label}</text>
+            </g>
+          );
+        })}
+
+        {/* TOOLS ring */}
+        {tools.map((tool, i) => {
+          const deg = at(i, tools.length, toolOffset);
+          const [x, y] = polar(R_TOOLS, deg);
+          const [lx, ly] = polar(R_TOOLS + 22, deg);
+          const col = healthColor(tool.health);
+          const on = tool.health === 'healthy' || tool.health === 'degraded';
+          return (
+            <g key={`tool-${tool.id}`}>
+              <rect x={x - 8} y={y - 8} width={16} height={16} rx={3} transform={`rotate(45 ${x} ${y})`}
+                fill={on ? col : 'none'} stroke={col} strokeWidth={2.5} strokeDasharray={tool.health === 'down' ? '3 3' : undefined}
+                filter={on ? 'url(#k-glow)' : undefined} />
+              <text x={lx} y={ly + 5} textAnchor={anchorFor(lx)} fontSize={16} fill={C.dim}>{tool.label}</text>
+            </g>
+          );
+        })}
+
+        {/* ROLES ring */}
+        {roles.map((role, i) => {
+          const deg = at(i, roles.length);
+          const [x, y] = polar(R_ROLES, deg);
+          const [lx, ly] = polar(R_ROLES - 30, deg);
+          const isActive = role.id === model.core.activeRoleId;
+          return (
+            <g key={`role-${role.id}`}>
+              {isActive && <circle cx={x} cy={y} r={22} fill={C.active} opacity={0.22} filter="url(#k-soft)" />}
+              <circle cx={x} cy={y} r={12} fill={isActive ? C.active : '#0d1524'} stroke={isActive ? C.active : '#3a4763'}
+                strokeWidth={2.5} filter={isActive ? 'url(#k-glow)' : undefined} />
+              <text x={lx} y={ly + 6} textAnchor={anchorFor(lx)} fontSize={18} fontWeight={isActive ? 700 : 500}
+                fill={isActive ? '#eafffb' : C.dim} letterSpacing="0.04em">{role.label.toUpperCase()}</text>
+            </g>
+          );
+        })}
+
+        {/* PEERS outer arc */}
+        {peers.map((peer, i) => {
+          const deg = peerAngle(i, peers.length);
+          const [x, y] = polar(R_PEERS, deg);
+          return (
+            <g key={`peer-${peer.id}`}>
+              <circle cx={x} cy={y} r={9} fill="none" stroke={peer.online ? C.active : C.unknown} strokeWidth={2.5} strokeDasharray="2 4" filter={peer.online ? 'url(#k-glow)' : undefined} />
+              <text x={x} y={y - 18} textAnchor="middle" fontSize={15} fill={C.dim}>{peer.label}</text>
+            </g>
+          );
+        })}
+
+        {/* voice spikes when listening/speaking — a burst ring around the core.
+            Coordinates are around the ORIGIN and the group is translated to the
+            core, so the CSS rotation (transform-origin: center) spins around the
+            core instead of the group's own displaced bbox. */}
+        {voiceActive && !reduced && (
+          <g opacity={0.85} transform={`translate(${CX} ${CY})`}>
+            <g className="k-spike">
+              {spikes.map((deg, i) => {
+                const len = 22 + ((i * 37) % 40);
+                const [x1, y1] = ray(R_CORE + 6, deg);
+                const [x2, y2] = ray(R_CORE + 6 + len, deg);
+                return <line key={i} x1={x1} y1={y1} x2={x2} y2={y2} stroke={coreColor} strokeWidth={2} strokeLinecap="round" />;
+              })}
+            </g>
+            <g className="k-spike2" opacity={0.5}>
+              {spikes.filter((_, i) => i % 2 === 0).map((deg, i) => {
+                const len = 14 + ((i * 53) % 28);
+                const [x1, y1] = ray(R_CORE + 10, deg);
+                const [x2, y2] = ray(R_CORE + 10 + len, deg);
+                return <line key={i} x1={x1} y1={y1} x2={x2} y2={y2} stroke={coreColor} strokeWidth={1.5} strokeLinecap="round" />;
+              })}
+            </g>
+          </g>
+        )}
+
+        {/* CORE bloom + orb */}
+        <circle cx={CX} cy={CY} r={R_CORE * 2.6} fill="url(#k-bloom)" className={reduced ? undefined : 'k-bloom'} />
+        <g className={reduced ? undefined : 'k-breathe'}>
+          <circle cx={CX} cy={CY} r={R_CORE} fill="url(#k-core)" filter="url(#k-glow)" />
+          <text x={CX} y={CY - 8} textAnchor="middle" fontSize={46} fill="#fff" className="font-display" style={{ letterSpacing: '0.01em' }}>Renfield</text>
+          <text x={CX} y={CY + 26} textAnchor="middle" fontSize={17} fontWeight={700} fill="#08131b" letterSpacing="0.22em">
+            {coreCaption(core, t).toUpperCase()}
+          </text>
+        </g>
+        {(activeRoom || activeRoleLabel) && (
+          <text x={CX} y={CY + R_CORE + 40} textAnchor="middle" fontSize={17} fill={coreColor} letterSpacing="0.06em">
+            {core === 'idle' && activeRoleLabel
+              ? activeRoleLabel
+              : activeRoom
+                ? t('kiosk.inRoom', { defaultValue: '{{state}} · {{room}}', state: coreCaption(core, t), room: activeRoom })
+                : ''}
+          </text>
+        )}
+      </svg>
+
+      {/* ---- HTML overlays (crisp typography over the SVG) ---- */}
+      {/* wordmark */}
+      <div className="absolute top-8 left-10 leading-tight">
+        <div className="font-display text-4xl text-white tracking-wide">RENFIELD</div>
+        <div className="text-[13px] tracking-[0.35em] mt-1" style={{ color: C.active }}>COMMAND CENTER</div>
+      </div>
+
+      {/* clock + daypart */}
+      <div className="absolute bottom-8 left-10 text-white/90">
+        <div className="text-5xl font-display tabular-nums">{clock.time}</div>
+        <div className="text-sm text-white/50 mt-1 capitalize">{clock.date}</div>
+      </div>
+
+      {/* ambient telemetry corner */}
+      <div className="absolute top-8 right-10 text-right space-y-3">
+        <Telem label={t('kiosk.telemetry.satellites', { defaultValue: 'Satellites' })}
+          value={`${telemetry.satellitesOnline}/${telemetry.satellitesTotal} ${t('kiosk.online', { defaultValue: 'online' })}`}
+          alert={telemetry.satellitesOnline < telemetry.satellitesTotal} />
+        <Telem label={t('kiosk.telemetry.present', { defaultValue: 'Present' })}
+          value={t('kiosk.presentValue', { defaultValue: '{{people}} in {{rooms}} rooms', people: telemetry.peoplePresent, rooms: telemetry.occupiedRooms })} />
+        <Telem label={t('kiosk.telemetry.tools', { defaultValue: 'Tools' })}
+          value={`${telemetry.toolsHealthy}/${telemetry.toolsTotal} ${t('kiosk.healthy', { defaultValue: 'healthy' })}`}
+          alert={telemetry.toolsHealthy < telemetry.toolsTotal} />
+        <Telem label={t('kiosk.telemetry.agent', { defaultValue: 'Agent' })}
+          value={activeRoleLabel ?? t('kiosk.idle', { defaultValue: 'idle' })} />
+      </div>
+
+      {/* legend */}
+      <div className="absolute bottom-8 right-10 flex flex-col gap-1.5 text-[13px]">
+        {([['healthy', t('commandCenter.legend.healthy', { defaultValue: 'Healthy / present' })],
+           ['degraded', t('commandCenter.legend.degraded', { defaultValue: 'Degraded' })],
+           ['down', t('commandCenter.legend.down', { defaultValue: 'Down / offline' })],
+           ['unknown', t('commandCenter.legend.unknown', { defaultValue: 'Idle / unknown' })]] as [NodeHealth, string][]).map(([h, label]) => (
+          <span key={h} className="inline-flex items-center justify-end gap-2 text-white/45">
+            {label}
+            <span className="inline-block w-2.5 h-2.5 rounded-full"
+              style={h === 'down' || h === 'unknown'
+                ? { border: `1.5px ${h === 'down' ? 'dashed' : 'solid'} ${healthColor(h)}` }
+                : { background: healthColor(h) }} />
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function coreCaption(core: CoreState, t: TFunction): string {
+  switch (core) {
+    case 'listening': return t('kiosk.state.listening', { defaultValue: 'listening' });
+    case 'processing': return t('kiosk.state.processing', { defaultValue: 'thinking' });
+    case 'speaking': return t('kiosk.state.speaking', { defaultValue: 'speaking' });
+    case 'busy': return t('kiosk.state.busy', { defaultValue: 'system busy' });
+    default: return t('kiosk.state.idle', { defaultValue: 'ready' });
+  }
+}
+
+function Telem({ label, value, alert }: { label: string; value: string; alert?: boolean }) {
+  return (
+    <div>
+      <div className="text-[11px] tracking-[0.25em] text-white/35 uppercase">{label}</div>
+      <div className={`text-lg font-medium tabular-nums ${alert ? 'text-[#f7a4ae]' : 'text-[#00e4b8]'}`}>{value}</div>
+    </div>
+  );
+}
+
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const on = () => setReduced(mq.matches);
+    on();
+    mq.addEventListener('change', on);
+    return () => mq.removeEventListener('change', on);
+  }, []);
+  return reduced;
+}
+
+function useClock(): { time: string; date: string } {
+  const { i18n } = useTranslation();
+  const [now, setNow] = useState(() => new Date());
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 10_000);
+    return () => clearInterval(id);
+  }, []);
+  const locale = i18n.language?.startsWith('de') ? 'de-DE' : 'en-US';
+  return {
+    time: now.toLocaleTimeString(locale, { hour: '2-digit', minute: '2-digit' }),
+    date: now.toLocaleDateString(locale, { weekday: 'long', day: 'numeric', month: 'long' }),
+  };
+}

--- a/src/frontend/src/components/command-center/useKioskModel.ts
+++ b/src/frontend/src/components/command-center/useKioskModel.ts
@@ -1,0 +1,89 @@
+// Kiosk model = the live CommandCenterModel + a voice-reactive core state
+// derived from the satellites' own state (idle/listening/processing/speaking).
+// The wall display reacts to real household voice activity, not a simulation.
+import { useMemo } from 'react';
+
+import { useCommandCenterModel } from './useCommandCenterModel';
+import { useSatellitesQuery } from '../../api/resources/satellites';
+import { roleLabel } from '../chat/AgentRoleBadge';
+import type { CommandCenterModel } from './types';
+import { useTranslation } from 'react-i18next';
+
+export type CoreState = 'idle' | 'listening' | 'processing' | 'speaking' | 'busy';
+
+/** Voice states in ascending priority — a speaking satellite wins over a
+ *  merely-listening one when several are active at once. */
+const STATE_PRIORITY: Record<string, number> = {
+  idle: 0,
+  error: 0,
+  listening: 1,
+  processing: 2,
+  speaking: 3,
+};
+
+export interface KioskState {
+  model: CommandCenterModel;
+  bootLoading: boolean;
+  backendUnreachable: boolean;
+  /** What the glowing core shows right now. */
+  core: CoreState;
+  /** Room where the active voice interaction is happening (if any). */
+  activeRoom: string | null;
+  /** Localized label of the agent role answering this turn (if any). */
+  activeRoleLabel: string | null;
+  /** At-a-glance counts for the ambient telemetry corner. */
+  telemetry: {
+    satellitesOnline: number;
+    satellitesTotal: number;
+    peoplePresent: number;
+    occupiedRooms: number;
+    toolsHealthy: number;
+    toolsTotal: number;
+  };
+}
+
+export function useKioskModel(): KioskState {
+  const { t } = useTranslation();
+  const { model, bootLoading, backendUnreachable } = useCommandCenterModel();
+  const satellitesQuery = useSatellitesQuery(true);
+  const sats = satellitesQuery.data?.satellites;
+
+  return useMemo<KioskState>(() => {
+    // ---- voice-reactive core state from the satellites' own state ---------
+    let core: CoreState = backendUnreachable ? 'busy' : 'idle';
+    let activeRoom: string | null = null;
+    let best = 0;
+    for (const sat of sats ?? []) {
+      const p = STATE_PRIORITY[sat.state] ?? 0;
+      if (p > best) {
+        best = p;
+        core = sat.state as CoreState;
+        activeRoom = sat.room;
+      }
+    }
+
+    const activeRoleLabel = model.core.activeRoleId
+      ? roleLabel(t, model.core.activeRoleId)
+      : null;
+
+    const peoplePresent = model.rooms.reduce((n, r) => n + r.occupants, 0);
+    const occupiedRooms = model.rooms.filter((r) => r.online && r.occupants > 0).length;
+
+    return {
+      model,
+      bootLoading,
+      backendUnreachable,
+      core,
+      activeRoom,
+      activeRoleLabel,
+      telemetry: {
+        satellitesOnline: model.rooms.filter((r) => r.online).length,
+        satellitesTotal: model.rooms.length,
+        peoplePresent,
+        occupiedRooms,
+        toolsHealthy: model.tools.filter((tool) => tool.health === 'healthy').length,
+        toolsTotal: model.tools.length,
+      },
+    };
+  }, [t, model, bootLoading, backendUnreachable, sats]);
+}

--- a/src/frontend/src/components/command-center/useKioskModel.ts
+++ b/src/frontend/src/components/command-center/useKioskModel.ts
@@ -12,14 +12,19 @@ import { useTranslation } from 'react-i18next';
 export type CoreState = 'idle' | 'listening' | 'processing' | 'speaking' | 'busy';
 
 /** Voice states in ascending priority — a speaking satellite wins over a
- *  merely-listening one when several are active at once. */
+ *  merely-listening one when several are active at once. ('error' is handled
+ *  separately, not here, so a fleet error can't read as idle.) */
 const STATE_PRIORITY: Record<string, number> = {
   idle: 0,
-  error: 0,
   listening: 1,
   processing: 2,
   speaking: 3,
 };
+
+/** A satellite whose last heartbeat is older than this is treated as offline —
+ *  its self-reported state (e.g. a stale 'listening') must NOT drive the core.
+ *  Mirrors the same window useCommandCenterModel applies. */
+const SATELLITE_OFFLINE_S = 90;
 
 export interface KioskState {
   model: CommandCenterModel;
@@ -49,11 +54,18 @@ export function useKioskModel(): KioskState {
   const sats = satellitesQuery.data?.satellites;
 
   return useMemo<KioskState>(() => {
-    // ---- voice-reactive core state from the satellites' own state ---------
+    const satList = sats ?? [];
+    // Only satellites with a fresh heartbeat count as live — a dead one can't
+    // be "listening", however it last reported.
+    const onlineSats = satList.filter((s) => s.heartbeat_ago_seconds < SATELLITE_OFFLINE_S);
+
+    // ---- voice-reactive core state from the ONLINE satellites' own state ---
     let core: CoreState = backendUnreachable ? 'busy' : 'idle';
     let activeRoom: string | null = null;
     let best = 0;
-    for (const sat of sats ?? []) {
+    let anyError = false;
+    for (const sat of onlineSats) {
+      if (sat.state === 'error') { anyError = true; continue; }
       const p = STATE_PRIORITY[sat.state] ?? 0;
       if (p > best) {
         best = p;
@@ -61,13 +73,17 @@ export function useKioskModel(): KioskState {
         activeRoom = sat.room;
       }
     }
+    // Nothing actively speaking/listening but a live satellite is erroring →
+    // surface it as a busy/alert core, not a false "ready".
+    if (!backendUnreachable && best === 0 && anyError) core = 'busy';
 
     const activeRoleLabel = model.core.activeRoleId
       ? roleLabel(t, model.core.activeRoleId)
       : null;
 
-    const peoplePresent = model.rooms.reduce((n, r) => n + r.occupants, 0);
-    const occupiedRooms = model.rooms.filter((r) => r.online && r.occupants > 0).length;
+    // People + occupied rooms from the SAME online-filtered set so the two
+    // telemetry numbers can never disagree ("2 in 0 rooms").
+    const liveOccupiedRooms = model.rooms.filter((r) => r.online && r.occupants > 0);
 
     return {
       model,
@@ -77,10 +93,12 @@ export function useKioskModel(): KioskState {
       activeRoom,
       activeRoleLabel,
       telemetry: {
-        satellitesOnline: model.rooms.filter((r) => r.online).length,
-        satellitesTotal: model.rooms.length,
-        peoplePresent,
-        occupiedRooms,
+        // From the real satellite list, not the room union (rooms dedupe
+        // multiple satellites and include presence-only rooms).
+        satellitesOnline: onlineSats.length,
+        satellitesTotal: satList.length,
+        peoplePresent: liveOccupiedRooms.reduce((n, r) => n + r.occupants, 0),
+        occupiedRooms: liveOccupiedRooms.length,
         toolsHealthy: model.tools.filter((tool) => tool.health === 'healthy').length,
         toolsTotal: model.tools.length,
       },

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -1841,6 +1841,7 @@
   },
   "kiosk": {
     "loading": "Kommandozentrale wird geweckt…",
+    "disconnected": "Verbindung zu Renfield wird wiederhergestellt…",
     "srSummary": "Renfield-Kommandozentrale. {{present}} Personen anwesend, {{online}} von {{total}} Satelliten online.",
     "idle": "inaktiv",
     "online": "online",

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -1839,9 +1839,33 @@
       "openInGraph": "Im Graph öffnen"
     }
   },
+  "kiosk": {
+    "loading": "Kommandozentrale wird geweckt…",
+    "srSummary": "Renfield-Kommandozentrale. {{present}} Personen anwesend, {{online}} von {{total}} Satelliten online.",
+    "idle": "inaktiv",
+    "online": "online",
+    "healthy": "gesund",
+    "inRoom": "{{state}} · {{room}}",
+    "presentValue": "{{people}} in {{rooms}} Räumen",
+    "state": {
+      "idle": "bereit",
+      "listening": "hört zu",
+      "processing": "denkt nach",
+      "speaking": "spricht",
+      "busy": "System ausgelastet"
+    },
+    "telemetry": {
+      "satellites": "Satelliten",
+      "present": "Anwesend",
+      "tools": "Werkzeuge",
+      "agent": "Agent"
+    }
+  },
   "commandCenter": {
     "title": "Kommandozentrale",
     "subtitle": "Live-Konstellation des laufenden Systems",
+    "kiosk": "Kiosk",
+    "openKiosk": "Vollbild-Wandanzeige öffnen",
     "idle": "inaktiv",
     "srSummary": "{{roles}} Agenten-Rollen, {{tools}} Werkzeuge, {{rooms}} Räume. Aktive Rolle: {{active}}.",
     "ring": {

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -1841,6 +1841,7 @@
   },
   "kiosk": {
     "loading": "Waking the command center…",
+    "disconnected": "Reconnecting to Renfield…",
     "srSummary": "Renfield command center. {{present}} people present, {{online}} of {{total}} satellites online.",
     "idle": "idle",
     "online": "online",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -1839,9 +1839,33 @@
       "openInGraph": "Open in Graph"
     }
   },
+  "kiosk": {
+    "loading": "Waking the command center…",
+    "srSummary": "Renfield command center. {{present}} people present, {{online}} of {{total}} satellites online.",
+    "idle": "idle",
+    "online": "online",
+    "healthy": "healthy",
+    "inRoom": "{{state}} · {{room}}",
+    "presentValue": "{{people}} in {{rooms}} rooms",
+    "state": {
+      "idle": "ready",
+      "listening": "listening",
+      "processing": "thinking",
+      "speaking": "speaking",
+      "busy": "system busy"
+    },
+    "telemetry": {
+      "satellites": "Satellites",
+      "present": "Present",
+      "tools": "Tools",
+      "agent": "Agent"
+    }
+  },
   "commandCenter": {
     "title": "Command Center",
     "subtitle": "Live constellation of the running system",
+    "kiosk": "Kiosk",
+    "openKiosk": "Open the fullscreen wall display",
     "idle": "idle",
     "srSummary": "{{roles}} agent roles, {{tools}} tools, {{rooms}} rooms. Active role: {{active}}.",
     "ring": {

--- a/src/frontend/src/pages/CommandCenterPage.tsx
+++ b/src/frontend/src/pages/CommandCenterPage.tsx
@@ -12,6 +12,7 @@ import {
   Bot,
   CheckCircle2,
   CloudOff,
+  Maximize2,
   Radar,
   Server,
   Sofa,
@@ -216,7 +217,18 @@ export default function CommandCenterPage() {
         subtitle={t('commandCenter.subtitle', {
           defaultValue: 'Live constellation of the running system',
         })}
-      />
+      >
+        <Link
+          to="/kiosk"
+          target="_blank"
+          rel="noopener"
+          className="btn btn-secondary inline-flex items-center gap-2"
+          title={t('commandCenter.openKiosk', { defaultValue: 'Open the fullscreen wall display' })}
+        >
+          <Maximize2 className="w-4 h-4" aria-hidden="true" />
+          {t('commandCenter.kiosk', { defaultValue: 'Kiosk' })}
+        </Link>
+      </PageHeader>
 
       {backendUnreachable && (
         <div

--- a/src/frontend/src/pages/KioskPage.tsx
+++ b/src/frontend/src/pages/KioskPage.tsx
@@ -37,7 +37,23 @@ export default function KioskPage() {
           {t('kiosk.loading', { defaultValue: 'Waking the command center…' })}
         </div>
       ) : (
-        <KioskConstellation kiosk={kiosk} />
+        <>
+          <KioskConstellation kiosk={kiosk} />
+          {/* Every source failed after a first load — the constellation is now
+              stale. Flag it plainly so a passerby doesn't read a frozen board
+              as live household state. The core already reads 'system busy'. */}
+          {kiosk.backendUnreachable && (
+            <div
+              role="status"
+              className="absolute top-8 left-1/2 -translate-x-1/2 flex items-center gap-2
+                px-4 py-2 rounded-full bg-[#e63e54]/15 border border-[#e63e54]/40 text-[#f7a4ae]
+                text-sm tracking-wide backdrop-blur-sm"
+            >
+              <span className="inline-block w-2 h-2 rounded-full bg-[#e63e54]" />
+              {t('kiosk.disconnected', { defaultValue: 'Reconnecting to Renfield…' })}
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/frontend/src/pages/KioskPage.tsx
+++ b/src/frontend/src/pages/KioskPage.tsx
@@ -1,0 +1,44 @@
+// /kiosk — the fullscreen wall-display command center. Renders OUTSIDE the app
+// Layout (no sidebar, no header) so it is truly edge-to-edge, and hides the
+// cursor after a few idle seconds like a proper kiosk. Content-free + dark.
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import KioskConstellation from '../components/command-center/KioskConstellation';
+import { useKioskModel } from '../components/command-center/useKioskModel';
+
+export default function KioskPage() {
+  const { t } = useTranslation();
+  const kiosk = useKioskModel();
+  const [cursorHidden, setCursorHidden] = useState(false);
+  const idleTimer = useRef<number | undefined>(undefined);
+
+  // Hide the cursor after 4s of no movement (wall-display polish).
+  useEffect(() => {
+    const bump = () => {
+      setCursorHidden(false);
+      window.clearTimeout(idleTimer.current);
+      idleTimer.current = window.setTimeout(() => setCursorHidden(true), 4000);
+    };
+    bump();
+    window.addEventListener('mousemove', bump);
+    window.addEventListener('touchstart', bump);
+    return () => {
+      window.clearTimeout(idleTimer.current);
+      window.removeEventListener('mousemove', bump);
+      window.removeEventListener('touchstart', bump);
+    };
+  }, []);
+
+  return (
+    <div className="fixed inset-0 bg-black" style={{ cursor: cursorHidden ? 'none' : 'auto' }}>
+      {kiosk.bootLoading ? (
+        <div className="w-full h-full flex items-center justify-center text-white/50 text-lg tracking-wide">
+          {t('kiosk.loading', { defaultValue: 'Waking the command center…' })}
+        </div>
+      ) : (
+        <KioskConstellation kiosk={kiosk} />
+      )}
+    </div>
+  );
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,62 +1,32 @@
-# Feature: Command Center — live constellation (Phase 1+2)
+# Feature: Command Center — Phase 3 Fullscreen Kiosk (DONE)
 
-Primary source: `docs/design/command-center.md`. Prototype exists
-(`src/frontend/src/components/command-center/`), unrouted, demo-fed.
-Goal: the routed, live, admin-gated `/admin/command-center` — stunning
-**within DESIGN.md** (warm editorial, no glowing-orb slop).
+Fullscreen ambient wall-display per the cinematic mockups
+(`docs/design/assets/command-center/`). Deliberately breaks DESIGN.md's
+restrained look — sanctioned in TODOS.md line 315 (glow aesthetic belongs on
+the kiosk, stays out of the restrained admin board).
 
-## Reality corrections vs the design doc (from exploration)
-- `/api/roles` = RBAC system roles, NOT agent roles. Agent roles live only in
-  `app.state.agent_router.roles` (loaded from `config/agent_roles.yaml`) —
-  **no REST endpoint exists** → add one (read-only, ADMIN).
-- The chat WS is chat-page-local (`useChatWebSocket`, no global WS context) and
-  per-session — an admin page riding it would only ever see *its own* turns.
-  → Better: poll a tiny content-free **activity endpoint** reading
-  `messages.message_metadata->>'agent_role'` (persisted by role-surfacing,
-  chat_handler:2211). Household-wide pulse, kiosk-safe (role + timestamp only).
-- Tools ring source: `GET /api/mcp/status` (per-server connected/last_error)
-  blended with `GET /api/tool-health` (failure rates) for degraded.
-- Rooms ring: `GET /api/satellites` (online) + `GET /api/presence/rooms` (occupants).
-- Peers: `GET /api/federation/peers` (last_seen_at).
+## Shipped
+- [x] `KioskConstellation.tsx` — the GLOW variant (separate from restrained
+      AgentConstellation): full-bleed dark cosmic field + stars, glowing bloom
+      core with idle/listening/processing/speaking states + voice-burst ring,
+      rings (roles/tools/rooms/peers), ambient telemetry corner, wordmark,
+      clock, legend. Reduced-motion honoured. Content-free.
+- [x] `useKioskModel.ts` — CommandCenterModel + voice-core state derived from
+      the satellites' real `state` (idle/listening/processing/speaking) + room.
+- [x] `KioskPage.tsx` — fullscreen, NO Layout chrome, hides cursor after 4s idle.
+- [x] Route `/kiosk` in App.tsx OUTSIDE the Layout (AdminRoute; auth-off = open)
+      + "Kiosk" link on the admin command-center header (opens in new tab).
+- [x] i18n de/en (`kiosk.*`).
+- [x] 3 RTL smoke tests (idle vs listening core state, telemetry counts).
 
-## Backend (new, small, read-only)
-- [ ] `api/routes/command_center.py` (prefix `/api/command-center`, ADMIN-gated,
-      rate-limited like tool_health.py):
-      - `GET /roles` → `[{name, description{de,en}, mcp_servers, internal_tools}]`
-        from `request.app.state.agent_router.roles` (None-safe → []).
-      - `GET /activity?limit=` → `[{role, at, ok}]` newest-first from assistant
-        messages' `message_metadata.agent_role` (+ `action_success`), dialect-safe
-        (fetch window, extract in Python). NO content, NO user ids.
-- [ ] Mount in `main.py`.
-- [ ] Tests `tests/backend/test_command_center.py` (run on .159).
+## Verified
+- [x] typecheck + lint + prod build green; 3/3 kiosk tests + guard tests pass.
+- [x] Browser at 1920×1080: idle (crimson "BEREIT" core) + listening (turquoise
+      "HÖRT ZU · Wohnzimmer" + voice-burst ring + active role beam), telemetry
+      corner, clock, legend. Matches cc_stunning_smarthome / cc_voice_listening.
+- [ ] Deploy frontend + prod check.
 
-## Frontend
-- [ ] `api/resources/commandCenter.ts` — `useAgentRolesQuery` (CONFIG stale),
-      `useRoleActivityQuery` (refetchInterval 3s); `keys.commandCenter.*`.
-- [ ] `components/command-center/useCommandCenterModel.ts` — compose the model
-      from the 6 queries; per-ring loading/empty/error; health mapping
-      (connected+clean=healthy, connected+last_error|success_rate<0.8=degraded,
-      disconnected=down, no-data=unknown).
-- [ ] Elevate `AgentConstellation.tsx`:
-      - live pulse + decaying trail (last N activations, opacity decay)
-      - hover role↔tool edges from the role's `mcp_servers`/`internal_tools`
-      - click drill-downs (roles→/admin/routing, tools→/admin/integrations,
-        rooms→/admin/satellites, peers→/brain/audit), keyboard-focusable
-      - all four interaction states; reduced-motion; DESIGN.md tokens only
-- [ ] `pages/CommandCenterPage.tsx` — page shell, constellation board,
-      live activity rail (content-free), narrow-width list fallback (<lg),
-      offline/"system busy" calm state.
-- [ ] Route in `App.tsx` (+lazy) + nav in `Layout.tsx` + i18n de/en
-      (nav key + new commandCenter.* additions in BOTH locales).
-- [ ] Vitest RTL tests `tests/frontend/react/pages/CommandCenterPage.test.tsx`.
-
-## Verification loop (iterate until perfect)
-- [ ] `npm run typecheck` + targeted vitest.
-- [ ] `npm run build` (prod Tailwind pass).
-- [ ] Browser walkthrough (light + dark, wide + narrow, reduced-motion).
-- [ ] `/review` + docs sweep (CLAUDE.md, docs/FEATURES.md, TODOS.md) before merge.
-
-## Deliberately NOT in scope (per design doc)
-Write actions; Phase-3 kiosk authz; always-on role↔tool edges (hover only);
-WS transport for the pulse (polling is household-wide + kiosk-safe; the chat WS
-is per-session and page-local).
+## Fast-follow (not in v1)
+Weather tile · next public Frist · now-playing (media-follow) in the telemetry
+zone; true circle-aware login-free projection (only needed once prod runs
+multi-user — today it's auth-off / one trust domain, kept content-free by design).

--- a/tests/frontend/react/pages/KioskPage.test.tsx
+++ b/tests/frontend/react/pages/KioskPage.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * KioskPage — the fullscreen wall-display command center. Smoke coverage:
+ * it composes the same sources as the admin board and derives the voice-core
+ * state from the satellites' own state (idle vs listening).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '../test-utils';
+import { server } from '../mocks/server';
+import KioskPage from '../../../../src/frontend/src/pages/KioskPage';
+import { TEST_CONFIG } from '../config';
+
+const BASE = TEST_CONFIG.API_BASE_URL;
+
+const roles = [
+  { name: 'presence', description: { de: 'Presence', en: 'Presence' }, mcp_servers: [], internal_tools: null, has_agent_loop: true },
+  { name: 'general', description: { de: 'General', en: 'General' }, mcp_servers: null, internal_tools: null, has_agent_loop: true },
+];
+const mcp = {
+  enabled: true, total_tools: 20,
+  servers: [
+    { name: 'homeassistant', connected: true, transport: 'stdio', tool_count: 10 },
+    { name: 'radio', connected: false, transport: 'stdio', tool_count: 0 },
+  ],
+};
+
+function mockAll(satState: string) {
+  server.use(
+    http.get(`${BASE}/api/command-center/roles`, () => HttpResponse.json(roles)),
+    http.get(`${BASE}/api/command-center/activity`, () => HttpResponse.json([])),
+    http.get(`${BASE}/api/mcp/status`, () => HttpResponse.json(mcp)),
+    http.get(`${BASE}/api/tool-health`, () => HttpResponse.json([])),
+    http.get(`${BASE}/api/satellites`, () => HttpResponse.json({
+      satellites: [
+        { satellite_id: 'sat-wohnzimmer', room: 'Wohnzimmer', state: satState, uptime_seconds: 100, heartbeat_ago_seconds: 4 },
+        { satellite_id: 'sat-esszimmer', room: 'Esszimmer', state: 'idle', uptime_seconds: 100, heartbeat_ago_seconds: 8 },
+      ],
+      total_count: 2, online_count: 2, active_sessions: 0, latest_version: '1.4.1',
+    })),
+    http.get(`${BASE}/api/presence/rooms`, () => HttpResponse.json([
+      { room_id: 1, room_name: 'Wohnzimmer', occupants: [{ user_id: 1, last_seen: 0, confidence: 0.9 }] },
+    ])),
+    http.get(`${BASE}/api/federation/peers`, () => HttpResponse.json({ peers: [] })),
+  );
+}
+
+afterEach(() => server.resetHandlers());
+
+describe('KioskPage', () => {
+  // Tests run in the German locale (test-utils sets it), so captions are the
+  // German strings: idle → "bereit", listening → "hört zu", healthy → "gesund".
+  it('renders the fullscreen kiosk with wordmark, telemetry and rings', async () => {
+    mockAll('idle');
+    renderWithProviders(<KioskPage />);
+    await waitFor(() => {
+      expect(screen.getAllByText('RENFIELD').length).toBeGreaterThan(0);
+    });
+    // ambient telemetry corner (content-free counts): both satellites online
+    expect(screen.getByText('2/2 online')).toBeInTheDocument();
+    // tools: 1 healthy of 2 (radio down)
+    expect(screen.getByText('1/2 gesund')).toBeInTheDocument();
+    const svg = document.querySelector('svg[role="img"]') as SVGElement;
+    expect(svg).toBeTruthy();
+  });
+
+  it('drives the core into a voice state from a listening satellite', async () => {
+    mockAll('listening');
+    renderWithProviders(<KioskPage />);
+    await waitFor(() => {
+      expect(screen.getAllByText(/hört zu/i).length).toBeGreaterThan(0);
+    });
+    // active room is surfaced content-free (room name only)
+    expect(screen.getAllByText(/Wohnzimmer/).length).toBeGreaterThan(0);
+  });
+
+  it('shows the ready core when every satellite is idle', async () => {
+    mockAll('idle');
+    renderWithProviders(<KioskPage />);
+    await waitFor(() => {
+      expect(screen.getAllByText(/bereit/i).length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/tests/frontend/react/pages/KioskPage.test.tsx
+++ b/tests/frontend/react/pages/KioskPage.test.tsx
@@ -81,4 +81,40 @@ describe('KioskPage', () => {
       expect(screen.getAllByText(/bereit/i).length).toBeGreaterThan(0);
     });
   });
+
+  it('counts the real satellite list and ignores a stale satellite in the core', async () => {
+    mockAll('idle');
+    // 3 satellites: two share a room (would collapse to 1 room), one is stale
+    // (heartbeat > 90s) AND still reporting 'listening' — it must not count as
+    // online nor drive the voice core.
+    server.use(http.get(`${BASE}/api/satellites`, () => HttpResponse.json({
+      satellites: [
+        { satellite_id: 'a', room: 'Wohnzimmer', state: 'idle', uptime_seconds: 100, heartbeat_ago_seconds: 3 },
+        { satellite_id: 'b', room: 'Wohnzimmer', state: 'idle', uptime_seconds: 100, heartbeat_ago_seconds: 5 },
+        { satellite_id: 'c', room: 'Esszimmer', state: 'listening', uptime_seconds: 0, heartbeat_ago_seconds: 4000 },
+      ],
+      total_count: 3, online_count: 2, active_sessions: 0, latest_version: '1.4.1',
+    })));
+    renderWithProviders(<KioskPage />);
+    // real count from the satellite list, not the deduped room union
+    await waitFor(() => expect(screen.getByText('2/3 online')).toBeInTheDocument());
+    // the stale 'listening' satellite does NOT drive the core
+    expect(screen.getAllByText(/bereit/i).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/hört zu/i)).toBeNull();
+  });
+
+  it('surfaces a live-satellite error as busy, not a false ready', async () => {
+    mockAll('idle');
+    server.use(http.get(`${BASE}/api/satellites`, () => HttpResponse.json({
+      satellites: [
+        { satellite_id: 'a', room: 'Wohnzimmer', state: 'error', uptime_seconds: 100, heartbeat_ago_seconds: 3 },
+      ],
+      total_count: 1, online_count: 1, active_sessions: 0, latest_version: '1.4.1',
+    })));
+    renderWithProviders(<KioskPage />);
+    await waitFor(() => {
+      expect(screen.getAllByText(/System ausgelastet/i).length).toBeGreaterThan(0);
+    });
+    expect(screen.queryByText(/bereit/i)).toBeNull();
+  });
 });


### PR DESCRIPTION
Der cinematic Fullscreen-Kiosk aus den Mockups (`docs/design/assets/command-center/cc_stunning_*`, `cc_voice_*`) — ein ambientes **Wand-Display**, getrennt vom zurückhaltenden Admin-Board. Route `/kiosk`, **außerhalb** der App-Layout-Chrome (kein Sidebar/Header), Cursor blendet nach Leerlauf aus.

## Was
- **`KioskConstellation`**: full-bleed dunkles Kosmos-Feld + Sterne; glühender Bloom-Kern, der auf **echte Haushalts-Sprachaktivität** reagiert (idle / listening / processing / speaking — abgeleitet aus dem `state` der Satelliten + Raum) mit rotierendem Voice-Burst-Kranz; konzentrische Ringe Rollen / Tools (Health) / Räume (Belegung) / Föderations-Peers; **ambiente Telemetrie-Ecke** (Satelliten online · anwesend · Tools gesund · aktiver Agent) statt der „Auf-einen-Blick"-Karte; Wortmarke, Uhr + Datum, Legende. `prefers-reduced-motion` respektiert.
- **Bricht bewusst DESIGN.md** (Glow/Bloom/Gradients) — sanktioniert in TODOS.md Zeile 315: die Marketing-/Kiosk-Ästhetik gehört hierher und bleibt **raus** aus dem zurückhaltenden `AgentConstellation` (deshalb separate Komponente).
- **Inhaltsfrei by design** (nur Zahlen + Rollen-/Raumnamen) → sicher auf geteiltem Schirm, multi-user-fest. Kein neues Backend (alle vorhandenen Endpunkte, inkl. Satelliten-State für den Voice-Kern). „Kiosk"-Link auf dem Admin-Board öffnet die Wandanzeige.

## Verifikation
3 RTL-Smoke-Tests (idle vs listening Kern, Telemetrie-Zahlen); tsc + eslint + build grün; bei 1920×1080 in idle („BEREIT") und listening („HÖRT ZU · Wohnzimmer" + Voice-Burst + aktiver Rollen-Beam) gegen die Mockups geprüft.

## Fast-follow (nicht in v1)
Wetter-Kachel · nächste öffentliche Frist · Now-Playing in der Telemetrie-Zone; echte circle-aware login-freie Projektion (erst nötig bei multi-user — heute auth-off/eine Vertrauensdomäne, per Design inhaltsfrei).

🤖 Generated with [Claude Code](https://claude.com/claude-code)