### PR TITLE
feat(federation): person-scoped identity mapping — F-ID-1 (dark by default)

### DIFF
--- a/src/backend/alembic/versions/pc20260712_federation_user_links.py
+++ b/src/backend/alembic/versions/pc20260712_federation_user_links.py
@@ -1,0 +1,78 @@
+"""federation_user_links — cross-instance person map for person-scoped federation (F-ID-1)
+
+Revision ID: pc20260712_federation_user_links
+Revises: pc20260707_speaker_candidates
+Create Date: 2026-07-12
+
+Maps an opaque per-(peer, person) ``querier_ref`` token to a LOCAL user so a
+federated query carrying that ref is served AS the mapped user (full circle
+reach) instead of the peer-scoped public/guest fallback. Same table serves both
+perspectives of a pairing (responder: ref->local user; asker: local user->ref).
+Design: docs/design/federation-identity-mapping.md.
+
+Idempotency: every DDL op is guarded — Base.metadata.create_all (backend boot)
+creates this table for a new model, so re-running this migration must be a no-op
+(same pattern as pc20260421_peer_users).
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "pc20260712_federation_user_links"
+down_revision = "pc20260707_speaker_candidates"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "federation_user_links" not in existing_tables:
+        op.create_table(
+            "federation_user_links",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "peer_id", sa.Integer(),
+                sa.ForeignKey("peer_users.id", ondelete="CASCADE"), nullable=False,
+            ),
+            # Opaque per-(peer, person) token agreed at link time. NOT the raw
+            # remote user id (avoids the multi-peer integer-collision class).
+            sa.Column("querier_ref", sa.String(128), nullable=False),
+            # SET NULL so deleting a local user demotes the link to unmapped
+            # (fail-closed → fallback) instead of blocking the delete.
+            sa.Column(
+                "local_user_id", sa.Integer(),
+                sa.ForeignKey("users.id", ondelete="SET NULL"), nullable=True,
+            ),
+            sa.Column(
+                "created_by", sa.Integer(),
+                sa.ForeignKey("users.id", ondelete="SET NULL"), nullable=True,
+            ),
+            sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        )
+
+    def _has_idx(idx_name: str) -> bool:
+        if "federation_user_links" not in existing_tables:
+            return False
+        return idx_name in {ix["name"] for ix in inspector.get_indexes("federation_user_links")}
+
+    if not _has_idx("uq_fed_user_links_peer_ref"):
+        op.create_index(
+            "uq_fed_user_links_peer_ref", "federation_user_links",
+            ["peer_id", "querier_ref"], unique=True,
+        )
+    if not _has_idx("ix_fed_user_links_peer_local"):
+        op.create_index(
+            "ix_fed_user_links_peer_local", "federation_user_links",
+            ["peer_id", "local_user_id"],
+        )
+    if not _has_idx("ix_federation_user_links_peer_id"):
+        op.create_index("ix_federation_user_links_peer_id", "federation_user_links", ["peer_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_federation_user_links_peer_id", table_name="federation_user_links")
+    op.drop_index("ix_fed_user_links_peer_local", table_name="federation_user_links")
+    op.drop_index("uq_fed_user_links_peer_ref", table_name="federation_user_links")
+    op.drop_table("federation_user_links")

--- a/src/backend/api/routes/federation_user_links.py
+++ b/src/backend/api/routes/federation_user_links.py
@@ -22,7 +22,7 @@ Design: docs/design/federation-identity-mapping.md.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -36,7 +36,6 @@ from services.federation_identity_link import (
     delete_link,
     list_links,
 )
-from utils.config import settings
 
 router = APIRouter()
 
@@ -45,8 +44,10 @@ class CreateLinkRequest(BaseModel):
     peer_id: int
     local_user_id: int
     # Omit to MINT a fresh ref (first side of a pairing); pass the minted ref
-    # when creating the mirror link on the other instance.
-    querier_ref: str | None = None
+    # when creating the mirror link on the other instance. Bounded to the DB
+    # column width (String(128)) so an oversized ref is a clean 422, not a 500
+    # DataError the IntegrityError handler wouldn't catch.
+    querier_ref: str | None = Field(default=None, max_length=128)
 
 
 class LinkResponse(BaseModel):
@@ -85,12 +86,9 @@ async def create_user_link(
     admin: User = Depends(require_permission(Permission.ADMIN)),
 ) -> LinkResponse:
     """Assert a person link. Validates the peer + local user exist. 409 if a link
-    already exists for (peer, querier_ref)."""
-    if not settings.federation_identity_links_enabled:
-        # The row can be created while dark, but flag it so the operator knows
-        # it won't take effect until the feature is enabled.
-        pass
-
+    already exists for (peer, querier_ref). Links may be created while the feature
+    is dark (`federation_identity_links_enabled=False`); they take effect only
+    once it's enabled."""
     peer = (await db.execute(
         select(PeerUser).where(PeerUser.id == body.peer_id, PeerUser.revoked_at.is_(None))
     )).scalar_one_or_none()

