### PR TITLE
fix(routing): smart-home overviews are an agent tool, not a router short-circuit (no hardcoded topics)

### DIFF
--- a/config/agent_roles.yaml
+++ b/config/agent_roles.yaml
@@ -25,50 +25,19 @@ roles:
     # can't target DLNA renderers and bypasses room routing).
     # internal.bluetooth_scan: "scan all bluetooth devices" fans a discovery scan
     # out to every satellite (gated by BT_SCAN_ENABLED).
-    internal_tools: [internal.resolve_room_player, internal.play_in_room, internal.media_control, internal.bluetooth_scan, internal.device_controls]
+    # internal.smart_home_overview: the four "read-only smart-home overview" views
+    # (status / sensors / active_devices / devices_per_room). These USED to be
+    # router short-circuits (dispatch_sub_intent hooks / sub_intents keyword sets)
+    # that answered BEFORE the LLM ran — which misfired whenever the fallible router
+    # mis-classified a message (e.g. "Wie spät ist es?" → sensors dumped room
+    # temperatures instead of the time). They are now this ONE agent-callable tool,
+    # so the LLM — seeing the real query + {time_context} — decides when to show an
+    # overview. Each view builds a typed Lane A artifact; inert when
+    # ARTIFACTS_TYPED_ENABLED is off. No sub_intents block on this role anymore.
+    internal_tools: [internal.resolve_room_player, internal.play_in_room, internal.media_control, internal.bluetooth_scan, internal.device_controls, internal.smart_home_overview]
     max_steps: 4
     prompt_key: agent_prompt_smart_home
     model: "qwen3:8b"
-    # Sub-intent dispatch: four "read-only smart-home overview" requests are fully
-    # handled by ha_glue `dispatch_sub_intent` hooks, each returning prose + ONE
-    # typed Lane A artifact. Actuation commands ("mach das Licht an") match NONE of
-    # these keyword sets (no actuation verbs appear) and fall through to the normal
-    # agent loop. Every handler is inert when ARTIFACTS_TYPED_ENABLED is off
-    # (declines → agent answers).
-    # NOTE: each description string doubles as comma-separated keywords for the
-    # router's _infer_sub_intent fast-path (the sub-intent with the MOST keyword
-    # hits wins), so the keyword sets are kept disjoint per sub-intent:
-    #   status         → table    (full device inventory, room×device×state)
-    #   sensors        → keyvalue  (per-room temperature/humidity readings)
-    #   active_devices → list      (controllable devices currently on)
-    #   devices_per_room → chart   (bar: device count per room)
-    # "was ist an / was ist gerade an" deliberately lives ONLY on active_devices
-    # (its true meaning) so it never collides with the status overview.
-    sub_intents:
-      status:
-        de: "Status, Übersicht, Überblick, Zustand, wie ist der status im haus, smart-home-status, geräteübersicht, alle geräte anzeigen, gesamtüberblick"
-        en: "status, overview, summary, state of the house, smart home status, device overview, show all devices, whole house status"
-        dispatch:
-          type: handler
-          handler: smarthome_status
-      sensors:
-        de: "Sensorwerte, Temperaturen, Temperatur in den räumen, wie warm ist es, wie warm ist es in den räumen, luftfeuchte, luftfeuchtigkeit, raumtemperatur, messwerte"
-        en: "sensor readings, temperatures, temperature in the rooms, how warm is it, how warm is it in the rooms, humidity, air humidity, room temperature, measured values"
-        dispatch:
-          type: handler
-          handler: smarthome_sensors
-      active_devices:
-        de: "Was ist gerade an, was ist an, was läuft gerade, welche geräte sind eingeschaltet, was ist eingeschaltet, welche geräte laufen, was ist aktiv"
-        en: "what is on, what is currently on, what is running, which devices are switched on, which devices are on, which devices are running, what is active"
-        dispatch:
-          type: handler
-          handler: smarthome_active_devices
-      devices_per_room:
-        de: "Geräte pro Raum, wie viele geräte pro raum, anzahl geräte je raum, geräteverteilung, wie viele geräte gibt es pro raum, geräte je raum"
-        en: "devices per room, how many devices per room, device count per room, device distribution, how many devices are there per room, devices by room"
-        dispatch:
-          type: handler
-          handler: smarthome_devices_per_room
 
   research:
     description:

--- a/src/backend/ha_glue/bootstrap.py
+++ b/src/backend/ha_glue/bootstrap.py
@@ -87,15 +87,6 @@ def register() -> None:
             ha_deliver_notification,
             ha_get_connected_device_summary,
         )
-        from ha_glue.services.smarthome_status import (
-            ha_dispatch_smarthome_status,
-        )
-        from ha_glue.services.smarthome_artifacts import (
-            ha_dispatch_active_devices,
-            ha_dispatch_devices_per_room,
-            ha_dispatch_sensors,
-        )
-
         register_hook("intent_fallback_resolve", ha_intent_fallback)
         register_hook("build_entity_context", ha_build_entity_context)
         register_hook("validate_classified_intent", ha_validate_classified_intent)
@@ -108,13 +99,12 @@ def register() -> None:
         register_hook("fetch_tts_audio_cache", ha_fetch_tts_audio_cache)
         register_hook("get_connected_device_summary", ha_get_connected_device_summary)
         register_hook("deliver_notification", ha_deliver_notification)
-        register_hook("dispatch_sub_intent", ha_dispatch_smarthome_status)
-        # Three more Lane A artifact producers (keyvalue / list / chart). Each is
-        # its own dispatch_sub_intent handler that declines unless it owns the
-        # classified smart_home sub-intent — so all four coexist on the one hook.
-        register_hook("dispatch_sub_intent", ha_dispatch_sensors)
-        register_hook("dispatch_sub_intent", ha_dispatch_active_devices)
-        register_hook("dispatch_sub_intent", ha_dispatch_devices_per_room)
+        # NOTE: the four "read-only smart-home overview" surfaces (status / sensors /
+        # active_devices / devices_per_room) used to register as dispatch_sub_intent
+        # hooks here — router short-circuits that answered BEFORE the LLM and misfired
+        # on router mis-classification (e.g. "Wie spät ist es?" → sensors). They are
+        # now the ONE agent-callable tool internal.smart_home_overview (registered via
+        # register_tools below), so the LLM decides when an overview is wanted.
         register_hook("register_tools", ha_glue_register_tools)
         register_hook("execute_tool", ha_glue_execute_tool)
         register_hook("startup", ha_glue_on_startup)
@@ -122,7 +112,7 @@ def register() -> None:
         register_hook("shutdown_finalize", ha_glue_on_shutdown_finalize)
         register_hook("register_routes", ha_glue_register_routes)
         logger.info(
-            "ha_glue.bootstrap: registered 21 handlers across 18 events"
+            "ha_glue.bootstrap: registered 18 handlers across 18 events"
         )
     except Exception:  # noqa: BLE001 — startup must never break on plugin error
         logger.opt(exception=True).warning(

--- a/src/backend/ha_glue/services/internal_tools.py
+++ b/src/backend/ha_glue/services/internal_tools.py
@@ -159,6 +159,24 @@ class InternalToolService:
             "description": "Show a PRESENCE-MAP widget — a read-only overview of which rooms currently have which people present. Use it for 'wer ist wo?', 'zeig mir wer zuhause ist', 'who is home', 'show me where everyone is'. The widget renders rooms with the present users; give a one-line final_answer alongside.",
             "parameters": {},
         },
