### PR TITLE
security(config): explicit auth-config posture in ConfigMap + fail-loud consistency assertion (#697)

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -1322,6 +1322,20 @@ EMBEDDING_DIMENSION=768
 
 ---
 
+### Deployment-Posture (`RENFIELD_ENV`)
+
+```bash
+# Deployment-Marker: development (Default) | dev | test | staging | production | prod
+RENFIELD_ENV=development
+```
+
+Jetzt ein **getracktes Settings-Feld** (#697, vorher nur via `os.getenv` gelesen), damit es introspektierbar/dokumentiert ist und in der ConfigMap neben den übrigen Posture-Keys gesetzt werden kann. Ein Real-Deployment-Wert (`production`/`prod`/`staging`) **scharfschaltet die JWT-Key-Boot-Sperre** auch bei ausgeschalteter Auth (#692) — vorher einen starken `SECRET_KEY` (>= 32 Zeichen) bereitstellen, sonst bootet das Backend nicht.
+
+**Konsistenz-Assertion (#697, `assert_auth_config_consistency`):**
+- **HARTER Boot-Fehler:** `AUTH_ENABLED=true` mit `WS_AUTH_ENABLED=false` — der WebSocket-Chat wäre unauthentifiziert und der WS-Session-Ownership-Check (#657) still deaktiviert. Beide Flags müssen gemeinsam an.
+- **WARN (nicht fatal):** `AUTH_ENABLED=true` mit `CORS_ORIGINS='*'`; `RENFIELD_ENV=production` mit `ALLOW_REGISTRATION=true`.
+- Bei der aktuellen Auth-off-Posture (alles false) greift nichts — byte-identisch.
+
 ### Authentication (RPBAC)
 
 ```bash

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -162,6 +162,17 @@ Labels are low-cardinality strings — never the username or token.
 
 A user with `must_change_password=true` (e.g. a bootstrapped admin with an auto-generated password) is enforced server-side in `get_current_user` (#694): every authenticated route returns `403 password_change_required` **except** an allowlist (`/api/auth/change-password`, `/api/auth/me`, `/api/auth/status`, `/api/auth/logout`), until the password is rotated via `/api/auth/change-password` (which clears the flag). Enforcement uses DB truth, so a token minted before the flag was set is still blocked. The `/auth/login` response carries `must_change_password` so the client can redirect straight to the change form.
 
+## Auth Config Posture
+
+The deployment posture is set **explicitly** in the ConfigMap (`k8s/configmap.yaml`) rather than left to code defaults, so the running state is auditable (#697): `RENFIELD_ENV`, `AUTH_ENABLED`, `WS_AUTH_ENABLED`, `ALLOW_REGISTRATION`, `CORS_ORIGINS`, `TRUSTED_PROXIES`, `API_RATE_LIMIT_STORAGE_URI`. Current values are the deliberate single-user, auth-off LAN posture (byte-identical to the code defaults).
+
+A startup validator (`assert_auth_config_consistency` in `utils/config.py`) **refuses to boot** on an incoherent combo:
+
+- **Hard fail:** `AUTH_ENABLED=true` with `WS_AUTH_ENABLED=false` — the WebSocket chat surface would be unauthenticated and the WS session-ownership check (#657) silently disabled. The two flags must be enabled together.
+- **Warn:** `AUTH_ENABLED=true` with wildcard `CORS_ORIGINS='*'`; a production `RENFIELD_ENV` with `ALLOW_REGISTRATION=true`.
+
+`RENFIELD_ENV` is a tracked setting; a real-deployment value (production/prod/staging) also arms the insecure-`SECRET_KEY` boot guard (#692), so a strong key must be provisioned before the auth-on cutover. The ConfigMap carries a commented **AUTH-ON CUTOVER** checklist of the values to flip together.
+
 ## Circuit Breaker
 
 The circuit breaker protects against cascading failures when the LLM or agent loop is unavailable.

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -6,6 +6,32 @@ metadata:
   labels:
     app.kubernetes.io/part-of: renfield
 data:
+  # === Auth / deployment posture (#697) ===
+  # These are set EXPLICITLY (not left to code defaults) so the running posture
+  # is auditable from the ConfigMap. Current values = the deliberate single-user,
+  # auth-off LAN posture — byte-identical to the code defaults, so setting them
+  # here changes nothing today. The consistency validator in utils/config.py
+  # (assert_auth_config_consistency) hard-fails on an incoherent combo.
+  RENFIELD_ENV: "development"       # NOT "production" — that arms the insecure-JWT-key boot guard; flip only with a strong SECRET_KEY (see cutover below)
+  AUTH_ENABLED: "false"            # single-user LAN; the whole multi-user surface is gated on this
+  WS_AUTH_ENABLED: "false"        # MUST flip to "true" together with AUTH_ENABLED (validator enforces)
+  ALLOW_REGISTRATION: "true"       # harmless while auth is off; set "false" at cutover unless self-signup is wanted
+  CORS_ORIGINS: "*"               # pin to the frontend origin at cutover
+  TRUSTED_PROXIES: ""             # empty = legacy XFF[0] (per-client keying behind Traefik); set to the Traefik pod CIDR for the spoof-resistant walk (#693)
+  API_RATE_LIMIT_STORAGE_URI: "memory://"   # per-pod; set to "redis://redis:6379" for shared per-cluster limiting when >1 backend pod runs
+  #
+  # ── AUTH-ON CUTOVER (xidra multi-user) — do NOT flip piecemeal ──────────────
+  # Provision a strong SECRET_KEY (>= 32 random chars) in the renfield-secrets
+  # Secret FIRST, then set together:
+  #   RENFIELD_ENV: "production"      (arms the SECRET_KEY boot guard — #692)
+  #   AUTH_ENABLED: "true"
+  #   WS_AUTH_ENABLED: "true"         (required with AUTH_ENABLED — validator hard-fails otherwise)
+  #   ALLOW_REGISTRATION: "false"
+  #   CORS_ORIGINS: "https://renfield.local"   (or the real origin)
+  #   TRUSTED_PROXIES: "<Traefik pod CIDR>"    (verify live: kubectl get pod -n kube-system -l app.kubernetes.io/name=traefik -o wide)
+  #   API_RATE_LIMIT_STORAGE_URI: "redis://redis:6379"
+  # ────────────────────────────────────────────────────────────────────────────
+
   # Infra endpoints (cluster-internal DNS)
   DATABASE_URL: "postgresql+asyncpg://renfield:__PG_PASSWORD__@postgres:5432/renfield"
   REDIS_URL: "redis://redis:6379"

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -788,6 +788,16 @@ class Settings(BaseSettings):
     # plugin sets the binding. Matched by spec.startswith(prefix).
     plugin_mcp_bindings: str = ""
 
+    # === Deployment environment ===
+    # Deployment posture marker: "development" (default) | "dev" | "test" |
+    # "staging" | "production" | "prod". Read by the security validators below —
+    # a real-deployment value (production/prod/staging) ARMS the insecure-JWT-key
+    # boot guard even when auth is off (#692) and gates the changeme-default
+    # warning. Previously read only via os.getenv at validation time; now a
+    # tracked Settings field so it is introspectable + documented and can be set
+    # in the ConfigMap alongside the other posture keys (#697). Env: RENFIELD_ENV.
+    renfield_env: str = "development"
+
     # === Authentication ===
     # Set to True to enable authentication (default: False for development)
     auth_enabled: bool = False
@@ -1133,7 +1143,7 @@ class Settings(BaseSettings):
         `"staging"`, or `"prod"`). Tests can opt in to the warning path
         by setting RENFIELD_ENV explicitly.
         """
-        env = os.getenv("RENFIELD_ENV", "development").lower()
+        env = self.renfield_env.lower()
         if env in {"development", "dev", "test"}:
             return self
 
@@ -1180,7 +1190,7 @@ class Settings(BaseSettings):
         arms once an operator declares production, at which point a strong
         SECRET_KEY must already be provisioned.
         """
-        env = os.getenv("RENFIELD_ENV", "development").lower()
+        env = self.renfield_env.lower()
         is_real_env = env in {"production", "prod", "staging"}
         if not (self.auth_enabled or is_real_env):
             return self
@@ -1207,6 +1217,57 @@ class Settings(BaseSettings):
                 f"RENFIELD_ENV={env!r}) — refusing to start. A weak/known key lets an "
                 "attacker forge JWTs. Set SECRET_KEY to a strong random value "
                 "(>= 32 random chars, env var or Docker secret)."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def assert_auth_config_consistency(self) -> "Settings":
+        """Security (#697): fail loud on an incoherent auth posture, warn on soft
+        misconfigurations. Prevents a deploy that *looks* authenticated but has a
+        security control silently disabled.
+
+        HARD FAIL — ``AUTH_ENABLED=true`` with ``WS_AUTH_ENABLED=false``. HTTP
+        routes would authenticate, but the WebSocket surface (the primary chat
+        channel) would not: ``authenticate_websocket`` short-circuits to
+        auth-skipped, so no ``user_id`` resolves and the WS chat-session
+        ownership check (#657) becomes a no-op — any LAN client could then
+        register against another user's conversation. Multi-user auth REQUIRES
+        both flags on together; refuse to boot on the mismatch rather than run
+        with a phantom control.
+
+        WARN (not fatal — may be intentional in some deploys):
+        - ``AUTH_ENABLED=true`` with wildcard ``CORS_ORIGINS='*'`` — with Bearer
+          tokens this is less severe than with cookies, but a real deployment
+          should pin origins.
+        - A real ``RENFIELD_ENV`` (production/prod/staging) with
+          ``ALLOW_REGISTRATION=true`` — open self-registration in a multi-user
+          deployment lets anyone mint a Gast account.
+
+        The current single-user posture (auth off) trips nothing: every check is
+        gated on ``auth_enabled`` (or a production env), so an all-false config
+        is byte-identical.
+        """
+        if self.auth_enabled and not self.ws_auth_enabled:
+            raise ValueError(
+                "Inconsistent auth config: AUTH_ENABLED=true but "
+                "WS_AUTH_ENABLED=false — the WebSocket surface would be "
+                "unauthenticated and the WS chat-session ownership check (#657) "
+                "silently disabled. Set WS_AUTH_ENABLED=true when enabling auth "
+                "(refusing to start with a phantom security control)."
+            )
+
+        if self.auth_enabled and self.cors_origins.strip() == "*":
+            logger.warning(
+                "⚠ AUTH_ENABLED=true with CORS_ORIGINS='*' (wildcard). A real "
+                "deployment should pin CORS_ORIGINS to the frontend origin(s)."
+            )
+
+        env = self.renfield_env.lower()
+        if env in {"production", "prod", "staging"} and self.allow_registration:
+            logger.warning(
+                f"⚠ RENFIELD_ENV={self.renfield_env!r} with ALLOW_REGISTRATION=true "
+                "— open self-registration lets anyone create an account. Set "
+                "ALLOW_REGISTRATION=false unless self-signup is intended."
             )
         return self
 

--- a/tests/backend/test_config_auth_consistency.py
+++ b/tests/backend/test_config_auth_consistency.py
@@ -1,0 +1,70 @@
+"""Tests for the auth-config consistency validator + RENFIELD_ENV field (#697).
+
+assert_auth_config_consistency hard-fails on AUTH_ENABLED without
+WS_AUTH_ENABLED (a phantom security control), warns on soft misconfigs, and is a
+no-op for the current auth-off posture. RENFIELD_ENV is now a tracked field.
+"""
+from pydantic import SecretStr
+
+import pytest
+
+from utils.config import Settings
+
+# A strong key so fail_closed_on_insecure_jwt_key (which runs first) passes and
+# the consistency validator is what we actually exercise.
+_STRONG = "x" * 48
+
+
+class TestAuthConfigConsistency:
+    @pytest.mark.unit
+    def test_auth_on_without_ws_auth_raises(self):
+        with pytest.raises(ValueError, match="WS_AUTH_ENABLED"):
+            Settings(auth_enabled=True, ws_auth_enabled=False, secret_key=SecretStr(_STRONG))
+
+    @pytest.mark.unit
+    def test_auth_on_with_ws_auth_ok(self):
+        s = Settings(auth_enabled=True, ws_auth_enabled=True, secret_key=SecretStr(_STRONG))
+        assert s.auth_enabled is True and s.ws_auth_enabled is True
+
+    @pytest.mark.unit
+    def test_auth_off_is_noop_regardless_of_ws_auth(self):
+        # The current single-user posture: everything off → never raises.
+        s = Settings(auth_enabled=False, ws_auth_enabled=False)
+        assert s.auth_enabled is False
+
+    @pytest.mark.unit
+    def test_wildcard_cors_with_auth_warns_not_fatal(self, caplog):
+        # WARN, not raise — construction still succeeds.
+        s = Settings(
+            auth_enabled=True, ws_auth_enabled=True,
+            cors_origins="*", secret_key=SecretStr(_STRONG),
+        )
+        assert s.cors_origins == "*"
+
+    @pytest.mark.unit
+    def test_production_with_registration_warns_not_fatal(self, monkeypatch):
+        monkeypatch.setenv("RENFIELD_ENV", "production")
+        # auth off + strong key so the only signal is the registration WARN.
+        s = Settings(allow_registration=True, secret_key=SecretStr(_STRONG))
+        assert s.allow_registration is True
+
+
+class TestRenfieldEnvField:
+    @pytest.mark.unit
+    def test_default_is_development(self, monkeypatch):
+        monkeypatch.delenv("RENFIELD_ENV", raising=False)
+        assert Settings().renfield_env == "development"
+
+    @pytest.mark.unit
+    def test_reads_from_env(self, monkeypatch):
+        monkeypatch.setenv("RENFIELD_ENV", "production")
+        # arms the JWT guard → needs a strong key to construct
+        s = Settings(secret_key=SecretStr(_STRONG))
+        assert s.renfield_env == "production"
+
+    @pytest.mark.unit
+    def test_field_drives_jwt_guard(self, monkeypatch):
+        """The insecure-key guard now reads the field: production + weak key raises."""
+        monkeypatch.setenv("RENFIELD_ENV", "production")
+        with pytest.raises(ValueError):
+            Settings(auth_enabled=False, secret_key=SecretStr("short"))

--- a/tests/backend/test_config_secret_failclosed.py
+++ b/tests/backend/test_config_secret_failclosed.py
@@ -23,7 +23,12 @@ class TestSecretKeyFailClosed:
             Settings(auth_enabled=True, secret_key=SecretStr(_PLACEHOLDER))
 
     def test_auth_on_with_strong_key_ok(self):
-        s = Settings(auth_enabled=True, secret_key=SecretStr(_STRONG))
+        # ws_auth_enabled=True is now required alongside auth_enabled (#697
+        # assert_auth_config_consistency); a strong key + coherent auth config
+        # must still construct cleanly.
+        s = Settings(
+            auth_enabled=True, ws_auth_enabled=True, secret_key=SecretStr(_STRONG)
+        )
         assert s.secret_key.get_secret_value() == _STRONG
 
     def test_auth_off_with_placeholder_key_ok(self):

--- a/tests/backend/test_config_w5_w13.py
+++ b/tests/backend/test_config_w5_w13.py
@@ -125,11 +125,18 @@ def test_w13_warns_in_production_when_postgres_password_is_changeme(monkeypatch)
     # explicitly to their class-level placeholder defaults (read live from
     # model_fields so this never drifts from the real default strings).
     placeholders = {}
-    for field_name in ("postgres_password", "secret_key", "default_admin_password"):
+    for field_name in ("postgres_password", "default_admin_password"):
         default = Settings.model_fields[field_name].default
         placeholders[field_name] = (
             default.get_secret_value() if hasattr(default, "get_secret_value") else default
         )
+    # secret_key must be STRONG here: #692's fail_closed_on_insecure_jwt_key
+    # HARD-RAISES on a production env + placeholder secret_key, which would
+    # propagate out of Settings(...) before this test can assert the W13 warn.
+    # The two guards share the production trigger; W13 is about the OTHER
+    # placeholder secrets (postgres_password / default_admin_password), so keep
+    # those placeholder and clear the JWT-key guard with a strong key.
+    placeholders["secret_key"] = "x" * 48
 
     captured = io.StringIO()
     sink_id = logger.add(captured, level="WARNING", format="{level}|{message}")


### PR DESCRIPTION
## Summary

Wave 2 of the security-hardening sprint. **Prerequisites-only scope** — the actual auth-on cutover stays deferred to the xidra multi-user milestone (documented as a commented checklist in the ConfigMap).

Closes #697.

### What changed
- **`RENFIELD_ENV` is now a tracked Pydantic Settings field** (was read only via `os.getenv` in two validators). It becomes introspectable/documented and settable in the ConfigMap alongside the other posture keys. Both existing validators (`warn_on_changeme_defaults`, `fail_closed_on_insecure_jwt_key`) now read `self.renfield_env` — semantically identical (`case_sensitive=False` maps `RENFIELD_ENV`→field).
- **New `assert_auth_config_consistency` validator:**
  - **Hard-fail** on `AUTH_ENABLED=true` without `WS_AUTH_ENABLED=true` — otherwise the WebSocket chat surface is unauthenticated and the #657 session-ownership check becomes a phantom control.
  - **Warn** on wildcard `CORS_ORIGINS='*'` + auth, and a production `RENFIELD_ENV` + `ALLOW_REGISTRATION=true`.
  - No-op for the current all-false posture (byte-identical).
- **`k8s/configmap.yaml`** — sets the 7 auth/posture keys **explicitly** at current-posture values (`AUTH_ENABLED=false` etc. — identical to code defaults, non-disruptive) so the running state is auditable, plus a commented **AUTH-ON CUTOVER** checklist.

### Test fixes (exposed alongside this work)
- `test_auth_on_with_strong_key_ok` — now sets `ws_auth_enabled=True` (the new invariant requires it; **no production caller** constructs auth-on without it — verified).
- `test_w13_warns_in_production...` — uses a strong `secret_key` so #692's hard-raise doesn't preempt the W13 warn assertion (was **pre-existing red on `main`**, a #692-vs-older-test conflict in the same validator this PR touches).

## Testing
`tests/backend/test_config_auth_consistency.py` (new, 8 cases) + the two fixes — **22/22 green on `.159`**.

## Review
Self-reviewed (proportionate to a small config diff): the new hard-fail invariant's blast radius is nil — no production code, conftest, or fixture constructs `Settings(auth_enabled=True)`; the singleton reads env, so a prod misconfig correctly refuses to boot (the intended behavior). Validator ordering verified (key guard runs before the consistency check).

## Docs
`SECURITY.md`, `ENVIRONMENT_VARIABLES.md` updated.

## Deploy notes
- **Non-disruptive** — current auth-off LAN posture unchanged. The ConfigMap values equal the prior effective defaults.
- The **cutover** (flip `RENFIELD_ENV=production` + `AUTH_ENABLED`/`WS_AUTH_ENABLED=true` + `TRUSTED_PROXIES`=Traefik pod CIDR + `API_RATE_LIMIT_STORAGE_URI=$REDIS_URL`, provision a strong `SECRET_KEY` first) is the deferred xidra auth-on step — see the ConfigMap comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QYAQhjWUKKKWk7FnChhZ5