### PR TITLE
security(auth): login-surface hardening — rate-limit storage, per-username lockout, auth metrics, forced password rotation (#693, #696, #694)

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -1244,9 +1244,11 @@ python3 -c "import secrets; print(secrets.token_urlsafe(64))"
 TRUSTED_PROXIES=172.18.0.0/16,127.0.0.1
 ```
 
-**Default:** `""` (leer = alle Proxies vertraut, rückwärtskompatibel)
+**Default:** `""` (leer = alle Proxies vertraut, `X-Forwarded-For[0]` wird gelesen, rückwärtskompatibel — **spoofbar**)
 
-**Wann setzen:** Hinter einem Reverse Proxy (nginx, Traefik), damit Rate Limiting die echte Client-IP nutzt statt der Proxy-IP. Nur wenn `TRUSTED_PROXIES` konfiguriert ist, werden `X-Forwarded-For` / `X-Real-IP` Header gelesen.
+**Wann setzen:** Hinter einem Reverse Proxy (nginx, Traefik), um die **spoof-sichere** Client-IP-Auflösung zu aktivieren. Ist `TRUSTED_PROXIES` gesetzt, werden `X-Forwarded-For` / `X-Real-IP` nur gelesen, wenn der direkte Peer eine Trusted-Proxy-CIDR ist, und die Client-IP wird durch **Rechts-nach-Links-Durchlauf** der XFF-Kette ermittelt (die rechteste Adresse, die **kein** Trusted Proxy ist) — so kann keine gefälschte XFF-Identität eingeschleust werden.
+
+> **Hinweis (#693):** Der leere Default bleibt bewusst rückwärtskompatibel (liest `X-Forwarded-For[0]`), damit per-Client-Limiting hinter einem Proxy out-of-the-box funktioniert — ein Umschalten auf die direkte Socket-IP würde alle Clients in den einen IP-Bucket des Proxys zusammenfallen lassen (cluster-weiter Rate-Limit-DoS). Die Härtung ist opt-in über `TRUSTED_PROXIES` (z. B. beim Auth-on-Cutover).
 
 ### REST API Rate Limiting
 
@@ -1261,7 +1263,31 @@ API_RATE_LIMIT_VOICE=30/minute
 API_RATE_LIMIT_CHAT=60/minute
 API_RATE_LIMIT_ADMIN=200/minute
 API_RATE_LIMIT_INGEST=1200/minute     # folder-/email-ingest PUSH-Routen (token-auth, MCP-Semaphor bändigt Durchsatz)
+
+# Storage-Backend des Rate-Limiters (slowapi/limits-URI)
+API_RATE_LIMIT_STORAGE_URI=memory://  # per-Pod; für per-Cluster: ${REDIS_URL}
 ```
+
+**`API_RATE_LIMIT_STORAGE_URI`** (Default `memory://`): Zähler sind standardmäßig
+pro Pod. Ein Multi-Replica-Deployment zählt zu niedrig (jeder Pod limitiert
+eigenständig) — auf die Redis-URL setzen (z. B. `redis://redis:6379`) für
+geteiltes **per-Cluster**-Limiting, sobald mehr als ein Backend-Pod läuft.
+
+### Account Lockout (Login)
+
+```bash
+LOGIN_LOCKOUT_ENABLED=true            # Pro-Username-Sperre nach wiederholten Fehlversuchen
+LOGIN_LOCKOUT_MAX_ATTEMPTS=5          # Fehlversuche im Fenster bis zur Sperre
+LOGIN_LOCKOUT_WINDOW_SECONDS=900      # rollierendes Fehler-Fenster
+LOGIN_LOCKOUT_DURATION_SECONDS=900    # Sperrdauer nach Auslösung
+```
+
+Ergänzt das per-IP-Rate-Limit: sperrt einen **Username** nach wiederholten
+Fehl-Logins (stoppt Credential-Stuffing über wechselnde Quell-IPs). Redis-basiert
+(`services/login_lockout.py`), **fail-OPEN** bei Redis-Ausfall (ein Ausfall darf
+nicht den ganzen Haushalt aussperren). Eine gesperrte Anmeldung liefert dasselbe
+opake 401 wie falsche Zugangsdaten (kein Enumerations-Oracle); sichtbar nur über
+Log + `renfield_login_failure_total{reason="locked_out"}`.
 
 `API_RATE_LIMIT_INGEST` gilt für die `/document`-Push-Routen von folder- und
 email-ingest. Diese werden vom vertrauenswürdigen, Bearer-authentifizierten MCP

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -743,7 +743,11 @@ Siehe [SECRETS_MANAGEMENT.md](SECRETS_MANAGEMENT.md) für Details.
 
 ### Weitere Sicherheitsfeatures
 - **CORS**: Konfigurierbare Origins (`CORS_ORIGINS`)
-- **Trusted Proxies**: CIDR-basiert (`TRUSTED_PROXIES`)
+- **Trusted Proxies**: CIDR-basiert (`TRUSTED_PROXIES`) — gesetzt: spoof-sicherer Rechts-nach-Links-XFF-Durchlauf; leer: legacy `X-Forwarded-For[0]` (rückwärtskompatibel, spoofbar)
+- **Rate-Limit-Storage**: per-Pod (`memory://`) oder per-Cluster (`API_RATE_LIMIT_STORAGE_URI=${REDIS_URL}`)
+- **Account Lockout**: Pro-Username-Sperre nach Fehl-Logins (`LOGIN_LOCKOUT_ENABLED`, Redis, fail-open)
+- **Auth-Observability**: `renfield_login_failure_total` / `renfield_authz_denied_total` + strukturierte Logs auf 401/403
+- **Forced Password Rotation**: `must_change_password` serverseitig erzwungen (Allowlist bis zur Rotation)
 - **WebSocket Auth**: Optional aktivierbar (`WS_AUTH_ENABLED`)
 - **Passwort-Hashing**: bcrypt
 - **MCP Response Limits**: Max Response-Größe begrenzt (`MCP_MAX_RESPONSE_SIZE`)

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -107,6 +107,23 @@ Rate limiting is enabled by default (`API_RATE_LIMIT_ENABLED=true`) using slowap
 | Chat | 60/minute | `API_RATE_LIMIT_CHAT` |
 | Admin | 200/minute | `API_RATE_LIMIT_ADMIN` |
 
+**Storage backend (`API_RATE_LIMIT_STORAGE_URI`, default `memory://`).** Counters are per-pod by default. A multi-replica deploy under-counts (each pod limits independently), so set this to the Redis URL (e.g. `${REDIS_URL}`) for shared **per-cluster** limiting once more than one backend pod runs.
+
+### Account Lockout
+
+Beyond the per-IP request cap, a **username** is locked after repeated failed logins (`LOGIN_LOCKOUT_ENABLED=true`), which stops credential-stuffing that rotates source IPs against one account.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `LOGIN_LOCKOUT_ENABLED` | true | Enable per-username lockout |
+| `LOGIN_LOCKOUT_MAX_ATTEMPTS` | 5 | Failures within the window before locking |
+| `LOGIN_LOCKOUT_WINDOW_SECONDS` | 900 | Rolling failure window |
+| `LOGIN_LOCKOUT_DURATION_SECONDS` | 900 | Lock duration once tripped |
+
+- Keyed on the normalized username, Redis-backed (`services/login_lockout.py`), **fails OPEN** on a Redis outage (a blip must not lock out the household; the per-IP limit remains the backstop).
+- A locked login returns the **same opaque 401** as bad credentials (no username-enumeration oracle). The event is surfaced via logging + the `login_failure_total{reason="locked_out"}` metric.
+- Trade-off: an attacker who knows a username can lock that user out for at most the duration (bounded, env-disable-able). This is the standard lockout trade-off, accepted over unbounded credential-stuffing.
+
 ### WebSocket
 
 WebSocket rate limiting uses a sliding window algorithm (`WS_RATE_LIMIT_ENABLED=true`):
@@ -127,8 +144,23 @@ When behind a reverse proxy (nginx, Traefik), configure `TRUSTED_PROXIES` so rat
 TRUSTED_PROXIES=172.18.0.0/16,127.0.0.1
 ```
 
-- Only reads `X-Forwarded-For` / `X-Real-IP` headers when the direct client IP is in a trusted network
-- If `TRUSTED_PROXIES` is empty (default), all proxies are trusted (backwards-compatible)
+- **When `TRUSTED_PROXIES` is configured** (spoof-resistant, #693): reads `X-Forwarded-For` / `X-Real-IP` only when the direct peer is a trusted proxy, and resolves the client by walking the `X-Forwarded-For` chain **right-to-left, returning the right-most address that is NOT a trusted proxy** (the genuine client from our trust boundary). An attacker cannot inject an untrusted address to the right of our own proxy hop, so `X-Forwarded-For` cannot be spoofed to change rate-limit identity.
+- **When `TRUSTED_PROXIES` is empty (default):** legacy backwards-compatible behavior — all proxies are trusted and `X-Forwarded-For[0]` (the left-most entry) is used. This preserves per-client keying behind a proxy out of the box, but **is spoofable** (a client can forge `X-Forwarded-For[0]`). Set `TRUSTED_PROXIES` to the proxy's network to get the spoof-resistant walk above. (Flipping the empty default to "use the direct socket IP" would collapse every client into the proxy's single IP bucket — a cluster-wide rate-limit DoS — so the default stays legacy; hardening is opt-in via `TRUSTED_PROXIES` at the auth-on cutover.)
+
+## Auth Observability
+
+Failed logins and authorization denials emit structured logs and Prometheus counters (`METRICS_ENABLED=true`) so credential-stuffing and privilege-probing are visible to monitoring. Responses stay opaque; only the telemetry distinguishes cases.
+
+| Metric | Labels | Fires on |
+|--------|--------|----------|
+| `renfield_login_failure_total` | `reason` (`bad_credentials`, `inactive`, `locked_out`) | Each failed `/auth/login` |
+| `renfield_authz_denied_total` | `permission` (required perm, or `inactive_account` / `password_change_required`) | Each 403 from `require_permission` / `require_any_permission` / the disabled-account + forced-rotation gates |
+
+Labels are low-cardinality strings — never the username or token.
+
+## Forced Password Rotation
+
+A user with `must_change_password=true` (e.g. a bootstrapped admin with an auto-generated password) is enforced server-side in `get_current_user` (#694): every authenticated route returns `403 password_change_required` **except** an allowlist (`/api/auth/change-password`, `/api/auth/me`, `/api/auth/status`, `/api/auth/logout`), until the password is rotated via `/api/auth/change-password` (which clears the flag). Enforcement uses DB truth, so a token minted before the flag was set is still blocked. The `/auth/login` response carries `must_change_password` so the client can redirect straight to the change form.
 
 ## Circuit Breaker
 

--- a/src/backend/api/routes/auth.py
+++ b/src/backend/api/routes/auth.py
@@ -48,6 +48,10 @@ class TokenResponse(BaseModel):
     refresh_token: str
     token_type: str = "bearer"
     expires_in: int  # seconds
+    # #694: tells the client the user must rotate their password before the
+    # token unlocks anything beyond /change-password. Enforced server-side in
+    # get_current_user; this flag lets the SPA redirect straight to the form.
+    must_change_password: bool = False
 
 
 class RefreshRequest(BaseModel):
@@ -126,6 +130,24 @@ async def login(
     # See auth/login_flow.py for the full resolution + standalone-fallback
     # contract.
     from auth.login_flow import resolve_login
+    from services.login_lockout import login_lockout
+    from utils.metrics import record_login_failure
+
+    # Account lockout (#693): a locked username is rejected BEFORE the credential
+    # walk (so a lockout also stops password-guessing that happens to be
+    # correct). Response is the SAME opaque 401 as bad credentials — never a
+    # distinct status — so it is not a username-enumeration oracle. The event is
+    # observable via the log + metric, not the response.
+    if await login_lockout.is_locked(form_data.username):
+        record_login_failure("locked_out")
+        logger.warning(
+            f"Login rejected: account locked out (username={form_data.username!r})"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
     outcome = await resolve_login(
         db=db,
@@ -137,6 +159,12 @@ async def login(
     if outcome is None:
         # Bad credentials OR a registered post_authenticate consumer declined
         # to resolve — both are an opaque 401 (do not leak which).
+        record_login_failure("bad_credentials")
+        tripped = await login_lockout.record_failure(form_data.username)
+        logger.warning(
+            f"Login failed: bad credentials (username={form_data.username!r})"
+            + (" — account now locked out" if tripped else "")
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect username or password",
@@ -152,11 +180,22 @@ async def login(
     # disabled account exists (no user-enumeration oracle).
     user = await get_user_by_id(db, outcome.user_id)
     if not user or not user.is_active:
+        # A disabled/vanished account is the SAME opaque 401 (no 403) so login
+        # never leaks that the account exists. A failed attempt here still counts
+        # toward lockout (a valid-username-but-disabled probe is still a probe).
+        record_login_failure("inactive")
+        await login_lockout.record_failure(form_data.username)
+        logger.warning(
+            f"Login failed: account missing or inactive (username={form_data.username!r})"
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect username or password",
             headers={"WWW-Authenticate": "Bearer"},
         )
+
+    # Successful auth — clear any accumulated lockout state for this username.
+    await login_lockout.clear(form_data.username)
 
     # Update last login time
     user.last_login = datetime.now(UTC).replace(tzinfo=None)
@@ -179,7 +218,8 @@ async def login(
         access_token=access_token,
         refresh_token=refresh_token,
         token_type="bearer",
-        expires_in=settings.access_token_expire_minutes * 60
+        expires_in=settings.access_token_expire_minutes * 60,
+        must_change_password=user.must_change_password,
     )
 
 
@@ -263,7 +303,11 @@ async def refresh_token(
         access_token=access_token,
         refresh_token=new_refresh_token,
         token_type="bearer",
-        expires_in=settings.access_token_expire_minutes * 60
+        expires_in=settings.access_token_expire_minutes * 60,
+        # #694: a token refresh must carry the still-current flag, else the SPA
+        # would think rotation is done and stop redirecting to /change-password
+        # (while the server keeps returning opaque 403s).
+        must_change_password=user.must_change_password,
     )
 
 

--- a/src/backend/services/api_rate_limiter.py
+++ b/src/backend/services/api_rate_limiter.py
@@ -49,33 +49,71 @@ def _is_trusted_proxy(ip: str) -> bool:
 
 def get_client_ip(request: Request) -> str:
     """
-    Get client IP address from request.
-    Only reads forwarded headers when the direct client IP is in trusted_proxies.
+    Resolve the client IP used as the rate-limit key.
+
+    When ``TRUSTED_PROXIES`` is CONFIGURED, resolution is spoof-resistant:
+    ``X-Forwarded-For`` is client-controllable, so we only trust hops we put
+    there ourselves. The direct peer must itself be a trusted proxy, and we walk
+    the XFF chain RIGHT-to-LEFT returning the first address that is NOT a trusted
+    proxy — the right-most-untrusted address, the genuine client as seen from our
+    trust boundary. An attacker can prepend arbitrary left-most entries but
+    cannot inject an untrusted address to the right of our own proxy hop.
+
+    When ``TRUSTED_PROXIES`` is EMPTY (the default) we keep the legacy,
+    backwards-compatible behavior: read ``X-Forwarded-For[0]`` / ``X-Real-IP``,
+    trusting all proxies. This preserves per-client keying behind a reverse
+    proxy (Traefik/nginx) out of the box — flipping to "use the direct socket
+    IP" would collapse every client into the proxy's single IP bucket and turn
+    the shared per-IP limit into a cluster-wide DoS. The trade-off is that the
+    empty default is spoofable (a client can forge ``X-Forwarded-For[0]``); set
+    ``TRUSTED_PROXIES`` to the proxy's network to get the spoof-resistant
+    right-most-untrusted walk. See docs/SECURITY.md.
     """
     direct_ip = get_remote_address(request)
 
+    networks = _get_trusted_networks()
+    if not networks:
+        # Legacy path: no trusted proxies configured → trust all, take the
+        # left-most forwarded entry (backwards-compatible per-client keying).
+        forwarded_for = request.headers.get("X-Forwarded-For")
+        if forwarded_for:
+            first = forwarded_for.split(",")[0].strip()
+            if first:
+                return first
+        real_ip = request.headers.get("X-Real-IP")
+        if real_ip and real_ip.strip():
+            return real_ip.strip()
+        return direct_ip
+
+    # Configured path: the direct peer must itself be a trusted proxy; otherwise
+    # the request did not come through our proxy and its forwarded headers are
+    # untrustworthy → key on the direct socket IP.
     if not _is_trusted_proxy(direct_ip):
         return direct_ip
 
-    # Check for X-Forwarded-For header (nginx, load balancer)
     forwarded_for = request.headers.get("X-Forwarded-For")
     if forwarded_for:
-        return forwarded_for.split(",")[0].strip()
+        # Right-to-left: skip our own trusted proxy hops, return the first
+        # untrusted address (the real client from our boundary's perspective).
+        for hop in reversed([h.strip() for h in forwarded_for.split(",") if h.strip()]):
+            if not _is_trusted_proxy(hop):
+                return hop
+        # Whole chain is trusted proxies (unusual) → fall through to direct_ip.
 
-    # Check for X-Real-IP header
     real_ip = request.headers.get("X-Real-IP")
-    if real_ip:
-        return real_ip
+    if real_ip and not _is_trusted_proxy(real_ip.strip()):
+        return real_ip.strip()
 
     return direct_ip
 
 
-# Create limiter instance with custom key function
+# Create limiter instance with custom key function. storage_uri is env-driven
+# (#693): "memory://" per-pod by default, Redis for shared per-cluster limiting.
 limiter = Limiter(
     key_func=get_client_ip,
     default_limits=[settings.api_rate_limit_default] if settings.api_rate_limit_enabled else [],
     enabled=settings.api_rate_limit_enabled,
-    storage_uri="memory://",  # In-memory storage (use Redis for production clusters)
+    storage_uri=settings.api_rate_limit_storage_uri,
 )
 
 

--- a/src/backend/services/auth_service.py
+++ b/src/backend/services/auth_service.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Union
 from uuid import uuid4
 
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError, jwt
 from loguru import logger
@@ -31,6 +31,17 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/login", auto_error=Fals
 
 # JWT configuration
 ALGORITHM = "HS256"
+
+# Endpoints a user with must_change_password=True may still reach (#694). A
+# flagged user is otherwise 403'd until they rotate their password — but they
+# must be able to actually DO the rotation (change-password), see their own
+# state (me/status), and log out. Matched on the full request path.
+_PASSWORD_CHANGE_ALLOWED_PATHS = frozenset({
+    "/api/auth/change-password",
+    "/api/auth/me",
+    "/api/auth/status",
+    "/api/auth/logout",
+})
 
 
 # =============================================================================
@@ -193,13 +204,18 @@ async def get_user_by_username(db: AsyncSession, username: str) -> User | None:
 
 async def get_current_user(
     token: str = Depends(oauth2_scheme),
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    request: Request = None,
 ) -> User | None:
     """
     FastAPI dependency to get the current authenticated user.
 
     If auth is disabled, returns None (endpoints should handle this).
     If auth is enabled but token is invalid/missing, raises 401.
+
+    ``request`` is auto-injected by FastAPI when this is used as a dependency;
+    it is optional so the direct positional call in ``get_optional_user`` keeps
+    working. It is used only to enforce ``must_change_password`` (#694).
     """
     # If auth is disabled, return None (anonymous access)
     if not settings.auth_enabled:
@@ -256,17 +272,42 @@ async def get_current_user(
         )
 
     if not user.is_active:
+        from utils.metrics import record_authz_denied
+        record_authz_denied("inactive_account")
+        logger.warning(f"Access denied: inactive account (user_id={user.id})")
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="User account is disabled"
         )
+
+    # Enforce forced password rotation (#694). A user flagged
+    # must_change_password may reach only the allowlisted endpoints (change the
+    # password, read own state, log out); everything else is 403 until they
+    # rotate. Enforced here — the single chokepoint every authenticated route
+    # passes through — using DB truth rather than a token claim, so a token
+    # minted before the flag was set is still blocked. `request` is None only on
+    # the internal get_optional_user path, which is fine to leave unenforced
+    # (those endpoints already tolerate anonymous callers).
+    if user.must_change_password and request is not None:
+        if request.url.path not in _PASSWORD_CHANGE_ALLOWED_PATHS:
+            from utils.metrics import record_authz_denied
+            record_authz_denied("password_change_required")
+            logger.warning(
+                f"Access denied: password change required "
+                f"(user_id={user.id}, path={request.url.path})"
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="password_change_required",
+            )
 
     return user
 
 
 async def get_optional_user(
     token: str = Depends(oauth2_scheme),
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    request: Request = None,
 ) -> User | None:
     """
     FastAPI dependency to optionally get the current user.
@@ -278,8 +319,16 @@ async def get_optional_user(
         return None
 
     try:
-        return await get_current_user(token, db)
-    except HTTPException:
+        return await get_current_user(token, db, request)
+    except HTTPException as exc:
+        # A missing/invalid token → anonymous (the point of "optional"). But a
+        # must_change_password user must NOT be silently downgraded to anonymous
+        # here (#694 review): that would let an optional-auth endpoint serve its
+        # anonymous branch to a flagged user instead of blocking them. Re-raise
+        # the forced-rotation 403 so the gate holds consistently across required
+        # and optional auth.
+        if exc.status_code == status.HTTP_403_FORBIDDEN and exc.detail == "password_change_required":
+            raise
         return None
 
 
@@ -382,6 +431,11 @@ def require_permission(permission: Union[Permission, str]):
         perm_value = permission.value if isinstance(permission, Permission) else permission
 
         if not user.has_permission(perm_value):
+            from utils.metrics import record_authz_denied
+            record_authz_denied(perm_value)
+            logger.warning(
+                f"Authz denied: user_id={user.id} lacks permission {perm_value!r}"
+            )
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=f"Permission required: {perm_value}"
@@ -416,6 +470,11 @@ def require_any_permission(permissions: list[Union[Permission, str]]):
                 return user
 
         perm_values = [p.value if isinstance(p, Permission) else p for p in permissions]
+        from utils.metrics import record_authz_denied
+        record_authz_denied(",".join(perm_values))
+        logger.warning(
+            f"Authz denied: user_id={user.id} lacks any of {perm_values!r}"
+        )
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=f"One of these permissions required: {perm_values}"

--- a/src/backend/services/login_lockout.py
+++ b/src/backend/services/login_lockout.py
@@ -1,0 +1,117 @@
+"""
+Login Account-Lockout Service
+
+Redis-backed per-username failed-login throttle (#693). Complements the per-IP
+REST rate limit (``API_RATE_LIMIT_AUTH``): the rate limit caps request VOLUME
+from one IP, while this locks a USERNAME after repeated failures regardless of
+source IP — so an attacker rotating IPs against one account is still stopped.
+
+Keyed on the normalized username (lower-cased, stripped), never on a secret.
+Two Redis keys per username:
+  - ``login_fail:<user>``  — a counter with a rolling TTL (the failure window).
+  - ``login_lock:<user>``  — a short-lived marker set once the counter trips.
+
+Fail-OPEN by design: if Redis is unreachable, ``is_locked`` returns False and
+``record_failure`` is a no-op. A revocation store (token blacklist) fails CLOSED
+because honoring a revoked token is the dangerous direction; a lockout store
+must fail OPEN because a Redis blip locking out the entire household is the
+dangerous direction here. The per-IP rate limit remains as the backstop.
+
+The lockout response stays OPAQUE (the caller returns the same 401 as bad
+credentials) so it never becomes a username-enumeration oracle; the event is
+surfaced via logging + the ``login_failure_total{reason="locked_out"}`` metric.
+"""
+from loguru import logger
+
+from services.redis_client import get_redis
+from utils.config import settings
+
+FAIL_PREFIX = "login_fail:"
+LOCK_PREFIX = "login_lock:"
+
+
+def _normalize(username: str) -> str:
+    return (username or "").strip().lower()
+
+
+class LoginLockout:
+    """Redis-backed per-username login-attempt lockout."""
+
+    def _get_redis(self):
+        # Reuse the process-wide pooled client so the connection is set up once
+        # and closed by lifecycle.close_redis() on shutdown (no leaked private
+        # connection). decode_responses=True matches this module's string ops.
+        return get_redis()
+
+    async def is_locked(self, username: str) -> bool:
+        """Return True if this username is currently locked out.
+
+        Fails OPEN (returns False) when disabled or on a Redis error.
+        """
+        if not settings.login_lockout_enabled:
+            return False
+        user = _normalize(username)
+        if not user:
+            return False
+        try:
+            redis = self._get_redis()
+            return await redis.exists(f"{LOCK_PREFIX}{user}") > 0
+        except Exception as e:
+            logger.error(f"Login lockout check failed — failing OPEN: {e}")
+            return False
+
+    async def record_failure(self, username: str) -> bool:
+        """Record a failed login for this username.
+
+        Increments the rolling-window failure counter; once it reaches
+        ``login_lockout_max_attempts`` the username is locked for
+        ``login_lockout_duration_seconds``. Returns True if THIS failure tripped
+        the lock (so the caller can log the transition). Best-effort — a Redis
+        error is swallowed (fail-open).
+        """
+        if not settings.login_lockout_enabled:
+            return False
+        user = _normalize(username)
+        if not user:
+            return False
+        try:
+            redis = self._get_redis()
+            fail_key = f"{FAIL_PREFIX}{user}"
+            count = await redis.incr(fail_key)
+            # Arm the window TTL on the first failure. We deliberately do NOT
+            # refresh it on later failures (a rolling reset would let a slow drip
+            # hold the window open forever) — the counter expires N seconds after
+            # the FIRST failure. BUT re-arm if the key somehow has no TTL (e.g. a
+            # transient Redis error dropped the earlier EXPIRE): a persistent,
+            # never-expiring counter would eventually lock a legitimate user out
+            # permanently. `ttl < 0` means no expiry set (-1) or missing (-2).
+            if count == 1 or await redis.ttl(fail_key) < 0:
+                await redis.expire(fail_key, settings.login_lockout_window_seconds)
+            if count >= settings.login_lockout_max_attempts:
+                await redis.setex(
+                    f"{LOCK_PREFIX}{user}",
+                    settings.login_lockout_duration_seconds,
+                    "1",
+                )
+                return True
+            return False
+        except Exception as e:
+            logger.error(f"Login lockout record_failure failed (ignored): {e}")
+            return False
+
+    async def clear(self, username: str) -> None:
+        """Clear the failure counter + lock for a username (call on success)."""
+        if not settings.login_lockout_enabled:
+            return
+        user = _normalize(username)
+        if not user:
+            return
+        try:
+            redis = self._get_redis()
+            await redis.delete(f"{FAIL_PREFIX}{user}", f"{LOCK_PREFIX}{user}")
+        except Exception as e:
+            logger.error(f"Login lockout clear failed (ignored): {e}")
+
+
+# Singleton instance
+login_lockout = LoginLockout()

--- a/src/backend/services/websocket_auth.py
+++ b/src/backend/services/websocket_auth.py
@@ -194,6 +194,16 @@ async def authenticate_websocket(
         if not user.is_active:
             logger.debug(f"WebSocket JWT auth: user_id={user_id_int} disabled")
             return None
+        # Forced password rotation (#694) also gates the WS surface — otherwise a
+        # flagged user could open /ws/chat and drive the full agent without ever
+        # rotating, bypassing the HTTP get_current_user gate. Rejecting the WS
+        # connection forces them through the HTTP /change-password flow first.
+        if user.must_change_password:
+            logger.warning(
+                f"WebSocket JWT auth: user_id={user_id_int} must change password "
+                "— rejecting connection until rotated"
+            )
+            return None
 
         logger.debug(f"WebSocket authenticated via JWT: user_id={user.id}")
         return {

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -909,6 +909,28 @@ class Settings(BaseSettings):
     # ceiling lets the MCP semaphore govern legit throughput while still capping a
     # leaked-token flood (the DB pool is the harder backstop). Env-tunable.
     api_rate_limit_ingest: str = "1200/minute"
+    # Storage backend for the REST rate limiter (slowapi/limits URI). Default
+    # "memory://" = per-pod counters (backwards-compatible; a multi-replica
+    # deploy under-counts because each pod limits independently). Set to the
+    # Redis URL (e.g. ${REDIS_URL}) for shared per-CLUSTER limiting so the auth
+    # limit holds across replicas — required once the multi-user clone runs >1
+    # backend pod (#693). limits accepts "redis://host:port/db".
+    api_rate_limit_storage_uri: str = "memory://"
+
+    # Account lockout — throttle credential-stuffing beyond the per-IP rate
+    # limit by locking a USERNAME after repeated failures (#693). Keyed on the
+    # normalized username (not IP), so it survives an attacker rotating IPs; the
+    # per-IP api_rate_limit_auth still caps request volume. Bounded duration +
+    # env-disable keep the username-targeted-DoS surface small (an attacker who
+    # knows a username can lock that user out for at most the duration). Backed
+    # by Redis (fail-OPEN on outage — a Redis blip must not lock out the whole
+    # household). Controlled solely by this flag; it is harmless-but-dormant in
+    # the auth-off posture (nobody logs in), so it is not additionally gated on
+    # auth_enabled.
+    login_lockout_enabled: bool = True
+    login_lockout_max_attempts: int = 5        # failures within the window → lock
+    login_lockout_window_seconds: int = 900    # 15 min rolling failure window
+    login_lockout_duration_seconds: int = 900  # 15 min lock once tripped
 
     # WebSocket Connection Limits
     ws_max_connections_per_ip: int = 10

--- a/src/backend/utils/metrics.py
+++ b/src/backend/utils/metrics.py
@@ -40,6 +40,8 @@ _injection_attempts_total = None
 _budget_reductions_total = None
 _output_guard_violations_total = None
 _auth_provider_unreachable_total = None
+_login_failure_total = None
+_authz_denied_total = None
 _kg_conflation_candidates = None
 _speaker_inprocess_embedding_blocked_total = None
 
@@ -56,6 +58,7 @@ def _init_metrics():
     global _agent_outcome_total, _injection_attempts_total
     global _budget_reductions_total, _output_guard_violations_total
     global _auth_provider_unreachable_total
+    global _login_failure_total, _authz_denied_total
     global _kg_conflation_candidates
     global _speaker_inprocess_embedding_blocked_total
 
@@ -174,6 +177,25 @@ def _init_metrics():
             "errored or timed out (fail-open). A non-zero rate means a "
             "provider is silently down.",
             ["provider_id"],
+        )
+
+        # Auth observability (#696). Failed logins and authz denials were
+        # previously silent (no log, no metric), leaving credential-stuffing and
+        # privilege-probing invisible to monitoring. Labels are low-cardinality
+        # reason/permission strings — never the username or token (no PII, no
+        # enumeration oracle from the metrics surface).
+        _login_failure_total = Counter(
+            "renfield_login_failure_total",
+            "Failed login attempts by reason (bad_credentials, inactive, "
+            "locked_out, provider_declined).",
+            ["reason"],
+        )
+
+        _authz_denied_total = Counter(
+            "renfield_authz_denied_total",
+            "Authorization denials (HTTP 403) by the permission that was "
+            "required (or 'inactive_account' / 'unauthenticated').",
+            ["permission"],
         )
 
         _speaker_inprocess_embedding_blocked_total = Counter(
@@ -312,6 +334,28 @@ def record_auth_provider_unreachable(provider_id: str):
     if not _metrics_initialized:
         return
     _auth_provider_unreachable_total.labels(provider_id=provider_id).inc()
+
+
+def record_login_failure(reason: str):
+    """Record a failed login attempt (#696).
+
+    `reason` is a low-cardinality label: "bad_credentials", "inactive",
+    "locked_out", or "provider_declined". Never pass the username.
+    """
+    if not _metrics_initialized:
+        return
+    _login_failure_total.labels(reason=reason).inc()
+
+
+def record_authz_denied(permission: str):
+    """Record an authorization denial / HTTP 403 (#696).
+
+    `permission` is the required permission string, or "inactive_account" /
+    "unauthenticated" for the non-permission 401/403 paths.
+    """
+    if not _metrics_initialized:
+        return
+    _authz_denied_total.labels(permission=permission).inc()
 
 
 def record_speaker_inprocess_embedding_blocked(path: str):

--- a/tests/backend/test_api_rate_limiter.py
+++ b/tests/backend/test_api_rate_limiter.py
@@ -81,58 +81,118 @@ def _make_request(headers: dict | None = None, client_host: str = "10.0.0.1") ->
 # get_client_ip tests
 # =============================================================================
 
+@pytest.fixture
+def _trusted(monkeypatch):
+    """Set TRUSTED_PROXIES and reset the module-level network cache.
+
+    #693: get_client_ip only honors forwarded headers when the direct peer is a
+    configured trusted proxy, and walks the chain right-to-left. These tests
+    drive that from a controlled trusted-proxy config.
+    """
+    import services.api_rate_limiter as arl
+
+    def _set(cidrs: str):
+        monkeypatch.setattr(arl.settings, "trusted_proxies", cidrs, raising=False)
+        arl._trusted_networks = None  # bust the lazy cache
+        return arl
+
+    yield _set
+    arl._trusted_networks = None  # restore lazy re-read for other tests
+
+
 class TestGetClientIp:
-    """Tests for the get_client_ip function."""
+    """Tests for the get_client_ip function (#693 right-most-untrusted walk)."""
 
     @pytest.mark.unit
-    def test_x_forwarded_for_single_ip(self):
-        """Should extract IP from X-Forwarded-For header."""
-        request = _make_request(headers={"X-Forwarded-For": "203.0.113.50"})
-        assert get_client_ip(request) == "203.0.113.50"
+    def test_no_trusted_proxies_legacy_reads_xff_first(self, _trusted):
+        """Empty TRUSTED_PROXIES = legacy backwards-compatible behavior.
 
-    @pytest.mark.unit
-    def test_x_forwarded_for_multiple_ips(self):
-        """Should take first IP from X-Forwarded-For chain."""
+        Reads X-Forwarded-For[0] so per-client keying keeps working behind a
+        proxy out of the box (flipping to direct-IP would collapse all clients
+        into the proxy's single bucket — a cluster-wide DoS). This path is
+        spoofable by design; TRUSTED_PROXIES enables the spoof-resistant walk.
+        """
+        _trusted("")
         request = _make_request(
-            headers={"X-Forwarded-For": "203.0.113.50, 70.41.3.18, 150.172.238.178"}
+            headers={"X-Forwarded-For": "203.0.113.50, 10.0.0.1", "X-Real-IP": "198.51.100.1"},
+            client_host="10.0.0.1",
         )
         assert get_client_ip(request) == "203.0.113.50"
 
     @pytest.mark.unit
-    def test_x_forwarded_for_with_spaces(self):
-        """Should strip whitespace from X-Forwarded-For value."""
-        request = _make_request(headers={"X-Forwarded-For": "  203.0.113.50 , 10.0.0.1"})
+    def test_no_trusted_proxies_falls_back_to_direct_when_no_headers(self, _trusted):
+        """Empty TRUSTED_PROXIES + no forwarded headers → direct socket IP."""
+        _trusted("")
+        request = _make_request(client_host="192.168.1.42")
+        assert get_client_ip(request) == "192.168.1.42"
+
+    @pytest.mark.unit
+    def test_untrusted_direct_peer_ignores_forwarded_headers(self, _trusted):
+        """A direct peer NOT in TRUSTED_PROXIES → its XFF is untrusted → direct IP."""
+        _trusted("172.18.0.0/16")
+        request = _make_request(
+            headers={"X-Forwarded-For": "203.0.113.50"},
+            client_host="8.8.8.8",  # not in the trusted range
+        )
+        assert get_client_ip(request) == "8.8.8.8"
+
+    @pytest.mark.unit
+    def test_trusted_proxy_single_client(self, _trusted):
+        """Trusted proxy forwarding one client → that client IP."""
+        _trusted("172.18.0.0/16")
+        request = _make_request(
+            headers={"X-Forwarded-For": "203.0.113.50"},
+            client_host="172.18.0.9",
+        )
         assert get_client_ip(request) == "203.0.113.50"
 
     @pytest.mark.unit
-    def test_x_real_ip_header(self):
-        """Should use X-Real-IP when X-Forwarded-For is absent."""
-        request = _make_request(headers={"X-Real-IP": "198.51.100.1"})
+    def test_right_most_untrusted_is_returned(self, _trusted):
+        """Walk right-to-left: return the right-most address NOT a trusted proxy.
+
+        Chain: realclient, proxy1(trusted), proxy2(trusted). The right-most
+        untrusted entry is `realclient`.
+        """
+        _trusted("172.18.0.0/16")
+        request = _make_request(
+            headers={"X-Forwarded-For": "203.0.113.50, 172.18.0.7, 172.18.0.8"},
+            client_host="172.18.0.9",
+        )
+        assert get_client_ip(request) == "203.0.113.50"
+
+    @pytest.mark.unit
+    def test_spoofed_left_entries_are_ignored(self, _trusted):
+        """An attacker prepending fake left-most entries cannot change identity.
+
+        The attacker's real address (right-most, appended by our trusted proxy)
+        is what we key on; the injected `1.2.3.4` left entry is ignored.
+        """
+        _trusted("172.18.0.0/16")
+        request = _make_request(
+            headers={"X-Forwarded-For": "1.2.3.4, 203.0.113.50"},
+            client_host="172.18.0.9",
+        )
+        assert get_client_ip(request) == "203.0.113.50"
+
+    @pytest.mark.unit
+    def test_x_real_ip_used_when_no_xff(self, _trusted):
+        """Trusted proxy with only X-Real-IP → that IP."""
+        _trusted("172.18.0.0/16")
+        request = _make_request(
+            headers={"X-Real-IP": "198.51.100.1"},
+            client_host="172.18.0.9",
+        )
         assert get_client_ip(request) == "198.51.100.1"
 
     @pytest.mark.unit
-    def test_x_forwarded_for_takes_priority_over_x_real_ip(self):
-        """X-Forwarded-For should have priority over X-Real-IP."""
-        request = _make_request(headers={
-            "X-Forwarded-For": "203.0.113.50",
-            "X-Real-IP": "198.51.100.1",
-        })
-        assert get_client_ip(request) == "203.0.113.50"
-
-    @pytest.mark.unit
-    def test_fallback_to_remote_address(self):
-        """Should fall back to direct client IP when no proxy headers."""
-        request = _make_request(client_host="192.168.1.42")
-        with patch("services.api_rate_limiter.get_remote_address", return_value="192.168.1.42"):
-            ip = get_client_ip(request)
-        assert ip == "192.168.1.42"
-
-    @pytest.mark.unit
-    def test_empty_forwarded_for_uses_real_ip(self):
-        """Empty X-Forwarded-For should fall through to X-Real-IP."""
-        # An empty string is falsy, so it should skip to X-Real-IP
-        request = _make_request(headers={"X-Forwarded-For": "", "X-Real-IP": "10.20.30.40"})
-        assert get_client_ip(request) == "10.20.30.40"
+    def test_all_hops_trusted_falls_back_to_direct(self, _trusted):
+        """If the whole XFF chain is trusted proxies, fall back to the direct IP."""
+        _trusted("172.18.0.0/16")
+        request = _make_request(
+            headers={"X-Forwarded-For": "172.18.0.5, 172.18.0.6"},
+            client_host="172.18.0.9",
+        )
+        assert get_client_ip(request) == "172.18.0.9"
 
 
 # =============================================================================

--- a/tests/backend/test_auth_metrics.py
+++ b/tests/backend/test_auth_metrics.py
@@ -1,0 +1,48 @@
+"""Tests for the auth observability metrics (#696).
+
+login_failure_total{reason} and authz_denied_total{permission} — no-op when
+metrics are disabled, and increment the right labeled counter when enabled.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class TestAuthMetricsNoop:
+    @pytest.mark.unit
+    def test_record_functions_noop_when_uninitialized(self):
+        import utils.metrics as m
+        m._metrics_initialized = False
+        # Must not raise even though the counters are None.
+        m.record_login_failure("bad_credentials")
+        m.record_authz_denied("chat.write")
+
+
+class TestAuthMetricsEnabled:
+    @pytest.mark.unit
+    def test_record_login_failure_increments_labeled_counter(self):
+        import utils.metrics as m
+        counter = MagicMock()
+        m._metrics_initialized = True
+        m._login_failure_total = counter
+        try:
+            m.record_login_failure("locked_out")
+            counter.labels.assert_called_once_with(reason="locked_out")
+            counter.labels.return_value.inc.assert_called_once()
+        finally:
+            m._metrics_initialized = False
+            m._login_failure_total = None
+
+    @pytest.mark.unit
+    def test_record_authz_denied_increments_labeled_counter(self):
+        import utils.metrics as m
+        counter = MagicMock()
+        m._metrics_initialized = True
+        m._authz_denied_total = counter
+        try:
+            m.record_authz_denied("password_change_required")
+            counter.labels.assert_called_once_with(permission="password_change_required")
+            counter.labels.return_value.inc.assert_called_once()
+        finally:
+            m._metrics_initialized = False
+            m._authz_denied_total = None

--- a/tests/backend/test_login_lockout.py
+++ b/tests/backend/test_login_lockout.py
@@ -1,0 +1,138 @@
+"""Tests for the per-username login lockout service (#693).
+
+Covers the trip threshold, is_locked, clear-on-success, username normalization,
+the disabled short-circuit, and the fail-OPEN guarantee on a Redis outage (a
+lockout store must never lock out the whole household when Redis blips).
+"""
+import pytest
+
+import services.login_lockout as ll_mod
+from services.login_lockout import LoginLockout
+
+
+class _FakeRedis:
+    """Minimal in-memory async Redis supporting the ops LoginLockout uses."""
+
+    def __init__(self):
+        self.store: dict[str, str] = {}
+        self.ttls: dict[str, int] = {}
+
+    async def incr(self, key):
+        val = int(self.store.get(key, "0")) + 1
+        self.store[key] = str(val)
+        return val
+
+    async def expire(self, key, ttl):
+        if key in self.store:
+            self.ttls[key] = ttl
+            return True
+        return False
+
+    async def ttl(self, key):
+        if key not in self.store:
+            return -2  # key does not exist
+        return self.ttls.get(key, -1)  # -1 = exists but no expiry set
+
+    async def setex(self, key, _ttl, value):
+        self.store[key] = value
+
+    async def exists(self, key):
+        return 1 if key in self.store else 0
+
+    async def delete(self, *keys):
+        for k in keys:
+            self.store.pop(k, None)
+            self.ttls.pop(k, None)
+
+
+@pytest.fixture
+def lockout(monkeypatch):
+    """A LoginLockout wired to a fresh fake Redis with a low trip threshold."""
+    monkeypatch.setattr(ll_mod.settings, "login_lockout_enabled", True, raising=False)
+    monkeypatch.setattr(ll_mod.settings, "login_lockout_max_attempts", 3, raising=False)
+    monkeypatch.setattr(ll_mod.settings, "login_lockout_window_seconds", 900, raising=False)
+    monkeypatch.setattr(ll_mod.settings, "login_lockout_duration_seconds", 900, raising=False)
+    lo = LoginLockout()
+    fake = _FakeRedis()
+    monkeypatch.setattr(lo, "_get_redis", lambda: fake)
+    lo._fake = fake  # expose for assertions
+    return lo
+
+
+class TestLoginLockout:
+    @pytest.mark.unit
+    async def test_not_locked_initially(self, lockout):
+        assert await lockout.is_locked("alice") is False
+
+    @pytest.mark.unit
+    async def test_trips_after_max_attempts(self, lockout):
+        # max_attempts = 3 → first two return False, the third trips.
+        assert await lockout.record_failure("alice") is False
+        assert await lockout.record_failure("alice") is False
+        assert await lockout.record_failure("alice") is True
+        assert await lockout.is_locked("alice") is True
+
+    @pytest.mark.unit
+    async def test_clear_resets_state(self, lockout):
+        for _ in range(3):
+            await lockout.record_failure("alice")
+        assert await lockout.is_locked("alice") is True
+        await lockout.clear("alice")
+        assert await lockout.is_locked("alice") is False
+
+    @pytest.mark.unit
+    async def test_username_normalized(self, lockout):
+        """Lockout is case/whitespace-insensitive on the username."""
+        for _ in range(3):
+            await lockout.record_failure("  Alice ")
+        assert await lockout.is_locked("alice") is True
+        assert await lockout.is_locked("ALICE") is True
+
+    @pytest.mark.unit
+    async def test_distinct_usernames_independent(self, lockout):
+        for _ in range(3):
+            await lockout.record_failure("alice")
+        assert await lockout.is_locked("alice") is True
+        assert await lockout.is_locked("bob") is False
+
+    @pytest.mark.unit
+    async def test_disabled_short_circuits(self, lockout, monkeypatch):
+        monkeypatch.setattr(ll_mod.settings, "login_lockout_enabled", False, raising=False)
+        for _ in range(5):
+            assert await lockout.record_failure("alice") is False
+        assert await lockout.is_locked("alice") is False
+
+    @pytest.mark.unit
+    async def test_empty_username_ignored(self, lockout):
+        assert await lockout.record_failure("") is False
+        assert await lockout.is_locked("") is False
+
+    @pytest.mark.unit
+    async def test_is_locked_fails_open_on_redis_error(self, lockout, monkeypatch):
+        """A Redis outage must NOT lock everyone out — is_locked returns False."""
+        def _boom():
+            raise ConnectionError("redis down")
+        monkeypatch.setattr(lockout, "_get_redis", _boom)
+        assert await lockout.is_locked("alice") is False
+
+    @pytest.mark.unit
+    async def test_record_failure_fails_open_on_redis_error(self, lockout, monkeypatch):
+        """record_failure swallows a Redis error (best-effort, never raises)."""
+        def _boom():
+            raise ConnectionError("redis down")
+        monkeypatch.setattr(lockout, "_get_redis", _boom)
+        assert await lockout.record_failure("alice") is False
+
+    @pytest.mark.unit
+    async def test_ttl_rearmed_if_lost(self, lockout):
+        """A counter left without a TTL (dropped EXPIRE) is re-armed on the next
+        failure, so it can never become a permanent lock (review #5)."""
+        fake = lockout._fake
+        # Simulate a first failure whose EXPIRE was lost: counter exists, no TTL.
+        fail_key = "login_fail:alice"
+        fake.store[fail_key] = "1"  # count present
+        # no entry in fake.ttls → ttl() returns -1 (no expiry)
+        assert fake.ttls.get(fail_key) is None
+        # Next failure (count becomes 2) must detect the missing TTL and re-arm.
+        await lockout.record_failure("alice")
+        assert fake.ttls.get(fail_key) == 900

--- a/tests/backend/test_must_change_password.py
+++ b/tests/backend/test_must_change_password.py
@@ -1,0 +1,167 @@
+"""Tests for must_change_password enforcement (#694).
+
+A user flagged must_change_password may reach ONLY the allowlisted auth
+endpoints until they rotate; every other route is 403 password_change_required.
+Enforced in get_current_user (the single authenticated chokepoint), using DB
+truth so a token minted before the flag was set is still blocked.
+"""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+import services.auth_service as auth_service
+from models.database import User
+
+
+def _user(must_change: bool):
+    u = User()
+    u.id = 1
+    u.username = "alice"
+    u.is_active = True
+    u.must_change_password = must_change
+    return u
+
+
+def _request(path: str):
+    req = MagicMock()
+    req.url = MagicMock()
+    req.url.path = path
+    return req
+
+
+@pytest.fixture
+def _wired(monkeypatch):
+    """Wire get_current_user so it resolves a fixed user from a fixed token."""
+    monkeypatch.setattr(auth_service.settings, "auth_enabled", True, raising=False)
+    monkeypatch.setattr(
+        auth_service, "decode_token",
+        lambda _t: {"type": "access", "jti": "jti-1", "sub": "1"},
+    )
+    # token blacklist is imported inside the function from services.token_blacklist
+    import services.token_blacklist as tbl
+    monkeypatch.setattr(tbl.token_blacklist, "is_blacklisted", AsyncMock(return_value=False))
+    return monkeypatch
+
+
+class TestMustChangePasswordEnforcement:
+    @pytest.mark.unit
+    async def test_flagged_user_blocked_on_normal_route(self, _wired):
+        _wired.setattr(auth_service, "get_user_by_id", AsyncMock(return_value=_user(True)))
+        with pytest.raises(HTTPException) as exc:
+            await auth_service.get_current_user(
+                token="x", db=MagicMock(), request=_request("/api/chat"),
+            )
+        assert exc.value.status_code == 403
+        assert exc.value.detail == "password_change_required"
+
+    @pytest.mark.unit
+    async def test_flagged_user_allowed_on_change_password(self, _wired):
+        _wired.setattr(auth_service, "get_user_by_id", AsyncMock(return_value=_user(True)))
+        user = await auth_service.get_current_user(
+            token="x", db=MagicMock(), request=_request("/api/auth/change-password"),
+        )
+        assert user.id == 1
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("path", [
+        "/api/auth/me", "/api/auth/status", "/api/auth/logout",
+    ])
+    async def test_flagged_user_allowed_on_allowlisted_paths(self, _wired, path):
+        _wired.setattr(auth_service, "get_user_by_id", AsyncMock(return_value=_user(True)))
+        user = await auth_service.get_current_user(
+            token="x", db=MagicMock(), request=_request(path),
+        )
+        assert user.id == 1
+
+    @pytest.mark.unit
+    async def test_unflagged_user_passes_everywhere(self, _wired):
+        _wired.setattr(auth_service, "get_user_by_id", AsyncMock(return_value=_user(False)))
+        user = await auth_service.get_current_user(
+            token="x", db=MagicMock(), request=_request("/api/chat"),
+        )
+        assert user.id == 1
+
+    @pytest.mark.unit
+    async def test_no_request_skips_enforcement(self, _wired):
+        """The internal get_optional_user path passes request=None → no enforcement."""
+        _wired.setattr(auth_service, "get_user_by_id", AsyncMock(return_value=_user(True)))
+        user = await auth_service.get_current_user(
+            token="x", db=MagicMock(), request=None,
+        )
+        assert user.id == 1
+
+
+class TestGetOptionalUserReraises:
+    """get_optional_user must re-raise the forced-rotation 403, not swallow it (#694 review)."""
+
+    @pytest.mark.unit
+    async def test_optional_user_reraises_password_change_403(self, _wired):
+        _wired.setattr(auth_service, "get_user_by_id", AsyncMock(return_value=_user(True)))
+        with pytest.raises(HTTPException) as exc:
+            await auth_service.get_optional_user(
+                token="x", db=MagicMock(), request=_request("/api/preferences"),
+            )
+        assert exc.value.status_code == 403
+        assert exc.value.detail == "password_change_required"
+
+    @pytest.mark.unit
+    async def test_optional_user_allows_flagged_on_allowlisted_path(self, _wired):
+        _wired.setattr(auth_service, "get_user_by_id", AsyncMock(return_value=_user(True)))
+        user = await auth_service.get_optional_user(
+            token="x", db=MagicMock(), request=_request("/api/auth/me"),
+        )
+        assert user.id == 1
+
+    @pytest.mark.unit
+    async def test_optional_user_returns_none_on_missing_token(self, _wired):
+        assert await auth_service.get_optional_user(
+            token=None, db=MagicMock(), request=_request("/api/preferences"),
+        ) is None
+
+
+class TestWebSocketMustChangePassword:
+    """The WS auth path must also reject a flagged user (#694 review — WS bypass)."""
+
+    @pytest.mark.unit
+    async def test_ws_auth_rejects_flagged_user(self, monkeypatch):
+        import services.auth_service as auth_svc
+        import services.websocket_auth as ws_auth
+
+        monkeypatch.setattr(ws_auth.settings, "ws_auth_enabled", True, raising=False)
+        monkeypatch.setattr(
+            auth_svc, "decode_token",
+            lambda _t: {"type": "access", "sub": "1"},
+        )
+        monkeypatch.setattr(auth_svc, "get_user_by_id", AsyncMock(return_value=_user(True)))
+
+        class _FakeSession:
+            async def __aenter__(self): return MagicMock()
+            async def __aexit__(self, *a): return False
+        import services.database as db_mod
+        monkeypatch.setattr(db_mod, "AsyncSessionLocal", lambda: _FakeSession())
+
+        result = await ws_auth.authenticate_websocket(MagicMock(), token="jwt")
+        assert result is None  # flagged user rejected on the WS surface
+
+    @pytest.mark.unit
+    async def test_ws_auth_allows_unflagged_user(self, monkeypatch):
+        import services.auth_service as auth_svc
+        import services.websocket_auth as ws_auth
+
+        monkeypatch.setattr(ws_auth.settings, "ws_auth_enabled", True, raising=False)
+        monkeypatch.setattr(
+            auth_svc, "decode_token",
+            lambda _t: {"type": "access", "sub": "1"},
+        )
+        monkeypatch.setattr(auth_svc, "get_user_by_id", AsyncMock(return_value=_user(False)))
+
+        class _FakeSession:
+            async def __aenter__(self): return MagicMock()
+            async def __aexit__(self, *a): return False
+        import services.database as db_mod
+        monkeypatch.setattr(db_mod, "AsyncSessionLocal", lambda: _FakeSession())
+
+        result = await ws_auth.authenticate_websocket(MagicMock(), token="jwt")
+        assert result is not None
+        assert result["user_id"] == 1


### PR DESCRIPTION
## Summary

Wave 2 of the security-hardening sprint (multi-user prerequisites for the xidra auth-on clone). Each issue was **re-verified against current code first** — the 2026-06-04 audit had drifted.

Closes #693, #696, #694.

### #693 — rate-limit hardening
- **`API_RATE_LIMIT_STORAGE_URI`** — per-pod `memory://` default; set to `${REDIS_URL}` for shared **per-cluster** limiting once >1 backend pod runs.
- **`get_client_ip`** — spoof-resistant **right-most-untrusted `X-Forwarded-For` walk** when `TRUSTED_PROXIES` is configured. The empty default stays legacy `XFF[0]` (backwards-compatible per-client keying) — flipping it to direct-IP would collapse every client into the proxy's one bucket (a cluster-wide DoS), so hardening is **opt-in via `TRUSTED_PROXIES`** at the auth-on cutover (belongs with #697's ConfigMap work).
- **`services/login_lockout.py`** — per-username failed-login lockout (Redis via the shared client, **fail-OPEN** on outage, TTL re-armed if lost). Opaque 401 (no enumeration oracle); surfaced via log + `login_failure_total{reason="locked_out"}`.