--- a/src/backend/api/routes/federation_user_links.py
+++ b/src/backend/api/routes/federation_user_links.py
@@ -1,0 +1,131 @@
+"""
+Federation identity-link admin API (F-ID-1 — person-scoped federation).
+
+ADMIN-gated CRUD over `federation_user_links` — the cross-instance person map
+that lets a federated query be served AS a mapped local user (full circle
+reach) instead of the peer-scoped public/guest fallback.
+
+This is the F-ID-1 "admin assertion" way to create links (design doc §4.2
+option B). F-ID-2 replaces it with a consent-signed double-login handshake that
+proves ownership of both accounts. Until then, only an ADMIN may assert a link.
+
+The `querier_ref` is the shared opaque token both sides of a pairing must hold:
+- On the RESPONDER instance, the link means "ref X → my local user Y".
+- On the ASKER instance, the link means "my local user Y, querying this peer,
+  presents ref X".
+So to make a person's mapping work end-to-end, the SAME (peer, ref, local_user)
+triple is created on both instances (with each side's own local_user_id).
+Create on one side without a ref to mint one, then reuse that ref on the other.
+
+Design: docs/design/federation-identity-mapping.md.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import FederationUserLink, PeerUser, User
+from models.permissions import Permission
+from services.auth_service import require_permission
+from services.database import get_db
+from services.federation_identity_link import (
+    create_link,
+    delete_link,
+    list_links,
+)
+from utils.config import settings
+
+router = APIRouter()
+
+
+class CreateLinkRequest(BaseModel):
+    peer_id: int
+    local_user_id: int
+    # Omit to MINT a fresh ref (first side of a pairing); pass the minted ref
+    # when creating the mirror link on the other instance.
+    querier_ref: str | None = None
+
+
+class LinkResponse(BaseModel):
+    id: int
+    peer_id: int
+    querier_ref: str
+    local_user_id: int | None
+    created_by: int | None
+
+
+def _to_response(link: FederationUserLink) -> LinkResponse:
+    return LinkResponse(
+        id=link.id, peer_id=link.peer_id, querier_ref=link.querier_ref,
+        local_user_id=link.local_user_id, created_by=link.created_by,
+    )
+
+
+@router.get("/user-links", response_model=list[LinkResponse])
+async def list_user_links(
+    request: Request,
+    peer_id: int | None = None,
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(require_permission(Permission.ADMIN)),
+) -> list[LinkResponse]:
+    """List identity links (optionally filtered by peer). The `querier_ref` is
+    returned so an admin can mirror it to the other instance."""
+    links = await list_links(db, peer_id=peer_id)
+    return [_to_response(link) for link in links]
+
+
+@router.post("/user-links", response_model=LinkResponse)
+async def create_user_link(
+    request: Request,
+    body: CreateLinkRequest,
+    db: AsyncSession = Depends(get_db),
+    admin: User = Depends(require_permission(Permission.ADMIN)),
+) -> LinkResponse:
+    """Assert a person link. Validates the peer + local user exist. 409 if a link
+    already exists for (peer, querier_ref)."""
+    if not settings.federation_identity_links_enabled:
+        # The row can be created while dark, but flag it so the operator knows
+        # it won't take effect until the feature is enabled.
+        pass
+
+    peer = (await db.execute(
+        select(PeerUser).where(PeerUser.id == body.peer_id, PeerUser.revoked_at.is_(None))
+    )).scalar_one_or_none()
+    if peer is None:
+        raise HTTPException(status_code=404, detail="Unknown or revoked peer")
+
+    user = (await db.execute(
+        select(User).where(User.id == body.local_user_id)
+    )).scalar_one_or_none()
+    if user is None:
+        raise HTTPException(status_code=404, detail="Unknown local user")
+
+    try:
+        link = await create_link(
+            db, peer_id=body.peer_id, local_user_id=body.local_user_id,
+            querier_ref=body.querier_ref,
+            created_by=(admin.id if admin is not None else None),
+        )
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="Link already exists for this (peer, querier_ref)")
+    return _to_response(link)
+
+
+@router.delete("/user-links/{link_id}")
+async def delete_user_link(
+    request: Request,
+    link_id: int,
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(require_permission(Permission.ADMIN)),
+) -> dict:
+    """Revoke a person link → that person reverts to the peer-scoped fallback."""
+    ok = await delete_link(db, link_id=link_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Link not found")
+    await db.commit()
+    return {"deleted": link_id}

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -28,6 +28,7 @@ from api.routes import (
     federation_audit,
     federation_pairing,
     federation_query,
+    federation_user_links,
     feedback,
     folder_ingest,
     intents,
@@ -205,6 +206,7 @@ app.include_router(circles.router, prefix="/api/circles", tags=["Circles - Membe
 app.include_router(federation_pairing.router, prefix="/api/federation", tags=["Federation - Pairing"])
 app.include_router(federation_query.router, prefix="/api/federation", tags=["Federation - Query"])
 app.include_router(federation_audit.router, prefix="/api/federation", tags=["Federation - Audit"])
+app.include_router(federation_user_links.router, prefix="/api/federation", tags=["Federation - Identity Links"])
 
 # WebSocket Routers
 app.include_router(chat_router, tags=["WebSocket Chat"])

--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -2396,6 +2396,49 @@ class PeerUser(Base):
     owner = relationship("User", foreign_keys=[circle_owner_id])
 
 
+class FederationUserLink(Base):
+    """Cross-instance person link for person-scoped federation (F-ID-1).
+
+    Maps an opaque per-(peer, person) ``querier_ref`` token to a LOCAL user.
+    The SAME table serves both perspectives of a pairing:
+      - As RESPONDER: (peer_id, querier_ref) -> local_user_id. An incoming
+        federated query carrying ``querier_ref`` is served AS ``local_user_id``
+        with full circle reach — NOT the peer-scoped public/guest fallback.
+      - As ASKER: (peer_id, local_user_id) -> querier_ref. When ``local_user_id``
+        federates a query to ``peer_id``, the outgoing envelope carries the ref.
+
+    ``querier_ref`` is a shared opaque token agreed at link time; it is NOT the
+    raw remote user id (avoids the multi-peer integer-collision class). A NULL
+    ``local_user_id`` (owner deleted, ON DELETE SET NULL) demotes the link to
+    unmapped → fallback (fail-closed). Design:
+    docs/design/federation-identity-mapping.md.
+    """
+    __tablename__ = "federation_user_links"
+
+    id = Column(Integer, primary_key=True, index=True)
+    peer_id = Column(
+        Integer, ForeignKey("peer_users.id", ondelete="CASCADE"),
+        nullable=False, index=True,
+    )
+    querier_ref = Column(String(128), nullable=False)
+    local_user_id = Column(
+        Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True,
+    )
+    created_by = Column(
+        Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True,
+    )
+    created_at = Column(DateTime, default=_utcnow, nullable=False)
+
+    __table_args__ = (
+        # Responder lookup + one local user per ref per peer.
+        Index("uq_fed_user_links_peer_ref", "peer_id", "querier_ref", unique=True),
+        # Asker lookup (peer, local user) -> ref.
+        Index("ix_fed_user_links_peer_local", "peer_id", "local_user_id"),
+    )
+
+    peer = relationship("PeerUser", foreign_keys=[peer_id])
+
+
 class FederationQueryLog(Base):
     """
     Asker-side audit row for each federated query.

