### PR TITLE
security(docs): correct stale "un-circle-filtered" docstrings in atoms query path (#695)

### DIFF
--- a/src/backend/api/routes/atoms.py
+++ b/src/backend/api/routes/atoms.py
@@ -190,16 +190,19 @@ async def query_atoms(
     """
     Query atoms accessible to the current user.
 
-    For now this returns un-filtered top-k matches across all sources;
-    the per-source circle_tier filter is wired up in Lane C alongside the
-    legacy-consumer rewrite. Until then `q` is passed through to the
-    Lane-A retrieval modules and results come back un-circle-filtered.
+    Results ARE circle-filtered (Lane C is wired): ``asker_id`` is passed to
+    every source (RAG / KG / memory / lexical / document-fact), each of which
+    constrains rows through ``services/circle_sql.py`` — owner OR public-tier OR
+    explicit grant OR tier-reach. So the caller only ever sees atoms it may
+    access; no source returns un-circle-filtered chunks (#695).
     """
     if top_k < 1 or top_k > 100:
         raise HTTPException(status_code=400, detail="top_k must be between 1 and 100")
 
     store = PolymorphicAtomStore(db)
-    # max_visible_tier=4 (public) until per-owner filtering is wired in Lane C.
+    # asker_id drives the actual per-source circle filter. max_visible_tier is
+    # currently not consulted by query() (the reach is computed per-owner inside
+    # each source's circle_sql clause); it is passed for signature-compat only.
     matches = await store.query(
         q,
         asker_id=current_user.id,

--- a/src/backend/services/polymorphic_atom_store.py
+++ b/src/backend/services/polymorphic_atom_store.py
@@ -70,17 +70,19 @@ class PolymorphicAtomStore:
         """
         Query each source in parallel; merge with RRF; return top_k.
 
-        max_visible_tier is the integer tier index the asker can reach in
-        the relevant atom owner's circles. For multi-owner queries (the
-        common case), this is computed per-source via CircleResolver inside
-        each retrieval module's filter clause.
+        Circle filtering (Lane C) is applied per source: rag / kg / memory /
+        lexical / document-fact retrieval all receive ``asker_id`` and constrain
+        results via ``circle_sql`` (owner + public-tier + explicit grants + tier
+        reach), which computes the asker's reach per-owner. A ``None`` asker
+        reduces every source to public-tier only. (RAG search previously omitted
+        ``user_id`` here and returned unfiltered chunks — fixed in #695 so no
+        source bypasses the circle filter.)
 
-        Circle filtering (Lane C) is applied per source: rag / kg / memory
-        retrieval all receive ``asker_id`` and constrain results via
-        ``circle_sql`` (owner + public-tier + explicit grants + tier reach).
-        A ``None`` asker reduces every source to public-tier only. (RAG search
-        previously omitted ``user_id`` here and returned unfiltered chunks —
-        fixed in #695 so no source bypasses the circle filter.)
+        ``max_visible_tier`` is currently NOT consulted: the effective reach is
+        derived per-owner inside each source's ``circle_sql`` clause from
+        ``asker_id``, not from a single scalar tier. The parameter is retained
+        for call-site compatibility (route + federation responder) and may back
+        a future global tier ceiling; do not read it as the active filter.
         """
         from services.document_fact_retrieval import DocumentFactRetrieval
         from services.kg_retrieval import KGRetrieval


### PR DESCRIPTION
## Summary

Wave 3 (final) of the security-hardening sprint. **Re-verify first:** the *code* fix for #695 — passing `user_id=asker_id` to `RAGRetrieval.search` in `PolymorphicAtomStore.query` so RAG isn't reduced to public-tier-only — **already landed in Wave-1 commit `f9c5b0d4`**. Every source (rag / kg / memory / lexical / document-fact) now receives `asker_id` and filters through `services/circle_sql.py`. The issue stayed open only for the **misleading docstrings** the audit flagged.

Closes #695. **Docs-only — no logic change** (`py_compile` clean).

## Change
- `api/routes/atoms.py::query_atoms` — the docstring claimed results come back *"un-circle-filtered … until Lane C"*. Lane C is wired; results **are** circle-filtered per source. Corrected, and noted that `max_visible_tier` is not consulted (the reach is derived per-owner from `asker_id` inside `circle_sql`).
- `PolymorphicAtomStore.query` docstring — removed the false claim that `max_visible_tier` is *"computed per-source via CircleResolver"* (it is unused); stated it is retained for call-site compatibility only, and `asker_id` is the active filter.

## Testing
No test run — the change is docstring/comment text only (verified: the `store.query(...)` call and all logic are untouched; `py_compile` passes). Not a leak; the underlying behavior was already correct and shipped in Wave 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QYAQhjWUKKKWk7FnChhZ5