### PR TITLE
feat(kiosk): phase 1a — WS push hub + snapshot + satellite_state/turn_activity deltas

### DIFF
--- a/src/backend/api/routes/command_center.py
+++ b/src/backend/api/routes/command_center.py
@@ -77,24 +77,20 @@ async def list_agent_roles(
 _ACTIVITY_SCAN_WINDOW = 400
 
 
-@router.get("/activity", response_model=list[RoleActivityEntry])
-@limiter.limit(settings.api_rate_limit_admin)
-async def recent_role_activity(
-    request: Request,
-    limit: int = Query(default=30, ge=1, le=100),
-    db: AsyncSession = Depends(get_db),
-    _: User = Depends(require_permission(Permission.ADMIN)),
-):
-    """Newest-first role activations. Content-free by construction: only the
-    role name, timestamp, and the turn's action_success leave this endpoint.
+async def recent_role_activity_entries(
+    db: AsyncSession, limit: int = 30
+) -> list[RoleActivityEntry]:
+    """Newest-first role activations, content-free by construction: only the
+    role name, timestamp, and the turn's action_success. Shared by the REST
+    ``/activity`` poll and the kiosk WS snapshot (``kiosk_handler``).
 
     The agent_role extraction happens in Python over a bounded recent window
     (JSON, not JSONB, column — portable across the test sqlite shim and prod
     Postgres without dialect-specific JSON operators).
     """
     # Order by the PK, not the unindexed timestamp column: id order is insert
-    # order (≈ chronological), and the PK index turns the 3s poll into a
-    # bounded backward index scan instead of a full-table sort.
+    # order (≈ chronological), and the PK index turns the scan into a bounded
+    # backward index scan instead of a full-table sort.
     result = await db.execute(
         select(Message.timestamp, Message.message_metadata)
         .where(Message.role == "assistant")
@@ -121,6 +117,19 @@ async def recent_role_activity(
     return entries
 
 
+@router.get("/activity", response_model=list[RoleActivityEntry])
+@limiter.limit(settings.api_rate_limit_admin)
+async def recent_role_activity(
+    request: Request,
+    limit: int = Query(default=30, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(require_permission(Permission.ADMIN)),
+):
+    """Newest-first role activations. Content-free by construction: only the
+    role name, timestamp, and the turn's action_success leave this endpoint."""
+    return await recent_role_activity_entries(db, limit)
+
+
 # ---------------------------------------------------------------------------
 # Ambient kiosk tiles — weather + now-playing. Both read-only, ADMIN-gated, and
 # degrade to an empty payload (never an error) when the feature is off or the
@@ -144,15 +153,13 @@ _WEATHER_TTL_SECONDS = 600
 _weather_cache: dict[str, object] = {"at": 0.0, "value": None}
 
 
-@router.get("/weather", response_model=KioskWeather | None)
-@limiter.limit(settings.api_rate_limit_admin)
-async def kiosk_weather(
-    request: Request,
-    _: User = Depends(require_permission(Permission.ADMIN)),
-):
-    """Current conditions for the configured home location, for the kiosk tile.
-    ``null`` (not an error) when weather is disabled, no location is configured,
-    or the MCP can't answer — the tile hides itself."""
+async def compute_kiosk_weather(mcp_manager) -> "KioskWeather | None":
+    """Current conditions for the configured home location (process-cached).
+
+    Shared by the REST ``/weather`` poll and the kiosk WS snapshot
+    (``kiosk_handler``). ``None`` (never an error) when weather is disabled, no
+    location is configured, or the MCP can't answer — the tile hides itself.
+    """
     location = (settings.kiosk_weather_location or "").strip()
     if not settings.weather_enabled or not location:
         return None
@@ -161,7 +168,6 @@ async def kiosk_weather(
     if _weather_cache["value"] is not None and now - float(_weather_cache["at"]) < _WEATHER_TTL_SECONDS:
         return _weather_cache["value"]
 
-    mcp_manager = getattr(request.app.state, "mcp_manager", None)
     if mcp_manager is None:
         return _weather_cache["value"]  # last good reading, or None
 
@@ -197,6 +203,16 @@ async def kiosk_weather(
     _weather_cache["at"] = now
     _weather_cache["value"] = weather
     return weather
+
+
+@router.get("/weather", response_model=KioskWeather | None)
+@limiter.limit(settings.api_rate_limit_admin)
+async def kiosk_weather(
+    request: Request,
+    _: User = Depends(require_permission(Permission.ADMIN)),
+):
+    """Current conditions for the configured home location, for the kiosk tile."""
+    return await compute_kiosk_weather(getattr(request.app.state, "mcp_manager", None))
 
 
 class KioskNowPlaying(BaseModel):

--- a/src/backend/api/websocket/__init__.py
+++ b/src/backend/api/websocket/__init__.py
@@ -4,6 +4,7 @@ WebSocket handlers for Renfield AI Assistant.
 This module contains the WebSocket endpoint handlers for:
 - /ws - Chat WebSocket
 - /ws/knowledge-graph - Live KG graph updates
+- /ws/kiosk - Live kiosk wall-display push hub (ADMIN-gated)
 - /ws/wakeword - Wake word detection WebSocket (still in main.py)
 
 `/ws/device` and `/ws/satellite` both moved to `ha_glue.api.websocket.*`
@@ -13,6 +14,7 @@ Platform-only deploys don't see these endpoints.
 
 from .chat_handler import router as chat_router
 from .kg_live_handler import router as kg_live_router
+from .kiosk_handler import router as kiosk_router
 from .shared import (
     ConversationSessionState,
     RAGSessionState,
@@ -28,5 +30,6 @@ __all__ = [
     "get_whisper_service",
     "is_followup_question",
     "kg_live_router",
+    "kiosk_router",
     "send_ws_error",
 ]

--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -209,6 +209,53 @@ def _extract_agent_sources(tool_results: list) -> list[dict]:
     return sources
 
 
+# Maps the platform-core / ha_glue ``internal.*`` tools (which have no MCP
+# server, hence no natural ring node) onto a kiosk subsystem id. Unknown
+# internal tools are intentionally skipped (no synthetic node). Keep in sync
+# with the kiosk's rendered subsystem nodes.
+INTERNAL_SUBSYSTEM_LABELS: dict[str, str] = {
+    "internal.knowledge_search": "knowledge",
+    "internal.presence_map": "presence",
+    "internal.bluetooth_scan": "presence",
+    "internal.device_action": "homeassistant",
+    "internal.device_controls": "homeassistant",
+}
+
+# A single turn rarely touches many subsystems; cap the pushed/persisted list so
+# an orchestrated fan-out can't bloat the event or the row.
+_MAX_SUBSYSTEMS_PER_TURN = 5
+
+
+def _extract_subsystems_used(tool_results: list) -> list[str]:
+    """Derive the content-free subsystem ids a turn touched, for the kiosk pulse.
+
+    ``mcp.<server>.<tool>`` → ``<server>``; ``internal.<tool>`` → the static
+    ``INTERNAL_SUBSYSTEM_LABELS`` allowlist (unknown internal tools skipped).
+    Deduped, order-preserved, capped at ``_MAX_SUBSYSTEMS_PER_TURN``. Empty when
+    the turn populated no ``agent_tool_results`` (direct-LLM / shortcut paths).
+    """
+    subsystems: list[str] = []
+    seen: set[str] = set()
+    for entry in tool_results:
+        tool_name = entry[0] if isinstance(entry, (tuple, list)) and entry else None
+        if not isinstance(tool_name, str) or not tool_name:
+            continue
+        if tool_name.startswith("mcp."):
+            parts = tool_name.split(".")
+            sub = parts[1] if len(parts) >= 3 and parts[1] else None
+        elif tool_name.startswith("internal."):
+            sub = INTERNAL_SUBSYSTEM_LABELS.get(tool_name)
+        else:
+            sub = None
+        if not sub or sub in seen:
+            continue
+        seen.add(sub)
+        subsystems.append(sub)
+        if len(subsystems) >= _MAX_SUBSYSTEMS_PER_TURN:
+            break
+    return subsystems
+
+
 def _collect_tool_artifacts(tool_results: list) -> list:
     """Gen-UI: gather typed artifacts a tool emitted in its result ``data``.
 
@@ -2218,6 +2265,33 @@ WICHTIG: Nutze die ECHTEN Daten aus dem Ergebnis! Gib NUR die Antwort, KEIN JSON
             agent_sources = _extract_agent_sources(agent_tool_results)
             if agent_sources:
                 assistant_metadata["sources"] = agent_sources
+
+            # Kiosk "active subsystem" pulse: which subsystems this turn touched.
+            # Persisted alongside agent_role (durable record + reconnect hydrate)
+            # AND broadcast to the kiosk hub as a content-free turn_activity delta
+            # (role + subsystems + ok). Omitted entirely when there's nothing to
+            # show (no role and no subsystems → a no-op push).
+            subsystems_used = _extract_subsystems_used(agent_tool_results)
+            if subsystems_used:
+                assistant_metadata["subsystems_used"] = subsystems_used
+            turn_role = role.name if role else None
+            if turn_role or subsystems_used:
+                try:
+                    from datetime import UTC, datetime
+
+                    from api.websocket.kiosk_handler import broadcast_kiosk_event
+
+                    await broadcast_kiosk_event(
+                        {
+                            "type": "turn_activity",
+                            "role": turn_role,
+                            "subsystems": subsystems_used,
+                            "ok": action_result.get("success") if action_result else None,
+                            "at": datetime.now(UTC).isoformat(),
+                        }
+                    )
+                except Exception as e:  # noqa: BLE001 — never break the turn on a push
+                    logger.debug(f"kiosk turn_activity broadcast failed: {e}")
 
             # Typed artifacts (Lane A) produced this turn by the sub-intent /
             # orchestration card path. Persisted as message_metadata["artifacts"]

--- a/src/backend/api/websocket/kiosk_handler.py
+++ b/src/backend/api/websocket/kiosk_handler.py
@@ -1,0 +1,316 @@
+"""
+Live Kiosk WebSocket endpoint (the /kiosk wall-display push hub).
+
+Precedent: this is the second instance of the ``kg_live_handler`` shape — a
+module-level client registry + a fire-and-forget ``broadcast_*`` called from
+wherever the source event happens + a ``/ws/...`` endpoint that accepts,
+registers, hydrates, and cleans up on disconnect. The only structural
+differences from ``kg_live_handler`` are:
+
+  * the registry is a plain ``set`` — kiosk content is **household-wide** by
+    design (like the Command Center it replaces), so there is no per-owner
+    scoping to carry; and
+  * the connect gate requires ``Permission.ADMIN`` (mirroring ``<AdminRoute>``
+    on the page), not merely authentication; and
+  * on connect the server sends one ``snapshot`` message (hydrate) before the
+    idle receive-loop (subscribe) — the standard hydrate-then-subscribe pattern
+    so a fresh / reconnecting tab has all current state immediately.
+
+Privacy bar (non-negotiable): every message this hub emits is CONTENT-FREE —
+ids, names, counts, health, and state strings only. Never an utterance, never
+an entity name, never a user id. See ``tasks/kiosk-active-subsystem-plan.md`` §5.
+"""
+
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
+from loguru import logger
+
+from models.permissions import Permission
+from services.auth_service import get_user_by_id
+from services.database import AsyncSessionLocal
+from services.websocket_auth import WSAuthError, authenticate_websocket
+
+router = APIRouter()
+
+# Connected kiosk wall displays. No per-viewer scoping: the kiosk projection is
+# household-wide (ADMIN-gated at connect), so every client sees every event.
+_kiosk_clients: set[WebSocket] = set()
+
+
+async def broadcast_kiosk_event(event: dict) -> None:
+    """Broadcast one content-free kiosk delta to every connected wall display.
+
+    Fire-and-forget, same broken-socket cleanup as ``broadcast_kg_update``: a
+    send that raises prunes that socket, never propagates. No-op when no client
+    is connected (the common case — cost of the publish points stays ~zero when
+    nobody is watching the kiosk).
+    """
+    if not _kiosk_clients:
+        return
+
+    broken: list[WebSocket] = []
+    for ws in _kiosk_clients:
+        try:
+            await ws.send_json(event)
+        except Exception:  # noqa: BLE001 — a dead socket must not break the caller
+            broken.append(ws)
+
+    for ws in broken:
+        _kiosk_clients.discard(ws)
+
+
+# ---------------------------------------------------------------------------
+# Snapshot builder — the one-time hydrate compute sent on connect. Reuses the
+# exact source calls the REST layer already reads; no new query logic.
+# ---------------------------------------------------------------------------
+
+# Tools whose per-(user,tool) success rate is below this are "degraded" in the
+# aggregated, user-id-free kiosk health view.
+_TOOL_HEALTH_DEGRADED_BELOW = 0.5
+
+# A federation peer is shown "reachable" if it was seen within this window. The
+# snapshot has no live heartbeat probe (peer reachability transitions are a
+# later delta phase, see the plan §1.6/§9); last-seen recency is the honest
+# best-effort signal at hydrate time.
+_PEER_REACHABLE_WITHIN_SECONDS = 300
+
+
+async def build_kiosk_snapshot(app) -> dict:
+    """Compute the full current kiosk state ONCE, for the connect ``snapshot``.
+
+    Every section is best-effort: a failing source degrades to an empty/None
+    value rather than aborting the whole snapshot (a fresh kiosk tab must always
+    hydrate). CONTENT-FREE by construction — see the module docstring.
+    """
+    snapshot: dict = {
+        "type": "snapshot",
+        "at": datetime.now(UTC).isoformat(),
+        "satellites": [],
+        "presence": {"rooms": [], "people_present": 0, "occupied_rooms": 0},
+        "mcp": {"enabled": False, "total_tools": 0, "servers": []},
+        "tool_health": [],
+        "roles": [],
+        "activity": [],
+        "peers": [],
+        "weather": None,
+        "now_playing": [],
+    }
+
+    # --- Satellites (roster + live state) --------------------------------
+    try:
+        from ha_glue.services.satellite_manager import get_satellite_manager
+
+        snapshot["satellites"] = get_satellite_manager().get_all_satellites()
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"kiosk snapshot: satellites unavailable: {e}")
+
+    # --- Presence (rooms → occupant counts; no user ids) -----------------
+    try:
+        from ha_glue.services.presence_service import get_presence_service
+
+        presence = get_presence_service()
+        rooms: dict[int | None, dict] = {}
+        for pres in presence.get_all_presence().values():
+            key = pres.room_id
+            if key is None:
+                continue
+            room = rooms.setdefault(
+                key, {"room_id": key, "room_name": pres.room_name, "occupants": 0}
+            )
+            room["occupants"] += 1
+        room_list = list(rooms.values())
+        snapshot["presence"] = {
+            "rooms": room_list,
+            "people_present": sum(r["occupants"] for r in room_list),
+            "occupied_rooms": len(room_list),
+        }
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"kiosk snapshot: presence unavailable: {e}")
+
+    # --- MCP connection status + tool counts -----------------------------
+    mcp_manager = getattr(app.state, "mcp_manager", None)
+    if mcp_manager is not None:
+        try:
+            snapshot["mcp"] = mcp_manager.get_status()
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"kiosk snapshot: mcp status unavailable: {e}")
+
+    # --- Tool-health classification (aggregated, user-id-free) -----------
+    try:
+        from services.tool_outcome_service import ToolOutcomeService
+
+        async with AsyncSessionLocal() as db:
+            stats = await ToolOutcomeService(db).list_stats(limit=500)
+        agg: dict[str, dict] = {}
+        for st in stats:
+            row = agg.setdefault(
+                st.tool_name, {"tool_name": st.tool_name, "success": 0, "failure": 0}
+            )
+            row["success"] += st.success_count
+            row["failure"] += st.failure_count
+        tool_health: list[dict] = []
+        for row in agg.values():
+            total = row["success"] + row["failure"]
+            rate = (row["success"] / total) if total else 1.0
+            tool_health.append(
+                {
+                    "tool_name": row["tool_name"],
+                    "total": total,
+                    "success_rate": round(rate, 3),
+                    "degraded": total > 0 and rate < _TOOL_HEALTH_DEGRADED_BELOW,
+                }
+            )
+        snapshot["tool_health"] = tool_health
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"kiosk snapshot: tool health unavailable: {e}")
+
+    # --- Agent roles (availability-filtered, as the router sees them) ----
+    try:
+        agent_router = getattr(app.state, "agent_router", None)
+        if agent_router is not None and getattr(agent_router, "roles", None):
+            snapshot["roles"] = [
+                {
+                    "name": role.name,
+                    "description": role.description,
+                    "mcp_servers": role.mcp_servers,
+                    "internal_tools": role.internal_tools,
+                    "has_agent_loop": role.has_agent_loop,
+                }
+                for role in agent_router.roles.values()
+            ]
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"kiosk snapshot: roles unavailable: {e}")
+
+    # --- Recent role activations (content-free pulse history) ------------
+    try:
+        from api.routes.command_center import recent_role_activity_entries
+
+        async with AsyncSessionLocal() as db:
+            entries = await recent_role_activity_entries(db, limit=30)
+        snapshot["activity"] = [
+            {"role": e.role, "at": e.at.isoformat() if e.at else None, "ok": e.ok}
+            for e in entries
+        ]
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"kiosk snapshot: activity unavailable: {e}")
+
+    # --- Federation peers (reachability, no message content) -------------
+    try:
+        from sqlalchemy import select
+
+        from models.database import PeerUser
+
+        now = datetime.now(UTC)
+        async with AsyncSessionLocal() as db:
+            rows = (
+                await db.execute(
+                    select(PeerUser).where(PeerUser.revoked_at.is_(None))
+                )
+            ).scalars().all()
+        peers: list[dict] = []
+        seen_peers: set = set()
+        for peer in rows:
+            # Different circle owners can pair with the same remote node; the
+            # kiosk shows one node per remote identity.
+            if peer.remote_pubkey in seen_peers:
+                continue
+            seen_peers.add(peer.remote_pubkey)
+            last_seen = peer.last_seen_at
+            reachable = False
+            if last_seen is not None:
+                ls = last_seen if last_seen.tzinfo else last_seen.replace(tzinfo=UTC)
+                reachable = (now - ls).total_seconds() < _PEER_REACHABLE_WITHIN_SECONDS
+            peers.append(
+                {
+                    "id": peer.id,
+                    "name": peer.remote_display_name,
+                    "last_seen_at": last_seen.isoformat() if last_seen else None,
+                    "reachable": reachable,
+                }
+            )
+        snapshot["peers"] = peers
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"kiosk snapshot: peers unavailable: {e}")
+
+    # --- Weather tile (process-cached; None hides the tile) --------------
+    try:
+        from api.routes.command_center import compute_kiosk_weather
+
+        weather = await compute_kiosk_weather(mcp_manager)
+        if weather is not None:
+            snapshot["weather"] = weather.model_dump()
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"kiosk snapshot: weather unavailable: {e}")
+
+    # --- Now-playing tile (one per room, PLAYING only, no user ids) ------
+    try:
+        from ha_glue.utils.config import ha_glue_settings
+
+        if ha_glue_settings.media_follow_enabled:
+            from ha_glue.services.media_follow_service import get_media_follow_service
+
+            snapshot["now_playing"] = get_media_follow_service().active_sessions()
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"kiosk snapshot: now-playing unavailable: {e}")
+
+    return snapshot
+
+
+@router.websocket("/ws/kiosk")
+async def kiosk_live(
+    websocket: WebSocket,
+    token: str = Query(None, description="Authentication token"),
+):
+    """WebSocket endpoint for the live kiosk projection (ADMIN-gated).
+
+    Gate: authenticate, then require ``Permission.ADMIN`` (mirroring
+    ``<AdminRoute>``) UNLESS auth is disabled (single-user/household mode, where
+    ``authenticate_websocket`` returns ``auth_skipped`` and the household is
+    trusted). An unauthenticated or non-admin client must not open this socket
+    and harvest the household-wide snapshot.
+    """
+    auth_result = await authenticate_websocket(websocket, token)
+    if not auth_result:
+        await websocket.close(
+            code=WSAuthError.UNAUTHORIZED, reason="Authentication required"
+        )
+        return
+
+    # Auth disabled → single-user/household mode, no per-user permission model.
+    if not auth_result.get("auth_skipped"):
+        user_id = auth_result.get("user_id") if isinstance(auth_result, dict) else None
+        is_admin = False
+        if user_id is not None:
+            try:
+                async with AsyncSessionLocal() as db:
+                    user = await get_user_by_id(db, user_id)
+                is_admin = bool(user and user.has_permission(Permission.ADMIN))
+            except Exception as e:  # noqa: BLE001
+                logger.warning(f"kiosk WS admin check failed: {e}")
+                is_admin = False
+        if not is_admin:
+            await websocket.close(
+                code=WSAuthError.UNAUTHORIZED, reason="Admin permission required"
+            )
+            return
+
+    await websocket.accept()
+    _kiosk_clients.add(websocket)
+    logger.info(f"🖥️ Kiosk display connected ({len(_kiosk_clients)} total)")
+
+    try:
+        # Hydrate: one full snapshot, then subscribe to deltas.
+        snapshot = await build_kiosk_snapshot(websocket.app)
+        await websocket.send_json(snapshot)
+
+        # Push-only channel: idle on receive (ping/pong handled by framework).
+        while True:
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        pass
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"Kiosk display connection error: {e}")
+    finally:
+        _kiosk_clients.discard(websocket)
+        logger.info(f"🖥️ Kiosk display disconnected ({len(_kiosk_clients)} total)")

--- a/src/backend/api/websocket/kiosk_handler.py
+++ b/src/backend/api/websocket/kiosk_handler.py
@@ -99,7 +99,7 @@ async def _broadcast_consumer() -> None:
                     *(_send_one(ws, event) for ws in clients),
                     return_exceptions=True,
                 )
-                for ws, result in zip(clients, results):
+                for ws, result in zip(clients, results, strict=True):
                     if isinstance(result, Exception):
                         _kiosk_clients.discard(ws)
         except Exception as e:  # never let one event kill the consumer

--- a/src/backend/api/websocket/kiosk_handler.py
+++ b/src/backend/api/websocket/kiosk_handler.py
@@ -21,6 +21,7 @@ ids, names, counts, health, and state strings only. Never an utterance, never
 an entity name, never a user id. See ``tasks/kiosk-active-subsystem-plan.md`` §5.
 """
 
+import asyncio
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
@@ -38,22 +39,45 @@ router = APIRouter()
 _kiosk_clients: set[WebSocket] = set()
 
 
+# Per-client send deadline. A backpressured wall display (tab asleep, WiFi
+# dropped → its send buffer fills) is pruned after this instead of hanging the
+# fan-out task forever.
+_SEND_TIMEOUT_SECONDS = 5.0
+
+# Strong refs to in-flight fan-out tasks. `asyncio.create_task` returns a task
+# the loop only weakly references, so without this the GC can cancel a pending
+# broadcast mid-send (the exact fire-and-forget-task strand bug fixed in the
+# satellite boot-reconnect work). Discard on completion.
+_fanout_tasks: set = set()
+
+
 async def broadcast_kiosk_event(event: dict) -> None:
     """Broadcast one content-free kiosk delta to every connected wall display.
 
-    Fire-and-forget, same broken-socket cleanup as ``broadcast_kg_update``: a
-    send that raises prunes that socket, never propagates. No-op when no client
-    is connected (the common case — cost of the publish points stays ~zero when
-    nobody is watching the kiosk).
+    TRULY fire-and-forget: schedules the fan-out on a background task and returns
+    immediately, so a slow/backpressured kiosk socket can NEVER block the caller.
+    This matters because callers hold latency-critical context — the
+    ``SatelliteManager`` lock (a blocked send there would freeze voice
+    house-wide) and the chat turn before its ``done`` frame. No-op when no client
+    is connected (the common case — publish-point cost stays ~zero when nobody is
+    watching the kiosk).
     """
     if not _kiosk_clients:
         return
+    task = asyncio.create_task(_fan_out_kiosk_event(event))
+    _fanout_tasks.add(task)
+    task.add_done_callback(_fanout_tasks.discard)
 
+
+async def _fan_out_kiosk_event(event: dict) -> None:
+    """Send ``event`` to each client, pruning dead/stalled sockets. Iterates a
+    SNAPSHOT of the client set so a concurrent connect/disconnect during a send
+    can't raise ``Set changed size during iteration``."""
     broken: list[WebSocket] = []
-    for ws in _kiosk_clients:
+    for ws in list(_kiosk_clients):
         try:
-            await ws.send_json(event)
-        except Exception:  # noqa: BLE001 — a dead socket must not break the caller
+            await asyncio.wait_for(ws.send_json(event), timeout=_SEND_TIMEOUT_SECONDS)
+        except Exception:  # noqa: BLE001 — a dead/stalled socket must not abort the fan-out
             broken.append(ws)
 
     for ws in broken:

--- a/src/backend/api/websocket/kiosk_handler.py
+++ b/src/backend/api/websocket/kiosk_handler.py
@@ -77,7 +77,7 @@ async def _fan_out_kiosk_event(event: dict) -> None:
     for ws in list(_kiosk_clients):
         try:
             await asyncio.wait_for(ws.send_json(event), timeout=_SEND_TIMEOUT_SECONDS)
-        except Exception:  # noqa: BLE001 — a dead/stalled socket must not abort the fan-out
+        except Exception:  # a dead/stalled socket must not abort the fan-out
             broken.append(ws)
 
     for ws in broken:
@@ -126,7 +126,7 @@ async def build_kiosk_snapshot(app) -> dict:
         from ha_glue.services.satellite_manager import get_satellite_manager
 
         snapshot["satellites"] = get_satellite_manager().get_all_satellites()
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.debug(f"kiosk snapshot: satellites unavailable: {e}")
 
     # --- Presence (rooms → occupant counts; no user ids) -----------------
@@ -149,7 +149,7 @@ async def build_kiosk_snapshot(app) -> dict:
             "people_present": sum(r["occupants"] for r in room_list),
             "occupied_rooms": len(room_list),
         }
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.debug(f"kiosk snapshot: presence unavailable: {e}")
 
     # --- MCP connection status + tool counts -----------------------------
@@ -157,7 +157,7 @@ async def build_kiosk_snapshot(app) -> dict:
     if mcp_manager is not None:
         try:
             snapshot["mcp"] = mcp_manager.get_status()
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.debug(f"kiosk snapshot: mcp status unavailable: {e}")
 
     # --- Tool-health classification (aggregated, user-id-free) -----------
@@ -186,7 +186,7 @@ async def build_kiosk_snapshot(app) -> dict:
                 }
             )
         snapshot["tool_health"] = tool_health
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.debug(f"kiosk snapshot: tool health unavailable: {e}")
 
     # --- Agent roles (availability-filtered, as the router sees them) ----
@@ -203,7 +203,7 @@ async def build_kiosk_snapshot(app) -> dict:
                 }
                 for role in agent_router.roles.values()
             ]
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.debug(f"kiosk snapshot: roles unavailable: {e}")
 
     # --- Recent role activations (content-free pulse history) ------------