--- a/src/backend/services/federation_identity_link.py
+++ b/src/backend/services/federation_identity_link.py
@@ -1,0 +1,110 @@
+"""Person-scoped federation — cross-instance identity link resolution (F-ID-1).
+
+The `federation_user_links` table maps an opaque per-(peer, person)
+``querier_ref`` token to a LOCAL user. The same rows serve both perspectives of
+a pairing:
+
+  * RESPONDER — ``resolve_linked_user(peer_id, querier_ref) -> local_user_id``:
+    an incoming federated query carrying ``querier_ref`` is served AS that local
+    user (full circle reach), not the peer-scoped public/guest fallback.
+  * ASKER — ``resolve_querier_ref(peer_id, local_user_id) -> querier_ref``: when
+    that local user federates a query to the peer, the outgoing envelope carries
+    the ref.
+
+``querier_ref`` is a shared opaque token agreed at link time (F-ID-2 will mint it
+via a consent handshake; F-ID-1 lets an admin assert it). It is NOT the raw
+remote user id — see the multi-peer collision note in TODOS.md. Design:
+docs/design/federation-identity-mapping.md.
+
+All lookups are fail-closed: a missing row, a NULL ``local_user_id`` (owner
+deleted, ON DELETE SET NULL), or a blank ref returns None → the caller falls
+back to the peer-scoped path.
+"""
+from __future__ import annotations
+
+import secrets
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import FederationUserLink
+
+
+def mint_querier_ref() -> str:
+    """A fresh opaque per-(peer, person) token. 256-bit, hex — unguessable and
+    not correlatable to any local id."""
+    return secrets.token_hex(32)
+
+
+async def resolve_linked_user(
+    db: AsyncSession, *, peer_id: int, querier_ref: str | None
+) -> int | None:
+    """RESPONDER side: (peer_id, querier_ref) -> local user id, or None.
+
+    None when: no ref, no matching row, or the row's local_user_id was NULLed by
+    a user delete. Callers treat None as unmapped → peer-scoped fallback.
+    """
+    if not querier_ref:
+        return None
+    row = (await db.execute(
+        select(FederationUserLink.local_user_id).where(
+            FederationUserLink.peer_id == peer_id,
+            FederationUserLink.querier_ref == querier_ref,
+        )
+    )).scalar_one_or_none()
+    return row  # int local_user_id, or None (no row / NULLed)
+
+
+async def resolve_querier_ref(
+    db: AsyncSession, *, peer_id: int, local_user_id: int | None
+) -> str | None:
+    """ASKER side: (peer_id, local_user_id) -> the ref to attach, or None.
+
+    None when the querying user has no link for this peer — the asker then sends
+    no querier_ref and the responder serves the fallback.
+    """
+    if local_user_id is None:
+        return None
+    return (await db.execute(
+        select(FederationUserLink.querier_ref).where(
+            FederationUserLink.peer_id == peer_id,
+            FederationUserLink.local_user_id == local_user_id,
+        )
+    )).scalar_one_or_none()
+
+
+# ---------------------------------------------------------------------------
+# Admin CRUD (F-ID-1 "admin assertion" link creation — F-ID-2 replaces this
+# with a consent-signed double-login handshake).
+# ---------------------------------------------------------------------------
+
+
+async def create_link(
+    db: AsyncSession, *, peer_id: int, local_user_id: int,
+    querier_ref: str | None = None, created_by: int | None = None,
+) -> FederationUserLink:
+    """Create (or return existing) a link. ``querier_ref`` is minted if omitted.
+
+    Idempotent on (peer_id, querier_ref): a duplicate ref for the same peer is a
+    unique-constraint violation the caller surfaces as 409.
+    """
+    ref = querier_ref or mint_querier_ref()
+    link = FederationUserLink(
+        peer_id=peer_id, querier_ref=ref,
+        local_user_id=local_user_id, created_by=created_by,
+    )
+    db.add(link)
+    await db.flush()
+    return link
+
+
+async def list_links(db: AsyncSession, *, peer_id: int | None = None) -> list[FederationUserLink]:
+    stmt = select(FederationUserLink)
+    if peer_id is not None:
+        stmt = stmt.where(FederationUserLink.peer_id == peer_id)
+    return list((await db.execute(stmt.order_by(FederationUserLink.id))).scalars().all())
+
+
+async def delete_link(db: AsyncSession, *, link_id: int) -> bool:
+    res = await db.execute(delete(FederationUserLink).where(FederationUserLink.id == link_id))
+    return res.rowcount > 0

