### PR TITLE
feat(satellite): align Esszimmer XVF3800 audio to Fitnessraum (channels:2 + ch0-select)

### DIFF
--- a/k8s/satellite-esszimmer.yaml
+++ b/k8s/satellite-esszimmer.yaml
@@ -40,11 +40,13 @@ data:
       codec: opus                 # C1 binary Opus transport → voice-server /stt-opus
       sample_rate: 16000
       chunk_size: 1280
-      channels: 1                 # XVF3800 delivers a single post-DSP stream
+      channels: 2                 # XVF3800 capture is STEREO (ch0=clean beam, ch1=AEC residual)
+      combine: "select"           # pick a single channel (the beam) — no downmix
+      select_channel: 0           # ch0 = the clean beamformed stream
       physical_mics: 4            # reported as array-size capability
       use_arecord: false          # USB UAC device; no AC108 in-process crash
-      device: "default"           # /etc/asound.conf maps default → XVF3800 (dsnoop)
-      playback_device: "default"  # → XVF3800 out jack (dmix); needs a speaker plugged in
+      device: "default"           # /etc/asound.conf maps default → plain plug → hw:Array (2ch)
+      playback_device: "default"  # → XVF3800 out jack (plain plug); needs a speaker plugged in
       beamforming:
         enabled: false            # XVF3800 does beamforming + AEC in hardware
     wakeword:
@@ -120,7 +122,7 @@ spec:
                     values: ["arm64"]
       containers:
         - name: satellite
-          image: renfield/satellite:esszimmer-v7
+          image: renfield/satellite:esszimmer-v8
           imagePullPolicy: Never   # imported into node containerd (k8s.io ns)
           securityContext:
             privileged: true        # raw /dev access for USB audio + xvf_host

--- a/src/satellite/config/asound.conf
+++ b/src/satellite/config/asound.conf
@@ -1,35 +1,25 @@
 # Renfield Satellite — ALSA config for ReSpeaker XVF3800 USB (container /etc/asound.conf)
-# Mirrors provisioning/templates/asoundrc-xvf3800-usb.j2 so the PortAudio
-# "default" device resolves to the XVF3800 (capture via dsnoop, playback via dmix).
+# Mirrors provisioning/templates/asoundrc-xvf3800-usb.j2 so the same soundcard
+# has identical settings on the bare-metal (Fitnessraum) and k8s-pod (Esszimmer)
+# XVF3800 satellites — plain plug, NO dmix/dsnoop.
 defaults.pcm.rate_converter "samplerate"
 
+# The satellite is the SOLE audio app on this device, so capture and playback
+# open the XVF3800's independent USB substreams directly via plug (format/rate
+# conversion only). We deliberately do NOT use dmix/dsnoop here: those allocate
+# System V IPC semaphore+shm objects that, if first created by a root process,
+# end up owner-locked at perms 0600 and can deadlock PortAudio's Pa_Initialize.
+# Capturing hw:Array directly (2ch: ch0=clean beam, ch1=AEC residual) lets the
+# app select ch0 via combine:select/select_channel:0 (the 2026-07-07 downmix fix).
 pcm.!default {
     type asym
-    playback.pcm "xvf_play"
-    capture.pcm "xvf_cap"
+    playback.pcm { type plug slave.pcm "hw:Array" }
+    capture.pcm  { type plug slave.pcm "hw:Array" }
 }
 
-pcm.xvf_play {
-    type plug
-    slave.pcm "dmixed"
-}
-
-pcm.xvf_cap {
-    type plug
-    slave.pcm "dsnooped"
-}
-
-pcm.dmixed {
-    type dmix
-    slave.pcm "hw:Array"
-    ipc_key 555555
-}
-
-pcm.dsnooped {
-    type dsnoop
-    slave {
-        pcm "hw:Array"
-        channels 1
-    }
-    ipc_key 666666
-}
+# Neutralize the ALSA -> PulseAudio bridge: the container has no PulseAudio/
+# PipeWire server, so when PortAudio's Pa_Initialize enumerates the "pulse" PCM,
+# libpulse spins forever trying to reach a server that will never exist. Route
+# it to null so audio init can't hang there.
+pcm.!pulse { type null }
+ctl.!pulse { type null }


### PR DESCRIPTION
## What
Make the same soundcard (ReSpeaker XVF3800 USB) have **identical settings** on the bare-metal (Fitnessraum) and k8s-pod (Esszimmer) satellites.

**Measured first** (standing rule): the old Esszimmer `channels:1 + dsnoop channels 1` path was actually clean (~38 dB SNR — `dsnoop` was isolating ch0, *not* downmixing ch0+ch1), so this is a **consistency change, not a quality fix**. Deployed at the user's request for uniformity.

## Changes (both ship together — channels:2 through a 1-ch dsnoop would mismatch)
- **`config/asound.conf`** (baked into the esszimmer image): dmix/dsnoop → Fitnessraum **plain-plug** (`plug → hw:Array` for playback + capture) + `pcm.!pulse`/`ctl.!pulse` null bridge.
- **`k8s/satellite-esszimmer.yaml`** ConfigMap audio: `channels 1→2` + `combine:select` + `select_channel:0` (pick ch0 = clean beam, no downmix); image → `esszimmer-v8`.

Image `esszimmer-v8` built natively on the Orange Pi + `ctr`-imported; the same rebuild also bakes the pending `satellite.py` #5/#6 BLE fixes.

## Verified live (already deployed)
- Pod: `Audio capture started: default (S16_LE/2ch)`, no `Pa_Initialize` hang (plain-plug + pulse-null works in-container)
- Wakeword `renfield_de` **0.98 / 0.99**, STT **"Wie spät ist es?"** transcribed correctly, TTS response played → back to idle
- BLE continuous scanning at 3 s

Config-only (ALSA + k8s manifest), no application logic changed, and it's validated end-to-end in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)