### PR TITLE
fix(meetings): fail-closed gates + review fixes for the diarization harness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,8 @@ docker exec -it renfield-backend alembic downgrade -1
 
 For architecture questions, use the `architecture-guide` agent.
 
+**In-flight (spike phase, nothing shipped):** Meeting transcription + diarization — locked design in `docs/design/meeting-transcription.md` (spike-gated: no product code before the gates in `tests/eval/diarization/gates.yaml` pass); persistent eval harness `bin/run_diarization_eval.py`. Related: the voice-identity design (`docs/design/voice-identity-wakeword-verification.md`) plans STREAMING diarization — coordinate before adding pyannote to the voice-server image twice.
+
 ### BLE phone presence via IRK resolution + the k8s satellite
 
 Modern phones advertise a **rotating** BLE Resolvable Private Address (RPA), so a static MAC whitelist can't track them. Renfield resolves the rotating address back to a stable identity using the device's **Identity Resolving Key (IRK)** — the same mechanism as Home Assistant's *Private BLE Device* / Bermuda. No app, no extra hardware. Design + status: [`docs/design/ble-presence-improvement.md`](docs/design/ble-presence-improvement.md) (SHIPPED + DEPLOYED).

--- a/TODOS.md
+++ b/TODOS.md
@@ -331,6 +331,26 @@ The hybrid extractor (deterministic Steuernummer/IBAN with whitespace normalizat
 
 ## P3 — Conditional / on signal
 
+### ℹ️ Reference (info only, NOT a work item): Meetily — self-hosted call-meeting notetaker
+
+Recorded 2026-07-06 on request — **deliberately no decision taken, no planned
+extension; info only.** [Meetily](https://github.com/Zackriya-Solutions/meetily)
+(MIT, Tauri: Rust backend + Next.js, ~19k stars, v0.4.x pre-release) captures
+system audio + mic locally ("bot-free", works with Teams/Zoom/Meet/any app),
+live-transcribes via whisper.cpp/Parakeet (multilingual incl. `de`) and
+summarizes via Ollama/OpenAI-compatible endpoints. 100% local, desktop
+single-user, no HTTP API.
+
+Relevance: **NO speaker diarization in the open-source Community Edition**
+(Pro-only promise, never shipped in CE release notes as of 2026-07) → it does
+NOT replace §2 (`docs/design/meeting-transcription.md`); room-meeting
+diarization + speaker identity + KB/circles integration stay our build. IF the
+online-call capture gap (voice-pipeline-plan.md out-of-scope item) ever gets
+prioritized for the work instance, the zero-code path would be: Meetily CE on
+the work machine → its exports into a watch folder → existing folder-ingest →
+project KB. Also noteworthy as a concept: system-audio capture instead of
+meeting-bots.
+
 ### Satellite meeting recording ("Renfield, starte Meeting-Aufnahme")
 
 **WHAT:** A satellite (primarily the XVF3800-equipped ones) records long-form meeting audio on voice command and pushes it into the meeting-transcription upload path (`POST /api/meetings/transcribe`). Own phase, deliberately kept OUT of the §2 diarization build (eng-review decision D15, 2026-07-06).

--- a/bin/run_diarization_eval.py
+++ b/bin/run_diarization_eval.py
@@ -4,7 +4,8 @@
 Persistent eval harness (eng-review 2026-07-06, D9): the spike IS this script,
 and it stays as the regression anchor for every later whisper/pyannote/threshold
 change. Gates live in tests/eval/diarization/gates.yaml and were FIXED BEFORE
-the first measurement — do not tune them to fit a run.
+the first measurement — do not tune them to fit a run. (Hardened fail-closed by
+the PR #924 review, still before any measurement — see the gates.yaml header.)
 
 Subcommands
 -----------
@@ -16,6 +17,9 @@ run                Diarize + transcribe + align + (optionally) embed one
 probe-live-stt     Latency probe against a running voice-server. Run once for a
                    baseline, once DURING a `run`, feed both to `report`.
 report             Evaluate metrics JSON(s) against the gates -> PASS/FAIL.
+                   Verdict is per candidate: overall PASS needs at least ONE
+                   metrics file passing every hard gate AND a passing live
+                   probe pair. Missing hard-gate metrics FAIL (fail-closed).
 
 Typical spike sequence (on a CUDA host, e.g. inside the voice-server image —
 see tests/eval/diarization/README.md):
@@ -25,8 +29,9 @@ see tests/eval/diarization/README.md):
       --reference tests/eval/diarization/fixtures/meeting_synthetic_de.reference.json \
       --whisper-model large-v3 --ecapa-onnx /models/ecapa.onnx \
       --out /tmp/metrics-large-v3.json
-  python bin/run_diarization_eval.py report \
-      --gates tests/eval/diarization/gates.yaml /tmp/metrics-*.json
+  python bin/run_diarization_eval.py report /tmp/metrics-*.json \
+      --gates tests/eval/diarization/gates.yaml \
+      --live-baseline /tmp/live-baseline.json --live-during /tmp/live-during.json
 
 Heavy deps (pyannote.audio, faster-whisper, torch, speechbrain, onnxruntime)
 are imported lazily inside `run` so that fixture generation and reporting work
@@ -44,6 +49,7 @@ import statistics
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -54,9 +60,16 @@ from pathlib import Path
 #   reference.json / hypothesis segments:
 #     {"sample_rate": 16000,
 #      "segments": [{"speaker": "S1", "start": 0.0, "end": 3.2, "text": "..."}]}
+#
+# Hand-written references must use NON-OVERLAPPING segments: the frame scorer
+# is single-label per 10 ms frame, so overlapping reference speech would be
+# silently mis-scored (last segment wins). Overlap robustness is judged
+# qualitatively on the attributed transcript, not by this scorer.
 # --------------------------------------------------------------------------
 
-FRAME_S = 0.010  # frame size for the frame-level diarization scoring
+FRAME_S = 0.010     # frame size for the frame-level diarization scoring
+SNAP_WINDOW_S = 0.5  # uncovered ASR word snaps to a diarization turn this close
+MERGE_GAP_S = 1.0    # consecutive same-speaker words merge across gaps up to this
 
 
 @dataclass
@@ -68,13 +81,24 @@ class Segment:
 
 
 def load_segments(path: Path) -> list[Segment]:
-    data = json.loads(path.read_text())
+    data = json.loads(path.read_text(encoding="utf-8"))
     return [Segment(s["speaker"], float(s["start"]), float(s["end"]), s.get("text", ""))
             for s in data["segments"]]
 
 
 def total_speech(segments: list[Segment]) -> float:
     return sum(s.end - s.start for s in segments)
+
+
+def _p95(values: list[float]) -> float | None:
+    """Nearest-rank (ceil) 95th percentile — shared by the separation and the
+    latency probe so the two copies cannot drift. The naive int()-1 variant
+    underestimates (returns the minimum at n=2), which would bias BOTH gates
+    in the permissive direction."""
+    if not values:
+        return None
+    vals = sorted(values)
+    return vals[min(len(vals) - 1, max(0, math.ceil(0.95 * len(vals)) - 1))]
 
 
 # --------------------------------------------------------------------------
@@ -84,7 +108,6 @@ def total_speech(segments: list[Segment]) -> float:
 def cmd_generate_fixture(args: argparse.Namespace) -> int:
     script_path = Path(args.script)
     out_wav = Path(args.out)
-    out_ref = out_wav.with_suffix("").with_suffix("")  # strip .wav
     out_ref = out_wav.parent / (out_wav.stem + ".reference.json")
 
     voice_map: dict[str, str] = {}
@@ -94,7 +117,7 @@ def cmd_generate_fixture(args: argparse.Namespace) -> int:
             voice_map[name.strip()] = voice.strip()
 
     lines: list[tuple[str, str]] = []
-    for raw in script_path.read_text().splitlines():
+    for raw in script_path.read_text(encoding="utf-8").splitlines():
         raw = raw.strip()
         if not raw or raw.startswith("#"):
             continue
@@ -145,7 +168,8 @@ def cmd_generate_fixture(args: argparse.Namespace) -> int:
     _write_wav_pcm16(out_wav, b"".join(audio), sr)
     out_ref.write_text(json.dumps(
         {"sample_rate": sr, "engine": args.engine,
-         "segments": [asdict(s) for s in segments]}, ensure_ascii=False, indent=2))
+         "segments": [asdict(s) for s in segments]}, ensure_ascii=False, indent=2),
+        encoding="utf-8")
     print(f"fixture: {out_wav}  ({cursor:.1f}s, {len(speakers)} speakers, "
           f"{len(segments)} turns)\nreference: {out_ref}")
     return 0
