### PR TITLE
fix(k8s): auth-on instance enablement — SECRET_KEY in worker/alembic + edition nav gate

### DIFF
--- a/.claude/skills/deploy-production/SKILL.md
+++ b/.claude/skills/deploy-production/SKILL.md
@@ -379,6 +379,18 @@ kubectl -n renfield delete job alembic-upgrade
 
 The job uses the same backend image; if you just pushed a new image, run migrations **before** the deployment restart so the new code doesn't hit an old schema. The Job's `backoffLimit: 2` means 3 attempts max — failures are usually a chain conflict (see check above) or a missed env var, not a transient retry-able problem.
 
+### Standing up a NEW instance (auth-on / separate namespace)
+
+The household runs `AUTH_ENABLED=false`, so its deploy path never exercises the auth-on boot guards. A **new isolated instance** (a business/multi-user clone in its own namespace, `RENFIELD_ENV=production` + `AUTH_ENABLED=true`) hits three traps the household hides — all learned standing up `renfield-xidra` (2026-07-11):
+
+1. **`SECRET_KEY` in every backend-image workload.** The v2.20.0 boot guard (`fail_closed_on_insecure_jwt_key`) validates `SECRET_KEY` at `Settings()` init — which fires for **any** process that imports the config, not just the API: the `document-worker` and the `alembic-upgrade` Job included. `k8s/backend.yaml` injects it; `k8s/document-worker.yaml` and `k8s/alembic-upgrade-job.yaml` now do too (`optional: true` — inject-if-present, so auth-off installs are unaffected). If you add a new backend-image Job/CronJob, inject `secret-key` from `renfield-secrets` or it crashes with *"SECRET_KEY is insecure: still the placeholder default"*.
+
+2. **A fresh DB self-bootstraps — do NOT run the `alembic-upgrade` Job on an empty DB.** `init_db()` (backend startup) runs `Base.metadata.create_all` + stamps alembic HEAD; the 41-migration history is *skipped*. Running `alembic upgrade head` from empty instead fails on `room_output_devices` (FK → `rooms`, which no migration creates — it's `create_all`-only). Just deploy the backend; it builds the schema itself. The migration Job is for **existing** DBs applying **new** migrations only (see its header).
+
+3. **`AUTH_ENABLED` + `WS_AUTH_ENABLED` flip together, strong key first.** `assert_auth_config_consistency` rejects a partial combo; provision a `secret-key` ≥32 random chars **before** arming `RENFIELD_ENV=production`.
+
+(Cross-namespace: the shared GPU/model tier — ollama/searxng — must be FQDN-qualified in the ConfigMap AND in the `wait-for-deps` init container, which wgets a bare `ollama:11434` that would resolve to the wrong namespace.)
+
 ### ConfigMap changes
 
 When `config/mcp_servers.yaml` / `config/agent_roles.yaml` / `config/kg_scopes.yaml` / `config/mail_accounts.*.yaml` change in the repo, rewrite the `renfield-mcp-config` ConfigMap **before** the rolling restart — otherwise pods get stuck in `ContainerCreating` on a missing subPath:

--- a/docs/KUBERNETES_DEPLOYMENT.md
+++ b/docs/KUBERNETES_DEPLOYMENT.md
@@ -128,6 +128,15 @@ For K8s this means:
 
 A follow-up that consolidates all 41 migrations into a single clean baseline is tracked separately.
 
+> **Auth-on instances (`AUTH_ENABLED=true` / `RENFIELD_ENV=production`):** the v2.20.0 boot
+> guard (`fail_closed_on_insecure_jwt_key`) validates `SECRET_KEY` at `Settings()` init, which
+> fires for *every* backend-image workload — not just the API, but the `document-worker` and the
+> `alembic-upgrade` Job (they import the config). All three manifests inject `secret-key` from
+> `renfield-secrets` (`optional: true` → inject-if-present, so auth-off installs are unaffected).
+> Any new backend-image Job/CronJob must do the same or it crashes with *"SECRET_KEY is insecure:
+> still the placeholder default"*. Provision a strong `secret-key` (≥32 random chars) **before**
+> arming `RENFIELD_ENV=production`, and flip `AUTH_ENABLED` + `WS_AUTH_ENABLED` together.
+
 ## Secrets
 
 The `renfield-secrets` Secret holds:

--- a/k8s/alembic-upgrade-job.yaml
+++ b/k8s/alembic-upgrade-job.yaml
@@ -43,6 +43,18 @@ spec:
                 secretKeyRef:
                   name: renfield-secrets
                   key: postgres-password
+            # The v2.20.0 boot guard (fail_closed_on_insecure_jwt_key) validates
+            # SECRET_KEY at Settings() init — which alembic/env.py triggers by
+            # importing models.database. Without this, `alembic upgrade` fails on
+            # any AUTH_ENABLED / RENFIELD_ENV=production instance (the household is
+            # auth-off, so it never hit this). optional:true = inject-if-present:
+            # auth-off installs without the key still run (the guard stays dormant).
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: renfield-secrets
+                  key: secret-key
+                  optional: true
             - name: DATABASE_URL
               value: postgresql+asyncpg://renfield:$(POSTGRES_PASSWORD)@postgres:5432/renfield
           resources:

--- a/k8s/document-worker.yaml
+++ b/k8s/document-worker.yaml
@@ -81,6 +81,13 @@ spec:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef: {name: renfield-secrets, key: postgres-password}
+            # The v2.20.0 boot guard (fail_closed_on_insecure_jwt_key) validates
+            # SECRET_KEY at Settings() init — the worker imports config too, so it
+            # crashes on any AUTH_ENABLED / RENFIELD_ENV=production instance without
+            # this. optional:true = inject-if-present (auth-off installs unaffected).
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef: {name: renfield-secrets, key: secret-key, optional: true}
             - name: DATABASE_URL
               value: postgresql+asyncpg://renfield:$(POSTGRES_PASSWORD)@postgres:5432/renfield
             # Integration secrets mirror the backend so Docling/RAG code paths

--- a/src/frontend/src/components/Layout.tsx
+++ b/src/frontend/src/components/Layout.tsx
@@ -91,7 +91,7 @@ const mainNavigationConfig: NavItemConfig[] = [
 ];
 
 const adminNavigationConfig: NavItemConfig[] = [
-  { nameKey: 'nav.kiosk', href: '/kiosk', icon: Radar, permission: ['admin'] },
+  { nameKey: 'nav.kiosk', href: '/kiosk', icon: Radar, permission: ['admin'], feature: 'satellites' },
   { nameKey: 'nav.rooms', href: '/rooms', icon: DoorOpen, permission: ['rooms.read', 'rooms.manage'], feature: 'smart_home' },
   { nameKey: 'nav.speakers', href: '/speakers', icon: Users, permission: ['speakers.own', 'speakers.all'], feature: 'voice' },
   { nameKey: 'nav.smarthome', href: '/homeassistant', icon: Lightbulb, permission: ['ha.read', 'ha.control', 'ha.full'], feature: 'smart_home' },
@@ -101,7 +101,7 @@ const adminNavigationConfig: NavItemConfig[] = [
   { nameKey: 'nav.users', href: '/admin/users', icon: UserCog, permission: ['admin'] },
   { nameKey: 'nav.roles', href: '/admin/roles', icon: Shield, permission: ['admin'] },
   { nameKey: 'nav.satellites', href: '/admin/satellites', icon: Satellite, permission: ['admin'], feature: 'satellites' },
-  { nameKey: 'nav.presence', href: '/admin/presence', icon: MapPin, permission: ['admin'] },
+  { nameKey: 'nav.presence', href: '/admin/presence', icon: MapPin, permission: ['admin'], feature: 'smart_home' },
   { nameKey: 'nav.paperlessAudit', href: '/admin/paperless-audit', icon: FileSearch, permission: ['admin'] },
   { nameKey: 'nav.maintenance', href: '/admin/maintenance', icon: Wrench, permission: ['admin'] },
   { nameKey: 'nav.settings', href: '/admin/settings', icon: Settings, permission: ['admin'] },


### PR DESCRIPTION
## Why

Standing up a **new auth-on instance** (a business/multi-user clone in its own namespace, `RENFIELD_ENV=production` + `AUTH_ENABLED=true`) surfaced three traps the household — which runs `AUTH_ENABLED=false` — never exercises. Feeding the fixes back so the next instance doesn't repeat them.

## Changes

**1. `SECRET_KEY` in every backend-image workload** (`k8s/document-worker.yaml`, `k8s/alembic-upgrade-job.yaml`)
The v2.20.0 boot guard (`fail_closed_on_insecure_jwt_key`) validates `SECRET_KEY` at `Settings()` init — which fires for *any* process importing the config, not just the API. The worker and the alembic Job never injected it, so both crash with *"SECRET_KEY is insecure: still the placeholder default"* on an auth-on/production instance. Injected as `optional: true` (inject-if-present) so auth-off installs are unaffected. `k8s/backend.yaml` already had it.

**2. Edition-gate the Kiosk + Presence nav** (`src/frontend/src/components/Layout.tsx`)
Both were admin-permission-only with no `feature` gate, so an edition with smart-home/satellites off still showed them (inert pages). Added `feature: 'satellites'` (Kiosk) and `feature: 'smart_home'` (Presence); `filterNavItems` already drops feature-off items (resolved from `/api/auth/status`). Household (community, both on) unaffected.

**3. Deploy skill: "Standing up a NEW instance (auth-on)"** (`.claude/skills/deploy-production/SKILL.md`)
Documents the SECRET_KEY-everywhere rule, the fresh-DB self-bootstrap (`init_db` does `create_all` + stamp HEAD — do **not** run the alembic Job on an empty DB; it fails on the `room_output_devices` FK, since `rooms` is `create_all`-only), and the auth-flag/strong-key ordering + cross-namespace FQDN init-container caveat.

## Testing

- Both manifests pass `kubectl apply --dry-run=client`.
- Verified live on the new `renfield-xidra` instance: with these fixes the worker + backend start under auth-on/production, the fresh DB self-bootstraps (64 tables + alembic stamped HEAD), and the nav gate hides Kiosk/Presence for the business edition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QYAQhjWUKKKWk7FnChhZ5