### PR TITLE
chore(gitignore): keep xidra business-instance manifests out of the public repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,10 @@ pids/
 # Private documents (not for repo)
 docs/private/
 
+# xidra business instance — PRIVATE infra manifests/config, NEVER public GitHub
+k8s/xidra/
+config/xidra/
+
 # Secrets (should use .env)
 *.pem
 *.key


### PR DESCRIPTION
## Was

Ignore `k8s/xidra/` and `config/xidra/` in `.gitignore`.

## Warum

The xidra business instance is a **private** deployment — its k8s manifests and
config carry internal hostnames, IPs, and share names that must never land on the
public GitHub remote. There was no ignore rule protecting these paths, so a stray
`git add` could have leaked them. This adds the guard.

## Scope

- One-line-block change to `.gitignore` (4 insertions).
- No functional/code impact; no xidra content is committed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)