@@ -180,58 +204,80 @@ def cmd_run(args: argparse.Namespace) -> int:
     audio_path = Path(args.audio)
     ref_segments = load_segments(Path(args.reference)) if args.reference else []
 
-    import numpy as np  # noqa: PLC0415
-
     waveform, sr = _load_audio_mono16k(audio_path)
     audio_len_s = len(waveform) / sr
     metrics: dict = {
-        "audio": str(audio_path), "audio_seconds": round(audio_len_s, 1),
+        "audio": str(audio_path), "audio_stem": audio_path.stem,
+        "audio_seconds": round(audio_len_s, 1),
         "whisper_model": args.whisper_model, "device": args.device,
         "diarization_model": args.diarization_model,
     }
 
-    gpu_peak = _GpuPeak(args.device)
+    vram = _VramPoller()
+    vram.start()
+    torch_peak = _TorchPeak(args.device)
 
-    # -- diarization ---------------------------------------------------------
+    # -- diarization (model load kept OUT of the timed inference window) -----
     t0 = time.monotonic()
-    diar_segments = _run_pyannote(args, waveform, sr)
+    pipeline = _load_pyannote(args)
+    t_load = time.monotonic() - t0
+
+    t0 = time.monotonic()
+    diar_segments = _diarize(pipeline, args, waveform, sr)
     t_diar = time.monotonic() - t0
+    del pipeline
+    _cuda_gc()
     metrics["t_diarization_s"] = round(t_diar, 1)
     metrics["hyp_speaker_count"] = len({s.speaker for s in diar_segments})
     if ref_segments:
         metrics["ref_speaker_count"] = len({s.speaker for s in ref_segments})
 
-    # -- ASR with word timestamps --------------------------------------------
+    # -- ASR with word timestamps ---------------------------------------------
     t0 = time.monotonic()
-    words = _run_whisper(args, audio_path)
-    t_asr = time.monotonic() - t0
-    metrics["t_asr_s"] = round(t_asr, 1)
+    model = _load_whisper(args)
+    t_load += time.monotonic() - t0
 
-    # -- alignment: word -> speaker ------------------------------------------
+    t0 = time.monotonic()
+    words = _transcribe(model, args, audio_path)
+    t_asr = time.monotonic() - t0
+    del model
+    _cuda_gc()
+    metrics["t_asr_s"] = round(t_asr, 1)
+    metrics["t_model_load_s"] = round(t_load, 1)
+
+    # -- alignment: word -> speaker -------------------------------------------
     hyp_segments = _align_words(words, diar_segments)
     metrics["hyp_segments"] = [asdict(s) for s in hyp_segments]
 
-    # -- scoring vs reference --------------------------------------------------
+    # -- scoring vs reference ----------------------------------------------------
     if ref_segments:
         metrics["diarization_scores"] = _score_frames(ref_segments, hyp_segments)
+        der_xcheck = _try_pyannote_der(ref_segments, hyp_segments)
+        if der_xcheck is not None:
+            metrics["der_pyannote_metrics"] = round(der_xcheck, 4)
         if any(s.text for s in ref_segments):
             wer = _try_wer(" ".join(s.text for s in ref_segments),
                            " ".join(w[2] for w in words))
             if wer is not None:
                 metrics["wer_sample"] = round(wer, 3)
 
-    # -- per-cluster ECAPA separation (auto-match gate) ------------------------
+    # -- per-cluster ECAPA separation (auto-match gate) --------------------------
     if args.ecapa_onnx:
         metrics["embedding_separation"] = _cluster_separation(
             args, waveform, sr, diar_segments)
 
+    # Inference-only cost; model load/download excluded so runs are comparable
+    # across cold/warm caches. Precision 2 so the gate compares the real value
+    # (a 30.04 must not round to a passing 30.0).
     metrics["gpu_seconds_per_audio_minute"] = round(
-        (t_diar + t_asr) / max(audio_len_s / 60.0, 1e-9), 1)
-    metrics["gpu_peak_vram_mb"] = gpu_peak.read()
+        (t_diar + t_asr) / max(audio_len_s / 60.0, 1e-9), 2)
+    vram.stop()
+    metrics["gpu_peak_vram_mb"] = vram.max_mb          # whole-GPU, allocator-agnostic
+    metrics["gpu_peak_vram_torch_mb"] = torch_peak.read()  # torch-only breakdown
 
     out = Path(args.out)
     out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(json.dumps(metrics, ensure_ascii=False, indent=2))
+    out.write_text(json.dumps(metrics, ensure_ascii=False, indent=2), encoding="utf-8")
     print(json.dumps({k: v for k, v in metrics.items() if k != "hyp_segments"},
                      ensure_ascii=False, indent=2))
     print(f"\nmetrics written: {out}")
@@ -246,20 +292,36 @@ def _load_audio_mono16k(path: Path):
             ["ffmpeg", "-loglevel", "error", "-i", str(path),
              "-f", "f32le", "-ac", "1", "-ar", "16000", "pipe:1"],
             check=True, capture_output=True).stdout
-        return np.frombuffer(raw, dtype=np.float32).copy(), 16000
+        # frombuffer view avoids a second full copy of hours-long audio; the
+        # consumers (torch.from_numpy, slicing) only read it.
+        return np.frombuffer(raw, dtype=np.float32), 16000
     pcm, _dur = _read_wav_pcm16(path, 16000)  # strict fallback: already-16k wav
     return (np.frombuffer(pcm, dtype=np.int16).astype(np.float32) / 32768.0), 16000
 
 
-def _run_pyannote(args, waveform, sr) -> list[Segment]:
+def _load_pyannote(args):
     import torch  # noqa: PLC0415
     from pyannote.audio import Pipeline  # noqa: PLC0415
 
     token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
     pipeline = Pipeline.from_pretrained(args.diarization_model, use_auth_token=token)
+    if pipeline is None:
+        # pyannote returns None (not an exception) when the gated model's
+        # license was never accepted or the token is missing/invalid.
+        raise SystemExit(
+            f"pyannote could not load {args.diarization_model!r}. Accept the model "
+            "license on huggingface.co with the account behind HF_TOKEN, and export "
+            "HF_TOKEN (or pre-populate the HF cache for offline hosts).")
     if args.device == "cuda":
         pipeline.to(torch.device("cuda"))
-    tensor = torch.from_numpy(waveform).unsqueeze(0)
+    return pipeline
+
+
+def _diarize(pipeline, args, waveform, sr) -> list[Segment]:
+    import numpy as np  # noqa: PLC0415
+    import torch  # noqa: PLC0415
+
+    tensor = torch.from_numpy(np.ascontiguousarray(waveform)).unsqueeze(0)
     kwargs = {}
     if args.num_speakers:
         kwargs["num_speakers"] = args.num_speakers
