### PR TITLE
feat(kiosk): phase 2 — backend liveness deltas (satellite/presence/now-playing/tool-health/weather)

### DIFF
--- a/src/backend/api/lifecycle.py
+++ b/src/backend/api/lifecycle.py
@@ -744,6 +744,42 @@ def _schedule_paperless_sweepers(app):
     )
 
 
+def _schedule_kiosk_weather_refresh(app):
+    """Backend-internal weather refresher → PUSHES a ``weather_updated`` delta to
+    the kiosk hub when the reading changes.
+
+    This is the §1.6-sanctioned exception to the no-polling rule: Open-Meteo has
+    no push, so a backend timer refreshes the external cache at the TTL cadence
+    and streams new values to the wall displays — the kiosk's browser never polls
+    our API for weather. Diff-gated in ``refresh_and_push_kiosk_weather`` so a
+    tick that produces the same reading stays silent. Gated on weather being on
+    AND a kiosk location configured; a no-op otherwise.
+    """
+    location = (settings.kiosk_weather_location or "").strip()
+    if not settings.weather_enabled or not location:
+        return
+
+    from api.routes.command_center import _WEATHER_TTL_SECONDS
+
+    async def _tick():
+        from api.routes.command_center import refresh_and_push_kiosk_weather
+
+        mgr = getattr(app.state, "mcp_manager", None)
+        if mgr is None:
+            return
+        await refresh_and_push_kiosk_weather(mgr)
+
+    _spawn_periodic_task(
+        name="Kiosk weather refresh",
+        interval=_WEATHER_TTL_SECONDS,
+        work=_tick,
+        started_msg=(
+            f"Kiosk weather refresher gestartet "
+            f"(interval={_WEATHER_TTL_SECONDS}s, location={location})"
+        ),
+    )
+
+
 def _schedule_notification_poller(app):
     """Start the MCP notification poller for servers with notifications enabled."""
     if not settings.notification_poller_enabled:
@@ -1066,6 +1102,7 @@ async def lifespan(app: "FastAPI"):
     _schedule_paperless_sweepers(app)
     _schedule_paperless_reconciler(app)
     _schedule_obligation_calendar_sync(app)
+    _schedule_kiosk_weather_refresh(app)
 
     # Self-learning Phase 1: load bundled seed skills into the database.
     # Idempotent — seeds with a matching title are skipped, so re-running

--- a/src/backend/api/lifecycle.py
+++ b/src/backend/api/lifecycle.py
@@ -763,7 +763,12 @@ def _schedule_kiosk_weather_refresh(app):
 
     async def _tick():
         from api.routes.command_center import refresh_and_push_kiosk_weather
+        from api.websocket.kiosk_handler import _kiosk_clients
 
+        # No wall display connected → skip the external MCP round-trip nobody
+        # would consume (the broadcast would no-op anyway).
+        if not _kiosk_clients:
+            return
         mgr = getattr(app.state, "mcp_manager", None)
         if mgr is None:
             return

--- a/src/backend/api/routes/command_center.py
+++ b/src/backend/api/routes/command_center.py
@@ -205,6 +205,34 @@ async def compute_kiosk_weather(mcp_manager) -> "KioskWeather | None":
     return weather
 
 
