### PR TITLE
fix(chat): gate ChatMessages /trace query on Wissensbasis availability (console 404 follow-up to #951)

### DIFF
--- a/src/frontend/src/pages/ChatPage/ChatMessages.tsx
+++ b/src/frontend/src/pages/ChatPage/ChatMessages.tsx
@@ -15,7 +15,7 @@ import ArtifactRenderer from '../../components/chat/artifacts/ArtifactRenderer';
 import { useFeatureFlags } from '../../api/resources/brain';
 import { useChatContext } from './context/ChatContext';
 import { CitationChip } from '../../components/wissensbasis/CitationChip';
-import { useTraceQuery, type TraceEntity } from '../../api/resources/wissensbasis';
+import { useTraceQuery, useWissensbasisAvailable, type TraceEntity } from '../../api/resources/wissensbasis';
 
 const IMAGE_URL_RE = /https?:\/\/[^\s)]+?\/Items\/[^\s)]+?\/Images\/[^\s)]+|https?:\/\/[^\s)]+\.(?:jpg|jpeg|png|gif|webp)(?:\?[^\s)]*)?/i;
 
@@ -173,8 +173,12 @@ export default function ChatMessages() {
   // wrap entity mentions in the assistant prose with CitationChips.
   // The trace is rebuilt server-side on every agent turn (drained from
   // the wb_annotations accumulator) so the entity list stays current.
-  // useTraceQuery gates on sessionId — null/missing returns empty data.
-  const traceQ = useTraceQuery(sessionId);
+  // Gate on Reva-Wissensbasis availability: /trace is a Reva-only route that
+  // 404s in standalone Renfield, so skip the request entirely when the feature
+  // is off (avoids console 404 noise). CitationChips only exist with Reva
+  // anyway. useTraceQuery also gates on sessionId (null → empty data).
+  const wissensbasisAvailable = useWissensbasisAvailable();
+  const traceQ = useTraceQuery(sessionId, wissensbasisAvailable === true);
   const chipEntities = useMemo(
     () => traceQ.data?.trace?.entities ?? [],
     [traceQ.data?.trace?.entities],


### PR DESCRIPTION
## Summary

Follow-up to #951 (which removed the `/me/mix` probe 404). A second, **ungated** caller remained: `ChatMessages` calls `useTraceQuery(sessionId)` on every chat turn, and `/trace` is a Reva-only route that **404s in standalone Renfield** — the author assumed the 404 was harmless (it fell through to empty data) but it still logged a red console error.

Gate it on `useWissensbasisAvailable() === true` (now the deterministic config flag from #951), so the request is skipped entirely in standalone. CitationChips only exist with Reva anyway. **Net: the last `/trace` console 404 is gone → clean console.**

Frontend `npm run build` (tsc) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QYAQhjWUKKKWk7FnChhZ5