@@ -268,46 +330,68 @@ def _run_pyannote(args, waveform, sr) -> list[Segment]:
             for turn, _track, label in annotation.itertracks(yield_label=True)]
 
 
-def _run_whisper(args, audio_path: Path) -> list[tuple[float, float, str]]:
+def _load_whisper(args):
     from faster_whisper import WhisperModel  # noqa: PLC0415
 
     compute = "float16" if args.device == "cuda" else "int8"
-    model = WhisperModel(args.whisper_model, device=args.device, compute_type=compute)
+    return WhisperModel(args.whisper_model, device=args.device, compute_type=compute)
+
+
+def _transcribe(model, args, audio_path: Path) -> list[tuple[float, float, str]]:
     seg_iter, _info = model.transcribe(str(audio_path), language=args.language,
                                        word_timestamps=True, vad_filter=True)
     words: list[tuple[float, float, str]] = []
     for seg in seg_iter:
         for w in seg.words or []:
             words.append((float(w.start), float(w.end), w.word.strip()))
-    del model
     return words
+
+
+def _cuda_gc() -> None:
+    """Release CUDA memory between pipeline stages: pyannote (torch), whisper
+    (CTranslate2) and the ECAPA ONNX session each use their OWN allocator, so
+    torch's cached blocks must actually be freed before the next stage or the
+    stages stack up in VRAM."""
+    import gc  # noqa: PLC0415
+    gc.collect()
+    try:
+        import torch  # noqa: PLC0415
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+    except ImportError:
+        pass
 
 
 def _align_words(words, diar_segments: list[Segment]) -> list[Segment]:
     """Assign each ASR word to the diarization turn with maximal time overlap.
 
+    Two-pointer sweep over the time-sorted streams (ASR words arrive in time
+    order; turns are sorted here) — O(W + D) instead of scanning every turn per
+    word, which matters at the 4 h ceiling (~40k words x ~3k turns).
     Overlapping turns: max-overlap wins. Uncovered words snap to the nearest
-    turn within 0.5 s, otherwise speaker 'UNK'. Consecutive same-speaker words
-    merge into hypothesis segments.
+    turn within SNAP_WINDOW_S (full scan — rare path), otherwise speaker 'UNK'.
+    Consecutive same-speaker words merge across gaps up to MERGE_GAP_S.
     """
-    def overlap(a0, a1, b0, b1):
-        return max(0.0, min(a1, b1) - max(a0, b0))
-
+    segs = sorted(diar_segments, key=lambda d: d.start)
     hyp: list[Segment] = []
+    j = 0
     for w0, w1, text in words:
+        # Turns entirely before this word can never overlap a later word either.
+        while j < len(segs) and segs[j].end < w0:
+            j += 1
         best, best_ov = None, 0.0
-        for d in diar_segments:
-            ov = overlap(w0, w1, d.start, d.end)
+        k = j
+        while k < len(segs) and segs[k].start < w1:
+            ov = min(w1, segs[k].end) - max(w0, segs[k].start)
             if ov > best_ov:
-                best, best_ov = d, ov
-        if best is None:
-            near = min(diar_segments,
-                       key=lambda d: min(abs(d.start - w1), abs(w0 - d.end)),
-                       default=None)
-            if near is not None and min(abs(near.start - w1), abs(w0 - near.end)) <= 0.5:
+                best, best_ov = segs[k], ov
+            k += 1
+        if best is None and segs:
+            near = min(segs, key=lambda d: min(abs(d.start - w1), abs(w0 - d.end)))
+            if min(abs(near.start - w1), abs(w0 - near.end)) <= SNAP_WINDOW_S:
                 best = near
         speaker = best.speaker if best else "UNK"
-        if hyp and hyp[-1].speaker == speaker and w0 - hyp[-1].end <= 1.0:
+        if hyp and hyp[-1].speaker == speaker and w0 - hyp[-1].end <= MERGE_GAP_S:
             hyp[-1].end = w1
             hyp[-1].text = f"{hyp[-1].text} {text}".strip()
         else:
@@ -316,47 +400,79 @@ def _align_words(words, diar_segments: list[Segment]) -> list[Segment]:
 
 
 def _score_frames(ref: list[Segment], hyp: list[Segment]) -> dict:
-    """Frame-level DER-style scoring with optimal (Hungarian) speaker mapping."""
+    """Frame-level DER-style scoring with optimal (Hungarian) speaker mapping.
+
+    attribution_error_rate is measured only on frames BOTH streams label —
+    which is why the report additionally gates der_like and hyp_coverage: a
+    hypothesis that labels almost nothing would otherwise score a perfect AER.
+    """
     import numpy as np  # noqa: PLC0415
     from scipy.optimize import linear_sum_assignment  # noqa: PLC0415
 
+    def fidx(t: float) -> int:
+        return int(round(t / FRAME_S))
+
     end = max(max(s.end for s in ref), max((s.end for s in hyp), default=0.0))
-    n = int(math.ceil(end / FRAME_S)) + 1
+    n = fidx(end) + 1
     ref_speakers = sorted({s.speaker for s in ref})
-    hyp_speakers = sorted({s.speaker for s in hyp})
+    # UNK means "unattributed", not a speaker — keeping it as a matrix column
+    # would let Hungarian map a real reference speaker onto an empty column.
+    hyp_speakers = sorted({s.speaker for s in hyp if s.speaker != "UNK"})
     ref_idx = {s: i for i, s in enumerate(ref_speakers)}
     hyp_idx = {s: i for i, s in enumerate(hyp_speakers)}
 
     ref_f = np.full(n, -1, dtype=np.int16)
     hyp_f = np.full(n, -1, dtype=np.int16)
     for s in ref:
-        ref_f[int(s.start / FRAME_S):int(s.end / FRAME_S)] = ref_idx[s.speaker]
+        ref_f[fidx(s.start):fidx(s.end)] = ref_idx[s.speaker]
     for s in hyp:
         if s.speaker == "UNK":
             continue
-        hyp_f[int(s.start / FRAME_S):int(s.end / FRAME_S)] = hyp_idx[s.speaker]
+        hyp_f[fidx(s.start):fidx(s.end)] = hyp_idx[s.speaker]
 
     # confusion matrix over frames where both streams see speech
     both = (ref_f >= 0) & (hyp_f >= 0)
-    conf = np.zeros((len(ref_speakers), len(hyp_speakers)), dtype=np.int64)
-    np.add.at(conf, (ref_f[both], hyp_f[both]), 1)
+    conf = np.zeros((len(ref_speakers), max(len(hyp_speakers), 1)), dtype=np.int64)
+    if both.any():
+        np.add.at(conf, (ref_f[both], hyp_f[both]), 1)
     rows, cols = linear_sum_assignment(-conf)
-    mapping = dict(zip(cols.tolist(), rows.tolist()))  # hyp -> ref
+    mapping = {c: r for r, c in zip(rows.tolist(), cols.tolist()) if c < len(hyp_speakers)}
 
-    correct = sum(int(conf[r, c]) for r, c in zip(rows, cols))
+    correct = sum(int(conf[r, c]) for r, c in zip(rows, cols) if c < len(hyp_speakers))
     confused = int(both.sum()) - correct
     missed = int(((ref_f >= 0) & (hyp_f < 0)).sum())
     false_alarm = int(((ref_f < 0) & (hyp_f >= 0)).sum())
     ref_speech = int((ref_f >= 0).sum())
 
     return {
-        "attribution_error_rate": round(confused / max(both.sum(), 1), 4),
+        "attribution_error_rate": round(confused / max(int(both.sum()), 1), 4),
         "der_like": round((missed + false_alarm + confused) / max(ref_speech, 1), 4),
         "missed_rate": round(missed / max(ref_speech, 1), 4),
         "false_alarm_rate": round(false_alarm / max(ref_speech, 1), 4),
+        "hyp_coverage": round(int(both.sum()) / max(ref_speech, 1), 4),
         "speaker_mapping": {hyp_speakers[c]: ref_speakers[r]
                             for c, r in mapping.items()},
     }