+# Last weather value PUSHED to the kiosk hub, so the periodic refresher only
+# broadcasts on an actual change (diff-gate). None until the first push.
+_weather_last_pushed: dict | None = None
+
+
+async def refresh_and_push_kiosk_weather(mcp_manager) -> None:
+    """Backend-internal weather refresh → PUSH to the kiosk hub on change.
+
+    NOT a client poll (plan §1.6): the timer refreshes an EXTERNAL cache
+    (Open-Meteo has no push of its own), and the moment the reading changes it
+    streams a ``weather_updated`` delta to the connected wall displays instead of
+    waiting for the next connect/snapshot. Runs at ``_WEATHER_TTL_SECONDS`` so
+    each tick actually re-fetches. Diff-gated + fire-and-forget.
+    """
+    global _weather_last_pushed
+    weather = await compute_kiosk_weather(mcp_manager)
+    payload = weather.model_dump() if weather is not None else None
+    if payload == _weather_last_pushed:
+        return
+    _weather_last_pushed = payload
+    try:
+        from api.websocket.kiosk_handler import broadcast_kiosk_event
+
+        await broadcast_kiosk_event({"type": "weather_updated", "weather": payload})
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"kiosk weather_updated broadcast failed: {e}")
+
+
 @router.get("/weather", response_model=KioskWeather | None)
 @limiter.limit(settings.api_rate_limit_admin)
 async def kiosk_weather(

--- a/src/backend/api/routes/command_center.py
+++ b/src/backend/api/routes/command_center.py
@@ -153,19 +153,27 @@ _WEATHER_TTL_SECONDS = 600
 _weather_cache: dict[str, object] = {"at": 0.0, "value": None}
 
 
-async def compute_kiosk_weather(mcp_manager) -> "KioskWeather | None":
+async def compute_kiosk_weather(mcp_manager, force: bool = False) -> "KioskWeather | None":
     """Current conditions for the configured home location (process-cached).
 
     Shared by the REST ``/weather`` poll and the kiosk WS snapshot
     (``kiosk_handler``). ``None`` (never an error) when weather is disabled, no
     location is configured, or the MCP can't answer — the tile hides itself.
+
+    ``force=True`` bypasses the TTL cache READ (used by the periodic refresher so
+    a tick genuinely re-fetches even if a client snapshot just warmed the cache
+    mid-cycle); it still writes the cache on success.
     """
     location = (settings.kiosk_weather_location or "").strip()
     if not settings.weather_enabled or not location:
         return None
 
     now = time.monotonic()
-    if _weather_cache["value"] is not None and now - float(_weather_cache["at"]) < _WEATHER_TTL_SECONDS:
+    if (
+        not force
+        and _weather_cache["value"] is not None
+        and now - float(_weather_cache["at"]) < _WEATHER_TTL_SECONDS
+    ):
         return _weather_cache["value"]
 
     if mcp_manager is None:
@@ -220,7 +228,7 @@ async def refresh_and_push_kiosk_weather(mcp_manager) -> None:
     each tick actually re-fetches. Diff-gated + fire-and-forget.
     """
     global _weather_last_pushed
-    weather = await compute_kiosk_weather(mcp_manager)
+    weather = await compute_kiosk_weather(mcp_manager, force=True)
     payload = weather.model_dump() if weather is not None else None
     if payload == _weather_last_pushed:
         return
@@ -229,7 +237,7 @@ async def refresh_and_push_kiosk_weather(mcp_manager) -> None:
         from api.websocket.kiosk_handler import broadcast_kiosk_event
 
         await broadcast_kiosk_event({"type": "weather_updated", "weather": payload})
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         logger.debug(f"kiosk weather_updated broadcast failed: {e}")
 
 

--- a/src/backend/api/websocket/kiosk_handler.py
+++ b/src/backend/api/websocket/kiosk_handler.py
@@ -19,6 +19,37 @@ differences from ``kg_live_handler`` are:
 Privacy bar (non-negotiable): every message this hub emits is CONTENT-FREE —
 ids, names, counts, health, and state strings only. Never an utterance, never
 an entity name, never a user id. See ``tasks/kiosk-active-subsystem-plan.md`` §5.
+
+Protocol (hydrate-then-subscribe). On connect: one ``snapshot`` (all keys below,
+one-time compute). Then small delta events as they happen — the frontend folds
+each into the same reducer-held model. Every event is CONTENT-FREE.
+
+  * ``snapshot`` — ``{type, at, satellites[], presence{rooms[],people_present,
+    occupied_rooms}, mcp{enabled,total_tools,servers[]}, tool_health[], roles[],
+    activity[], peers[], weather|null, now_playing[]}``.
+  * ``satellite_state`` — ``{type, satellite_id, room, room_id, state}`` — a
+    satellite's SESSION state changed (idle/listening/processing/speaking/error).
+  * ``satellite_online`` / ``satellite_offline`` — ``{type, satellite_id, room,
+    room_id, online}`` — a satellite REGISTERED (connect/reconnect) or DROPPED
+    (disconnect / heartbeat-timeout). The liveness signal the frontend needs so a
+    crashed satellite stops pinning the voice core and a resumed one reappears —
+    distinct from ``satellite_state`` (which only carries the session state of an
+    already-online satellite). Phase 2.
+  * ``presence_changed`` — ``{type, rooms:[{room_id,room_name,occupants}],
+    people_present, occupied_rooms}`` — fires ONLY on an actual room-occupant-set
+    change (someone entered/left a room), never on a bare BLE RSSI tick. Same
+    shape as the snapshot's ``presence`` section. Phase 2.
+  * ``turn_activity`` — ``{type, role, subsystems[], ok, at}`` — one completed
+    chat turn (role + the subsystems it touched).
+  * ``now_playing_changed`` — ``{type, sessions:[…]}`` — the deduped per-room
+    PLAYING media set changed (start/stop/track/room move). ``sessions`` has the
+    same shape as the snapshot's ``now_playing``. Phase 2.
+  * ``tool_health_changed`` — ``{type, server, connected}`` — an MCP server's
+    connection flipped (reconnect healed it / it dropped). Phase 2.
+  * ``weather_updated`` — ``{type, weather:{…}|null}`` — pushed when the
+    backend-internal weather cache refreshes (never a client poll). Phase 2.
+  * ``peer_status_changed`` — see the plan §1.4/§9; REMAINING (needs a small
+    backend-internal reachability timer — no discrete federation event exists).
 """
 
 import asyncio
@@ -134,6 +165,31 @@ _TOOL_HEALTH_DEGRADED_BELOW = 0.5
 _PEER_REACHABLE_WITHIN_SECONDS = 300
 
 
+def build_presence_payload(presence) -> dict:
+    """Content-free rooms→occupant-count rollup of the live presence map.
+
+    The one shared shape behind both the connect ``snapshot``'s ``presence``
+    section and the ``presence_changed`` delta (``presence_service`` calls this
+    when an occupant set actually changes). Never emits user ids — only room
+    ids/names and integer counts.
+    """
+    rooms: dict[int, dict] = {}
+    for pres in presence.get_all_presence().values():
+        key = pres.room_id
+        if key is None:
+            continue
+        room = rooms.setdefault(
+            key, {"room_id": key, "room_name": pres.room_name, "occupants": 0}
+        )
+        room["occupants"] += 1
+    room_list = list(rooms.values())
+    return {
+        "rooms": room_list,
+        "people_present": sum(r["occupants"] for r in room_list),
+        "occupied_rooms": len(room_list),
+    }
+
+
 async def build_kiosk_snapshot(app) -> dict:
     """Compute the full current kiosk state ONCE, for the connect ``snapshot``.
 
@@ -167,22 +223,7 @@ async def build_kiosk_snapshot(app) -> dict:
     try:
         from ha_glue.services.presence_service import get_presence_service
 
-        presence = get_presence_service()
-        rooms: dict[int | None, dict] = {}
-        for pres in presence.get_all_presence().values():
-            key = pres.room_id
-            if key is None:
-                continue
-            room = rooms.setdefault(
-                key, {"room_id": key, "room_name": pres.room_name, "occupants": 0}
-            )
-            room["occupants"] += 1
-        room_list = list(rooms.values())
-        snapshot["presence"] = {
-            "rooms": room_list,
-            "people_present": sum(r["occupants"] for r in room_list),
-            "occupied_rooms": len(room_list),
-        }
+        snapshot["presence"] = build_presence_payload(get_presence_service())
     except Exception as e:
         logger.debug(f"kiosk snapshot: presence unavailable: {e}")
 

--- a/src/backend/ha_glue/api/websocket/satellite_handler.py
+++ b/src/backend/ha_glue/api/websocket/satellite_handler.py
@@ -893,4 +893,4 @@ Gib eine kurze, natürliche Antwort. KEIN JSON, nur Text."""
             wakeword_config_manager = get_wakeword_config_manager()
             wakeword_config_manager.unsubscribe(websocket)
 
-            await satellite_manager.unregister(satellite_id)
+            await satellite_manager.unregister(satellite_id, websocket=websocket)

--- a/src/backend/ha_glue/services/media_follow_service.py
+++ b/src/backend/ha_glue/services/media_follow_service.py
@@ -61,6 +61,15 @@ class MediaFollowService:
 
     def __init__(self) -> None:
         self._sessions: dict[int, MediaSession] = {}   # user_id → session
+        # Last now-playing set we broadcast to the kiosk hub. The delta is
+        # diff-gated against this so a no-op mutation (e.g. a suspend that leaves
+        # the PLAYING set unchanged) never fires a spurious push. None = never
+        # broadcast yet.
+        self._last_now_playing: list[dict] | None = None
+        # Strong refs to fire-and-forget broadcast tasks scheduled from SYNC
+        # mutation sites, so they aren't GC'd mid-flight (the boot-reconnect
+        # strand bug). Discarded on completion.
+        self._np_bg_tasks: set[asyncio.Task] = set()
 
     # ------------------------------------------------------------------
     # Playback Registration (called by InternalToolService)
@@ -96,12 +105,14 @@ class MediaFollowService:
             f"🎵 Media session registered: user={user_id} "
             f"type={media_type.value} room={room_name}"
         )