@@ -216,7 +216,7 @@ async def build_kiosk_snapshot(app) -> dict:
             {"role": e.role, "at": e.at.isoformat() if e.at else None, "ok": e.ok}
             for e in entries
         ]
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.debug(f"kiosk snapshot: activity unavailable: {e}")
 
     # --- Federation peers (reachability, no message content) -------------
@@ -254,7 +254,7 @@ async def build_kiosk_snapshot(app) -> dict:
                 }
             )
         snapshot["peers"] = peers
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.debug(f"kiosk snapshot: peers unavailable: {e}")
 
     # --- Weather tile (process-cached; None hides the tile) --------------
@@ -264,7 +264,7 @@ async def build_kiosk_snapshot(app) -> dict:
         weather = await compute_kiosk_weather(mcp_manager)
         if weather is not None:
             snapshot["weather"] = weather.model_dump()
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.debug(f"kiosk snapshot: weather unavailable: {e}")
 
     # --- Now-playing tile (one per room, PLAYING only, no user ids) ------
@@ -275,7 +275,7 @@ async def build_kiosk_snapshot(app) -> dict:
             from ha_glue.services.media_follow_service import get_media_follow_service
 
             snapshot["now_playing"] = get_media_follow_service().active_sessions()
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.debug(f"kiosk snapshot: now-playing unavailable: {e}")
 
     return snapshot
