### PR TITLE
fix(speakers): clear success state after guided enrollment

### DIFF
--- a/src/frontend/src/components/speakers/GuidedEnrollModal.tsx
+++ b/src/frontend/src/components/speakers/GuidedEnrollModal.tsx
@@ -100,6 +100,12 @@ export default function GuidedEnrollModal({
 
   const stopRecording = useCallback(() => recorderRef.current?.stop(), []);
   const removeSample = (i: number) => setSamples((s) => s.filter((_, idx) => idx !== i));
+  const resetForm = () => {
+    setName('');
+    setUserId('');
+    setSamples([]);
+    setResult(null);
+  };
 
   const submit = async () => {
     setResult(null);
@@ -118,6 +124,32 @@ export default function GuidedEnrollModal({
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} title={t('speakers.enrollGuided')}>
+      {result?.ok ? (
+        <div className="space-y-4">
+          <div className="rounded p-4 text-center bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-300">
+            <div className="text-3xl mb-1">✓</div>
+            <div className="font-medium">{t('speakers.enrollDone', { name: result.name ?? name })}</div>
+            <div className="text-sm mt-1">
+              {t('speakers.enrollOk', {
+                cohesion: (result.cohesion ?? 0).toFixed(2), accepted: result.accepted,
+              })}
+            </div>
+            {result.displaced_user_ids && result.displaced_user_ids.length > 0 && (
+              <div className="text-xs mt-2 text-amber-600 dark:text-amber-400">
+                {t('speakers.enrollDisplaced')}
+              </div>
+            )}
+          </div>
+          <div className="flex justify-end gap-2 pt-2">
+            <button type="button" className="btn-secondary" onClick={resetForm}>
+              {t('speakers.enrollAnother')}
+            </button>
+            <button type="button" className="btn-primary" onClick={onClose}>
+              {t('speakers.enrollCloseDone')}
+            </button>
+          </div>
+        </div>
+      ) : (
       <div className="space-y-4">
         <p className="text-sm text-gray-600 dark:text-gray-400">{t('speakers.enrollGuidedHint')}</p>
 
@@ -194,19 +226,9 @@ export default function GuidedEnrollModal({
           </button>
         </div>
 
-        {result && (
-          <div
-            className={`text-sm rounded p-3 ${
-              result.ok
-                ? 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-300'
-                : 'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300'
-            }`}
-          >
-            {result.ok
-              ? t('speakers.enrollOk', {
-                  cohesion: (result.cohesion ?? 0).toFixed(2), accepted: result.accepted,
-                })
-              : result.reason}
+        {result && !result.ok && (
+          <div className="text-sm rounded p-3 bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300">
+            {result.reason}
           </div>
         )}
 
@@ -219,6 +241,7 @@ export default function GuidedEnrollModal({
           </button>
         </div>
       </div>
+      )}
     </Modal>
   );
 }

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -553,7 +553,11 @@
     "enrollSubmit": "Einlernen",
     "enrolling": "Wird eingelernt …",
     "enrollSuccess": "Sprecher erfolgreich eingelernt.",
-    "enrollFailed": "Einlernen fehlgeschlagen."
+    "enrollFailed": "Einlernen fehlgeschlagen.",
+    "enrollDone": "{{name}} wurde eingelernt",
+    "enrollAnother": "Weitere einlernen",
+    "enrollCloseDone": "Schließen",
+    "enrollDisplaced": "Hinweis: Ein anderes Benutzerkonto war mit diesem Sprecher verknüpft — die Verknüpfung wurde entfernt."
   },
   "tasks": {
     "title": "Aufgaben",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -553,7 +553,11 @@
     "enrollSubmit": "Enroll",
     "enrolling": "Enrolling…",
     "enrollSuccess": "Speaker enrolled successfully.",
-    "enrollFailed": "Enrollment failed."
+    "enrollFailed": "Enrollment failed.",
+    "enrollDone": "{{name}} enrolled",
+    "enrollAnother": "Enroll another",
+    "enrollCloseDone": "Close",
+    "enrollDisplaced": "Note: another user account was linked to this speaker; that link was removed."
   },
   "tasks": {
     "title": "Tasks",

--- a/tests/frontend/react/components/GuidedEnrollModal.test.tsx
+++ b/tests/frontend/react/components/GuidedEnrollModal.test.tsx
@@ -68,6 +68,10 @@ describe('GuidedEnrollModal', () => {
     const arg = mutateAsync.mock.calls[0][0];
     expect(arg.name).toBe('Eduard');
     expect(arg.samples).toHaveLength(3);
+
+    // success shows a clear done-state with a Close button (unique to that state)
+    await waitFor(() =>
+      screen.getByRole('button', { name: /^close$|^schließen$/i }));
   });
 
   it('shows the rejection reason when the samples do not cohere', async () => {


### PR DESCRIPTION
## Report
After recording samples and clicking **Einlernen**, the modal left the same `[Abbrechen][Einlernen]` buttons + a small inline message — so it was unclear the enrollment had succeeded ("no OK button" — but **Einlernen** *is* the submit). Investigation confirmed the enroll actually **worked** (speaker enrolled, cohesion 0.87, linked to the user); this is purely a missing post-success confirmation. (The separate "Unbekannter Sprecher" the reporter also saw is **unrelated** — passive satellite auto-enroll, still on until Phase 3, cleaned by `bin/purge_unknown_speakers.py`.)

## Fix
On success the modal now shows a prominent **done-state** (✓ "{name} enrolled", cohesion, + a displaced-user note when a link was moved) with explicit **"Enroll another"** (reset) and **"Close"** buttons, replacing the form. Rejections keep the form + inline reason for a re-record.

de/en i18n (4 keys); RTL test asserts the success state (unique Close button) renders. TS-clean; prod build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NL6AcbQW7zjdtXiCb7iV4j