+        self._schedule_now_playing_broadcast()
 
     def clear_session(self, user_id: int) -> None:
         """Remove a user's media session."""
         removed = self._sessions.pop(user_id, None)
         if removed:
             logger.debug(f"🎵 Media session cleared: user={user_id}")
+            self._schedule_now_playing_broadcast()
 
     def clear_session_by_room(self, room_id: int) -> None:
         """Clear all sessions in a given room (e.g. on explicit stop)."""
@@ -112,6 +123,8 @@ class MediaFollowService:
         for uid in to_remove:
             self._sessions.pop(uid, None)
             logger.debug(f"🎵 Media session cleared by room stop: user={uid} room_id={room_id}")
+        if to_remove:
+            self._schedule_now_playing_broadcast()
 
     def get_session(self, user_id: int) -> MediaSession | None:
         return self._sessions.get(user_id)
@@ -146,6 +159,40 @@ class MediaFollowService:
         return out
 
     # ------------------------------------------------------------------
+    # Kiosk push (now_playing_changed delta)
+    # ------------------------------------------------------------------
+
+    async def _broadcast_now_playing_if_changed(self) -> None:
+        """Push a content-free ``now_playing_changed`` delta to the kiosk hub,
+        but ONLY when the deduped per-room PLAYING set actually changed
+        (start / stop / track / room move). Diff-gated against the last broadcast
+        so a mutation that leaves the visible set identical stays silent — the
+        transition guard that keeps this from firing on every internal touch.
+        Fire-and-forget: a hub failure must never disrupt playback."""
+        try:
+            sessions = self.active_sessions()
+            if sessions == self._last_now_playing:
+                return
+            self._last_now_playing = sessions
+            from api.websocket.kiosk_handler import broadcast_kiosk_event
+
+            await broadcast_kiosk_event(
+                {"type": "now_playing_changed", "sessions": sessions}
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"kiosk now_playing broadcast failed: {e}")
+
+    def _schedule_now_playing_broadcast(self) -> None:
+        """Fire the diff-gated now_playing broadcast from a SYNC mutation site
+        (register/clear). Strong-refs the task so it isn't GC'd before it runs."""
+        try:
+            task = asyncio.ensure_future(self._broadcast_now_playing_if_changed())
+        except RuntimeError:
+            return  # no running loop (e.g. a unit test poking the sync setter)
+        self._np_bg_tasks.add(task)
+        task.add_done_callback(self._np_bg_tasks.discard)
+
+    # ------------------------------------------------------------------
     # Presence Hook Handlers
     # ------------------------------------------------------------------
 
@@ -173,6 +220,7 @@ class MediaFollowService:
         await self._stop_playback(session)
         session.state = SessionState.SUSPENDED
         session.suspended_at = time.time()
+        await self._broadcast_now_playing_if_changed()
 
     async def on_user_enter_room(
         self, user_id: int, room_id: int, room_name: str, **kw
@@ -251,6 +299,8 @@ class MediaFollowService:
             await self._stop_playback(session)
             session.state = SessionState.SUSPENDED
             session.suspended_at = time.time()
+        if to_stop:
+            await self._broadcast_now_playing_if_changed()
 
     # ------------------------------------------------------------------
     # Internal: Stop / Resume
@@ -346,6 +396,7 @@ class MediaFollowService:
                     new_room_name,
                     session.title or session.station_name or session.album_name or "Media",
                 )
+                await self._broadcast_now_playing_if_changed()
             else:
                 logger.warning(
                     f"🎵 Resume failed for user {session.user_id} in {new_room_name}: "

--- a/src/backend/ha_glue/services/media_follow_service.py
+++ b/src/backend/ha_glue/services/media_follow_service.py
@@ -179,7 +179,7 @@ class MediaFollowService:
             await broadcast_kiosk_event(
                 {"type": "now_playing_changed", "sessions": sessions}
             )
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.debug(f"kiosk now_playing broadcast failed: {e}")
 
     def _schedule_now_playing_broadcast(self) -> None:
@@ -262,6 +262,10 @@ class MediaFollowService:
                     f"🎵 Conflict in {room_name}: user {existing_user_id} wins, "
                     f"user {user_id} stays suspended"
                 )
+                # The mover's old-room playback was already stopped above, so the
+                # kiosk now-playing tile must reflect that (diff-gated → no-op if
+                # nothing actually changed).
+                await self._broadcast_now_playing_if_changed()
                 return
             else:
                 # Entering user wins — suspend existing
@@ -402,6 +406,9 @@ class MediaFollowService:
                     f"🎵 Resume failed for user {session.user_id} in {new_room_name}: "
                     f"{result.get('message', 'unknown error')}"
                 )
+                # The old-room session was already stopped before this resume
+                # attempt, so reflect the now-stopped state on the kiosk too.
+                await self._broadcast_now_playing_if_changed()
 
         except Exception as e:
             logger.error(f"🎵 Error resuming playback in {new_room_name}: {e}")