+        "internal.smart_home_overview": {
+            "description": (
+                "Show a READ-ONLY smart-home OVERVIEW widget of the current state of the house. "
+                "Use it ONLY when the user asks to SEE an overview of the home — a device inventory, "
+                "the room temperatures/humidity, what is currently switched on, or how many devices are "
+                "in each room. Pick the matching `view`:\n"
+                "  • 'status'          — full device inventory table (room × device × state)\n"
+                "  • 'sensors'         — per-room temperature/humidity readings\n"
+                "  • 'active_devices'  — which controllable devices are currently on\n"
+                "  • 'devices_per_room'— bar chart of the device count per room\n"
+                "This is NOT for controlling/operating devices (that is internal.device_controls) and NOT "
+                "for a one-off command like 'mach das Licht an' (do that directly with HassTurnOn). "
+                "The widget IS the answer — after it renders, give a one-line final_answer alongside it."
+            ),
+            "parameters": {
+                "view": "Which overview to show: 'status' (default), 'sensors', 'active_devices', or 'devices_per_room'.",
+            },
+        },
         "internal.presence_history": {
             "description": "Query a user's PERSISTED presence history (survives restarts, unlike the live current-location tools). Use for 'where was X earlier/yesterday', 'when was X last in the kitchen', or 'who was in the living room this morning'. Accepts username or first/last name.",
             "parameters": {
@@ -190,6 +208,7 @@ class InternalToolService:
         "internal.bluetooth_scan": "_bluetooth_scan",
         "internal.device_controls": "_device_controls",
         "internal.presence_map": "_presence_map",
+        "internal.smart_home_overview": "_smart_home_overview",
         # NOT in TOOLS — not agent-advertised. Dispatched only by the chat
         # handler's `device_action` WS-frame route (after the HA_CONTROL gate),
         # never chosen by the agent.
@@ -621,6 +640,111 @@ class InternalToolService:
             "message": f"{total} Person(en) in {len(rooms)} Raum/Räumen.",
             "data": {"artifacts": [artifact]},
         }
+
+    # The four read-only smart-home OVERVIEW views this tool can render. Each is a
+    # (builder, prose, internal-hint-keys, empty-prose) recipe over the SAME cached
+    # HA entity map. These used to be four router short-circuits (dispatch_sub_intent
+    # hooks) that fired BEFORE the LLM — which mis-fired whenever the fallible router
+    # mis-classified a message (e.g. "Wie spät ist es?" → sensors). They are now ONE
+    # agent-callable tool, so the LLM — seeing the real query + {time_context} —
+    # decides when an overview is actually wanted. NO topic/keyword special-casing
+    # lives here: the tool just builds the requested view.
+    _OVERVIEW_VIEWS = frozenset({"status", "sensors", "active_devices", "devices_per_room"})
+
+    async def _smart_home_overview(self, params: dict) -> dict:
+        """Producer: a read-only smart-home OVERVIEW — one of four `view`s
+        (status/sensors/active_devices/devices_per_room) over the cached HA entity
+        map. Always returns a prose lede; ATTACHES a typed Lane-A artifact only when
+        ``artifacts_typed_enabled`` is on (flag off → prose-only, still a real
+        answer). Distinguishes an HA outage ("couldn't read the house") from a
+        genuinely-empty view ("nothing is on"). Language follows
+        ``settings.default_language``. The AGENT decides when to call it; this method
+        does NO query interpretation."""
+        from utils.config import settings
+
+        # Language follows the deployment default (the removed dispatch path used
+        # ollama.default_lang = settings.default_language); an explicit params["lang"]
+        # still overrides (used by tests). NOT hardcoded German — the builders and
+        # prose helpers are de/en, and hardcoding "de" made the en paths dead.
+        lang = str(params.get("lang") or settings.default_language or "de")
+
+        view = str(params.get("view") or "status").strip().lower()
+        if view not in self._OVERVIEW_VIEWS:
+            view = "status"  # unknown view → the full status overview
+
+        from ha_glue.services.smarthome_artifacts import (
+            _active_prose,
+            _devperroom_prose,
+            _safe_entity_map,
+            _sensors_prose,
+            build_active_list,
+            build_devices_per_room_chart,
+            build_sensor_keyvalue,
+        )
+        from ha_glue.services.smarthome_status import (
+            _prose as _status_prose,
+            build_status_table,
+        )
+
+        # `_safe_entity_map` never raises — it returns [] on any HA failure. Treat
+        # an empty map as "couldn't read the house" so an HA OUTAGE never
+        # masquerades as "nothing is on" / "no sensors". A builder returning None
+        # AFTER a non-empty map is the genuine-empty case (handled per-view below).
+        entity_map = await _safe_entity_map(f"overview:{view}")
+        if not entity_map:
+            return {
+                "success": True, "action_taken": False,
+                "message": (
+                    "Ich konnte den aktuellen Hausstatus gerade nicht abrufen."
+                    if lang.startswith("de") else
+                    "I couldn't read the current house state right now."
+                ),
+            }
+
+        # Each view: build the artifact, and prepare BOTH the populated lede and
+        # the genuine-empty lede (used when the builder returns None despite a
+        # readable house).
+        if view == "status":
+            artifact = build_status_table(entity_map, lang=lang)
+            empty_msg = _status_prose(0, 0, False, lang)
+            if artifact is not None:
+                truncated = bool(artifact.pop("_truncated", False))
+                total = int(artifact.pop("_total", len(artifact["data"]["rows"])))
+                message = _status_prose(len(artifact["data"]["rows"]), total, truncated, lang)
+        elif view == "sensors":
+            artifact = build_sensor_keyvalue(entity_map, lang=lang)
+            empty_msg = _sensors_prose(0, False, lang)
+            if artifact is not None:
+                truncated = bool(artifact.pop("_truncated", False))
+                count = int(artifact.pop("_count", len(artifact["data"]["pairs"])))
+                message = _sensors_prose(count, truncated, lang)
+        elif view == "active_devices":
+            artifact = build_active_list(entity_map, lang=lang)
+            empty_msg = _active_prose(0, False, lang)  # house read OK, nothing on
+            if artifact is not None:
+                truncated = bool(artifact.pop("_truncated", False))
+                count = int(artifact.pop("_count", len(artifact["data"]["items"])))
+                message = _active_prose(count, truncated, lang)
+        else:  # devices_per_room
+            artifact = build_devices_per_room_chart(entity_map, lang=lang)
+            empty_msg = _devperroom_prose([], [], False, lang)
+            if artifact is not None:
+                room_labels = artifact.pop("_room_labels", [])
+                truncated = bool(artifact.pop("_truncated", False))
+                artifact.pop("_count", None)
+                counts = [int(p["y"]) for p in artifact["data"]["series"][0]["points"]]
+                message = _devperroom_prose(room_labels, counts, truncated, lang)
+
+        if artifact is None:
+            return {"success": True, "action_taken": False, "message": empty_msg}
+
+        result = {"success": True, "action_taken": False, "message": message}
+        # Attach the typed artifact ONLY when the renderer is enabled; the prose
+        # lede is always returned, so a flag-off deployment still gets a real
+        # answer (better than the empty result the first cut returned).
+        if settings.artifacts_typed_enabled:
+            result["data"] = {"artifacts": [artifact]}
+        return result
 
     # Bound on concurrent per-room announces during a broadcast. Each
     # _announce_core opens its OWN AsyncSession (an AsyncSession is not

--- a/src/backend/ha_glue/services/smarthome_artifacts.py
+++ b/src/backend/ha_glue/services/smarthome_artifacts.py
@@ -1,52 +1,42 @@
 """
-Three more Lane A artifact producers — lighting up the `keyvalue`, `list` and
+Three more Lane A artifact builders — lighting up the `keyvalue`, `list` and
 `chart` renderers with REAL Home Assistant data.
 
-These mirror the FIRST producer (``smarthome_status.py`` → `table`) exactly:
+These mirror the FIRST builder (``smarthome_status.py`` → `table`):
 
-  * each is a ``dispatch_sub_intent`` hook for a distinct ``smart_home/<x>``
-    sub-intent and returns ``{"handled": True, "answer": <prose>, "card": None,
-    "artifacts": [<typed dict>]}``;
+  * ``build_sensor_keyvalue`` / ``build_active_list`` /
+    ``build_devices_per_room_chart`` each turn the HA entity map into ONE typed
+    artifact dict (with internal ``_truncated``/``_count``/``_room_labels`` hint
+    keys the caller pops before emit);
+  * they are called by the agent-callable ``internal.smart_home_overview`` tool
+    (views ``sensors`` / ``active_devices`` / ``devices_per_room``) in
+    ``ha_glue/services/internal_tools.py`` — the AGENT decides when to show an
+    overview, so these are now pure builders with no router/dispatch coupling.
+    (They used to own ``dispatch_sub_intent`` hooks that short-circuited the agent
+    loop and misfired on router mis-classification; those were removed.)
   * the single data source is ``HomeAssistantClient.get_entity_map()`` — the SAME
-    cached (60s TTL) entity view ``smarthome_status`` uses. No new HA client, no
-    new MCP call, no DB session (so none of the asyncpg-under-pytest segfault
-    risk);
-  * each is INERT when ``settings.artifacts_typed_enabled`` is off — it returns
-    ``None`` (declines, the normal agent answers) BEFORE touching HA, so the
-    feature ships dark with zero extra HA load;
-  * each degrades gracefully (prose only, no artifact) when HA is unavailable or
-    the relevant data is empty — never a crash, never an empty artifact;
-  * each produces localized (de/en) prose, like ``smarthome_status``.
+    cached (60s TTL) entity view ``smarthome_status`` uses, fetched via
+    ``_safe_entity_map`` below. No new HA client, no new MCP call, no DB session;
+  * each returns ``None`` when there is nothing to show, so the tool degrades
+    gracefully to prose-only — never a crash, never an empty artifact;
+  * each produces localized (de/en) prose via the ``_*_prose`` helpers.
 
-The three producers:
+The three builders:
 
-  1. ``smart_home/sensors``        → `keyvalue` (room → temperature · humidity)
-  2. ``smart_home/active_devices`` → `list`     ("<Raum>: <Gerät>" currently on)
-  3. ``smart_home/devices_per_room`` → `chart`  (bar: device count per room)
+  1. sensors          → `keyvalue` (room → temperature · humidity)
+  2. active_devices   → `list`     ("<Raum>: <Gerät>" currently on)
+  3. devices_per_room → `chart`    (bar: device count per room)
 
-CHART SOURCE CHOICE: device-count-per-room (option (a) in the brief). It is real,
-numeric, and derivable from the cached ``get_entity_map()`` alone — no history and
-no presence-analytics DB plumbing (option (b) would need an ``AsyncSessionLocal``
-session in the producer path, which the test-isolation lesson warns against and
-which adds latency to a chat turn). A count-per-room bar exercises the hand-rolled
-SVG bar chart + its CVD-safe palette with honest data.
-
-Why these don't collide with actuation or with ``smart_home/status``: the router's
-``_infer_sub_intent`` scores each sub-intent by how many of its comma-separated
-keywords appear in the message and picks the highest. Each producer's keyword set
-(in ``agent_roles.yaml``) is built from terms unique to it ("sensorwerte",
-"temperaturen" / "eingeschaltet", "gerade an" / "geräte pro raum", "wie viele
-geräte") and contains NO actuation verb ("mach … an", "schalte", "dimme"), so an
-actuation command scores zero on all of them and falls through to the agent loop.
+CHART SOURCE CHOICE: device-count-per-room. It is real, numeric, and derivable from
+the cached ``get_entity_map()`` alone — no history and no presence-analytics DB
+plumbing. A count-per-room bar exercises the hand-rolled SVG bar chart + its
+CVD-safe palette with honest data.
 """
 from __future__ import annotations
 
 import uuid
-from typing import Any
 
 from loguru import logger
-
-from utils.config import settings
 
 # --- caps (kept well under the artifact_service backend caps) ----------------
 # keyvalue: MAX_KEYVALUE_PAIRS=100 — a household has far fewer rooms.
@@ -223,36 +213,6 @@ def _sensors_prose(count: int, truncated: bool, lang: str) -> str:
     return base
 
 
-async def ha_dispatch_sensors(
-    *,
-    role: str = "",
-    sub_intent: str = "",
-    handler_name: str = "",
-    lang: str = "de",
-    **_: Any,
-) -> dict | None:
-    """`dispatch_sub_intent` handler for ``smart_home/sensors`` → `keyvalue`."""
-    if role != "smart_home" or sub_intent != "sensors":
-        return None
-    if handler_name and handler_name != "smarthome_sensors":
-        return None
-    if not settings.artifacts_typed_enabled:
-        return None
-
-    entity_map = await _safe_entity_map("sensors")
-    artifact = build_sensor_keyvalue(entity_map, lang=lang)
-    if artifact is None:
-        return {"handled": True, "answer": _sensors_prose(0, False, lang), "card": None}
-    truncated = bool(artifact.pop("_truncated", False))
-    count = int(artifact.pop("_count", len(artifact["data"]["pairs"])))
-    return {
-        "handled": True,
-        "answer": _sensors_prose(count, truncated, lang),
-        "card": None,
-        "artifacts": [artifact],
-    }
-
-
 # ===========================================================================
 # Producer 2: active_devices → `list` ("<Raum>: <Gerät>" currently on)
 # ===========================================================================
@@ -321,37 +281,6 @@ def _active_prose(count: int, truncated: bool, lang: str) -> str:
     if truncated:
         base += f" (Truncated to the first {count}.)"
     return base
-
-
-async def ha_dispatch_active_devices(
-    *,
-    role: str = "",
-    sub_intent: str = "",
-    handler_name: str = "",
-    lang: str = "de",
-    **_: Any,
-) -> dict | None:
-    """`dispatch_sub_intent` handler for ``smart_home/active_devices`` → `list`."""
-    if role != "smart_home" or sub_intent != "active_devices":
-        return None
-    if handler_name and handler_name != "smarthome_active_devices":
-        return None
-    if not settings.artifacts_typed_enabled:
-        return None
-
-    entity_map = await _safe_entity_map("active_devices")
-    artifact = build_active_list(entity_map, lang=lang)
-    if artifact is None:
-        # Either HA empty or nothing on — both answer "nothing is on" in prose.
-        return {"handled": True, "answer": _active_prose(0, False, lang), "card": None}
-    truncated = bool(artifact.pop("_truncated", False))
-    count = int(artifact.pop("_count", len(artifact["data"]["items"])))
-    return {
-        "handled": True,
-        "answer": _active_prose(count, truncated, lang),
-        "card": None,
-        "artifacts": [artifact],
-    }
 
 
 # ===========================================================================
@@ -425,38 +354,6 @@ def _devperroom_prose(room_labels: list[str], counts_for_rooms: list[int],
     if truncated:
         base += f" (Truncated to the first {len(room_labels)} rooms.)"
     return base
-
-
-async def ha_dispatch_devices_per_room(
-    *,
-    role: str = "",
-    sub_intent: str = "",
-    handler_name: str = "",
-    lang: str = "de",
-    **_: Any,
-) -> dict | None:
-    """`dispatch_sub_intent` handler for ``smart_home/devices_per_room`` → `chart`."""
-    if role != "smart_home" or sub_intent != "devices_per_room":
-        return None
-    if handler_name and handler_name != "smarthome_devices_per_room":
-        return None
-    if not settings.artifacts_typed_enabled:
-        return None
-
-    entity_map = await _safe_entity_map("devices_per_room")
-    artifact = build_devices_per_room_chart(entity_map, lang=lang)
-    if artifact is None:
-        return {"handled": True, "answer": _devperroom_prose([], [], False, lang), "card": None}
-    room_labels = artifact.pop("_room_labels", [])
-    truncated = bool(artifact.pop("_truncated", False))
-    artifact.pop("_count", None)
-    counts = [int(p["y"]) for p in artifact["data"]["series"][0]["points"]]
-    return {
-        "handled": True,
-        "answer": _devperroom_prose(room_labels, counts, truncated, lang),
-        "card": None,
-        "artifacts": [artifact],
-    }
 
 
 # ===========================================================================

--- a/src/backend/ha_glue/services/smarthome_status.py
+++ b/src/backend/ha_glue/services/smarthome_status.py
@@ -1,41 +1,30 @@
 """
-Smart-home status → typed `table` artifact (the first Lane A artifact producer).
+Smart-home status → typed `table` artifact builder (a Lane A artifact producer).
 
-This is the FIRST thing in Renfield that emits a chat artifact (PR #801 added the
-plumbing — `services/artifact_service.py` + the three `_emit_turn_artifacts` seams
-in `chat_handler.py` — but nothing produced one). A natural German status/overview
-request ("Wie ist der Status im Haus?", "Zeig mir den Smart-Home-Status",
-"Übersicht der Geräte") now returns a prose answer AND a typed `table` artifact
-that renders inline + persists + rehydrates on history reload.
-
-Seam: the **`dispatch_sub_intent` hook** (`smart_home/status`, handler
-``smarthome_status``). The chat handler's sub-intent path accumulates the returned
-``artifacts`` into ``turn_artifacts`` BEFORE the assistant message is persisted, so
-this rehydrates on reload (unlike the live-only ``build_assistant_card`` hook). The
-orchestration card path was rejected: it only fires for multi-domain queries when
-``agent_orchestrator_enabled`` is set, and a status request is single-domain.
+``build_status_table`` turns the Home Assistant entity map into ONE typed `table`
+artifact (room × device × state). It is called by the agent-callable
+``internal.smart_home_overview`` tool (view=``status``) in
+``ha_glue/services/internal_tools.py`` — the AGENT decides when to show the
+overview, so this module is now a pure builder with no router/dispatch coupling.
+(It used to own a ``dispatch_sub_intent`` hook that short-circuited the agent loop;
+that misfired on router mis-classification and was removed — the LLM decides now.)
 
 Data source: ``HomeAssistantClient.get_entity_map()`` — the SAME cached (60s TTL)
-entity view the intent recognizer uses. No new HA client, no new MCP call. Each
-entry already carries ``entity_id``, ``friendly_name``, ``domain``, ``room`` and
-``state``.
+entity view the intent recognizer uses (the tool fetches it via ``_safe_entity_map``
+in ``smarthome_artifacts``). Each entry already carries ``entity_id``,
+``friendly_name``, ``domain``, ``room`` and ``state``.
 
 Shape: a `table` (not `keyvalue`) because the data is three-dimensional
 (room × device × state); a flat key/value list would either lose the room grouping
 or collide keys for same-named devices in different rooms.
 
-The producer is INERT when ``settings.artifacts_typed_enabled`` is off — it returns
-``handled=False`` (declines the turn so the normal agent answers) WITHOUT doing the
-HA fetch, so the feature ships dark with zero extra HA load.
+``build_status_table`` returns ``None`` when there is nothing to show (HA
+unavailable / empty map) so the tool answers prose-only — never a crash, never an
+empty table.
 """
 from __future__ import annotations
 
 import uuid
-from typing import Any
-
-from loguru import logger
-
-from utils.config import settings
 
 # How many device rows we put in the artifact before truncating. Well under the
 # backend table cap (MAX_TABLE_ROWS = 200); a household with more entities than
@@ -169,57 +158,3 @@ def _prose(rows: int, total: int, truncated: bool, lang: str) -> str:
     if truncated:
         base += f" (There are {total} devices in total — the table shows the first {rows}.)"
     return base
-
-
-async def ha_dispatch_smarthome_status(
-    *,
-    role: str = "",
-    sub_intent: str = "",
-    handler_name: str = "",
-    message: str = "",
-    lang: str = "de",
-    **_: Any,
-) -> dict | None:
-    """`dispatch_sub_intent` handler — owns the smart-home status/overview turn.
-
-    Declines (returns ``None``) unless the router classified this as
-    ``smart_home/status`` with our handler name AND the typed-artifacts flag is on.
-    Declining lets the normal smart_home agent answer (so an actuation command like
-    "mach das Licht an" — which never classifies as the ``status`` sub-intent —
-    still actuates). On HA-unavailable it returns prose only (no artifact),
-    never a crash.
-    """
-    # Only our sub-intent. Be lenient on handler_name (config may omit it) but
-    # strict on the role + sub_intent pair.
-    if role != "smart_home" or sub_intent != "status":
-        return None
-    if handler_name and handler_name != "smarthome_status":
-        return None
-
-    # Dark when the flag is off — decline WITHOUT touching HA so there is zero
-    # extra load and the agent answers normally.
-    if not settings.artifacts_typed_enabled:
-        return None
-
-    try:
-        from ha_glue.integrations.homeassistant import HomeAssistantClient
-        entity_map = await HomeAssistantClient().get_entity_map()
-    except Exception as e:  # noqa: BLE001 — HA down must degrade to prose, not crash
-        logger.warning(f"smarthome_status: HA entity map fetch failed: {e}")
-        entity_map = []
-
-    artifact = build_status_table(entity_map, lang=lang)
-    if artifact is None:
-        # HA unavailable / no devices → prose-only, no artifact.
-        return {"handled": True, "answer": _prose(0, 0, False, lang), "card": None}
-
-    truncated = bool(artifact.pop("_truncated", False))
-    total = int(artifact.pop("_total", len(artifact["data"]["rows"])))
-    rows = len(artifact["data"]["rows"])
-
-    return {
-        "handled": True,
-        "answer": _prose(rows, total, truncated, lang),
-        "card": None,
-        "artifacts": [artifact],
-    }

--- a/src/backend/prompts/agent.yaml
+++ b/src/backend/prompts/agent.yaml
@@ -118,7 +118,8 @@ de:
     - "Licht aus" (mit Raum-Kontext) → HassTurnOff mit {{"area": "<aktueller_raum>", "domain": ["light"]}}
     - "Licht aus in der Kueche" → HassTurnOff mit {{"area": "Kueche", "domain": ["light"]}}
     - "Deckenlicht Kueche aus" → HassTurnOff mit {{"name": "Deckenlicht Kueche"}}
-    - STEUERUNGS-WIDGET: Will der Nutzer Geraete per Bedien-Panel SELBST schalten ("steuere die Lichter", "zeig mir die Lichtsteuerung", "gib mir die Schalter fuers Wohnzimmer", "Steuerung anzeigen"), rufe internal.device_controls (optional room="<Raum>") auf — das zeigt klickbare Schalter. Das ist NICHT fuer einen einmaligen Befehl ("mach das Licht an" → HassTurnOn) und NICHT fuer eine Status-Uebersicht (das ist die status-Sub-Intent).
+    - STEUERUNGS-WIDGET: Will der Nutzer Geraete per Bedien-Panel SELBST schalten ("steuere die Lichter", "zeig mir die Lichtsteuerung", "gib mir die Schalter fuers Wohnzimmer", "Steuerung anzeigen"), rufe internal.device_controls (optional room="<Raum>") auf — das zeigt klickbare Schalter. Das ist NICHT fuer einen einmaligen Befehl ("mach das Licht an" → HassTurnOn) und NICHT fuer eine Status-Uebersicht.
+    - UEBERSICHTS-WIDGET: Will der Nutzer eine reine ANSICHT/Uebersicht des Hauses, rufe internal.smart_home_overview mit dem passenden view auf — view="status" (Geraete-Inventar), "sensors" (Raumtemperaturen/Luftfeuchte), "active_devices" (was ist gerade an) oder "devices_per_room" (Anzahl Geraete pro Raum). Nur fuer eine reine Ansicht, NICHT zum Schalten von Geraeten (dafuer internal.device_controls oder HassTurnOn/HassTurnOff).
     - Wenn kein Raum im Befehl UND kein Raum-Kontext → nutze nur "domain" ohne "area"
     - Fuer Helligkeiten/Farben: Nutze HassLightSet mit "area"+"domain" oder "name"
     - Fuer Sensorwerte: Nutze GetLiveContext mit "name" und optional "area"
@@ -712,7 +713,8 @@ en:
     - "Turn off lights" (with room context) → HassTurnOff with {{"area": "<current_room>", "domain": ["light"]}}
     - "Turn off lights in kitchen" → HassTurnOff with {{"area": "Kitchen", "domain": ["light"]}}
     - "Kitchen ceiling light off" → HassTurnOff with {{"name": "Kitchen Ceiling Light"}}
-    - CONTROL WIDGET: when the user wants to operate devices THEMSELVES via a panel ("control the lights", "show me the light controls", "give me the switches for the living room", "show the controls"), call internal.device_controls (optional room="<Room>") — it renders clickable switches. NOT for a one-off command ("turn the light on" → HassTurnOn) and NOT for a status overview (that is the status sub-intent).
+    - CONTROL WIDGET: when the user wants to operate devices THEMSELVES via a panel ("control the lights", "show me the light controls", "give me the switches for the living room", "show the controls"), call internal.device_controls (optional room="<Room>") — it renders clickable switches. NOT for a one-off command ("turn the light on" → HassTurnOn) and NOT for a status overview.
+    - OVERVIEW WIDGET: when the user wants a read-only VIEW/overview of the house, call internal.smart_home_overview with the matching view — view="status" (device inventory), "sensors" (room temperatures/humidity), "active_devices" (what is currently on) or "devices_per_room" (device count per room). Only for a read-only view, NOT for operating devices (use internal.device_controls or HassTurnOn/HassTurnOff for that).
     - If no room in command AND no room context → use only "domain" without "area"
     - For brightness/colors: Use HassLightSet with "area"+"domain" or "name"
     - For sensor values: Use GetLiveContext with "name" and optionally "area"

--- a/tests/backend/test_device_widget_tools.py
+++ b/tests/backend/test_device_widget_tools.py
@@ -294,3 +294,181 @@ async def test_device_controls_no_controllable_returns_message(monkeypatch):
     assert out["success"] is True
     assert "data" not in out  # no artifact
     assert "keine schaltbaren" in out["message"].lower()
+
+
+# --- _smart_home_overview: the agent-callable read-only overview tool ---------
+# These four views used to be router short-circuits (dispatch_sub_intent hooks)
+# that answered BEFORE the LLM and misfired on router mis-classification (e.g.
+# "Wie spät ist es?" → sensors). They are now ONE agent-callable tool: the AGENT
+# decides when to call it, and the tool has NO notion of the user's query text —
+# it only knows the requested `view`. The tests pin exactly that.
+
+_OVERVIEW_ENTITY_MAP = [
+    {"entity_id": "light.wohnzimmer", "friendly_name": "Wohnzimmer Decke",
+     "domain": "light", "room": "wohnzimmer", "state": "on"},
+    {"entity_id": "switch.kueche_kaffee", "friendly_name": "Kaffeemaschine",
+     "domain": "switch", "room": "küche", "state": "on"},
+    {"entity_id": "media_player.bad_radio", "friendly_name": "Bad Radio",
+     "domain": "media_player", "room": "bad", "state": "idle"},
+    {"entity_id": "climate.bad", "friendly_name": "Bad Thermostat",
+     "domain": "climate", "room": "bad", "state": "heat"},
+    {"entity_id": "sensor.wohnzimmer_temp", "friendly_name": "Wohnzimmer Temperatur",
+     "domain": "sensor", "room": "wohnzimmer", "state": "21.4"},
+    {"entity_id": "sensor.wohnzimmer_hum", "friendly_name": "Wohnzimmer Luftfeuchte",
+     "domain": "sensor", "room": "wohnzimmer", "state": "45"},
+]
+
+
+def _ha_entity_map_mock(entity_map, *, raises=False):
+    ha = AsyncMock()
+    if raises:
+        ha.get_entity_map = AsyncMock(side_effect=RuntimeError("HA unreachable"))
+    else:
+        ha.get_entity_map = AsyncMock(return_value=entity_map)
+    return ha
+
+
+def _enable_typed(monkeypatch, value=True):
+    from utils.config import settings
+    monkeypatch.setattr(settings, "artifacts_typed_enabled", value, raising=False)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("view,kind", [
+    ("status", "table"),
+    ("sensors", "keyvalue"),
+    ("active_devices", "list"),
+    ("devices_per_room", "chart"),
+])
+async def test_smart_home_overview_view_returns_expected_kind(monkeypatch, view, kind):
+    _enable_typed(monkeypatch, True)
+    svc = InternalToolService()
+    with patch("ha_glue.integrations.homeassistant.HomeAssistantClient",
+               return_value=_ha_entity_map_mock(_OVERVIEW_ENTITY_MAP)):
+        out = await svc._smart_home_overview({"view": view})
+    assert out["success"] is True
+    assert out["action_taken"] is False
+    arts = out["data"]["artifacts"]
+    assert len(arts) == 1 and arts[0]["kind"] == kind
+    # Internal builder-hint keys must be stripped before returning.
+    for hint in ("_truncated", "_total", "_count", "_room_labels"):
+        assert hint not in arts[0]
+    assert isinstance(out["message"], str) and out["message"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_smart_home_overview_defaults_to_status(monkeypatch):
+    _enable_typed(monkeypatch, True)
+    svc = InternalToolService()
+    with patch("ha_glue.integrations.homeassistant.HomeAssistantClient",
+               return_value=_ha_entity_map_mock(_OVERVIEW_ENTITY_MAP)):
+        # no view given → status
+        out_default = await svc._smart_home_overview({})
+        # unknown view → falls back to status (never an error)
+        out_unknown = await svc._smart_home_overview({"view": "does_not_exist"})
+    assert out_default["data"]["artifacts"][0]["kind"] == "table"
+    assert out_unknown["data"]["artifacts"][0]["kind"] == "table"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_smart_home_overview_english_lede(monkeypatch):
+    _enable_typed(monkeypatch, True)
+    svc = InternalToolService()
+    with patch("ha_glue.integrations.homeassistant.HomeAssistantClient",
+               return_value=_ha_entity_map_mock(_OVERVIEW_ENTITY_MAP)):
+        out = await svc._smart_home_overview({"view": "status", "lang": "en"})
+    # English lede + English title from the builder.
+    assert out["data"]["artifacts"][0]["title"] == "Smart home status"
+    assert "devices in the house" in out["message"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_smart_home_overview_ha_unavailable_is_prose_only(monkeypatch):
+    _enable_typed(monkeypatch, True)
+    svc = InternalToolService()
+    with patch("ha_glue.integrations.homeassistant.HomeAssistantClient",
+               return_value=_ha_entity_map_mock([], raises=True)):
+        out = await svc._smart_home_overview({"view": "sensors"})
+    assert out["success"] is True
+    assert "data" not in out          # graceful: no artifact, never a crash
+    assert isinstance(out["message"], str) and out["message"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_smart_home_overview_empty_map_is_prose_only(monkeypatch):
+    _enable_typed(monkeypatch, True)
+    svc = InternalToolService()
+    with patch("ha_glue.integrations.homeassistant.HomeAssistantClient",
+               return_value=_ha_entity_map_mock([])):
+        out = await svc._smart_home_overview({"view": "devices_per_room"})
+    assert out["success"] is True
+    assert "data" not in out
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_smart_home_overview_prose_only_when_flag_off(monkeypatch):
+    """Flag off: still answer in PROSE (the lede), just without the typed artifact
+    — better than the empty result the first cut returned, which wasted the
+    agent's tool step (review finding 3)."""
+    _enable_typed(monkeypatch, False)
+    svc = InternalToolService()
+    with patch("ha_glue.integrations.homeassistant.HomeAssistantClient",
+               return_value=_ha_entity_map_mock(_OVERVIEW_ENTITY_MAP)):
+        out = await svc._smart_home_overview({"view": "status"})
+    assert out["success"] is True
+    assert isinstance(out["message"], str) and out["message"]  # real prose answer
+    assert "data" not in out  # but NO typed artifact when the renderer is off
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_smart_home_overview_lang_follows_settings(monkeypatch):
+    """Language follows settings.default_language, not a hardcoded 'de' (review
+    finding 1) — the LLM never passes `lang`, so an en deployment must render en."""
+    from utils.config import settings
+    _enable_typed(monkeypatch, True)
+    monkeypatch.setattr(settings, "default_language", "en", raising=False)
+    svc = InternalToolService()
+    with patch("ha_glue.integrations.homeassistant.HomeAssistantClient",
+               return_value=_ha_entity_map_mock(_OVERVIEW_ENTITY_MAP)):
+        out = await svc._smart_home_overview({"view": "status"})  # no lang param
+    assert out["data"]["artifacts"][0]["title"] == "Smart home status"
+    assert "devices in the house" in out["message"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_smart_home_overview_ha_outage_not_reported_as_nothing_on(monkeypatch):
+    """On an HA OUTAGE, active_devices must say 'couldn't read the house', NOT
+    'nothing is on' (review finding 2). Proof: the outage lede is identical across
+    views (the uniform couldn't-read message), not each view's genuine-empty prose."""
+    _enable_typed(monkeypatch, True)
+    svc = InternalToolService()
+    with patch("ha_glue.integrations.homeassistant.HomeAssistantClient",
+               return_value=_ha_entity_map_mock([], raises=True)):
+        active = await svc._smart_home_overview({"view": "active_devices"})
+        sensors = await svc._smart_home_overview({"view": "sensors"})
+    assert "data" not in active and "data" not in sensors
+    # Same couldn't-read lede regardless of view → no false "nothing is on".
+    assert active["message"] == sensors["message"]
+
+
+@pytest.mark.unit
+def test_smart_home_overview_tool_has_no_time_special_casing():
+    """The key behavioral proof of the refactor: the tool is a pure view builder
+    with NO time/clock notion. Its schema must not mention time/clock (so the LLM
+    never treats it as a time answer), and it exposes exactly the four views."""
+    defn = InternalToolService.TOOLS["internal.smart_home_overview"]
+    blob = (defn["description"] + " " + " ".join(defn["parameters"].values())).lower()
+    for term in ("uhrzeit", "clock", "wie spät", "time of day"):
+        assert term not in blob
+    # Exactly the four read-only overview views, nothing time-ish.
+    assert InternalToolService._OVERVIEW_VIEWS == frozenset(
+        {"status", "sensors", "active_devices", "devices_per_room"}
+    )

--- a/tests/backend/test_smarthome_artifacts.py
+++ b/tests/backend/test_smarthome_artifacts.py
@@ -1,23 +1,17 @@
 """
-Tests for the three additional Lane A artifact producers (keyvalue / list / chart)
+Tests for the three additional Lane A artifact BUILDERS (keyvalue / list / chart)
 in ``ha_glue.services.smarthome_artifacts``.
 
-Each producer mirrors the FIRST one (``smarthome_status`` → table). For every one
-we cover, per the task brief:
-  * builds a well-formed artifact of the right KIND for its trigger (mocked data),
-    and the artifact passes ``validate_artifacts`` (within the backend caps);
-  * returns NO artifact (graceful, prose-only) on empty / unavailable data;
-  * the dispatch handler is INERT (declines, returns None) when the flag is off,
-    WITHOUT touching HA (so a broken flag gate would crash — no HA patched);
-  * declines for any role / sub_intent / handler that isn't its own.
+These builders back the agent-callable ``internal.smart_home_overview`` tool (views
+``sensors`` / ``active_devices`` / ``devices_per_room``). The tool-level tests
+(dispatch, HA-unavailable, flag-off, view routing) live in
+``test_device_widget_tools.py``; here we cover each builder in isolation:
 
-Plus a shared ``_infer_sub_intent`` block that proves the new sub-intents fire on
-their German triggers and do NOT fire on actuation commands or on each other's
-triggers.
-
-The HA fetch is mocked everywhere (the producers call ``_safe_entity_map`` which
-lazily imports ``HomeAssistantClient`` — we patch that symbol), so no real asyncpg
-or HA connect happens (test-isolation lesson).
+  * builds a well-formed artifact of the right KIND for its data (mocked entity
+    map), and the artifact passes ``validate_artifacts`` (within the backend caps);
+  * returns ``None`` (graceful — the tool answers prose-only) on empty / no-match
+    data;
+  * truncation over the per-kind cap is honest (flagged, never silent).
 """
 import pytest
 
@@ -28,9 +22,6 @@ from ha_glue.services.smarthome_artifacts import (
     build_active_list,
     build_devices_per_room_chart,
     build_sensor_keyvalue,
-    ha_dispatch_active_devices,
-    ha_dispatch_devices_per_room,
-    ha_dispatch_sensors,
 )
 from services.artifact_service import (
     MAX_CHART_POINTS,
@@ -66,33 +57,8 @@ _ENTITY_MAP = [
 ]
 
 
-class _FakeHAClient:
-    def __init__(self, entity_map):
-        self._entity_map = entity_map
-
-    async def get_entity_map(self):
-        return self._entity_map
-
-
-def _patch_ha(monkeypatch, entity_map=None, *, raises=False):
-    """Patch the HomeAssistantClient the producers import lazily."""
-    import ha_glue.integrations.homeassistant as ha_mod
-
-    def _factory():
-        if raises:
-            raise RuntimeError("HA unreachable")
-        return _FakeHAClient(entity_map if entity_map is not None else [])
-
-    monkeypatch.setattr(ha_mod, "HomeAssistantClient", _factory)
-
-
-def _enable_flag(monkeypatch, value=True):
-    from utils.config import settings
-    monkeypatch.setattr(settings, "artifacts_typed_enabled", value, raising=False)
-
-
 # ===========================================================================
-# Producer 1: sensors → keyvalue
+# Builder 1: sensors → keyvalue
 # ===========================================================================
 
 @pytest.mark.unit
@@ -161,75 +127,8 @@ def test_build_sensor_keyvalue_truncates_over_cap():
     assert len(art["data"]["pairs"]) <= MAX_KEYVALUE_PAIRS
 
 
-@pytest.mark.unit
-async def test_dispatch_sensors_returns_artifact(monkeypatch):
-    _enable_flag(monkeypatch, True)
-    _patch_ha(monkeypatch, _ENTITY_MAP)
-    res = await ha_dispatch_sensors(
-        role="smart_home", sub_intent="sensors",
-        handler_name="smarthome_sensors", lang="de",
-    )
-    assert res["handled"] is True
-    assert res["card"] is None
-    assert isinstance(res["answer"], str) and res["answer"]
-    arts = res["artifacts"]
-    assert len(arts) == 1 and arts[0]["kind"] == "keyvalue"
-    assert "_truncated" not in arts[0] and "_count" not in arts[0]
-    assert len(validate_artifacts(arts)) == 1
-
-
-@pytest.mark.unit
-async def test_dispatch_sensors_ha_unavailable_graceful(monkeypatch):
-    _enable_flag(monkeypatch, True)
-    _patch_ha(monkeypatch, raises=True)
-    res = await ha_dispatch_sensors(
-        role="smart_home", sub_intent="sensors",
-        handler_name="smarthome_sensors", lang="de",
-    )
-    assert res["handled"] is True
-    assert "artifacts" not in res
-    assert res["answer"]
-
-
-@pytest.mark.unit
-async def test_dispatch_sensors_empty_graceful(monkeypatch):
-    _enable_flag(monkeypatch, True)
-    _patch_ha(monkeypatch, [])
-    res = await ha_dispatch_sensors(
-        role="smart_home", sub_intent="sensors",
-        handler_name="smarthome_sensors", lang="de",
-    )
-    assert res["handled"] is True
-    assert "artifacts" not in res
-
-
-@pytest.mark.unit
-async def test_dispatch_sensors_inert_when_flag_off(monkeypatch):
-    _enable_flag(monkeypatch, False)
-    # No HA patched — if the flag gate were broken, this would raise.
-    res = await ha_dispatch_sensors(
-        role="smart_home", sub_intent="sensors",
-        handler_name="smarthome_sensors", lang="de",
-    )
-    assert res is None
-
-
-@pytest.mark.unit
-async def test_dispatch_sensors_declines_other_sub_intent(monkeypatch):
-    _enable_flag(monkeypatch, True)
-    assert await ha_dispatch_sensors(
-        role="smart_home", sub_intent="status",
-        handler_name="smarthome_sensors", lang="de") is None
-    assert await ha_dispatch_sensors(
-        role="media", sub_intent="sensors",
-        handler_name="smarthome_sensors", lang="de") is None
-    assert await ha_dispatch_sensors(
-        role="smart_home", sub_intent="sensors",
-        handler_name="something_else", lang="de") is None
-
-
 # ===========================================================================
-# Producer 2: active_devices → list
+# Builder 2: active_devices → list
 # ===========================================================================
 
 @pytest.mark.unit
@@ -302,72 +201,8 @@ def test_build_active_list_truncates_over_cap():
     assert len(art["data"]["items"]) <= MAX_LIST_ITEMS
 
 
-@pytest.mark.unit
-async def test_dispatch_active_returns_artifact(monkeypatch):
-    _enable_flag(monkeypatch, True)
-    _patch_ha(monkeypatch, _ENTITY_MAP)
-    res = await ha_dispatch_active_devices(
-        role="smart_home", sub_intent="active_devices",
-        handler_name="smarthome_active_devices", lang="de",
-    )
-    assert res["handled"] is True and res["card"] is None
-    arts = res["artifacts"]
-    assert len(arts) == 1 and arts[0]["kind"] == "list"
-    assert "_truncated" not in arts[0] and "_count" not in arts[0]
-    assert len(validate_artifacts(arts)) == 1
-
-
-@pytest.mark.unit
-async def test_dispatch_active_nothing_on_prose_only(monkeypatch):
-    _enable_flag(monkeypatch, True)
-    all_off = [
-        {"entity_id": "light.x", "friendly_name": "Lampe", "domain": "light",
-         "room": "wohnzimmer", "state": "off"},
-    ]
-    _patch_ha(monkeypatch, all_off)
-    res = await ha_dispatch_active_devices(
-        role="smart_home", sub_intent="active_devices",
-        handler_name="smarthome_active_devices", lang="de",
-    )
-    assert res["handled"] is True
-    assert "artifacts" not in res
-    assert "nichts" in res["answer"].lower()
-
-
-@pytest.mark.unit
-async def test_dispatch_active_ha_unavailable_graceful(monkeypatch):
-    _enable_flag(monkeypatch, True)
-    _patch_ha(monkeypatch, raises=True)
-    res = await ha_dispatch_active_devices(
-        role="smart_home", sub_intent="active_devices",
-        handler_name="smarthome_active_devices", lang="de",
-    )
-    assert res["handled"] is True and "artifacts" not in res
-
-
-@pytest.mark.unit
-async def test_dispatch_active_inert_when_flag_off(monkeypatch):
-    _enable_flag(monkeypatch, False)
-    res = await ha_dispatch_active_devices(
-        role="smart_home", sub_intent="active_devices",
-        handler_name="smarthome_active_devices", lang="de",
-    )
-    assert res is None
-
-
-@pytest.mark.unit
-async def test_dispatch_active_declines_other_sub_intent(monkeypatch):
-    _enable_flag(monkeypatch, True)
-    assert await ha_dispatch_active_devices(
-        role="smart_home", sub_intent="status",
-        handler_name="smarthome_active_devices", lang="de") is None
-    assert await ha_dispatch_active_devices(
-        role="media", sub_intent="active_devices",
-        handler_name="smarthome_active_devices", lang="de") is None
-
-
 # ===========================================================================
-# Producer 3: devices_per_room → chart
+# Builder 3: devices_per_room → chart
 # ===========================================================================
 
 @pytest.mark.unit
@@ -386,7 +221,6 @@ def test_build_chart_well_formed():
     # every x/y is a finite float
     for p in points:
         assert isinstance(p["x"], float) and isinstance(p["y"], float)
-    # counts: wohnzimmer=3 (light, media_player, 2 sensors=4?) — recompute honestly.
     # wohnzimmer: light.wohnzimmer, media_player.wohnzimmer_tv,
     #             sensor.wohnzimmer_temp, sensor.wohnzimmer_hum = 4
     # küche: light.kueche, switch.kueche_kaffee = 2
@@ -438,130 +272,3 @@ def test_build_chart_truncates_over_cap():
     assert len(pts) == MAX_ROOM_BARS
     assert art["_truncated"] is True
     assert len(pts) <= MAX_CHART_POINTS
-
-
-@pytest.mark.unit
-async def test_dispatch_chart_returns_artifact(monkeypatch):
-    _enable_flag(monkeypatch, True)
-    _patch_ha(monkeypatch, _ENTITY_MAP)
-    res = await ha_dispatch_devices_per_room(
-        role="smart_home", sub_intent="devices_per_room",
-        handler_name="smarthome_devices_per_room", lang="de",
-    )
-    assert res["handled"] is True and res["card"] is None
-    arts = res["artifacts"]
-    assert len(arts) == 1 and arts[0]["kind"] == "chart"
-    # internal hint keys stripped
-    assert "_room_labels" not in arts[0]
-    assert "_truncated" not in arts[0] and "_count" not in arts[0]
-    # legend prose names the rooms left-to-right
-    assert "Wohnzimmer" in res["answer"]
-    assert len(validate_artifacts(arts)) == 1
-
-
-@pytest.mark.unit
-async def test_dispatch_chart_ha_unavailable_graceful(monkeypatch):
-    _enable_flag(monkeypatch, True)
-    _patch_ha(monkeypatch, raises=True)
-    res = await ha_dispatch_devices_per_room(
-        role="smart_home", sub_intent="devices_per_room",
-        handler_name="smarthome_devices_per_room", lang="de",
-    )
-    assert res["handled"] is True and "artifacts" not in res
-
-
-@pytest.mark.unit
-async def test_dispatch_chart_empty_graceful(monkeypatch):
-    _enable_flag(monkeypatch, True)
-    _patch_ha(monkeypatch, [])
-    res = await ha_dispatch_devices_per_room(
-        role="smart_home", sub_intent="devices_per_room",
-        handler_name="smarthome_devices_per_room", lang="de",
-    )
-    assert res["handled"] is True and "artifacts" not in res
-
-
-@pytest.mark.unit
-async def test_dispatch_chart_inert_when_flag_off(monkeypatch):
-    _enable_flag(monkeypatch, False)
-    res = await ha_dispatch_devices_per_room(
-        role="smart_home", sub_intent="devices_per_room",
-        handler_name="smarthome_devices_per_room", lang="de",
-    )
-    assert res is None
-
-
-@pytest.mark.unit
-async def test_dispatch_chart_declines_other_sub_intent(monkeypatch):
-    _enable_flag(monkeypatch, True)
-    assert await ha_dispatch_devices_per_room(
-        role="smart_home", sub_intent="status",
-        handler_name="smarthome_devices_per_room", lang="de") is None
-
-
-# ===========================================================================
-# Sub-intent routing: _infer_sub_intent over the configured keyword sets
-# ===========================================================================
-
-def _all_sub_intent_definitions():
-    """The four smart_home sub_intent definitions exactly as agent_router parses
-    them from agent_roles.yaml (de/en keyword strings)."""
-    return {
-        "status": {
-            "de": ("Status, Übersicht, Überblick, Zustand, wie ist der status im haus, "
-                   "smart-home-status, geräteübersicht, alle geräte anzeigen, gesamtüberblick"),
-            "en": ("status, overview, summary, state of the house, smart home status, "
-                   "device overview, show all devices, whole house status"),
-        },
-        "sensors": {
-            "de": ("Sensorwerte, Temperaturen, Temperatur in den räumen, wie warm ist es, "
-                   "wie warm ist es in den räumen, luftfeuchte, luftfeuchtigkeit, "
-                   "raumtemperatur, messwerte"),
-            "en": ("sensor readings, temperatures, temperature in the rooms, how warm is it, "
-                   "how warm is it in the rooms, humidity, air humidity, room temperature, "
-                   "measured values"),
-        },
-        "active_devices": {
-            "de": ("Was ist gerade an, was ist an, was läuft gerade, welche geräte sind "
-                   "eingeschaltet, was ist eingeschaltet, welche geräte laufen, was ist aktiv"),
-            "en": ("what is on, what is currently on, what is running, which devices are "
-                   "switched on, which devices are on, which devices are running, "
-                   "what is active"),
-        },
-        "devices_per_room": {
-            "de": ("Geräte pro Raum, wie viele geräte pro raum, anzahl geräte je raum, "
-                   "geräteverteilung, wie viele geräte gibt es pro raum, geräte je raum"),
-            "en": ("devices per room, how many devices per room, device count per room, "
-                   "device distribution, how many devices are there per room, devices by room"),
-        },
-    }
-
-
-@pytest.mark.unit
-@pytest.mark.parametrize("msg,expected", [
-    ("Wie sind die Temperaturen?", "sensors"),
-    ("Zeig mir die Sensorwerte", "sensors"),
-    ("Wie warm ist es in den Räumen?", "sensors"),
-    ("Was ist gerade an?", "active_devices"),
-    ("Welche Geräte sind eingeschaltet?", "active_devices"),
-    ("Was läuft gerade?", "active_devices"),
-    ("Geräte pro Raum bitte", "devices_per_room"),
-    ("Wie viele Geräte pro Raum gibt es?", "devices_per_room"),
-    ("Gib mir einen Überblick", "status"),
-    ("Smart-Home-Status", "status"),
-])
-def test_infer_sub_intent_routes_to_correct_producer(msg, expected):
-    from services.agent_router import AgentRouter
-    assert AgentRouter._infer_sub_intent(msg, _all_sub_intent_definitions(), "de") == expected
-
-
-@pytest.mark.unit
-@pytest.mark.parametrize("msg", [
-    "mach das Licht an",
-    "schalte die Heizung aus",
-    "dimme das Wohnzimmer auf 50%",
-    "spiel Musik im Bad",
-])
-def test_infer_sub_intent_does_not_fire_on_actuation(msg):
-    from services.agent_router import AgentRouter
-    assert AgentRouter._infer_sub_intent(msg, _all_sub_intent_definitions(), "de") is None

--- a/tests/backend/test_smarthome_status_artifact.py
+++ b/tests/backend/test_smarthome_status_artifact.py
@@ -1,21 +1,21 @@
 """
-Tests for the first Lane A artifact producer: smart-home status → typed `table`.
+Tests for the smart-home status → typed `table` artifact BUILDER.
 
-Covers (per the task brief):
-  * the producer returns a well-formed `table` artifact for a status request
-    given mocked HA state, and it passes ``validate_artifacts`` (within caps);
-  * NO artifact (graceful, prose-only) when HA is unavailable / empty;
-  * the dispatch handler is INERT (declines) when the flag is off, and declines
-    for any role/sub_intent that isn't ``smart_home/status``;
-  * intent detection (``_infer_sub_intent``) fires on the German status triggers
-    and does NOT fire on an actuation command ("mach das Licht an").
+``build_status_table`` is the pure builder behind the agent-callable
+``internal.smart_home_overview`` tool (view=``status``). The tool-level tests
+(dispatch, HA-unavailable, flag-off, view routing) live in
+``test_device_widget_tools.py``; here we cover the builder in isolation:
+
+  * it returns a well-formed `table` artifact for a status request given a mocked
+    entity map, and the artifact passes ``validate_artifacts`` (within caps);
+  * it returns ``None`` (graceful, prose-only for the caller) on empty input;
+  * truncation over the row cap is honest (flagged, never silent).
 """
 import pytest
 
 from ha_glue.services.smarthome_status import (
     MAX_STATUS_ROWS,
     build_status_table,
-    ha_dispatch_smarthome_status,
 )
 from services.artifact_service import validate_artifacts
 
@@ -32,33 +32,6 @@ _ENTITY_MAP = [
     {"entity_id": "sensor.flur_temp", "friendly_name": "Flur Temperatur",
      "domain": "sensor", "room": None, "state": "21.4"},
 ]
-
-
-class _FakeHAClient:
-    """Stand-in for HomeAssistantClient with a canned get_entity_map()."""
-
-    def __init__(self, entity_map):
-        self._entity_map = entity_map
-
-    async def get_entity_map(self):
-        return self._entity_map
-
-
-def _patch_ha(monkeypatch, entity_map=None, *, raises=False):
-    """Patch the HomeAssistantClient the handler imports lazily."""
-    import ha_glue.integrations.homeassistant as ha_mod
-
-    def _factory():
-        if raises:
-            raise RuntimeError("HA unreachable")
-        return _FakeHAClient(entity_map if entity_map is not None else [])
-
-    monkeypatch.setattr(ha_mod, "HomeAssistantClient", _factory)
-
-
-def _enable_flag(monkeypatch, value=True):
-    from utils.config import settings
-    monkeypatch.setattr(settings, "artifacts_typed_enabled", value, raising=False)
 
 
 # --- build_status_table -----------------------------------------------------
@@ -131,7 +104,7 @@ def test_build_status_table_missing_friendly_name_falls_back_to_entity_id():
 @pytest.mark.unit
 def test_artifact_passes_validate_artifacts():
     art = build_status_table(_ENTITY_MAP, lang="de")
-    # The internal hint keys must be stripped before emit — simulate the handler.
+    # The internal hint keys must be stripped before emit — simulate the tool.
     art.pop("_truncated", None)
     art.pop("_total", None)
     cleaned = validate_artifacts([art])
@@ -141,164 +114,3 @@ def test_artifact_passes_validate_artifacts():
     # No internal underscore keys leak into the validated output.
     assert "_truncated" not in cleaned[0]
     assert "_total" not in cleaned[0]
-
-
-# --- dispatch handler: happy path -------------------------------------------
-
-@pytest.mark.unit
-async def test_dispatch_returns_artifact_for_status(monkeypatch):
-    _enable_flag(monkeypatch, True)
-    _patch_ha(monkeypatch, _ENTITY_MAP)
-    res = await ha_dispatch_smarthome_status(
-        role="smart_home", sub_intent="status",
-        handler_name="smarthome_status", message="Wie ist der Status im Haus?",
-        lang="de",
-    )
-    assert res is not None
-    assert res["handled"] is True
-    assert res["card"] is None
-    assert isinstance(res["answer"], str) and res["answer"]
-    arts = res["artifacts"]
-    assert len(arts) == 1
-    # Internal hint keys stripped before return.
-    assert "_truncated" not in arts[0]
-    assert "_total" not in arts[0]
-    # And it validates against the backend caps gate.
-    assert len(validate_artifacts(arts)) == 1
-
-
-@pytest.mark.unit
-async def test_dispatch_truncation_mentioned_in_prose(monkeypatch):
-    _enable_flag(monkeypatch, True)
-    big = [
-        {"entity_id": f"light.x{i}", "friendly_name": f"Lampe {i}",
-         "domain": "light", "room": "wohnzimmer", "state": "on"}
-        for i in range(MAX_STATUS_ROWS + 10)
-    ]
-    _patch_ha(monkeypatch, big)
-    res = await ha_dispatch_smarthome_status(
-        role="smart_home", sub_intent="status", handler_name="smarthome_status",
-        message="Übersicht der Geräte", lang="de",
-    )
-    # Prose must honestly say the table is truncated (never silent).
-    assert "insgesamt" in res["answer"].lower()
-    assert len(res["artifacts"][0]["data"]["rows"]) == MAX_STATUS_ROWS
-
-
-# --- dispatch handler: HA unavailable / empty → prose only ------------------
-
-@pytest.mark.unit
-async def test_dispatch_ha_unavailable_is_graceful(monkeypatch):
-    _enable_flag(monkeypatch, True)
-    _patch_ha(monkeypatch, raises=True)
-    res = await ha_dispatch_smarthome_status(
-        role="smart_home", sub_intent="status", handler_name="smarthome_status",
-        message="Status im Haus", lang="de",
-    )
-    assert res["handled"] is True
-    assert res["card"] is None
-    # No artifact (graceful), prose only — never a crash, never an empty table.
-    assert "artifacts" not in res
-    assert isinstance(res["answer"], str) and res["answer"]
-
-
-@pytest.mark.unit
-async def test_dispatch_empty_entity_map_is_graceful(monkeypatch):
-    _enable_flag(monkeypatch, True)
-    _patch_ha(monkeypatch, [])
-    res = await ha_dispatch_smarthome_status(
-        role="smart_home", sub_intent="status", handler_name="smarthome_status",
-        message="Status", lang="de",
-    )
-    assert res["handled"] is True
-    assert "artifacts" not in res
-
-
-# --- dispatch handler: inert / declines --------------------------------------
-
-@pytest.mark.unit
-async def test_dispatch_inert_when_flag_off(monkeypatch):
-    _enable_flag(monkeypatch, False)
-    # If the flag gate were broken this would crash (no HA patched) — assert it
-    # declines WITHOUT touching HA.
-    res = await ha_dispatch_smarthome_status(
-        role="smart_home", sub_intent="status", handler_name="smarthome_status",
-        message="Status", lang="de",
-    )
-    assert res is None
-
-
-@pytest.mark.unit
-async def test_dispatch_declines_other_role(monkeypatch):
-    _enable_flag(monkeypatch, True)
-    res = await ha_dispatch_smarthome_status(
-        role="media", sub_intent="status", handler_name="smarthome_status",
-        message="Status", lang="de",
-    )
-    assert res is None
-
-
-@pytest.mark.unit
-async def test_dispatch_declines_other_sub_intent(monkeypatch):
-    _enable_flag(monkeypatch, True)
-    res = await ha_dispatch_smarthome_status(
-        role="smart_home", sub_intent="volume_control",
-        handler_name="smarthome_status", message="lauter", lang="de",
-    )
-    assert res is None
-
-
-@pytest.mark.unit
-async def test_dispatch_declines_wrong_handler_name(monkeypatch):
-    _enable_flag(monkeypatch, True)
-    res = await ha_dispatch_smarthome_status(
-        role="smart_home", sub_intent="status", handler_name="something_else",
-        message="Status", lang="de",
-    )
-    assert res is None
-
-
-# --- intent detection: _infer_sub_intent over the configured keywords --------
-
-def _status_definitions():
-    """The sub_intent definition exactly as agent_router parses it from YAML."""
-    return {
-        "status": {
-            "de": (
-                "Status, Übersicht, Überblick, Zustand, wie ist der status im haus, "
-                "smart-home-status, geräteübersicht, alle geräte anzeigen, was ist an, "
-                "gesamtüberblick"
-            ),
-            "en": (
-                "status, overview, summary, state of the house, smart home status, "
-                "device overview, show all devices, what is on, whole house status"
-            ),
-            # dispatch key is ignored by _infer_sub_intent (it reads only de/en).
-            "dispatch": {"type": "handler", "handler": "smarthome_status"},
-        }
-    }
-
-
-@pytest.mark.unit
-@pytest.mark.parametrize("msg", [
-    "Wie ist der Status im Haus?",
-    "Zeig mir den Smart-Home-Status",
-    "Übersicht der Geräte bitte",
-    "Gib mir einen Überblick",
-])
-def test_infer_sub_intent_fires_on_status_triggers(msg):
-    from services.agent_router import AgentRouter
-    assert AgentRouter._infer_sub_intent(msg, _status_definitions(), "de") == "status"
-
-
-@pytest.mark.unit
-@pytest.mark.parametrize("msg", [
-    "mach das Licht an",
-    "schalte die Heizung aus",
-    "dimme das Wohnzimmer auf 50%",
-    "ist das Fenster im Bad offen?",
-])
-def test_infer_sub_intent_does_not_fire_on_actuation(msg):
-    from services.agent_router import AgentRouter
-    # No status/overview keyword → None → falls through to the normal agent loop.
-    assert AgentRouter._infer_sub_intent(msg, _status_definitions(), "de") is None


### PR DESCRIPTION
## Summary

**Bug:** "Wie spät ist es?" / "Wieviel Uhr haben wir?" non-deterministically dumped room temperatures ("Sensorwerte aus 4 Räumen") instead of the time.

**Root cause (the class of bug, not just time):** the `smart_home` role had 4 sub-intents (`status`/`sensors`/`active_devices`/`devices_per_room`) wired to `dispatch_sub_intent` hooks that **short-circuit the agent loop** — when the fallible LLM router classified a message into one, `chat_handler` returned a canned widget and the LLM never ran, so the `{time_context}` every agent prompt carries could not answer. Any misroute into those buckets produced a wrong canned answer; time was just the visible symptom.

**Fix (agent orchestrates — no regex, no topic lists):** replace the 4 short-circuits with ONE agent-callable tool `internal.smart_home_overview(view=status|sensors|active_devices|devices_per_room)`, mirroring `internal.device_controls` / `internal.presence_map`. The router now only picks the coarse `smart_home` role; the agent LLM — seeing the real query + `{time_context}` — decides whether to render an overview. Robust to **every** misroute, not just time. (Replaces an earlier band-aid regex + router prompt rule, both reverted.)

- `internal_tools.py`: new tool + `_smart_home_overview` handler reusing the existing `build_*` producers over the shared cached HA entity map.
- `bootstrap.py`: removed the 4 `register_hook("dispatch_sub_intent", …)` (the only ones); hook infra stays for other transports (inert).
- `smarthome_artifacts.py` / `smarthome_status.py`: deleted the `ha_dispatch_*` handlers; kept the `build_*` builders.
- `agent_roles.yaml`: removed the smart_home `sub_intents`; added the tool to `internal_tools`. **(ConfigMap-served — the live `renfield-mcp-config` is patched on deploy.)**
- `prompts/agent.yaml`: topic-neutral overview-widget line (de+en).

## Review
Reviewed via the workflow `/review` (high). 3 findings fixed in `_smart_home_overview`: (1) `lang` follows `settings.default_language` (was hardcoded `"de"` → dead en paths); (2) HA outage → uniform "couldn't read the house" (no false "nothing is on"); (3) flag-off → still returns a prose answer (artifact attached only when `artifacts_typed_enabled`).

## Testing
`test_device_widget_tools.py` (+ `test_smarthome_artifacts.py`, `test_smarthome_status_artifact.py`, `test_internal_tools.py`) — **241 passed on `.159`**, incl. the 3 review-fix cases (lang-follows-settings, HA-outage-not-nothing-on, prose-when-flag-off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QYAQhjWUKKKWk7FnChhZ5