+
+
+def _try_pyannote_der(ref: list[Segment], hyp: list[Segment]):
+    """Cross-check the hand-rolled scorer against pyannote.metrics DER when it
+    is importable (it ships with pyannote.audio, i.e. in every `run` env).
+    Disagreement between der_like and this value on the synthetic fixture
+    means the decision instrument itself is buggy — investigate before
+    trusting any gate verdict."""
+    try:
+        from pyannote.core import Annotation, Segment as PSegment  # noqa: PLC0415
+        from pyannote.metrics.diarization import DiarizationErrorRate  # noqa: PLC0415
+    except ImportError:
+        return None
+    ref_ann, hyp_ann = Annotation(), Annotation()
+    for s in ref:
+        ref_ann[PSegment(s.start, s.end)] = s.speaker
+    for s in hyp:
+        if s.speaker != "UNK":
+            hyp_ann[PSegment(s.start, s.end)] = s.speaker
+    return float(DiarizationErrorRate()(ref_ann, hyp_ann))
 
 
 def _try_wer(ref_text: str, hyp_text: str):
@@ -372,9 +488,11 @@ def _cluster_separation(args, waveform, sr, diar_segments: list[Segment]) -> dic
 
     Splits every cluster's speech into chunks, embeds each chunk, then reports
     same-cluster vs cross-cluster cosine statistics. The auto-match gate is
-    separation = same_mean - cross_p95  (gates.yaml: auto_match_separation_min).
+    separation = same_mean - cross_p95 (gates.yaml: auto_match_separation_min);
+    the report treats it as unmeasured below the minimum pair counts.
     Requires the speechbrain feature pipeline — run inside the voice-server
