### PR TITLE
feat(satellite): enable Opus on the Esszimmer k8s-pod satellite

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -620,9 +620,11 @@ angezeigt). Rollout gestaffelt: dark → Flotte einschreiben → `…_ENABLED=tr
 # opuslib/libopus0 sind aus dem Backend-Image entfernt). STT/Speaker-Pfade
 # unverändert. Setzt voice_server_url voraus. Satellit-Seite: satellite.yaml
 # audio.codec: "opus" PLUS opuslib + libopus0 auf dem Satelliten (Encode-Seite):
-# bare-metal über group_vars satellite_python_packages (opuslib) + system_packages
-# (libopus0), k8s-Pod-Sat (Esszimmer) über das Satelliten-Image. Fehlt opuslib,
-# fällt der Satellit auf pcm zurück. Flotte auf Opus (2026-07-09): Fitnessraum,
+# bare-metal über die dedizierte opuslib-Task in provision.yml ([python, app],
+# damit auch ein Code-only `--tags app`-Deploy sie mitnimmt) + libopus0 in
+# satellite_system_packages ([system]), k8s-Pod-Sat (Esszimmer) über das
+# Satelliten-Image (Dockerfile). Fehlt opuslib/libopus0, fällt der Satellit
+# graceful auf pcm zurück. Flotte auf Opus (2026-07-09): Fitnessraum,
 # Arbeitszimmer, Wohnzimmer, Kinderbad (bare-metal) + Esszimmer (Pod).
 #
 # DEPLOY-INVARIANTE: Vor dem Aktivieren MUSS das Voice-Server-Image opuslib +

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -619,7 +619,11 @@ angezeigt). Rollout gestaffelt: dark → Flotte einschreiben → `…_ENABLED=tr
 # (Opus-Decode liegt seit C2 Phase 1 auf der Media-Schicht, nicht mehr im Backend;
 # opuslib/libopus0 sind aus dem Backend-Image entfernt). STT/Speaker-Pfade
 # unverändert. Setzt voice_server_url voraus. Satellit-Seite: satellite.yaml
-# audio.codec: "opus".
+# audio.codec: "opus" PLUS opuslib + libopus0 auf dem Satelliten (Encode-Seite):
+# bare-metal über group_vars satellite_python_packages (opuslib) + system_packages
+# (libopus0), k8s-Pod-Sat (Esszimmer) über das Satelliten-Image. Fehlt opuslib,
+# fällt der Satellit auf pcm zurück. Flotte auf Opus (2026-07-09): Fitnessraum,
+# Arbeitszimmer, Wohnzimmer, Kinderbad (bare-metal) + Esszimmer (Pod).
 #
 # DEPLOY-INVARIANTE: Vor dem Aktivieren MUSS das Voice-Server-Image opuslib +
 # libopus0 enthalten (seit C2 Phase 1 im voice-server Dockerfile/requirements).

--- a/k8s/satellite-esszimmer.yaml
+++ b/k8s/satellite-esszimmer.yaml
@@ -37,6 +37,7 @@ data:
       verify_tls: false           # ingress uses a self-signed cert
       max_disconnected_seconds: 300
     audio:
+      codec: opus                 # C1 binary Opus transport → voice-server /stt-opus
       sample_rate: 16000
       chunk_size: 1280
       channels: 1                 # XVF3800 delivers a single post-DSP stream
@@ -119,7 +120,7 @@ spec:
                     values: ["arm64"]
       containers:
         - name: satellite
-          image: renfield/satellite:esszimmer-v6
+          image: renfield/satellite:esszimmer-v7
           imagePullPolicy: Never   # imported into node containerd (k8s.io ns)
           securityContext:
             privileged: true        # raw /dev access for USB audio + xvf_host

--- a/src/satellite/Dockerfile
+++ b/src/satellite/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libasound2 libasound2-plugins alsa-utils \
         mpv libmpv2 \
         libsamplerate0 libopenblas0 \
