### PR TITLE
security(authz): consolidate atom-ownership checks into a shared load_owned_atom chokepoint (#445)

### DIFF
--- a/docs/CIRCLES.md
+++ b/docs/CIRCLES.md
@@ -148,9 +148,14 @@ Shared Komponenten: `TierBadge` + `TierPicker` + `FactProvenance` (✓ determini
 
 ---
 
+## Object-Level Authorization (Owner-Guard, #445)
+
+Circle-Reach regelt *Lesen*. **Schreiben/Ändern eines Atoms ist strikt Owner-only** und wird an *einer* Stelle erzwungen: dem Shared-Helper `load_owned_atom(db, atom_id, user, *, for_update, not_found_detail)` in `api/routes/atoms.py`. Jede atom-mutierende Route (`PATCH /api/atoms/{id}/tier`, `DELETE /api/atoms/{id}`, Fakt-Tier-Reset) löst ihr Ziel darüber auf, statt den Owner-Check pro Route zu kopieren — so kann eine neue Schreib-Route den Check nicht vergessen. Der Helper liefert ein **uniformes 404** (nie 403) für „existiert nicht" *und* „gehört dir nicht" (Existenz-Oracle-Abwehr) und sperrt die Zeile per `SELECT … FOR UPDATE` von der Owner-Prüfung bis zum Schreiben (TOCTOU-Schutz). `upsert_atom`/`create_with_source` sind interne Schreib-Primitive ohne User-facing Route; ihr Owner stammt aus dem authentifizierten Ingest-Kontext.
+
 ## Anti-Patterns
 
 - **Direkter INSERT in Source-Tabellen** — umgeht AtomService, produziert inkonsistente denormalisierte Spalten. Review blockiert.
+- **Atom-Schreib-Route ohne `load_owned_atom`** — der Owner-Check gehört an den geteilten Chokepoint, nicht pro Route dupliziert (#445).
 - **Retrieval mit `user_id=None` im auth-enabled Modus** — reduziert die Ergebnisse still auf Tier 4 alleine. Jede `rag.search()`-Call-Site muss den Asker übergeben.
 - **Tier auf Source-Tabelle statt über AtomService ändern** — die `atoms.policy`-Quelle bleibt dann falsch.
 - **Circles mit RPBAC verwechseln** — RPBAC (`docs/ACCESS_CONTROL.md`) ist eine Schicht darunter (*kann der Nutzer überhaupt mit Renfield sprechen?*); Circles ist darüber (*wessen Wissen bekommt er zu sehen?*).

--- a/src/backend/api/routes/atoms.py
+++ b/src/backend/api/routes/atoms.py
@@ -51,6 +51,44 @@ router = APIRouter()
 
 
 # =============================================================================
+# Ownership guard (#445)
+# =============================================================================
+
+async def load_owned_atom(
+    db: AsyncSession,
+    atom_id: str,
+    user: User,
+    *,
+    for_update: bool = False,
+    not_found_detail: str = "Atom not found",
+) -> AtomModel:
+    """Load an ``atoms`` row and assert ``user`` owns it, else raise 404.
+
+    The single ownership chokepoint for atom-mutating routes (#445). Every
+    write/tier route that reaches ``AtomService`` must resolve its target
+    through this helper so a new route cannot forget the check — the authz
+    lives in one reviewed place instead of being copy-pasted per route.
+
+    Returns a **uniform 404** (never 403) for both "no such atom" and "not
+    yours", so an attacker cannot use the response to probe which atom_ids
+    exist (existence-oracle defense — matches the pre-existing per-route
+    behavior this consolidates).
+
+    ``for_update=True`` issues ``SELECT ... FOR UPDATE`` so the row is locked
+    from this check through the caller's subsequent write, closing the
+    owner-check→mutate TOCTOU (per PR #402 review SHOULD-FIX #6). Use it on any
+    route that mutates the atom after loading it.
+    """
+    stmt = select(AtomModel).where(AtomModel.atom_id == atom_id)
+    if for_update:
+        stmt = stmt.with_for_update()
+    atom_orm = (await db.execute(stmt)).scalar_one_or_none()
+    if atom_orm is None or atom_orm.owner_user_id != user.id:
+        raise HTTPException(status_code=404, detail=not_found_detail)
+    return atom_orm
+
+
+# =============================================================================
 # Schemas
 # =============================================================================
 
@@ -496,12 +534,12 @@ async def reset_fact_tier(
     )).scalar_one_or_none()
     if fact is None:
         raise HTTPException(status_code=404, detail="Fact not found")
-    # Lock the fact's atom + verify ownership (mirrors the tier-PATCH route).
-    atom_orm = (await db.execute(
-        select(AtomModel).where(AtomModel.atom_id == fact.atom_id).with_for_update()
-    )).scalar_one_or_none()
-    if atom_orm is None or atom_orm.owner_user_id != current_user.id:
-        raise HTTPException(status_code=404, detail="Fact not found")
+    # Lock the fact's atom + verify ownership (shared #445 guard); "Fact not
+    # found" keeps the fact-centric existence-oracle defense.
+    await load_owned_atom(
+        db, fact.atom_id, current_user,
+        for_update=True, not_found_detail="Fact not found",
+    )
 
     new_tier = await AtomService(db).reset_fact_tier(fact_id)
     return FactTierResetResponse(
@@ -546,16 +584,10 @@ async def update_atom_tier(
     until the transaction commits, eliminating the TOCTOU between the
     owner check and the update_tier call (per PR #402 review SHOULD-FIX #6).
     """
-    # SELECT FOR UPDATE locks the row until commit; concurrent deletes/owner
-    # changes block until we're done.
-    atom_orm = (await db.execute(
-        select(AtomModel).where(AtomModel.atom_id == atom_id).with_for_update()
-    )).scalar_one_or_none()
-    if atom_orm is None:
-        raise HTTPException(status_code=404, detail="Atom not found")
-    if atom_orm.owner_user_id != current_user.id:
-        # Uniform 404 to avoid leaking owner identity.
-        raise HTTPException(status_code=404, detail="Atom not found")
+    # SELECT FOR UPDATE locks the row from the ownership check through the
+    # update_tier write (shared #445 guard); concurrent deletes/owner changes
+    # block until we're done.
+    await load_owned_atom(db, atom_id, current_user, for_update=True)
 
     service = AtomService(db)
     await service.update_tier(atom_id, body.policy)
@@ -578,13 +610,10 @@ async def delete_atom(
     Soft-delete an atom (marks source row inactive). Owner-only.
     The atoms row stays for audit trail.
     """
-    atom_orm = (await db.execute(
-        select(AtomModel).where(AtomModel.atom_id == atom_id)
-    )).scalar_one_or_none()
-    if atom_orm is None:
-        raise HTTPException(status_code=404, detail="Atom not found")
-    if atom_orm.owner_user_id != current_user.id:
-        raise HTTPException(status_code=404, detail="Atom not found")
+    # Shared #445 guard. for_update locks the row through the soft-delete write
+    # (the prior version did a plain SELECT, leaving a small owner-check→delete
+    # TOCTOU; the lock closes it — same hardening as the tier PATCH).
+    await load_owned_atom(db, atom_id, current_user, for_update=True)
 
     service = AtomService(db)
     await service.soft_delete(atom_id)

--- a/tests/backend/test_atom_ownership_helper.py
+++ b/tests/backend/test_atom_ownership_helper.py
@@ -1,0 +1,75 @@
+"""Tests for the shared atom-ownership guard load_owned_atom (#445).
+
+The single ownership chokepoint for atom-mutating routes. Verifies it returns
+the row for the owner, and raises a UNIFORM 404 (never 403) for both
+not-found and not-owner — the existence-oracle defense the per-route checks
+had, now in one reviewed place.
+"""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes.atoms import load_owned_atom
+
+
+def _db_returning(atom_orm):
+    """A mock AsyncSession whose execute(...).scalar_one_or_none() yields atom_orm."""
+    result = MagicMock()
+    result.scalar_one_or_none = MagicMock(return_value=atom_orm)
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=result)
+    return db
+
+
+def _atom(owner_id: int):
+    a = MagicMock()
+    a.owner_user_id = owner_id
+    return a
+
+
+def _user(uid: int):
+    u = MagicMock()
+    u.id = uid
+    return u
+
+
+class TestLoadOwnedAtom:
+    @pytest.mark.unit
+    async def test_returns_row_for_owner(self):
+        atom = _atom(7)
+        db = _db_returning(atom)
+        got = await load_owned_atom(db, "atom-1", _user(7))
+        assert got is atom
+
+    @pytest.mark.unit
+    async def test_404_when_not_found(self):
+        db = _db_returning(None)
+        with pytest.raises(HTTPException) as exc:
+            await load_owned_atom(db, "atom-1", _user(7))
+        assert exc.value.status_code == 404
+
+    @pytest.mark.unit
+    async def test_404_uniform_when_not_owner(self):
+        # Not 403 — an attacker must not be able to tell "exists but not yours"
+        # from "does not exist".
+        db = _db_returning(_atom(999))
+        with pytest.raises(HTTPException) as exc:
+            await load_owned_atom(db, "atom-1", _user(7))
+        assert exc.value.status_code == 404
+
+    @pytest.mark.unit
+    async def test_custom_not_found_detail(self):
+        db = _db_returning(None)
+        with pytest.raises(HTTPException) as exc:
+            await load_owned_atom(db, "atom-1", _user(7), not_found_detail="Fact not found")
+        assert exc.value.detail == "Fact not found"
+
+    @pytest.mark.unit
+    async def test_for_update_path_returns_owner_row(self):
+        # for_update just adds .with_for_update() to the stmt; execute is mocked,
+        # so this asserts the branch builds + returns without error.
+        atom = _atom(3)
+        db = _db_returning(atom)
+        got = await load_owned_atom(db, "atom-1", _user(3), for_update=True)
+        assert got is atom


### PR DESCRIPTION
## Summary

Wave 2 of the security-hardening sprint. **Re-verify first** materially changed the issue — the 2026-06-04 audit's named targets are stale:
- `upsert_atom` has **no live user-facing caller** (internal write primitive; owner comes from the ingest context, not user input). Guarding it protects nothing reachable.
- `share_kb` is called from exactly one route, which already enforces owner/admin (when auth on).
- Every user-facing atom **write/tier/delete** route (`update_atom_tier`, `delete_atom`, `reset_fact_tier`, `change_skill_tier`, KB share/revoke) already enforced ownership at the route layer.

So there was **no unguarded user-facing write path**. The genuine residual is defense-in-depth: the owner-check was **copy-pasted per route**, so a new write route could forget it.

Closes #445.

## Change (light-touch — chosen over threading acting-user through the service layer)
Extract the repeated "load `atoms` row + assert owner else uniform 404" into one reviewed helper — `load_owned_atom(db, atom_id, user, *, for_update, not_found_detail)` in `api/routes/atoms.py` — and route the three mutating handlers through it. The authz now lives in **one chokepoint** instead of per-route duplication.

- **Behavior-preserving:** uniform **404** for both not-found and not-owner (existence-oracle defense) is intact.
- `delete_atom` additionally gains `SELECT ... FOR UPDATE`, closing its prior small owner-check→delete TOCTOU (matching the tier PATCH).
- `for_update=True` holds the row lock from the ownership check through the caller's write on the same session.

## Testing
`tests/backend/test_atom_ownership_helper.py` (new, 5 cases) + the existing route-boundary suites (`test_atoms_routes.py`, `test_fact_tier_override_pg.py`, `test_atom_service.py`) — **31 passed on `.159`**, including the owner-mismatch→404 route test, confirming no regression.

## Review
Self-reviewed (proportionate to a small consolidation): none of the three routes used the loaded row beyond the ownership gate, so discarding the return is correct; the `for_update` lock persists to the write (same `db` session). No behavior change beyond the delete-route TOCTOU hardening.

## Docs
`docs/CIRCLES.md` — new "Object-Level Authorization (Owner-Guard, #445)" section + anti-pattern.

## Note
`upsert_atom` / `share_kb` service-layer guards were **deliberately not added** — no reachable IDOR path, and threading an acting-user through methods whose only callers are internal cascades (with no acting user) would be over-engineering. The route-layer chokepoint is the enforcement point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QYAQhjWUKKKWk7FnChhZ5