### PR TITLE
security(auth): refresh-token rotation + reuse-detection (#698); #690/#692 verified done

### DIFF
--- a/src/backend/api/routes/auth.py
+++ b/src/backend/api/routes/auth.py
@@ -227,6 +227,32 @@ async def refresh_token(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
+    # #698: refresh-token rotation WITH reuse-detection. A refresh token is
+    # single-use. (1) If its jti is already blacklisted it was spent (rotated) or
+    # revoked → this is a replay of a stolen/old token → reject. (2) Otherwise
+    # blacklist it now so it can never be replayed. NB: decode_token() only
+    # validates signature/exp and does NOT consult the blacklist (that check lives
+    # in get_current_user, for access tokens), so /refresh must do it explicitly.
+    # is_blacklisted() fails CLOSED — a Redis outage rejects refresh (re-login)
+    # rather than silently honoring a possibly-revoked token. Without this a
+    # stolen refresh token stayed valid its full 30-day life, revocable only by
+    # rotating SECRET_KEY.
+    old_jti = payload.get("jti")
+    old_exp = payload.get("exp")
+    if old_jti:
+        from services.token_blacklist import token_blacklist
+        if await token_blacklist.is_blacklisted(old_jti):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Refresh token already used or revoked",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        if old_exp:
+            import time
+            ttl = int(old_exp - time.time())
+            if ttl > 0:
+                await token_blacklist.add(old_jti, ttl)
+
     # Create new tokens
     access_token = create_access_token(
         data={"sub": str(user.id), "username": user.username}

--- a/tests/backend/test_auth.py
+++ b/tests/backend/test_auth.py
@@ -247,6 +247,76 @@ class TestJWTTokens:
         assert decode_token("") is None
 
 
+class TestRefreshTokenRotation:
+    """#698 — /refresh rotates the refresh token and detects reuse."""
+
+    @staticmethod
+    def _real_request():
+        # slowapi's @limiter.limit on /refresh requires a real starlette Request
+        # (keyed by client IP; conftest resets the limiter between tests).
+        from starlette.requests import Request
+        from services.api_rate_limiter import limiter as app_limiter
+        state = type("S", (), {})()
+        state.limiter = app_limiter
+        app = type("A", (), {})()
+        app.state = state
+        return Request({
+            "type": "http", "method": "POST", "path": "/api/auth/refresh",
+            "headers": [], "client": ("127.0.0.1", 12345), "app": app,
+        })
+
+    @pytest.mark.asyncio
+    async def test_refresh_rotates_and_detects_reuse(self, monkeypatch):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from fastapi import HTTPException
+
+        from api.routes import auth as auth_route
+        from services import token_blacklist as tb_mod
+        from services.api_rate_limiter import limiter as app_limiter
+        from services.auth_service import create_refresh_token, decode_token
+
+        # Bypass the slowapi @limiter.limit on /refresh when calling the handler
+        # directly (its wrapper guards everything behind `if self.enabled`).
+        monkeypatch.setattr(app_limiter, "enabled", False)
+
+        # In-memory blacklist (the handler does `from services.token_blacklist
+        # import token_blacklist` at call time, so patching the module attr works)
+        class FakeBlacklist:
+            def __init__(self):
+                self._s = set()
+
+            async def add(self, jti, ttl):
+                self._s.add(jti)
+
+            async def is_blacklisted(self, jti):
+                return jti in self._s
+
+        monkeypatch.setattr(tb_mod, "token_blacklist", FakeBlacklist())
+
+        user = MagicMock(id=123, is_active=True, username="u")
+
+        async def fake_get_user(db, uid):
+            return user
+        monkeypatch.setattr(auth_route, "get_user_by_id", fake_get_user)
+
+        old = create_refresh_token(123)
+        req = auth_route.RefreshRequest(refresh_token=old)
+
+        # First refresh succeeds and returns a NEW (rotated) refresh token
+        resp = await auth_route.refresh_token(request=self._real_request(), refresh_request=req, db=AsyncMock())
+        assert resp.refresh_token != old
+
+        # The old token's jti is now blacklisted (single-use spent)
+        old_jti = decode_token(old)["jti"]
+        assert await tb_mod.token_blacklist.is_blacklisted(old_jti)
+
+        # Reuse of the old (rotated) token is rejected — 401, no new tokens minted
+        with pytest.raises(HTTPException) as exc:
+            await auth_route.refresh_token(MagicMock(), req, db=AsyncMock())
+        assert exc.value.status_code == 401
+
+
 # ============================================================================
 # Role Model Tests
 # ============================================================================


### PR DESCRIPTION
## Security-hardening sprint — PR 2 (Wave 1)

Re-verification found the auth hardening largely landed **after** the 2026-06-04 audit — 90% of PR 2 was already in. This PR completes the one genuinely-missing piece and documents the rest.

### #698 — refresh-token rotation + reuse-detection (NEW, this PR)
`/refresh` minted a new refresh token but never invalidated the presented one → a stolen refresh token stayed valid its full **30-day** life (revocable only by rotating `SECRET_KEY`). Now single-use:
- **Reuse-detection:** a refresh whose jti is already blacklisted (rotated/revoked) → **401**.
- **Rotation:** blacklist the presented jti after validation (TTL = remaining lifetime).
- `decode_token()` only validates signature/exp (the blacklist check lives in `get_current_user` for access tokens), so `/refresh` checks the blacklist **explicitly**. `is_blacklisted()` fails **closed** (Redis outage → re-login, not silent-honor).
- Test: `TestRefreshTokenRotation` (rotate + reuse→401), green on .159.

### Already done since the audit (verified in current code)
- **#690 → close.** `chat_handler.py:1308` — auth-on permission-load failure sets `user_permissions = []` (deny), not `None` (allow-all). `None` is now only the intentional auth-off / unidentified-voice case (mcp_client docstring tagged #690).
- **#692 code → done.** `fail_closed_on_insecure_jwt_key` refuses to boot on a placeholder/<32-char `SECRET_KEY` when `AUTH_ENABLED=true OR RENFIELD_ENV∈{production,prod,staging}` — closes the "auth-off but weak key" gap. **Remaining:** set `RENFIELD_ENV=production` in the ConfigMap — a multi-user **cutover** step (arms the guard + needs a strong key provisioned first), tracked for the xidra auth-on milestone, not today's single-user posture.

The 14 unrelated `test_auth.py` failures on .159 are pre-existing async-fixture infra issues (not touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)