### PR TITLE
fix(wakeword): browser detects ALL server-pushed wake words (#8)

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -462,6 +462,7 @@ RAG_CONTEXT_WINDOW=1              # Benachbarte Chunks (0=deaktiviert)
 - Admin-UI für zentrale Konfiguration
 - Automatische Synchronisation per WebSocket an alle Geräte
 - Konfigurierbare Keywords (Alexa, Hey Mycroft, Hey Jarvis, etc.)
+- **Mehrsprachiger Haushalt**: Sowohl Satelliten als auch der Browser-Detektor laden **alle** gepushten Wake-Words gleichzeitig (kommagetrennter Satz, z.B. `renfield_de` + `renfield_en`) — nicht nur das erste.
 
 Siehe [WAKEWORD_CONFIGURATION.md](WAKEWORD_CONFIGURATION.md) für Details.
 

--- a/docs/WAKEWORD_CONFIGURATION.md
+++ b/docs/WAKEWORD_CONFIGURATION.md
@@ -268,6 +268,16 @@ case 'config_update':
   break;
 ```
 
+The browser detector loads the **full** pushed set — every id in `wake_words`,
+not just the first — so a multi-language household (e.g. `renfield_de` +
+`renfield_en`) wakes on any of them, matching the satellites. `useWakeWord`
+persists the active set (comma-joined in `localStorage`, survives reload),
+filters it to keywords a model ships for, and — because the engine can only load
+models chosen at construction — **rebuilds** the engine (stop → drop → recreate
+with the full set → start) whenever the set changes; it never relies on
+`setActiveKeywords` (which can only toggle among already-loaded models). The
+ChatHeader keyword picker is a multi-checkbox set (at least one stays selected).
+
 ### Web Listening Recovery
 
 The browser wake-word engine (`useWakeWord` + onnxruntime WASM) runs **locally**
@@ -288,9 +298,16 @@ three ways, all of which previously needed a manual page reload:
 (edge-triggered on `wsConnected`), tab becoming **visible** (`visibilitychange`),
 and network coming back **online**. A pure `shouldRearmWakeWord` predicate
 (`pages/ChatPage/context/wakeWordRecovery.ts`) gates the resume: it skips the
-happy path (already listening), an active capture, and a live wake-word turn. An
-in-flight start latch in `useWakeWord` coalesces simultaneous triggers (e.g. a
-laptop wake firing all three at once) so the engine can't double-start.
+happy path (already listening), an active capture, and a live wake-word turn.
+`useWakeWord` reconciles the engine to a desired state: **turn-ON transitions**
+(enable/resume/keyword-rebuild) are serialized through one "arm" promise chain,
+while **turn-OFF transitions** (disable/pause) and the error handler are
+**pre-emptive** — they run immediately and bump a generation counter that an
+in-flight arm re-checks after every await and aborts on. So simultaneous
+triggers (a laptop wake firing all three at once) or a server config push
+landing mid-start can't double-start the engine; a hung `start()` can never
+block mic-off; an engine error can't leave a green-but-dead UI; and an unmount
+mid-build never leaks the mic/AudioContext.
 
 On reconnect, a chat turn that was streaming over the dropped WS is dead: the
 stuck "thinking" spinner is cleared, the half-streamed bubble is finalized, and an

--- a/src/frontend/src/config/wakeword.ts
+++ b/src/frontend/src/config/wakeword.ts
@@ -147,6 +147,55 @@ export function getKeywordConfig(keywordId: string): KeywordConfig | null {
 }
 
 /**
+ * Parse a keyword selection into a clean, ordered, de-duplicated list of
+ * keyword ids we actually ship a model for. The browser engine loads one model
+ * per id, so an unknown id (e.g. a server pushing a wake word this build has no
+ * `.onnx` for) is dropped rather than crashing the load.
+ *
+ * The value may be a single id (`"renfield_de"`) or a comma-separated set
+ * (`"renfield_de,renfield_en"`) — the same on-the-wire form the server settings
+ * page uses — so a multi-language household loads every keyword together.
+ */
+export function parseKeywords(value: string | null | undefined): string[] {
+  if (!value) return [];
+  const known = new Set(WAKEWORD_CONFIG.availableKeywords.map((k) => k.id));
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of value.split(',')) {
+    const id = raw.trim();
+    if (id && known.has(id) && !seen.has(id)) {
+      seen.add(id);
+      out.push(id);
+    }
+  }
+  return out;
+}
+
+/**
+ * Whether two keyword selections resolve to the same set (order/whitespace/
+ * duplicate/unknown-id insensitive). Used to avoid rebuilding the running
+ * engine when a server config push doesn't actually change the active set.
+ */
+export function sameKeywordSet(a: string | null | undefined, b: string | null | undefined): boolean {
+  const pa = parseKeywords(a);
+  const pb = parseKeywords(b);
+  if (pa.length !== pb.length) return false;
+  const sb = new Set(pb);
+  return pa.every((id) => sb.has(id));
+}
+
+/**
+ * Human-readable label for a keyword selection — joins each active keyword's
+ * label so the UI can honestly show a multi-keyword set (e.g. "Renfield
+ * (Deutsch) + Renfield (English)") instead of only the first.
+ */
+export function describeKeywords(value: string | null | undefined): string {
+  return parseKeywords(value)
+    .map((id) => getKeywordConfig(id)?.label ?? id)
+    .join(' + ');
+}
+
+/**
  * Load saved wake word settings from localStorage
  */
 export function loadWakeWordSettings(): WakeWordSettings {

--- a/src/frontend/src/hooks/useWakeWord.ts
+++ b/src/frontend/src/hooks/useWakeWord.ts
@@ -97,6 +97,8 @@ export function useWakeWord({
   const engineRef = useRef<WakeWordEngine | null>(null);
   const unsubscribersRef = useRef<Array<() => void>>([]);
   const builtKeywordsRef = useRef<string[]>([]); // the set the live engine was built with
+  const builtThresholdRef = useRef<number>(settings.threshold); // its detection threshold
+  const engineStartedRef = useRef(false); // whether the live engine is capturing (started)
   const callbacksRef = useRef({ onWakeWordDetected, onSpeechStart, onSpeechEnd, onError, onReady });
 
   // Actual-state mirrors (kept in sync synchronously with the setState calls).
@@ -158,6 +160,7 @@ export function useWakeWord({
     const engine = engineRef.current;
     engineRef.current = null;
     builtKeywordsRef.current = [];
+    engineStartedRef.current = false;
     setIsReady(false);
     if (engine) {
       try {
@@ -255,6 +258,10 @@ export function useWakeWord({
     const loaded = await loadWakeWordEngine();
     if (!loaded) {
       setIsAvailable(false);
+      // If we were listening (a rebuild path), clear it so the UI isn't left
+      // green-but-dead and recovery can fire.
+      isListeningRef.current = false;
+      setIsListening(false);
       const err =
         getWakeWordLoadError() ||
         new Error(
@@ -267,10 +274,12 @@ export function useWakeWord({
     setIsAvailable(true);
     if (myGen !== genRef.current || !mountedRef.current || !desiredEnabledRef.current) return;
 
-    // Rebuild if the live engine's loaded set drifted from the desired set.
+    // Rebuild if the live engine drifted from the desired keyword set OR threshold
+    // (both are only read at construction).
     if (
       engineRef.current &&
-      !sameKeywordSet(builtKeywordsRef.current.join(','), keywordsRef.current.join(','))
+      (!sameKeywordSet(builtKeywordsRef.current.join(','), keywordsRef.current.join(',')) ||
+        builtThresholdRef.current !== thresholdRef.current)
     ) {
       await teardownEngine();
       if (myGen !== genRef.current || !mountedRef.current || !desiredEnabledRef.current) return;
@@ -283,6 +292,10 @@ export function useWakeWord({
         engine = await initEngine();
         await engine.load();
       } catch (err) {
+        // Build failed — if we were listening (rebuild path), clear it so the UI
+        // isn't stranded green with no engine.
+        isListeningRef.current = false;
+        setIsListening(false);
         reportEnableError(err);
         return;
       }
@@ -298,25 +311,30 @@ export function useWakeWord({
       subscribe(engine);
       engineRef.current = engine;
       builtKeywordsRef.current = [...keywordsRef.current];
+      builtThresholdRef.current = thresholdRef.current;
     }
 
-    // Start capturing if we should be listening.
+    // Start capturing if we should be listening. Guard on engineStartedRef so a
+    // second arm queued behind the first can't double-start the same engine.
     if (desiredListeningRef.current) {
-      try {
-        await engineRef.current.start({ gain: WAKEWORD_CONFIG.defaults.gain });
-      } catch (err) {
-        await teardownEngine();
-        isListeningRef.current = false;
-        setIsListening(false);
-        reportEnableError(err);
-        return;
-      }
-      if (myGen !== genRef.current || !mountedRef.current) {
-        // disable / pause / unmount / keyword-change landed during start — undo.
-        await teardownEngine();
-        isListeningRef.current = false;
-        setIsListening(false);
-        return;
+      if (!engineStartedRef.current) {
+        try {
+          await engineRef.current.start({ gain: WAKEWORD_CONFIG.defaults.gain });
+        } catch (err) {
+          await teardownEngine();
+          isListeningRef.current = false;
+          setIsListening(false);
+          reportEnableError(err);
+          return;
+        }
+        if (myGen !== genRef.current || !mountedRef.current || !desiredListeningRef.current) {
+          // disable / pause / unmount / keyword-change landed during start — undo.
+          await teardownEngine();
+          isListeningRef.current = false;
+          setIsListening(false);
+          return;
+        }
+        engineStartedRef.current = true;
       }
       isEnabledRef.current = true;
       isListeningRef.current = true;
@@ -376,19 +394,26 @@ export function useWakeWord({
   // engine immediately so recording never overlaps a live wake-word mic.
   const pause = useCallback(async () => {
     debug.log('⏸️ pause() called - isListening:', isListeningRef.current, 'hasEngine:', !!engineRef.current);
-    if (!isListeningRef.current || !engineRef.current) {
-      debug.log('⚠️ pause() skipped: not listening or no engine');
+    if (!isListeningRef.current) {
+      debug.log('⚠️ pause() skipped: not listening');
       return;
     }
+    // Record the pause intent + abort any in-flight arm FIRST — even if the
+    // engine is transiently null mid-rebuild — so a rebuild-in-progress can't
+    // re-start the mic on top of the recording that's about to begin.
     desiredListeningRef.current = false;
-    genRef.current++; // abort any in-flight arm that would re-start
+    genRef.current++;
     isListeningRef.current = false;
     setIsListening(false);
-    try {
-      await engineRef.current.stop();
-      debug.log('✅ Wake word paused (isEnabled stays true)');
-    } catch (err) {
-      console.error('Failed to pause wake word:', err);
+    engineStartedRef.current = false;
+    const engine = engineRef.current;
+    if (engine) {
+      try {
+        await engine.stop();
+        debug.log('✅ Wake word paused (isEnabled stays true)');
+      } catch (err) {
+        console.error('Failed to pause wake word:', err);
+      }
     }
   }, []);
 
@@ -438,12 +463,23 @@ export function useWakeWord({
     [setKeyword],
   );
 
-  // Update threshold. Takes effect on the next engine build (kept in a ref).
-  const setThreshold = useCallback((threshold: number) => {
-    thresholdRef.current = threshold;
-    setSettings((prev) => ({ ...prev, threshold }));
-    saveWakeWordSettings({ threshold });
-  }, []);
+  // Update threshold. The engine only reads detectionThreshold at construction,
+  // so when we're listening this rebuilds to apply the new sensitivity. Rapid
+  // slider drags bump the generation each tick, so intermediate rebuilds abort
+  // and only the last value is applied.
+  const setThreshold = useCallback(
+    (threshold: number) => {
+      if (threshold === thresholdRef.current) return;
+      thresholdRef.current = threshold;
+      setSettings((prev) => ({ ...prev, threshold }));
+      saveWakeWordSettings({ threshold });
+      genRef.current++;
+      if (desiredListeningRef.current) {
+        void arm();
+      }
+    },
+    [arm],
+  );
 
   // Cleanup on unmount — pre-empt any in-flight arm and stop the engine so the
   // mic/AudioContext never leak after navigation.

--- a/src/frontend/src/hooks/useWakeWord.ts
+++ b/src/frontend/src/hooks/useWakeWord.ts
@@ -49,6 +49,7 @@ export interface UseWakeWordResult {
   pause: () => Promise<void>;
   resume: () => Promise<void>;
   setKeyword: (keyword: string) => Promise<void>;
+  toggleKeyword: (id: string) => Promise<void>;
   setThreshold: (threshold: number) => void;
   availableKeywords: KeywordConfig[];
 }
@@ -56,20 +57,22 @@ export interface UseWakeWordResult {
 /**
  * React hook for wake word detection using OpenWakeWord WASM.
  *
- * Supports a **multi-keyword** active set: `settings.keyword` may be a single id
- * or a comma-separated set (the same form the server settings page uses). The
- * engine loads one model per id, so a German+English household detects every
- * pushed wake word — satellites already do this; the browser now matches them.
+ * **Multi-keyword:** `settings.keyword` is a comma-separated active SET (the same
+ * form the server settings page uses). The engine loads one model per id, so a
+ * German+English household detects every pushed wake word — satellites already
+ * do this; the browser now matches them. The engine's `start()` opens a fresh
+ * mic + AudioContext and `stop()` closes them, so changing the set means
+ * recreating the engine (it can only load models chosen at construction — we
+ * never rely on `setActiveKeywords`).
  *
- * The engine's `start()` opens a fresh mic + AudioContext and `stop()` closes
- * them, so every pause/resume already rebuilds the audio graph — adding/removing
- * a keyword just means recreating the engine (initEngine loads the full set).
- *
- * **All engine lifecycle transitions (enable/disable/pause/resume/keyword-change/
- * error-recovery) run through `runExclusive`, a promise chain that serializes
- * them.** Without it, a server config push (WS `config_update`) that lands mid
- * enable()/resume() could tear the half-built engine out from under the in-flight
- * start — the exact race a multi-language household hits on page load.
+ * **Concurrency model.** Turn-ON transitions (enable/resume/keyword-rebuild) are
+ * serialized through a single "arm" promise chain and reconcile the engine to
+ * the desired state (`desiredEnabledRef`/`desiredListeningRef`/`keywordsRef`).
+ * Turn-OFF transitions (disable/pause) and the error handler are PRE-EMPTIVE:
+ * they run immediately and bump `genRef`, which an in-flight arm re-checks after
+ * every await and aborts on — so a hung `start()` can never block mic-off, an
+ * engine error can never leave a green-but-dead UI, and an unmount mid-build
+ * never leaks the mic.
  */
 export function useWakeWord({
   onWakeWordDetected,
@@ -90,58 +93,50 @@ export function useWakeWord({
     !wasWakeWordLoadAttempted() || getWakeWordEngineClass() !== null,
   );
 
-  // Refs
+  // Engine + subscriptions
   const engineRef = useRef<WakeWordEngine | null>(null);
   const unsubscribersRef = useRef<Array<() => void>>([]);
+  const builtKeywordsRef = useRef<string[]>([]); // the set the live engine was built with
   const callbacksRef = useRef({ onWakeWordDetected, onSpeechStart, onSpeechEnd, onError, onReady });
-  // Live mirrors of the enabled/listening state, updated SYNCHRONOUSLY by the
-  // transitions below so a serialized op reads the true current state (not the
-  // render closure it was created in) when it finally runs.
+
+  // Actual-state mirrors (kept in sync synchronously with the setState calls).
   const isEnabledRef = useRef(false);
   const isListeningRef = useRef(false);
-  // The active keyword id set + threshold, mirrored into refs so the engine
-  // build path (initEngine) reads the CURRENT values synchronously.
+  // Desired state — what the user/serve wants. The arm loop reconciles to these.
+  const desiredEnabledRef = useRef(false);
+  const desiredListeningRef = useRef(false);
+  // Desired keyword set + threshold, read at engine-build time.
   const keywordsRef = useRef<string[]>(parseKeywords(settings.keyword));
   const thresholdRef = useRef<number>(settings.threshold);
 
-  // Serializes every engine lifecycle transition. Each queued op runs only
-  // after the previous one settles (success OR failure), so no two transitions
-  // ever touch engineRef concurrently. Errors don't poison the chain.
-  const opChainRef = useRef<Promise<unknown>>(Promise.resolve());
-  const runExclusive = useCallback((op: () => Promise<void>): Promise<void> => {
-    const run = opChainRef.current.then(op, op);
-    opChainRef.current = run.catch(() => undefined);
-    return run;
-  }, []);
+  // Generation counter — bumped by every pre-emptive turn-OFF (disable/pause),
+  // by an engine error, by a keyword change, and by unmount. An in-flight arm
+  // captures the generation and aborts if it changed across an await.
+  const genRef = useRef(0);
+  const mountedRef = useRef(true);
+  // Serializes turn-ON (arm) transitions so two builds never race engineRef.
+  const armChainRef = useRef<Promise<unknown>>(Promise.resolve());
 
   // Keep callbacks ref updated
   useEffect(() => {
     callbacksRef.current = { onWakeWordDetected, onSpeechStart, onSpeechEnd, onError, onReady };
   }, [onWakeWordDetected, onSpeechStart, onSpeechEnd, onError, onReady]);
 
-  // Keep the engine-build refs in sync with settings (belt-and-suspenders: the
-  // mutators update these synchronously; this catches any external settings set)
-  useEffect(() => {
-    keywordsRef.current = parseKeywords(settings.keyword);
-    thresholdRef.current = settings.threshold;
-  }, [settings.keyword, settings.threshold]);
-
-  // Build a fresh engine from the CURRENT keyword set + threshold (read from
-  // refs, so this never captures a stale set).
+  // Build a fresh engine from the CURRENT keyword set + threshold (from refs).
   const initEngine = useCallback(async (): Promise<WakeWordEngine> => {
     const EngineClass = getWakeWordEngineClass();
     if (!EngineClass) {
       throw new Error('Wake word detection not available. Please rebuild the application.');
     }
 
-    // Build model file map from config (includes custom keywords like hey_renfield)
+    // Model file map (includes custom keywords like hey_renfield).
     const modelFiles: Record<string, string> = {};
     for (const kw of WAKEWORD_CONFIG.availableKeywords) {
       modelFiles[kw.id] = kw.model;
     }
 
-    // Load EVERY active keyword's model (multi-language household). Fall back to
-    // the default single keyword if the set somehow resolved to nothing.
+    // Load EVERY active keyword's model. Fall back to the default single keyword
+    // if the set somehow resolved to nothing.
     const keywords = keywordsRef.current.length
       ? [...keywordsRef.current]
       : [WAKEWORD_CONFIG.defaults.keyword];
@@ -156,13 +151,13 @@ export function useWakeWord({
   }, []);
 
   // Fully tear down the engine: unsubscribe, stop (closes mic + AudioContext),
-  // drop the ref. Low-level primitive — only called from inside runExclusive
-  // (or unmount cleanup).
+  // drop the ref. Low-level; callers own the state/gen bookkeeping.
   const teardownEngine = useCallback(async () => {
     unsubscribersRef.current.forEach((unsub) => unsub?.());
     unsubscribersRef.current = [];
     const engine = engineRef.current;
     engineRef.current = null;
+    builtKeywordsRef.current = [];
     setIsReady(false);
     if (engine) {
       try {
@@ -173,56 +168,10 @@ export function useWakeWord({
     }
   }, []);
 
-  // Build + load + subscribe an engine if none exists. Low-level primitive.
-  const buildEngine = useCallback(async () => {
-    if (engineRef.current) return;
-    const engine = await initEngine();
-    await engine.load();
-
-    // Wire the engine's events to hook state/callbacks.
-    const unsubReady = engine.on('ready', () => {
-      setIsReady(true);
-      callbacksRef.current.onReady?.();
-    });
-    const unsubDetect = engine.on('detect', ({ keyword, score, at }) => {
-      const detection: WakeWordDetection = { keyword, score, timestamp: at || Date.now() };
-      setLastDetection(detection);
-      callbacksRef.current.onWakeWordDetected?.(keyword, score);
-    });
-    const unsubSpeechStart = engine.on('speech-start', () => {
-      callbacksRef.current.onSpeechStart?.();
-    });
-    const unsubSpeechEnd = engine.on('speech-end', () => {
-      callbacksRef.current.onSpeechEnd?.();
-    });
-    const unsubError = engine.on('error', (err: Error) => {
-      setError(err);
-      // The engine errored — it is no longer detecting. Reflect that in
-      // isListening (it previously stayed stale-true, lying to the UI) so the
-      // status dot goes yellow AND the recovery triggers in ChatContext
-      // (WS-reconnect / tab-visible / network-online) can resume it. isEnabled
-      // stays true so the user's intent is preserved and the resume path stays
-      // open. DROP the dead engine (serialized) so recovery resume() rebuilds a
-      // fresh one rather than start()-ing the broken instance.
-      isListeningRef.current = false;
-      setIsListening(false);
-      callbacksRef.current.onError?.(err);
-      void runExclusive(() => teardownEngine());
-    });
-
-    unsubscribersRef.current = [
-      unsubReady,
-      unsubDetect,
-      unsubSpeechStart,
-      unsubSpeechEnd,
-      unsubError,
-    ];
-    engineRef.current = engine;
-  }, [initEngine, runExclusive, teardownEngine]);
-
-  // Map raw engine/browser errors to friendly, actionable messages.
+  // Map raw engine/browser errors to friendly, actionable messages. Used by
+  // every build/start failure path (enable, resume, keyword-rebuild).
   const reportEnableError = useCallback((err: unknown) => {
-    console.error('Failed to enable wake word:', err);
+    console.error('Failed to start wake word:', err);
     const raw = err instanceof Error ? err : new Error(String(err));
 
     let out = raw;
@@ -252,67 +201,167 @@ export function useWakeWord({
     callbacksRef.current.onError?.(out);
   }, []);
 
-  // Enable wake word listening.
-  const enable = useCallback(() => {
-    // Flip the loading indicator synchronously (before the op is queued) so the
-    // spinner appears on the click, not a microtask later.
-    setIsLoading(true);
-    setError(null);
-    return runExclusive(async () => {
+  // Wire a fresh engine's events to hook state/callbacks.
+  const subscribe = useCallback(
+    (engine: WakeWordEngine) => {
+      const unsubReady = engine.on('ready', () => {
+        setIsReady(true);
+        callbacksRef.current.onReady?.();
+      });
+      const unsubDetect = engine.on('detect', ({ keyword, score, at }) => {
+        const detection: WakeWordDetection = { keyword, score, timestamp: at || Date.now() };
+        setLastDetection(detection);
+        callbacksRef.current.onWakeWordDetected?.(keyword, score);
+      });
+      const unsubSpeechStart = engine.on('speech-start', () => {
+        callbacksRef.current.onSpeechStart?.();
+      });
+      const unsubSpeechEnd = engine.on('speech-end', () => {
+        callbacksRef.current.onSpeechEnd?.();
+      });
+      const unsubError = engine.on('error', (err: Error) => {
+        setError(err);
+        callbacksRef.current.onError?.(err);
+        // The engine died — reflect it honestly (status dot goes yellow) and
+        // DROP it so a recovery resume() rebuilds a fresh one. Bump the
+        // generation so any in-flight arm can't re-mark this dead engine as
+        // listening (the green-but-dead race). isEnabled stays true so the
+        // user's intent is preserved and recovery can fire.
+        isListeningRef.current = false;
+        setIsListening(false);
+        genRef.current++;
+        void teardownEngine();
+      });
+
+      unsubscribersRef.current = [
+        unsubReady,
+        unsubDetect,
+        unsubSpeechStart,
+        unsubSpeechEnd,
+        unsubError,
+      ];
+    },
+    [teardownEngine],
+  );
+
+  // Reconcile the engine to the desired state. Serialized via `arm()`. Re-checks
+  // the generation / mounted / desired flags after every await and bails (tearing
+  // down any half-built engine) if a pre-emptive op superseded it.
+  const armInner = useCallback(async () => {
+    if (!mountedRef.current || !desiredEnabledRef.current) return;
+    const myGen = genRef.current;
+
+    // Ensure the WASM module is available.
+    const loaded = await loadWakeWordEngine();
+    if (!loaded) {
+      setIsAvailable(false);
+      const err =
+        getWakeWordLoadError() ||
+        new Error(
+          'Wake word detection not available. Please run: npm install && docker compose up -d --build',
+        );
+      setError(err);
+      callbacksRef.current.onError?.(err);
+      return;
+    }
+    setIsAvailable(true);
+    if (myGen !== genRef.current || !mountedRef.current || !desiredEnabledRef.current) return;
+
+    // Rebuild if the live engine's loaded set drifted from the desired set.
+    if (
+      engineRef.current &&
+      !sameKeywordSet(builtKeywordsRef.current.join(','), keywordsRef.current.join(','))
+    ) {
+      await teardownEngine();
+      if (myGen !== genRef.current || !mountedRef.current || !desiredEnabledRef.current) return;
+    }
+
+    // Build (load + subscribe) if there's no engine.
+    if (!engineRef.current) {
+      let engine: WakeWordEngine;
       try {
-        if (isEnabledRef.current && isListeningRef.current) return;
-
-        // Lazy load the wake word engine module
-        const loaded = await loadWakeWordEngine();
-        if (!loaded) {
-          setIsAvailable(false);
-          const err =
-            getWakeWordLoadError() ||
-            new Error(
-              'Wake word detection not available. Please run: npm install && docker compose up -d --build',
-            );
-          setError(err);
-          callbacksRef.current.onError?.(err);
-          return;
-        }
-        setIsAvailable(true);
-
-        await buildEngine();
-        await engineRef.current!.start({ gain: WAKEWORD_CONFIG.defaults.gain });
-
-        isEnabledRef.current = true;
-        isListeningRef.current = true;
-        setIsEnabled(true);
-        setIsListening(true);
-        saveWakeWordSettings({ enabled: true });
+        engine = await initEngine();
+        await engine.load();
       } catch (err) {
-        // Drop any half-built engine so a retry rebuilds cleanly.
+        reportEnableError(err);
+        return;
+      }
+      if (myGen !== genRef.current || !mountedRef.current || !desiredEnabledRef.current) {
+        // Superseded during the build — discard the engine we just made.
+        try {
+          await engine.stop();
+        } catch {
+          /* discarded */
+        }
+        return;
+      }
+      subscribe(engine);
+      engineRef.current = engine;
+      builtKeywordsRef.current = [...keywordsRef.current];
+    }
+
+    // Start capturing if we should be listening.
+    if (desiredListeningRef.current) {
+      try {
+        await engineRef.current.start({ gain: WAKEWORD_CONFIG.defaults.gain });
+      } catch (err) {
         await teardownEngine();
         isListeningRef.current = false;
         setIsListening(false);
         reportEnableError(err);
-      } finally {
-        setIsLoading(false);
+        return;
       }
-    });
-  }, [runExclusive, buildEngine, teardownEngine, reportEnableError]);
-
-  // Disable wake word listening. Works from ANY state (listening, paused, or
-  // post-error) — the guard is "is there anything to turn off?", not isListening,
-  // so the toggle can always turn the mic off (and clear the persisted flag).
-  const disable = useCallback(
-    () =>
-      runExclusive(async () => {
-        if (!isEnabledRef.current && !engineRef.current) return;
+      if (myGen !== genRef.current || !mountedRef.current) {
+        // disable / pause / unmount / keyword-change landed during start — undo.
         await teardownEngine();
-        isEnabledRef.current = false;
         isListeningRef.current = false;
-        setIsEnabled(false);
         setIsListening(false);
-        saveWakeWordSettings({ enabled: false });
-      }),
-    [runExclusive, teardownEngine],
-  );
+        return;
+      }
+      isEnabledRef.current = true;
+      isListeningRef.current = true;
+      setIsEnabled(true);
+      setIsListening(true);
+      saveWakeWordSettings({ enabled: true });
+    }
+  }, [initEngine, subscribe, teardownEngine, reportEnableError]);
+
+  // Queue an arm (turn-ON reconcile) after any in-flight one. Errors in one op
+  // don't poison the chain.
+  const arm = useCallback((): Promise<void> => {
+    const next = armChainRef.current.then(armInner, armInner);
+    armChainRef.current = next.catch(() => undefined);
+    return next;
+  }, [armInner]);
+
+  // Enable wake word listening.
+  const enable = useCallback((): Promise<void> => {
+    if (isEnabledRef.current && isListeningRef.current) return Promise.resolve();
+    // Only flip the spinner once we know there's real work (avoids a flicker when
+    // called redundantly while already listening).
+    setIsLoading(true);
+    setError(null);
+    desiredEnabledRef.current = true;
+    desiredListeningRef.current = true;
+    return arm().finally(() => setIsLoading(false));
+  }, [arm]);
+
+  // Disable wake word listening. PRE-EMPTIVE: runs immediately (not queued behind
+  // a possibly-hung arm) and stops the engine directly, so the mic can ALWAYS be
+  // turned off. Works from any state (listening, paused, post-error).
+  const disable = useCallback(async () => {
+    if (!desiredEnabledRef.current && !engineRef.current) return;
+    desiredEnabledRef.current = false;
+    desiredListeningRef.current = false;
+    genRef.current++; // abort any in-flight arm
+    isEnabledRef.current = false;
+    isListeningRef.current = false;
+    setIsEnabled(false);
+    setIsListening(false);
+    setIsLoading(false);
+    saveWakeWordSettings({ enabled: false });
+    await teardownEngine();
+  }, [teardownEngine]);
 
   // Toggle wake word
   const toggle = useCallback(async () => {
@@ -323,119 +372,91 @@ export function useWakeWord({
     }
   }, [isEnabled, enable, disable]);
 
-  // Pause listening temporarily (e.g., while recording). Serialized, so it runs
-  // AFTER any in-flight rebuild — it never sees a transient null engine.
-  const pause = useCallback(
-    () =>
-      runExclusive(async () => {
-        if (!isListeningRef.current || !engineRef.current) {
-          debug.log('⚠️ pause() skipped: not listening or no engine');
-          return;
-        }
-        try {
-          await engineRef.current.stop();
-          isListeningRef.current = false;
-          setIsListening(false);
-          debug.log('✅ Wake word paused (isEnabled stays true)');
-        } catch (err) {
-          console.error('Failed to pause wake word:', err);
-        }
-      }),
-    [runExclusive],
-  );
+  // Pause listening temporarily (e.g., while recording). PRE-EMPTIVE: stops the
+  // engine immediately so recording never overlaps a live wake-word mic.
+  const pause = useCallback(async () => {
+    debug.log('⏸️ pause() called - isListening:', isListeningRef.current, 'hasEngine:', !!engineRef.current);
+    if (!isListeningRef.current || !engineRef.current) {
+      debug.log('⚠️ pause() skipped: not listening or no engine');
+      return;
+    }
+    desiredListeningRef.current = false;
+    genRef.current++; // abort any in-flight arm that would re-start
+    isListeningRef.current = false;
+    setIsListening(false);
+    try {
+      await engineRef.current.stop();
+      debug.log('✅ Wake word paused (isEnabled stays true)');
+    } catch (err) {
+      console.error('Failed to pause wake word:', err);
+    }
+  }, []);
 
-  // Resume listening after pause. buildEngine() rebuilds if the engine was
-  // dropped (keyword change while paused, or an error), then start()s — start
-  // always opens a fresh mic + AudioContext, so a rebuild here is no different
-  // from a normal resume.
-  const resume = useCallback(
-    () =>
-      runExclusive(async () => {
-        if (isListeningRef.current) return;
-        if (!isEnabledRef.current) return;
+  // Resume listening after pause. arm() rebuilds if the engine was dropped
+  // (keyword change while paused, or an error), else just re-starts.
+  const resume = useCallback((): Promise<void> => {
+    if (isListeningRef.current) return Promise.resolve();
+    if (!desiredEnabledRef.current) return Promise.resolve();
+    desiredListeningRef.current = true;
+    return arm();
+  }, [arm]);
 
-        try {
-          await buildEngine();
-          await engineRef.current!.start({ gain: WAKEWORD_CONFIG.defaults.gain });
-          isListeningRef.current = true;
-          setIsListening(true);
-          debug.log('✅ Wake word engine resumed');
-        } catch (err) {
-          console.error('Failed to resume wake word:', err);
-          setError(err instanceof Error ? err : new Error(String(err)));
-        }
-      }),
-    [runExclusive, buildEngine],
-  );
-
-  // Rebuild the engine to match the current keyword set. Serialized. Because the
-  // engine can only load models chosen at construction, changing the set means a
-  // full stop → drop → recreate. Preserves the listening/paused state.
-  const applyKeywordChange = useCallback(
-    () =>
-      runExclusive(async () => {
-        // Not running: just drop any stale engine — enable() will build fresh
-        // with the new set.
-        if (!isEnabledRef.current) {
-          await teardownEngine();
-          return;
-        }
-        const wasListening = isListeningRef.current;
-        await teardownEngine();
-        if (wasListening) {
-          try {
-            await buildEngine();
-            await engineRef.current!.start({ gain: WAKEWORD_CONFIG.defaults.gain });
-            isListeningRef.current = true;
-            setIsListening(true);
-          } catch (err) {
-            console.error('Failed to rebuild wake word engine:', err);
-            setError(err instanceof Error ? err : new Error(String(err)));
-            isListeningRef.current = false;
-            setIsListening(false);
-          }
-        }
-        // If paused: leave the engine dropped; resume() rebuilds with the new set.
-      }),
-    [runExclusive, teardownEngine, buildEngine],
-  );
-
-  // Update the active keyword set. Accepts a single id or a comma-separated set.
-  // Persists it (survives reload) and, if the set actually changed, rebuilds the
+  // Update the active keyword set (single id or comma-separated). Persists it
+  // (survives reload) and, if the set changed while listening, rebuilds the
   // engine so every keyword is loaded.
   const setKeyword = useCallback(
     async (keyword: string) => {
       const ids = parseKeywords(keyword);
-      // Ignore a selection that resolves to nothing we ship a model for — keep
-      // the current set rather than blanking detection.
+      // Ignore a selection that resolves to nothing we ship a model for.
       if (ids.length === 0) return;
       const normalized = ids.join(',');
       if (sameKeywordSet(normalized, keywordsRef.current.join(','))) return;
 
-      keywordsRef.current = ids; // synchronous — the rebuild below reads this
+      keywordsRef.current = ids; // read by the next engine build
       setSettings((prev) => ({ ...prev, keyword: normalized }));
       saveWakeWordSettings({ keyword: normalized });
+      genRef.current++; // supersede any in-flight arm building the old set
 
-      await applyKeywordChange();
+      // Reconcile now if we should be listening; otherwise the next resume()/
+      // enable() picks up the new set (arm's drift check rebuilds).
+      if (desiredListeningRef.current) {
+        await arm();
+      }
     },
-    [applyKeywordChange],
+    [arm],
   );
 
-  // Update threshold. Takes effect on the next engine build (kept in a ref so a
-  // rebuild picks it up); we don't force a rebuild for a sensitivity nudge.
+  // Toggle one keyword in/out of the active set. Reads the CURRENT set from the
+  // ref (not a render closure) so rapid successive toggles don't lose updates.
+  const toggleKeyword = useCallback(
+    async (id: string) => {
+      const current = keywordsRef.current;
+      const next = current.includes(id) ? current.filter((k) => k !== id) : [...current, id];
+      if (next.length === 0) return; // keep at least one active
+      await setKeyword(next.join(','));
+    },
+    [setKeyword],
+  );
+
+  // Update threshold. Takes effect on the next engine build (kept in a ref).
   const setThreshold = useCallback((threshold: number) => {
     thresholdRef.current = threshold;
     setSettings((prev) => ({ ...prev, threshold }));
     saveWakeWordSettings({ threshold });
   }, []);
 
-  // Cleanup on unmount
+  // Cleanup on unmount — pre-empt any in-flight arm and stop the engine so the
+  // mic/AudioContext never leak after navigation.
   useEffect(() => {
     return () => {
+      mountedRef.current = false;
+      genRef.current++;
       unsubscribersRef.current.forEach((unsub) => unsub?.());
-      if (engineRef.current) {
-        engineRef.current.stop().catch(() => {});
-        engineRef.current = null;
+      unsubscribersRef.current = [];
+      const engine = engineRef.current;
+      engineRef.current = null;
+      if (engine) {
+        engine.stop().catch(() => {});
       }
     };
   }, []);
@@ -498,6 +519,7 @@ export function useWakeWord({
     pause,
     resume,
     setKeyword,
+    toggleKeyword,
     setThreshold,
 
     // Config access

--- a/src/frontend/src/hooks/useWakeWord.ts
+++ b/src/frontend/src/hooks/useWakeWord.ts
@@ -212,6 +212,10 @@ export function useWakeWord({
         callbacksRef.current.onReady?.();
       });
       const unsubDetect = engine.on('detect', ({ keyword, score, at }) => {
+        // Ignore detections while not actively listening — a paused engine keeps
+        // its subscription (resume fast-path) and could emit a buffered detect
+        // mid-recording, spuriously re-triggering the wake word.
+        if (!isListeningRef.current) return;
         const detection: WakeWordDetection = { keyword, score, timestamp: at || Date.now() };
         setLastDetection(detection);
         callbacksRef.current.onWakeWordDetected?.(keyword, score);
@@ -394,13 +398,16 @@ export function useWakeWord({
   // engine immediately so recording never overlaps a live wake-word mic.
   const pause = useCallback(async () => {
     debug.log('⏸️ pause() called - isListening:', isListeningRef.current, 'hasEngine:', !!engineRef.current);
-    if (!isListeningRef.current) {
-      debug.log('⚠️ pause() skipped: not listening');
+    // Nothing to pause only if we're neither listening NOR arming toward it. If
+    // an enable()/resume() arm is in flight (desiredListening=true, isListening
+    // still false), we must still cancel it so it can't open the mic on top of
+    // the recording that's starting.
+    if (!isListeningRef.current && !desiredListeningRef.current) {
+      debug.log('⚠️ pause() skipped: not listening and not arming');
       return;
     }
     // Record the pause intent + abort any in-flight arm FIRST — even if the
-    // engine is transiently null mid-rebuild — so a rebuild-in-progress can't
-    // re-start the mic on top of the recording that's about to begin.
+    // engine is transiently null mid-rebuild — so nothing re-starts the mic.
     desiredListeningRef.current = false;
     genRef.current++;
     isListeningRef.current = false;
@@ -412,10 +419,14 @@ export function useWakeWord({
         await engine.stop();
         debug.log('✅ Wake word paused (isEnabled stays true)');
       } catch (err) {
+        // stop() failed — the engine may still be capturing. Drop it entirely so
+        // a later resume() rebuilds a fresh one instead of double-starting a
+        // still-live engine (mic leak).
         console.error('Failed to pause wake word:', err);
+        await teardownEngine();
       }
     }
-  }, []);
+  }, [teardownEngine]);
 
   // Resume listening after pause. arm() rebuilds if the engine was dropped
   // (keyword change while paused, or an error), else just re-starts.

--- a/src/frontend/src/hooks/useWakeWord.ts
+++ b/src/frontend/src/hooks/useWakeWord.ts
@@ -3,38 +3,19 @@ import {
   WAKEWORD_CONFIG,
   loadWakeWordSettings,
   saveWakeWordSettings,
+  parseKeywords,
+  sameKeywordSet,
   type WakeWordSettings,
   type KeywordConfig,
 } from '../config/wakeword';
+import {
+  loadWakeWordEngine,
+  getWakeWordEngineClass,
+  getWakeWordLoadError,
+  wasWakeWordLoadAttempted,
+  type WakeWordEngine,
+} from './wakewordEngineLoader';
 import { debug } from '../utils/debug';
-
-// Wake word engine interface (from openwakeword-wasm-browser)
-interface WakeWordEngine {
-  load(): Promise<void>;
-  start(options?: { gain?: number }): Promise<void>;
-  stop(): Promise<void>;
-  setActiveKeywords(keywords: string[]): void;
-  on(event: 'ready', callback: () => void): () => void;
-  on(event: 'detect', callback: (data: { keyword: string; score: number; at?: number }) => void): () => void;
-  on(event: 'speech-start', callback: () => void): () => void;
-  on(event: 'speech-end', callback: () => void): () => void;
-  on(event: 'error', callback: (error: Error) => void): () => void;
-}
-
-interface WakeWordEngineConstructor {
-  new (options: {
-    baseAssetUrl: string;
-    keywords: string[];
-    /**
-     * Optional override of the built-in keyword -> model-file map. Required
-     * for custom wake words like `hey_renfield` which aren't in the
-     * library's default `MODEL_FILE_MAP`.
-     */
-    modelFiles?: Record<string, string>;
-    detectionThreshold: number;
-    cooldownMs: number;
-  }): WakeWordEngine;
-}
 
 // Detection result
 interface WakeWordDetection {
@@ -72,50 +53,23 @@ export interface UseWakeWordResult {
   availableKeywords: KeywordConfig[];
 }
 
-// Lazy-loaded wake word engine class
-let WakeWordEngineClass: WakeWordEngineConstructor | null = null;
-let loadAttempted = false;
-let loadError: Error | null = null;
-
 /**
- * Lazy load the wake word engine module
- */
-async function loadWakeWordEngine(): Promise<boolean> {
-  if (loadAttempted) {
-    return WakeWordEngineClass !== null;
-  }
-
-  loadAttempted = true;
-
-  try {
-    // Configure ONNX Runtime before importing the engine
-    const ort = await import('onnxruntime-web');
-
-    // Disable multi-threading to avoid SharedArrayBuffer requirement
-    ort.env.wasm.numThreads = 1;
-
-    // Disable proxy mode - it causes dynamic import issues with Vite
-    ort.env.wasm.proxy = false;
-
-    // Set explicit WASM file paths to avoid Vite module interception
-    ort.env.wasm.wasmPaths = '/ort/';
-
-    debug.log('✅ ONNX Runtime (WASM) configured with paths:', ort.env.wasm.wasmPaths);
-
-    const module = await import('openwakeword-wasm-browser');
-    WakeWordEngineClass = module.default || module.WakeWordEngine;
-    debug.log('✅ Wake word engine loaded successfully');
-    return true;
-  } catch (e) {
-    loadError = e instanceof Error ? e : new Error(String(e));
-    console.warn('⚠️ openwakeword-wasm-browser not available:', loadError.message);
-    console.warn('💡 Run: npm install && docker compose up -d --build');
-    return false;
-  }
-}
-
-/**
- * React hook for wake word detection using OpenWakeWord WASM
+ * React hook for wake word detection using OpenWakeWord WASM.
+ *
+ * Supports a **multi-keyword** active set: `settings.keyword` may be a single id
+ * or a comma-separated set (the same form the server settings page uses). The
+ * engine loads one model per id, so a German+English household detects every
+ * pushed wake word — satellites already do this; the browser now matches them.
+ *
+ * The engine's `start()` opens a fresh mic + AudioContext and `stop()` closes
+ * them, so every pause/resume already rebuilds the audio graph — adding/removing
+ * a keyword just means recreating the engine (initEngine loads the full set).
+ *
+ * **All engine lifecycle transitions (enable/disable/pause/resume/keyword-change/
+ * error-recovery) run through `runExclusive`, a promise chain that serializes
+ * them.** Without it, a server config push (WS `config_update`) that lands mid
+ * enable()/resume() could tear the half-built engine out from under the in-flight
+ * start — the exact race a multi-language household hits on page load.
  */
 export function useWakeWord({
   onWakeWordDetected,
@@ -132,34 +86,51 @@ export function useWakeWord({
   const [lastDetection, setLastDetection] = useState<WakeWordDetection | null>(null);
   const [error, setError] = useState<Error | null>(null);
   const [settings, setSettings] = useState<WakeWordSettings>(() => loadWakeWordSettings());
-  const [isAvailable, setIsAvailable] = useState(!loadAttempted || WakeWordEngineClass !== null);
+  const [isAvailable, setIsAvailable] = useState(
+    !wasWakeWordLoadAttempted() || getWakeWordEngineClass() !== null,
+  );
 
   // Refs
   const engineRef = useRef<WakeWordEngine | null>(null);
   const unsubscribersRef = useRef<Array<() => void>>([]);
   const callbacksRef = useRef({ onWakeWordDetected, onSpeechStart, onSpeechEnd, onError, onReady });
-  const isEnabledRef = useRef(false); // Ref to avoid stale closure in resume()
-  // In-flight guard around engine.start(). isListening only flips true AFTER
-  // the async start resolves, so without this two near-simultaneous resume()
-  // calls (e.g. tab-visible + network-online + WS-reconnect all firing on a
-  // laptop wake) would both pass the isListening check and start() the engine
-  // twice. Coalesces concurrent starts across both enable() and resume().
-  const isStartingRef = useRef(false);
+  // Live mirrors of the enabled/listening state, updated SYNCHRONOUSLY by the
+  // transitions below so a serialized op reads the true current state (not the
+  // render closure it was created in) when it finally runs.
+  const isEnabledRef = useRef(false);
+  const isListeningRef = useRef(false);
+  // The active keyword id set + threshold, mirrored into refs so the engine
+  // build path (initEngine) reads the CURRENT values synchronously.
+  const keywordsRef = useRef<string[]>(parseKeywords(settings.keyword));
+  const thresholdRef = useRef<number>(settings.threshold);
+
+  // Serializes every engine lifecycle transition. Each queued op runs only
+  // after the previous one settles (success OR failure), so no two transitions
+  // ever touch engineRef concurrently. Errors don't poison the chain.
+  const opChainRef = useRef<Promise<unknown>>(Promise.resolve());
+  const runExclusive = useCallback((op: () => Promise<void>): Promise<void> => {
+    const run = opChainRef.current.then(op, op);
+    opChainRef.current = run.catch(() => undefined);
+    return run;
+  }, []);
 
   // Keep callbacks ref updated
   useEffect(() => {
     callbacksRef.current = { onWakeWordDetected, onSpeechStart, onSpeechEnd, onError, onReady };
   }, [onWakeWordDetected, onSpeechStart, onSpeechEnd, onError, onReady]);
 
-  // Keep isEnabledRef in sync with state
+  // Keep the engine-build refs in sync with settings (belt-and-suspenders: the
+  // mutators update these synchronously; this catches any external settings set)
   useEffect(() => {
-    isEnabledRef.current = isEnabled;
-    debug.log('🔄 isEnabledRef updated to:', isEnabled);
-  }, [isEnabled]);
+    keywordsRef.current = parseKeywords(settings.keyword);
+    thresholdRef.current = settings.threshold;
+  }, [settings.keyword, settings.threshold]);
 
-  // Initialize engine
+  // Build a fresh engine from the CURRENT keyword set + threshold (read from
+  // refs, so this never captures a stale set).
   const initEngine = useCallback(async (): Promise<WakeWordEngine> => {
-    if (!WakeWordEngineClass) {
+    const EngineClass = getWakeWordEngineClass();
+    if (!EngineClass) {
       throw new Error('Wake word detection not available. Please rebuild the application.');
     }
 
@@ -169,158 +140,179 @@ export function useWakeWord({
       modelFiles[kw.id] = kw.model;
     }
 
-    const engine = new WakeWordEngineClass({
+    // Load EVERY active keyword's model (multi-language household). Fall back to
+    // the default single keyword if the set somehow resolved to nothing.
+    const keywords = keywordsRef.current.length
+      ? [...keywordsRef.current]
+      : [WAKEWORD_CONFIG.defaults.keyword];
+
+    return new EngineClass({
       baseAssetUrl: WAKEWORD_CONFIG.modelBasePath,
-      keywords: [settings.keyword],
+      keywords,
       modelFiles,
-      detectionThreshold: settings.threshold,
+      detectionThreshold: thresholdRef.current,
       cooldownMs: WAKEWORD_CONFIG.defaults.cooldownMs,
     });
+  }, []);
 
-    return engine;
-  }, [settings.keyword, settings.threshold]);
+  // Fully tear down the engine: unsubscribe, stop (closes mic + AudioContext),
+  // drop the ref. Low-level primitive — only called from inside runExclusive
+  // (or unmount cleanup).
+  const teardownEngine = useCallback(async () => {
+    unsubscribersRef.current.forEach((unsub) => unsub?.());
+    unsubscribersRef.current = [];
+    const engine = engineRef.current;
+    engineRef.current = null;
+    setIsReady(false);
+    if (engine) {
+      try {
+        await engine.stop();
+      } catch (err) {
+        console.error('Failed to stop wake word engine:', err);
+      }
+    }
+  }, []);
 
-  // Enable wake word listening
-  const enable = useCallback(async () => {
-    if (isListening || isLoading || isStartingRef.current) return;
+  // Build + load + subscribe an engine if none exists. Low-level primitive.
+  const buildEngine = useCallback(async () => {
+    if (engineRef.current) return;
+    const engine = await initEngine();
+    await engine.load();
 
+    // Wire the engine's events to hook state/callbacks.
+    const unsubReady = engine.on('ready', () => {
+      setIsReady(true);
+      callbacksRef.current.onReady?.();
+    });
+    const unsubDetect = engine.on('detect', ({ keyword, score, at }) => {
+      const detection: WakeWordDetection = { keyword, score, timestamp: at || Date.now() };
+      setLastDetection(detection);
+      callbacksRef.current.onWakeWordDetected?.(keyword, score);
+    });
+    const unsubSpeechStart = engine.on('speech-start', () => {
+      callbacksRef.current.onSpeechStart?.();
+    });
+    const unsubSpeechEnd = engine.on('speech-end', () => {
+      callbacksRef.current.onSpeechEnd?.();
+    });
+    const unsubError = engine.on('error', (err: Error) => {
+      setError(err);
+      // The engine errored — it is no longer detecting. Reflect that in
+      // isListening (it previously stayed stale-true, lying to the UI) so the
+      // status dot goes yellow AND the recovery triggers in ChatContext
+      // (WS-reconnect / tab-visible / network-online) can resume it. isEnabled
+      // stays true so the user's intent is preserved and the resume path stays
+      // open. DROP the dead engine (serialized) so recovery resume() rebuilds a
+      // fresh one rather than start()-ing the broken instance.
+      isListeningRef.current = false;
+      setIsListening(false);
+      callbacksRef.current.onError?.(err);
+      void runExclusive(() => teardownEngine());
+    });
+
+    unsubscribersRef.current = [
+      unsubReady,
+      unsubDetect,
+      unsubSpeechStart,
+      unsubSpeechEnd,
+      unsubError,
+    ];
+    engineRef.current = engine;
+  }, [initEngine, runExclusive, teardownEngine]);
+
+  // Map raw engine/browser errors to friendly, actionable messages.
+  const reportEnableError = useCallback((err: unknown) => {
+    console.error('Failed to enable wake word:', err);
+    const raw = err instanceof Error ? err : new Error(String(err));
+
+    let out = raw;
+    if (raw.message && raw.message.includes('sample-rate')) {
+      // Firefox: AudioContext sample rate mismatch
+      out = new Error(
+        'Wake word detection is not supported in Firefox due to AudioContext sample rate limitations. ' +
+          'Please use Chrome or Edge for wake word detection, or use the manual recording button.',
+      );
+      out.name = 'BrowserNotSupportedError';
+    } else if (
+      raw.message &&
+      (raw.message.includes('SharedArrayBuffer') ||
+        raw.message.includes('cross-origin isolated') ||
+        raw.message.includes('CompileError') ||
+        raw.message.includes('WebAssembly'))
+    ) {
+      // Safari/WebKit: WASM or SharedArrayBuffer issues
+      out = new Error(
+        'Wake word detection requires WebAssembly threading which may not be available in this browser. ' +
+          'Please use Chrome or Edge, or use the manual recording button.',
+      );
+      out.name = 'BrowserNotSupportedError';
+    }
+
+    setError(out);
+    callbacksRef.current.onError?.(out);
+  }, []);
+
+  // Enable wake word listening.
+  const enable = useCallback(() => {
+    // Flip the loading indicator synchronously (before the op is queued) so the
+    // spinner appears on the click, not a microtask later.
     setIsLoading(true);
     setError(null);
-    isStartingRef.current = true;
+    return runExclusive(async () => {
+      try {
+        if (isEnabledRef.current && isListeningRef.current) return;
 
-    try {
-      // Lazy load the wake word engine module
-      const loaded = await loadWakeWordEngine();
-      if (!loaded) {
-        setIsAvailable(false);
-        const err = loadError || new Error('Wake word detection not available. Please run: npm install && docker compose up -d --build');
-        setError(err);
-        callbacksRef.current.onError?.(err);
-        setIsLoading(false);
-        return;
-      }
-      setIsAvailable(true);
+        // Lazy load the wake word engine module
+        const loaded = await loadWakeWordEngine();
+        if (!loaded) {
+          setIsAvailable(false);
+          const err =
+            getWakeWordLoadError() ||
+            new Error(
+              'Wake word detection not available. Please run: npm install && docker compose up -d --build',
+            );
+          setError(err);
+          callbacksRef.current.onError?.(err);
+          return;
+        }
+        setIsAvailable(true);
 
-      // Create engine if not exists
-      if (!engineRef.current) {
-        engineRef.current = await initEngine();
-      }
+        await buildEngine();
+        await engineRef.current!.start({ gain: WAKEWORD_CONFIG.defaults.gain });
 
-      const engine = engineRef.current;
-
-      // Load models
-      await engine.load();
-
-      // Subscribe to events
-      const unsubReady = engine.on('ready', () => {
-        setIsReady(true);
-        callbacksRef.current.onReady?.();
-      });
-
-      const unsubDetect = engine.on('detect', ({ keyword, score, at }) => {
-        const detection: WakeWordDetection = { keyword, score, timestamp: at || Date.now() };
-        setLastDetection(detection);
-        callbacksRef.current.onWakeWordDetected?.(keyword, score);
-      });
-
-      const unsubSpeechStart = engine.on('speech-start', () => {
-        callbacksRef.current.onSpeechStart?.();
-      });
-
-      const unsubSpeechEnd = engine.on('speech-end', () => {
-        callbacksRef.current.onSpeechEnd?.();
-      });
-
-      const unsubError = engine.on('error', (err: Error) => {
-        setError(err);
-        // The engine errored — it is no longer detecting. Reflect that in
-        // isListening (it previously stayed stale-true, lying to the UI) so the
-        // status dot goes yellow AND the recovery triggers in ChatContext
-        // (WS-reconnect / tab-visible / network-online) can resume it: their
-        // guard requires !isListening. isEnabled stays true so the user's
-        // intent is preserved and the resume path stays open.
+        isEnabledRef.current = true;
+        isListeningRef.current = true;
+        setIsEnabled(true);
+        setIsListening(true);
+        saveWakeWordSettings({ enabled: true });
+      } catch (err) {
+        // Drop any half-built engine so a retry rebuilds cleanly.
+        await teardownEngine();
+        isListeningRef.current = false;
         setIsListening(false);
-        callbacksRef.current.onError?.(err);
-      });
-
-      unsubscribersRef.current = [
-        unsubReady,
-        unsubDetect,
-        unsubSpeechStart,
-        unsubSpeechEnd,
-        unsubError,
-      ];
-
-      // Start listening
-      await engine.start({
-        gain: WAKEWORD_CONFIG.defaults.gain,
-      });
-
-      setIsEnabled(true);
-      setIsListening(true);
-      saveWakeWordSettings({ enabled: true });
-    } catch (err) {
-      console.error('Failed to enable wake word:', err);
-      const error = err instanceof Error ? err : new Error(String(err));
-
-      // Check for browser-specific errors
-      if (error.message && error.message.includes('sample-rate')) {
-        // Firefox: AudioContext sample rate mismatch
-        const browserError = new Error(
-          'Wake word detection is not supported in Firefox due to AudioContext sample rate limitations. ' +
-          'Please use Chrome or Edge for wake word detection, or use the manual recording button.'
-        );
-        browserError.name = 'BrowserNotSupportedError';
-        setError(browserError);
-        callbacksRef.current.onError?.(browserError);
-      } else if (
-        error.message && (
-          error.message.includes('SharedArrayBuffer') ||
-          error.message.includes('cross-origin isolated') ||
-          error.message.includes('CompileError') ||
-          error.message.includes('WebAssembly')
-        )
-      ) {
-        // Safari/WebKit: WASM or SharedArrayBuffer issues
-        const browserError = new Error(
-          'Wake word detection requires WebAssembly threading which may not be available in this browser. ' +
-          'Please use Chrome or Edge, or use the manual recording button.'
-        );
-        browserError.name = 'BrowserNotSupportedError';
-        setError(browserError);
-        callbacksRef.current.onError?.(browserError);
-      } else {
-        setError(error);
-        callbacksRef.current.onError?.(error);
+        reportEnableError(err);
+      } finally {
+        setIsLoading(false);
       }
-    } finally {
-      isStartingRef.current = false;
-      setIsLoading(false);
-    }
-  }, [isListening, isLoading, initEngine]);
+    });
+  }, [runExclusive, buildEngine, teardownEngine, reportEnableError]);
 
-  // Disable wake word listening
-  const disable = useCallback(async () => {
-    if (!isListening) return;
-
-    try {
-      // Unsubscribe from events
-      unsubscribersRef.current.forEach(unsub => unsub?.());
-      unsubscribersRef.current = [];
-
-      // Stop engine
-      if (engineRef.current) {
-        await engineRef.current.stop();
-      }
-
-      setIsListening(false);
-      setIsEnabled(false);
-      setIsReady(false);
-      saveWakeWordSettings({ enabled: false });
-    } catch (err) {
-      console.error('Failed to disable wake word:', err);
-    }
-  }, [isListening]);
+  // Disable wake word listening. Works from ANY state (listening, paused, or
+  // post-error) — the guard is "is there anything to turn off?", not isListening,
+  // so the toggle can always turn the mic off (and clear the persisted flag).
+  const disable = useCallback(
+    () =>
+      runExclusive(async () => {
+        if (!isEnabledRef.current && !engineRef.current) return;
+        await teardownEngine();
+        isEnabledRef.current = false;
+        isListeningRef.current = false;
+        setIsEnabled(false);
+        setIsListening(false);
+        saveWakeWordSettings({ enabled: false });
+      }),
+    [runExclusive, teardownEngine],
+  );
 
   // Toggle wake word
   const toggle = useCallback(async () => {
@@ -331,99 +323,116 @@ export function useWakeWord({
     }
   }, [isEnabled, enable, disable]);
 
-  // Pause listening temporarily (e.g., while recording)
-  const pause = useCallback(async () => {
-    debug.log('⏸️ pause() called - isListening:', isListening, 'hasEngine:', !!engineRef.current);
+  // Pause listening temporarily (e.g., while recording). Serialized, so it runs
+  // AFTER any in-flight rebuild — it never sees a transient null engine.
+  const pause = useCallback(
+    () =>
+      runExclusive(async () => {
+        if (!isListeningRef.current || !engineRef.current) {
+          debug.log('⚠️ pause() skipped: not listening or no engine');
+          return;
+        }
+        try {
+          await engineRef.current.stop();
+          isListeningRef.current = false;
+          setIsListening(false);
+          debug.log('✅ Wake word paused (isEnabled stays true)');
+        } catch (err) {
+          console.error('Failed to pause wake word:', err);
+        }
+      }),
+    [runExclusive],
+  );
 
-    if (!isListening || !engineRef.current) {
-      debug.log('⚠️ pause() skipped: not listening or no engine');
-      return;
-    }
+  // Resume listening after pause. buildEngine() rebuilds if the engine was
+  // dropped (keyword change while paused, or an error), then start()s — start
+  // always opens a fresh mic + AudioContext, so a rebuild here is no different
+  // from a normal resume.
+  const resume = useCallback(
+    () =>
+      runExclusive(async () => {
+        if (isListeningRef.current) return;
+        if (!isEnabledRef.current) return;
 
-    try {
-      await engineRef.current.stop();
-      setIsListening(false);
-      debug.log('✅ Wake word paused (isEnabled stays true)');
-    } catch (err) {
-      console.error('Failed to pause wake word:', err);
-    }
-  }, [isListening]);
+        try {
+          await buildEngine();
+          await engineRef.current!.start({ gain: WAKEWORD_CONFIG.defaults.gain });
+          isListeningRef.current = true;
+          setIsListening(true);
+          debug.log('✅ Wake word engine resumed');
+        } catch (err) {
+          console.error('Failed to resume wake word:', err);
+          setError(err instanceof Error ? err : new Error(String(err)));
+        }
+      }),
+    [runExclusive, buildEngine],
+  );
 
-  // Resume listening after pause
-  const resume = useCallback(async () => {
-    // Use refs to avoid stale closure issues
-    const currentIsEnabled = isEnabledRef.current;
+  // Rebuild the engine to match the current keyword set. Serialized. Because the
+  // engine can only load models chosen at construction, changing the set means a
+  // full stop → drop → recreate. Preserves the listening/paused state.
+  const applyKeywordChange = useCallback(
+    () =>
+      runExclusive(async () => {
+        // Not running: just drop any stale engine — enable() will build fresh
+        // with the new set.
+        if (!isEnabledRef.current) {
+          await teardownEngine();
+          return;
+        }
+        const wasListening = isListeningRef.current;
+        await teardownEngine();
+        if (wasListening) {
+          try {
+            await buildEngine();
+            await engineRef.current!.start({ gain: WAKEWORD_CONFIG.defaults.gain });
+            isListeningRef.current = true;
+            setIsListening(true);
+          } catch (err) {
+            console.error('Failed to rebuild wake word engine:', err);
+            setError(err instanceof Error ? err : new Error(String(err)));
+            isListeningRef.current = false;
+            setIsListening(false);
+          }
+        }
+        // If paused: leave the engine dropped; resume() rebuilds with the new set.
+      }),
+    [runExclusive, teardownEngine, buildEngine],
+  );
 
-    debug.log('🔄 resume() called - checking conditions:', {
-      isListening,
-      isEnabled: currentIsEnabled,
-      isEnabledRef: isEnabledRef.current,
-      hasEngine: !!engineRef.current
-    });
+  // Update the active keyword set. Accepts a single id or a comma-separated set.
+  // Persists it (survives reload) and, if the set actually changed, rebuilds the
+  // engine so every keyword is loaded.
+  const setKeyword = useCallback(
+    async (keyword: string) => {
+      const ids = parseKeywords(keyword);
+      // Ignore a selection that resolves to nothing we ship a model for — keep
+      // the current set rather than blanking detection.
+      if (ids.length === 0) return;
+      const normalized = ids.join(',');
+      if (sameKeywordSet(normalized, keywordsRef.current.join(','))) return;
 
-    if (isListening) {
-      debug.log('⚠️ resume() skipped: already listening');
-      return;
-    }
-    if (!currentIsEnabled) {
-      debug.log('⚠️ resume() skipped: wake word not enabled (using ref)');
-      return;
-    }
-    if (!engineRef.current) {
-      debug.log('⚠️ resume() skipped: no engine');
-      return;
-    }
-    if (isStartingRef.current) {
-      debug.log('⚠️ resume() skipped: a start is already in flight');
-      return;
-    }
+      keywordsRef.current = ids; // synchronous — the rebuild below reads this
+      setSettings((prev) => ({ ...prev, keyword: normalized }));
+      saveWakeWordSettings({ keyword: normalized });
 
-    try {
-      isStartingRef.current = true;
-      debug.log('▶️ Starting wake word engine...');
-      await engineRef.current.start({
-        gain: WAKEWORD_CONFIG.defaults.gain,
-      });
-      setIsListening(true);
-      debug.log('✅ Wake word engine resumed successfully');
-    } catch (err) {
-      console.error('Failed to resume wake word:', err);
-      setError(err instanceof Error ? err : new Error(String(err)));
-    } finally {
-      isStartingRef.current = false;
-    }
-  }, [isListening]); // Removed isEnabled from deps since we use ref
+      await applyKeywordChange();
+    },
+    [applyKeywordChange],
+  );
 
-  // Update keyword
-  const setKeyword = useCallback(async (keyword: string) => {
-    const newSettings = { ...settings, keyword };
-    setSettings(newSettings);
-    saveWakeWordSettings({ keyword });
-
-    // If currently listening, restart with new keyword
-    if (isListening && engineRef.current) {
-      try {
-        engineRef.current.setActiveKeywords([keyword]);
-      } catch {
-        // If setActiveKeywords fails, restart engine
-        await disable();
-        await enable();
-      }
-    }
-  }, [settings, isListening, disable, enable]);
-
-  // Update threshold
+  // Update threshold. Takes effect on the next engine build (kept in a ref so a
+  // rebuild picks it up); we don't force a rebuild for a sensitivity nudge.
   const setThreshold = useCallback((threshold: number) => {
-    const newSettings = { ...settings, threshold };
-    setSettings(newSettings);
+    thresholdRef.current = threshold;
+    setSettings((prev) => ({ ...prev, threshold }));
     saveWakeWordSettings({ threshold });
-    // Note: threshold changes may require engine restart
-  }, [settings]);
+  }, []);
 
   // Cleanup on unmount
   useEffect(() => {
     return () => {
-      unsubscribersRef.current.forEach(unsub => unsub?.());
+      unsubscribersRef.current.forEach((unsub) => unsub?.());
       if (engineRef.current) {
         engineRef.current.stop().catch(() => {});
         engineRef.current = null;
@@ -444,31 +453,32 @@ export function useWakeWord({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Only run once on mount
 
-  // Listen for config updates from server (via WebSocket)
+  // Listen for config updates from server (via WebSocket). Loads the FULL
+  // server-pushed wake_words set, not just the first (multi-language household).
   useEffect(() => {
     const handleConfigUpdate = (event: CustomEvent<{ wake_words?: string[]; threshold?: number }>) => {
       const config = event.detail;
       debug.log('🔄 Wake word config update from server:', config);
 
-      // Update keyword if provided
-      if (config.wake_words && config.wake_words[0]) {
-        const newKeyword = config.wake_words[0];
-        if (newKeyword !== settings.keyword) {
-          debug.log(`🎤 Updating wake word: ${settings.keyword} -> ${newKeyword}`);
-          setKeyword(newKeyword);
+      if (config.wake_words && config.wake_words.length > 0) {
+        const ids = parseKeywords(config.wake_words.join(','));
+        if (ids.length > 0 && !sameKeywordSet(ids.join(','), keywordsRef.current.join(','))) {
+          debug.log(
+            `🎤 Updating wake words: [${keywordsRef.current.join(', ')}] -> [${ids.join(', ')}]`,
+          );
+          void setKeyword(ids.join(','));
         }
       }
 
-      // Update threshold if provided
-      if (config.threshold !== undefined && config.threshold !== settings.threshold) {
-        debug.log(`🎚️ Updating threshold: ${settings.threshold} -> ${config.threshold}`);
+      if (config.threshold !== undefined && config.threshold !== thresholdRef.current) {
+        debug.log(`🎚️ Updating threshold: ${thresholdRef.current} -> ${config.threshold}`);
         setThreshold(config.threshold);
       }
     };
 
     window.addEventListener('wakeword-config-update', handleConfigUpdate as EventListener);
     return () => window.removeEventListener('wakeword-config-update', handleConfigUpdate as EventListener);
-  }, [settings.keyword, settings.threshold, setKeyword, setThreshold]);
+  }, [setKeyword, setThreshold]);
 
   return {
     // State

--- a/src/frontend/src/hooks/useWakeWord.ts
+++ b/src/frontend/src/hooks/useWakeWord.ts
@@ -413,19 +413,15 @@ export function useWakeWord({
     isListeningRef.current = false;
     setIsListening(false);
     engineStartedRef.current = false;
-    const engine = engineRef.current;
-    if (engine) {
-      try {
-        await engine.stop();
-        debug.log('✅ Wake word paused (isEnabled stays true)');
-      } catch (err) {
-        // stop() failed — the engine may still be capturing. Drop it entirely so
-        // a later resume() rebuilds a fresh one instead of double-starting a
-        // still-live engine (mic leak).
-        console.error('Failed to pause wake word:', err);
-        await teardownEngine();
-      }
-    }
+    // Drop the engine entirely rather than keeping it for a resume fast-path. A
+    // retained instance let pause()'s async stop() race a concurrent resume()'s
+    // start() on the SAME engine (stop landing after start → green-but-dead; or a
+    // failed stop → double-start mic leak), and let its still-registered detect
+    // handler fire mid-recording. resume() rebuilds a fresh engine — start()
+    // always reopens the mic + AudioContext anyway, so this costs only a model
+    // reload, and pause()'s stop() now runs on an instance nobody else touches.
+    await teardownEngine();
+    debug.log('✅ Wake word paused (isEnabled stays true)');
   }, [teardownEngine]);
 
   // Resume listening after pause. arm() rebuilds if the engine was dropped

--- a/src/frontend/src/hooks/wakewordEngineLoader.ts
+++ b/src/frontend/src/hooks/wakewordEngineLoader.ts
@@ -1,0 +1,97 @@
+/**
+ * Lazy loader + singleton for the OpenWakeWord WASM engine class.
+ *
+ * Extracted from `useWakeWord` so the dynamic `import('openwakeword-wasm-browser')`
+ * lives behind a small, resolvable module seam. That keeps the hook free of a
+ * module-level singleton AND makes the "engine loaded successfully" path
+ * testable: a test can `vi.mock('.../wakewordEngineLoader')` to inject a stub
+ * engine class without the real WASM module (which isn't installed in the test
+ * environment) — the previous harness could only ever exercise the load-failure
+ * path.
+ */
+import { debug } from '../utils/debug';
+
+// Wake word engine interface (from openwakeword-wasm-browser)
+export interface WakeWordEngine {
+  load(): Promise<void>;
+  start(options?: { gain?: number }): Promise<void>;
+  stop(): Promise<void>;
+  setActiveKeywords(keywords: string[]): void;
+  on(event: 'ready', callback: () => void): () => void;
+  on(event: 'detect', callback: (data: { keyword: string; score: number; at?: number }) => void): () => void;
+  on(event: 'speech-start', callback: () => void): () => void;
+  on(event: 'speech-end', callback: () => void): () => void;
+  on(event: 'error', callback: (error: Error) => void): () => void;
+}
+
+export interface WakeWordEngineConstructor {
+  new (options: {
+    baseAssetUrl: string;
+    keywords: string[];
+    /**
+     * Optional override of the built-in keyword -> model-file map. Required
+     * for custom wake words like `hey_renfield` which aren't in the
+     * library's default `MODEL_FILE_MAP`.
+     */
+    modelFiles?: Record<string, string>;
+    detectionThreshold: number;
+    cooldownMs: number;
+  }): WakeWordEngine;
+}
+
+let WakeWordEngineClass: WakeWordEngineConstructor | null = null;
+let loadAttempted = false;
+let loadError: Error | null = null;
+
+/**
+ * Lazy load the wake word engine module. Idempotent: after the first attempt it
+ * returns the cached result. Resolves `true` when the engine class is available.
+ */
+export async function loadWakeWordEngine(): Promise<boolean> {
+  if (loadAttempted) {
+    return WakeWordEngineClass !== null;
+  }
+
+  loadAttempted = true;
+
+  try {
+    // Configure ONNX Runtime before importing the engine
+    const ort = await import('onnxruntime-web');
+
+    // Disable multi-threading to avoid SharedArrayBuffer requirement
+    ort.env.wasm.numThreads = 1;
+
+    // Disable proxy mode - it causes dynamic import issues with Vite
+    ort.env.wasm.proxy = false;
+
+    // Set explicit WASM file paths to avoid Vite module interception
+    ort.env.wasm.wasmPaths = '/ort/';
+
+    debug.log('✅ ONNX Runtime (WASM) configured with paths:', ort.env.wasm.wasmPaths);
+
+    const module = await import('openwakeword-wasm-browser');
+    WakeWordEngineClass = module.default || module.WakeWordEngine;
+    debug.log('✅ Wake word engine loaded successfully');
+    return WakeWordEngineClass !== null;
+  } catch (e) {
+    loadError = e instanceof Error ? e : new Error(String(e));
+    console.warn('⚠️ openwakeword-wasm-browser not available:', loadError.message);
+    console.warn('💡 Run: npm install && docker compose up -d --build');
+    return false;
+  }
+}
+
+/** The loaded engine class, or null before a successful load. */
+export function getWakeWordEngineClass(): WakeWordEngineConstructor | null {
+  return WakeWordEngineClass;
+}
+
+/** The error from a failed load attempt, if any. */
+export function getWakeWordLoadError(): Error | null {
+  return loadError;
+}
+
+/** Whether a load has been attempted (drives the initial `isAvailable`). */
+export function wasWakeWordLoadAttempted(): boolean {
+  return loadAttempted;
+}

--- a/src/frontend/src/pages/ChatPage/ChatHeader.tsx
+++ b/src/frontend/src/pages/ChatPage/ChatHeader.tsx
@@ -19,7 +19,7 @@ export default function ChatHeader() {
     error: wakeWordError,
     settings: wakeWordSettings,
     toggle: toggleWakeWord,
-    setKeyword: setWakeWordKeyword,
+    toggleKeyword: toggleWakeWordKeyword,
     setThreshold: setWakeWordThreshold,
     availableKeywords,
     lastDetection,
@@ -151,14 +151,9 @@ export default function ChatHeader() {
                       <input
                         type="checkbox"
                         checked={checked}
-                        onChange={() => {
-                          const next = checked
-                            ? activeKeywords.filter(id => id !== kw.id)
-                            : [...activeKeywords, kw.id];
-                          // Keep at least one wake word active.
-                          if (next.length === 0) return;
-                          setWakeWordKeyword?.(next.join(','));
-                        }}
+                        // toggleKeyword reads the current set from a ref, so
+                        // rapid successive toggles can't clobber each other.
+                        onChange={() => toggleWakeWordKeyword?.(kw.id)}
                         className="accent-primary-600"
                       />
                       <span>{kw.label}</span>

--- a/src/frontend/src/pages/ChatPage/ChatHeader.tsx
+++ b/src/frontend/src/pages/ChatPage/ChatHeader.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Loader, Ear, EarOff, Settings } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
 import { useChatContext } from './context/ChatContext';
+import { describeKeywords, parseKeywords } from '../../config/wakeword';
 
 export default function ChatHeader() {
   const { t } = useTranslation();
@@ -24,6 +25,13 @@ export default function ChatHeader() {
     lastDetection,
     status: wakeWordStatus,
   } = wakeWord;
+
+  // Honest label for the ACTIVE set — a multi-language household loads several
+  // keywords, so show them all (e.g. "Renfield (Deutsch) + Renfield (English)")
+  // instead of only the first. Falls back to a friendly name (never a raw id
+  // string) if the set resolves to nothing we ship a model for.
+  const activeKeywords = parseKeywords(wakeWordSettings.keyword);
+  const activeKeywordLabel = describeKeywords(wakeWordSettings.keyword) || 'Renfield';
 
   return (
     <div className="card mb-4 mx-4 mt-4 md:mx-0 md:mt-0">
@@ -48,7 +56,7 @@ export default function ChatHeader() {
               title={wakeWordError
                 ? `${t('wakeword.notAvailable')}: ${wakeWordError.message}`
                 : wakeWordEnabled
-                  ? t('wakeword.listening', { keyword: availableKeywords.find(k => k.id === wakeWordSettings.keyword)?.label || 'Hey Jarvis' })
+                  ? t('wakeword.listening', { keyword: activeKeywordLabel })
                   : t('wakeword.enable')
               }
             >
@@ -105,7 +113,7 @@ export default function ChatHeader() {
             <div className={`w-2 h-2 rounded-full ${wakeWordListening ? 'bg-green-500 animate-pulse' : 'bg-yellow-500'}`} />
             <span className="text-sm text-green-700 dark:text-green-300">
               {wakeWordListening
-                ? t('wakeword.listening', { keyword: availableKeywords.find(k => k.id === wakeWordSettings.keyword)?.label || 'Hey Jarvis' })
+                ? t('wakeword.listening', { keyword: activeKeywordLabel })
                 : wakeWordStatus === 'activated'
                   ? t('wakeword.detected')
                   : t('wakeword.paused')
@@ -126,18 +134,38 @@ export default function ChatHeader() {
           <h3 className="text-sm font-medium text-gray-900 dark:text-white mb-3">{t('wakeword.settings')}</h3>
 
           <div className="space-y-3">
-            {/* Keyword Selection */}
+            {/* Keyword Selection — multi-select: a multi-language household can
+                load several wake words at once, so this is a checkbox set, not a
+                single-value dropdown (which silently collapsed the set). At least
+                one keyword must stay selected. */}
             <div>
               <label className="text-xs text-gray-500 dark:text-gray-400 mb-1 block">{t('wakeword.keyword')}</label>
-              <select
-                value={wakeWordSettings.keyword || ''}
-                onChange={(e) => setWakeWordKeyword?.(e.target.value)}
-                className="w-full bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-white text-sm rounded-lg px-3 py-2 border border-gray-300 dark:border-gray-600 focus:border-primary-500 focus:outline-hidden"
-              >
-                {availableKeywords.map(kw => (
-                  <option key={kw.id} value={kw.id}>{kw.label}</option>
-                ))}
-              </select>
+              <div className="space-y-1">
+                {availableKeywords.map(kw => {
+                  const checked = activeKeywords.includes(kw.id);
+                  return (
+                    <label
+                      key={kw.id}
+                      className="flex items-center gap-2 text-sm text-gray-900 dark:text-white cursor-pointer"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => {
+                          const next = checked
+                            ? activeKeywords.filter(id => id !== kw.id)
+                            : [...activeKeywords, kw.id];
+                          // Keep at least one wake word active.
+                          if (next.length === 0) return;
+                          setWakeWordKeyword?.(next.join(','));
+                        }}
+                        className="accent-primary-600"
+                      />
+                      <span>{kw.label}</span>
+                    </label>
+                  );
+                })}
+              </div>
             </div>
 
             {/* Threshold Slider */}

--- a/tests/frontend/react/hooks/useWakeWord.multiKeyword.test.tsx
+++ b/tests/frontend/react/hooks/useWakeWord.multiKeyword.test.tsx
@@ -32,10 +32,16 @@ const h = vi.hoisted(() => {
   // Test controls consulted by each engine's load():
   //  - loadGate: when set, load() blocks on this promise (pre-emption tests).
   //  - failLoad: when true, load() rejects (rebuild-failure tests).
-  const gate: { loadGate: Promise<void> | null; failLoad: boolean; failStop: boolean } = {
+  const gate: {
+    loadGate: Promise<void> | null;
+    failLoad: boolean;
+    failStop: boolean;
+    stopGate: Promise<void> | null;
+  } = {
     loadGate: null,
     failLoad: false,
     failStop: false,
+    stopGate: null,
   };
 
   class MockEngine {
@@ -44,7 +50,9 @@ const h = vi.hoisted(() => {
       gate.failLoad ? Promise.reject(new Error('load failed')) : (gate.loadGate ?? Promise.resolve()),
     );
     start = vi.fn().mockResolvedValue(undefined);
-    stop = vi.fn(() => (gate.failStop ? Promise.reject(new Error('stop failed')) : Promise.resolve()));
+    stop = vi.fn(() =>
+      gate.failStop ? Promise.reject(new Error('stop failed')) : (gate.stopGate ?? Promise.resolve()),
+    );
     setActiveKeywords = vi.fn();
     on = (event: string, cb: (data?: unknown) => void) => {
       this.listeners[event] = cb;
@@ -168,6 +176,7 @@ describe('useWakeWord — multi-keyword (loaded engine)', () => {
     h.gate.loadGate = null;
     h.gate.failLoad = false;
     h.gate.failStop = false;
+    h.gate.stopGate = null;
     localStorage.clear();
   });
 
@@ -512,9 +521,45 @@ describe('useWakeWord — multi-keyword (loaded engine)', () => {
       await Promise.all([r1, r2]);
     });
 
-    // The engine must be started exactly once more, not twice.
-    expect(engine.start).toHaveBeenCalledTimes(2);
+    // Exactly one additional start() across all engines — never a double-start.
+    const totalStarts = h.created.reduce((n, e) => n + e.start.mock.calls.length, 0);
+    expect(totalStarts).toBe(2); // enable + one resume
     expect(result.current.isListening).toBe(true);
+    // The paused engine was not re-started (pause tore it down; resume rebuilt).
+    expect(engine.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('a resume() racing pause()’s in-flight stop() ends listening on a FRESH engine (no green-but-dead)', async () => {
+    const useWakeWord = await importHook();
+    const { result } = renderHook(() => useWakeWord());
+
+    await act(async () => {
+      await result.current.enable();
+    });
+    const engine1 = h.created[0];
+
+    // pause() tears down engine1 but its stop() hangs; a resume lands during it.
+    let releaseStop!: () => void;
+    h.gate.stopGate = new Promise<void>((r) => {
+      releaseStop = r;
+    });
+
+    await act(async () => {
+      const pausing = result.current.pause(); // nulls engineRef, awaits hung stop
+      await Promise.resolve();
+      const resuming = result.current.resume(); // must build a FRESH engine
+      await resuming;
+      h.gate.stopGate = null;
+      releaseStop();
+      await pausing;
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // A new engine is listening; the old one's late stop() didn't kill it.
+    expect(h.created.length).toBe(2);
+    expect(h.created[1].start).toHaveBeenCalledTimes(1);
+    expect(result.current.isListening).toBe(true);
+    expect(engine1.start).toHaveBeenCalledTimes(1); // never re-started
   });
 
   it('a failed rebuild while listening clears isListening (never green-but-dead)', async () => {

--- a/tests/frontend/react/hooks/useWakeWord.multiKeyword.test.tsx
+++ b/tests/frontend/react/hooks/useWakeWord.multiKeyword.test.tsx
@@ -29,9 +29,13 @@ const h = vi.hoisted(() => {
     listeners: Listeners;
   }> = [];
 
+  // When set, the NEXT engine's load() blocks on this promise (to test
+  // pre-emption of an in-flight arm). Cleared per test.
+  const gate: { loadGate: Promise<void> | null } = { loadGate: null };
+
   class MockEngine {
     listeners: Listeners = {};
-    load = vi.fn().mockResolvedValue(undefined);
+    load = vi.fn(() => gate.loadGate ?? Promise.resolve());
     start = vi.fn().mockResolvedValue(undefined);
     stop = vi.fn().mockResolvedValue(undefined);
     setActiveKeywords = vi.fn();
@@ -53,7 +57,7 @@ const h = vi.hoisted(() => {
     }
   }
 
-  return { created, MockEngine };
+  return { created, MockEngine, gate };
 });
 
 // Mock the engine loader so the engine is "available" and construction is captured.
@@ -154,6 +158,7 @@ describe('useWakeWord — multi-keyword (loaded engine)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     h.created.length = 0;
+    h.gate.loadGate = null;
     localStorage.clear();
   });
 
@@ -373,6 +378,105 @@ describe('useWakeWord — multi-keyword (loaded engine)', () => {
     const latest = h.created[h.created.length - 1];
     expect(sortedKeywords(latest)).toEqual(['alexa', 'hey_jarvis']);
     expect(latest.start).toHaveBeenCalled();
+    expect(result.current.isListening).toBe(true);
+  });
+
+  it('disable() pre-empts an in-flight enable() (a hung load never blocks mic-off)', async () => {
+    const useWakeWord = await importHook();
+    const { result } = renderHook(() => useWakeWord());
+
+    // The next engine's load() hangs until we release it.
+    let releaseLoad!: () => void;
+    h.gate.loadGate = new Promise<void>((r) => {
+      releaseLoad = r;
+    });
+
+    let enabling: Promise<void>;
+    await act(async () => {
+      enabling = result.current.enable();
+      await Promise.resolve(); // let the arm reach the hung load()
+    });
+
+    // Turn it off while enable is stuck loading — disable must NOT be queued
+    // behind the hung arm.
+    await act(async () => {
+      await result.current.disable();
+    });
+    expect(result.current.isEnabled).toBe(false);
+    expect(result.current.isListening).toBe(false);
+
+    // Release the hung load: the superseded arm must discard its engine and
+    // never open the mic (never call start()).
+    await act(async () => {
+      h.gate.loadGate = null;
+      releaseLoad();
+      await enabling;
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(h.created.every((e) => e.start.mock.calls.length === 0)).toBe(true);
+    expect(result.current.isListening).toBe(false);
+    expect(result.current.isEnabled).toBe(false);
+  });
+
+  it('unmounting during an in-flight enable() stops the discarded engine (no mic leak)', async () => {
+    const useWakeWord = await importHook();
+    const { result, unmount } = renderHook(() => useWakeWord());
+
+    let releaseLoad!: () => void;
+    h.gate.loadGate = new Promise<void>((r) => {
+      releaseLoad = r;
+    });
+
+    let enabling: Promise<void>;
+    await act(async () => {
+      enabling = result.current.enable();
+      await Promise.resolve();
+    });
+
+    // Navigate away mid-build.
+    unmount();
+
+    await act(async () => {
+      h.gate.loadGate = null;
+      releaseLoad();
+      await enabling;
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // The engine built after unmount must have been stopped, never started.
+    const built = h.created[0];
+    expect(built.start).not.toHaveBeenCalled();
+    expect(built.stop).toHaveBeenCalled();
+  });
+
+  it('an error during an in-flight arm never leaves a green-but-dead UI', async () => {
+    const useWakeWord = await importHook();
+    const { result } = renderHook(() => useWakeWord());
+
+    await act(async () => {
+      await result.current.enable();
+    });
+    const engine = h.created[0];
+
+    // Error fires AFTER start resolved (the worklet reports a runtime glitch).
+    await act(async () => {
+      engine.listeners.error?.(new Error('runtime glitch'));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // The UI must be honest: not listening, and the engine dropped so recovery
+    // resume() can rebuild (never isListening=true with a null engine).
+    expect(result.current.isListening).toBe(false);
+    expect(engine.stop).toHaveBeenCalled();
+
+    await act(async () => {
+      await result.current.resume();
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(h.created.length).toBe(2);
     expect(result.current.isListening).toBe(true);
   });
 });

--- a/tests/frontend/react/hooks/useWakeWord.multiKeyword.test.tsx
+++ b/tests/frontend/react/hooks/useWakeWord.multiKeyword.test.tsx
@@ -1,0 +1,378 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+/**
+ * These tests exercise the LOADED-engine path (isListening === true), which the
+ * sibling `useWakeWord.test.tsx` can't reach — there the real WASM engine module
+ * isn't installed, so `loadWakeWordEngine()` always fails. Here we mock the
+ * engine-loader seam (`wakewordEngineLoader`) with a controllable stub engine so
+ * we can assert the multi-keyword contract: the browser loads EVERY server-pushed
+ * wake word, and rebuilds the running engine when the active set changes.
+ */
+
+// Shared mutable capture state — hoisted so the vi.mock factory can close over it.
+const h = vi.hoisted(() => {
+  type Listeners = Record<string, ((data?: unknown) => void) | undefined>;
+  interface EngineOptions {
+    keywords: string[];
+    detectionThreshold: number;
+    modelFiles?: Record<string, string>;
+    baseAssetUrl: string;
+    cooldownMs: number;
+  }
+  const created: Array<{
+    opts: EngineOptions;
+    load: ReturnType<typeof vi.fn>;
+    start: ReturnType<typeof vi.fn>;
+    stop: ReturnType<typeof vi.fn>;
+    setActiveKeywords: ReturnType<typeof vi.fn>;
+    listeners: Listeners;
+  }> = [];
+
+  class MockEngine {
+    listeners: Listeners = {};
+    load = vi.fn().mockResolvedValue(undefined);
+    start = vi.fn().mockResolvedValue(undefined);
+    stop = vi.fn().mockResolvedValue(undefined);
+    setActiveKeywords = vi.fn();
+    on = (event: string, cb: (data?: unknown) => void) => {
+      this.listeners[event] = cb;
+      return () => {
+        this.listeners[event] = undefined;
+      };
+    };
+    constructor(opts: EngineOptions) {
+      created.push({
+        opts,
+        load: this.load,
+        start: this.start,
+        stop: this.stop,
+        setActiveKeywords: this.setActiveKeywords,
+        listeners: this.listeners,
+      });
+    }
+  }
+
+  return { created, MockEngine };
+});
+
+// Mock the engine loader so the engine is "available" and construction is captured.
+vi.mock('../../../../src/frontend/src/hooks/wakewordEngineLoader', () => ({
+  loadWakeWordEngine: vi.fn(async () => true),
+  getWakeWordEngineClass: () => h.MockEngine,
+  getWakeWordLoadError: () => null,
+  wasWakeWordLoadAttempted: () => true,
+}));
+
+// Mock the config with a small, known keyword set.
+vi.mock('../../../../src/frontend/src/config/wakeword', () => {
+  const availableKeywords = [
+    { id: 'hey_jarvis', label: 'Hey Jarvis', model: 'hey_jarvis.onnx', description: 'Test' },
+    { id: 'alexa', label: 'Alexa', model: 'alexa.onnx', description: 'Test' },
+    { id: 'renfield_de', label: 'Renfield (Deutsch)', model: 'renfield_de.onnx', description: 'Test' },
+  ];
+  const known = new Set(availableKeywords.map((k) => k.id));
+  const parseKeywords = (value?: string | null): string[] => {
+    if (!value) return [];
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const raw of value.split(',')) {
+      const id = raw.trim();
+      if (id && known.has(id) && !seen.has(id)) {
+        seen.add(id);
+        out.push(id);
+      }
+    }
+    return out;
+  };
+  const sameKeywordSet = (a?: string | null, b?: string | null): boolean => {
+    const pa = parseKeywords(a);
+    const pb = parseKeywords(b);
+    if (pa.length !== pb.length) return false;
+    const sb = new Set(pb);
+    return pa.every((id) => sb.has(id));
+  };
+  return {
+    WAKEWORD_CONFIG: {
+      modelBasePath: '/wakeword-models',
+      ortWasmPath: '/ort/',
+      availableKeywords,
+      defaults: {
+        enabled: false,
+        keyword: 'hey_jarvis',
+        threshold: 0.5,
+        cooldownMs: 2000,
+        audioFeedback: true,
+        gain: 1.0,
+      },
+      storageKeys: {
+        enabled: 'renfield_wakeword_enabled',
+        keyword: 'renfield_wakeword_keyword',
+        threshold: 'renfield_wakeword_threshold',
+        audioFeedback: 'renfield_wakeword_audio_feedback',
+      },
+    },
+    parseKeywords,
+    sameKeywordSet,
+    describeKeywords: (value?: string | null) =>
+      parseKeywords(value)
+        .map((id) => availableKeywords.find((k) => k.id === id)?.label ?? id)
+        .join(' + '),
+    loadWakeWordSettings: vi.fn(() => ({
+      enabled: false,
+      keyword: 'hey_jarvis',
+      threshold: 0.5,
+      audioFeedback: true,
+    })),
+    saveWakeWordSettings: vi.fn(),
+  };
+});
+
+vi.mock('../../../../src/frontend/src/utils/debug', () => ({
+  debug: { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const sortedKeywords = (engine: (typeof h.created)[number]) => [...engine.opts.keywords].sort();
+
+// Dispatch a server config update and drain the fire-and-forget setKeyword() +
+// its serialized engine rebuild (a few promise hops) so assertions see the
+// settled state.
+async function pushConfig(detail: { wake_words?: string[]; threshold?: number }) {
+  await act(async () => {
+    window.dispatchEvent(new CustomEvent('wakeword-config-update', { detail }));
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
+async function importHook() {
+  const mod = await import('../../../../src/frontend/src/hooks/useWakeWord');
+  return mod.useWakeWord;
+}
+
+describe('useWakeWord — multi-keyword (loaded engine)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.created.length = 0;
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('enable() builds an engine loaded with the single default keyword', async () => {
+    const useWakeWord = await importHook();
+    const { result } = renderHook(() => useWakeWord());
+
+    await act(async () => {
+      await result.current.enable();
+    });
+
+    expect(result.current.isEnabled).toBe(true);
+    expect(result.current.isListening).toBe(true);
+    expect(h.created).toHaveLength(1);
+    expect(h.created[0].opts.keywords).toEqual(['hey_jarvis']);
+    expect(h.created[0].start).toHaveBeenCalled();
+  });
+
+  it('a server config push with multiple wake_words rebuilds the engine with ALL of them', async () => {
+    const useWakeWord = await importHook();
+    const { result } = renderHook(() => useWakeWord());
+
+    await act(async () => {
+      await result.current.enable();
+    });
+    const firstEngine = h.created[0];
+
+    await pushConfig({ wake_words: ['hey_jarvis', 'alexa', 'renfield_de'] });
+
+    // A NEW engine was built (setActiveKeywords can't load new models).
+    expect(h.created.length).toBe(2);
+    expect(sortedKeywords(h.created[1])).toEqual(['alexa', 'hey_jarvis', 'renfield_de']);
+    // Old engine torn down, new one started and listening.
+    expect(firstEngine.stop).toHaveBeenCalled();
+    expect(h.created[1].start).toHaveBeenCalled();
+    expect(result.current.isListening).toBe(true);
+  });
+
+  it('drops server-pushed keywords with no shipped model, keeps the rest', async () => {
+    const useWakeWord = await importHook();
+    const { result } = renderHook(() => useWakeWord());
+
+    await act(async () => {
+      await result.current.enable();
+    });
+
+    await pushConfig({ wake_words: ['renfield_de', 'nonexistent_keyword'] });
+
+    expect(h.created.length).toBe(2);
+    expect(sortedKeywords(h.created[1])).toEqual(['renfield_de']);
+  });
+
+  it('a config push with the SAME set (reordered) does not rebuild', async () => {
+    const useWakeWord = await importHook();
+    const { result } = renderHook(() => useWakeWord());
+
+    await act(async () => {
+      await result.current.setKeyword('hey_jarvis,alexa');
+      await result.current.enable();
+    });
+    expect(h.created.length).toBe(1);
+    expect(sortedKeywords(h.created[0])).toEqual(['alexa', 'hey_jarvis']);
+
+    await pushConfig({ wake_words: ['alexa', 'hey_jarvis'] }); // same set, different order
+
+    // No rebuild — still the one engine.
+    expect(h.created.length).toBe(1);
+  });
+
+  it('setKeyword persists the full set and rebuilds while listening', async () => {
+    const useWakeWord = await importHook();
+    const { saveWakeWordSettings } = await import('../../../../src/frontend/src/config/wakeword');
+    const { result } = renderHook(() => useWakeWord());
+
+    await act(async () => {
+      await result.current.enable();
+    });
+
+    await act(async () => {
+      await result.current.setKeyword('hey_jarvis,renfield_de');
+    });
+
+    expect(saveWakeWordSettings).toHaveBeenCalledWith({ keyword: 'hey_jarvis,renfield_de' });
+    expect(result.current.settings.keyword).toBe('hey_jarvis,renfield_de');
+    expect(h.created.length).toBe(2);
+    expect(sortedKeywords(h.created[1])).toEqual(['hey_jarvis', 'renfield_de']);
+    expect(result.current.isListening).toBe(true);
+  });
+
+  it('a config change while paused rebuilds on the NEXT resume() with the new set', async () => {
+    const useWakeWord = await importHook();
+    const { result } = renderHook(() => useWakeWord());
+
+    await act(async () => {
+      await result.current.enable();
+    });
+    expect(h.created.length).toBe(1);
+
+    // Pause (keeps engine), then a multi-keyword config arrives while paused.
+    await act(async () => {
+      await result.current.pause();
+    });
+    expect(result.current.isListening).toBe(false);
+
+    await pushConfig({ wake_words: ['hey_jarvis', 'alexa'] });
+    // While paused we drop the stale engine but don't start a new one yet.
+    expect(result.current.isListening).toBe(false);
+
+    await act(async () => {
+      await result.current.resume();
+    });
+
+    // resume rebuilt with the new set.
+    expect(result.current.isListening).toBe(true);
+    const latest = h.created[h.created.length - 1];
+    expect(sortedKeywords(latest)).toEqual(['alexa', 'hey_jarvis']);
+    expect(latest.start).toHaveBeenCalled();
+  });
+
+  it('detection fires the callback for any keyword in the loaded set', async () => {
+    const onWakeWordDetected = vi.fn();
+    const useWakeWord = await importHook();
+    const { result } = renderHook(() => useWakeWord({ onWakeWordDetected }));
+
+    await act(async () => {
+      await result.current.setKeyword('hey_jarvis,alexa');
+      await result.current.enable();
+    });
+
+    // Simulate the engine detecting the SECOND keyword.
+    await act(async () => {
+      h.created[0].listeners.detect?.({ keyword: 'alexa', score: 0.9, at: 1234 });
+    });
+
+    expect(onWakeWordDetected).toHaveBeenCalledWith('alexa', 0.9);
+    expect(result.current.lastDetection?.keyword).toBe('alexa');
+  });
+
+  // ---- regression tests for the /review findings ----
+
+  it('disable() turns the wake word off from the PAUSED state (not just while listening)', async () => {
+    const useWakeWord = await importHook();
+    const { saveWakeWordSettings } = await import('../../../../src/frontend/src/config/wakeword');
+    const { result } = renderHook(() => useWakeWord());
+
+    await act(async () => {
+      await result.current.enable();
+      await result.current.pause();
+    });
+    expect(result.current.isEnabled).toBe(true);
+    expect(result.current.isListening).toBe(false);
+
+    await act(async () => {
+      await result.current.disable();
+    });
+
+    expect(result.current.isEnabled).toBe(false);
+    expect(h.created[0].stop).toHaveBeenCalled();
+    expect(saveWakeWordSettings).toHaveBeenCalledWith({ enabled: false });
+  });
+
+  it('an engine error drops the dead engine and keeps intent, so resume() rebuilds a fresh one', async () => {
+    const useWakeWord = await importHook();
+    const { result } = renderHook(() => useWakeWord());
+
+    await act(async () => {
+      await result.current.enable();
+    });
+    const firstEngine = h.created[0];
+
+    // The engine emits a fatal error (WASM crash / closed AudioContext).
+    await act(async () => {
+      firstEngine.listeners.error?.(new Error('engine crashed'));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(result.current.isListening).toBe(false);
+    expect(result.current.isEnabled).toBe(true); // intent preserved
+    expect(result.current.error).toBeTruthy();
+    expect(firstEngine.stop).toHaveBeenCalled(); // dead engine torn down
+
+    // A recovery trigger resumes — it must build a NEW engine, not start the dead one.
+    await act(async () => {
+      await result.current.resume();
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(h.created.length).toBe(2);
+    expect(h.created[1].start).toHaveBeenCalled();
+    expect(result.current.isListening).toBe(true);
+  });
+
+  it('a config push racing an in-flight enable() ends on the pushed set (serialized, not lost)', async () => {
+    const useWakeWord = await importHook();
+    const { result } = renderHook(() => useWakeWord());
+
+    await act(async () => {
+      // Start enable() but do NOT await — the config push lands mid-start, the
+      // exact race a multi-language household hits on page load.
+      const enabling = result.current.enable();
+      window.dispatchEvent(
+        new CustomEvent('wakeword-config-update', {
+          detail: { wake_words: ['hey_jarvis', 'alexa'] },
+        }),
+      );
+      await enabling;
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // Serialization guarantees the keyword change applied AFTER enable finished,
+    // so the live engine loads the pushed multi set — never the stale default.
+    const latest = h.created[h.created.length - 1];
+    expect(sortedKeywords(latest)).toEqual(['alexa', 'hey_jarvis']);
+    expect(latest.start).toHaveBeenCalled();
+    expect(result.current.isListening).toBe(true);
+  });
+});

--- a/tests/frontend/react/hooks/useWakeWord.multiKeyword.test.tsx
+++ b/tests/frontend/react/hooks/useWakeWord.multiKeyword.test.tsx
@@ -32,9 +32,10 @@ const h = vi.hoisted(() => {
   // Test controls consulted by each engine's load():
   //  - loadGate: when set, load() blocks on this promise (pre-emption tests).
   //  - failLoad: when true, load() rejects (rebuild-failure tests).
-  const gate: { loadGate: Promise<void> | null; failLoad: boolean } = {
+  const gate: { loadGate: Promise<void> | null; failLoad: boolean; failStop: boolean } = {
     loadGate: null,
     failLoad: false,
+    failStop: false,
   };
 
   class MockEngine {
@@ -43,7 +44,7 @@ const h = vi.hoisted(() => {
       gate.failLoad ? Promise.reject(new Error('load failed')) : (gate.loadGate ?? Promise.resolve()),
     );
     start = vi.fn().mockResolvedValue(undefined);
-    stop = vi.fn().mockResolvedValue(undefined);
+    stop = vi.fn(() => (gate.failStop ? Promise.reject(new Error('stop failed')) : Promise.resolve()));
     setActiveKeywords = vi.fn();
     on = (event: string, cb: (data?: unknown) => void) => {
       this.listeners[event] = cb;
@@ -166,6 +167,7 @@ describe('useWakeWord — multi-keyword (loaded engine)', () => {
     h.created.length = 0;
     h.gate.loadGate = null;
     h.gate.failLoad = false;
+    h.gate.failStop = false;
     localStorage.clear();
   });
 
@@ -591,5 +593,96 @@ describe('useWakeWord — multi-keyword (loaded engine)', () => {
     expect(h.created.length).toBe(2);
     expect(h.created[1].opts.detectionThreshold).toBe(0.7);
     expect(result.current.isListening).toBe(true);
+  });
+
+  // ---- regression tests for the 4th /review round (pause edge cases) ----
+
+  it('pause() during the initial arming window cancels the arm (mic never opens)', async () => {
+    const useWakeWord = await importHook();
+    const { result } = renderHook(() => useWakeWord());
+
+    // Hold enable's arm at the engine load() — isListening still false, but
+    // desiredListening is true (arming).
+    let releaseLoad!: () => void;
+    h.gate.loadGate = new Promise<void>((r) => {
+      releaseLoad = r;
+    });
+
+    let enabling: Promise<void>;
+    await act(async () => {
+      enabling = result.current.enable();
+      await Promise.resolve();
+    });
+    expect(result.current.isListening).toBe(false);
+
+    // Record starts → pause() during the arming window must cancel the arm.
+    await act(async () => {
+      await result.current.pause();
+    });
+
+    await act(async () => {
+      h.gate.loadGate = null;
+      releaseLoad();
+      await enabling;
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // The mic must never have opened.
+    const totalStarts = h.created.reduce((n, e) => n + e.start.mock.calls.length, 0);
+    expect(totalStarts).toBe(0);
+    expect(result.current.isListening).toBe(false);
+  });
+
+  it('pause() whose stop() fails drops the engine so resume() rebuilds fresh (no mic leak)', async () => {
+    const useWakeWord = await importHook();
+    const { result } = renderHook(() => useWakeWord());
+
+    await act(async () => {
+      await result.current.enable();
+    });
+    const engine1 = h.created[0];
+
+    // stop() rejects during pause.
+    h.gate.failStop = true;
+    await act(async () => {
+      await result.current.pause();
+    });
+    expect(result.current.isListening).toBe(false);
+
+    // resume() must rebuild a NEW engine, not re-start the still-live one.
+    h.gate.failStop = false;
+    await act(async () => {
+      await result.current.resume();
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(h.created.length).toBe(2);
+    expect(engine1.start).toHaveBeenCalledTimes(1); // never re-started
+    expect(h.created[1].start).toHaveBeenCalledTimes(1);
+    expect(result.current.isListening).toBe(true);
+  });
+
+  it('a detect event while paused does not fire the wake-word callback', async () => {
+    const onWakeWordDetected = vi.fn();
+    const useWakeWord = await importHook();
+    const { result } = renderHook(() => useWakeWord({ onWakeWordDetected }));
+
+    await act(async () => {
+      await result.current.enable();
+    });
+    const engine = h.created[0];
+
+    await act(async () => {
+      await result.current.pause();
+    });
+    expect(result.current.isListening).toBe(false);
+
+    // The paused-but-still-subscribed engine emits a buffered detect.
+    await act(async () => {
+      engine.listeners.detect?.({ keyword: 'hey_jarvis', score: 0.9, at: 1 });
+    });
+
+    expect(onWakeWordDetected).not.toHaveBeenCalled();
   });
 });

--- a/tests/frontend/react/hooks/useWakeWord.multiKeyword.test.tsx
+++ b/tests/frontend/react/hooks/useWakeWord.multiKeyword.test.tsx
@@ -29,13 +29,19 @@ const h = vi.hoisted(() => {
     listeners: Listeners;
   }> = [];
 
-  // When set, the NEXT engine's load() blocks on this promise (to test
-  // pre-emption of an in-flight arm). Cleared per test.
-  const gate: { loadGate: Promise<void> | null } = { loadGate: null };
+  // Test controls consulted by each engine's load():
+  //  - loadGate: when set, load() blocks on this promise (pre-emption tests).
+  //  - failLoad: when true, load() rejects (rebuild-failure tests).
+  const gate: { loadGate: Promise<void> | null; failLoad: boolean } = {
+    loadGate: null,
+    failLoad: false,
+  };
 
   class MockEngine {
     listeners: Listeners = {};
-    load = vi.fn(() => gate.loadGate ?? Promise.resolve());
+    load = vi.fn(() =>
+      gate.failLoad ? Promise.reject(new Error('load failed')) : (gate.loadGate ?? Promise.resolve()),
+    );
     start = vi.fn().mockResolvedValue(undefined);
     stop = vi.fn().mockResolvedValue(undefined);
     setActiveKeywords = vi.fn();
@@ -159,6 +165,7 @@ describe('useWakeWord — multi-keyword (loaded engine)', () => {
     vi.clearAllMocks();
     h.created.length = 0;
     h.gate.loadGate = null;
+    h.gate.failLoad = false;
     localStorage.clear();
   });
 
@@ -477,6 +484,112 @@ describe('useWakeWord — multi-keyword (loaded engine)', () => {
       await new Promise((r) => setTimeout(r, 0));
     });
     expect(h.created.length).toBe(2);
+    expect(result.current.isListening).toBe(true);
+  });
+
+  // ---- regression tests for the 3rd /review round ----
+
+  it('two concurrent resume() calls start the engine only once (no double-start)', async () => {
+    const useWakeWord = await importHook();
+    const { result } = renderHook(() => useWakeWord());
+
+    await act(async () => {
+      await result.current.enable();
+    });
+    const engine = h.created[0];
+    expect(engine.start).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.pause();
+    });
+
+    // Two near-simultaneous recovery triggers both see isListening=false and arm.
+    await act(async () => {
+      const r1 = result.current.resume();
+      const r2 = result.current.resume();
+      await Promise.all([r1, r2]);
+    });
+
+    // The engine must be started exactly once more, not twice.
+    expect(engine.start).toHaveBeenCalledTimes(2);
+    expect(result.current.isListening).toBe(true);
+  });
+
+  it('a failed rebuild while listening clears isListening (never green-but-dead)', async () => {
+    const useWakeWord = await importHook();
+    const { result } = renderHook(() => useWakeWord());
+
+    await act(async () => {
+      await result.current.enable();
+    });
+    expect(result.current.isListening).toBe(true);
+
+    // The rebuilt engine's load() fails.
+    h.gate.failLoad = true;
+    await act(async () => {
+      await result.current.setKeyword('hey_jarvis,alexa');
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // Old engine torn down, new build failed → must NOT be left green-but-dead.
+    expect(result.current.isListening).toBe(false);
+    expect(result.current.error).toBeTruthy();
+  });
+
+  it('pause() during an async rebuild prevents the rebuilt engine from starting', async () => {
+    const useWakeWord = await importHook();
+    const { result } = renderHook(() => useWakeWord());
+
+    await act(async () => {
+      await result.current.enable();
+    });
+
+    // The rebuild's load() hangs; pause lands during that window.
+    let releaseLoad!: () => void;
+    h.gate.loadGate = new Promise<void>((r) => {
+      releaseLoad = r;
+    });
+
+    let rebuilding: Promise<void>;
+    await act(async () => {
+      rebuilding = result.current.setKeyword('hey_jarvis,alexa');
+      await Promise.resolve(); // reach the hung load (old engine already torn down)
+      await result.current.pause();
+    });
+    expect(result.current.isListening).toBe(false);
+
+    await act(async () => {
+      h.gate.loadGate = null;
+      releaseLoad();
+      await rebuilding;
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // No engine may be started after the pause — the only start() ever made is
+    // the original enable(). (The aborted rebuild may or may not have reached
+    // building a second engine, but it must never start one.)
+    const totalStarts = h.created.reduce((n, e) => n + e.start.mock.calls.length, 0);
+    expect(totalStarts).toBe(1);
+    expect(result.current.isListening).toBe(false);
+  });
+
+  it('setThreshold rebuilds the running engine with the new sensitivity', async () => {
+    const useWakeWord = await importHook();
+    const { result } = renderHook(() => useWakeWord());
+
+    await act(async () => {
+      await result.current.enable();
+    });
+    expect(h.created[0].opts.detectionThreshold).toBe(0.5);
+
+    await act(async () => {
+      result.current.setThreshold(0.7);
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(h.created.length).toBe(2);
+    expect(h.created[1].opts.detectionThreshold).toBe(0.7);
     expect(result.current.isListening).toBe(true);
   });
 });

--- a/tests/frontend/react/hooks/useWakeWord.test.tsx
+++ b/tests/frontend/react/hooks/useWakeWord.test.tsx
@@ -2,37 +2,68 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
 // Mock the wakeword config
-vi.mock('../../../../src/frontend/src/config/wakeword', () => ({
-  WAKEWORD_CONFIG: {
-    modelBasePath: '/wakeword-models',
-    ortWasmPath: '/ort/',
-    availableKeywords: [
-      { id: 'hey_jarvis', label: 'Hey Jarvis', model: 'hey_jarvis.onnx', description: 'Test' },
-      { id: 'alexa', label: 'Alexa', model: 'alexa.onnx', description: 'Test' },
-    ],
-    defaults: {
+vi.mock('../../../../src/frontend/src/config/wakeword', () => {
+  const availableKeywords = [
+    { id: 'hey_jarvis', label: 'Hey Jarvis', model: 'hey_jarvis.onnx', description: 'Test' },
+    { id: 'alexa', label: 'Alexa', model: 'alexa.onnx', description: 'Test' },
+  ];
+  const known = new Set(availableKeywords.map((k) => k.id));
+  const parseKeywords = (value?: string | null): string[] => {
+    if (!value) return [];
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const raw of value.split(',')) {
+      const id = raw.trim();
+      if (id && known.has(id) && !seen.has(id)) {
+        seen.add(id);
+        out.push(id);
+      }
+    }
+    return out;
+  };
+  const sameKeywordSet = (a?: string | null, b?: string | null): boolean => {
+    const pa = parseKeywords(a);
+    const pb = parseKeywords(b);
+    if (pa.length !== pb.length) return false;
+    const sb = new Set(pb);
+    return pa.every((id) => sb.has(id));
+  };
+  const describeKeywords = (value?: string | null): string =>
+    parseKeywords(value)
+      .map((id) => availableKeywords.find((k) => k.id === id)?.label ?? id)
+      .join(' + ');
+  return {
+    WAKEWORD_CONFIG: {
+      modelBasePath: '/wakeword-models',
+      ortWasmPath: '/ort/',
+      availableKeywords,
+      defaults: {
+        enabled: false,
+        keyword: 'hey_jarvis',
+        threshold: 0.5,
+        cooldownMs: 2000,
+        audioFeedback: true,
+        gain: 1.0,
+      },
+      storageKeys: {
+        enabled: 'renfield_wakeword_enabled',
+        keyword: 'renfield_wakeword_keyword',
+        threshold: 'renfield_wakeword_threshold',
+        audioFeedback: 'renfield_wakeword_audio_feedback',
+      },
+    },
+    parseKeywords,
+    sameKeywordSet,
+    describeKeywords,
+    loadWakeWordSettings: vi.fn(() => ({
       enabled: false,
       keyword: 'hey_jarvis',
       threshold: 0.5,
-      cooldownMs: 2000,
       audioFeedback: true,
-      gain: 1.0,
-    },
-    storageKeys: {
-      enabled: 'renfield_wakeword_enabled',
-      keyword: 'renfield_wakeword_keyword',
-      threshold: 'renfield_wakeword_threshold',
-      audioFeedback: 'renfield_wakeword_audio_feedback',
-    },
-  },
-  loadWakeWordSettings: vi.fn(() => ({
-    enabled: false,
-    keyword: 'hey_jarvis',
-    threshold: 0.5,
-    audioFeedback: true,
-  })),
-  saveWakeWordSettings: vi.fn(),
-}));
+    })),
+    saveWakeWordSettings: vi.fn(),
+  };
+});
 
 // Mock debug utility
 vi.mock('../../../../src/frontend/src/utils/debug', () => ({

--- a/tests/frontend/react/pages/ChatPage.test.tsx
+++ b/tests/frontend/react/pages/ChatPage.test.tsx
@@ -38,6 +38,7 @@ const wakeWordMock: UseWakeWordResult = {
   pause: async () => {},
   resume: async () => {},
   setKeyword: async () => {},
+  toggleKeyword: async () => {},
   setThreshold: () => {},
   availableKeywords: [{ id: 'hey_jarvis', label: 'Hey Jarvis', model: 'hey_jarvis_v0.1', description: 'pre-trained' }],
 };

--- a/tests/frontend/react/pages/ChatUpload.test.tsx
+++ b/tests/frontend/react/pages/ChatUpload.test.tsx
@@ -38,6 +38,7 @@ const wakeWordMock: UseWakeWordResult = {
   pause: async () => {},
   resume: async () => {},
   setKeyword: async () => {},
+  toggleKeyword: async () => {},
   setThreshold: () => {},
   availableKeywords: [{ id: 'hey_jarvis', label: 'Hey Jarvis', model: 'hey_jarvis_v0.1', description: 'pre-trained' }],
 };

--- a/tests/frontend/react/test-chat-mock.ts
+++ b/tests/frontend/react/test-chat-mock.ts
@@ -24,6 +24,7 @@ const wakeWordStub: UseWakeWordResult = {
   pause: async () => {},
   resume: async () => {},
   setKeyword: async () => {},
+  toggleKeyword: async () => {},
   setThreshold: () => {},
   availableKeywords: [
     { id: 'hey_jarvis', label: 'Hey Jarvis', model: 'hey_jarvis_v0.1', description: 'pre-trained' },


### PR DESCRIPTION
## What & why

Closes the #8 backlog item: the browser wake-word engine only ever loaded a **single** keyword (`settings.keyword` + `wake_words[0]` from server pushes), so a multi-language household (e.g. German + English) could wake on just one — satellites already load the whole set. This is a **from-scratch rework** of the parked `feature/browser-multi-keyword-wakeword` branch, which had 7 confirmed defects.

## Changes
- **Multi-keyword active set.** `settings.keyword` is now a comma-separated set (same form the server settings page uses). New `parseKeywords`/`sameKeywordSet`/`describeKeywords` helpers filter to shipped models, de-dup, and label honestly. The engine loads **every** active keyword's model; changing the set rebuilds the engine (it can only load models chosen at construction — we never rely on `setActiveKeywords`).
- **Mockable engine seam.** Extracted `wakewordEngineLoader.ts` so tests can drive the loaded, `isListening=true` path (the old harness could only ever hit load-failure).
- **Reconcile lifecycle model.** Turn-ON (enable/resume/keyword-rebuild) is serialized through one "arm" chain that reconciles the engine to desired state (enabled/listening/keyword set), re-checking a generation counter after every await. Turn-OFF (disable/pause) and the error handler are **pre-emptive** — immediate stop + generation bump so an in-flight arm aborts.
- **ChatHeader** keyword picker is a multi-checkbox set (was a single-value `<select>` that silently collapsed a multi-set); label falls back to a friendly name, never a raw id.

## Review history (this branch fixes all findings)
- **High review, cut 1** → 8 defects (disable-from-paused, error-recovery teardown, `<select>` collapse, config-push-vs-enable race, …) — fixed.
- **High review, cut 2** (the serialization) → 3 confirmed liveness/ordering bugs (hung-start blocks mic-off; error→green-but-dead; unmount mic leak) + 6 lower — **all 9 fixed** by the reconcile model above.
- **Low review, cut 3** → ⚠️ aborted (account session limit); **still needs to run** before merge.

## Tests
28 wakeword unit tests incl. deterministic regressions for the 3 confirmed liveness bugs (disable-preempts-hung-enable, unmount-discards-engine, error-never-green-dead) via a load-gate. Typecheck + prod build clean.

## ⚠️ Before merge
- The final low-effort `/code-review` **did not run** (session limit resets 14:00 Europe/Berlin) — re-run it first.
- Full multi-keyword **detection** can only be confirmed by **post-deploy browser E2E** (WASM mic path).

## Docs
`docs/WAKEWORD_CONFIGURATION.md` + `docs/FEATURES.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>