-    image (same preprocessing as production, see voice-server speaker_service).
+    image (same preprocessing as production; verify parity once per the README
+    checklist before trusting the numbers).
     """
     import numpy as np  # noqa: PLC0415
     import onnxruntime as ort  # noqa: PLC0415
@@ -389,7 +507,7 @@ def _cluster_separation(args, waveform, sr, diar_segments: list[Segment]) -> dic
     input_name = sess.get_inputs()[0].name
 
     def embed(chunk: "np.ndarray") -> "np.ndarray":
-        wav = torch.from_numpy(chunk).unsqueeze(0)
+        wav = torch.from_numpy(np.ascontiguousarray(chunk)).unsqueeze(0)
         feats = norm(fbank(wav), torch.ones(1))
         out = sess.run(None, {input_name: feats.numpy()})[0]
         vec = np.squeeze(out).astype(np.float32)
@@ -401,7 +519,8 @@ def _cluster_separation(args, waveform, sr, diar_segments: list[Segment]) -> dic
         a, b = int(seg.start * sr), int(seg.end * sr)
         by_cluster.setdefault(seg.speaker, []).append(waveform[a:b])
 
-    cluster_embs: dict[str, list] = {}
+    cluster_embs: dict[str, "np.ndarray"] = {}
+    dropped: list[str] = []
     for speaker, pieces in by_cluster.items():
         speech = np.concatenate(pieces) if len(pieces) > 1 else pieces[0]
         n_chunks = int(len(speech) / (chunk_s * sr))
@@ -411,47 +530,68 @@ def _cluster_separation(args, waveform, sr, diar_segments: list[Segment]) -> dic
         if len(rest) >= min_s * sr:
             embs.append(embed(rest))
         if embs:
-            cluster_embs[speaker] = embs
+            cluster_embs[speaker] = np.stack(embs)
+        else:
+            dropped.append(speaker)  # too little speech — visible, not silent
 
-    same, cross = [], []
+    same: list[float] = []
+    cross: list[float] = []
     speakers = list(cluster_embs)
     for i, si in enumerate(speakers):
         ei = cluster_embs[si]
-        same += [float(a @ b) for x, a in enumerate(ei) for b in ei[x + 1:]]
+        sims = ei @ ei.T  # embeddings are L2-normalized -> dot == cosine
+        iu = np.triu_indices(len(ei), k=1)
+        same += sims[iu].tolist()
         for sj in speakers[i + 1:]:
-            cross += [float(a @ b) for a in ei for b in cluster_embs[sj]]
-
-    def p95(vals):
-        return sorted(vals)[max(0, int(0.95 * len(vals)) - 1)] if vals else None
+            cross += (ei @ cluster_embs[sj].T).ravel().tolist()
 
     same_mean = round(statistics.fmean(same), 4) if same else None
-    cross_p95 = round(p95(cross), 4) if cross else None
+    cross_p95 = round(_p95(cross), 4) if cross else None
     separation = (round(same_mean - cross_p95, 4)
                   if same_mean is not None and cross_p95 is not None else None)
     return {
-        "chunks_per_cluster": {s: len(e) for s, e in cluster_embs.items()},
+        "chunks_per_cluster": {s: int(len(e)) for s, e in cluster_embs.items()},
+        "clusters_dropped_too_short": dropped,
+        "same_pairs": len(same),
+        "cross_pairs": len(cross),
         "same_cluster_cosine_mean": same_mean,
         "cross_cluster_cosine_p95": cross_p95,
         "separation": separation,
     }
 
 
-class _GpuPeak:
-    """Peak-VRAM tracker: torch counter when on CUDA, else nvidia-smi snapshot."""
+class _TorchPeak:
+    """torch-only VRAM counter — a BREAKDOWN, not the capacity number: it
+    cannot see CTranslate2 (faster-whisper) or onnxruntime allocations."""
 
     def __init__(self, device: str):
-        self.device = device
+        self._torch = None
         if device == "cuda":
             try:
                 import torch  # noqa: PLC0415
                 torch.cuda.reset_peak_memory_stats()
                 self._torch = torch
             except Exception:
-                self._torch = None
+                pass
 
     def read(self):
-        if self.device == "cuda" and getattr(self, "_torch", None):
+        if self._torch is not None:
             return round(self._torch.cuda.max_memory_allocated() / 2**20)
+        return None
+
+
+class _VramPoller:
+    """Whole-GPU peak via periodic `nvidia-smi memory.used` sampling in a
+    background thread — allocator-agnostic, so it sees torch + CTranslate2 +
+    ONNX together. This is the number the D5 deployment decision reads."""
+
+    def __init__(self, interval_s: float = 1.0):
+        self.interval_s = interval_s
+        self.max_mb: int | None = None
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def _sample(self):
         try:
             out = subprocess.run(
                 ["nvidia-smi", "--query-gpu=memory.used", "--format=csv,noheader,nounits"],
@@ -460,23 +600,55 @@ class _GpuPeak:
         except Exception:
             return None
 
+    def _loop(self):
+        while not self._stop.is_set():
+            mb = self._sample()
+            if mb is not None and (self.max_mb is None or mb > self.max_mb):
+                self.max_mb = mb
+            self._stop.wait(self.interval_s)
+
+    def start(self):
+        if self._sample() is None:
+            return  # no nvidia-smi — poller stays inert, max_mb stays None
+        self._thread = threading.Thread(target=self._loop, daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=self.interval_s + 6)
+
 
 # --------------------------------------------------------------------------
 # probe-live-stt — measure live STT latency (baseline vs during a batch run)
 # --------------------------------------------------------------------------
 
 def cmd_probe_live_stt(args: argparse.Namespace) -> int:
+    import ssl  # noqa: PLC0415
+    import urllib.error  # noqa: PLC0415
     import urllib.request  # noqa: PLC0415
     import uuid  # noqa: PLC0415
 
     sample = Path(args.sample).read_bytes()
-    latencies: list[float] = []
-    deadline = time.monotonic() + args.duration_s
     boundary = uuid.uuid4().hex
     body = (f"--{boundary}\r\nContent-Disposition: form-data; name=\"audio\"; "
             f"filename=\"probe.wav\"\r\nContent-Type: audio/wav\r\n\r\n"
             ).encode() + sample + f"\r\n--{boundary}--\r\n".encode()
+    if args.ca_bundle:
+        ctx = ssl.create_default_context(cafile=args.ca_bundle)
+    elif args.insecure:
+        # Last resort for the self-signed renfield.local cert on a trusted LAN;
+        # prefer --ca-bundle with the local CA (no MITM blind spot).
+        ctx = ssl._create_unverified_context()
+    else:
+        ctx = None
 
+    # Failed probes are counted as timeout-clamped samples, NOT dropped:
+    # the exact failure mode this gate exists for (batch load pushing live
+    # STT into timeouts) must WORSEN the p95, not clean it up.
+    latencies: list[float] = []
+    errors = 0
+    deadline = time.monotonic() + args.duration_s
     while time.monotonic() < deadline:
         req = urllib.request.Request(
             args.url.rstrip("/") + "/api/voice/stt", data=body, method="POST",
@@ -484,70 +656,130 @@ def cmd_probe_live_stt(args: argparse.Namespace) -> int:
                      **({"Authorization": f"Bearer {args.token}"} if args.token else {})})
         t0 = time.monotonic()
         try:
-            with urllib.request.urlopen(req, timeout=60):
+            with urllib.request.urlopen(req, timeout=args.timeout_s, context=ctx):
                 pass
             latencies.append(time.monotonic() - t0)
         except Exception as exc:  # noqa: BLE001 — a probe records failures, never aborts
-            print(f"probe error: {exc}", file=sys.stderr)
+            errors += 1
+            latencies.append(args.timeout_s)
+            print(f"probe error (counted as {args.timeout_s}s): {exc}", file=sys.stderr)
         time.sleep(args.interval_s)
 
     if not latencies:
-        print("no successful probes", file=sys.stderr)
+        print("no probes executed", file=sys.stderr)
         return 1
-    latencies.sort()
+    ok = sorted(latencies)
     result = {
         "samples": len(latencies),
-        "p50_s": round(latencies[len(latencies) // 2], 3),
-        "p95_s": round(latencies[max(0, int(0.95 * len(latencies)) - 1)], 3),
+        "errors": errors,
+        "error_rate": round(errors / len(latencies), 3),
+        "p50_s": round(ok[len(ok) // 2], 3),
+        "p95_s": round(_p95(latencies), 3),
         "mean_s": round(statistics.fmean(latencies), 3),
+        "timeout_s": args.timeout_s,
     }
-    Path(args.out).write_text(json.dumps(result, indent=2))
+    Path(args.out).write_text(json.dumps(result, indent=2), encoding="utf-8")
     print(json.dumps(result, indent=2))
     return 0
 
 
 # --------------------------------------------------------------------------
-# report — gates
+# report — gates (fail-closed: a missing hard metric FAILS; verdict is per
+# candidate, overall PASS = at least one candidate passes all hard gates AND
+# the live probe pair passes)
 # --------------------------------------------------------------------------
 
 def cmd_report(args: argparse.Namespace) -> int:
     gates = _load_gates(Path(args.gates))
-    rows: list[tuple[str, str, str, str, bool | None]] = []
+    print(f"{'gate':58} {'value':>12} {'threshold':>10}  verdict")
+    print("-" * 96)
 
+    any_candidate_passes = False
     for metrics_path in args.metrics:
-        m = json.loads(Path(metrics_path).read_text())
-        label = m.get("whisper_model", Path(metrics_path).stem)
+        m = json.loads(Path(metrics_path).read_text(encoding="utf-8"))
+        label = f"{m.get('whisper_model', '?')}|{m.get('audio_stem', Path(metrics_path).stem)}"
+        scores = m.get("diarization_scores") or {}
+        sep = m.get("embedding_separation") or {}
 
-        aer = (m.get("diarization_scores") or {}).get("attribution_error_rate")
-        rows.append(_gate(f"[{label}] attribution_error_rate", aer,
-                          gates["attribution_error_rate_max"], "<="))
-        gpm = m.get("gpu_seconds_per_audio_minute")
-        rows.append(_gate(f"[{label}] gpu_s_per_audio_min", gpm,
-                          gates["gpu_seconds_per_audio_minute_max"], "<="))
-        sep = (m.get("embedding_separation") or {}).get("separation")
-        rows.append(_gate(f"[{label}] auto_match_separation", sep,
-                          gates["auto_match_separation_min"], ">=",
-                          note="gate for BUILDING auto-match, not for shipping §2"))
+        rows = [
+            _gate("attribution_error_rate", scores.get("attribution_error_rate"),
+                  gates["attribution_error_rate_max"], "<="),
+            _gate("der_like", scores.get("der_like"), gates["der_like_max"], "<="),
+            _gate("hyp_coverage", scores.get("hyp_coverage"),
+                  gates["min_hyp_coverage"], ">="),
+            _gate("gpu_s_per_audio_min", m.get("gpu_seconds_per_audio_minute"),
+                  gates["gpu_seconds_per_audio_minute_max"], "<="),
+            _separation_gate(sep, gates),
+        ]
+        candidate_pass = all(ok for _, _, _, _, ok, advisory in rows if not advisory)
+        any_candidate_passes = any_candidate_passes or candidate_pass
+        for name, val, thr, note, ok, advisory in rows:
+            verdict = ("PASS" if ok else "FAIL") if not advisory else \
+                      ("pass" if ok else ("n/a" if ok is None else "no-build"))
+            print(f"[{label}] {name:{max(1, 56 - len(label))}} {val:>12} {thr:>10}  "
+                  f"{verdict}{'  # ' + note if note else ''}")
+        print(f"[{label}] {'-> candidate verdict':{max(1, 56 - len(label))}} "
+              f"{'':>12} {'':>10}  {'PASS' if candidate_pass else 'FAIL'}")
 
+    # Live-latency gate is global (one probe pair per spike run). Missing
+    # probe data is a missing HARD gate -> the overall verdict cannot pass.
+    live_ok = False
     if args.live_baseline and args.live_during:
-        base = json.loads(Path(args.live_baseline).read_text())["p95_s"]
-        during = json.loads(Path(args.live_during).read_text())["p95_s"]
-        factor = round(during / base, 2) if base else None
-        rows.append(_gate("live_stt_p95_factor", factor,
-                          gates["live_stt_p95_factor_max"], "<="))
+        base = json.loads(Path(args.live_baseline).read_text(encoding="utf-8"))
+        during = json.loads(Path(args.live_during).read_text(encoding="utf-8"))
+        factor = round(during["p95_s"] / base["p95_s"], 2) if base.get("p95_s") else None
+        name, val, thr, note, ok, _ = _gate("live_stt_p95_factor", factor,
+                                            gates["live_stt_p95_factor_max"], "<=")
+        live_ok = bool(ok)
+        extra = f"baseline_err={base.get('error_rate')} during_err={during.get('error_rate')}"
+        print(f"{name:58} {val:>12} {thr:>10}  {'PASS' if ok else 'FAIL'}  # {extra}")
+    else:
+        print(f"{'live_stt_p95_factor':58} {'—':>12} "
+              f"{'<=' + str(gates['live_stt_p95_factor_max']):>10}  FAIL  # not measured "
+              "(pass --live-baseline/--live-during)")
 
-    print(f"{'gate':55} {'value':>10} {'threshold':>10}  verdict")
-    print("-" * 90)
-    hard_fail = False
-    for name, val, thr, note, ok in rows:
-        verdict = "PASS" if ok else ("n/a" if ok is None else "FAIL")
-        print(f"{name:55} {val:>10} {thr:>10}  {verdict}{'  # ' + note if note else ''}")
-        if ok is False and "auto_match" not in name:
-            hard_fail = True
-    print("-" * 90)
-    print("OVERALL:", "FAIL — do not start the §2 build" if hard_fail
-          else "PASS — §2 build unblocked (auto-match only if its gate passed)")
-    return 1 if hard_fail else 0
+    print("-" * 96)
+    overall = any_candidate_passes and live_ok
+    print("OVERALL:", "PASS — §2 build unblocked (auto-match only if its gate passed)"
+          if overall else "FAIL — do not start the §2 build "
+          "(no candidate passed all hard gates and/or live latency unmeasured/failed)")
+    return 0 if overall else 1
+
+
+def _gate(name, value, threshold, op, advisory=False):
+    """Row tuple: (name, value, threshold, note, ok, advisory). A missing value
+    on a HARD gate is ok=False (fail-closed); on an advisory gate it is None."""
+    if value is None:
+        ok = None if advisory else False
+        return (name, "—", f"{op}{threshold}", "metric missing", ok, advisory)
+    ok = value <= threshold if op == "<=" else value >= threshold
+    return (name, str(value), f"{op}{threshold}", "", ok, advisory)
+
+
+def _separation_gate(sep: dict, gates: dict):
+    """Advisory auto-match gate (never blocks §2). Below the minimum pair
+    counts the metric is 'insufficient data', not a number vs threshold."""
+    note = "gate for BUILDING auto-match, not for shipping §2"
+    if not sep:
+        return ("auto_match_separation", "—",
+                f">={gates['auto_match_separation_min']}", note + " (not measured)",
+                None, True)
+    if (sep.get("same_pairs", 0) < gates["separation_min_same_pairs"]
+            or sep.get("cross_pairs", 0) < gates["separation_min_cross_pairs"]):
+        return ("auto_match_separation",
+                f"{sep.get('separation')}",
+                f">={gates['auto_match_separation_min']}",
+                note + f" (insufficient data: {sep.get('same_pairs', 0)} same/"
+                       f"{sep.get('cross_pairs', 0)} cross pairs)",
+                None, True)
+    value = sep.get("separation")
+    if value is None:
+        return ("auto_match_separation", "—",
+                f">={gates['auto_match_separation_min']}", note + " (not measured)",
+                None, True)
+    ok = value >= gates["auto_match_separation_min"]
+    return ("auto_match_separation", str(value),
+            f">={gates['auto_match_separation_min']}", note, ok, True)
 
 
 def _load_gates(path: Path) -> dict:
@@ -555,23 +787,16 @@ def _load_gates(path: Path) -> dict:
     (the file is a single `gates:` mapping of numeric thresholds)."""
     try:
         import yaml  # noqa: PLC0415