--- a/src/backend/services/federation_identity_link.py
+++ b/src/backend/services/federation_identity_link.py
@@ -65,12 +65,16 @@ async def resolve_querier_ref(
     """
     if local_user_id is None:
         return None
+    # (peer_id, local_user_id) is NOT unique — only (peer_id, querier_ref) is —
+    # so an admin MAY have created two refs for one (peer, user). Take the first
+    # deterministically rather than raising MultipleResultsFound (which would
+    # fail the query closed to fallback, but noisily).
     return (await db.execute(
         select(FederationUserLink.querier_ref).where(
             FederationUserLink.peer_id == peer_id,
             FederationUserLink.local_user_id == local_user_id,
-        )
-    )).scalar_one_or_none()
+        ).order_by(FederationUserLink.id).limit(1)
+    )).scalars().first()
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/services/federation_pending_store.py
+++ b/src/backend/services/federation_pending_store.py
@@ -94,9 +94,16 @@ def _to_jsonable(pr: _PendingRequest) -> dict:
 
 def _from_jsonable(d: dict) -> _PendingRequest:
     """Reverse of `_to_jsonable`. Accepts either dataclass-asdict or
-    raw dict provenance entries."""
+    raw dict provenance entries.
+
+    Forward-compat: DROP unknown keys so a row serialized by a NEWER code
+    version (extra fields) doesn't `TypeError` when read by an OLDER worker
+    during a rolling deploy on the Redis backend. Missing keys still fall back
+    to the dataclass defaults (the common older-row case)."""
+    from dataclasses import fields as _dc_fields
     prov_dicts = d.pop("provenance", [])
-    pr = _PendingRequest(**d)
+    known = {f.name for f in _dc_fields(_PendingRequest)}
+    pr = _PendingRequest(**{k: v for k, v in d.items() if k in known})
     pr.provenance = [Provenance(**p) for p in prov_dicts]
     return pr
 

--- a/src/backend/services/federation_pending_store.py
+++ b/src/backend/services/federation_pending_store.py
@@ -71,6 +71,10 @@ class _PendingRequest:
     max_visible_tier: int
     query: str
     initiated_at: float
+    # F-ID-1: True = peer-scoped fallback (public/guest); False = the querier was
+    # identity-mapped to `asker_local_user_id`, so run AS that local user with
+    # full circle reach. Defaults True so any un-updated caller stays fail-closed.
+    enforce_circles: bool = True
     status: str = STATUS_PROCESSING
     progress_label: str = PROGRESS_LABEL_RETRIEVING
     progress_count: int = 0

--- a/src/backend/services/federation_query_asker.py
+++ b/src/backend/services/federation_query_asker.py
@@ -112,11 +112,19 @@ class FederationQueryAsker:
         self._client = client
 
     async def query_peer(
-        self, peer: PeerUser, query_text: str,
+        self, peer: PeerUser, query_text: str, user_id: int | None = None,
     ) -> AsyncIterator[ProgressChunk | dict[str, Any]]:
         """
         Drive a federated query against `peer`. Yields ProgressChunks
         during polling and a final FinalResult dict at the end.
+
+        F-ID-1: `user_id` is the authenticated asker (this instance's local
+        user). When `federation_identity_links_enabled` and this user has a
+        `federation_user_links` row for `peer`, we attach the opaque
+        `querier_ref` so the responder can serve AS the mapped remote user.
+        No link / flag off / anonymous → no ref → the responder's peer-scoped
+        fallback (byte-identical to pre-F-ID-1). Design:
+        docs/design/federation-identity-mapping.md.
 
         The FinalResult shape matches `MCPManager.execute_tool`'s
         contract — `{"success": bool, "message": str, "data": Any}` —
@@ -133,9 +141,24 @@ class FederationQueryAsker:
             yield _final_error("Peer has no usable transport endpoint")
             return
 
+        # F-ID-1: resolve the opaque per-(peer, person) querier_ref for the
+        # authenticated asker. Fail-open to None (fallback) on any error — a
+        # link-lookup hiccup must never break federation.
+        querier_ref: str | None = None
+        if settings.federation_identity_links_enabled and user_id is not None:
+            try:
+                from services.database import AsyncSessionLocal
+                from services.federation_identity_link import resolve_querier_ref
+                async with AsyncSessionLocal() as session:
+                    querier_ref = await resolve_querier_ref(
+                        session, peer_id=peer.id, local_user_id=user_id,
+                    )
+            except Exception as e:  # noqa: BLE001
+                logger.warning(f"Federation querier_ref resolve failed (fallback): {e}")
+
         if self._client is not None:
             # Injected client (test path) — don't own its lifecycle.
-            async for item in self._run(self._client, peer, endpoint, query_text):
+            async for item in self._run(self._client, peer, endpoint, query_text, querier_ref):
                 yield item
             return
 
@@ -147,7 +170,7 @@ class FederationQueryAsker:
             client_kwargs["verify"] = verify
 
         async with httpx.AsyncClient(**client_kwargs) as client:
-            async for item in self._run(client, peer, endpoint, query_text):
+            async for item in self._run(client, peer, endpoint, query_text, querier_ref):
                 yield item
 
     async def _run(
@@ -156,6 +179,7 @@ class FederationQueryAsker:
         peer: PeerUser,
         endpoint: str,
         query_text: str,
+        querier_ref: str | None = None,
     ) -> AsyncIterator[ProgressChunk | dict[str, Any]]:
         """Shared query loop for both owned + injected client paths."""
         # F5d — TLS cert-pin pre-flight. If the peer has a fingerprint
@@ -181,7 +205,7 @@ class FederationQueryAsker:
                 )
                 return
 
-        initiate_resp = await self._initiate(client, endpoint, query_text)
+        initiate_resp = await self._initiate(client, endpoint, query_text, querier_ref)
         if initiate_resp is None:
             yield _final_error("Peer rejected initiate")
             return
@@ -241,6 +265,7 @@ class FederationQueryAsker:
         client: httpx.AsyncClient,
         endpoint: str,
         query_text: str,
+        querier_ref: str | None = None,
     ) -> QueryBrainInitiateResponse | None:
         """Sign + POST the initiate request. Returns None on HTTP error.
 
@@ -256,7 +281,7 @@ class FederationQueryAsker:
         any specific cascade design.
         """
         my_pubkey = self.identity.public_key_hex()
-        unsigned = {
+        unsigned: dict[str, Any] = {
             "version": 2,
             "asker_pubkey": my_pubkey,
             "query": query_text,
@@ -265,6 +290,11 @@ class FederationQueryAsker:
             "depth": settings.federation_max_depth,
             "path": [my_pubkey],
         }
+        # F-ID-1: fold querier_ref into the SIGNED bytes only when set — mirrors
+        # initiate_canonical_payload's conditional inclusion so signer + verifier
+        # produce identical bytes, and a flag-off asker stays byte-identical.
+        if querier_ref is not None:
+            unsigned["querier_ref"] = querier_ref
         signature = self.identity.sign(_canonical_bytes(unsigned)).hex()
         req = QueryBrainInitiateRequest(**unsigned, signature=signature)
 

--- a/src/backend/services/federation_query_responder.py
+++ b/src/backend/services/federation_query_responder.py
@@ -299,8 +299,20 @@ class FederationQueryResponder:
         # `federation_identity_links_enabled`; a stripped/absent ref, a missing
         # link, or a NULLed local user all fail closed to the fallback below.
         # Design: docs/design/federation-identity-mapping.md.
+        # The mapped path (enforce_circles=False = run AS the local user) is only
+        # meaningful — and only SAFE — when auth is ON. Under AUTH_ENABLED=false
+        # there are no per-user circles to enforce, and enforce_circles=False
+        # would hit the single-user `return ("TRUE", {})` bypass in every
+        # retrieval module → the WHOLE brain (every member, every tier), not the
+        # mapped user's reach. That is exactly the leak the fallback path (#957)
+        # was built to prevent, so on an auth-off responder we refuse to map and
+        # serve the peer-scoped fallback instead.
         mapped_user_id: int | None = None
-        if settings.federation_identity_links_enabled and req.querier_ref:
+        if (
+            settings.federation_identity_links_enabled
+            and settings.auth_enabled
+            and req.querier_ref
+        ):
             from services.federation_identity_link import resolve_linked_user
             mapped_user_id = await resolve_linked_user(
                 self.db, peer_id=peer.id, querier_ref=req.querier_ref,

--- a/src/backend/services/federation_query_responder.py
+++ b/src/backend/services/federation_query_responder.py
@@ -292,21 +292,36 @@ class FederationQueryResponder:
 
         peer = await self._lookup_peer(req.asker_pubkey)
 
-        # Resolve the asker's local visible tier. The responder granted
-        # the asker a tier via CircleMembership when they paired (F2).
-        # Use that as `max_visible_tier`. The asker's own user_id on
-        # OUR side is the PeerUser.remote_user_id echo (cosmetic), but
-        # the actual membership lookup keys on (circle_owner_id, member_user_id).
-        # We don't have a stable remote-user-id ↔ local-user-id map, so
-        # the membership is keyed on peer.remote_user_id directly: the
-        # pairing flow wrote CircleMembership(
-        #   circle_owner_id=responder, member_user_id=remote_user_id
-        # ). Look that up.
-        asker_local_user_id = peer.remote_user_id
-        max_visible_tier = await self._resolve_asker_tier(
-            owner_user_id=peer.circle_owner_id,
-            member_user_id=peer.remote_user_id,
-        )
+        # F-ID-1 (person-scoped federation): if the envelope names a person
+        # (`querier_ref`) AND we have a link mapping it to a LOCAL user, serve
+        # the query AS that user — full circle reach (their own atoms + grants +
+        # memberships), NOT the peer-scoped public/guest fallback. Gated dark by
+        # `federation_identity_links_enabled`; a stripped/absent ref, a missing
+        # link, or a NULLed local user all fail closed to the fallback below.
+        # Design: docs/design/federation-identity-mapping.md.
+        mapped_user_id: int | None = None
+        if settings.federation_identity_links_enabled and req.querier_ref:
+            from services.federation_identity_link import resolve_linked_user
+            mapped_user_id = await resolve_linked_user(
+                self.db, peer_id=peer.id, querier_ref=req.querier_ref,
+            )
+
+        if mapped_user_id is not None:
+            # MAPPED — run as the local user with full circle semantics.
+            asker_local_user_id = mapped_user_id
+            max_visible_tier = 0          # not consulted when enforce_circles=False
+            enforce_circles = False
+        else:
+            # FALLBACK — the peer-scoped path (PR #957). The responder granted
+            # the whole peer instance a tier via CircleMembership at pairing;
+            # the asker's id on OUR side is the PeerUser.remote_user_id echo, and
+            # the membership lookup keys on (circle_owner_id, member_user_id).
+            asker_local_user_id = peer.remote_user_id
+            max_visible_tier = await self._resolve_asker_tier(
+                owner_user_id=peer.circle_owner_id,
+                member_user_id=peer.remote_user_id,
+            )
+            enforce_circles = True
 
         request_id = str(uuid.uuid4())
         await _prune_expired(now=now)
@@ -318,6 +333,7 @@ class FederationQueryResponder:
             max_visible_tier=max_visible_tier,
             query=req.query,
             initiated_at=now,
+            enforce_circles=enforce_circles,
         ))
 
         # Schedule the background work. The task is fire-and-forget —
@@ -473,13 +489,15 @@ class FederationQueryResponder:
             asker_id=pending.asker_local_user_id or 0,
             max_visible_tier=pending.max_visible_tier,
             top_k=10,
-            # FEDERATION: force peer-scoped circle enforcement regardless of
-            # settings.auth_enabled. A federated peer is never the local single
-            # user — without this, an auth-off (household) responder bypasses ALL
-            # circle filters and leaks its entire brain, and even with auth on the
-            # remote-supplied asker_id can collide with a local owner id. See
-            # PolymorphicAtomStore.query + circle_sql peer_scoped.
-            enforce_circles=True,
+            # FALLBACK (enforce_circles=True): peer-scoped circle enforcement
+            # regardless of settings.auth_enabled — a federated peer is never the
+            # local single user, so without it an auth-off responder leaks its
+            # whole brain and a colliding asker_id could hit the owner branch
+            # (PR #957 + circle_sql peer_scoped).
+            # MAPPED (enforce_circles=False, F-ID-1): the querier was identity-
+            # linked to `asker_local_user_id`, so run AS that user with full
+            # circle reach. Set in _handle_initiate; defaults True (fail-closed).
+            enforce_circles=pending.enforce_circles,
         )
 
     async def _synthesize(self, query: str, matches: list) -> str:

--- a/src/backend/services/federation_query_schemas.py
+++ b/src/backend/services/federation_query_schemas.py
@@ -115,6 +115,16 @@ class QueryBrainInitiateRequest(BaseModel):
     # as trust claims; only the envelope's `asker_pubkey` signature
     # is authoritative. Max 10 at schema level bounds path growth.
     path: list[str] = Field(default_factory=list, max_length=10)
+    # F-ID-1 (person-scoped federation) — OPTIONAL opaque per-(peer, person)
+    # token identifying WHICH person on the asker instance is querying. When
+    # present AND the responder has a matching `federation_user_links` row, the
+    # responder serves AS that mapped local user (full circle reach) instead of
+    # the peer-scoped public/guest fallback. Absent (default None) → today's
+    # fallback behavior. Signed (see initiate_canonical_payload) ONLY when set,
+    # so a flag-off asker's payload is byte-identical to pre-F-ID-1 and a
+    # stripping attack breaks the signature. Design:
+    # docs/design/federation-identity-mapping.md.
+    querier_ref: str | None = Field(default=None, max_length=128)
     signature: str = Field(..., min_length=128, max_length=128)  # hex
 
 
@@ -188,7 +198,7 @@ def initiate_canonical_payload(req: QueryBrainInitiateRequest) -> dict[str, Any]
     after the fact to bypass cycle detection / hop budget. `path` is
     encoded in order (it's a call chain, not a set).
     """
-    return {
+    payload: dict[str, Any] = {
         "version": req.version,
         "asker_pubkey": req.asker_pubkey,
         "query": req.query,
@@ -197,6 +207,14 @@ def initiate_canonical_payload(req: QueryBrainInitiateRequest) -> dict[str, Any]
         "depth": req.depth,
         "path": list(req.path),  # copy so later mutations don't alias
     }
+    # F-ID-1: include querier_ref in the signed bytes ONLY when set. Keeps a
+    # flag-off / no-person asker byte-identical to the pre-F-ID-1 payload
+    # (backward-compatible signatures), while still binding the ref under the
+    # signature when it IS sent — stripping it flips the responder's recomputed
+    # payload and fails verification.
+    if req.querier_ref is not None:
+        payload["querier_ref"] = req.querier_ref
+    return payload
 
 
 def retrieve_canonical_payload(req: QueryBrainRetrieveRequest) -> dict[str, Any]:

--- a/src/backend/services/mcp_client.py
+++ b/src/backend/services/mcp_client.py
@@ -1825,7 +1825,9 @@ class MCPManager:
         asker = FederationQueryAsker()
         final_item: dict | None = None
         try:
-            async for item in asker.query_peer(peer, query_text):
+            # F-ID-1: pass the authenticated asker so the asker side can attach
+            # the person-scoped querier_ref (dark unless the link + flag exist).
+            async for item in asker.query_peer(peer, query_text, user_id=user_id):
                 # F4c — relay ProgressChunks to the chat WS sink if one was
                 # threaded in. Enrich with stable peer identity (remote_pubkey)
                 # so the frontend can key status lines per-peer even when the

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -745,6 +745,15 @@ class Settings(BaseSettings):
     # across workers (replay defense).
     federation_pending_use_redis: bool = False
 
+    # Federation (F-ID-1 — person-scoped identity links).
+    # Default off (DARK): the responder ignores any `querier_ref` in a query
+    # envelope and always serves the peer-scoped public/guest fallback, and the
+    # asker never attaches a `querier_ref` — byte-identical to pre-F-ID-1. When
+    # on, a query whose `querier_ref` matches a `federation_user_links` row is
+    # served AS the mapped local user (full circle reach). Design:
+    # docs/design/federation-identity-mapping.md.
+    federation_identity_links_enabled: bool = False
+
     # Monitoring
     metrics_enabled: bool = False  # Enable Prometheus /metrics endpoint
 

--- a/tests/backend/test_federation_identity_link_pg.py
+++ b/tests/backend/test_federation_identity_link_pg.py
@@ -68,11 +68,15 @@ async def test_resolve_fail_closed(pg_db_session, linked_world):
 
 
 async def test_mint_is_unique_and_opaque(pg_db_session, linked_world):
-    a, b = mint_querier_ref(), mint_querier_ref()
-    assert a != b
-    assert len(a) == 64  # 32 bytes hex
-    # Not derivable from any local id.
-    assert str(linked_world["person_id"]) not in a
+    # 256-bit random hex: unique per call, fixed length, hex charset. (A
+    # substring check against a short numeric id is meaningless here — single
+    # decimal digits appear in 64-char random hex ~99% of the time; opaqueness
+    # is proven by "not derived from the id at all" = randomness + uniqueness.)
+    mints = {mint_querier_ref() for _ in range(50)}
+    assert len(mints) == 50                       # all unique
+    for m in mints:
+        assert len(m) == 64                       # 32 bytes hex
+        assert all(c in "0123456789abcdef" for c in m)
 
 
 async def test_delete_reverts_to_fallback(pg_db_session, linked_world):

--- a/tests/backend/test_federation_identity_link_pg.py
+++ b/tests/backend/test_federation_identity_link_pg.py
@@ -1,0 +1,89 @@
+"""Postgres-gated round-trip for the federation identity-link service (F-ID-1).
+
+Proves the real SQL: create a link, resolve it both ways (responder ref->user,
+asker user->ref), and confirm fail-closed on a missing ref / user. Gated on
+`RENFIELD_TEST_PG_URL` via `pg_db_session` (skipped on sqlite-only laptop runs).
+Design: docs/design/federation-identity-mapping.md.
+"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import PeerUser, Role, User
+from services.federation_identity_link import (
+    create_link,
+    delete_link,
+    mint_querier_ref,
+    resolve_linked_user,
+    resolve_querier_ref,
+)
+
+pytestmark = [pytest.mark.postgres, pytest.mark.asyncio]
+
+
+@pytest.fixture
+async def linked_world(pg_db_session: AsyncSession) -> dict:
+    role = Role(name="fed-link-role", description="t", permissions=[])
+    pg_db_session.add(role)
+    await pg_db_session.flush()
+    owner = User(username="fed-link-owner", password_hash="x", is_active=True, role_id=role.id)
+    person = User(username="fed-link-person", password_hash="x", is_active=True, role_id=role.id)
+    pg_db_session.add_all([owner, person])
+    await pg_db_session.flush()
+    peer = PeerUser(
+        circle_owner_id=owner.id, remote_pubkey="ab" * 32,
+        remote_display_name="peer", remote_user_id=555, transport_config={},
+    )
+    pg_db_session.add(peer)
+    await pg_db_session.flush()
+    return {"peer_id": peer.id, "owner_id": owner.id, "person_id": person.id}
+
+
+async def test_create_and_resolve_both_directions(pg_db_session, linked_world):
+    peer_id = linked_world["peer_id"]
+    person_id = linked_world["person_id"]
+    ref = mint_querier_ref()
+
+    link = await create_link(
+        pg_db_session, peer_id=peer_id, local_user_id=person_id,
+        querier_ref=ref, created_by=linked_world["owner_id"],
+    )
+    await pg_db_session.flush()
+    assert link.querier_ref == ref
+
+    # Responder direction: ref -> local user.
+    assert await resolve_linked_user(pg_db_session, peer_id=peer_id, querier_ref=ref) == person_id
+    # Asker direction: local user -> ref.
+    assert await resolve_querier_ref(pg_db_session, peer_id=peer_id, local_user_id=person_id) == ref
+
+
+async def test_resolve_fail_closed(pg_db_session, linked_world):
+    peer_id = linked_world["peer_id"]
+    # No ref / unknown ref / unknown user → None (fallback).
+    assert await resolve_linked_user(pg_db_session, peer_id=peer_id, querier_ref=None) is None
+    assert await resolve_linked_user(pg_db_session, peer_id=peer_id, querier_ref="nope") is None
+    assert await resolve_querier_ref(pg_db_session, peer_id=peer_id, local_user_id=None) is None
+    assert await resolve_querier_ref(pg_db_session, peer_id=peer_id, local_user_id=999999) is None
+
+
+async def test_mint_is_unique_and_opaque(pg_db_session, linked_world):
+    a, b = mint_querier_ref(), mint_querier_ref()
+    assert a != b
+    assert len(a) == 64  # 32 bytes hex
+    # Not derivable from any local id.
+    assert str(linked_world["person_id"]) not in a
+
+
+async def test_delete_reverts_to_fallback(pg_db_session, linked_world):
+    peer_id = linked_world["peer_id"]
+    person_id = linked_world["person_id"]
+    ref = mint_querier_ref()
+    link = await create_link(pg_db_session, peer_id=peer_id, local_user_id=person_id, querier_ref=ref)
+    await pg_db_session.flush()
+
+    assert await delete_link(pg_db_session, link_id=link.id) is True
+    await pg_db_session.flush()
+    assert await resolve_linked_user(pg_db_session, peer_id=peer_id, querier_ref=ref) is None
+    # Deleting a non-existent link is a no-op False.
+    assert await delete_link(pg_db_session, link_id=link.id) is False

--- a/tests/backend/test_federation_query_responder.py
+++ b/tests/backend/test_federation_query_responder.py
@@ -55,6 +55,7 @@ from services.mcp_streaming import (
     PROGRESS_LABEL_SYNTHESIZING,
 )
 from services.pairing_service import _canonical_bytes
+from utils.config import settings
 
 
 # =============================================================================
@@ -124,12 +125,15 @@ def _sign_initiate(
     timestamp: int | None = None,
     depth: int = 3,
     path: list[str] | None = None,
+    querier_ref: str | None = None,
 ) -> QueryBrainInitiateRequest:
     """Build a signed v2 initiate envelope.
 
     `path` defaults to `[asker.pubkey]` — the realistic first-hop shape
     after F5a. Tests that want to exercise cycle detection pass an
-    explicit `path` carrying the responder's own pubkey.
+    explicit `path` carrying the responder's own pubkey. `querier_ref`
+    (F-ID-1) is folded into the signed bytes ONLY when set, mirroring
+    initiate_canonical_payload's conditional inclusion.
     """
     import secrets
 
@@ -143,6 +147,8 @@ def _sign_initiate(
         "depth": depth,
         "path": path if path is not None else [my_pubkey],
     }
+    if querier_ref is not None:
+        unsigned["querier_ref"] = querier_ref
     sig = asker.sign(_canonical_bytes(unsigned)).hex()
     return QueryBrainInitiateRequest(**unsigned, signature=sig)
 
@@ -636,3 +642,119 @@ class TestEnforceCirclesOnRetrieve:
 
         assert captured["enforce_circles"] is True
         assert captured["asker_id"] == 42
+
+
+class TestPersonScopedMapping:
+    """F-ID-1: a querier_ref that maps (via federation_user_links) to a local
+    user must serve AS that user (enforce_circles=False); everything else —
+    flag off, no ref, no link — must fall back to the peer-scoped path
+    (enforce_circles=True). The pending record carries the decision."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_flag_off_ignores_querier_ref_and_falls_back(
+        self, responder_identity, asker_identity, mock_db_with_peer, monkeypatch,
+    ):
+        monkeypatch.setattr(settings, "federation_identity_links_enabled", False)
+        responder = FederationQueryResponder(db=mock_db_with_peer)
+        responder._run_query = AsyncMock()
+
+        req = _sign_initiate(asker_identity, querier_ref="deadbeef" * 8)
+        resp = await responder.handle_initiate(req)
+
+        pending = await get_pending_store().get(resp.request_id)
+        assert pending.enforce_circles is True                 # fallback
+        assert pending.asker_local_user_id == 42               # peer.remote_user_id echo
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_flag_on_no_link_falls_back(
+        self, responder_identity, asker_identity, mock_db_with_peer, monkeypatch,
+    ):
+        monkeypatch.setattr(settings, "federation_identity_links_enabled", True)
+        # resolve_linked_user is imported inside _handle_initiate — patch at source.
+        import services.federation_identity_link as fil
+        monkeypatch.setattr(fil, "resolve_linked_user", AsyncMock(return_value=None))
+
+        responder = FederationQueryResponder(db=mock_db_with_peer)
+        responder._run_query = AsyncMock()
+
+        req = _sign_initiate(asker_identity, querier_ref="deadbeef" * 8)
+        resp = await responder.handle_initiate(req)
+
+        pending = await get_pending_store().get(resp.request_id)
+        assert pending.enforce_circles is True                 # fallback
+        assert pending.asker_local_user_id == 42
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_flag_on_with_link_maps_to_local_user(
+        self, responder_identity, asker_identity, mock_db_with_peer, monkeypatch,
+    ):
+        monkeypatch.setattr(settings, "federation_identity_links_enabled", True)
+        import services.federation_identity_link as fil
+        monkeypatch.setattr(fil, "resolve_linked_user", AsyncMock(return_value=99))
+
+        responder = FederationQueryResponder(db=mock_db_with_peer)
+        responder._run_query = AsyncMock()
+
+        req = _sign_initiate(asker_identity, querier_ref="cafebabe" * 8)
+        resp = await responder.handle_initiate(req)
+
+        pending = await get_pending_store().get(resp.request_id)
+        assert pending.enforce_circles is False                # MAPPED — run as the user
+        assert pending.asker_local_user_id == 99               # the linked local user
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_no_querier_ref_never_consults_links(
+        self, responder_identity, asker_identity, mock_db_with_peer, monkeypatch,
+    ):
+        monkeypatch.setattr(settings, "federation_identity_links_enabled", True)
+        import services.federation_identity_link as fil
+        spy = AsyncMock(return_value=99)
+        monkeypatch.setattr(fil, "resolve_linked_user", spy)
+
+        responder = FederationQueryResponder(db=mock_db_with_peer)
+        responder._run_query = AsyncMock()
+
+        req = _sign_initiate(asker_identity)  # no querier_ref
+        resp = await responder.handle_initiate(req)
+
+        spy.assert_not_awaited()                               # short-circuit on empty ref
+        pending = await get_pending_store().get(resp.request_id)
+        assert pending.enforce_circles is True
+
+
+class TestQuerierRefCanonicalPayload:
+    """The querier_ref must be in the signed bytes ONLY when set — so a flag-off
+    asker's payload is byte-identical to pre-F-ID-1 (backward-compatible
+    signatures) and a stripped ref flips the verifier's recomputed payload."""
+
+    @pytest.mark.unit
+    def test_absent_querier_ref_omitted_from_payload(self, asker_identity):
+        req = _sign_initiate(asker_identity)  # no querier_ref
+        payload = initiate_canonical_payload(req)
+        assert "querier_ref" not in payload
+
+    @pytest.mark.unit
+    def test_present_querier_ref_included_in_payload(self, asker_identity):
+        req = _sign_initiate(asker_identity, querier_ref="abc123" * 4)
+        payload = initiate_canonical_payload(req)
+        assert payload["querier_ref"] == "abc123" * 4
+
+    @pytest.mark.unit
+    def test_signature_covers_querier_ref(self, asker_identity):
+        # A ref-bearing envelope verifies; stripping the ref (recompute without
+        # it) breaks verification — proving the ref is bound under the signature.
+        req = _sign_initiate(asker_identity, querier_ref="feed" * 8)
+        good = _canonical_bytes(initiate_canonical_payload(req))
+        assert FederationIdentity.verify(
+            bytes.fromhex(req.asker_pubkey), bytes.fromhex(req.signature), good
+        )
+        stripped = dict(initiate_canonical_payload(req))
+        stripped.pop("querier_ref")
+        assert not FederationIdentity.verify(
+            bytes.fromhex(req.asker_pubkey), bytes.fromhex(req.signature),
+            _canonical_bytes(stripped),
+        )

--- a/tests/backend/test_federation_query_responder.py
+++ b/tests/backend/test_federation_query_responder.py
@@ -672,6 +672,7 @@ class TestPersonScopedMapping:
         self, responder_identity, asker_identity, mock_db_with_peer, monkeypatch,
     ):
         monkeypatch.setattr(settings, "federation_identity_links_enabled", True)