+        libopus0 \
         libusb-1.0-0 \
         bluez bluez-tools \
         ca-certificates curl \
@@ -62,6 +63,7 @@ RUN pip3 install --break-system-packages \
         bleak \
         cryptography \
         Pillow \
+        "opuslib>=3.0.1" \
     && pip3 install --break-system-packages --no-deps openwakeword
 
 # --- Wake word + VAD models (baked) ---

--- a/src/satellite/provisioning/group_vars/satellites.yml
+++ b/src/satellite/provisioning/group_vars/satellites.yml
@@ -174,6 +174,9 @@ satellite_python_packages:
   - bleak
   - cryptography   # IRK-based RPA resolution (ble/rpa.py) — resolve rotating phone addresses
   - Pillow
+  # NB: opuslib is NOT listed here — it has a dedicated `[python, app]` task in
+  # provision.yml (so a code-only `--tags app` deploy installs it, like
+  # cryptography). libopus0 (its C lib) is in satellite_system_packages above.
 
 # XVF3800 LED control
 xvf_host_path: "/opt/renfield-satellite/bin/xvf_host"


### PR DESCRIPTION
## Summary

Puts the **Esszimmer** satellite (the k8s-pod one — Orange Pi Zero 3W, XVF3800-USB) on the C1 binary-Opus transport, **durably**. Unlike the bare-metal Pi-Zeros (surgical live-config edit), Esszimmer's code is baked into its image and its config is a read-only mounted ConfigMap, so it needs an image rebuild + a manifest change to survive a pod restart.

**Fleet Opus state after this: 5/6 sats** — Fitnessraum, Arbeitszimmer, Wohnzimmer, Kinderbad (bare-metal) + Esszimmer (pod). Only Benszimmer remains (offline).

## Changes
- **`k8s/satellite-esszimmer.yaml`** — ConfigMap `audio.codec: opus`, image `esszimmer-v6 → v7`. The v7 image was rebuilt natively on the node (with `opus_codec.py` + opuslib) and `ctr`-imported into node containerd **before** applying (required by `imagePullPolicy: Never`). Rolled out (Recreate) and verified live: pod on v7, `opus_codec + opuslib OK`, backend registered `sat-esszimmer` with **no downgrade line** (= opus negotiated), `renfield_de` wakeword active, XVF3800 capturing.
- **`src/satellite/Dockerfile`** — add `opuslib>=3.0.1` (pip) + `libopus0` (apt). opuslib was missing entirely (the image pip list is hand-maintained, not from `requirements.txt`); libopus0 was only transitively present via mpv — now explicit. This is what v7 was built from.
- **`group_vars/satellites.yml`** — clarifying comment only. opuslib is deliberately *not* in `satellite_python_packages` because `provision.yml` already has a dedicated `[python, app]` opuslib task.
- **docs/ENVIRONMENT_VARIABLES.md** — document the satellite encode-side dep + fleet state.

## Verification
Pod v7 live and healthy (registered, opus negotiated, wakeword active, mic capturing). Live wakeword-over-opus is confirmed on next in-room use (mic works + opus negotiated).

## Review
High-effort `/review` ran on the branch — 2 findings, both handled:
- **libopus0/opuslib provision-tag drift (CONFIRMED, low):** the initial diff added opuslib to `satellite_python_packages`, which was **redundant** with the existing dedicated `[python, app]` opuslib task. Reverted to a single source of truth (the task); replaced with a clarifying comment. libopus0 stays a `[system]` package (opuslib degrades gracefully to pcm without it, and libopus0 is present on every sat from its initial full provision) — line 571-572 already documents this.
- **`imagePullPolicy: Never` + v7 (PLAUSIBLE):** applying the manifest without first `ctr`-importing v7 would `ErrImageNeverPull`. This is the established operational model for this hardware-pinned pod (v6 was the same); v7 **was** imported before apply (verified), and the commit/comment call it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)