### #696 — auth observability
- `renfield_login_failure_total{reason}` + `renfield_authz_denied_total{permission}` + structured logging on the 401 login and 403 authz paths. Responses stay opaque.

### #694 — enforce `must_change_password`
- Gated in `get_current_user` (DB-truth, allowlist: change-password/me/status/logout) **and** `authenticate_websocket` (WS surface); `get_optional_user` re-raises the `password_change_required` 403. Flag surfaced in the login + refresh responses.

## Testing
4 new/rewritten test files — **88 passed on `.159`** (incl. `test_auth` 37/37 + `test_metrics` 10/10, no regressions).

## Review
Reviewed via the workflow `/review` at **high** effort; all 8 findings addressed (WS bypass, optional-user re-raise, empty-default DoS revert, `/refresh` flag, TTL re-arm, shared Redis client, config comment).

## Docs
`SECURITY.md`, `ENVIRONMENT_VARIABLES.md`, `FEATURES.md` updated.

## Deploy notes
- **No k8s ConfigMap changes** (deferred to #697 / auth-on cutover). Current auth-off LAN posture is unaffected; the `must_change_password`, lockout, and metrics paths only bite when auth is on.
- The `TRUSTED_PROXIES` spoof-resistant walk activates only once `TRUSTED_PROXIES` is set to the Traefik pod CIDR — to be done in #697.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QYAQhjWUKKKWk7FnChhZ5