-        return yaml.safe_load(path.read_text())["gates"]
+        return yaml.safe_load(path.read_text(encoding="utf-8"))["gates"]
     except ImportError:
         gates: dict[str, float] = {}
-        for line in path.read_text().splitlines():
+        for line in path.read_text(encoding="utf-8").splitlines():
             line = line.split("#", 1)[0].strip()
             if not line or line.endswith(":"):
                 continue
             key, _, value = line.partition(":")
             gates[key.strip()] = float(value)
         return gates
-
-
-def _gate(name, value, threshold, op, note=""):
-    if value is None:
-        return (name, "—", str(threshold), note or "metric missing", None)
-    ok = value <= threshold if op == "<=" else value >= threshold
-    return (name, str(value), f"{op}{threshold}", note, ok)
 
 
 # --------------------------------------------------------------------------
@@ -593,7 +818,8 @@ def main() -> int:
 
     r = sub.add_parser("run", help="run diarization+ASR+alignment on one fixture")
     r.add_argument("--audio", required=True)
-    r.add_argument("--reference", help="reference.json (omit for exploratory runs)")
+    r.add_argument("--reference", help="reference.json (omit for exploratory runs; "
+                                       "the report then FAILS that candidate)")
     r.add_argument("--out", required=True, help="metrics JSON output path")
     r.add_argument("--whisper-model", default="large-v3")
     r.add_argument("--language", default="de")
@@ -607,11 +833,20 @@ def main() -> int:
     r.set_defaults(func=cmd_run)
 
     s = sub.add_parser("probe-live-stt", help="latency probe against voice-server")
-    s.add_argument("--url", required=True, help="voice-server base url")
-    s.add_argument("--token", default=os.environ.get("VOICE_TOKEN", ""))
+    s.add_argument("--url", required=True, help="voice-server / backend base url")
+    s.add_argument("--token", default=os.environ.get("VOICE_TOKEN", ""),
+                   help="bearer token; PREFER the VOICE_TOKEN env var — argv is "
+                        "visible in `ps` and shell history")
     s.add_argument("--sample", required=True, help="short wav to POST repeatedly")
     s.add_argument("--interval-s", type=float, default=2.0)
     s.add_argument("--duration-s", type=float, default=120.0)
+    s.add_argument("--timeout-s", type=float, default=60.0,
+                   help="per-request timeout; failures are clamped to this value")
+    s.add_argument("--ca-bundle", help="PEM file with the local CA that signed the "
+                                       "server cert (preferred over --insecure)")
+    s.add_argument("--insecure", action="store_true",
+                   help="skip TLS verification — last resort for self-signed certs "
+                        "on a trusted LAN; prefer --ca-bundle")
     s.add_argument("--out", required=True)
     s.set_defaults(func=cmd_probe_live_stt)
 

--- a/docs/design/meeting-transcription.md
+++ b/docs/design/meeting-transcription.md
@@ -11,6 +11,11 @@ Upload a multi-speaker meeting recording → speaker-attributed transcript → r
 in the knowledge base (RAG + Wissen workspace). Written notes and single-voice dictation
 already work via existing paths; this adds the multi-speaker piece.
 
