### PR TITLE
feat(knowledge): expose + set document circle tier (tier-control backend)

### DIFF
--- a/src/backend/api/routes/knowledge.py
+++ b/src/backend/api/routes/knowledge.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.database import Document, KnowledgeBase, User
 from models.permissions import Permission, has_permission
+from services.atom_service import AtomService
 from services.auth_service import get_optional_user
 from services.database import get_db
 from services.progress import DocumentProgress
@@ -90,6 +91,7 @@ async def _augment_with_progress(
 
 # Import all schemas from separate file
 from .knowledge_schemas import (
+    BulkSetDocumentTierRequest,
     DocumentResponse,
     KBPermissionCreate,
     KBPermissionResponse,
@@ -101,6 +103,7 @@ from .knowledge_schemas import (
     SearchResult,
     SearchResultChunk,
     SearchResultDocument,
+    SetDocumentTierRequest,
     StatsResponse,
 )
 
@@ -508,6 +511,10 @@ def _doc_to_response_kwargs(doc: Document) -> dict:
         "knowledge_base_id": doc.knowledge_base_id,
         "created_at": doc.created_at.isoformat() if doc.created_at else "",
         "processed_at": doc.processed_at.isoformat() if doc.processed_at else None,
+        # Circle visibility for the tier-control UX. Denormalized on the
+        # documents row; atom_id may be NULL on legacy / global-RAG docs.
+        "circle_tier": doc.circle_tier or 0,
+        "atom_id": str(doc.atom_id) if doc.atom_id else None,
     }
 
 
@@ -742,6 +749,135 @@ async def move_documents(
         }
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+
+
+# =============================================================================
+# Document visibility (circle tier) — tier-control UX
+# =============================================================================
+
+async def _assert_document_tier_write(
+    doc: Document, user: User | None, db: AsyncSession
+) -> None:
+    """Owner/write gate for changing a document's circle tier.
+
+    Mirrors the established bar: a ``kb.own`` baseline (as ``move_documents``)
+    plus per-document KB write access (as ``reindex_document``). KB-less
+    (global-RAG) docs are gated by the ``kb.own`` baseline alone — there is no
+    KB ACL to consult, and tiering is owner-scoped by construction. No-op when
+    auth is disabled (single-user mode).
+    """
+    if not settings.auth_enabled:
+        return
+    if not user:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    if not has_permission(user.get_permissions(), Permission.KB_OWN):
+        raise HTTPException(status_code=403, detail="Permission required: kb.own or higher")
+    if doc.knowledge_base_id:
+        kb = (await db.execute(
+            select(KnowledgeBase).where(KnowledgeBase.id == doc.knowledge_base_id)
+        )).scalar_one_or_none()
+        if kb and not await check_kb_access(kb, user, "write", db):
+            raise HTTPException(status_code=403, detail="No write access to this document")
+
+
+async def _ensure_document_atom(doc: Document, rag: RAGService, db: AsyncSession) -> str:
+    """Resolve the document's atoms-row UUID, minting one if absent.
+
+    Normally-ingested docs already carry ``atom_id`` (set at create time), so
+    this is a no-op lookup. Legacy / KB-less docs may have ``atom_id = NULL``
+    (the ``circle_sql`` owner-branch atom fallback exists precisely for these);
+    for those we mint a ``kb_document`` atom owned by the resolved owner so the
+    tier PATCH has a real atoms row to update + cascade from. ``documents.atom_id``
+    is a nullable FK, so we pass the real ``source_id`` upfront (no placeholder
+    dance).
+    """
+    if doc.atom_id:
+        return str(doc.atom_id)
+    atom_svc = AtomService(db)
+    kb_owner: int | None = None
+    if doc.knowledge_base_id:
+        kb_owner = (await db.execute(
+            select(KnowledgeBase.owner_id).where(KnowledgeBase.id == doc.knowledge_base_id)
+        )).scalar()
+    owner = await rag._resolve_owner_user_id(kb_owner)
+    if owner is None:
+        raise HTTPException(
+            status_code=409,
+            detail="Document has no owner to attach visibility to — reindex it first",
+        )
+    atom_id = await atom_svc.create_with_source(
+        atom_type="kb_document",
+        owner_user_id=owner,
+        tier=doc.circle_tier or 0,
+        source_id=doc.id,
+    )
+    doc.atom_id = atom_id
+    await db.flush()
+    return atom_id
+
+
+@router.patch("/documents/{document_id}/tier", response_model=DocumentResponse)
+async def set_document_tier(
+    document_id: int,
+    body: SetDocumentTierRequest,
+    rag: RAGService = Depends(get_rag_service),
+    user: User | None = Depends(get_optional_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Set a document's circle tier (0 self … 4 public). Owner-gated.
+
+    Resolves (or mints) the document's ``kb_document`` atom and delegates to
+    ``AtomService.update_tier``, which cascades the new tier to the document's
+    chunks + non-overridden facts. This keeps the frontend out of the atom-UUID
+    id-space and closes the null-``atom_id`` gap the raw ``/api/atoms`` route
+    can't handle for KB-less docs.
+    """
+    doc = await rag.get_document(document_id)
+    if not doc:
+        raise HTTPException(status_code=404, detail=f"Dokument {document_id} nicht gefunden")
+    await _assert_document_tier_write(doc, user, db)
+
+    atom_id = await _ensure_document_atom(doc, rag, db)
+    await AtomService(db).update_tier(atom_id, {"tier": body.tier})
+    await db.commit()
+
+    # update_tier issues raw Core UPDATEs that don't expire ORM-tracked rows,
+    # and the session runs expire_on_commit=False — so without expiring, the
+    # re-read would return the identity-map-cached doc with its pre-update tier.
+    db.expire_all()
+    fresh = await rag.get_document(document_id)
+    return DocumentResponse(**_doc_to_response_kwargs(fresh))
+
+
+@router.post("/documents/tier")
+async def bulk_set_document_tier(
+    request: BulkSetDocumentTierRequest,
+    rag: RAGService = Depends(get_rag_service),
+    user: User | None = Depends(get_optional_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Set the circle tier for several documents at once. Owner-gated per doc.
+
+    Mirrors ``/documents/move``: a single round-trip for a bulk selection.
+    Documents the caller can't write are skipped (not fatal); missing ids are
+    skipped. Returns the count actually updated.
+    """
+    updated = 0
+    for doc_id in request.document_ids:
+        doc = await rag.get_document(doc_id)
+        if not doc:
+            continue
+        try:
+            await _assert_document_tier_write(doc, user, db)
+        except HTTPException as e:
+            if e.status_code == 401:
+                raise
+            continue  # 403 → skip this doc, keep going
+        atom_id = await _ensure_document_atom(doc, rag, db)
+        await AtomService(db).update_tier(atom_id, {"tier": request.tier})
+        updated += 1
+    await db.commit()
+    return {"message": f"{updated} Dokument(e) aktualisiert", "updated_count": updated, "tier": request.tier}
 
 
 # =============================================================================

--- a/src/backend/api/routes/knowledge_schemas.py
+++ b/src/backend/api/routes/knowledge_schemas.py
@@ -79,12 +79,30 @@ class DocumentResponse(BaseModel):
     knowledge_base_id: int | None
     created_at: str
     processed_at: str | None
+    # Circle visibility (tier-control UX). circle_tier is the document's
+    # denormalized tier (0 self … 4 public); atom_id is its atoms-row UUID
+    # (nullable for legacy / global-RAG docs that were never atom-registered).
+    # Both default so flag-off / legacy callers still serialize cleanly.
+    circle_tier: int = 0
+    atom_id: str | None = None
     # Live progress fields (#388). All three default to None so legacy
     # callers that don't augment the response (flag off path) still
     # serialize cleanly.
     stage: str | None = None
     pages: DocumentProgressPages | None = None
     queue_position: int | None = None
+
+
+class SetDocumentTierRequest(BaseModel):
+    """Set a single document's circle tier (0 self … 4 public)."""
+    tier: int = Field(..., ge=0, le=4)
+
+
+class BulkSetDocumentTierRequest(BaseModel):
+    """Set the circle tier for several documents at once (mirrors
+    MoveDocumentsRequest's bulk shape)."""
+    document_ids: list[int] = Field(..., min_length=1)
+    tier: int = Field(..., ge=0, le=4)
 
 
 # --- Search Models ---

--- a/tests/backend/test_document_tier.py
+++ b/tests/backend/test_document_tier.py
@@ -1,0 +1,96 @@
+"""Backend tests for document circle-tier control — HTTP-validation cases.
+
+These exercise the tier endpoints' request validation + response shape, which
+are backend-agnostic and run on the default (SQLite) ``async_client`` fixture:
+- ``DocumentResponse`` exposes ``circle_tier`` + ``atom_id``.
+- tier out of range → 422; missing document → 404.
+
+The tier-MUTATING cases (PATCH/bulk cascade, null-atom mint) go through
+``AtomService.update_tier``, whose ``id::text`` cast is Postgres-only, so they
+live in ``test_document_tier_pg.py`` against real Postgres.
+"""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import Document, DocumentChunk, KnowledgeBase, User
+from services.atom_service import AtomService
+
+
+async def _make_doc(
+    db: AsyncSession,
+    kb: KnowledgeBase,
+    owner: User,
+    *,
+    tier: int = 0,
+    chunks: int = 2,
+    with_atom: bool = True,
+) -> Document:
+    """Create a completed document (+ chunks), optionally with a kb_document atom."""
+    doc = Document(
+        filename="tier_doc.pdf",
+        title="Tier Doc",
+        file_path="/tmp/tier_doc.pdf",
+        file_type="pdf",
+        file_size=42,
+        status="completed",
+        chunk_count=chunks,
+        knowledge_base_id=kb.id,
+        circle_tier=tier,
+    )
+    db.add(doc)
+    await db.commit()
+    await db.refresh(doc)
+
+    for i in range(chunks):
+        db.add(DocumentChunk(
+            document_id=doc.id,
+            content=f"chunk {i} content",
+            chunk_index=i,
+            chunk_type="paragraph",
+            circle_tier=tier,
+        ))
+    await db.commit()
+
+    if with_atom:
+        atom_id = await AtomService(db).create_with_source(
+            atom_type="kb_document",
+            owner_user_id=owner.id,
+            tier=tier,
+            source_id=doc.id,
+        )
+        doc.atom_id = atom_id
+        await db.commit()
+        await db.refresh(doc)
+    return doc
+
+
+@pytest.mark.database
+async def test_tier_out_of_range_rejected(
+    db_session: AsyncSession, async_client, test_knowledge_base_with_owner, test_user
+):
+    doc = await _make_doc(db_session, test_knowledge_base_with_owner, test_user)
+    resp = await async_client.patch(
+        f"/api/knowledge/documents/{doc.id}/tier", json={"tier": 5}
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.database
+async def test_tier_missing_document_404(async_client):
+    resp = await async_client.patch(
+        "/api/knowledge/documents/999999/tier", json={"tier": 4}
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.database
+async def test_document_response_exposes_tier(
+    db_session: AsyncSession, async_client, test_knowledge_base_with_owner, test_user
+):
+    doc = await _make_doc(db_session, test_knowledge_base_with_owner, test_user, tier=2)
+    resp = await async_client.get(f"/api/knowledge/documents/{doc.id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["circle_tier"] == 2
+    assert body["atom_id"]

--- a/tests/backend/test_document_tier_pg.py
+++ b/tests/backend/test_document_tier_pg.py
@@ -1,0 +1,142 @@
+"""Document tier-control endpoints against real Postgres.
+
+The tier cascade (``AtomService.update_tier``) uses Postgres-only ``id::text``
+syntax, so the PATCH/bulk/mint paths must run against real PG. Pure HTTP
+validation (422/404/response-exposure) lives in ``test_document_tier.py``.
+
+Drives the real endpoints through an ``AsyncClient`` whose ``get_db`` is bound
+to the rolled-back ``pg_db_session`` (the endpoints' ``db.commit()`` is patched
+to ``flush`` so writes stay inside the fixture's outer transaction).
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import Atom, Document, DocumentChunk, KnowledgeBase, Role, User
+
+pytestmark = [pytest.mark.postgres, pytest.mark.asyncio]
+
+_seq = 0
+
+
+def _commit_as_flush(db, monkeypatch):
+    """The endpoints call db.commit(); make it a flush so the pg_db_session
+    outer transaction stays open and rolls back on teardown."""
+    monkeypatch.setattr(db, "commit", db.flush)
+
+
+@pytest.fixture
+async def pg_client(pg_db_session, monkeypatch):
+    from main import app
+    from services.database import get_db
+
+    _commit_as_flush(pg_db_session, monkeypatch)
+
+    async def _override():
+        yield pg_db_session
+
+    app.dependency_overrides[get_db] = _override
+    transport = ASGITransport(app=app)
+    try:
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            yield client
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+async def _make_user(db: AsyncSession, name: str) -> User:
+    role = Role(name=f"{name}_role")
+    db.add(role)
+    await db.flush()
+    u = User(username=name, email=f"{name}@ex.test", password_hash="x",
+             role_id=role.id, is_active=True)
+    db.add(u)
+    await db.flush()
+    return u
+
+
+async def _make_kb(db: AsyncSession, owner: User) -> KnowledgeBase:
+    kb = KnowledgeBase(name="Tier KB", is_active=True, owner_id=owner.id)
+    db.add(kb)
+    await db.flush()
+    return kb
+
+
+async def _make_doc(
+    db: AsyncSession, kb: KnowledgeBase, owner: User,
+    *, tier: int = 0, chunks: int = 2, with_atom: bool = True,
+) -> Document:
+    global _seq
+    _seq += 1
+    atom_id = None
+    if with_atom:
+        atom_id = f"00000000-0000-0000-0000-{_seq:012d}"
+        db.add(Atom(atom_id=atom_id, atom_type="kb_document", source_table="documents",
+                    source_id=f"doc-{_seq}", owner_user_id=owner.id, policy={"tier": tier}))
+        await db.flush()
+    doc = Document(filename="d.pdf", file_path="/x/d.pdf", status="completed",
+                   chunk_count=chunks, knowledge_base_id=kb.id, circle_tier=tier, atom_id=atom_id)
+    db.add(doc)
+    await db.flush()
+    if with_atom:
+        await db.execute(text("UPDATE atoms SET source_id = :s WHERE atom_id = :a"),
+                         {"s": str(doc.id), "a": atom_id})
+    for i in range(chunks):
+        db.add(DocumentChunk(document_id=doc.id, content=f"c{i}", chunk_index=i,
+                             chunk_type="paragraph", circle_tier=tier))
+    await db.flush()
+    return doc
+
+
+async def _chunk_tiers(db: AsyncSession, doc_id: int) -> list[int]:
+    return list((await db.execute(
+        text("SELECT circle_tier FROM document_chunks WHERE document_id = :d"),
+        {"d": doc_id})).scalars().all())
+
+
+async def test_set_document_tier_cascades_to_chunks(pg_db_session, pg_client):
+    owner = await _make_user(pg_db_session, "tc_cascade")
+    kb = await _make_kb(pg_db_session, owner)
+    doc = await _make_doc(pg_db_session, kb, owner, tier=0)
+
+    resp = await pg_client.patch(f"/api/knowledge/documents/{doc.id}/tier", json={"tier": 4})
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["circle_tier"] == 4
+    assert body["atom_id"]
+    assert await _chunk_tiers(pg_db_session, doc.id) == [4, 4]
+
+
+async def test_bulk_set_document_tier(pg_db_session, pg_client):
+    owner = await _make_user(pg_db_session, "tc_bulk")
+    kb = await _make_kb(pg_db_session, owner)
+    docs = [await _make_doc(pg_db_session, kb, owner) for _ in range(3)]
+    ids = [d.id for d in docs]
+
+    resp = await pg_client.post("/api/knowledge/documents/tier",
+                                json={"document_ids": ids, "tier": 4})
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["updated_count"] == 3
+    for d in docs:
+        assert all(t == 4 for t in await _chunk_tiers(pg_db_session, d.id))
+
+
+async def test_null_atom_document_mints_atom(pg_db_session, pg_client):
+    owner = await _make_user(pg_db_session, "tc_mint")
+    kb = await _make_kb(pg_db_session, owner)
+    doc = await _make_doc(pg_db_session, kb, owner, with_atom=False)
+    assert doc.atom_id is None
+
+    resp = await pg_client.patch(f"/api/knowledge/documents/{doc.id}/tier", json={"tier": 3})
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["atom_id"]
+    await pg_db_session.refresh(doc)
+    assert doc.atom_id is not None
+    assert doc.circle_tier == 3
+    assert all(t == 3 for t in await _chunk_tiers(pg_db_session, doc.id))


### PR DESCRIPTION
Backend slice of the document tier-control UX redesign. **Root cause the design review found:** `DocumentResponse` never carried `circle_tier`/`atom_id`, so the document list couldn't show or edit a document's visibility even in principle — the reason "make a document public" was undiscoverable (surfaced during federation testing).

## Changes
- **Expose** `circle_tier` + `atom_id` on `DocumentResponse` (mapped in the shared `_doc_to_response_kwargs` → list, batch, single GET all gain it).
- **`PATCH /api/knowledge/documents/{id}/tier`** — owner-gated (kb.own baseline + per-doc KB write, mirrors move/reindex); **resolve-or-create** the `kb_document` atom (closes the null-`atom_id` gap for KB-less/global-RAG docs) → `AtomService.update_tier` cascades the tier to the document's chunks + non-overridden facts.
- **`POST /api/knowledge/documents/tier`** — bulk, mirrors `/documents/move`; per-doc owner gate, skips forbidden/missing, returns `updated_count`.

## Bug caught by the real-PG test
The endpoint re-reads the doc for its response after `update_tier`'s raw Core `UPDATE`. With `expire_on_commit=False` (prod), the ORM identity map kept the pre-update tier, so the **response returned the stale tier** (DB was correct). Fixed with `db.expire_all()` before the re-read. This only reproduces on real Postgres — exactly why the tier-mutating tests run against `.159`'s Postgres.

## Tests (all green on .159)
- `test_document_tier.py` (SQLite): 422 out-of-range, 404 missing, response exposes tier — 3/3.
- `test_document_tier_pg.py` (real Postgres): cascade-to-chunks, bulk, null-atom mint — 3/3.

## Next slice (not in this PR)
Frontend: `.tier-ring` + always-visible clickable `TierBadge` on the document card, popover `TierPicker`, bulk "set visibility", and a warning-confirm for → Public. Plan captured (F-ID design-review output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)