--- a/src/backend/ha_glue/services/presence_service.py
+++ b/src/backend/ha_glue/services/presence_service.py
@@ -464,7 +464,7 @@ class PresenceService:
 
             payload = build_presence_payload(self)
             await broadcast_kiosk_event({"type": "presence_changed", **payload})
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.debug(f"kiosk presence_changed broadcast failed: {e}")
 
     async def register_voice_presence(

--- a/src/backend/ha_glue/services/presence_service.py
+++ b/src/backend/ha_glue/services/presence_service.py
@@ -443,6 +443,30 @@ class PresenceService:
         for event_name, kwargs in events:
             await run_hooks(event_name, **kwargs)
 
+        # Push ONE content-free presence_changed delta to the kiosk hub — but
+        # only when a room-occupant set actually changed this pass. _pending_events
+        # is populated exclusively by the enter/leave/last-left/first-arrived
+        # branches (already de-bounced by the room-assignment hysteresis), so an
+        # empty list means a bare RSSI tick with no membership change → no push.
+        # This is the §6 presence-chatter guard: we ride the existing transition
+        # signal, never the raw sensor cadence.
+        if events:
+            await self._broadcast_presence_changed()
+
+    async def _broadcast_presence_changed(self):
+        """Fire-and-forget a content-free rooms→occupant-count delta. A hub
+        failure must never disrupt presence tracking."""
+        try:
+            from api.websocket.kiosk_handler import (
+                broadcast_kiosk_event,
+                build_presence_payload,
+            )
+
+            payload = build_presence_payload(self)
+            await broadcast_kiosk_event({"type": "presence_changed", **payload})
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"kiosk presence_changed broadcast failed: {e}")
+
     async def register_voice_presence(
         self,
         user_id: int,

--- a/src/backend/ha_glue/services/satellite_manager.py
+++ b/src/backend/ha_glue/services/satellite_manager.py
@@ -233,29 +233,45 @@ class SatelliteManager:
             })
 
             # Push liveness so the kiosk reinstates a (re)connected satellite.
+            # room_id may still be None here (DB sync + set_room_id run after
+            # register); the delta carries the room NAME regardless, and the
+            # kiosk resolves the precise room_id from the next satellite_state
+            # delta / the next snapshot (handled Phase 3, frontend).
             await self._broadcast_satellite_liveness(
                 satellite_id, room, self.satellites[satellite_id].room_id, online=True
             )
 
             return True
 
-    async def unregister(self, satellite_id: str):
-        """Remove a satellite from the registry"""
+    async def unregister(self, satellite_id: str, websocket=None):
+        """Remove a satellite from the registry.
+
+        Pass the caller's ``websocket`` so a FAST RECONNECT is handled safely: if
+        a new connection already re-registered this id (its ``register`` ran
+        before this dying socket's ``finally``), the stored entry belongs to the
+        NEW socket — deleting it would drop a live satellite and push a spurious
+        ``satellite_offline``. The identity guard skips that. ``websocket=None``
+        keeps the legacy unconditional behavior for any caller without it.
+        """
         async with self._lock:
-            if satellite_id in self.satellites:
-                sat = self.satellites[satellite_id]
+            sat = self.satellites.get(satellite_id)
+            if sat is None:
+                return
+            if websocket is not None and sat.websocket is not websocket:
+                # A newer connection already replaced this entry — leave it.
+                return
 
-                # End any active session
-                if sat.current_session_id:
-                    await self._end_session_internal(sat.current_session_id)
+            # End any active session
+            if sat.current_session_id:
+                await self._end_session_internal(sat.current_session_id)
 
-                del self.satellites[satellite_id]
-                logger.info(f"👋 Satellite unregistered: {satellite_id}")
+            del self.satellites[satellite_id]
+            logger.info(f"👋 Satellite unregistered: {satellite_id}")
 
-                # Push liveness so the kiosk drops the departed satellite.
-                await self._broadcast_satellite_liveness(
-                    satellite_id, sat.room, sat.room_id, online=False
-                )
+            # Push liveness so the kiosk drops the departed satellite.
+            await self._broadcast_satellite_liveness(
+                satellite_id, sat.room, sat.room_id, online=False
+            )
 
     async def start_session(
         self,
@@ -406,7 +422,7 @@ class SatelliteManager:
                     "state": state.value,
                 }
             )
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.debug(f"kiosk satellite_state broadcast failed: {e}")
 
     async def _broadcast_satellite_liveness(
@@ -436,7 +452,7 @@ class SatelliteManager:
                     "online": online,
                 }
             )
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.debug(f"kiosk satellite liveness broadcast failed: {e}")
 
     async def set_session_state(

--- a/src/backend/ha_glue/services/satellite_manager.py
+++ b/src/backend/ha_glue/services/satellite_manager.py
@@ -232,6 +232,11 @@ class SatelliteManager:
                 "capabilities": capabilities
             })
 
+            # Push liveness so the kiosk reinstates a (re)connected satellite.
+            await self._broadcast_satellite_liveness(
+                satellite_id, room, self.satellites[satellite_id].room_id, online=True
+            )
+
             return True
 
     async def unregister(self, satellite_id: str):
@@ -246,6 +251,11 @@ class SatelliteManager:
 
                 del self.satellites[satellite_id]
                 logger.info(f"👋 Satellite unregistered: {satellite_id}")
+
+                # Push liveness so the kiosk drops the departed satellite.
+                await self._broadcast_satellite_liveness(
+                    satellite_id, sat.room, sat.room_id, online=False
+                )
 
     async def start_session(
         self,
@@ -398,6 +408,36 @@ class SatelliteManager:
             )
         except Exception as e:  # noqa: BLE001
             logger.debug(f"kiosk satellite_state broadcast failed: {e}")