+        monkeypatch.setattr(settings, "auth_enabled", True)
         # resolve_linked_user is imported inside _handle_initiate — patch at source.
         import services.federation_identity_link as fil
         monkeypatch.setattr(fil, "resolve_linked_user", AsyncMock(return_value=None))
@@ -692,6 +693,7 @@ class TestPersonScopedMapping:
         self, responder_identity, asker_identity, mock_db_with_peer, monkeypatch,
     ):
         monkeypatch.setattr(settings, "federation_identity_links_enabled", True)
+        monkeypatch.setattr(settings, "auth_enabled", True)
         import services.federation_identity_link as fil
         monkeypatch.setattr(fil, "resolve_linked_user", AsyncMock(return_value=99))
 
@@ -704,6 +706,31 @@ class TestPersonScopedMapping:
         pending = await get_pending_store().get(resp.request_id)
         assert pending.enforce_circles is False                # MAPPED — run as the user
         assert pending.asker_local_user_id == 99               # the linked local user
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_auth_off_never_maps_even_with_link(
+        self, responder_identity, asker_identity, mock_db_with_peer, monkeypatch,
+    ):
+        # SECURITY: under AUTH_ENABLED=false, enforce_circles=False would hit the
+        # single-user full-bypass and leak the WHOLE brain. The mapped path must
+        # be refused (fall back to peer-scoped) regardless of a matching link.
+        monkeypatch.setattr(settings, "federation_identity_links_enabled", True)
+        monkeypatch.setattr(settings, "auth_enabled", False)
+        import services.federation_identity_link as fil
+        spy = AsyncMock(return_value=99)
+        monkeypatch.setattr(fil, "resolve_linked_user", spy)
+
+        responder = FederationQueryResponder(db=mock_db_with_peer)
+        responder._run_query = AsyncMock()
+
+        req = _sign_initiate(asker_identity, querier_ref="cafebabe" * 8)
+        resp = await responder.handle_initiate(req)
+
+        spy.assert_not_awaited()                               # never even consults the link
+        pending = await get_pending_store().get(resp.request_id)
+        assert pending.enforce_circles is True                 # forced fallback
+        assert pending.asker_local_user_id == 42               # peer echo, not the linked user
 
     @pytest.mark.asyncio
     @pytest.mark.unit


