### PR TITLE
fix(wissensbasis): kill console 404 noise — detect Reva Wissensbasis via config flag, not a 404-probe

### DIFF
--- a/src/backend/api/routes/config.py
+++ b/src/backend/api/routes/config.py
@@ -17,7 +17,7 @@ sees the same flags.
 """
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel
 
 from models.database import User
@@ -25,6 +25,21 @@ from services.auth_service import get_user_or_default
 from utils.config import settings
 
 router = APIRouter()
+
+# The richer Reva Wissensbasis surface (`/api/wissensbasis/trace` + `/me/mix`)
+# is injected by the Reva adapter and is ABSENT in standalone Renfield, which
+# only mounts /graph, /focus, /search. We expose its availability here so the
+# frontend can hide the Reva-only side panels WITHOUT probing /me/mix — that
+# probe 404s by design in standalone and spammed the browser console with red
+# "Failed to load resource" + "API Error" lines. Detect by route presence.
+_REVA_WISSENSBASIS_PROBE_PATH = "/api/wissensbasis/me/mix"
+
+
+def _reva_wissensbasis_mounted(request: Request) -> bool:
+    return any(
+        getattr(r, "path", None) == _REVA_WISSENSBASIS_PROBE_PATH
+        for r in request.app.routes
+    )
 
 
 class FeatureFlags(BaseModel):
@@ -56,10 +71,15 @@ class FeatureFlags(BaseModel):
     # fork_from_message_id. The conversation tree + active-path query are always
     # on. See utils/config.py::chat_branching_enabled.
     chat_branching_enabled: bool
+    # True when the Reva-only Wissensbasis surface (/trace + /me/mix) is mounted
+    # (Reva adapter present). Standalone Renfield => False. Lets the frontend
+    # hide the Reva-only side panels without probing an endpoint that 404s.
+    wissensbasis_reva_available: bool
 
 
 @router.get("/features", response_model=FeatureFlags)
 async def get_features(
+    request: Request,
     _current_user: User = Depends(get_user_or_default),
 ) -> FeatureFlags:
     """Return the frontend-visible feature-flag allowlist."""
@@ -72,4 +92,5 @@ async def get_features(
         artifacts_typed_enabled=settings.artifacts_typed_enabled,
         room_handoff_enabled=settings.room_handoff_enabled,
         chat_branching_enabled=settings.chat_branching_enabled,
+        wissensbasis_reva_available=_reva_wissensbasis_mounted(request),
     )

--- a/src/frontend/src/api/resources/brain.ts
+++ b/src/frontend/src/api/resources/brain.ts
@@ -107,6 +107,10 @@ export interface FeatureFlags {
   room_handoff_enabled: boolean;
   /** Gates the chat message-branching UI (edit/regenerate per-message fork actions). */
   chat_branching_enabled: boolean;
+  /** True when the Reva-only Wissensbasis surface (/trace + /me/mix) is mounted.
+   *  Standalone Renfield => false. Lets the frontend hide the Reva-only side
+   *  panels without probing an endpoint that 404s (console-noise fix). */
+  wissensbasis_reva_available: boolean;
 }
 
 async function fetchAtomSearch(query: string): Promise<AtomMatch[]> {

--- a/src/frontend/src/api/resources/wissensbasis.ts
+++ b/src/frontend/src/api/resources/wissensbasis.ts
@@ -10,6 +10,7 @@
  * - GET /api/wissensbasis/me/mix → A2/A4 layout split for the user's role
  */
 
+import { useFeatureFlags } from './brain';
 import apiClient from '../../utils/axios';
 import { useApiQuery } from '../hooks';
 import { STALE } from '../keys';
@@ -230,30 +231,25 @@ export function useRoleMixQuery(role: string | null, enabled = true) {
 }
 
 /**
- * Check whether the Wissensbasis feature is enabled on the backend.
+ * Check whether the richer Reva Wissensbasis surface (/trace + /me/mix) is
+ * available on the backend.
  *
- * The backend gates the entire `/api/wissensbasis/*` surface on the
- * `REVA_WISSENSBASIS_ENABLED` env var: routes return 404 when off and
- * authenticated 200/data when on. Frontend probes /me/mix once per
- * session and treats 404 as "feature off".
+ * Reads the `wissensbasis_reva_available` flag from `/api/config/features`
+ * (the backend reports whether the Reva-only /me/mix route is mounted). This
+ * REPLACES the previous approach of PROBING /me/mix and treating a 404 as
+ * "off": that probe 404s by design in standalone Renfield and spammed the
+ * browser console with "Failed to load resource" + "API Error" lines. Reading
+ * a 200 config flag keeps the console clean and makes availability
+ * deterministic (no transient-true window that would briefly mount the
+ * Reva-only side panel and fire its own /trace 404).
  *
- * Use this to hide the nav entry + skip mounting the side panel when
- * the backend is gated, avoiding empty-placeholder UX in flag-off
- * environments. Returns:
- *   - undefined while the probe is in flight (don't flash nav entry)
- *   - true  when reachable (200) or auth-gated (401, meaning route is mounted)
- *   - false on 404 (route gated off)
+ * Returns:
+ *   - undefined while the feature flags are loading (don't flash the nav entry)
+ *   - true  when the Reva Wissensbasis routes are mounted
+ *   - false in standalone Renfield (routes absent)
  */
 export function useWissensbasisAvailable(): boolean | undefined {
-  // Reuses the role-mix query — it's the cheapest probe and operators
-  // already pay for it on first nav. CONFIG staleness keeps it cheap.
-  const q = useRoleMixQuery(null);
-  if (q.isLoading) return undefined;
-  // 404 = feature gated off → unavailable.
-  // Any other state (200 success, 401 unauth, 5xx server error) means
-  // the route is mounted on the backend, so the feature is "available"
-  // even if the user can't load data right now.
-  const status = (q.error as { response?: { status?: number } } | null)?.response?.status;
-  if (status === 404) return false;
-  return true;
+  const { data, isLoading } = useFeatureFlags();
+  if (isLoading || !data) return undefined;
+  return data.wissensbasis_reva_available;
 }

--- a/tests/backend/test_config_features.py
+++ b/tests/backend/test_config_features.py
@@ -54,3 +54,43 @@ async def test_features_reports_role_surfacing_flag(monkeypatch, enabled):
         app.dependency_overrides.clear()
     assert resp.status_code == 200
     assert resp.json()["role_surfacing_enabled"] is enabled
+
+
+async def test_features_wissensbasis_reva_false_in_standalone():
+    """Standalone Renfield does NOT mount the Reva-only /me/mix route, so the
+    flag is False — the frontend then hides the Reva panels WITHOUT probing an
+    endpoint that 404s (the console-noise fix)."""
+    from main import app
+    _auth_default(app)
+    try:
+        async with await _client(app) as c:
+            resp = await c.get("/api/config/features")
+    finally:
+        app.dependency_overrides.clear()
+    assert resp.status_code == 200
+    assert resp.json()["wissensbasis_reva_available"] is False
+
+
+async def test_features_wissensbasis_reva_true_when_route_mounted():
+    """When the Reva adapter has mounted /api/wissensbasis/me/mix, the route
+    introspection reports the surface as available."""
+    from main import app
+    _auth_default(app)
+
+    @app.get("/api/wissensbasis/me/mix")
+    async def _fake_mix():  # pragma: no cover - presence is what matters
+        return {}
+
+    try:
+        async with await _client(app) as c:
+            resp = await c.get("/api/config/features")
+        assert resp.status_code == 200
+        assert resp.json()["wissensbasis_reva_available"] is True
+    finally:
+        app.dependency_overrides.clear()
+        # Remove the temporary route so other tests see standalone topology.
+        app.router.routes = [
+            r for r in app.router.routes
+            if getattr(r, "path", None) != "/api/wissensbasis/me/mix"
+        ]
+        app.openapi_schema = None


### PR DESCRIPTION
## Summary

The standalone-Renfield browser console showed **6 red errors**: the frontend *probed* `/api/wissensbasis/me/mix` (404 by design — the Reva-only `/trace` + `/me/mix` routes aren't mounted in standalone) to detect availability, and the blunt axios interceptor logged each 404 as `API Error`. A transient non-404 read could also briefly mount the Reva side panel, firing its own `/trace` 404.

**Fix:** report availability through the existing **200 `/api/config/features`** seam (the same channel `schicht_a` / `wissen_workspace` use) instead of probing an endpoint that 404s.

- **Backend:** `FeatureFlags` gains `wissensbasis_reva_available`, computed by **route introspection** (is `/api/wissensbasis/me/mix` registered?). Standalone → `False`, Reva (adapter-injected route) → `True`. `get_features` takes `request: Request`.
- **Frontend:** `useWissensbasisAvailable` reads the flag from `useFeatureFlags` instead of `useRoleMixQuery(null)`; returns `undefined` while flags load, then the bool. `useRoleMixQuery`/`fetchMix` stay (the panel still loads real mix data when available). Deterministic → the ChatPage `=== true` gate never mounts the Reva panel in standalone → no `/trace` request either.

**Net:** zero `/me/mix` + `/trace` 404s in standalone; the availability check now piggybacks the already-fetched feature-flags query (cheaper than the old dedicated probe).

## Testing
`tests/backend/test_config_features.py` — new standalone-`False` + mounted-`True` cases, **6/6 green on `.159`** (incl. the 2 pre-existing flag tests, confirming the new `request` param didn't break them). Frontend `npm run build` (tsc) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QYAQhjWUKKKWk7FnChhZ5