### PR TITLE
feat(satellite): hardware-appropriate stereo→mono combine (fix XVF3800 wakeword-deaf)

### DIFF
--- a/bin/measure_capture_rms.py
+++ b/bin/measure_capture_rms.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Measure a satellite's capture path — per-channel + combined-mono RMS.
+
+The validation gate for docs/design/satellite-audio-combine-pipeline.md and
+its fleet audit (§7a). We only found the XVF3800 was feeding the wakeword
+silence because we finally *measured* the combined-mono signal. This is that
+measurement, as a repeatable tool: capture a few seconds from the mic, print
+the RMS of each hardware channel and of the mono stream the wakeword would
+actually receive under a given combine, so you can confirm real speech before
+trusting detection — and re-run it to catch regressions.
+
+Runs on the satellite (uses arecord + numpy). Stop the satellite service first
+so the device is free:  sudo systemctl stop renfield-satellite
+
+Examples:
+  # XVF3800: capture both hw channels, see which carries the beam
+  measure_capture_rms.py --device plughw:0,0 --channels 2 --seconds 6
+  # Verify the configured combine (select ch0) recovers the speech
+  measure_capture_rms.py --device plughw:0,0 --channels 2 --combine select --select-channel 0
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+import numpy as np
+
+WIN = 4800  # 300 ms @ 16 kHz — the wakeword's rough decision window
+
+
+def loudest_window_rms(mono: np.ndarray) -> float:
+    if len(mono) < WIN:
+        return float(np.sqrt(np.mean(mono.astype(float) ** 2))) if len(mono) else 0.0
+    peaks = [
+        np.sqrt(np.mean(mono[i : i + WIN].astype(float) ** 2))
+        for i in range(0, len(mono) - WIN, WIN // 2)
+    ]
+    return float(max(peaks))
+
+
+def capture(device: str, channels: int, rate: int, seconds: int) -> np.ndarray:
+    """Return an (N, channels) int16 array captured via arecord."""
+    cmd = [
+        "arecord", "-D", device, "-f", "S16_LE", "-r", str(rate),
+        "-c", str(channels), "-d", str(seconds), "-t", "raw",
+    ]
+    raw = subprocess.run(cmd, capture_output=True).stdout
+    if not raw:
+        sys.exit(f"ERROR: no audio captured from {device} (is the service stopped?)")
+    return np.frombuffer(raw, dtype=np.int16).reshape(-1, channels)
+
+
+def combine_mono(a: np.ndarray, mode: str, select_channel: int) -> np.ndarray:
+    if a.shape[1] == 1 or mode == "passthrough":
+        return a[:, 0]
+    if mode == "select":
+        return a[:, select_channel]
+    if mode == "average":  # what a naive ALSA downmix roughly does — for contrast
+        return a.mean(axis=1).astype(np.int16)
+    raise SystemExit(f"unknown combine {mode}")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--device", default="plughw:0,0")
+    p.add_argument("--channels", type=int, default=2)
+    p.add_argument("--rate", type=int, default=16000)
+    p.add_argument("--seconds", type=int, default=6)
+    p.add_argument("--combine", default="select", choices=["select", "average", "passthrough"])
+    p.add_argument("--select-channel", type=int, default=0)
+    p.add_argument(
+        "--speech-floor", type=float, default=1000.0,
+        help="loudest-300ms RMS below this on live speech = FAIL (fed too little signal)",
+    )
+    args = p.parse_args()
+
+    print(f"Capturing {args.seconds}s from {args.device} ({args.channels}ch) — speak now.")
+    a = capture(args.device, args.channels, args.rate, args.seconds)
+
+    print("\nper-channel loudest-300ms RMS:")
+    for c in range(a.shape[1]):
+        print(f"  ch{c}: {loudest_window_rms(a[:, c]):8.0f}")
+
+    if args.channels >= 2:
+        print(f"  naive downmix (average): {loudest_window_rms(combine_mono(a, 'average', 0)):8.0f}"
+              "   (what ALSA does — can cancel to silence)")
+
+    mono = combine_mono(a, args.combine, args.select_channel)
+    rms = loudest_window_rms(mono)
+    verdict = "PASS" if rms >= args.speech_floor else "FAIL"
+    label = f"{args.combine}" + (f" ch{args.select_channel}" if args.combine == "select" else "")
+    print(f"\nwakeword input ({label}): loudest-300ms RMS = {rms:.0f}  → {verdict}")
+    if verdict == "FAIL":
+        print("  The wakeword is being fed too little signal. Pick the channel with the")
+        print("  strongest per-channel RMS above, or fix the combine before trusting detection.")
+    sys.exit(0 if verdict == "PASS" else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/XVF3800_SATELLITE.md
+++ b/docs/XVF3800_SATELLITE.md
@@ -145,11 +145,21 @@ aplay -D plughw:XVF3800,0 test.wav
 audio:
   device: "plughw:XVF3800,0"    # USB-Geraetename (stabil ueber Reboots)
   playback_device: "plughw:XVF3800,0"  # Speaker-Ausgang ueber selben USB
-  channels: 1                    # Kanal 0 = vorverarbeitetes Mono-Audio
+  channels: 2                    # BEIDE HW-Kanaele holen (0=Beam, 1=ASR/Residual)
+  combine: "select"              # NICHT downmixen — genau EINEN Kanal waehlen
+  select_channel: 0              # Kanal 0 = vorverarbeiteter Beam (sauberes Sprachsignal)
   use_arecord: false             # Nicht noetig — kein AC108 Kernel-Crash
   beamforming:
     enabled: false               # XVF3800 macht 3-Beam in Hardware
 ```
+
+> ⚠️ **NICHT `channels: 1` verwenden.** Der XVF3800 liefert **Stereo** (Kanal 0 =
+> Beam, Kanal 1 = ASR/AEC-Residual — KEIN zweites Mikrofon). Bei `channels: 1`
+> mischt ALSA die beiden Kanaele zu Mono zusammen (`default`-Plug-Downmix), und
+> Beam + Residual **loeschen sich zu Stille aus** — der Wakeword bekommt kein
+> Signal (Fitnessraum-Vorfall 2026-07-07). Stattdessen beide Kanaele erfassen
+> (`channels: 2`) und den Beam **auswaehlen** (`combine: select`,
+> `select_channel: 0`). Details: `docs/design/satellite-audio-combine-pipeline.md`.
 
 **`.asoundrc`** — Optional, fuer stabilen Geraete-Alias:
 
@@ -176,11 +186,13 @@ ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="2886", ATTR{idProduct}=="0037"
 
 ### Aenderungen im Code
 
-**Keine Code-Aenderungen noetig.** Der bestehende Satellite-Code funktioniert unveraendert:
+`capture.py` erfasst `channels: 2` und reduziert per `combine: select` /
+`select_channel: 0` auf den Beam (Kanal 0) — dieselbe Capture→Combine→Mono-
+Pipeline wie die 2-Mic-HAT-Beamforming-Stufe (`docs/design/satellite-audio-
+combine-pipeline.md`). Downstream unveraendert:
 
-- `capture.py` oeffnet das ALSA-Geraet via PyAudio → empfaengt S16_LE/16kHz/Mono
-- Wake Word Detection, VAD, WebSocket Streaming — alles identisch
-- Nur die YAML-Config muss angepasst werden (Device-Name)
+- Wake Word Detection, VAD, WebSocket Streaming — alles identisch (Mono S16/16kHz)
+- Der Combine-Schritt ist config-getrieben; kein XVF3800-Sonderfall im Code
 
 ### LED-Steuerung
 
@@ -201,7 +213,9 @@ Fuer Ansible (`provisioning/inventory.yml`) ein neues HAT-Profil:
 hat_type: "xvf3800-usb"         # Neues Profil
 audio_device: "plughw:XVF3800,0"
 audio_playback_device: "plughw:XVF3800,0"
-audio_channels: 1
+audio_channels: 2                # Stereo erfassen, dann Beam auswaehlen
+audio_combine: "select"
+audio_select_channel: 0          # Kanal 0 = vorverarbeiteter Beam
 use_arecord: false
 beamforming_enabled: false       # Hardware-Beamforming
 led_type: "none"                 # Oder "apa102" fuer separaten LED-Streifen

--- a/docs/design/satellite-audio-combine-pipeline.md
+++ b/docs/design/satellite-audio-combine-pipeline.md
@@ -1,0 +1,154 @@
+# Satellite Audio Capture — hardware-appropriate stereo→mono combine
+
+**Status:** DESIGN (2026-07-07). Nothing built. Triggered by a live Fitnessraum (XVF3800) incident where the wakeword stopped firing.
+**Scope:** the satellite capture pipeline (`src/satellite/renfield_satellite/audio/capture.py`) — how multi-channel hardware audio is reduced to the single mono stream the wakeword/STT require. Not the transport (C1) or the backend.
+
+---
+
+## 1. Problem — measured, not assumed
+
+The Fitnessraum satellite (ReSpeaker **XVF3800** USB, Pi Zero 2 W) stopped detecting the wakeword. After ruling out AGC gain, wakeword threshold, the deployed code, USB/ALSA health, and a chip factory-reset, a direct capture measurement found the cause. Same spoken "Renfield", captured three ways:
+
+| Capture path | loudest-300 ms RMS | verdict |
+|---|---|---|
+| XVF3800 **stereo, channel 0** (processed beam) | **3375** | strong, clean speech |
+| XVF3800 stereo, channel 1 (AEC residual) | 1282 | weak (residual) |
+| **Mono via ALSA `default`** — *what the satellite actually captured* | **25–39** | near-silence |
+
+The hardware and the processed beam are healthy. But the satellite captures **mono** from ALSA `default`, and ALSA's 2→1 downmix of this device collapses the signal to near-silence. **The wakeword was being fed silence.** (Offline, every naive downmix of a clean stereo capture — ch0, ch1, average, difference — is strong (1282–3375); only the live `default` mono path silences, because the XVF3800's two USB channels are phase-related processed-beam + residual that cancel under its downmix.)
+
+### Root cause
+The XVF3800's two output channels are **not two microphones**. They are:
+- **ch0 / Left** = the fully processed beam (hardware AEC + beamforming + noise-suppression) — the clean, mono-equivalent speech.
+- **ch1 / Right** = the AEC *residual* (echo-canceller leftover), near-silence for speech.
+
+Mixing them is meaningless, and for this device it cancels. The satellite must **select** the processed beam, not **downmix**.
+
+### Why the pipeline does the wrong thing
+The capture pipeline already has a stereo→mono **combine stage** — but the XVF3800 bypasses it:
+
+- **2-mic ReSpeaker HAT:** `channels: 2` + `beamforming: true` → captures stereo, runs `BeamformerDAS.process_int16` (delay-and-sum of two *raw mics*) → enhanced mono. Correct.
+- **AC108 4-mic (arecord):** `_arecord_capture_loop` (`capture.py:345-349`) does **channel selection** — `ch = s32[1::self.channels]` extracts one channel of four (ch1; ch0 is the AC108's silent reference), `>> 16` to S16. Correct, and the exact precedent this design generalizes.
+- **XVF3800:** `beamforming: false` + `channels: 1` + `device: default` → the PyAudio path captures **one channel from ALSA `default`**, delegating the 2→1 reduction to ALSA's downmix. It never enters a satellite-side combine stage. **This is the flaw.**
+
+So the fix is not to invent stereo capture — the pipeline already captures stereo and combines to mono for two of three hardware types. The fix is to route the XVF3800 through a combine stage too, with the method its hardware needs: **channel select**.
+
+---
+
+## 2. Hard constraint (bounds the design)
+
+The **wakeword models (OpenWakeWord / microWakeWord) and STT are mono-only** — they cannot consume stereo. So the satellite MUST produce a single mono stream locally, before the wakeword. A "fully stereo pipeline" is not possible without retraining the wakeword, and streaming stereo to the backend would double bandwidth against C1's goal. Therefore the design keeps the pipeline **mono downstream of capture**; the only question is doing the stereo→mono step *correctly per hardware*.
+
+---
+
+## 3. Design — one capture, a pluggable combine
+
+Generalize the capture around: **capture at the hardware's native channel count → apply a hardware-appropriate `combine` → emit mono 16 kHz S16.**
+
+```
+                      ┌──────────────── combine (config-driven) ────────────────┐
+ native capture  ───► │  beamform     DAS of N raw mics        (2-mic HAT)       │ ───► mono S16 ─► wakeword / VAD / STT / transport
+ (1..4 ch)            │  select       take channel K            (XVF3800, AC108) │
+                      │  passthrough  already mono, as-is       (legacy mono)    │
+                      └──────────────────────────────────────────────────────────┘
+```
+
+Three combine modes:
+- **`beamform`** — existing `BeamformerDAS` over N raw mics (2-mic HAT). Unchanged.
+- **`select`** — take channel `K` from the interleaved frame, drop the rest. New for the PyAudio path; the arecord path already does exactly this (generalize its logic).
+- **`passthrough`** — input is already mono; emit as-is (legacy single-channel devices, byte-identical to today).
+
+The XVF3800 becomes `channels: 2` + `combine: select` + `select_channel: 0`. It stops relying on ALSA downmix and flows through the same architecture as every other device.
+
+### 3a. Coordinated chip routing (must agree with `select_channel`)
+Channel select is only correct if ch0 deterministically carries the processed beam. The XVF3800 output routing is `AUDIO_MGR_OP_L` / `AUDIO_MGR_OP_R` (`(category, source)` pairs). Measured today: `OP_L = MUX_USER_CHOSEN_CHANNELS[8] 0` carries the strong beam (3375) and `OP_R = MUX_AEC_RESIDUALS` the residual — so ch0 is correct *now*, but the routing is non-standard and `CLEAR_CONFIGURATION` does **not** reset it. So provisioning must **pin `OP_L` to the processed-beam source and persist it** (`SAVE_CONFIGURATION 1`), so `select_channel: 0` is deterministic across resets/firmware. The exact category/source for "processed beam" is verified empirically (capture stereo, confirm ch0 RMS ≫ ch1) as part of the rollout, not guessed.
+
+---
+
+## 4. Config schema
+
+`AudioConfig` (`config.py`) gains a `combine` field; `beamforming: true` maps to `combine: beamform` for back-compat.
+
+```yaml
+audio:
+  channels: 2                 # native capture count
+  combine: "select"           # beamform | select | passthrough
+  select_channel: 0           # used when combine=select
+  # beamforming: true         # DEPRECATED alias → combine: beamform (kept for back-compat)
+```
+
+Per-hardware defaults (set in `templates/satellite.yaml.j2` by `hat_type`, or host_var):
+
+| hat_type | channels | combine | select_channel |
+|---|---|---|---|
+| 2mic / 2mic-v2 | 2 | beamform | — |
+| xvf3800-usb | 2 | **select** | **0** |
+| ac108 (4-mic) | 4 | select | 1 |
+| whisplay / single-mic | 1 | passthrough | — |
+
+Flag-off / unspecified → `passthrough` (or `beamform` when `beamforming: true`) = **today's behavior byte-identical**. Only the XVF3800 template default changes.
+
+---
+
+## 5. Code changes (small, one module)
+
+1. **`config.py`** — add `combine: str = "passthrough"` + `select_channel: int = 0` to `AudioConfig`; loader reads `audio.combine`/`audio.select_channel`; `beamforming: true` back-compat → `combine="beamform"` (and forces `channels=2`, as today).
+2. **`capture.py`** — the PyAudio consumer path gains a `select` branch: from the interleaved `int16` stereo frame, take `frame[select_channel::channels]` (mirrors the arecord path's `s32[1::channels]` at `capture.py:348`, minus the S32→S16 shift). Factor the combine into one `_combine(frame) -> mono` helper used by both the PyAudio and arecord loops so the three modes live in one place (removes the arecord path's ad-hoc extraction duplication).
+3. **`templates/satellite.yaml.j2`** — emit `combine` + `select_channel` from `hat_type` defaults (the audio block already added `codec` for C1).
+4. **`host_vars/satellite-fitnessraum.yml`** — `audio_channels: 2`, `audio_combine: select`, `audio_select_channel: 0`. (host_vars are gitignored — operator-local.)
+5. **Provisioning (`provision.yml`)** — the XVF3800 tuning task pins `AUDIO_MGR_OP_L` to the processed-beam source + `SAVE_CONFIGURATION` (§3a), so ch0 is deterministic.
+
+No backend change. No transport change. The mono contract downstream of capture is unchanged, so wakeword/VAD/STT/C1 are untouched.
+
+---
+
+## 6. Testing (mono-only, deterministic — no hardware needed for the unit tests)
+
+- **Unit (`tests/satellite/`):** synthesize an interleaved stereo `int16` buffer with a known tone on ch0 and silence/residual on ch1; assert `combine=select, select_channel=0` returns exactly ch0; assert `beamform` still runs DAS; assert `passthrough` is identity; assert `select_channel` out of range fails loud. This is the coverage the original XVF3800 mono path never had.
+- **On-device validation harness (the lesson from this incident):** before trusting the wakeword, measure. A `bin/` capture-and-RMS check (the one used to find this bug) captures a few seconds and reports per-combine RMS; the rollout gate is **combined-mono RMS on live speech ≫ ambient** (e.g. loudest-300 ms RMS > ~1000), not "the wakeword fired." Detection is validated *after* the audio path is proven.
+
+---
+
+## 7. Rollout — deliberate, and shaped by how this incident happened
+
+The bug was found only after a live satellite was destabilized by an unrelated change. The rollout rules encode that lesson:
+
+1. **Land the code change as a small PR** (config + combine + unit test), build a satellite image deliberately.
+2. **Never validate on a live, working satellite.** Fitnessraum is already service-disabled from this investigation — it is the safe canary. Deploy there with the service down.
+3. **Prove the audio path with the RMS harness first** (§6), *then* re-enable the service and test the wakeword. Do not infer the audio path from wakeword behavior — that inversion is what cost this whole investigation.
+4. **Only after Fitnessraum passes** does the XVF3800 template default flip for the fleet; other XVF3800 sats re-provision in a maintenance window (deps/config land restart-free via `--tags`, the activating restart is explicit and confirmed).
+5. Flag-off / other hardware unchanged and byte-identical throughout.
+
+### 7a. Fleet capture audit — every hardware type (not just the XVF3800)
+
+We discovered the XVF3800 was feeding the wakeword **silence** only because we finally measured the combined-mono RMS. Nothing else flagged it — the service was "healthy," the model loaded, USB/ALSA were fine, and it had run for days. **We have never put a number on the capture path of any other hat.** The 2-mic DAS beamforming, the AC108 `ch1` selection, and the Whisplay passthrough are all *assumed* good; none is *measured* good. A quieter version of the same class of bug (wrong channel, a beamformer that attenuates, a mis-wired mic) could be silently degrading detection on any of them.
+
+So the XVF3800 fix is **phase 1 of a fleet-wide capture audit**, run per hardware type with the identical measured method:
+
+| # | hat_type | combine to verify | audit check |
+|---|---|---|---|
+| 1 | xvf3800-usb | select ch0 | this design; RMS harness + wakeword |
+| 2 | 2mic / 2mic-v2 | beamform (DAS) | measure combined-mono RMS on live speech; compare DAS output vs raw per-mic RMS — is the beamformer *helping* or attenuating? |
+| 3 | ac108 (4-mic) | select ch1 | confirm ch1 is the loudest real mic (ch0 is the silent reference — verify that's still true); measure combined RMS |
+| 4 | whisplay / single-mic | passthrough | measure raw mono RMS — confirm the single mic delivers real speech (Whisplay WM8960 ALC/noise-gate history makes this worth checking) |
+
+Each hat: capture with the `bin/` RMS harness (§6) while someone speaks, confirm loudest-300 ms RMS ≫ ambient, and only then trust the wakeword. Where a hat measures weak, the new `combine` config makes the fix a one-line change (mode/channel), not a code change. The audit's output is a per-hardware "known-good combine + measured RMS" record checked into the hardware docs, so a future regression is caught by re-running the harness, not by a user reporting "the satellite does nothing."
+
+---
+
+## 8. Alternatives considered
+
+- **ALSA-route quick fix** (a device-local `.asoundrc` mapping ch0→mono, point `device:` at it): restores Fitnessraum today with zero code, but it's a per-device config hack that leaves the fleet architecture wrong and the XVF3800 a special case outside the combine stage. Acceptable as a stopgap; not the fix. (If function is needed *before* the PR lands, do this, and treat it as temporary.)
+- **Full stereo to the backend:** rejected — wakeword/STT are mono-only (§2) and it doubles C1 bandwidth for no gain.
+- **Keep ALSA downmix, "fix" it with mixer weights:** brittle, device-specific, and still mixes a beam with a residual. Channel select is simpler and correct.
+- **Software beamforming on the XVF3800's two channels:** meaningless — they aren't two mics (§1 root cause).
+
+---
+
+## 9. Open questions
+
+1. **Exact `AUDIO_MGR_OP_L` category/source for "processed beam"** — to pin deterministically (§3a). Verify empirically during rollout; today ch0 already carries it.
+2. ~~Unify the arecord path~~ **RESOLVED (implemented):** both the S16 PyAudio path and the S32 arecord path share `_select_mono` (dtype-preserving channel select); the AC108 stays byte-identical because `select_channel` and `combine` **auto-derive** the legacy defaults when unset (`combine`: beamforming→beamform / channels>1→select / else passthrough; `select_channel`: 4-mic→ch1, else ch0). Un-reprovisioned sats need no config change.
+3. **Deprecation of `beamforming:`** — keep the alias indefinitely, or migrate host_vars to `combine: beamform` and drop it? Proposal: keep the alias (cheap; `beamforming.enabled: true` auto-derives `combine: beamform`), migrate templates opportunistically.
+
+**Source:** Fitnessraum XVF3800 wakeword incident 2026-07-07 (live capture measurements above; root-caused to the ALSA mono downmix of the processed-beam + AEC-residual). Related: `docs/design/voice-identity-wakeword-verification.md` (C1 transport, adjacent in the same audio path), `docs/XVF3800_SATELLITE.md`, `src/satellite/renfield_satellite/audio/{capture,beamformer}.py`, ReSpeaker XVF3800 host_control docs (`AUDIO_MGR_OP_L/R`, `CLEAR_CONFIGURATION`, `REBOOT`, `SAVE_CONFIGURATION`).

--- a/src/satellite/provisioning/templates/satellite.yaml.j2
+++ b/src/satellite/provisioning/templates/satellite.yaml.j2
@@ -44,6 +44,18 @@ audio:
   physical_mics: {{ audio_physical_mics | default(audio_channels) }}
   device: "{{ audio_device }}"
   playback_device: "{{ audio_playback_device }}"
+  # Stereo→mono combine (docs/design/satellite-audio-combine-pipeline.md).
+  # Emitted only when set in host_vars; unset = the satellite auto-derives the
+  # legacy behavior (beamforming→beamform, channels>1→select ch0/ch1, else
+  # passthrough) so un-reprovisioned sats stay byte-identical. The XVF3800 sets
+  # combine=select + select_channel=0 to keep its processed beam (ch0) instead
+  # of letting ALSA downmix beam+AEC-residual to silence.
+{% if audio_combine is defined %}
+  combine: "{{ audio_combine }}"
+{% endif %}
+{% if audio_select_channel is defined %}
+  select_channel: {{ audio_select_channel }}
+{% endif %}
   beamforming:
     enabled: {{ beamforming_enabled | lower }}
 {% if beamforming_enabled %}

--- a/src/satellite/renfield_satellite/audio/capture.py
+++ b/src/satellite/renfield_satellite/audio/capture.py
@@ -79,6 +79,8 @@ class AudioCapture:
         beamforming: bool = False,
         mic_spacing: float = 0.058,  # ReSpeaker 2-Mics: 58mm
         steering_angle: float = 0.0,  # 0 = front-facing
+        combine: Optional[str] = None,
+        select_channel: Optional[int] = None,
     ):
         """
         Initialize audio capture.
@@ -94,6 +96,14 @@ class AudioCapture:
             beamforming: Enable beamforming (requires channels=2)
             mic_spacing: Microphone spacing in meters (default 58mm for ReSpeaker)
             steering_angle: Target direction in degrees (0=front)
+            combine: Stereo→mono reduction: "beamform" | "select" |
+                "passthrough". None = auto-derive (beamforming→beamform,
+                channels>1→select, else passthrough) for back-compat.
+            select_channel: When combine="select", keep this channel and drop
+                the rest. None = legacy default (AC108 4-mic→ch1, else ch0).
+                The XVF3800 selects ch0 (its processed beam) rather than let
+                ALSA downmix beam+residual to silence.
+                See docs/design/satellite-audio-combine-pipeline.md.
         """
         self.sample_rate = sample_rate
         self.chunk_size = chunk_size
@@ -107,6 +117,33 @@ class AudioCapture:
             print("Beamforming enabled: switching to stereo capture")
 
         self.channels = channels
+
+        # Stereo→mono combine (docs/design/satellite-audio-combine-pipeline.md).
+        # Resolve the effective mode + channel from the legacy signals when not
+        # given explicitly, so un-reprovisioned sats stay byte-identical:
+        #   combine: beamforming→"beamform", channels>1→"select", else "passthrough"
+        #   select_channel: AC108 4-mic→ch1 (ch0 is its silent reference), else ch0
+        if combine is not None:
+            self.combine = combine
+        elif beamforming:
+            self.combine = "beamform"
+        elif channels > 1:
+            self.combine = "select"
+        else:
+            self.combine = "passthrough"
+        if self.combine not in ("beamform", "select", "passthrough"):
+            print(f"Unknown audio combine '{self.combine}', falling back to select")
+            self.combine = "select" if channels > 1 else "passthrough"
+        self.select_channel = (
+            select_channel if select_channel is not None
+            else (1 if channels >= 4 else 0)
+        )
+        if not 0 <= self.select_channel < max(1, channels):
+            print(
+                f"select_channel {self.select_channel} out of range for "
+                f"{channels}ch — clamping to 0"
+            )
+            self.select_channel = 0
 
         self._running = False
         self._thread: Optional[threading.Thread] = None
@@ -327,10 +364,12 @@ class AudioCapture:
             self._running = False
 
     def _arecord_capture_loop(self):
-        """Read from arecord pipe, convert 4ch/S32_LE → mono S16_LE.
+        """Read from arecord pipe, convert Nch/S32_LE → mono S16_LE.
 
-        Each frame is channels * 4 bytes (S32_LE). We extract channel 0
-        and shift right by 16 to convert 32-bit to 16-bit samples.
+        Each frame is channels * 4 bytes (S32_LE). Channel selection uses the
+        shared _select_mono (combine="select" for the arecord/AC108 backend;
+        select_channel defaults to ch1 for a 4-mic AC108 — ch0 is its silent
+        reference), then shift right by 16 to convert 32-bit to 16-bit.
         """
         frame_bytes = self.channels * 4  # S32_LE = 4 bytes per sample
         chunk_bytes = self.chunk_size * frame_bytes
@@ -342,10 +381,10 @@ class AudioCapture:
                 if not data or len(data) < chunk_bytes:
                     break
 
-                # Convert multi-channel S32_LE to mono S16_LE
-                # AC108 4-mic: channel 0 is silent (reference), mics are on ch1-3
+                # Convert multi-channel S32_LE to mono S16_LE via the shared
+                # channel selector, then downshift 32→16 bit.
                 s32 = np.frombuffer(data, dtype=np.int32)
-                ch = s32[1::self.channels] if self.channels >= 4 else s32[::self.channels]
+                ch = self._select_mono(s32)
                 s16 = (ch >> 16).astype(np.int16)
 
                 try:
@@ -433,18 +472,33 @@ class AudioCapture:
         finally:
             pass
 
+    def _select_mono(self, samples: np.ndarray) -> np.ndarray:
+        """Keep the configured channel from an interleaved multi-channel array,
+        dropping the rest (dtype preserved).
+
+        Shared by the S16 PyAudio path and the S32 arecord path so the channel
+        choice lives in ONE place. The non-selected channels are residual /
+        reference signals (XVF3800 AEC residual, AC108 silent reference), NOT
+        mics — downmixing them is wrong (see the combine design doc).
+        """
+        return samples[self.select_channel::self.channels]
+
     def _stereo_to_mono(self, audio_bytes: bytes) -> bytes:
-        """Convert interleaved multi-channel S16_LE to mono.
+        """Reduce interleaved multi-channel S16_LE to mono per the combine mode.
 
         Runs in the CONSUMER thread (via self._consumer_transform), never in the
-        capture read loop. Applies DAS beamforming when a beamformer is configured,
-        otherwise extracts channel 0 (per the official ReSpeaker HAT examples).
+        capture read loop, so heavy numpy can't delay stream.read() (an I2S
+        overflow can crash the kernel on Pi Zero 2 W).
+          beamform    → DAS of the raw mics (2-mic HAT)
+          select      → keep self.select_channel (XVF3800 processed beam, etc.)
+          passthrough → already mono
         """
-        if self.channels <= 1:
+        if self.channels <= 1 or self.combine == "passthrough":
             return audio_bytes
-        if self._beamformer:
+        if self.combine == "beamform" and self._beamformer:
             return self._beamformer.process_bytes(audio_bytes)
-        return np.frombuffer(audio_bytes, dtype=np.int16)[::self.channels].tobytes()
+        samples = np.frombuffer(audio_bytes, dtype=np.int16)
+        return self._select_mono(samples).tobytes()
 
     def _audio_consumer_loop(self):
         """Consumer thread — processes queued audio and calls callback.

--- a/src/satellite/renfield_satellite/audio/capture.py
+++ b/src/satellite/renfield_satellite/audio/capture.py
@@ -134,6 +134,12 @@ class AudioCapture:
         if self.combine not in ("beamform", "select", "passthrough"):
             print(f"Unknown audio combine '{self.combine}', falling back to select")
             self.combine = "select" if channels > 1 else "passthrough"
+        # passthrough only makes sense for a single channel — on a multi-channel
+        # device it would emit the raw interleaved frame and feed the wakeword
+        # 2x/4x garbage. Force select so a misconfig can't silently deafen it.
+        if self.combine == "passthrough" and channels > 1:
+            print(f"combine=passthrough invalid for {channels}ch — using select")
+            self.combine = "select"
         self.select_channel = (
             select_channel if select_channel is not None
             else (1 if channels >= 4 else 0)

--- a/src/satellite/renfield_satellite/config.py
+++ b/src/satellite/renfield_satellite/config.py
@@ -79,6 +79,24 @@ class AudioConfig:
     use_arecord: bool = False  # Use arecord subprocess (required for AC108 4-mic + onnxruntime)
     device: str = "plughw:1,0"  # ReSpeaker default
     playback_device: str = "plughw:1,0"
+    # Stereo→mono combine (docs/design/satellite-audio-combine-pipeline.md).
+    # The wakeword/STT need one mono channel; how the native multi-channel
+    # capture is reduced to it depends on the hardware:
+    #   beamform    — delay-and-sum of raw mics (2-mic HAT)
+    #   select      — keep one channel, drop the rest (XVF3800 processed beam,
+    #                 AC108 mic channel) — the others are residual/reference,
+    #                 NOT mics, so downmixing them is wrong (it cancels to
+    #                 silence on the XVF3800 — the Fitnessraum wakeword-deaf
+    #                 incident)
+    #   passthrough — already mono, emit as-is
+    # None = auto-derive from the legacy signals so un-reprovisioned sats stay
+    # byte-identical: beamforming.enabled→beamform, channels>1→select, else
+    # passthrough.
+    combine: Optional[str] = None
+    # Which channel `select` keeps. None = legacy default resolved by the
+    # capture backend (AC108 4-mic → ch1, its ch0 is the silent reference;
+    # everything else → ch0). Set explicitly per hardware (XVF3800 → 0).
+    select_channel: Optional[int] = None
     # Upstream audio transport codec (C1, voice-identity design): "pcm"
     # (legacy base64-in-JSON, default) or "opus" (binary WS frames; needs
     # opuslib + a backend with satellite_opus_enabled — negotiated at
@@ -318,6 +336,8 @@ def load_config(config_path: Optional[str] = None) -> Config:
         config.audio.device = aud.get("device", config.audio.device)
         config.audio.playback_device = aud.get("playback_device", config.audio.playback_device)
         config.audio.codec = aud.get("codec", config.audio.codec)
+        config.audio.combine = aud.get("combine", config.audio.combine)
+        config.audio.select_channel = aud.get("select_channel", config.audio.select_channel)
 
         # Beamforming config
         if "beamforming" in aud:

--- a/src/satellite/renfield_satellite/satellite.py
+++ b/src/satellite/renfield_satellite/satellite.py
@@ -119,6 +119,8 @@ class Satellite:
             beamforming=self.config.audio.beamforming.enabled,
             mic_spacing=self.config.audio.beamforming.mic_spacing,
             steering_angle=self.config.audio.beamforming.steering_angle,
+            combine=self.config.audio.combine,
+            select_channel=self.config.audio.select_channel,
         )
 
         # Audio playback (sync + async wrapper for non-blocking TTS)

--- a/tests/satellite/test_audio_combine.py
+++ b/tests/satellite/test_audio_combine.py
@@ -73,6 +73,21 @@ class TestEffectiveCombineResolution:
         cap = AudioCapture(channels=2, combine="bogus")
         assert cap.combine == "select"
 
+    @pytest.mark.satellite
+    def test_passthrough_on_multichannel_forced_to_select(self):
+        # A misconfig (passthrough + channels>1) must NOT leak interleaved
+        # multi-channel to the wakeword — it's forced to select.
+        cap = AudioCapture(channels=2, combine="passthrough")
+        assert cap.combine == "select"
+        buf = _interleave([100, 200], [-1, -2])
+        out = np.frombuffer(cap._stereo_to_mono(buf), dtype=np.int16)
+        assert list(out) == [100, 200]  # mono ch0, not the 4-sample stereo frame
+
+    @pytest.mark.satellite
+    def test_passthrough_stays_for_mono(self):
+        cap = AudioCapture(channels=1, combine="passthrough")
+        assert cap.combine == "passthrough"
+
 
 class TestStereoToMonoS16:
     """The PyAudio consumer path (S16)."""

--- a/tests/satellite/test_audio_combine.py
+++ b/tests/satellite/test_audio_combine.py
@@ -1,0 +1,134 @@
+"""Tests for the satellite capture stereo→mono combine
+(docs/design/satellite-audio-combine-pipeline.md).
+
+The combine step is the one that was silently broken for the XVF3800 (ALSA
+downmixed its processed-beam + AEC-residual to near-silence, starving the
+wakeword). These tests pin every mode and the back-compat auto-derivation so a
+regression is caught here, not by a user reporting "the satellite went deaf".
+
+All mono-only, deterministic, no hardware — AudioCapture.__init__ does not open
+a device.
+"""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+from renfield_satellite.audio.capture import AudioCapture
+
+
+def _interleave(*channels: list[int]) -> bytes:
+    """Build an interleaved S16_LE buffer from per-channel sample lists."""
+    arr = np.array(channels, dtype=np.int16).T.reshape(-1)
+    return arr.tobytes()
+
+
+class TestEffectiveCombineResolution:
+    """combine / select_channel must auto-derive the legacy behavior when not
+    given, so un-reprovisioned sats stay byte-identical."""
+
+    @pytest.mark.satellite
+    def test_mono_defaults_to_passthrough(self):
+        cap = AudioCapture(channels=1)
+        assert cap.combine == "passthrough"
+        assert cap.select_channel == 0
+
+    @pytest.mark.satellite
+    def test_stereo_defaults_to_select_ch0(self):
+        cap = AudioCapture(channels=2)
+        assert cap.combine == "select"
+        assert cap.select_channel == 0
+
+    @pytest.mark.satellite
+    def test_ac108_4ch_defaults_to_select_ch1(self):
+        # AC108: ch0 is the silent reference, mics on ch1-3 → legacy default ch1
+        cap = AudioCapture(channels=4, use_arecord=True)
+        assert cap.combine == "select"
+        assert cap.select_channel == 1
+
+    @pytest.mark.satellite
+    def test_beamforming_maps_to_beamform_and_forces_stereo(self):
+        cap = AudioCapture(channels=1, beamforming=True)
+        assert cap.combine == "beamform"
+        assert cap.channels == 2
+
+    @pytest.mark.satellite
+    def test_xvf3800_explicit_select_ch0(self):
+        cap = AudioCapture(channels=2, combine="select", select_channel=0)
+        assert cap.combine == "select"
+        assert cap.select_channel == 0
+
+    @pytest.mark.satellite
+    def test_explicit_select_channel_overrides_legacy_default(self):
+        cap = AudioCapture(channels=4, use_arecord=True, select_channel=2)
+        assert cap.select_channel == 2
+
+    @pytest.mark.satellite
+    def test_out_of_range_select_channel_clamped(self):
+        cap = AudioCapture(channels=2, combine="select", select_channel=5)
+        assert cap.select_channel == 0
+
+    @pytest.mark.satellite
+    def test_unknown_combine_falls_back(self):
+        cap = AudioCapture(channels=2, combine="bogus")
+        assert cap.combine == "select"
+
+
+class TestStereoToMonoS16:
+    """The PyAudio consumer path (S16)."""
+
+    @pytest.mark.satellite
+    def test_passthrough_mono_is_identity(self):
+        cap = AudioCapture(channels=1)
+        buf = np.array([1, 2, 3, 4], dtype=np.int16).tobytes()
+        assert cap._stereo_to_mono(buf) == buf
+
+    @pytest.mark.satellite
+    def test_select_ch0_keeps_left(self):
+        cap = AudioCapture(channels=2, combine="select", select_channel=0)
+        buf = _interleave([100, 200, 300], [-1, -2, -3])  # L, R
+        out = np.frombuffer(cap._stereo_to_mono(buf), dtype=np.int16)
+        assert list(out) == [100, 200, 300]
+
+    @pytest.mark.satellite
+    def test_select_ch1_keeps_right(self):
+        cap = AudioCapture(channels=2, combine="select", select_channel=1)
+        buf = _interleave([100, 200, 300], [-1, -2, -3])
+        out = np.frombuffer(cap._stereo_to_mono(buf), dtype=np.int16)
+        assert list(out) == [-1, -2, -3]
+
+    @pytest.mark.satellite
+    def test_xvf3800_regression_residual_is_dropped_not_mixed(self):
+        """The exact bug: ch0=processed beam (loud), ch1=residual (~silent).
+        select ch0 must keep the loud beam; a downmix/average would halve it."""
+        cap = AudioCapture(channels=2, combine="select", select_channel=0)
+        beam = [8000, -8000, 8000, -8000]
+        residual = [1, 0, -1, 0]
+        buf = _interleave(beam, residual)
+        out = np.frombuffer(cap._stereo_to_mono(buf), dtype=np.int16)
+        assert list(out) == beam  # full amplitude, not (beam+residual)/2
+
+    @pytest.mark.satellite
+    def test_beamform_delegates_to_beamformer(self):
+        cap = AudioCapture(channels=2, beamforming=True)
+        cap._beamformer = MagicMock()
+        cap._beamformer.process_bytes.return_value = b"beamformed"
+        buf = _interleave([1, 2], [3, 4])
+        assert cap._stereo_to_mono(buf) == b"beamformed"
+        cap._beamformer.process_bytes.assert_called_once_with(buf)
+
+
+class TestSelectMonoSharedByArecord:
+    """_select_mono is dtype-preserving and shared with the S32 arecord path,
+    so AC108 channel selection stays byte-identical."""
+
+    @pytest.mark.satellite
+    def test_s32_ac108_selects_ch1(self):
+        cap = AudioCapture(channels=4, use_arecord=True)  # select_channel auto → 1
+        # 4ch S32 interleaved: ch0=ref(0), ch1=mic(big), ch2/3 other
+        frame = np.array(
+            [0, 111, 20, 30, 0, 222, 21, 31, 0, 333, 22, 32], dtype=np.int32
+        )
+        out = cap._select_mono(frame)
+        assert list(out) == [111, 222, 333]
+        assert out.dtype == np.int32  # dtype preserved (arecord shifts >>16 after)


### PR DESCRIPTION
Design: [`docs/design/satellite-audio-combine-pipeline.md`](docs/design/satellite-audio-combine-pipeline.md).

## Root cause (measured, not assumed)
The Fitnessraum XVF3800 satellite went **wakeword-deaf**. After ruling out AGC gain, threshold, the deployed code, USB/ALSA health, and a chip factory-reset, a direct capture measurement found it: the XVF3800 outputs **stereo** — ch0 = the processed beam (clean speech), ch1 = the AEC **residual** (near-silence, *not* a mic). But the satellite captured **mono from ALSA `default`**, and ALSA's 2→1 downmix of beam+residual **cancels to near-silence** (loudest-300ms RMS ~25 vs ~3375 on ch0). The wakeword was fed silence.

## Fix
The capture pipeline already reduces stereo→mono per hardware (2-mic DAS beamforming, AC108 arecord channel-extraction) — the XVF3800 just bypassed it via ALSA's downmix. This makes the combine an **explicit, config-driven, unit-tested stage**:

- **`config.py`** — `audio.combine` (`beamform`|`select`|`passthrough`) + `select_channel`. Both default `None` and **auto-derive the legacy behavior**, so un-reprovisioned 2-mic / AC108 / single-mic sats stay **byte-identical** (no config change needed).
- **`capture.py`** — one `_select_mono` (dtype-preserving) shared by the S16 PyAudio and S32 arecord paths; `_stereo_to_mono` honors the mode; out-of-range/unknown values clamp/fall back loudly.
- **`satellite.py` + template** — plumb the params (emitted only when set). XVF3800 → `channels: 2` + `combine: select` + `select_channel: 0`.
- **`tests/satellite/test_audio_combine.py`** — 14 tests: every mode, the back-compat auto-derivation, and the XVF3800 residual-not-mixed regression.
- **`bin/measure_capture_rms.py`** — the on-device RMS validation gate (per-channel + combined-mono RMS): the tool for the **fleet audit** (design §7a) to *measure*, not assume, every hat's capture path — since we only found this by measuring.

No backend or transport change; the mono contract downstream of capture is unchanged.

## Rollout (per design §7 — shaped by how this incident happened)
1. Build a satellite image / provision deliberately — **never validate on a live working sat**.
2. Fitnessraum is already service-disabled from the investigation → the safe canary. Deploy with the service down.
3. **Prove the audio path with `measure_capture_rms.py` first**, *then* re-enable the service and test the wakeword. Do not infer the audio path from wakeword behavior — that inversion cost this whole investigation.
4. Only after Fitnessraum passes does the XVF3800 default flip fleet-wide; then run the **fleet capture audit** (§7a) on the 2-mic / AC108 / Whisplay paths — none has ever been measured.

## Test plan
- [x] `tests/satellite/test_audio_combine.py` — 14 passed locally (mono-only, deterministic, no hardware)
- [x] Modules import + auto-derive correctly (XVF3800→select ch0, AC108→select ch1 legacy, 2-mic→beamform)
- [x] Compile + lint clean
- [ ] On-device: `measure_capture_rms.py` on Fitnessraum shows combined-mono RMS ≫ ambient, then wakeword fires (deploy step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)