### PR TITLE
fix(voice-server): pin onnxruntime-gpu <1.27 (CUDA-12 base)

### DIFF
--- a/voice-server/Dockerfile
+++ b/voice-server/Dockerfile
@@ -114,7 +114,10 @@ RUN pip install \
 RUN rm -rf /opt/venv/lib/python3.12/site-packages/onnxruntime \
            /opt/venv/lib/python3.12/site-packages/onnxruntime-*.dist-info \
            /opt/venv/lib/python3.12/site-packages/onnxruntime_gpu-*.dist-info \
- && pip install --no-cache-dir "onnxruntime-gpu>=1.20"
+ && pip install --no-cache-dir "onnxruntime-gpu>=1.20,<1.27"
+# ^ Cap <1.27: 1.27.0 moved the PyPI wheel to CUDA 13 (libcudart.so.13); the
+#   base is nvidia/cuda:12.6.3 (libcudart.so.12). Keep both this reinstall and
+#   requirements.txt on the CUDA-12 line (1.26.x) or warmup CrashLoops.
 
 COPY voice_server /app/voice_server
 COPY scripts /app/scripts

--- a/voice-server/requirements.txt
+++ b/voice-server/requirements.txt
@@ -8,7 +8,11 @@ httpx>=0.27
 opuslib>=3.0.1
 faster-whisper>=1.1.0
 piper-tts>=1.3.0
-onnxruntime-gpu>=1.20
+# Cap <1.27: onnxruntime-gpu 1.27.0 switched its PyPI wheel to CUDA 13
+# (dlopens libcudart.so.13), but the base image is nvidia/cuda:12.6.3-runtime
+# (libcudart.so.12) → the CUDA-13 wheel CrashLoops at speaker warmup with
+# "libcudart.so.13: cannot open shared object file". 1.26.x is the CUDA-12 line.
+onnxruntime-gpu>=1.20,<1.27
 ffmpeg-python>=0.2
 prometheus-client>=0.20
 loguru>=0.7


### PR DESCRIPTION
## Summary

Deploy-blocker found while rolling out C2 Phase 1. Rebuilding the voice-server image re-resolved the **unbounded** `onnxruntime-gpu>=1.20` to **1.27.0** — the release that switched its PyPI wheel to **CUDA 13** (`dlopen libcudart.so.13`). The base image is `nvidia/cuda:12.6.3-runtime` (**libcudart.so.12**), so the new pod CrashLooped at speaker-service warmup:

```
ImportError: libcudart.so.13: cannot open shared object file: No such file or directory
```

## Fix

Pin `onnxruntime-gpu>=1.20,<1.27` in **both** `requirements.txt` and the Dockerfile's final clean reinstall (both install sites must agree). 1.26.x is the CUDA-12 line — the version the last healthy image (v0.1.7) runs.

## Verification (on .159)

- Rebuilt image resolves **onnxruntime-gpu 1.26.0**.
- `python3 -c "import onnxruntime.capi._pybind_state"` → clean (no `libcudart.so.13`).
- `tests/test_opus_decode.py` → 11/11.
- Live voice-server rolled back to v0.1.7 during the incident → `1/1 Running`, 0 restarts (no outage; opus is dark).

## Note

Latent landmine unmasked by any rebuild — not caused by the opus code. When the base image is deliberately moved to CUDA 13, lift the cap in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)