### PR DESCRIPTION
## What

Builds **F-ID-1** of `docs/design/federation-identity-mapping.md`: a federated `query_brain` can be served **as a mapped local user** (their full circle reach) instead of the peer-scoped public/guest fallback, when the querying person is linked across the two instances. **Dark by default** (`federation_identity_links_enabled=False`) → 100% today's behavior.

## How

- **Schema** — `federation_user_links` (peer_id, `querier_ref`, local_user_id) + idempotent migration `pc20260712` (create_all-safe) + model. `querier_ref` is an opaque 256-bit token, never a raw user id (dodges the multi-peer collision class).
- **Envelope** — optional `querier_ref` on the initiate request, folded into the **signed** canonical payload **only when set** → flag-off byte-identical, and stripping it breaks the signature (`_canonical_bytes` sorts keys, so no drift).
- **Responder** — `_handle_initiate` resolves `(peer.id, querier_ref)` → local user. **Mapped** → `enforce_circles=False` as that user; **unmapped / flag-off / no-ref / auth-off** → the peer-scoped fallback from #957. Decision rides on `_PendingRequest.enforce_circles`.
- **Asker** — `query_peer` threads the authenticated `user_id` → resolves the person's `querier_ref` → attaches it. Fail-open to fallback on any error.
- **Admin API** — `/api/federation/user-links` (ADMIN-gated) to assert links (F-ID-1 "admin assertion"; F-ID-2 replaces with a consent handshake).
- **`services/federation_identity_link.py`** — resolve (both directions) + mint + CRUD.

## Security (reviewed — security + adversarial passes)

- **Trust escalation is tightly gated:** the mapped path (`enforce_circles=False`) is reachable ONLY when the flag is on, **auth is on**, `querier_ref` is truthy, AND a real link row matches for the **signature-verified** peer. `mapped_user_id` is admin-set DB data, never attacker-influenced. Peer-scoped lookup → no cross-peer ref replay.
- **Caught + fixed in review — [P1]:** the mapped path on an `AUTH_ENABLED=false` responder would hit the single-user retrieval bypass and leak the whole brain; now refused (falls back to peer-scoped) — per-user circles aren't enforceable auth-off anyway.
- Fail-open asker / fail-closed responder; signature binding of `querier_ref`; FK `SET NULL` demotes to fallback; `_from_jsonable` forward-compat for redis rolling deploys; `max_length` on the ref.

## Not in scope (separate tracks)

- **P0 prereq:** the personal instance going **auth-on** (what makes the mapped *exception* usable end-to-end).
- **F-ID-2:** the consent-signed double-login handshake to replace admin-asserted links.

## Tests

`.159` real-Postgres: responder mapped/fallback branch (incl. the auth-off leak guard), `querier_ref` signature-binding + backward-compat, PG round-trip of the link service, alembic single-head confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)