### PR TITLE
fix(kiosk): emit active-subsystem pulse from the voice path

### DIFF
--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -209,84 +209,10 @@ def _extract_agent_sources(tool_results: list) -> list[dict]:
     return sources
 
 
-# Maps the platform-core / ha_glue ``internal.*`` tools (which have no MCP
-# server, hence no natural ring node) onto a kiosk subsystem id. Unknown internal
-# tools are intentionally skipped (no pulse). ``homeassistant`` and ``weather``
-# are REAL MCP servers (they already render as tool-ring nodes); ``knowledge`` /
-# ``presence`` / ``media`` are INTERNAL-ONLY subsystems with no MCP server — the
-# kiosk renders synthetic pulse-only nodes for exactly those three, so this map's
-# internal-only value set MUST stay in sync with the frontend
-# ``INTERNAL_SUBSYSTEM_NODES`` (components/kiosk/useKioskModel.ts). Pure Gen-UI
-# formatting tools (render_table / render_list) touch no subsystem → omitted.
-INTERNAL_SUBSYSTEM_LABELS: dict[str, str] = {
-    # knowledge / second brain — RAG, memory, document ingest + maintenance
-    "internal.knowledge_search": "knowledge",
-    "internal.list_my_memories": "knowledge",
-    "internal.forward_attachment_to_paperless": "knowledge",
-    "internal.paperless_commit_upload": "knowledge",
-    "internal.ingest_file": "knowledge",
-    "internal.ingest_status": "knowledge",
-    "internal.reindex_documents": "knowledge",
-    "internal.list_chunkless_documents": "knowledge",
-    # presence
-    "internal.presence_map": "presence",
-    "internal.presence_history": "presence",
-    "internal.get_all_presence": "presence",
-    "internal.get_user_location": "presence",
-    "internal.bluetooth_scan": "presence",
-    # home assistant — device control + spoken announcements via HA speakers
-    "internal.device_action": "homeassistant",
-    "internal.device_controls": "homeassistant",
-    "internal.announce_in_room": "homeassistant",
-    "internal.broadcast_announcement": "homeassistant",
-    # weather (wraps the weather MCP)
-    "internal.weather_widget": "weather",
-    # media — DLNA / radio / server playback orchestration
-    "internal.media_control": "media",
-    "internal.play_radio": "media",
-    "internal.play_in_room": "media",
-    "internal.play_from_server": "media",
-    "internal.play_album_on_dlna": "media",
-    "internal.play_video_on_dlna": "media",
-    "internal.list_radio_favorites": "media",
-    "internal.save_radio_favorite": "media",
-    "internal.remove_radio_favorite": "media",
-    "internal.resolve_room_player": "media",
-}
-
-# A single turn rarely touches many subsystems; cap the pushed/persisted list so
-# an orchestrated fan-out can't bloat the event or the row.
-_MAX_SUBSYSTEMS_PER_TURN = 5
-
-
-def _extract_subsystems_used(tool_results: list) -> list[str]:
-    """Derive the content-free subsystem ids a turn touched, for the kiosk pulse.
-
-    ``mcp.<server>.<tool>`` → ``<server>``; ``internal.<tool>`` → the static
-    ``INTERNAL_SUBSYSTEM_LABELS`` allowlist (unknown internal tools skipped).
-    Deduped, order-preserved, capped at ``_MAX_SUBSYSTEMS_PER_TURN``. Empty when
-    the turn populated no ``agent_tool_results`` (direct-LLM / shortcut paths).
-    """
-    subsystems: list[str] = []
-    seen: set[str] = set()
-    for entry in tool_results:
-        tool_name = entry[0] if isinstance(entry, (tuple, list)) and entry else None
-        if not isinstance(tool_name, str) or not tool_name:
-            continue
-        if tool_name.startswith("mcp."):
-            parts = tool_name.split(".")
-            sub = parts[1] if len(parts) >= 3 and parts[1] else None
-        elif tool_name.startswith("internal."):
-            sub = INTERNAL_SUBSYSTEM_LABELS.get(tool_name)
-        else:
-            sub = None
-        if not sub or sub in seen:
-            continue
-        seen.add(sub)
-        subsystems.append(sub)
-        if len(subsystems) >= _MAX_SUBSYSTEMS_PER_TURN:
-            break
-    return subsystems
+# The kiosk active-subsystem pulse helpers (INTERNAL_SUBSYSTEM_LABELS,
+# extract_subsystems_used, broadcast_turn_activity) moved to
+# ``api.websocket.kiosk_data`` so the voice path (satellite_handler) can emit the
+# same pulse — imported at the emit site below.
 
 
 def _collect_tool_artifacts(tool_results: list) -> list:
@@ -2301,30 +2227,21 @@ WICHTIG: Nutze die ECHTEN Daten aus dem Ergebnis! Gib NUR die Antwort, KEIN JSON
 
             # Kiosk "active subsystem" pulse: which subsystems this turn touched.
             # Persisted alongside agent_role (durable record + reconnect hydrate)
-            # AND broadcast to the kiosk hub as a content-free turn_activity delta
-            # (role + subsystems + ok). Omitted entirely when there's nothing to
-            # show (no role and no subsystems → a no-op push).
-            subsystems_used = _extract_subsystems_used(agent_tool_results)
+            # AND broadcast to the kiosk hub as a content-free turn_activity delta.
+            from api.websocket.kiosk_data import (
+                broadcast_turn_activity,
+                extract_subsystems_used,
+            )
+
+            subsystems_used = extract_subsystems_used(agent_tool_results)
             if subsystems_used:
                 assistant_metadata["subsystems_used"] = subsystems_used
             turn_role = role.name if role else None
-            if turn_role or subsystems_used:
-                try:
-                    from datetime import UTC, datetime
-
-                    from api.websocket.kiosk_handler import broadcast_kiosk_event
-
-                    await broadcast_kiosk_event(
-                        {
-                            "type": "turn_activity",
-                            "role": turn_role,
-                            "subsystems": subsystems_used,
-                            "ok": action_result.get("success") if action_result else None,
-                            "at": datetime.now(UTC).isoformat(),
-                        }
-                    )
-                except Exception as e:  # noqa: BLE001 — never break the turn on a push
-                    logger.debug(f"kiosk turn_activity broadcast failed: {e}")
+            await broadcast_turn_activity(
+                turn_role,
+                subsystems_used,
+                action_result.get("success") if action_result else None,
+            )
 
             # Typed artifacts (Lane A) produced this turn by the sub-intent /
             # orchestration card path. Persisted as message_metadata["artifacts"]