+
+    async def _broadcast_satellite_liveness(
+        self, satellite_id: str, room: str | None, room_id: int | None, online: bool
+    ):
+        """Push a content-free ``satellite_online``/``satellite_offline`` delta.
+
+        This is the Phase-2 LIVENESS signal — distinct from ``satellite_state``
+        (which only carries the SESSION state of an already-connected satellite).
+        It fires when a satellite REGISTERS (connect/reconnect → online) or DROPS
+        (unregister / heartbeat-timeout → offline), so the kiosk drops a crashed
+        satellite out of the constellation (stops it pinning the voice core) and
+        reinstates a resumed one, instead of decaying frozen roster data against
+        the wall clock. Fire-and-forget: a hub failure must never break voice.
+        Called under ``self._lock`` — safe because ``broadcast_kiosk_event`` only
+        enqueues (the hub offloads the real send).
+        """
+        try:
+            from api.websocket.kiosk_handler import broadcast_kiosk_event
+
+            await broadcast_kiosk_event(
+                {
+                    "type": "satellite_online" if online else "satellite_offline",
+                    "satellite_id": satellite_id,
+                    "room": room,
+                    "room_id": room_id,
+                    "online": online,
+                }
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"kiosk satellite liveness broadcast failed: {e}")
 
     async def set_session_state(
         self,
@@ -875,7 +915,12 @@ class SatelliteManager:
                 sat = self.satellites[sat_id]
                 if sat.current_session_id:
                     await self._end_session_internal(sat.current_session_id, reason="disconnect")
+                room, room_id = sat.room, sat.room_id
                 del self.satellites[sat_id]
+                # Push liveness so the kiosk drops a satellite that timed out.
+                await self._broadcast_satellite_liveness(
+                    sat_id, room, room_id, online=False
+                )
 
 
 # Global singleton instance

--- a/src/backend/services/mcp_client.py
+++ b/src/backend/services/mcp_client.py
@@ -849,12 +849,15 @@ class MCPManager:
         if state.connected == connected:
             return
         state.connected = connected
+        # Check for a running loop BEFORE creating the coroutine, so the
+        # config-time / sync path doesn't leave an un-awaited coroutine.
         try:
-            task = asyncio.ensure_future(
-                self._broadcast_tool_health(state.config.name, connected)
-            )
+            loop = asyncio.get_running_loop()
         except RuntimeError:
             return  # no running loop (config-time / sync test path)
+        task = loop.create_task(
+            self._broadcast_tool_health(state.config.name, connected)
+        )
         self._health_bg_tasks.add(task)
         task.add_done_callback(self._health_bg_tasks.discard)
 
@@ -869,7 +872,7 @@ class MCPManager:
                     "connected": connected,
                 }
             )
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             logger.debug(f"kiosk tool_health broadcast failed: {e}")
 
     def load_config(self, path: str, only: set[str] | None = None) -> None:

--- a/src/backend/services/mcp_client.py
+++ b/src/backend/services/mcp_client.py
@@ -831,6 +831,46 @@ class MCPManager:
         self._tool_index: dict[str, MCPToolInfo] = {}  # namespaced_name -> MCPToolInfo
         self._tool_overrides: dict[str, list[str] | None] = {}  # DB overrides per server
         self._refresh_task: asyncio.Task | None = None
