### PR TITLE
fix(satellite): strip stale I2S HAT overlays when provisioning 2-mic-v2

### DIFF
--- a/src/satellite/provisioning/provision.yml
+++ b/src/satellite/provisioning/provision.yml
@@ -285,6 +285,27 @@
         state: present
       notify: reboot after driver install
 
+    # A 2-Mic HAT V2 swapped onto a board that previously ran a V1/other I2S HAT
+    # (e.g. this box: XVF3800-USB → V2, but the stale V1 `seeed-2mic-gpclk-simple`
+    # overlay was still in config.txt loading wm8960) leaves a conflicting second
+    # codec on the same I2S bus, so the TLV320 card may not enumerate. Strip the
+    # stale I2S overlays so only respeaker-2mic-v2_0 binds — mirrors the
+    # xvf3800-usb stale-overlay cleanup. Reboot applies it in the same cycle.
+    - name: Remove stale conflicting I2S HAT overlays from config.txt (2-mic-v2)
+      tags: [driver]
+      when: hat_type == "2mic-v2"
+      ansible.builtin.lineinfile:
+        path: /boot/firmware/config.txt
+        regexp: "^dtoverlay={{ item }}"
+        state: absent
+      loop:
+        - seeed-2mic-gpclk-simple
+        - seeed-2mic-gpclk-full
+        - seeed-2mic-voicecard
+        - seeed-4mic-voicecard
+        - wm8960-soundcard
+      notify: reboot after driver install
+
     # --- Whisplay HAT: WM8960 codec driver ---
 
     - name: Clone Whisplay driver for WM8960 codec


### PR DESCRIPTION
## Problem

When a board that previously ran a V1/other I2S HAT gets a **ReSpeaker 2-Mic HAT
V2** swapped on (real case: BensZimmer, XVF3800-USB → V2), the stale
`dtoverlay=seeed-2mic-gpclk-simple` line stays in `config.txt` and loads the
**wm8960 (V1)** codec driver. That leaves a conflicting second codec on the I2S
bus, so the **TLV320 (V2)** card never enumerates — the satellite boots with **no
capture device at all** (only HDMI), and provisioning it for `2mic-v2` doesn't
help because the conflicting overlay is still present.

## Fix

Add a `2mic-v2` task that removes the known stale I2S overlays
(`seeed-2mic-gpclk-simple`/`-full`, `seeed-2mic-voicecard`, `seeed-4mic-voicecard`,
`wm8960-soundcard`) from `config.txt` **before** the driver install, so only the
V2 overlay binds. Mirrors the existing stale-overlay cleanup for other HATs and
notifies the same reboot handler, so it applies in one cycle.

## Verification

Verified live on BensZimmer: after the swap + this task, the `seeed2micvoicec`
card enumerates and the mic captures (`S16_LE/2ch`); wake word active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)