### PR TITLE
fix(federation): resolver must use is_file() not exists() (absent secret leaves a dir)

### DIFF
--- a/src/backend/services/federation_identity.py
+++ b/src/backend/services/federation_identity.py
@@ -123,7 +123,12 @@ def _resolve_key_path() -> Path:
     try:
         from utils.config import settings
         persisted = settings.federation_identity_persisted_key_path
-        if persisted and Path(persisted).exists():
+        # `.is_file()`, NOT `.exists()`: an ABSENT optional secret volume leaves a
+        # DIRECTORY at the key path (verified on the live cluster — kubelet
+        # projects an empty dir), and `.exists()` is True for a directory →
+        # loading it would IsADirectoryError. A real provisioned key is a file
+        # (a symlink-to-file for a secret projection, which is_file() follows).
+        if persisted and Path(persisted).is_file():
             return Path(persisted)
         return Path(settings.federation_identity_key_path or _DEFAULT_KEY_PATH)
     except Exception:  # noqa: BLE001 — config import must never break identity load

--- a/tests/backend/test_federation_identity.py
+++ b/tests/backend/test_federation_identity.py
@@ -92,6 +92,20 @@ class TestResolveKeyPath:
         monkeypatch.setattr(settings, "federation_identity_key_path", str(writable))
         assert _resolve_key_path() == writable
 
+    @pytest.mark.unit
+    def test_persisted_path_directory_falls_back_to_writable(self, tmp_path, monkeypatch):
+        # REGRESSION (caught in live deploy): an ABSENT optional secret volume
+        # leaves a DIRECTORY at the key path. `.exists()` is True for a dir, so the
+        # resolver MUST use `.is_file()` and fall through, else it picks the dir
+        # and loading IsADirectoryErrors.
+        init_federation_identity(None)
+        as_dir = tmp_path / "mount" / "federation_identity_key"
+        as_dir.mkdir(parents=True)  # a directory, not a file
+        writable = tmp_path / "writable_key"
+        monkeypatch.setattr(settings, "federation_identity_persisted_key_path", str(as_dir))
+        monkeypatch.setattr(settings, "federation_identity_key_path", str(writable))
+        assert _resolve_key_path() == writable
+
 
 class TestLoadOrGenerate:
     @pytest.mark.unit


### PR DESCRIPTION
Fast-follow to #960, **caught during the live PR-A deploy** (not review — both review passes reasoned `.exists()` would be False for an absent optional secret; the real cluster proved otherwise).

## Bug
`_resolve_key_path()` used `Path(persisted).exists()` to decide whether to load the mounted persisted key. But an **absent** `optional: true` secret volume mounts an **empty directory** at the key path (kubelet projects `federation_identity_key` as a dir). `.exists()` is `True` for a directory, so the two-path resolver **selected the directory** → `_load_existing` → `path.read_bytes()` → `IsADirectoryError` on first federation use.

Verified live on the household pod:
```
/app/federation-identity/federation_identity_key  → exists: True  is_file: False  is_dir: True
```

## Fix
`Path(persisted).is_file()` — a real provisioned key is a regular file (a symlink-to-file for a secret projection, which `is_file()` follows); a directory or absent path falls through to the writable generate path (correct pre-provision behavior).

## Test
+`TestResolveKeyPath::test_persisted_path_directory_falls_back_to_writable` — a directory at the persisted path resolves to the writable path. 15/15 on `.159`.

Dormant on the running household (identity is lazy-loaded; no federation activity yet, guard flag not set), so nothing is broken in prod — but this blocks the durable-key load the deploy is establishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)