### PR TITLE
fix(smart-home): steer the agent to the overview widget tool, not raw GetLiveContext

### DIFF
--- a/src/backend/ha_glue/services/internal_tools.py
+++ b/src/backend/ha_glue/services/internal_tools.py
@@ -161,15 +161,19 @@ class InternalToolService:
         },
         "internal.smart_home_overview": {
             "description": (
-                "Show a READ-ONLY smart-home OVERVIEW widget of the current state of the house. "
-                "Use it ONLY when the user asks to SEE an overview of the home — a device inventory, "
-                "the room temperatures/humidity, what is currently switched on, or how many devices are "
-                "in each room. Pick the matching `view`:\n"
+                "Show the user a smart-home OVERVIEW widget — room sensor readings & "
+                "temperatures/humidity, the device-status inventory, what is currently switched ON, "
+                "or a devices-per-room chart. This is the PREFERRED, REQUIRED way to ANSWER any "
+                "'show me / zeig mir / wie warm ist es / Sensorwerte / was ist an / Übersicht / "
+                "Status' request about the home's current state — it renders a typed widget. "
+                "Do NOT use raw state tools (GetLiveContext / GetLiveState) to ANSWER these requests; "
+                "those are for YOUR OWN internal lookups before an action, not for showing the user. "
+                "Pick the matching `view`:\n"
                 "  • 'status'          — full device inventory table (room × device × state)\n"
                 "  • 'sensors'         — per-room temperature/humidity readings\n"
                 "  • 'active_devices'  — which controllable devices are currently on\n"
                 "  • 'devices_per_room'— bar chart of the device count per room\n"
-                "This is NOT for controlling/operating devices (that is internal.device_controls) and NOT "
+                "NOT for controlling/operating devices (that is internal.device_controls) and NOT "
                 "for a one-off command like 'mach das Licht an' (do that directly with HassTurnOn). "
                 "The widget IS the answer — after it renders, give a one-line final_answer alongside it."
             ),

--- a/src/backend/prompts/agent.yaml
+++ b/src/backend/prompts/agent.yaml
@@ -122,7 +122,7 @@ de:
     - UEBERSICHTS-WIDGET: Will der Nutzer eine reine ANSICHT/Uebersicht des Hauses, rufe internal.smart_home_overview mit dem passenden view auf — view="status" (Geraete-Inventar), "sensors" (Raumtemperaturen/Luftfeuchte), "active_devices" (was ist gerade an) oder "devices_per_room" (Anzahl Geraete pro Raum). Nur fuer eine reine Ansicht, NICHT zum Schalten von Geraeten (dafuer internal.device_controls oder HassTurnOn/HassTurnOff).
     - Wenn kein Raum im Befehl UND kein Raum-Kontext → nutze nur "domain" ohne "area"
     - Fuer Helligkeiten/Farben: Nutze HassLightSet mit "area"+"domain" oder "name"
-    - Fuer Sensorwerte: Nutze GetLiveContext mit "name" und optional "area"
+    - Sensorwerte/Temperaturen ZEIGEN (der Nutzer will sie SEHEN: "zeig mir die Sensorwerte", "wie warm ist es in den Raeumen", "Raumtemperaturen"): rufe internal.smart_home_overview view="sensors" auf — das rendert ein Widget. GetLiveContext (name/optional area) NUR fuer deine EIGENE interne Abfrage eines EINZELNEN Sensors vor einer Aktion, NICHT um dem Nutzer eine Werte-Uebersicht zu praesentieren.
     - Uebergib NIEMALS "device_class"
     - Lautstaerke eines Raum-Players: Nutze internal.media_control mit room_name (NICHT HassSetVolume/HassSetPosition). "auf X% setzen" → action="volume", volume=X; "um X% leiser/lauter" → action="volume", volume_step=-X / +X (Prozentpunkte). z.B. {{"action": "internal.media_control", "parameters": {{"action": "volume", "volume_step": -20, "room_name": "<aktueller_raum>"}}}}
     - Stummschalten: "mute"/"stumm" → internal.media_control action="mute"; "unmute"/"Ton an" → action="unmute" (mit room_name). NICHT pause oder volume=0 dafuer verwenden.
@@ -717,7 +717,7 @@ en:
     - OVERVIEW WIDGET: when the user wants a read-only VIEW/overview of the house, call internal.smart_home_overview with the matching view — view="status" (device inventory), "sensors" (room temperatures/humidity), "active_devices" (what is currently on) or "devices_per_room" (device count per room). Only for a read-only view, NOT for operating devices (use internal.device_controls or HassTurnOn/HassTurnOff for that).
     - If no room in command AND no room context → use only "domain" without "area"
     - For brightness/colors: Use HassLightSet with "area"+"domain" or "name"
-    - For sensor values: Use GetLiveContext with "name" and optionally "area"
+    - To SHOW sensor values/temperatures (the user wants to SEE them: "show me the sensor values", "how warm is it in the rooms", "room temperatures"): call internal.smart_home_overview view="sensors" — it renders a widget. Use GetLiveContext (name/optional area) ONLY for your OWN internal lookup of a SINGLE sensor before an action, NOT to present a values overview to the user.
     - NEVER pass "device_class"
     - Volume of a room player: Use internal.media_control with room_name (NOT HassSetVolume/HassSetPosition). "set to X%" → action="volume", volume=X; "X% quieter/louder" → action="volume", volume_step=-X / +X (percentage points). e.g. {{"action": "internal.media_control", "parameters": {{"action": "volume", "volume_step": -20, "room_name": "<current_room>"}}}}
     - Mute: "mute" → internal.media_control action="mute"; "unmute" → action="unmute" (with room_name). Do NOT use pause or volume=0 to mute.


### PR DESCRIPTION
## Summary

Follow-up to the smart-home-overview migration (#952). After removing the router short-circuits, the agent answered "Zeig mir die Sensorwerte" via `mcp.homeassistant.GetLiveContext` (raw data → prose) and **never** called `internal.smart_home_overview` — so the typed widgets stopped rendering. Two competing signals caused it:

1. The agent prompt (`prompts/agent.yaml`, de+en) literally said **"Für Sensorwerte: Nutze GetLiveContext"** — a direct instruction to the competing tool.
2. `internal.smart_home_overview`'s description didn't front-load its triggers, so the tool-preselector (which sees only the first 80 chars of each description) under-ranked it.

**Fix (LLM steering via descriptions/prompt — not hardcoded routing):**
- Rewrote the prompt's sensor line (de+en): "show me the sensor values / temperatures / room temperatures" → `internal.smart_home_overview view="sensors"`; `GetLiveContext` is reserved for the agent's OWN single-sensor lookup before an action, not for presenting a values overview.
- Front-loaded the tool description with its triggers and made it the PREFERRED/REQUIRED way to ANSWER "show me / zeig mir / wie warm / Status" requests, explicitly over `GetLiveContext`/`GetLiveState`.

Image-only (description + prompt baked in the backend image; `agent_roles.yaml` unchanged → no ConfigMap patch). Behavioral change verified live post-deploy.

## Testing
`test_device_widget_tools.py` — 29 passed on `.159` (incl. the no-time-special-casing check); `agent.yaml` valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QYAQhjWUKKKWk7FnChhZ5