@@ -310,7 +310,7 @@ async def kiosk_live(
                 async with AsyncSessionLocal() as db:
                     user = await get_user_by_id(db, user_id)
                 is_admin = bool(user and user.has_permission(Permission.ADMIN))
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 logger.warning(f"kiosk WS admin check failed: {e}")
                 is_admin = False
         if not is_admin:
@@ -333,7 +333,7 @@ async def kiosk_live(
             await websocket.receive_text()
     except WebSocketDisconnect:
         pass
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.debug(f"Kiosk display connection error: {e}")
     finally:
         _kiosk_clients.discard(websocket)

--- a/src/backend/api/websocket/kiosk_handler.py
+++ b/src/backend/api/websocket/kiosk_handler.py
@@ -55,12 +55,22 @@ _SEND_TIMEOUT_SECONDS = 5.0
 # a fresh one) and revived if the consumer ever dies.
 _event_queue: "asyncio.Queue[dict] | None" = None
 _consumer_task: "asyncio.Task | None" = None
+_consumer_loop = None  # the loop the queue+consumer are bound to
 
 
 def _ensure_consumer() -> "asyncio.Queue[dict]":
-    global _event_queue, _consumer_task
-    if _event_queue is None:
+    """Return the broadcast queue, (re)creating the queue + consumer bound to the
+    CURRENTLY-running loop. Rebinding on a loop change matters because an
+    ``asyncio.Queue``/``Task`` is tied to the loop it was made in: if the app (or
+    a pytest-asyncio per-test) loop is ever replaced, a stale consumer left
+    pending on the dead loop reads ``.done() == False`` and would otherwise
+    silently starve the new loop's broadcasts."""
+    global _event_queue, _consumer_task, _consumer_loop
+    loop = asyncio.get_running_loop()
+    if _event_queue is None or _consumer_loop is not loop:
         _event_queue = asyncio.Queue()
+        _consumer_loop = loop
+        _consumer_task = None
     if _consumer_task is None or _consumer_task.done():
         _consumer_task = asyncio.create_task(_broadcast_consumer())
     return _event_queue
@@ -344,14 +354,28 @@ async def kiosk_live(
             return
 
     await websocket.accept()
-    _kiosk_clients.add(websocket)
+
+    # Hydrate BEFORE registering. If we joined _kiosk_clients first, the
+    # single-consumer could fan a delta out to this socket (a send_json) while
+    # this coroutine is still awaiting/sending its own snapshot on the SAME
+    # socket — a concurrent send (unsafe on a Starlette WebSocket), and the
+    # client could also apply a delta before it has hydrated. Sending the
+    # snapshot while unregistered closes both. Cost: a delta landing in the tiny
+    # build+send window is missed by this socket — fine for an ambient display
+    # (the next delta for that entity corrects it; a reconnect re-snapshots).
+    try:
+        snapshot = await build_kiosk_snapshot(websocket.app)
+        await websocket.send_json(snapshot)
+    except WebSocketDisconnect:
+        return
+    except Exception as e:
+        logger.debug(f"Kiosk hydrate failed: {e}")
+        return
+
+    _kiosk_clients.add(websocket)  # now broadcast-eligible
     logger.info(f"🖥️ Kiosk display connected ({len(_kiosk_clients)} total)")
 
     try:
-        # Hydrate: one full snapshot, then subscribe to deltas.
-        snapshot = await build_kiosk_snapshot(websocket.app)
-        await websocket.send_json(snapshot)
-
         # Push-only channel: idle on receive (ping/pong handled by framework).
         while True:
             await websocket.receive_text()

--- a/src/backend/api/websocket/kiosk_handler.py
+++ b/src/backend/api/websocket/kiosk_handler.py
@@ -41,47 +41,71 @@ _kiosk_clients: set[WebSocket] = set()
 
 # Per-client send deadline. A backpressured wall display (tab asleep, WiFi
 # dropped → its send buffer fills) is pruned after this instead of hanging the
-# fan-out task forever.
+# broadcast pipeline forever.
 _SEND_TIMEOUT_SECONDS = 5.0
 
-# Strong refs to in-flight fan-out tasks. `asyncio.create_task` returns a task
-# the loop only weakly references, so without this the GC can cancel a pending
-# broadcast mid-send (the exact fire-and-forget-task strand bug fixed in the
-# satellite boot-reconnect work). Discard on completion.
-_fanout_tasks: set = set()
+# Serialized broadcast pipeline: callers ENQUEUE (non-blocking) and a single
+# consumer task drains it FIFO. Deliberately a queue+single-consumer, NOT a
+# task-per-event — per-event tasks would (a) deliver deltas out of ORDER and
+# (b) call send_json CONCURRENTLY on the same Starlette WebSocket (unsafe → a
+# spurious error would prune a healthy display). The consumer handles one event
+# at a time, so each socket is sent to sequentially; within one event the
+# fan-out across DIFFERENT sockets is concurrent (safe). Created lazily in the
+# running loop (so the queue binds to the app's loop, and each test's loop gets
+# a fresh one) and revived if the consumer ever dies.
+_event_queue: "asyncio.Queue[dict] | None" = None
+_consumer_task: "asyncio.Task | None" = None
+
+
+def _ensure_consumer() -> "asyncio.Queue[dict]":
+    global _event_queue, _consumer_task
+    if _event_queue is None:
+        _event_queue = asyncio.Queue()
+    if _consumer_task is None or _consumer_task.done():
+        _consumer_task = asyncio.create_task(_broadcast_consumer())
+    return _event_queue
 
 
 async def broadcast_kiosk_event(event: dict) -> None:
-    """Broadcast one content-free kiosk delta to every connected wall display.
+    """Enqueue one content-free kiosk delta for delivery to every wall display.
 
-    TRULY fire-and-forget: schedules the fan-out on a background task and returns
-    immediately, so a slow/backpressured kiosk socket can NEVER block the caller.
-    This matters because callers hold latency-critical context — the
-    ``SatelliteManager`` lock (a blocked send there would freeze voice
-    house-wide) and the chat turn before its ``done`` frame. No-op when no client
-    is connected (the common case — publish-point cost stays ~zero when nobody is
-    watching the kiosk).
+    NON-BLOCKING: the caller — which may hold the ``SatelliteManager`` lock (a
+    blocked send there would freeze voice house-wide) or be mid chat-turn before
+    the ``done`` frame — enqueues and returns; the background consumer does the
+    ordered fan-out. No-op when no client is connected (the common case —
+    publish-point cost stays ~zero when nobody is watching the kiosk).
     """
     if not _kiosk_clients:
         return
-    task = asyncio.create_task(_fan_out_kiosk_event(event))
-    _fanout_tasks.add(task)
-    task.add_done_callback(_fanout_tasks.discard)
+    _ensure_consumer().put_nowait(event)
 
 
-async def _fan_out_kiosk_event(event: dict) -> None:
-    """Send ``event`` to each client, pruning dead/stalled sockets. Iterates a
-    SNAPSHOT of the client set so a concurrent connect/disconnect during a send
-    can't raise ``Set changed size during iteration``."""
-    broken: list[WebSocket] = []
-    for ws in list(_kiosk_clients):
+async def _send_one(ws: WebSocket, event: dict) -> None:
+    await asyncio.wait_for(ws.send_json(event), timeout=_SEND_TIMEOUT_SECONDS)
+
+
+async def _broadcast_consumer() -> None:
+    """Drain the queue FIFO; fan each event out to all current clients
+    concurrently (across distinct sockets), pruning any whose send fails or
+    times out. One event at a time → no concurrent send on a single socket and
+    strict delivery order. A bad event or a dead socket never kills the loop."""
+    assert _event_queue is not None
+    while True:
+        event = await _event_queue.get()
         try:
-            await asyncio.wait_for(ws.send_json(event), timeout=_SEND_TIMEOUT_SECONDS)
-        except Exception:  # a dead/stalled socket must not abort the fan-out
-            broken.append(ws)
-
-    for ws in broken:
-        _kiosk_clients.discard(ws)
+            clients = list(_kiosk_clients)
+            if clients:
+                results = await asyncio.gather(
+                    *(_send_one(ws, event) for ws in clients),
+                    return_exceptions=True,
+                )
+                for ws, result in zip(clients, results):
+                    if isinstance(result, Exception):
+                        _kiosk_clients.discard(ws)
+        except Exception as e:  # never let one event kill the consumer
+            logger.debug(f"kiosk broadcast consumer error: {e}")
+        finally:
+            _event_queue.task_done()
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/ha_glue/services/satellite_manager.py
+++ b/src/backend/ha_glue/services/satellite_manager.py
@@ -292,7 +292,7 @@ class SatelliteManager:
 
             self.sessions[session_id] = session
             sat.current_session_id = session_id
-            sat.state = SatelliteState.LISTENING
+            await self._set_satellite_state(sat, SatelliteState.LISTENING)
 
             logger.info(f"🎙️ Session started: {session_id}")
             logger.info(f"   Room: {sat.room}, Wake word: {keyword} ({confidence:.2f})")
@@ -374,6 +374,31 @@ class SatelliteManager:
         # Concatenate all chunks
         return b"".join(session.audio_chunks)
 
+    async def _set_satellite_state(
+        self, sat: "SatelliteInfo", state: SatelliteState
+    ):
+        """Single funnel for every satellite state transition.
+
+        Mutates ``sat.state`` AND pushes a content-free ``satellite_state`` delta
+        to the kiosk hub, so any future transition gets the push "for free". The
+        broadcast is fire-and-forget: a hub failure must never break voice.
+        """
+        sat.state = state
+        try:
+            from api.websocket.kiosk_handler import broadcast_kiosk_event
+
+            await broadcast_kiosk_event(
+                {
+                    "type": "satellite_state",
+                    "satellite_id": sat.satellite_id,
+                    "room": sat.room,
+                    "room_id": sat.room_id,
+                    "state": state.value,
+                }
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"kiosk satellite_state broadcast failed: {e}")
+
     async def set_session_state(
         self,
         session_id: str,
@@ -389,7 +414,7 @@ class SatelliteManager:
         # Update satellite state too
         if session.satellite_id in self.satellites:
             sat = self.satellites[session.satellite_id]
-            sat.state = state
+            await self._set_satellite_state(sat, state)
 
             # Notify satellite of state change
             try:
@@ -511,7 +536,7 @@ class SatelliteManager:
         if session.satellite_id in self.satellites:
             sat = self.satellites[session.satellite_id]
             sat.current_session_id = None
-            sat.state = SatelliteState.IDLE
+            await self._set_satellite_state(sat, SatelliteState.IDLE)
 
             # Notify satellite to return to idle
             try:

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -49,7 +49,7 @@ from api.routes import knowledge_graph as kg_routes
 from api.routes import mcp as mcp_routes
 from api.routes import settings as settings_routes
 from api.routes import wissensbasis as wissensbasis_routes
-from api.websocket import chat_router, kg_live_router
+from api.websocket import chat_router, kg_live_router, kiosk_router
 # NOTE: device_router, satellite_router, and the HA-specific REST routers
 # (camera, homeassistant, paperless_audit, presence, rooms, satellites)
 # all moved to ha_glue.api.* and are mounted via the register_routes hook
@@ -213,6 +213,8 @@ app.include_router(chat_router, tags=["WebSocket Chat"])
 # satellite_router + device_router mounted via ha_glue register_routes hook.
 if settings.knowledge_graph_enabled:
     app.include_router(kg_live_router, tags=["WebSocket Knowledge Graph"])
+# Kiosk push hub (/ws/kiosk) — ADMIN-gated live wall-display projection.
+app.include_router(kiosk_router, tags=["WebSocket Kiosk"])
 
 
 # WebSocket for Wake Word Detection (Server-Side Fallback)

--- a/tests/backend/test_kiosk_handler.py
+++ b/tests/backend/test_kiosk_handler.py
@@ -17,12 +17,12 @@ import asyncio
 
 import pytest
 
-import api.websocket.kiosk_handler as kiosk
 from api.websocket.chat_handler import (
     INTERNAL_SUBSYSTEM_LABELS,
     _MAX_SUBSYSTEMS_PER_TURN,
     _extract_subsystems_used,
 )
+import api.websocket.kiosk_handler as kiosk
 from api.websocket.kiosk_handler import broadcast_kiosk_event, build_kiosk_snapshot
 
 

--- a/tests/backend/test_kiosk_handler.py
+++ b/tests/backend/test_kiosk_handler.py
@@ -17,12 +17,12 @@ import asyncio
 
 import pytest
 
+import api.websocket.kiosk_handler as kiosk
 from api.websocket.chat_handler import (
     INTERNAL_SUBSYSTEM_LABELS,
     _MAX_SUBSYSTEMS_PER_TURN,
     _extract_subsystems_used,
 )
-import api.websocket.kiosk_handler as kiosk
 from api.websocket.kiosk_handler import broadcast_kiosk_event, build_kiosk_snapshot
 
 

--- a/tests/backend/test_kiosk_handler.py
+++ b/tests/backend/test_kiosk_handler.py
@@ -13,6 +13,8 @@ Run on the .159 build box (CI is non-functional): see
 """
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 import api.websocket.kiosk_handler as kiosk
@@ -22,9 +24,6 @@ from api.websocket.chat_handler import (
     _extract_subsystems_used,
 )
 from api.websocket.kiosk_handler import broadcast_kiosk_event, build_kiosk_snapshot
-
-
-import asyncio
 
 
 class _FakeWS:

--- a/tests/backend/test_kiosk_handler.py
+++ b/tests/backend/test_kiosk_handler.py
@@ -24,12 +24,22 @@ from api.websocket.chat_handler import (
 from api.websocket.kiosk_handler import broadcast_kiosk_event, build_kiosk_snapshot
 
 
+import asyncio
+
+
 class _FakeWS:
     def __init__(self):
         self.sent: list[dict] = []
 
     async def send_json(self, msg):
         self.sent.append(msg)
+
+
+async def _drain_fanout():
+    """broadcast_kiosk_event now schedules the fan-out on a background task (so a
+    slow socket can't block the caller); await those tasks before asserting."""
+    while kiosk._fanout_tasks:
+        await asyncio.gather(*list(kiosk._fanout_tasks), return_exceptions=True)
 
 
 @pytest.fixture(autouse=True)
@@ -131,6 +141,7 @@ async def test_broadcast_delivers_to_connected_clients():
     kiosk._kiosk_clients.update({a, b})
     event = {"type": "turn_activity", "role": "smart_home", "subsystems": ["homeassistant"]}
     await broadcast_kiosk_event(event)
+    await _drain_fanout()
     assert a.sent == [event]
     assert b.sent == [event]
 
@@ -145,6 +156,7 @@ async def test_broadcast_prunes_broken_socket_not_raises():
     good, bad = _FakeWS(), _BrokenWS()
     kiosk._kiosk_clients.update({good, bad})
     await broadcast_kiosk_event({"type": "satellite_state"})
+    await _drain_fanout()
     assert bad not in kiosk._kiosk_clients  # pruned
     assert good in kiosk._kiosk_clients
     assert len(good.sent) == 1  # good socket still delivered

--- a/tests/backend/test_kiosk_handler.py
+++ b/tests/backend/test_kiosk_handler.py
@@ -1,0 +1,239 @@
+"""Backend unit tests for the kiosk push hub (Phase 1a).
+
+Covers:
+  * ``_extract_subsystems_used`` — mcp-vs-internal mapping, the internal
+    allowlist, dedup, order-preservation, the cap, and the empty case.
+  * ``broadcast_kiosk_event`` — fire-and-forget: an empty registry is a no-op,
+    a broken socket is pruned (not raised), a good socket receives the event.
+  * ``build_kiosk_snapshot`` — the snapshot dict shape / content-free contract
+    with all sources stubbed out (no DB / no app state required).
+
+Run on the .159 build box (CI is non-functional): see
+``memory/reference_test_runner_159.md``.
+"""
+from __future__ import annotations
+
+import pytest
+
+import api.websocket.kiosk_handler as kiosk
+from api.websocket.chat_handler import (
+    INTERNAL_SUBSYSTEM_LABELS,
+    _MAX_SUBSYSTEMS_PER_TURN,
+    _extract_subsystems_used,
+)
+from api.websocket.kiosk_handler import broadcast_kiosk_event, build_kiosk_snapshot
+
+
+class _FakeWS:
+    def __init__(self):
+        self.sent: list[dict] = []
+
+    async def send_json(self, msg):
+        self.sent.append(msg)
+
+
+@pytest.fixture(autouse=True)
+def _clear_clients():
+    kiosk._kiosk_clients.clear()
+    yield
+    kiosk._kiosk_clients.clear()
+
+
+# --------------------------------------------------------------------------
+# _extract_subsystems_used
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.backend
+@pytest.mark.unit
+def test_extract_mcp_tool_maps_to_server():
+    assert _extract_subsystems_used(
+        [("mcp.homeassistant.turn_on", {})]
+    ) == ["homeassistant"]
+
+
+@pytest.mark.backend
+@pytest.mark.unit
+def test_extract_internal_tool_uses_allowlist():
+    assert _extract_subsystems_used(
+        [("internal.knowledge_search", {})]
+    ) == ["knowledge"]
+    assert _extract_subsystems_used(
+        [("internal.device_controls", {})]
+    ) == ["homeassistant"]
+
+
+@pytest.mark.backend
+@pytest.mark.unit
+def test_extract_unknown_internal_tool_skipped():
+    assert _extract_subsystems_used([("internal.something_new", {})]) == []
+
+
+@pytest.mark.backend
+@pytest.mark.unit
+def test_extract_dedup_preserves_first_seen_order():
+    results = [
+        ("mcp.homeassistant.turn_on", {}),
+        ("internal.device_action", {}),  # also -> homeassistant (dupe)
+        ("mcp.weather.get_weather", {}),
+        ("internal.knowledge_search", {}),  # -> knowledge
+    ]
+    assert _extract_subsystems_used(results) == [
+        "homeassistant",
+        "weather",
+        "knowledge",
+    ]
+
+
+@pytest.mark.backend
+@pytest.mark.unit
+def test_extract_caps_at_five_distinct_subsystems():
+    results = [(f"mcp.server{i}.tool", {}) for i in range(8)]
+    out = _extract_subsystems_used(results)
+    assert len(out) == _MAX_SUBSYSTEMS_PER_TURN == 5
+    assert out == ["server0", "server1", "server2", "server3", "server4"]
+
+
+@pytest.mark.backend
+@pytest.mark.unit
+def test_extract_empty_and_malformed_are_safe():
+    assert _extract_subsystems_used([]) == []
+    # Malformed / non-tool entries are ignored, not raised.
+    assert _extract_subsystems_used(
+        [(), ("", {}), ("plain_intent", {}), ("mcp.", {}), ("mcp.only", {})]
+    ) == []
+
+
+@pytest.mark.backend
+@pytest.mark.unit
+def test_allowlist_values_are_known_subsystem_ids():
+    # Guard: every allowlisted internal tool maps to a non-empty id.
+    assert all(v for v in INTERNAL_SUBSYSTEM_LABELS.values())
+
+
+# --------------------------------------------------------------------------
+# broadcast_kiosk_event
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.backend
+@pytest.mark.asyncio
+async def test_broadcast_empty_registry_is_noop():
+    # No clients registered — must return without error.
+    await broadcast_kiosk_event({"type": "satellite_state"})
+    assert kiosk._kiosk_clients == set()
+
+
+@pytest.mark.backend
+@pytest.mark.asyncio
+async def test_broadcast_delivers_to_connected_clients():
+    a, b = _FakeWS(), _FakeWS()
+    kiosk._kiosk_clients.update({a, b})
+    event = {"type": "turn_activity", "role": "smart_home", "subsystems": ["homeassistant"]}
+    await broadcast_kiosk_event(event)
+    assert a.sent == [event]
+    assert b.sent == [event]
+
+
+@pytest.mark.backend
+@pytest.mark.asyncio
+async def test_broadcast_prunes_broken_socket_not_raises():
+    class _BrokenWS(_FakeWS):
+        async def send_json(self, msg):
+            raise RuntimeError("closed")
+
+    good, bad = _FakeWS(), _BrokenWS()
+    kiosk._kiosk_clients.update({good, bad})
+    await broadcast_kiosk_event({"type": "satellite_state"})
+    assert bad not in kiosk._kiosk_clients  # pruned
+    assert good in kiosk._kiosk_clients
+    assert len(good.sent) == 1  # good socket still delivered
+
+
+# --------------------------------------------------------------------------
+# build_kiosk_snapshot (shape + content-free)
+# --------------------------------------------------------------------------
+
+
+class _FakeState:
+    def __init__(self):
+        self.mcp_manager = None
+        self.agent_router = None
+
+
+class _FakeApp:
+    def __init__(self):
+        self.state = _FakeState()
+
+
+@pytest.mark.backend
+@pytest.mark.asyncio
+async def test_snapshot_shape_with_all_sources_down(monkeypatch):
+    """Every source failing must still yield a fully-shaped, content-free
+    snapshot (a fresh tab always hydrates)."""
+    # Neutralize the DB-backed sections so no database is required.
+    async def _boom(*a, **k):
+        raise RuntimeError("no db in unit test")
+
+    # Force the tool-health / activity / peers / weather / now-playing sources
+    # to their degraded empty branches by making their imports/queries fail.
+    monkeypatch.setattr(kiosk, "AsyncSessionLocal", _boom, raising=True)
+
+    snap = await build_kiosk_snapshot(_FakeApp())
+
+    assert snap["type"] == "snapshot"
+    assert isinstance(snap["at"], str)
+    # All expected top-level keys present with safe empty defaults.
+    for key in (
+        "satellites",
+        "presence",
+        "mcp",
+        "tool_health",
+        "roles",
+        "activity",
+        "peers",
+        "weather",
+        "now_playing",
+    ):
+        assert key in snap
+    assert snap["presence"] == {"rooms": [], "people_present": 0, "occupied_rooms": 0}
+    assert snap["tool_health"] == []
+    assert snap["activity"] == []
+    assert snap["peers"] == []
+    assert snap["weather"] is None
+    assert snap["now_playing"] == []
+
+
+@pytest.mark.backend
+@pytest.mark.asyncio
+async def test_snapshot_roles_content_free(monkeypatch):
+    """Roles ride straight off the router; the shape is names + reach lists
+    only (no message content)."""
+    async def _boom(*a, **k):
+        raise RuntimeError("no db")
+
+    monkeypatch.setattr(kiosk, "AsyncSessionLocal", _boom, raising=True)
+
+    class _Role:
+        name = "smart_home"
+        description = {"de": "Haussteuerung", "en": "Smart home"}
+        mcp_servers = ["homeassistant"]
+        internal_tools = ["internal.device_action"]
+        has_agent_loop = True
+
+    class _Router:
+        roles = {"smart_home": _Role()}
+
+    app = _FakeApp()
+    app.state.agent_router = _Router()
+
+    snap = await build_kiosk_snapshot(app)
+    assert snap["roles"] == [
+        {
+            "name": "smart_home",
+            "description": {"de": "Haussteuerung", "en": "Smart home"},
+            "mcp_servers": ["homeassistant"],
+            "internal_tools": ["internal.device_action"],
+            "has_agent_loop": True,
+        }
+    ]

--- a/tests/backend/test_kiosk_handler.py
+++ b/tests/backend/test_kiosk_handler.py
@@ -35,17 +35,25 @@ class _FakeWS:
 
 
 async def _drain_fanout():
-    """broadcast_kiosk_event now schedules the fan-out on a background task (so a
-    slow socket can't block the caller); await those tasks before asserting."""
-    while kiosk._fanout_tasks:
-        await asyncio.gather(*list(kiosk._fanout_tasks), return_exceptions=True)
+    """broadcast_kiosk_event enqueues; a single consumer drains the queue. Wait
+    for every queued event to be fully processed before asserting."""
+    if kiosk._event_queue is not None:
+        await kiosk._event_queue.join()
 
 
 @pytest.fixture(autouse=True)
 def _clear_clients():
+    # Reset the lazily-created queue+consumer so each test's event loop gets a
+    # fresh pipeline (an asyncio.Queue/Task is bound to the loop it was made in).
     kiosk._kiosk_clients.clear()
+    kiosk._event_queue = None
+    kiosk._consumer_task = None
     yield
+    if kiosk._consumer_task is not None:
+        kiosk._consumer_task.cancel()
     kiosk._kiosk_clients.clear()
+    kiosk._event_queue = None
+    kiosk._consumer_task = None
 
 
 # --------------------------------------------------------------------------
@@ -159,6 +167,27 @@ async def test_broadcast_prunes_broken_socket_not_raises():
     assert bad not in kiosk._kiosk_clients  # pruned
     assert good in kiosk._kiosk_clients
     assert len(good.sent) == 1  # good socket still delivered
+
+
+@pytest.mark.backend
+@pytest.mark.asyncio
+async def test_broadcast_prunes_stalled_socket(monkeypatch):
+    """A socket whose send_json HANGS (backpressure — never raises) is pruned via
+    the wait_for timeout, and a healthy peer is still delivered. This is the core
+    of the non-blocking fix; without the timeout the consumer would hang here."""
+    monkeypatch.setattr(kiosk, "_SEND_TIMEOUT_SECONDS", 0.05)
+
+    class _StallWS(_FakeWS):
+        async def send_json(self, msg):
+            await asyncio.sleep(10)  # never completes within the timeout
+
+    good, stalled = _FakeWS(), _StallWS()
+    kiosk._kiosk_clients.update({good, stalled})
+    await broadcast_kiosk_event({"type": "satellite_state"})
+    await _drain_fanout()
+    assert stalled not in kiosk._kiosk_clients  # pruned on timeout
+    assert good in kiosk._kiosk_clients
+    assert len(good.sent) == 1
 
 
 # --------------------------------------------------------------------------

--- a/tests/backend/test_kiosk_handler.py
+++ b/tests/backend/test_kiosk_handler.py
@@ -48,12 +48,14 @@ def _clear_clients():
     kiosk._kiosk_clients.clear()
     kiosk._event_queue = None
     kiosk._consumer_task = None
+    kiosk._consumer_loop = None
     yield
     if kiosk._consumer_task is not None:
         kiosk._consumer_task.cancel()
     kiosk._kiosk_clients.clear()
     kiosk._event_queue = None
     kiosk._consumer_task = None
+    kiosk._consumer_loop = None
 
 
 # --------------------------------------------------------------------------
@@ -188,6 +190,52 @@ async def test_broadcast_prunes_stalled_socket(monkeypatch):
     assert stalled not in kiosk._kiosk_clients  # pruned on timeout
     assert good in kiosk._kiosk_clients
     assert len(good.sent) == 1
+
+
+@pytest.mark.backend
+@pytest.mark.asyncio
+async def test_hydrate_before_register(monkeypatch):
+    """The socket must receive its snapshot BEFORE joining _kiosk_clients — else
+    the consumer could send a delta on the same socket concurrently with the
+    snapshot send, or the client would apply a delta before hydrating."""
+    from unittest.mock import AsyncMock
+
+    from fastapi import WebSocketDisconnect
+
+    monkeypatch.setattr(
+        kiosk, "authenticate_websocket",
+        AsyncMock(return_value={"authenticated": True, "auth_skipped": True}),
+    )
+    monkeypatch.setattr(
+        kiosk, "build_kiosk_snapshot", AsyncMock(return_value={"type": "snapshot"})
+    )
+
+    class _RecordingWS:
+        def __init__(self):
+            self.app = _FakeApp()
+            self.sent: list[dict] = []
+            self.registered_at_send: bool | None = None
+
+        async def accept(self):
+            pass
+
+        async def send_json(self, msg):
+            # Capture whether this socket was broadcast-eligible when hydrated.
+            self.registered_at_send = self in kiosk._kiosk_clients
+            self.sent.append(msg)
+
+        async def receive_text(self):
+            raise WebSocketDisconnect()
+
+        async def close(self, **kwargs):
+            pass
+
+    ws = _RecordingWS()
+    await kiosk.kiosk_live(ws, token=None)
+
+    assert ws.sent == [{"type": "snapshot"}]
+    assert ws.registered_at_send is False  # snapshot sent while UNREGISTERED
+    assert ws not in kiosk._kiosk_clients  # disconnect cleaned up
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Phase 1a of the kiosk "active subsystem" feature (design: `tasks/kiosk-active-subsystem-plan.md`). **Backend push infrastructure only** — no frontend change, no command-center decommission (later phases). The kiosk still polls today; this lands the hub it will consume in 1b.

## What
- **`/ws/kiosk` WS hub** (`api/websocket/kiosk_handler.py`), modeled on the reviewed `kg_live_handler.py`. **ADMIN-gated** at connect (`user.has_permission(ADMIN)`; `auth_skipped` allowed in single-user mode) — fail-closed.
- **Snapshot-on-connect** (`build_kiosk_snapshot`) — full current state (satellites, presence, MCP status, tool-health, roles, activity, peers, weather, now-playing) in one compute from the existing source functions. **Content-free** (ids/names/counts/health/state only — never utterances, entity names, or user ids).
- Two **delta events**: `satellite_state` (via a single `_set_satellite_state` setter, 3 mutation sites) and `turn_activity` (role **+ content-free subsystem ids** from `agent_tool_results` — the active-subsystem signal; `internal.*` mapped via a small allowlist).
- Two behavior-preserving helper extractions in `command_center.py`.

## Broadcast correctness (3 review rounds)
The fan-out went through three `/review` rounds, converging on the canonical design: `broadcast_kiosk_event` **enqueues** (non-blocking — never blocks the caller under the `SatelliteManager` lock or before the chat `done` frame); a **single consumer** drains the queue FIFO and fans each event out via `asyncio.gather` (concurrent across distinct sockets, serialized across events → ordered, never a concurrent `send_json` on one socket); per-send timeout prunes a stalled client; **hydrate-before-register** so a delta can't race the snapshot send; loop-aware consumer.

## Tests / lint
14 backend tests on `.159` (subsystem extraction, broadcast delivery/broken-prune/**stalled-prune**, **hydrate-before-register**, snapshot shape + content-free). Ruff clean. No regressions (satellite_manager/command_center/chat_handler suites verified green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>