### PR TITLE
feat(kiosk): live peer_status_changed delta (federation reachability)

### DIFF
--- a/src/backend/api/lifecycle.py
+++ b/src/backend/api/lifecycle.py
@@ -817,6 +817,36 @@ def _schedule_kiosk_internal_health_refresh(app):
     )
 
 
+def _schedule_kiosk_peer_status_refresh(app):
+    """Backend-internal refresher → PUSHES a ``peer_status_changed`` delta to the
+    kiosk hub when federation-peer reachability changes.
+
+    Same no-poll model as the weather + internal-health refreshers: peer
+    ``last_seen_at`` has no push of its own, so a backend timer recomputes
+    reachability and streams only actual changes to the wall displays. Diff-gated
+    in ``refresh_and_push_peer_status``; skipped when no wall display is connected.
+    """
+    from api.websocket.kiosk_data import _PEER_STATUS_REFRESH_SECONDS
+
+    async def _tick():
+        from api.websocket.kiosk_data import refresh_and_push_peer_status
+        from api.websocket.kiosk_handler import _kiosk_clients
+
+        if not _kiosk_clients:
+            return
+        await refresh_and_push_peer_status()
+
+    _spawn_periodic_task(
+        name="Kiosk peer-status refresh",
+        interval=_PEER_STATUS_REFRESH_SECONDS,
+        work=_tick,
+        started_msg=(
+            f"Kiosk peer-status refresher gestartet "
+            f"(interval={_PEER_STATUS_REFRESH_SECONDS}s)"
+        ),
+    )
+
+
 def _schedule_notification_poller(app):
     """Start the MCP notification poller for servers with notifications enabled."""
     if not settings.notification_poller_enabled:
@@ -1177,6 +1207,7 @@ async def lifespan(app: "FastAPI"):
     _schedule_obligation_calendar_sync(app)
     _schedule_kiosk_weather_refresh(app)
     _schedule_kiosk_internal_health_refresh(app)
+    _schedule_kiosk_peer_status_refresh(app)
 
     # Self-learning Phase 1: load bundled seed skills into the database.
     # Idempotent — seeds with a matching title are skipped, so re-running