+> Related design: `docs/design/voice-identity-wakeword-verification.md` plans ONLINE
+> (streaming) diarization for session continuity — a different pyannote mode than the
+> batch pipeline here. Coordinate the voice-server image change (GPU torch + pyannote
+> layer split) so both land ONE pyannote integration, not two.
+
 ## Locked architecture (all decisions from the review)
 
 ```

--- a/docs/voice-pipeline-plan.md
+++ b/docs/voice-pipeline-plan.md
@@ -185,7 +185,7 @@ Both via the same plugin-hook architecture in Renfield, customized at integratio
 
 ## 7. Out of scope
 
-- **Echo cancellation / diarization** for live meeting scenarios. Renfield has no Teams Calls integration; Reva's doc lists it out of scope too.
+- **Echo cancellation / diarization** for live meeting scenarios. Renfield has no Teams Calls integration; Reva's doc lists it out of scope too. *(Update 2026-07-06: diarization of RECORDED meetings now has a locked, spike-gated design — `docs/design/meeting-transcription.md`; live/streaming diarization remains out of scope here, see the voice-identity design.)*
 - **Wake-word retraining** — covered by `src/satellite/TECHNICAL_DEBT.md` low-priority section, separate work.
 - **Multi-speaker simultaneous input** — single-speaker per session for now.
 - **Languages beyond `de`/`en`** — `supported_languages="de,en"` is the current commitment.

--- a/tests/eval/diarization/README.md
+++ b/tests/eval/diarization/README.md
@@ -1,7 +1,8 @@
 # Diarization eval — spike T1 & permanent regression harness
 
 Harness: [`bin/run_diarization_eval.py`](../../../bin/run_diarization_eval.py) ·
-Gates: [`gates.yaml`](gates.yaml) (fixed 2026-07-06, before first measurement) ·
+Gates: [`gates.yaml`](gates.yaml) (fixed 2026-07-06 before first measurement; fail-closed
+hardening amended same day by the PR #924 review) ·
 Design: [`docs/design/meeting-transcription.md`](../../../docs/design/meeting-transcription.md)
 
 ## Two-tier fixture policy
@@ -11,9 +12,20 @@ Design: [`docs/design/meeting-transcription.md`](../../../docs/design/meeting-tr
 | Synthetic (committed) | `fixtures/` | Privacy-clean regression anchor — placeholder names, TTS voices. Re-run after every whisper/pyannote/threshold change. |
 | Real recordings (NEVER committed) | `local/` (gitignored) | Actual room/mic/German-household acoustics. The gates are judged on THESE; the synthetic fixture guards against regressions. |
 
+Fixture provenance: `meeting_synthetic_de.wav` is generated from
+`meeting_script_de.txt` (command below); `probe_short.wav` is a 4 s ffmpeg cut
+of that same synthetic file (`ffmpeg -i meeting_synthetic_de.wav -ss 0.6 -t 4
+probe_short.wav`) — no real voices anywhere in `fixtures/`.
+
 Synthetic audio is sequential turns with gaps — it cannot exercise overlapping
 speech or room reverb. Treat synthetic results as an upper bound; real
 recordings decide the gates.
+
+**Writing a `reference.json` by hand:** segments must be NON-OVERLAPPING (the
+frame scorer is single-label; overlapping reference speech would be silently
+mis-scored). Label a 2-3 minute excerpt; ±0.3 s boundary precision is fine —
+speaker identity dominates the metric. For genuinely overlapping passages,
+place the boundary where the dominant speaker changes.
 
 ## 1. Generate the synthetic fixture (macOS, one-time)
 
@@ -21,52 +33,81 @@ recordings decide the gates.
 python3 bin/run_diarization_eval.py generate-fixture \
   --script tests/eval/diarization/fixtures/meeting_script_de.txt \
   --out tests/eval/diarization/fixtures/meeting_synthetic_de.wav \
-  --voices "Anna=Anna,Ben=Rocko,Clara=Sandy,David=Eddy (Deutsch (Deutschland))"
+  --voices "Anna=Anna,Ben=Rocko (Deutsch (Deutschland)),Clara=Sandy (Deutsch (Deutschland)),David=Eddy (Deutsch (Deutschland))"
 ```
 
 ## 2. Record real fixtures (drop into `local/`)
 
 Per capture comparison (D15): record the SAME short meeting (~10 min, 3-4
 speakers) twice — phone in the table center AND an XVF3800 satellite test
-capture. Write a `*.reference.json` by hand for a 2-3 minute excerpt (segment
-starts/ends ±0.3 s is fine; that dominates the metric far less than speaker
-identity).
+capture. Write a `*.reference.json` for a 2-3 minute excerpt (rules above).
 
 ## 3. Run on a GPU host
 
 The run needs pyannote.audio + faster-whisper + speechbrain + onnxruntime —
 exactly the voice-server stack plus pyannote. Easiest: a one-off container from
 the voice-server image on a GPU box (e.g. cuda.local, which has docker + GPU;
-avoid gpu-3 during the day — it serves live voice):
+avoid gpu-3 during the day — it serves live voice).
+
+Export `HF_TOKEN` in your shell first (gated pyannote model — one-time license
+accept on huggingface.co), then pass it through WITHOUT putting the value on
+the command line (`-e HF_TOKEN` pass-through form, so it never lands in shell
+history or `docker inspect` of the command):
 
 ```bash
+export HF_TOKEN=...   # or use --env-file with a chmod-600 env file
+
 docker run --rm --gpus all \
   -v /path/to/renfield:/eval -w /eval \
-  -e HF_TOKEN=hf_...   # gated pyannote models — one-time license accept on HF \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  -e HF_TOKEN \
   registry.treehouse.x-idra.de/renfield/voice-server:<current-tag> \
-  bash -lc "pip install 'pyannote.audio>=3.1' scipy pyyaml && \
+  bash -lc 'pip install "pyannote.audio>=3.1" scipy pyyaml && \
     for M in base medium large-v3; do \
       python bin/run_diarization_eval.py run \
         --audio tests/eval/diarization/local/meeting_phone.wav \
         --reference tests/eval/diarization/local/meeting_phone.reference.json \
-        --whisper-model \$M --ecapa-onnx \$SPEAKER_MODEL_PATH \
-        --out /tmp/metrics-\$M.json ; done"
+        --whisper-model $M --ecapa-onnx "$SPEAKER_MODEL_PATH" \
+        --out /tmp/metrics-$M.json ; done'
 ```
 
-Note: this pip-installs pyannote at runtime for the SPIKE only — the build
-phase bakes model + deps into the image (offline-first, no runtime HF access).
-Pre-download the pyannote model once on a connected machine and mount the HF
-cache (`-v ~/.cache/huggingface:/root/.cache/huggingface`) if the GPU host
-should stay offline.
+Notes:
+- The runtime `pip install` is for the SPIKE only — the §2 build bakes model +
+  deps into the image (offline-first, no runtime HF access). Mounting the HF
+  cache lets an offline GPU host reuse a model downloaded elsewhere.
+- Model load/download time is excluded from `gpu_seconds_per_audio_minute`
+  (reported separately as `t_model_load_s`), so cold- and warm-cache runs are
+  comparable.
+- **Embedding-space parity check (once per image tag):** the separation metric
+  must live in the SAME ONNX space as production. Verify: extract the
+  `speaker_embedding` for `fixtures/probe_short.wav` via the voice-server REST
+  `/api/voice/stt` response, embed the same file with the harness
+  (`--ecapa-onnx`), and confirm cosine ≥ 0.99. If not, the preprocessing
+  drifted — fix before trusting any separation number.
 
-## 4. Live-latency impact (gate 4)
+## 4. Live-latency impact (gate)
 
 ```bash
 # baseline (no batch running), then again DURING a `run`:
+export VOICE_TOKEN=...   # bearer token — env var, NOT argv (visible in ps)
 python3 bin/run_diarization_eval.py probe-live-stt \
-  --url https://renfield.local --sample tests/eval/diarization/fixtures/probe_short.wav \
+  --url https://renfield.local --ca-bundle /path/to/local-ca.pem \
+  --sample tests/eval/diarization/fixtures/probe_short.wav \
   --duration-s 120 --out /tmp/live-baseline.json
 ```
+
+Probe caveats (all deliberate):
+- `/api/voice/stt` requires auth → `VOICE_TOKEN`; renfield.local is
+  self-signed → pass the local CA via `--ca-bundle` (or `--insecure` as a
+  last resort on a trusted LAN).
+- Failed/timed-out probes are counted as timeout-clamped samples — degradation
+  cannot hide by dropping requests. `error_rate` lands in the JSON.
+- The default 2 s interval ≈ 60 requests / 120 s — stay under the voice rate
+  limit or raise `--interval-s`.
+- **Side effects:** every probe is a REAL STT request and hits the
+  speaker-recognition path (review-bucket entries under controlled
+  enrollment). Run against a non-prod instance if possible, or expect ~60
+  synthetic-voice candidates in the review bucket and clean them up after.
 
 ## 5. Verdict
 
