### PR TITLE
feat(kiosk): core shows processing for web-chat turns

### DIFF
--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -858,6 +858,11 @@ async def websocket_endpoint(
     except Exception as e:
         logger.warning(f"⚠️ Failed to detect room context: {e}")
 
+    # Kiosk core-activity: True between marking THIS connection's in-flight chat
+    # turn active and clearing it, so a mid-turn disconnect/error still decrements
+    # the global counter in the outer handlers below (no stuck "processing" core).
+    _chat_turn_marked = False
+
     try:
         while True:
             # Receive message
@@ -1164,6 +1169,16 @@ async def websocket_endpoint(
                 await websocket.send_json({"type": "stream", "content": blocked_msg})
                 await websocket.send_json({"type": "done"})
                 continue
+
+            # Kiosk core-activity: past all turn-level early-exits (validation /
+            # injection block), this turn is committed to processing → the kiosk
+            # core shows "processing" (cleared at the `done` frame + crash-safe in
+            # the outer finally). Remaining `continue`s below are inner loops only.
+            if not _chat_turn_marked:
+                from api.websocket.kiosk_handler import note_chat_turn_active
+
+                _chat_turn_marked = True
+                await note_chat_turn_active(True)
 
             # Handle session_id for conversation persistence
             if msg_session_id:
@@ -2498,6 +2513,13 @@ WICHTIG: Nutze die ECHTEN Daten aus dem Ergebnis! Gib NUR die Antwort, KEIN JSON
                 done_msg["role"] = role.name
             await websocket.send_json(done_msg)
 
+            # Kiosk core-activity: turn finished → clear its "processing" mark.
+            if _chat_turn_marked:
+                from api.websocket.kiosk_handler import note_chat_turn_active
+
+                _chat_turn_marked = False
+                await note_chat_turn_active(False)
+
             # Proactive feedback: ask user when action failed or returned empty
             should_request_feedback = False
             if intent and intent.get("intent") != "general.conversation":
@@ -2635,3 +2657,11 @@ WICHTIG: Nutze die ECHTEN Daten aus dem Ergebnis! Gib NUR die Antwort, KEIN JSON
         import traceback
         logger.error(traceback.format_exc())
         await websocket.close()
+    finally:
+        # Crash-safe: a turn interrupted between its start-mark and the `done`
+        # clear (disconnect / mid-turn error) must still decrement the global
+        # counter, or the kiosk core would stay stuck "processing".
+        if _chat_turn_marked:
+            from api.websocket.kiosk_handler import note_chat_turn_active
+
+            await note_chat_turn_active(False)

--- a/src/backend/api/websocket/kiosk_handler.py
+++ b/src/backend/api/websocket/kiosk_handler.py
@@ -48,6 +48,10 @@ each into the same reducer-held model. Every event is CONTENT-FREE.
     connection flipped (reconnect healed it / it dropped). Phase 2.
   * ``weather_updated`` — ``{type, weather:{…}|null}`` — pushed when the
     backend-internal weather cache refreshes (never a client poll). Phase 2.
+  * ``chat_activity`` — ``{type, active}`` — pushed on the 0↔1 edge of the
+    web-chat turn counter, so the core shows "processing" while Renfield handles
+    a TYPED turn (voice already drives the core via satellite_state). Snapshot
+    carries ``chat_active``.
   * ``peer_status_changed`` — see the plan §1.4/§9; REMAINING (needs a small
     backend-internal reachability timer — no discrete federation event exists).
 """
@@ -68,6 +72,29 @@ router = APIRouter()
 # Connected kiosk wall displays. No per-viewer scoping: the kiosk projection is
 # household-wide (ADMIN-gated at connect), so every client sees every event.
 _kiosk_clients: set[WebSocket] = set()
+
+# How many web-chat turns are being processed right now (across all chat sockets
+# on this process). Lets the kiosk core show "processing" while Renfield handles
+# ANY turn — typed web-chat, not just satellite voice (rooms stay satellite-
+# driven; a web-chat turn has no room). Counter (not a bool) so concurrent turns
+# don't cancel each other; floored at 0.
+_active_chat_turns = 0
+
+
+async def note_chat_turn_active(active: bool) -> None:
+    """Mark a web-chat turn as starting (``True``) / ending (``False``) and push a
+    ``chat_activity`` delta only on the 0↔1 edge (so redundant concurrent-turn
+    increments don't spam the hub). Fire-and-forget; a hub failure must never
+    break the chat turn."""
+    global _active_chat_turns
+    was_active = _active_chat_turns > 0
+    _active_chat_turns = max(0, _active_chat_turns + (1 if active else -1))
+    now_active = _active_chat_turns > 0
+    if now_active != was_active:
+        try:
+            await broadcast_kiosk_event({"type": "chat_activity", "active": now_active})
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"kiosk chat_activity broadcast failed: {e}")
 
 
 # Per-client send deadline. A backpressured wall display (tab asleep, WiFi
@@ -209,6 +236,9 @@ async def build_kiosk_snapshot(app) -> dict:
         "peers": [],
         "weather": None,
         "now_playing": [],
+        # True while ≥1 web-chat turn is being processed → the core shows
+        # "processing" even with no satellite active (reconnect hydrate).
+        "chat_active": _active_chat_turns > 0,
     }
 
     # --- Satellites (roster + live state) --------------------------------

--- a/src/frontend/src/components/kiosk/useKioskModel.ts
+++ b/src/frontend/src/components/kiosk/useKioskModel.ts
@@ -329,6 +329,17 @@ export function useKioskModel(): KioskState {
     }
     if (!backendUnreachable && best === 0 && anyError) core = 'busy';
 
+    // A typed web-chat turn has no satellite/room, but Renfield IS working — show
+    // the core "thinking" when no satellite outranks it and nothing's errored.
+    if (
+      !backendUnreachable &&
+      live.chatActive &&
+      best < STATE_PRIORITY.processing &&
+      !anyError
+    ) {
+      core = 'processing';
+    }
+
     const activeRoleLabel = model.core.activeRoleId
       ? roleLabel(t, model.core.activeRoleId)
       : null;

--- a/src/frontend/src/components/kiosk/useKioskSocket.ts
+++ b/src/frontend/src/components/kiosk/useKioskSocket.ts
@@ -95,6 +95,9 @@ export interface KioskLiveModel {
   peers: KioskPeer[];
   weather: KioskWeather | null;
   nowPlaying: KioskNowPlaying[];
+  /** True while ≥1 web-chat turn is being processed → the core shows
+   *  "processing" even with no satellite active (typed commands have no room). */
+  chatActive: boolean;
   /** subsystem id → epoch-ms of its most recent `turn_activity` mention. Drives
    *  the active-subsystem pulse; the view fades it on a render tick. Preserved
    *  across snapshots (it is delta-sourced state with its own decay). */
@@ -125,6 +128,12 @@ interface SnapshotMessage {
   peers?: KioskPeer[];
   weather?: KioskWeather | null;
   now_playing?: KioskNowPlaying[];
+  chat_active?: boolean;
+}
+
+interface ChatActivityDelta {
+  type: 'chat_activity';
+  active: boolean;
 }
 
 interface SatelliteStateDelta {
@@ -185,6 +194,7 @@ type KioskMessage =
   | ToolHealthChangedDelta
   | WeatherUpdatedDelta
   | TurnActivityDelta
+  | ChatActivityDelta
   | { type: string; [key: string]: unknown };
 
 // ---- reducer ---------------------------------------------------------------
@@ -201,6 +211,7 @@ const EMPTY_MODEL: KioskLiveModel = {
   peers: [],
   weather: null,
   nowPlaying: [],
+  chatActive: false,
   subsystemPulses: {},
 };
 
@@ -239,6 +250,7 @@ function hydrate(prev: KioskLiveModel, msg: SnapshotMessage): KioskLiveModel {
     peers: msg.peers ?? [],
     weather: msg.weather ?? null,
     nowPlaying: msg.now_playing ?? [],
+    chatActive: msg.chat_active ?? false,
     // Preserve the pulse map: it is delta-sourced and self-decays in the view,
     // so a reconnect snapshot must not wipe an in-flight subsystem pulse.
     subsystemPulses: prev.subsystemPulses,
@@ -360,6 +372,11 @@ function reduce(state: KioskLiveModel, msg: KioskMessage): KioskLiveModel {
     case 'weather_updated': {
       const delta = msg as WeatherUpdatedDelta;
       return { ...state, weather: delta.weather ?? null };
+    }
+
+    case 'chat_activity': {
+      const delta = msg as ChatActivityDelta;
+      return { ...state, chatActive: !!delta.active };
     }
 
     case 'turn_activity': {

--- a/tests/backend/test_kiosk_handler.py
+++ b/tests/backend/test_kiosk_handler.py
@@ -52,6 +52,7 @@ def _clear_clients():
     kiosk._event_queue = None
     kiosk._consumer_task = None
     kiosk._consumer_loop = None
+    kiosk._active_chat_turns = 0
     yield
     if kiosk._consumer_task is not None:
         kiosk._consumer_task.cancel()
@@ -206,6 +207,35 @@ async def test_broadcast_delivers_to_connected_clients():
     await _drain_fanout()
     assert a.sent == [event]
     assert b.sent == [event]
+
+
+@pytest.mark.backend
+@pytest.mark.asyncio
+async def test_note_chat_turn_active_edges_and_floor():
+    """The core-activity counter broadcasts a chat_activity delta ONLY on the
+    0↔1 edge (concurrent turns don't spam), and never goes negative."""
+    kiosk._active_chat_turns = 0
+    client = _FakeWS()
+    kiosk._kiosk_clients.add(client)
+
+    await kiosk.note_chat_turn_active(True)   # 0 -> 1 : edge, broadcast active
+    await kiosk.note_chat_turn_active(True)   # 1 -> 2 : no edge, silent
+    await _drain_fanout()
+    assert kiosk._active_chat_turns == 2
+    assert [e["active"] for e in client.sent] == [True]  # only the 0->1 edge
+
+    await kiosk.note_chat_turn_active(False)  # 2 -> 1 : no edge, silent
+    await kiosk.note_chat_turn_active(False)  # 1 -> 0 : edge, broadcast inactive
+    await _drain_fanout()
+    assert kiosk._active_chat_turns == 0
+    assert [e["active"] for e in client.sent] == [True, False]
+
+    # floor at 0 — a stray decrement (double-clear) can't go negative
+    await kiosk.note_chat_turn_active(False)
+    await _drain_fanout()
+    assert kiosk._active_chat_turns == 0
+    assert len(client.sent) == 2  # no extra broadcast
+    kiosk._active_chat_turns = 0
 
 
 @pytest.mark.backend

--- a/tests/frontend/react/pages/KioskPage.test.tsx
+++ b/tests/frontend/react/pages/KioskPage.test.tsx
@@ -225,6 +225,23 @@ describe('KioskPage', () => {
     );
   });
 
+  it('drives the core to processing on a chat_activity delta (typed web-chat)', async () => {
+    renderWithProviders(<KioskPage />);
+    pushSnapshot(snapshot('idle')); // all satellites idle, no voice activity
+    await waitFor(() => expect(coreState()).toBe('idle'));
+    const ws = MockWebSocket.instances[MockWebSocket.instances.length - 1];
+    // a web-chat turn starts processing → the core thinks even with no satellite
+    act(() => {
+      ws.fireMessage({ type: 'chat_activity', active: true });
+    });
+    await waitFor(() => expect(coreState()).toBe('processing'));
+    // turn ends → core returns to idle
+    act(() => {
+      ws.fireMessage({ type: 'chat_activity', active: false });
+    });
+    await waitFor(() => expect(coreState()).toBe('idle'));
+  });
+
   it('does not duplicate a synthetic node when a real MCP server owns its id', async () => {
     renderWithProviders(<KioskPage />);
     // an operator adds an output-provider MCP server literally named 'media'


### PR DESCRIPTION
The kiosk core reflected only satellite **voice** state, so a typed web-chat command left it idle — you'd only see the (subtle) MCP-node pulse. Now the core "thinks" while Renfield handles **any** turn, voice or typed. Rooms stay satellite-driven (a typed turn has no room).

## Backend
- `kiosk_handler.py`: a process-global `_active_chat_turns` counter + `note_chat_turn_active(active)` that pushes a `chat_activity` delta only on the 0↔1 edge (concurrent turns don't spam; floored at 0). Snapshot carries `chat_active` for reconnect.
- `chat_handler.py`: marks the turn active once past the validation/injection early-exits (an aborted turn never marks), clears it at the `done` frame, and a crash-safe outer `finally` decrements on a mid-turn disconnect/error — so the core can't get stuck "processing".

## Frontend
- `chatActive` on the live model (reducer + snapshot hydrate); the core shows `processing` when chatActive and no satellite outranks it and nothing's errored (a speaking satellite still wins). Rooms unchanged.

## Verification
- Backend: `test_kiosk_handler.py` **17/17** on .159 (incl. the counter edge/floor test) + `import main` clean.
- Frontend: tsc + prod build clean, **22/22** kiosk vitest (incl. a chat_activity idle→processing→idle core test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)