### PR TITLE
fix(deploy): robust remote-command quoting in deploy-production.sh

### DIFF
--- a/bin/deploy-production.sh
+++ b/bin/deploy-production.sh
@@ -62,7 +62,15 @@ KUBECTL=(kubectl --context "$KCTX" -n "$NS")
 # --- helpers ----------------------------------------------------------------
 log() { printf '\n\033[1;36m=== %s ===\033[0m\n' "$*"; }
 run() { if [[ $DRY_RUN == 1 ]]; then printf '  [dry-run] %s\n' "$*"; else eval "$@"; fi; }
-on_build() { run "ssh $BUILD_HOST '$*'"; }
+# Run a command on the build host. The command is passed to ssh as ONE argument,
+# so the REMOTE shell does all the quoting — a payload containing single quotes
+# (e.g. the prune's `--format '{{.Repository}}:{{.Tag}}'`) no longer breaks the
+# way the old `run "ssh $HOST '$*'"` nested-single-quoting did under `eval`
+# + `set -e` (which exited the script non-zero AFTER a successful deploy).
+on_build() {
+  if [[ $DRY_RUN == 1 ]]; then printf '  [dry-run] ssh %s: %s\n' "$BUILD_HOST" "$*"
+  else ssh "$BUILD_HOST" "$*"; fi
+}
 
 # --- preflight --------------------------------------------------------------
 log "preflight"
@@ -156,6 +164,7 @@ on_build "rm -rf $STAGING; \
     docker images \"$REGISTRY/\$repo\" --format '{{.Repository}}:{{.Tag}}' | tail -n +4 | xargs -r -n1 docker rmi 2>/dev/null || true; \
   done; \
   docker image prune -f >/dev/null 2>&1; docker builder prune -f --keep-storage 10GB >/dev/null 2>&1; \
-  df -h / | tail -1"
+  df -h / | tail -1" \
+  || echo "WARNING: build-box cleanup failed (non-fatal — deploy already succeeded); check disk on $BUILD_HOST" >&2
 
 log "DONE"


### PR DESCRIPTION
## Problem

`on_build()` wrapped the remote command in single quotes and `eval`'d it:
```sh
on_build() { run "ssh $BUILD_HOST '$*'"; }
```
Any single quote in the payload — notably the final image-prune's
`--format '{{.Repository}}:{{.Tag}}'` — produced mismatched nested quotes, so
under `set -euo pipefail` the cleanup step failed and the script **exited
non-zero after an already-successful deploy** (the "prune fails the deploy"
symptom noted in ops memory).

## Fix

- Pass the remote command to `ssh` as a **single argument** (`ssh "$BUILD_HOST" "$*"`)
  so the *remote* shell does the quoting — no local nesting, quotes preserved.
- `--dry-run` prints the **raw readable** remote command (not a `%q`-escaped blob).
- Build-box cleanup is non-fatal but now emits a **WARNING** on failure instead of
  being silently swallowed, so a real ssh/prune failure still surfaces.

## Verification

- `bash -n` clean.
- Functional test: new `on_build` forwards a single-quote-heavy payload
  (`--format '{{.Repository}}:{{.Tag}}'` + `for repo …; do`) to ssh **intact as one
  arg**; the old version stripped/mangled the quotes.
- High-effort code review run; both surfaced findings (dry-run readability,
  cleanup-failure masking) addressed in this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)