@@ -76,6 +117,17 @@ python3 bin/run_diarization_eval.py report /tmp/metrics-*.json \
   --live-baseline /tmp/live-baseline.json --live-during /tmp/live-during.json
 ```
 
-Exit 0 = §2 build unblocked. The `auto_match_separation` gate only decides
-whether the auto-matcher gets BUILT (D12) — failing it does not block §2
-(pseudonyms + one-click labeling are the baseline product).
+Semantics (fail-closed, per the PR #924 hardening):
+- Verdict is **per candidate** (whisper model × recording): overall PASS needs
+  **at least one** candidate passing every hard gate (AER, der_like,
+  hyp_coverage, GPU cost) — `base` may fail while `large-v3` passes.
+- A **missing** hard-gate metric (e.g. `run` without `--reference`, or no
+  probe pair) is a FAIL, never an "n/a" — a run that measured nothing cannot
+  green-light the build.
+- `auto_match_separation` is advisory: it only decides whether the
+  auto-matcher gets BUILT (D12); with fewer than the minimum pair counts it
+  reports "insufficient data" instead of a number.
+- Exit 0 = §2 build unblocked. The `run` also writes `der_pyannote_metrics`
+  when pyannote.metrics is importable — if it disagrees materially with
+  `der_like` on the synthetic fixture, the scorer itself is buggy;
+  investigate before trusting any verdict.

--- a/tests/eval/diarization/gates.yaml
+++ b/tests/eval/diarization/gates.yaml
@@ -1,25 +1,54 @@
 # Diarization spike gates — FIXED 2026-07-06 during /plan-eng-review, BEFORE the
-# first measurement (D12 / outside-voice amendment 5). Do not tune these to fit
-# a run; a gate change needs its own reviewed decision.
+# first measurement. Do not tune these to fit a run; a gate change needs its own
+# reviewed decision.
+#
+# AMENDED 2026-07-06 (same day, still before any measurement) by the PR #924
+# /review fix round: the review proved the original contract was fail-open —
+# a run that measured nothing (empty diarization, missing metrics) reported
+# PASS. Hardened: missing hard-gate metrics now FAIL; der_like + hyp-coverage
+# gates close the "diarizer labels almost nothing → AER=0" hole; the report
+# verdict is per-model (PASS if at least ONE candidate passes all hard gates);
+# the separation metric requires minimum pair counts to count as measured.
+#
+# NOTE for the no-PyYAML fallback parser in bin/run_diarization_eval.py:
+# keep this file a FLAT numeric mapping under `gates:`.
 gates:
-  # Share of overlapping speech frames attributed to the wrong speaker after
-  # optimal cluster->reference mapping (Hungarian). Above this, transcripts are
-  # not trustworthy enough to ship §2 at all.
+  # HARD — share of overlapping speech frames attributed to the wrong speaker
+  # after optimal cluster->reference mapping (Hungarian). Above this,
+  # transcripts are not trustworthy enough to ship §2 at all.
   attribution_error_rate_max: 0.20
 
-  # Processing cost ceiling: 60 min of audio must finish in <= 30 GPU-minutes
-  # (diarization + ASR combined), else the serialized-batch deployment shape
-  # (D5) starves the box.
+  # HARD — DER-style total (missed + false alarm + confusion) / ref speech.
+  # Catches the degenerate case AER alone cannot see: a diarizer that labels
+  # almost nothing has AER ~0 but der_like ~1.
+  der_like_max: 0.30
+
+  # HARD — fraction of reference speech frames the hypothesis also labels
+  # (both-streams coverage). Below this the AER was measured on too little
+  # of the meeting to mean anything.
+  min_hyp_coverage: 0.70
+
+  # HARD — processing cost ceiling: 60 min of audio must finish in <= 30
+  # GPU-minutes of INFERENCE (model load/download time excluded), else the
+  # serialized-batch deployment shape (D5) starves the box.
   gpu_seconds_per_audio_minute_max: 30
 
-  # AUTO-MATCH gate (D12): per-cluster ECAPA separation on meeting-length audio,
-  # same_cluster_cosine_mean - cross_cluster_cosine_p95, in the voice-server
-  # ONNX space. Below this, auto-match is NOT built — pseudonyms + one-click
-  # human labeling remain the product. (Context: short chat turns measured
-  # same-speaker ~0.28 vs cross p95 ~0.22 — separation 0.06, unusable.)
+  # HARD (global) — live satellite STT p95 latency during a running batch
+  # job, relative to the idle baseline. Failed/timed-out probes count as
+  # timeout-clamped samples so degradation cannot hide in dropped requests.
+  live_stt_p95_factor_max: 2.0
+
+  # ADVISORY (auto-match gate, D12): per-cluster ECAPA separation on
+  # meeting-length audio, same_cluster_cosine_mean - cross_cluster_cosine_p95,
+  # in the voice-server ONNX space. Below this, auto-match is NOT built —
+  # pseudonyms + one-click human labeling remain the product. (Context: short
+  # chat turns measured same-speaker ~0.28 vs cross p95 ~0.22 — separation
+  # 0.06, unusable.) Failing this gate does NOT block the §2 build.
   auto_match_separation_min: 0.15
 
-  # Live satellite STT p95 latency during a running batch job, relative to the
-  # idle baseline (probe-live-stt baseline vs during). Above 2x, escalate per
-  # the ladder in docs/design/meeting-transcription.md (night-window first).
-  live_stt_p95_factor_max: 2.0
+  # Data-sufficiency floor for the separation metric: below these pair counts
+  # the metric reports "insufficient data" instead of a number (the committed
+  # synthetic fixture yields ~3 same / ~18 cross pairs — not enough to judge
+  # a 0.15 threshold; real recordings decide).
+  separation_min_same_pairs: 10
+  separation_min_cross_pairs: 30


### PR DESCRIPTION
## Summary

Follow-up to #924 (merged mid-review): the full `/review` round on the diarization spike harness — 5 parallel passes (critical, testing, maintainability, security, performance specialists + adversarial), 24 unique findings, all actioned. #924 merged while the fix round was in flight, so the fixes land as this follow-up instead of on the original branch.

**Gate-contract hardening (approved, still before any measurement has run):**
- A missing hard-gate metric now **FAILS** the report — previously a run that measured nothing printed "PASS — §2 build unblocked" (found independently by the testing specialist and the adversarial pass).
- New `der_like_max` + `min_hyp_coverage` gates close the degenerate hole where an empty/sparse diarization scored `attribution_error_rate = 0.0` and passed.
- Verdict is now **per candidate**: overall PASS = at least one whisper-model run passes all hard gates AND the live probe pair passes (`base` may fail while `large-v3` passes — previously any failing candidate failed everything).
- Separation metric reports "insufficient data" below minimum pair counts instead of a meaningless number vs the 0.15 threshold.

**Measurement correctness:** probe failures/timeouts are clamped into the latency distribution (+`error_rate`) so degradation can't hide in dropped requests; model load/download excluded from `gpu_seconds_per_audio_minute`; shared nearest-rank `_p95` (the old formula returned the *minimum* at n=2, biasing both gates permissive); whole-GPU VRAM peak via an nvidia-smi polling thread (torch counter can't see CTranslate2/ONNX); CUDA freed between pipeline stages; O(W+D) two-pointer alignment (equivalence proven over 1000 randomized trials); optional pyannote.metrics DER cross-check of the scorer.

**Robustness/docs:** UTF-8 everywhere, actionable error for the gated pyannote model, advisory flag instead of substring-keyed hard-fail, README fixes (broken docker line-continuation, HF_TOKEN pass-through, probe auth/TLS via `--ca-bundle`, rate-limit + speaker-pipeline side-effect caveats, `probe_short.wav` provenance, no-overlap reference rule, ECAPA parity check).

## Verification

- 6-case report smoke test: degenerate-AER FAILs, missing-metrics FAILs, missing-live FAILs, 30.04-GPU-s FAILs, multi-model any-pass PASSes, thin separation → "insufficient data" while overall PASSes.
- Alignment rewrite: byte-identical output vs the old algorithm over 1000 randomized trials (canonical sorted input) + empty-input edge cases; `_p95` boundary cases verified.
- Scorer/alignment/gates-parser unit tests remain deferred to the §2 build PR (T8) per the review test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)