+        # Strong refs to fire-and-forget kiosk tool_health broadcasts scheduled
+        # from _set_connected (a sync funnel called from both sync and async
+        # contexts), so a task isn't GC'd before it runs.
+        self._health_bg_tasks: set[asyncio.Task] = set()
+
+    def _set_connected(self, state: "MCPServerState", connected: bool) -> None:
+        """Single funnel for every server-connection flip.
+
+        Sets ``state.connected`` AND, on an actual TRANSITION (not a redundant
+        re-assign of the same value), fire-and-forget pushes a content-free
+        ``tool_health_changed`` delta to the kiosk hub — so a wall display learns
+        a server dropped or a reconnect healed it within one WS round-trip,
+        instead of decaying frozen tool-health status. Fire-and-forget: a hub
+        failure must never affect MCP operation. Every ``state.connected =`` site
+        routes through here so no transition is missed."""
+        if state.connected == connected:
+            return
+        state.connected = connected
+        try:
+            task = asyncio.ensure_future(
+                self._broadcast_tool_health(state.config.name, connected)
+            )
+        except RuntimeError:
+            return  # no running loop (config-time / sync test path)
+        self._health_bg_tasks.add(task)
+        task.add_done_callback(self._health_bg_tasks.discard)
+
+    async def _broadcast_tool_health(self, server_name: str, connected: bool) -> None:
+        try:
+            from api.websocket.kiosk_handler import broadcast_kiosk_event
+
+            await broadcast_kiosk_event(
+                {
+                    "type": "tool_health_changed",
+                    "server": server_name,
+                    "connected": connected,
+                }
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"kiosk tool_health broadcast failed: {e}")
 
     def load_config(self, path: str, only: set[str] | None = None) -> None:
         """Load MCP server configuration from YAML file.
@@ -1072,7 +1112,7 @@ class MCPManager:
 
             state.session = session
             state.exit_stack = exit_stack
-            state.connected = True
+            self._set_connected(state, True)
             state.all_discovered_tools = all_tools
             state.last_error = None
 
@@ -1096,7 +1136,7 @@ class MCPManager:
                 logger.info(f"MCP server '{config.name}' connected: {len(state.tools)} tools")
 
         except Exception as e:
-            state.connected = False
+            self._set_connected(state, False)
             state.last_error = str(e)
 
             # Record failure for exponential backoff
@@ -1206,7 +1246,7 @@ class MCPManager:
             return {"ok": True, "latency_ms": latency, "detail": None}
 
         # Probe failed → mark stale and try one reconnect, then re-probe.
-        state.connected = False
+        self._set_connected(state, False)
         state.last_error = detail
         reconnected = await self._reconnect_server(state)
         if not reconnected:
@@ -1218,7 +1258,7 @@ class MCPManager:
             # Reconnect succeeded but the fresh session still can't list_tools.
             # Don't leave state.connected=True after we've seen evidence of
             # breakage — next caller would try to use a known-bad session.
-            state.connected = False
+            self._set_connected(state, False)
             state.last_error = detail
         return {"ok": ok, "latency_ms": latency, "detail": detail}
 
@@ -1490,7 +1530,7 @@ class MCPManager:
                         f"MCP session died on {namespaced_name}: {type(e).__name__}: {e}; "
                         f"reconnecting and retrying once"
                     )
-                    state.connected = False
+                    self._set_connected(state, False)
                     state.last_error = str(e)
                     reconnected = await self._reconnect_server(state)
                     if not reconnected:
@@ -1499,7 +1539,7 @@ class MCPManager:
                 logger.error(
                     f"MCP tool call failed after reconnect: {namespaced_name}: {e}"
                 )
-                state.connected = False
+                self._set_connected(state, False)
                 state.last_error = str(e)
 
         if result is None:
@@ -1948,7 +1988,7 @@ class MCPManager:
             return
         except Exception as e:
             logger.error(f"MCP tool call failed: {namespaced_name}: {e}")
-            state.connected = False
+            self._set_connected(state, False)
             state.last_error = str(e)
             yield {
                 "success": False,
@@ -2093,7 +2133,7 @@ class MCPManager:
 
                 except Exception as e:
                     logger.warning(f"MCP refresh failed for '{state.config.name}': {e}")
-                    state.connected = False
+                    self._set_connected(state, False)
                     state.last_error = str(e)
             elif not state.connected:
                 # Check if backoff allows reconnection attempt
@@ -2215,7 +2255,7 @@ class MCPManager:
                     await state.exit_stack.__aexit__(None, None, None)
                 except Exception as e:
                     logger.warning(f"MCP shutdown error for '{state.config.name}': {e}")
-            state.connected = False
+            self._set_connected(state, False)
             state.session = None
             state.exit_stack = None
 

--- a/tests/backend/test_kiosk_deltas.py
+++ b/tests/backend/test_kiosk_deltas.py
@@ -330,7 +330,7 @@ async def test_weather_updated_diff_gated(monkeypatch):
         condition="clear",
     )
 
-    async def _fake_compute(_mgr):
+    async def _fake_compute(_mgr, force=False):
         return weather
 
     monkeypatch.setattr(cc, "compute_kiosk_weather", _fake_compute)
@@ -352,7 +352,7 @@ async def test_weather_updated_pushes_none_when_unavailable(monkeypatch):
 
     monkeypatch.setattr(cc, "_weather_last_pushed", {"temp": 5.0}, raising=False)
 
-    async def _fake_compute(_mgr):
+    async def _fake_compute(_mgr, force=False):
         return None
 
     monkeypatch.setattr(cc, "compute_kiosk_weather", _fake_compute)

--- a/tests/backend/test_kiosk_deltas.py
+++ b/tests/backend/test_kiosk_deltas.py
@@ -90,6 +90,28 @@ async def test_unregister_broadcasts_satellite_offline():
 
 @pytest.mark.backend
 @pytest.mark.asyncio
+async def test_stale_unregister_does_not_drop_reconnected_satellite():
+    """Fast reconnect: a NEW connection re-registers sat-1 before the OLD
+    socket's finally→unregister runs. The identity-guarded unregister(old_ws)
+    must NOT delete the live (new) entry nor push a spurious satellite_offline."""
+    from ha_glue.services.satellite_manager import SatelliteManager
+
+    mgr = SatelliteManager()
+    old_ws, new_ws = AsyncMock(), AsyncMock()
+    await mgr.register("sat-1", "Room", old_ws, {})
+    await mgr.register("sat-1", "Room", new_ws, {})  # reconnect replaces the entry
+    assert mgr.satellites["sat-1"].websocket is new_ws
+
+    with _patch_broadcast() as bcast:
+        await mgr.unregister("sat-1", websocket=old_ws)  # the DYING old socket
+
+    assert "sat-1" in mgr.satellites  # live entry preserved
+    assert mgr.satellites["sat-1"].websocket is new_ws
+    assert _events_of_type(bcast, "satellite_offline") == []  # no spurious offline
+
+
+@pytest.mark.backend
+@pytest.mark.asyncio
 async def test_cleanup_stale_broadcasts_satellite_offline():
     from ha_glue.services.satellite_manager import SatelliteManager
 

--- a/tests/backend/test_kiosk_deltas.py
+++ b/tests/backend/test_kiosk_deltas.py
@@ -1,0 +1,343 @@
+"""Backend tests for the Phase-2 kiosk liveness deltas.
+
+Each producer pushes a CONTENT-FREE delta through the merged
+``broadcast_kiosk_event`` at the right transition — and, critically, does NOT
+over-fire on a non-transition (the presence-chatter / now-playing / tool-health
+diff guards). Every producer does a lazy ``from api.websocket.kiosk_handler
+import broadcast_kiosk_event`` at call time, so patching the module attribute
+intercepts the push.
+
+Covers:
+  * satellite liveness  — ``satellite_online`` on register, ``satellite_offline``
+    on unregister and heartbeat-timeout.
+  * ``presence_changed`` — fires on an occupant-set change, NOT on a bare RSSI
+    tick with no membership change.
+  * ``now_playing_changed`` — diff-gated: fires on a real change, silent on a
+    repeat.
+  * ``tool_health_changed`` — ``_set_connected`` fires only on a transition.
+  * ``weather_updated`` — ``refresh_and_push_kiosk_weather`` diff-gated.
+
+Run on the .159 build box (CI is non-functional): see
+``memory/reference_test_runner_159.md``.
+"""
+from __future__ import annotations
+
+import asyncio
+import types
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+def _patch_broadcast() -> AsyncMock:
+    """Patch the hub broadcast and return the mock. Callers use it inside a
+    ``with`` block (context manager) so the patch is scoped to the test."""
+    return patch("api.websocket.kiosk_handler.broadcast_kiosk_event", new=AsyncMock())
+
+
+def _events(mock: AsyncMock) -> list[dict]:
+    return [c.args[0] for c in mock.call_args_list]
+
+
+def _events_of_type(mock: AsyncMock, type_: str) -> list[dict]:
+    return [e for e in _events(mock) if e.get("type") == type_]
+
+
+# ==========================================================================
+# 1. Satellite liveness
+# ==========================================================================
+
+
+@pytest.mark.backend
+@pytest.mark.asyncio
+async def test_register_broadcasts_satellite_online():
+    from ha_glue.services.satellite_manager import SatelliteManager
+
+    mgr = SatelliteManager()
+    with _patch_broadcast() as bcast:
+        await mgr.register(
+            satellite_id="sat-küche",
+            room="Küche",
+            websocket=AsyncMock(),
+            capabilities={},
+        )
+
+    online = _events_of_type(bcast, "satellite_online")
+    assert len(online) == 1
+    ev = online[0]
+    assert ev["satellite_id"] == "sat-küche"
+    assert ev["room"] == "Küche"
+    assert ev["online"] is True
+    # Content-free: only ids/names/state keys, never an utterance or user id.
+    assert set(ev) == {"type", "satellite_id", "room", "room_id", "online"}
+
+
+@pytest.mark.backend
+@pytest.mark.asyncio
+async def test_unregister_broadcasts_satellite_offline():
+    from ha_glue.services.satellite_manager import SatelliteManager
+
+    mgr = SatelliteManager()
+    await mgr.register("sat-1", "Room", AsyncMock(), {})
+    with _patch_broadcast() as bcast:
+        await mgr.unregister("sat-1")
+
+    offline = _events_of_type(bcast, "satellite_offline")
+    assert len(offline) == 1
+    assert offline[0]["satellite_id"] == "sat-1"
+    assert offline[0]["online"] is False
+
+
+@pytest.mark.backend
+@pytest.mark.asyncio
+async def test_cleanup_stale_broadcasts_satellite_offline():
+    from ha_glue.services.satellite_manager import SatelliteManager
+
+    mgr = SatelliteManager()
+    await mgr.register("sat-stale", "Room", AsyncMock(), {})
+    # Force the heartbeat far into the past so cleanup_stale evicts it.
+    mgr.satellites["sat-stale"].last_heartbeat = 0.0
+    with _patch_broadcast() as bcast:
+        await mgr.cleanup_stale()
+
+    assert "sat-stale" not in mgr.satellites
+    offline = _events_of_type(bcast, "satellite_offline")
+    assert len(offline) == 1
+    assert offline[0]["satellite_id"] == "sat-stale"
+    assert offline[0]["online"] is False
+
+
+# ==========================================================================
+# 2. presence_changed
+# ==========================================================================
+
+
+def _presence_service():
+    """A fresh PresenceService with the attributes the hot path touches, without
+    importing settings (mirrors test_presence_service's fixture)."""
+    from ha_glue.services.presence_service import PresenceService
+
+    svc = PresenceService.__new__(PresenceService)
+    svc._mac_to_user = {"AA:BB:CC:DD:EE:01": 1}
+    svc._mac_to_method = {"AA:BB:CC:DD:EE:01": "ble"}
+    svc._presence = {}
+    svc._sightings = {}
+    svc._hysteresis_threshold = 2
+    svc._stale_timeout = 120.0
+    svc._rssi_threshold = -80
+    svc._room_names = {}
+    svc._user_names = {1: "alice"}
+    svc._user_first_names = {}
+    svc._user_last_names = {}
+    svc._pending_events = []
+    return svc
+
+
+@pytest.mark.backend
+@pytest.mark.asyncio
+async def test_presence_changed_fires_on_occupant_change():
+    svc = _presence_service()
+    with _patch_broadcast() as bcast:
+        await svc.process_ble_report(
+            satellite_id="sat-kitchen",
+            room_id=10,
+            devices=[{"mac": "AA:BB:CC:DD:EE:01", "rssi": -50}],
+            room_name="Kitchen",
+        )
+
+    changed = _events_of_type(bcast, "presence_changed")
+    assert len(changed) == 1
+    ev = changed[0]
+    assert ev["people_present"] == 1
+    assert ev["occupied_rooms"] == 1
+    assert ev["rooms"] == [{"room_id": 10, "room_name": "Kitchen", "occupants": 1}]
+    # Content-free: no user ids anywhere in the payload.
+    assert set(ev) == {"type", "rooms", "people_present", "occupied_rooms"}
+
+
+@pytest.mark.backend
+@pytest.mark.asyncio
+async def test_presence_changed_does_not_fire_on_bare_rssi_tick():
+    """The §6 chatter guard: once the user holds a room, a further identical
+    sighting is a bare RSSI tick with no membership change → NO broadcast."""
+    svc = _presence_service()
+    # First report establishes the room (fires once).
+    await svc.process_ble_report(
+        satellite_id="sat-kitchen",
+        room_id=10,
+        devices=[{"mac": "AA:BB:CC:DD:EE:01", "rssi": -50}],
+        room_name="Kitchen",
+    )
+    # Second identical report — same room, no occupant-set change.
+    with _patch_broadcast() as bcast:
+        await svc.process_ble_report(
+            satellite_id="sat-kitchen",
+            room_id=10,
+            devices=[{"mac": "AA:BB:CC:DD:EE:01", "rssi": -50}],
+            room_name="Kitchen",
+        )
+
+    assert _events_of_type(bcast, "presence_changed") == []
+
+
+# ==========================================================================
+# 3. now_playing_changed
+# ==========================================================================
+
+
+@pytest.mark.backend
+@pytest.mark.asyncio
+async def test_now_playing_broadcast_diff_gated():
+    from ha_glue.services.media_follow_service import MediaFollowService, MediaType
+
+    svc = MediaFollowService()
+    svc.register_playback(
+        user_id=1,
+        room_id=10,
+        room_name="Wohnzimmer",
+        media_type=MediaType.RADIO,
+        station_name="BBC",
+        title="BBC",
+    )
+    # register_playback scheduled a fire-and-forget push (real hub = no-op with
+    # no clients, but it may set _last_now_playing). Drain it and reset the
+    # diff-gate so this test exercises the helper deterministically.
+    await asyncio.sleep(0)
+    if svc._np_bg_tasks:
+        await asyncio.gather(*svc._np_bg_tasks)
+    svc._last_now_playing = None
+    with _patch_broadcast() as bcast:
+        # First push: the set changed vs the (None) baseline.
+        await svc._broadcast_now_playing_if_changed()
+        assert len(_events_of_type(bcast, "now_playing_changed")) == 1
+        ev = _events_of_type(bcast, "now_playing_changed")[0]
+        assert ev["sessions"] and ev["sessions"][0]["room"] == "Wohnzimmer"
+        # Second push with nothing changed: diff-gated → silent.
+        await svc._broadcast_now_playing_if_changed()
+        assert len(_events_of_type(bcast, "now_playing_changed")) == 1
+
+
+@pytest.mark.backend
+@pytest.mark.asyncio
+async def test_register_playback_schedules_now_playing_push():
+    from ha_glue.services.media_follow_service import MediaFollowService, MediaType
+
+    svc = MediaFollowService()
+    with _patch_broadcast() as bcast:
+        svc.register_playback(
+            user_id=1,
+            room_id=10,
+            room_name="Wohnzimmer",
+            media_type=MediaType.RADIO,
+            title="BBC",
+        )
+        # The sync mutation site scheduled a fire-and-forget task; let it run.
+        await asyncio.sleep(0)
+        await asyncio.gather(*svc._np_bg_tasks)
+
+    assert len(_events_of_type(bcast, "now_playing_changed")) == 1
+
+
+# ==========================================================================
+# 4. tool_health_changed
+# ==========================================================================
+
+
+def _fake_state(name: str, connected: bool = False):
+    return types.SimpleNamespace(
+        connected=connected, config=types.SimpleNamespace(name=name)
+    )
+
+
+@pytest.mark.backend
+@pytest.mark.asyncio
+async def test_tool_health_broadcast_on_transition():
+    from services.mcp_client import MCPManager
+
+    mgr = MCPManager()
+    state = _fake_state("weather", connected=False)
+    with _patch_broadcast() as bcast:
+        mgr._set_connected(state, True)  # False → True (transition)
+        await asyncio.sleep(0)
+        await asyncio.gather(*mgr._health_bg_tasks)
+
+    events = _events_of_type(bcast, "tool_health_changed")
+    assert len(events) == 1
+    assert events[0] == {
+        "type": "tool_health_changed",
+        "server": "weather",
+        "connected": True,
+    }
+    assert state.connected is True
+
+
+@pytest.mark.backend
+@pytest.mark.asyncio
+async def test_tool_health_no_broadcast_on_same_value():
+    from services.mcp_client import MCPManager
+
+    mgr = MCPManager()
+    state = _fake_state("weather", connected=True)
+    with _patch_broadcast() as bcast:
+        mgr._set_connected(state, True)  # True → True (no transition)
+        await asyncio.sleep(0)
+        if mgr._health_bg_tasks:
+            await asyncio.gather(*mgr._health_bg_tasks)
+
+    assert _events_of_type(bcast, "tool_health_changed") == []
+
+
+# ==========================================================================
+# 5. weather_updated
+# ==========================================================================
+
+
+@pytest.mark.backend
+@pytest.mark.asyncio
+async def test_weather_updated_diff_gated(monkeypatch):
+    import api.routes.command_center as cc
+
+    # Reset the module-level push-dedup state so the test is order-independent.
+    monkeypatch.setattr(cc, "_weather_last_pushed", None, raising=False)
+
+    weather = cc.KioskWeather(
+        location="Korschenbroich",
+        temp=18.0,
+        unit="°C",
+        code=1,
+        condition="clear",
+    )
+
+    async def _fake_compute(_mgr):
+        return weather
+
+    monkeypatch.setattr(cc, "compute_kiosk_weather", _fake_compute)
+
+    with _patch_broadcast() as bcast:
+        await cc.refresh_and_push_kiosk_weather(mcp_manager=object())
+        assert len(_events_of_type(bcast, "weather_updated")) == 1
+        ev = _events_of_type(bcast, "weather_updated")[0]
+        assert ev["weather"]["temp"] == 18.0
+        # Same reading again → diff-gated silent.
+        await cc.refresh_and_push_kiosk_weather(mcp_manager=object())
+        assert len(_events_of_type(bcast, "weather_updated")) == 1
+
+
+@pytest.mark.backend
+@pytest.mark.asyncio
+async def test_weather_updated_pushes_none_when_unavailable(monkeypatch):
+    import api.routes.command_center as cc
+
+    monkeypatch.setattr(cc, "_weather_last_pushed", {"temp": 5.0}, raising=False)
+
+    async def _fake_compute(_mgr):
+        return None
+
+    monkeypatch.setattr(cc, "compute_kiosk_weather", _fake_compute)
+
+    with _patch_broadcast() as bcast:
+        await cc.refresh_and_push_kiosk_weather(mcp_manager=object())
+
+    events = _events_of_type(bcast, "weather_updated")
+    assert len(events) == 1
+    assert events[0]["weather"] is None  # tile hides itself


### PR DESCRIPTION
Phase 2 of the kiosk push feature (design: `tasks/kiosk-active-subsystem-plan.md`). Backend liveness deltas so the frontend port (phase 3) never has to decay frozen snapshot data against the wall clock — the root cause of the phase-1b-port regressions. All pushed via the merged content-free fire-and-forget `broadcast_kiosk_event`.

## Deltas wired
- **Satellite liveness** (`satellite_online`/`satellite_offline`) at register/unregister/heartbeat-timeout — the piece that makes a crashed satellite drop out of the voice core and a resumed one reappear.
- **`presence_changed`** — only on a real occupant-set change (rides the enter/leave events, NOT every RSSI tick — §6 guard).
- **`now_playing_changed`** — diff-gated on the per-room PLAYING set.
- **`tool_health_changed`** — MCP connect/disconnect, via a `_set_connected` funnel routing all 9 sites, transition-only.
- **`weather_updated`** — a backend-internal refresh timer that PUSHES on change (Open-Meteo has no push; the browser never polls — §1.6), gated on connected clients.

## Review (all findings addressed)
`/review` found + fixed: a **fast-reconnect race** (the dying socket's `unregister` deleted the freshly re-registered live entry + pushed a spurious offline → now websocket-identity-guarded, with a regression test); media-follow broadcast gaps at conflict-lose/resume-fail exits; the weather refresher reading a stale cache (force-fresh + client-gate); a no-loop coroutine leak in `_set_connected`.

## Deferred (small follow-up, don't block the port)
`peer_status_changed` (needs a backend-internal reachability timer) and the per-call tool-degraded threshold. Phase 3's frontend uses the snapshot's `reachable`/health directly, so these aren't blocking. Also: `satellite_online` may carry `room_id=None` at register (DB sync runs after) — phase 3 resolves it from the next state delta/snapshot.

## Tests
12 delta tests on `.159` (each fires at the right transition, content-free shape, and does NOT over-fire — presence-tick / diff-gate / transition-only). No consumer regressions. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>