--- a/src/backend/api/websocket/kiosk_data.py
+++ b/src/backend/api/websocket/kiosk_data.py
@@ -82,6 +82,122 @@ async def recent_role_activity_entries(
 
 
 # ---------------------------------------------------------------------------
+# Active-subsystem pulse — which subsystem(s) a completed turn touched. Shared by
+# BOTH the web-chat path (chat_handler) AND the voice path (satellite_handler) so
+# a spoken "turn off the light" lights the same kiosk node a typed one does. It
+# lived in chat_handler until the voice path was found to never pulse (the household
+# talks to satellites, not the web chat) — moved here so both can emit it.
+# ---------------------------------------------------------------------------
+
+# Maps the platform-core / ha_glue ``internal.*`` tools (which have no MCP server,
+# hence no natural ring node) onto a kiosk subsystem id. Unknown internal tools
+# are intentionally skipped (no pulse). ``homeassistant`` and ``weather`` are REAL
+# MCP servers (they already render as tool-ring nodes); ``knowledge`` / ``presence``
+# / ``media`` are INTERNAL-ONLY subsystems with no MCP server — the kiosk renders
+# synthetic pulse-only nodes for exactly those three, so this map's internal-only
+# value set MUST stay in sync with the frontend ``INTERNAL_SUBSYSTEM_NODES``
+# (components/kiosk/useKioskModel.ts). Pure Gen-UI formatting tools (render_table /
+# render_list) touch no subsystem → omitted.
+INTERNAL_SUBSYSTEM_LABELS: dict[str, str] = {
+    # knowledge / second brain — RAG, memory, document ingest + maintenance
+    "internal.knowledge_search": "knowledge",
+    "internal.list_my_memories": "knowledge",
+    "internal.forward_attachment_to_paperless": "knowledge",
+    "internal.paperless_commit_upload": "knowledge",
+    "internal.ingest_file": "knowledge",
+    "internal.ingest_status": "knowledge",
+    "internal.reindex_documents": "knowledge",
+    "internal.list_chunkless_documents": "knowledge",
+    # presence
+    "internal.presence_map": "presence",
+    "internal.presence_history": "presence",
+    "internal.get_all_presence": "presence",
+    "internal.get_user_location": "presence",
+    "internal.bluetooth_scan": "presence",
+    # home assistant — device control + spoken announcements via HA speakers
+    "internal.device_action": "homeassistant",
+    "internal.device_controls": "homeassistant",
+    "internal.announce_in_room": "homeassistant",
+    "internal.broadcast_announcement": "homeassistant",
+    # weather (wraps the weather MCP)
+    "internal.weather_widget": "weather",
+    # media — DLNA / radio / server playback orchestration
+    "internal.media_control": "media",
+    "internal.play_radio": "media",
+    "internal.play_in_room": "media",
+    "internal.play_from_server": "media",
+    "internal.play_album_on_dlna": "media",
+    "internal.play_video_on_dlna": "media",
+    "internal.list_radio_favorites": "media",
+    "internal.save_radio_favorite": "media",
+    "internal.remove_radio_favorite": "media",
+    "internal.resolve_room_player": "media",
+}
+
+# A single turn rarely touches many subsystems; cap the pushed/persisted list so
+# an orchestrated fan-out can't bloat the event or the row.
+_MAX_SUBSYSTEMS_PER_TURN = 5
+
+
+def extract_subsystems_used(tool_results: list) -> list[str]:
+    """Derive the content-free subsystem ids a turn touched, for the kiosk pulse.
+
+    Each entry is a ``(tool_name, data)`` pair (only ``tool_name`` is read).
+    ``mcp.<server>.<tool>`` → ``<server>``; ``internal.<tool>`` → the static
+    ``INTERNAL_SUBSYSTEM_LABELS`` allowlist (unknown internal tools skipped).
+    Deduped, order-preserved, capped at ``_MAX_SUBSYSTEMS_PER_TURN``. Empty when a
+    turn ran no tool (direct-LLM / ``general.conversation`` / shortcut paths).
+    """
+    subsystems: list[str] = []
+    seen: set[str] = set()
+    for entry in tool_results:
+        tool_name = entry[0] if isinstance(entry, (tuple, list)) and entry else None
+        if not isinstance(tool_name, str) or not tool_name:
+            continue
+        if tool_name.startswith("mcp."):
+            parts = tool_name.split(".")
+            sub = parts[1] if len(parts) >= 3 and parts[1] else None
+        elif tool_name.startswith("internal."):
+            sub = INTERNAL_SUBSYSTEM_LABELS.get(tool_name)
+        else:
+            sub = None
+        if not sub or sub in seen:
+            continue
+        seen.add(sub)
+        subsystems.append(sub)
+        if len(subsystems) >= _MAX_SUBSYSTEMS_PER_TURN:
+            break
+    return subsystems
+
+
+async def broadcast_turn_activity(
+    role: str | None, subsystems: list[str], ok: bool | None
+) -> None:
+    """Push ONE content-free ``turn_activity`` pulse to the kiosk hub (role +
+    which subsystems this turn touched). No-op when there's nothing to show (no
+    role AND no subsystems), so a plain conversation turn pushes nothing.
+    Fire-and-forget: a hub failure must never break the turn."""
+    if not role and not subsystems:
+        return
+    try:
+        from datetime import UTC, datetime
+
+        from api.websocket.kiosk_handler import broadcast_kiosk_event
+
+        await broadcast_kiosk_event(
+            {
+                "type": "turn_activity",
+                "role": role,
+                "subsystems": subsystems,
+                "ok": ok,
+                "at": datetime.now(UTC).isoformat(),
+            }
+        )
+    except Exception as e:  # noqa: BLE001 — never break a turn on a kiosk push
+        logger.debug(f"kiosk turn_activity broadcast failed: {e}")
+
+
+# ---------------------------------------------------------------------------
 # Ambient kiosk weather tile. Read-only, degrades to None (never an error) when
 # the feature is off or the source is unavailable, so the kiosk hides the tile.
 # ---------------------------------------------------------------------------

--- a/src/backend/ha_glue/api/websocket/satellite_handler.py
+++ b/src/backend/ha_glue/api/websocket/satellite_handler.py
@@ -706,6 +706,32 @@ Gib eine kurze, natürliche Antwort. KEIN JSON, nur Text."""
                     # never reaches the LLM, only the agent prompt builder and the DB.
                     assistant_metadata = _build_assistant_metadata(intent, action_result)
 
+                    # Kiosk active-subsystem pulse (VOICE path — mirrors the web-chat
+                    # emit in chat_handler). Without this a spoken "turn off the light"
+                    # lights nothing on the kiosk; only typed chat commands pulsed. The
+                    # executed intent name is already in ``mcp.<server>.<tool>`` /
+                    # ``internal.<tool>`` form, so the same extractor maps it. A plain
+                    # ``general.conversation`` turn maps to no subsystem → no-op push.
+                    try:
+                        from api.websocket.kiosk_data import (
+                            broadcast_turn_activity,
+                            extract_subsystems_used,
+                        )
+
+                        _intent_name = intent.get("intent") if intent else None
+                        _subs = (
+                            extract_subsystems_used([(_intent_name, action_result)])
+                            if _intent_name
+                            else []
+                        )
+                        await broadcast_turn_activity(
+                            None,
+                            _subs,
+                            action_result.get("success") if action_result else None,
+                        )
+                    except Exception as e:  # noqa: BLE001 — never break the turn on a push
+                        logger.debug(f"kiosk turn_activity (voice) broadcast failed: {e}")
+
                     # Update in-memory conversation history (keep max 5 exchanges = 10 messages)
                     satellite_conversation_history.append({"role": "user", "content": text})
                     satellite_conversation_history.append({

--- a/tests/backend/test_ha_glue_boundary.py
+++ b/tests/backend/test_ha_glue_boundary.py
@@ -79,6 +79,17 @@ ALLOWED_IMPORTERS = frozenset({
     # a platform-only deploy never reaches it. Same lazy-pattern rule as the shims
     # above.
     "services/daypart_service.py",
+    # (2) Lazy, try/except-guarded — build_kiosk_snapshot() pulls the satellite
+    # roster / presence / media-follow / ha_glue config for the /ws/kiosk snapshot
+    # via function-body `from ha_glue.services...` imports inside try blocks (each
+    # degrades to an empty section when ha_glue is absent). Never reached on a
+    # platform-only deploy. Same lazy-pattern rule as the shims above.
+    "api/websocket/kiosk_handler.py",
+    # (2) Lazy, try/except-guarded — emit_continued_handoff_frame() does a
+    # function-body `from ha_glue.services.device_manager import get_device_manager`
+    # inside a try block to broadcast the room-handoff chip; deferred + guarded, so
+    # a platform-only deploy never reaches it. Same lazy-pattern rule as above.
+    "services/conversation_handoff.py",
 })
 
 

--- a/tests/backend/test_kiosk_handler.py
+++ b/tests/backend/test_kiosk_handler.py
@@ -1,7 +1,7 @@
 """Backend unit tests for the kiosk push hub (Phase 1a).
 
 Covers:
-  * ``_extract_subsystems_used`` — mcp-vs-internal mapping, the internal
+  * ``extract_subsystems_used`` — mcp-vs-internal mapping, the internal
     allowlist, dedup, order-preservation, the cap, and the empty case.
   * ``broadcast_kiosk_event`` — fire-and-forget: an empty registry is a no-op,
     a broken socket is pruned (not raised), a good socket receives the event.
@@ -20,10 +20,11 @@ from pathlib import Path
 import pytest
 
 import api.websocket.kiosk_handler as kiosk
-from api.websocket.chat_handler import (
+from api.websocket.kiosk_data import (
     INTERNAL_SUBSYSTEM_LABELS,
     _MAX_SUBSYSTEMS_PER_TURN,
-    _extract_subsystems_used,
+    broadcast_turn_activity,
+    extract_subsystems_used,
 )
 from api.websocket.kiosk_handler import broadcast_kiosk_event, build_kiosk_snapshot
 
@@ -61,14 +62,14 @@ def _clear_clients():
 
 
 # --------------------------------------------------------------------------
-# _extract_subsystems_used
+# extract_subsystems_used
 # --------------------------------------------------------------------------
 
 
 @pytest.mark.backend
 @pytest.mark.unit
 def test_extract_mcp_tool_maps_to_server():
-    assert _extract_subsystems_used(
+    assert extract_subsystems_used(
         [("mcp.homeassistant.turn_on", {})]
     ) == ["homeassistant"]
 
@@ -76,22 +77,22 @@ def test_extract_mcp_tool_maps_to_server():
 @pytest.mark.backend
 @pytest.mark.unit
 def test_extract_internal_tool_uses_allowlist():
-    assert _extract_subsystems_used([("internal.knowledge_search", {})]) == ["knowledge"]
-    assert _extract_subsystems_used([("internal.list_my_memories", {})]) == ["knowledge"]
-    assert _extract_subsystems_used([("internal.device_controls", {})]) == ["homeassistant"]
-    assert _extract_subsystems_used([("internal.announce_in_room", {})]) == ["homeassistant"]
-    assert _extract_subsystems_used([("internal.presence_history", {})]) == ["presence"]
-    assert _extract_subsystems_used([("internal.play_radio", {})]) == ["media"]
-    assert _extract_subsystems_used([("internal.weather_widget", {})]) == ["weather"]
+    assert extract_subsystems_used([("internal.knowledge_search", {})]) == ["knowledge"]
+    assert extract_subsystems_used([("internal.list_my_memories", {})]) == ["knowledge"]
+    assert extract_subsystems_used([("internal.device_controls", {})]) == ["homeassistant"]
+    assert extract_subsystems_used([("internal.announce_in_room", {})]) == ["homeassistant"]
+    assert extract_subsystems_used([("internal.presence_history", {})]) == ["presence"]
+    assert extract_subsystems_used([("internal.play_radio", {})]) == ["media"]
+    assert extract_subsystems_used([("internal.weather_widget", {})]) == ["weather"]
 
 
 @pytest.mark.backend
 @pytest.mark.unit
 def test_extract_unknown_internal_tool_skipped():
-    assert _extract_subsystems_used([("internal.something_new", {})]) == []
+    assert extract_subsystems_used([("internal.something_new", {})]) == []
     # Pure Gen-UI formatting tools touch no subsystem → no pulse.
-    assert _extract_subsystems_used([("internal.render_table", {})]) == []
-    assert _extract_subsystems_used([("internal.render_list", {})]) == []
+    assert extract_subsystems_used([("internal.render_table", {})]) == []
+    assert extract_subsystems_used([("internal.render_list", {})]) == []
 
 
 # Real MCP servers that `internal.*` tools bridge to — they already render as
@@ -149,7 +150,7 @@ def test_extract_dedup_preserves_first_seen_order():
         ("mcp.weather.get_weather", {}),
         ("internal.knowledge_search", {}),  # -> knowledge
     ]
-    assert _extract_subsystems_used(results) == [
+    assert extract_subsystems_used(results) == [
         "homeassistant",
         "weather",
         "knowledge",
@@ -160,7 +161,7 @@ def test_extract_dedup_preserves_first_seen_order():
 @pytest.mark.unit
 def test_extract_caps_at_five_distinct_subsystems():
     results = [(f"mcp.server{i}.tool", {}) for i in range(8)]
-    out = _extract_subsystems_used(results)
+    out = extract_subsystems_used(results)
     assert len(out) == _MAX_SUBSYSTEMS_PER_TURN == 5
     assert out == ["server0", "server1", "server2", "server3", "server4"]
 
@@ -168,9 +169,9 @@ def test_extract_caps_at_five_distinct_subsystems():
 @pytest.mark.backend
 @pytest.mark.unit
 def test_extract_empty_and_malformed_are_safe():
-    assert _extract_subsystems_used([]) == []
+    assert extract_subsystems_used([]) == []
     # Malformed / non-tool entries are ignored, not raised.
-    assert _extract_subsystems_used(
+    assert extract_subsystems_used(
         [(), ("", {}), ("plain_intent", {}), ("mcp.", {}), ("mcp.only", {})]
     ) == []
 
@@ -205,6 +206,32 @@ async def test_broadcast_delivers_to_connected_clients():
     await _drain_fanout()
     assert a.sent == [event]
     assert b.sent == [event]
+
+
+@pytest.mark.backend
+@pytest.mark.asyncio
+async def test_broadcast_turn_activity_pushes_pulse_and_noops_when_empty():
+    client = _FakeWS()
+    kiosk._kiosk_clients.add(client)
+
+    # nothing to show (no role AND no subsystems) → no push
+    await broadcast_turn_activity(None, [], None)
+    await _drain_fanout()
+    assert client.sent == []
+
+    # a voice turn that ran a tool → one content-free turn_activity pulse
+    await broadcast_turn_activity(None, ["homeassistant"], True)
+    await _drain_fanout()
+    assert len(client.sent) == 1
+    evt = client.sent[0]
+    assert evt["type"] == "turn_activity"
+    assert evt["subsystems"] == ["homeassistant"]
+    assert evt["ok"] is True
+    assert "at" in evt  # timestamp stamped
+    # role-only turn (no tool) still pulses the role ring
+    await broadcast_turn_activity("smart_home", [], None)
+    await _drain_fanout()
+    assert client.sent[-1]["role"] == "smart_home"
 
 
 @pytest.mark.backend


### PR DESCRIPTION
The kiosk active-subsystem pulse (the MCP/subsystem node glow) was emitted **only from the web-chat path** (`chat_handler`). Voice commands to a satellite run through `satellite_handler` (intent → `ActionExecutor`) and never broadcast `turn_activity` — so a spoken "turn off the light" lit nothing on the kiosk; only typed chat commands pulsed.

(The room dot + core DO glow for voice via the separate `satellite_state` lifecycle — LISTENING→PROCESSING→SPEAKING→IDLE — so this PR is specifically the MCP-node pulse. The commonly-observed "nothing glows at all" is the stale PWA bundle on the wall tablet; a reload fixes that.)

## Changes
- Moved the shared pulse helpers (`INTERNAL_SUBSYSTEM_LABELS`, `extract_subsystems_used`, `_MAX_SUBSYSTEMS_PER_TURN`) from `chat_handler` into kiosk-owned `api/websocket/kiosk_data.py`; added `broadcast_turn_activity(role, subsystems, ok)` (no-op when nothing to show). `chat_handler` calls it.
- Wired the voice path: `satellite_handler` derives the subsystem from the executed intent name (already `mcp.<server>.<tool>` / `internal.<tool>`) and emits the same pulse once per turn. `general.conversation` → no-op.
- `test_ha_glue_boundary`: allowlisted the two **pre-existing** legit lazy importers this run surfaced (`kiosk_handler.py` snapshot builder + `conversation_handoff.py` — both function-body, try/except-guarded `from ha_glue...`, same pattern as the existing shims). Greens the boundary test on main.

## Verification (.159)
`test_kiosk_handler.py` 16/16 (incl. new `broadcast_turn_activity` test + the cross-file coupling guard), `test_ha_glue_boundary.py` green, `import main` + `import ha_glue…satellite_handler` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)