--- a/src/backend/api/websocket/kiosk_data.py
+++ b/src/backend/api/websocket/kiosk_data.py
@@ -365,6 +365,93 @@ async def refresh_and_push_internal_health() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Federation-peer reachability. The peer set has no push of its own (last_seen_at
+# is written only when a remote peer queries us), so a backend timer recomputes
+# reachability and streams a ``peer_status_changed`` delta on change — closing
+# the deferred kiosk peer-liveness gap so the wall board's peer nodes go
+# green/red live instead of only on kiosk reconnect + a frontend wall-clock decay.
+# ---------------------------------------------------------------------------
+
+# A peer is "reachable" if it queried THIS instance within this many seconds.
+_PEER_REACHABLE_WITHIN_SECONDS = 300
+
+# How often the backend recomputes peer reachability for the push refresher. The
+# reachability window is 5 min; a 60s tick surfaces a peer going quiet within a
+# glance without hammering the DB.
+_PEER_STATUS_REFRESH_SECONDS = 60
+
+# Last peer list PUSHED to the kiosk hub (diff-gate). None until the first push.
+_peer_status_last_pushed: list[dict] | None = None
+
+
+def reset_peer_status_gate() -> None:
+    """Force the next refresher tick to re-push peer status (same no-client-gap
+    rationale as reset_internal_health_gate)."""
+    global _peer_status_last_pushed
+    _peer_status_last_pushed = None
+
+
+async def compute_peer_status() -> list[dict]:
+    """Content-free federation-peer reachability for the kiosk.
+
+    One node per remote identity (dedup by pubkey); ``reachable`` = the peer
+    queried THIS instance within :data:`_PEER_REACHABLE_WITHIN_SECONDS`. No
+    pubkey, no message content. Shared by the snapshot builder and the refresher.
+    """
+    from datetime import UTC
+
+    from models.database import PeerUser
+    from services.database import AsyncSessionLocal
+
+    now = datetime.now(UTC)
+    async with AsyncSessionLocal() as db:
+        rows = (
+            await db.execute(select(PeerUser).where(PeerUser.revoked_at.is_(None)))
+        ).scalars().all()
+    peers: list[dict] = []
+    seen: set = set()
+    for peer in rows:
+        # Different circle owners can pair with the same remote node; the kiosk
+        # shows one node per remote identity.
+        if peer.remote_pubkey in seen:
+            continue
+        seen.add(peer.remote_pubkey)
+        last_seen = peer.last_seen_at
+        reachable = False
+        if last_seen is not None:
+            ls = last_seen if last_seen.tzinfo else last_seen.replace(tzinfo=UTC)
+            reachable = (now - ls).total_seconds() < _PEER_REACHABLE_WITHIN_SECONDS
+        peers.append(
+            {
+                "id": peer.id,
+                "name": peer.remote_display_name,
+                "last_seen_at": last_seen.isoformat() if last_seen else None,
+                "reachable": reachable,
+            }
+        )
+    return peers
+
+
+async def refresh_and_push_peer_status() -> None:
+    """Recompute peer reachability → PUSH a ``peer_status_changed`` delta on
+    change. Diff-gated, fire-and-forget — same pattern as the internal-health and
+    weather refreshers."""
+    global _peer_status_last_pushed
+    peers = await compute_peer_status()
+    if peers == _peer_status_last_pushed:
+        return
+    try:
+        from api.websocket.kiosk_handler import broadcast_kiosk_event
+
+        await broadcast_kiosk_event({"type": "peer_status_changed", "peers": peers})
+    except Exception as e:
+        # Do NOT advance the gate on a failed broadcast (see internal-health).
+        logger.debug(f"kiosk peer_status_changed broadcast failed: {e}")
+        return
+    _peer_status_last_pushed = peers
+
+
+# ---------------------------------------------------------------------------
 # Ambient kiosk weather tile. Read-only, degrades to None (never an error) when
 # the feature is off or the source is unavailable, so the kiosk hides the tile.
 # ---------------------------------------------------------------------------

--- a/src/backend/api/websocket/kiosk_handler.py
+++ b/src/backend/api/websocket/kiosk_handler.py
@@ -52,8 +52,10 @@ each into the same reducer-held model. Every event is CONTENT-FREE.
     web-chat turn counter, so the core shows "processing" while Renfield handles
     a TYPED turn (voice already drives the core via satellite_state). Snapshot
     carries ``chat_active``.
-  * ``peer_status_changed`` — see the plan §1.4/§9; REMAINING (needs a small
-    backend-internal reachability timer — no discrete federation event exists).
+  * ``peer_status_changed`` — ``{type, peers:[…]}`` — pushed when federation-peer
+    reachability changes. A backend timer recomputes it (no discrete federation
+    event exists) and diff-pushes; the kiosk peer nodes go green/red live instead
+    of only on reconnect. See ``kiosk_data.refresh_and_push_peer_status``.
 """
 
 import asyncio
@@ -184,13 +186,6 @@ async def _broadcast_consumer() -> None:
 # Tools whose per-(user,tool) success rate is below this are "degraded" in the
 # aggregated, user-id-free kiosk health view.
 _TOOL_HEALTH_DEGRADED_BELOW = 0.5
-
-# A federation peer is shown "reachable" if it was seen within this window. The
-# snapshot has no live heartbeat probe (peer reachability transitions are a
-# later delta phase, see the plan §1.6/§9); last-seen recency is the honest
-# best-effort signal at hydrate time.
-_PEER_REACHABLE_WITHIN_SECONDS = 300
-
 
 def build_presence_payload(presence) -> dict:
     """Content-free rooms→occupant-count rollup of the live presence map.
@@ -334,40 +329,11 @@ async def build_kiosk_snapshot(app) -> dict:
         logger.debug(f"kiosk snapshot: activity unavailable: {e}")
 
     # --- Federation peers (reachability, no message content) -------------
+    # Shared with the peer_status_changed refresher so snapshot + delta agree.
     try:
-        from sqlalchemy import select
+        from api.websocket.kiosk_data import compute_peer_status
 
-        from models.database import PeerUser
-
-        now = datetime.now(UTC)
-        async with AsyncSessionLocal() as db:
-            rows = (
-                await db.execute(
-                    select(PeerUser).where(PeerUser.revoked_at.is_(None))
-                )
-            ).scalars().all()
-        peers: list[dict] = []
-        seen_peers: set = set()
-        for peer in rows:
-            # Different circle owners can pair with the same remote node; the
-            # kiosk shows one node per remote identity.
-            if peer.remote_pubkey in seen_peers:
-                continue
-            seen_peers.add(peer.remote_pubkey)
-            last_seen = peer.last_seen_at
-            reachable = False
-            if last_seen is not None:
-                ls = last_seen if last_seen.tzinfo else last_seen.replace(tzinfo=UTC)
-                reachable = (now - ls).total_seconds() < _PEER_REACHABLE_WITHIN_SECONDS
-            peers.append(
-                {
-                    "id": peer.id,
-                    "name": peer.remote_display_name,
-                    "last_seen_at": last_seen.isoformat() if last_seen else None,
-                    "reachable": reachable,
-                }
-            )
-        snapshot["peers"] = peers
+        snapshot["peers"] = await compute_peer_status()
     except Exception as e:
         logger.debug(f"kiosk snapshot: peers unavailable: {e}")
 
@@ -456,9 +422,10 @@ async def kiosk_live(
     # Reset the internal-health diff-gate so the next refresher tick re-pushes the
     # current verdicts — the gate isn't advanced while no kiosk is connected, so
     # it can hold a stale pre-gap value that would otherwise suppress a real delta.
-    from api.websocket.kiosk_data import reset_internal_health_gate
+    from api.websocket.kiosk_data import reset_internal_health_gate, reset_peer_status_gate
 
     reset_internal_health_gate()
+    reset_peer_status_gate()
     logger.info(f"🖥️ Kiosk display connected ({len(_kiosk_clients)} total)")
 
     try:

--- a/src/frontend/src/components/kiosk/useKioskSocket.ts
+++ b/src/frontend/src/components/kiosk/useKioskSocket.ts
@@ -222,6 +222,11 @@ interface InternalHealthChangedDelta {
   subsystems?: KioskInternalHealth[];
 }
 
+interface PeerStatusChangedDelta {
+  type: 'peer_status_changed';
+  peers?: KioskPeer[];
+}
+
 interface TurnActivityDelta {
   type: 'turn_activity';
   role: string;
@@ -240,6 +245,7 @@ type KioskMessage =
   | ToolHealthChangedDelta
   | WeatherUpdatedDelta
   | InternalHealthChangedDelta
+  | PeerStatusChangedDelta
   | TurnActivityDelta
   | ChatActivityDelta
   | { type: string; [key: string]: unknown };
@@ -437,6 +443,13 @@ function reduce(state: KioskLiveModel, msg: KioskMessage): KioskLiveModel {
       // change (diff-gated), so we never merge partial verdicts.
       const delta = msg as InternalHealthChangedDelta;
       return { ...state, internalHealth: foldInternalHealth(delta.subsystems) };
+    }
+
+    case 'peer_status_changed': {
+      // Full replace — backend diff-pushes the whole peer set on any reachability
+      // change, so peer nodes go green/red live instead of only on reconnect.
+      const delta = msg as PeerStatusChangedDelta;
+      return { ...state, peers: delta.peers ?? [] };
     }
 
     case 'chat_activity': {

--- a/tests/backend/test_kiosk_handler.py
+++ b/tests/backend/test_kiosk_handler.py
@@ -375,6 +375,10 @@ async def test_snapshot_shape_with_all_sources_down(monkeypatch):
     # Force the tool-health / activity / peers / weather / now-playing sources
     # to their degraded empty branches by making their imports/queries fail.
     monkeypatch.setattr(kiosk, "AsyncSessionLocal", _boom, raising=True)
+    # Peers moved to the shared kiosk_data.compute_peer_status (its own session,
+    # not kiosk.AsyncSessionLocal), so neutralize it explicitly for the no-db path.
+    import api.websocket.kiosk_data as kiosk_data
+    monkeypatch.setattr(kiosk_data, "compute_peer_status", _boom, raising=True)
 
     snap = await build_kiosk_snapshot(_FakeApp())
 

--- a/tests/backend/test_kiosk_peer_status.py
+++ b/tests/backend/test_kiosk_peer_status.py
@@ -1,0 +1,68 @@
+"""Kiosk peer-status refresher — the diff-gated ``peer_status_changed`` delta.
+
+Closes the deferred kiosk peer-liveness gap: a backend timer recomputes
+federation-peer reachability and pushes only on change, so the wall board's
+peer nodes go green/red live instead of only on reconnect.
+"""
+from __future__ import annotations
+
+import pytest
+
+import api.websocket.kiosk_data as kiosk_data
+import api.websocket.kiosk_handler as handler
+from api.websocket.kiosk_data import refresh_and_push_peer_status, reset_peer_status_gate
+
+pytestmark = pytest.mark.asyncio
+
+
+def _stub_peers(monkeypatch, seq):
+    """compute_peer_status returns successive values from `seq` (last repeats)."""
+    calls = {"i": 0}
+
+    async def _compute():
+        v = seq[min(calls["i"], len(seq) - 1)]
+        calls["i"] += 1
+        return v
+
+    monkeypatch.setattr(kiosk_data, "compute_peer_status", _compute)
+
+
+async def test_diff_gate_pushes_only_on_change(monkeypatch):
+    pushed = []
+
+    async def _capture(ev):
+        pushed.append(ev)
+
+    monkeypatch.setattr(handler, "broadcast_kiosk_event", _capture)
+    kiosk_data._peer_status_last_pushed = None
+
+    offline = [{"id": 1, "name": "xidra", "last_seen_at": None, "reachable": False}]
+    online = [{"id": 1, "name": "xidra", "last_seen_at": "2026-07-13T00:00:00+00:00", "reachable": True}]
+    _stub_peers(monkeypatch, [offline, offline, online])
+
+    await refresh_and_push_peer_status()  # first → push
+    await refresh_and_push_peer_status()  # unchanged → no push
+    await refresh_and_push_peer_status()  # reachability flipped → push
+
+    assert len(pushed) == 2
+    assert pushed[0]["type"] == "peer_status_changed"
+    assert pushed[0]["peers"] == offline
+    assert pushed[1]["peers"] == online
+
+
+async def test_failed_broadcast_does_not_advance_gate(monkeypatch):
+    async def _flaky(ev):
+        raise RuntimeError("ws down")
+
+    monkeypatch.setattr(handler, "broadcast_kiosk_event", _flaky)
+    kiosk_data._peer_status_last_pushed = None
+    _stub_peers(monkeypatch, [[{"id": 1, "name": "x", "last_seen_at": None, "reachable": False}]])
+
+    await refresh_and_push_peer_status()  # broadcast raises → gate must NOT advance
+    assert kiosk_data._peer_status_last_pushed is None
+
+
+async def test_reset_gate_forces_repush(monkeypatch):
+    kiosk_data._peer_status_last_pushed = [{"id": 1}]
+    reset_peer_status_gate()
+    assert kiosk_data._peer_status_last_pushed is None


### PR DESCRIPTION
Closes the deferred kiosk peer-liveness gap. Federation-peer `last_seen_at` has no push of its own, so the kiosk's peer nodes only refreshed on reconnect + a frontend wall-clock decay — a freshly-paired idle peer read as offline/red with no live transition (confirmed while wiring up the household↔xidra pairing).

## Changes
- **kiosk_data:** `compute_peer_status()` extracted from the snapshot builder (snapshot + delta now share one source, DRY) + `refresh_and_push_peer_status()` diff-gated broadcast + `reset_peer_status_gate()` — same pattern as the internal-health/weather refreshers.
- **kiosk_handler:** snapshot uses the shared compute; reset the peer gate on kiosk connect (no-client-gap reconciliation); the dead `_PEER_REACHABLE` constant moved to kiosk_data; doc comment updated (no longer "REMAINING").
- **lifecycle:** `_schedule_kiosk_peer_status_refresh` — 60s, `_kiosk_clients`-gated (no work when no wall display is connected).
- **frontend:** `peer_status_changed` reducer case (full-replace peers) + type.

Peer nodes now go green/red **live** instead of only on reconnect.

## Tests (3/3 green on .159)
diff-gate pushes only on change · failed broadcast does NOT advance the gate · reset re-emits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)