### PR TITLE
feat(satellite): provision WM8960 input capture path (mic→ADC route + boost)

### DIFF
--- a/src/satellite/provisioning/README.md
+++ b/src/satellite/provisioning/README.md
@@ -51,9 +51,29 @@ ansible-playbook -i inventory.yml provision.yml --limit satellite-fitnessraum --
 
 # Just update models
 ansible-playbook -i inventory.yml provision.yml --limit satellite-fitnessraum --tags models
+
+# Just (re)apply WM8960 audio-mixer tuning (ALC + mic input path) — restart-free
+ansible-playbook -i inventory.yml provision.yml --limit satellite-wohnzimmer --tags audio
 ```
 
-Available tags: `system`, `boot`, `driver`, `python`, `app`, `config`, `models`, `service`
+Available tags: `system`, `boot`, `driver`, `python`, `app`, `config`, `models`, `service`, `audio`
+
+### WM8960 audio tuning (`2mic` / Whisplay)
+
+openWakeWord scores on raw amplitude, so WM8960-based HATs need mixer tuning in
+front of the model (`--tags audio`, restart-free):
+
+- **ALC** (`wm8960_alc_enabled`, + `wm8960_alc_*` / `wm8960_noise_gate_*`) —
+  hardware AGC that lifts quiet/far speech toward a target level.
+- **Input capture path** (`wm8960_input_path_enabled`, + `wm8960_input_boost`
+  0–3) — routes the mics to the ADC (unmutes the input path) and sets the
+  **pre-ALC** Input Boost. The Seeed 2-Mic (`2mic`) ships this **muted / maxed**,
+  which starves the ADC — a `2mic` sat that never fires a wakeword is almost
+  certainly this. An SNR sweep found the maxed boost (+29 dB) buries speech in
+  ALC-amplified noise (SNR ~4.6 dB); `wm8960_input_boost: 1` (+13 dB) → ~17.8 dB.
+  The ALC normalizes loudness, so the **Input Boost, not the PGA, is the SNR
+  lever**. NB: `2mic-v2` is a different codec (TLV320AIC3x) — these vars don't
+  apply. Persisted on-device by `alsactl store`.
 
 ## Dry Run
 

--- a/src/satellite/provisioning/README.md
+++ b/src/satellite/provisioning/README.md
@@ -66,7 +66,7 @@ front of the model (`--tags audio`, restart-free):
 - **ALC** (`wm8960_alc_enabled`, + `wm8960_alc_*` / `wm8960_noise_gate_*`) —
   hardware AGC that lifts quiet/far speech toward a target level.
 - **Input capture path** (`wm8960_input_path_enabled`, + `wm8960_input_boost`
-  0–3) — routes the mics to the ADC (unmutes the input path) and sets the
+  1–3; 0 re-mutes) — routes the mics to the ADC (unmutes the input path) and sets the
   **pre-ALC** Input Boost. The Seeed 2-Mic (`2mic`) ships this **muted / maxed**,
   which starves the ADC — a `2mic` sat that never fires a wakeword is almost
   certainly this. An SNR sweep found the maxed boost (+29 dB) buries speech in

--- a/src/satellite/provisioning/group_vars/satellites.yml
+++ b/src/satellite/provisioning/group_vars/satellites.yml
@@ -102,19 +102,21 @@ wm8960_noise_gate_threshold: 5         # 0-31 (1.5dB steps), a few steps above t
 # the mic never reaches the ADC. Enable per-host to route + unmute + set the
 # pre-ALC Input Boost. Off by default (no effect on Whisplay, which is fine).
 wm8960_input_path_enabled: false       # enable the mic→ADC input-routing task
-wm8960_input_boost: 1                  # pre-ALC Input Boost Mixer 0-3 (+11..+29dB); 1 (+13dB) tuned for SNR
+# pre-ALC Input Boost Mixer level. VALID RANGE 1-3 (+13/+21/+29 dB). Do NOT use
+# 0 — it disconnects the boost mixer and re-MUTES the mic (the exact bug this
+# task fixes). 1 (+13 dB) is tuned for SNR (higher buries speech in ALC noise).
+wm8960_input_boost: 1
 
 # LED
 led_brightness: 20
 led_night_brightness: 5
 led_type: "apa102"
-# LED GPIO pins — only meaningful for led_type "gpio_rgb"; the template emits
-# gpio_red/green/blue for every led_type, so they need defaults (harmless/unused
-# on apa102/xvf3800). led_power_pin is guarded by `is not none`, so null omits
-# it; a gpio_rgb host with a power-enable pin overrides these in host_vars.
-led_gpio_red: 0
-led_gpio_green: 0
-led_gpio_blue: 0
+# led_power_pin is referenced (guarded by `is not none`) in the non-gpio_rgb LED
+# branch that apa102/xvf3800 hit, so it must be DEFINED — null omits the line.
+# A gpio_rgb host with a power-enable pin sets it in host_vars.
+# (led_gpio_red/green/blue are deliberately NOT defaulted: they're emitted only
+# for led_type "gpio_rgb", so a gpio_rgb host that forgets them should fail LOUD
+# at render rather than silently drive reserved BCM GPIO0.)
 led_power_pin: null
 
 # Display

--- a/src/satellite/provisioning/group_vars/satellites.yml
+++ b/src/satellite/provisioning/group_vars/satellites.yml
@@ -98,11 +98,24 @@ wm8960_alc_max_gain: 7                 # 0-7, caps PGA so ALC can't run away int
 wm8960_alc_min_gain: 0                 # 0-7
 wm8960_noise_gate_enabled: true        # stops ALC pumping/pulling up idle hiss between utterances
 wm8960_noise_gate_threshold: 5         # 0-31 (1.5dB steps), a few steps above the room's idle floor
+# Seeed 2-Mic (hat_type "2mic") ships the mic INPUT path muted / boost maxed, so
+# the mic never reaches the ADC. Enable per-host to route + unmute + set the
+# pre-ALC Input Boost. Off by default (no effect on Whisplay, which is fine).
+wm8960_input_path_enabled: false       # enable the mic→ADC input-routing task
+wm8960_input_boost: 1                  # pre-ALC Input Boost Mixer 0-3 (+11..+29dB); 1 (+13dB) tuned for SNR
 
 # LED
 led_brightness: 20
 led_night_brightness: 5
 led_type: "apa102"
+# LED GPIO pins — only meaningful for led_type "gpio_rgb"; the template emits
+# gpio_red/green/blue for every led_type, so they need defaults (harmless/unused
+# on apa102/xvf3800). led_power_pin is guarded by `is not none`, so null omits
+# it; a gpio_rgb host with a power-enable pin overrides these in host_vars.
+led_gpio_red: 0
+led_gpio_green: 0
+led_gpio_blue: 0
+led_power_pin: null
 
 # Display
 display_enabled: false

--- a/src/satellite/provisioning/provision.yml
+++ b/src/satellite/provisioning/provision.yml
@@ -479,11 +479,6 @@
             label: "{{ item.ctl }} = {{ item.val }}"
           changed_when: true
 
-        - name: Persist ALSA mixer state (restored on boot by alsa-restore.service)
-          ansible.builtin.command:
-            argv: [alsactl, store]
-          changed_when: true
-
     # --- WM8960 input capture path: mic → boost → PGA → ADC (route + unmute) ---
     # Complements the ALC task above (which tunes loudness). The Seeed 2-Mic
     # Voicecard (hat_type "2mic", card seeed2micvoicec) ships with the mic INPUT
@@ -492,8 +487,8 @@
     # wakeword until this was fixed (2026-07-08). This routes the mics to the ADC
     # and sets the pre-ALC Input Boost. An SNR sweep found the maxed boost (+29 dB)
     # buries speech in ALC-amplified room noise (SNR 4.6 dB); +13 dB → SNR 17.8 dB.
-    # Off by default; enable + tune per host (wm8960_input_boost 0-3). Same `audio`
-    # tag → (re)applies restart-free: `... --tags audio --limit <host>`.
+    # Off by default; enable + tune per host (wm8960_input_boost 1-3; 0 re-mutes).
+    # Same `audio` tag → (re)applies restart-free: `... --tags audio --limit <host>`.
     - name: Configure WM8960 input capture path (route + unmute + boost)
       tags: [driver, config, audio]
       when: wm8960_input_path_enabled | default(false)
@@ -518,10 +513,15 @@
             label: "{{ item.ctl }} = {{ item.val }}"
           changed_when: true
 
-        - name: Persist ALSA mixer state (input path; restored on boot by alsa-restore.service)
-          ansible.builtin.command:
-            argv: [alsactl, store]
-          changed_when: true
+    # Persist the WM8960 mixer state ONCE, after whichever of the two tuning
+    # tasks above ran — so a host with BOTH ALC + input-path enabled doesn't
+    # store twice. Restored on boot by alsa-restore.service.
+    - name: Persist WM8960 ALSA mixer state
+      tags: [driver, config, audio]
+      when: (wm8960_alc_enabled | default(false)) or (wm8960_input_path_enabled | default(false))
+      ansible.builtin.command:
+        argv: [alsactl, store]
+      changed_when: true
 
     # =========================================================================
     # PYTHON — Python virtual environment

--- a/src/satellite/provisioning/provision.yml
+++ b/src/satellite/provisioning/provision.yml
@@ -484,6 +484,45 @@
             argv: [alsactl, store]
           changed_when: true
 
+    # --- WM8960 input capture path: mic → boost → PGA → ADC (route + unmute) ---
+    # Complements the ALC task above (which tunes loudness). The Seeed 2-Mic
+    # Voicecard (hat_type "2mic", card seeed2micvoicec) ships with the mic INPUT
+    # path effectively muted and the pre-ALC Input Boost maxed, so the mic never
+    # reaches the ADC usefully — the sat-wohnzimmer satellite had NEVER fired a
+    # wakeword until this was fixed (2026-07-08). This routes the mics to the ADC
+    # and sets the pre-ALC Input Boost. An SNR sweep found the maxed boost (+29 dB)
+    # buries speech in ALC-amplified room noise (SNR 4.6 dB); +13 dB → SNR 17.8 dB.
+    # Off by default; enable + tune per host (wm8960_input_boost 0-3). Same `audio`
+    # tag → (re)applies restart-free: `... --tags audio --limit <host>`.
+    - name: Configure WM8960 input capture path (route + unmute + boost)
+      tags: [driver, config, audio]
+      when: wm8960_input_path_enabled | default(false)
+      block:
+        - name: Apply WM8960 input-routing + boost mixer controls
+          ansible.builtin.command:
+            argv:
+              - amixer
+              - -c
+              - "{{ wm8960_alsa_card }}"
+              - sset
+              - "{{ item.ctl }}"
+              - "{{ item.val }}"
+          loop:
+            - { ctl: "Left Boost Mixer LINPUT1",        val: "on" }
+            - { ctl: "Right Boost Mixer RINPUT1",       val: "on" }
+            - { ctl: "Left Input Mixer Boost",          val: "on" }
+            - { ctl: "Right Input Mixer Boost",         val: "on" }
+            - { ctl: "Left Input Boost Mixer LINPUT1",  val: "{{ wm8960_input_boost | string }}" }
+            - { ctl: "Right Input Boost Mixer RINPUT1", val: "{{ wm8960_input_boost | string }}" }
+          loop_control:
+            label: "{{ item.ctl }} = {{ item.val }}"
+          changed_when: true
+
+        - name: Persist ALSA mixer state (input path; restored on boot by alsa-restore.service)
+          ansible.builtin.command:
+            argv: [alsactl, store]
+          changed_when: true
+
     # =========================================================================
     # PYTHON — Python virtual environment
     # =========================================================================


### PR DESCRIPTION
## Summary

Provisions the WM8960 **input capture path** so the fix that resurrected the **Wohnzimmer** satellite is reproducible across re-provisions/reflashes (not just the on-device `alsactl store`).

**Root cause:** the Seeed 2-Mic Voicecard (`hat_type: 2mic`, card `seeed2micvoicec`, WM8960) ships with the mic **input path muted** and the **pre-ALC Input Boost maxed** — so the mic never reaches the ADC usefully. `sat-wohnzimmer` had **never fired a wakeword**; its mic-mixer was simply never provisioned (it also had **no host_var at all** — the underlying gap).

## What's in this PR (committed)
- **`provision.yml`** — new `Configure WM8960 input capture path` task (tags `driver,config,audio`; gated `wm8960_input_path_enabled`, **off by default** so the Whisplay is untouched). Routes the mics to the ADC + sets the pre-ALC Input Boost. Restart-free via `--tags audio`.
- **`group_vars/satellites.yml`** — `wm8960_input_path_enabled: false` + `wm8960_input_boost: 1`. Also `led_power_pin: null` (the template guards it with `is not none` in the non-gpio_rgb branch, so apa102/xvf3800 hosts couldn't render once a host with no host_var hit the template).
- **README** — documents the `audio` tag + a "WM8960 audio tuning" section (ALC + input path), incl. the "a 2mic sat that never wakes is almost certainly the muted input path" diagnosis.

**Not in this PR:** the per-host `satellite-wohnzimmer.yml` host_var (reconstructed from live config; sets `wm8960_input_path_enabled: true` + `input_boost: 1`) — gitignored.

## The tuning (data-driven)
An SNR sweep on Wohnzimmer: maxed boost (+29 dB) buries speech in ALC-amplified room noise (SNR **4.6 dB**); Input Boost **1 (+13 dB) → 17.8 dB**. The WM8960 ALC normalizes loudness, so the **Input Boost — not the PGA — is the SNR lever**. Applied + persisted → wakeword now fires **0.97 / 0.80** (first time ever), and opus enabled on top.

`2mic-v2` (Kinderbad) is a **different codec** (TLV320AIC3x) — these vars don't apply; it already works.

## Review
High-effort `/review`: 5 findings. Fixed the two correctness footguns I'd introduced — `wm8960_input_boost: 0` re-mutes the mic (documented range now **1-3**), and the `led_gpio_*: 0` defaults would silently drive a future gpio_rgb host onto reserved GPIO0 (**removed**; kept only the required `led_power_pin: null`). Deduped the `alsactl store`. Syntax-check + `--check --diff` config-render pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)