### PR TITLE
feat(projects): business-instance Phase 1 — Project model + per-project KB + CRUD

### DIFF
--- a/src/backend/alembic/versions/pc20260713_projects.py
+++ b/src/backend/alembic/versions/pc20260713_projects.py
@@ -1,0 +1,68 @@
+"""projects — business-instance Phase 1 (minimal Project model + 1:1 KB)
+
+Revision ID: pc20260713_projects
+Revises: pc20260712_federation_user_links
+Create Date: 2026-07-13
+
+A lightweight ``projects`` table: each row owns exactly ONE KnowledgeBase via
+``knowledge_base_id`` (1:1, enforced in services/project_service.py). Gated by
+``settings.projects_enabled``; the household instance leaves the feature off.
+Design: the business-instance plan (§3 + §7.1).
+
+Idempotency: every DDL op is guarded — Base.metadata.create_all (backend boot)
+creates this table for a new model, so re-running this migration must be a no-op
+(same pattern as pc20260712_federation_user_links). Fully transactional
+(transaction_per_migration).
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "pc20260713_projects"
+down_revision = "pc20260712_federation_user_links"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "projects" not in existing_tables:
+        op.create_table(
+            "projects",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("name", sa.String(255), nullable=False),
+            sa.Column("description", sa.Text(), nullable=True),
+            # SET NULL so deleting a user demotes the project to unowned rather
+            # than blocking the delete (mirrors knowledge_bases.owner_id semantics).
+            sa.Column(
+                "owner_id", sa.Integer(),
+                sa.ForeignKey("users.id", ondelete="SET NULL"), nullable=True,
+            ),
+            # The project's dedicated KnowledgeBase (1:1). SET NULL so dropping a
+            # KB out of band never blocks; the service always links a fresh KB.
+            sa.Column(
+                "knowledge_base_id", sa.Integer(),
+                sa.ForeignKey("knowledge_bases.id", ondelete="SET NULL"), nullable=True,
+            ),
+            sa.Column("circle_tier", sa.Integer(), nullable=False, server_default="2"),
+            sa.Column("status", sa.String(50), nullable=False, server_default="active"),
+            sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        )
+
+    def _has_idx(idx_name: str) -> bool:
+        if "projects" not in existing_tables:
+            return False
+        return idx_name in {ix["name"] for ix in inspector.get_indexes("projects")}
+
+    if not _has_idx("ix_projects_owner_id"):
+        op.create_index("ix_projects_owner_id", "projects", ["owner_id"])
+    if not _has_idx("ix_projects_knowledge_base_id"):
+        op.create_index("ix_projects_knowledge_base_id", "projects", ["knowledge_base_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_projects_knowledge_base_id", table_name="projects")
+    op.drop_index("ix_projects_owner_id", table_name="projects")
+    op.drop_table("projects")

--- a/src/backend/api/routes/config.py
+++ b/src/backend/api/routes/config.py
@@ -71,6 +71,9 @@ class FeatureFlags(BaseModel):
     # fork_from_message_id. The conversation tree + active-path query are always
     # on. See utils/config.py::chat_branching_enabled.
     chat_branching_enabled: bool
+    # Gates the /projects nav + page (business-instance Phase 1). Off => no
+    # Projects nav entry rendered. See utils/config.py::projects_enabled.
+    projects_enabled: bool
     # True when the Reva-only Wissensbasis surface (/trace + /me/mix) is mounted
     # (Reva adapter present). Standalone Renfield => False. Lets the frontend
     # hide the Reva-only side panels without probing an endpoint that 404s.
@@ -92,5 +95,6 @@ async def get_features(
         artifacts_typed_enabled=settings.artifacts_typed_enabled,
         room_handoff_enabled=settings.room_handoff_enabled,
         chat_branching_enabled=settings.chat_branching_enabled,
+        projects_enabled=settings.projects_enabled,
         wissensbasis_reva_available=_reva_wissensbasis_mounted(request),
     )

--- a/src/backend/api/routes/projects.py
+++ b/src/backend/api/routes/projects.py
@@ -1,0 +1,164 @@
+"""Projects API — business-instance Phase 1.
+
+Minimal CRUD over the ``Project`` model: create a project (+ its dedicated 1:1
+KnowledgeBase), list/get owner-scoped, delete the project row. Ingest-to-project
+then just targets the project's KB via the existing knowledge routes, so a
+project becomes usable for chat/doc-based history immediately.
+
+Gated by ``settings.projects_enabled`` — every route 404s when off, so the
+household instance never exposes this surface. Owner-scoped when auth is on;
+auth-disabled single-user mode sees all (mirrors the Circles-v1 pattern).
+
+Meetings, timeline, and the minutes pipeline are later phases (business-instance
+plan §7) and are NOT here.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import Project, User
+from services.auth_service import get_optional_user
+from services.database import get_db
+from services.project_service import create_project, document_count_for_kb
+from utils.config import settings
+
+router = APIRouter()
+
+
+def _require_enabled() -> None:
+    """404 the whole surface when the feature flag is off."""
+    if not settings.projects_enabled:
+        raise HTTPException(status_code=404, detail="Projects feature is not enabled")
+
+
+class ProjectCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+    description: str | None = None
+    # Circles tier for team/project access; default 2 = household/team.
+    circle_tier: int = Field(default=2, ge=0, le=4)
+
+
+class ProjectResponse(BaseModel):
+    id: int
+    name: str
+    description: str | None
+    owner_id: int | None
+    knowledge_base_id: int | None
+    circle_tier: int
+    status: str
+    created_at: str
+    document_count: int
+
+
+async def _to_response(db: AsyncSession, project: Project) -> ProjectResponse:
+    return ProjectResponse(
+        id=project.id,
+        name=project.name,
+        description=project.description,
+        owner_id=project.owner_id,
+        knowledge_base_id=project.knowledge_base_id,
+        circle_tier=project.circle_tier,
+        status=project.status,
+        created_at=project.created_at.isoformat() if project.created_at else "",
+        document_count=await document_count_for_kb(db, project.knowledge_base_id),
+    )
+
+
+@router.post("", response_model=ProjectResponse)
+async def create_project_route(
+    data: ProjectCreate,
+    user: User | None = Depends(get_optional_user),
+    db: AsyncSession = Depends(get_db),
+) -> ProjectResponse:
+    """Create a project and its dedicated (1:1) KnowledgeBase.
+
+    Auth on → the authenticated user owns both rows. Auth off → single-user
+    mode, owner_id is left NULL (mirrors ``POST /api/knowledge/bases``).
+    """
+    _require_enabled()
+    if settings.auth_enabled and not user:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    project = await create_project(
+        db,
+        name=data.name,
+        description=data.description,
+        owner_id=user.id if user else None,
+        circle_tier=data.circle_tier,
+    )
+    return await _to_response(db, project)
+
+
+@router.get("", response_model=list[ProjectResponse])
+async def list_projects_route(
+    user: User | None = Depends(get_optional_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[ProjectResponse]:
+    """List projects. Owner-scoped when auth is on; auth-off single-user sees all."""
+    _require_enabled()
+
+    stmt = select(Project).order_by(Project.created_at.desc())
+    if settings.auth_enabled:
+        if not user:
+            return []
+        stmt = stmt.where(Project.owner_id == user.id)
+
+    result = await db.execute(stmt)
+    projects = result.scalars().all()
+    return [await _to_response(db, p) for p in projects]
+
+
+async def _get_owned_project(
+    project_id: int, user: User | None, db: AsyncSession
+) -> Project:
+    """Fetch a project, enforcing owner scoping. 404 when missing OR not the
+    caller's (owner-gated 404 — never leak existence). Auth off => any project."""
+    project = await db.get(Project, project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    if settings.auth_enabled:
+        if not user:
+            raise HTTPException(status_code=401, detail="Authentication required")
+        if project.owner_id != user.id:
+            raise HTTPException(status_code=404, detail="Project not found")
+    return project
+
+
+@router.get("/{project_id}", response_model=ProjectResponse)
+async def get_project_route(
+    project_id: int,
+    user: User | None = Depends(get_optional_user),
+    db: AsyncSession = Depends(get_db),
+) -> ProjectResponse:
+    """Get one project (owner-gated 404)."""
+    _require_enabled()
+    project = await _get_owned_project(project_id, user, db)
+    return await _to_response(db, project)
+
+
+@router.delete("/{project_id}")
+async def delete_project_route(
+    project_id: int,
+    user: User | None = Depends(get_optional_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Delete the project row only (owner-gated 404).
+
+    Deliberately does NOT delete the linked KnowledgeBase or its documents —
+    the KB and its ingested history are kept so a project delete is never a
+    silent data-loss of the corpus. Detach/cleanup of the KB is a later phase.
+    """
+    _require_enabled()
+    project = await _get_owned_project(project_id, user, db)
+    kb_id = project.knowledge_base_id
+    await db.delete(project)
+    await db.commit()
+    return {
+        "message": "Project deleted",
+        "id": project_id,
+        "knowledge_base_id": kb_id,
+        "knowledge_base_retained": True,
+    }

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -36,6 +36,7 @@ from api.routes import (
     memory,
     notifications,
     preferences,
+    projects,
     roles,
     skills,
     speakers,
@@ -192,6 +193,7 @@ app.include_router(folder_ingest.router, prefix="/api/folder-ingest", tags=["Fol
 app.include_router(email_ingest.router, prefix="/api/email-ingest", tags=["Email Ingest"])
 app.include_router(memory.router, prefix="/api/memory", tags=["Memory"])
 app.include_router(preferences.router, prefix="/api/preferences", tags=["Preferences"])
+app.include_router(projects.router, prefix="/api/projects", tags=["Projects"])
 app.include_router(mcp_routes.router, prefix="/api/mcp", tags=["MCP"])
 app.include_router(intents.router, prefix="/api/intents", tags=["Intents"])
 app.include_router(feedback.router, prefix="/api/feedback", tags=["Feedback"])

--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -311,6 +311,40 @@ class KnowledgeBase(Base):
     # legacy permissions by creating one grant per (chunk, user, permission).
 
 
+class Project(Base):
+    """Business-instance project (Phase 1).
+
+    A lightweight container that owns exactly ONE KnowledgeBase (``knowledge_base_id``,
+    1:1 — enforced in ``services/project_service.py``), giving a project its own
+    tier-scoped document/chat history for RAG. Meetings, timeline, and the
+    minutes pipeline are later phases (business-instance plan §7) and are NOT
+    modelled here.
+
+    Gated by ``settings.projects_enabled``; the household instance leaves it off.
+    """
+    __tablename__ = "projects"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(255), nullable=False)
+    description = Column(Text, nullable=True)
+
+    # Ownership (nullable for auth-disabled single-user deploys, mirrors KnowledgeBase).
+    owner_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True)
+
+    # The project's dedicated KnowledgeBase (1:1). Nullable so a half-built row is
+    # never a hard failure; the service always links a fresh KB on create.
+    knowledge_base_id = Column(Integer, ForeignKey("knowledge_bases.id", ondelete="SET NULL"), nullable=True, index=True)
+
+    # Circles v1 tier for team/project access. Default 2 = household/team.
+    circle_tier = Column(Integer, nullable=False, default=2)
+
+    status = Column(String(50), nullable=False, default="active")
+
+    created_at = Column(DateTime, default=_utcnow)
+
+    knowledge_base = relationship("KnowledgeBase", foreign_keys=[knowledge_base_id])
+
+
 class Document(Base):
     """Hochgeladene Dokumente (Metadaten)"""
     __tablename__ = "documents"

--- a/src/backend/services/project_service.py
+++ b/src/backend/services/project_service.py
@@ -1,0 +1,67 @@
+"""Project service — business-instance Phase 1.
+
+Owns the one invariant that the CRUD route must not get wrong: **each Project
+gets exactly ONE fresh KnowledgeBase**, owned by the project's creator and
+tier-scoped to the project's ``circle_tier``. Meetings / timeline / minutes are
+later phases (business-instance plan §7) and live
+nowhere in here.
+
+``KnowledgeBase.name`` is UNIQUE, so the per-project KB name embeds the freshly
+minted project id (guaranteed unique) to avoid a collision on same-named projects.
+"""
+from __future__ import annotations
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import Document, KnowledgeBase, Project
+
+
+async def create_project(
+    db: AsyncSession,
+    *,
+    name: str,
+    description: str | None,
+    owner_id: int | None,
+    circle_tier: int,
+    status: str = "active",
+) -> Project:
+    """Create a Project and its dedicated (1:1) KnowledgeBase, then link them.
+
+    The project row is flushed first so its id can seed the unique KB name.
+    Commits once at the end; the caller gets a refreshed row with
+    ``knowledge_base_id`` populated.
+    """
+    project = Project(
+        name=name,
+        description=description,
+        owner_id=owner_id,
+        circle_tier=circle_tier,
+        status=status,
+    )
+    db.add(project)
+    await db.flush()  # assign project.id for the unique KB name
+
+    kb = KnowledgeBase(
+        name=f"Projekt: {name} #{project.id}",
+        description=f"Wissensbasis für Projekt '{name}'",
+        owner_id=owner_id,
+        default_circle_tier=circle_tier,
+    )
+    db.add(kb)
+    await db.flush()  # assign kb.id
+
+    project.knowledge_base_id = kb.id
+    await db.commit()
+    await db.refresh(project)
+    return project
+
+
+async def document_count_for_kb(db: AsyncSession, kb_id: int | None) -> int:
+    """Count documents in a project's KnowledgeBase (0 when the KB is unset)."""
+    if kb_id is None:
+        return 0
+    result = await db.execute(
+        select(func.count(Document.id)).where(Document.knowledge_base_id == kb_id)
+    )
+    return int(result.scalar_one() or 0)

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -456,6 +456,12 @@ class Settings(BaseSettings):
     # backfill makes flag-off byte-identical to pre-branching. Ships dark; flip
     # without a rebuild. See docs/design/chat-ui-modernization.md.
     chat_branching_enabled: bool = False
+    # Business-instance Projects — Phase 1: a minimal Project model +
+    # one KnowledgeBase per project + CRUD. Gates BOTH the backend /api/projects
+    # routes (404 when off) and the frontend /projects nav (exposed via
+    # /api/config/features). Off => the household instance is byte-identical.
+    # See the business-instance plan §7.1.
+    projects_enabled: bool = False
     # Chat artifacts Lane B (free-form HTML/SVG in a sandboxed iframe). DEFERRED —
     # NOT wired to anything in this delivery. Placeholder so the per-lane flag
     # split (§8 Q5) exists; defaults off and requires its own security review

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import { queryClient } from './api/queryClient';
 
 // Lazy-loaded admin/secondary pages
 const TasksPage = lazy(() => import('./pages/TasksPage'));
+const ProjectsPage = lazy(() => import('./pages/ProjectsPage'));
 const CameraPage = lazy(() => import('./pages/CameraPage'));
 const HomeAssistantPage = lazy(() => import('./pages/HomeAssistantPage'));
 const SpeakersPage = lazy(() => import('./pages/SpeakersPage'));
@@ -60,6 +61,9 @@ function AppRoutes() {
   // safe default, so a slow/failed flag fetch never breaks navigation.
   const { data: featureFlags } = useFeatureFlags();
   const wissenWorkspace = featureFlags?.wissen_workspace_enabled ?? false;
+  // Business-instance Phase 1: the /projects surface is gated by a runtime flag
+  // (/api/config/features). Off (the household default) => the route is absent.
+  const projectsEnabled = featureFlags?.projects_enabled ?? false;
 
   return (
     <Routes>
@@ -86,6 +90,13 @@ function AppRoutes() {
             } />
             <Route path="/chat" element={<Navigate to="/" replace />} />
             <Route path="/tasks" element={<TasksPage />} />
+            {projectsEnabled && (
+              <Route path="/projects" element={
+                <ProtectedRoute>
+                  <ProjectsPage />
+                </ProtectedRoute>
+              } />
+            )}
             {isFeatureEnabled('cameras') && (
               <Route path="/camera" element={
                 <ProtectedRoute permission={['cam.view', 'cam.full']} requireAny>

--- a/src/frontend/src/api/keys.ts
+++ b/src/frontend/src/api/keys.ts
@@ -116,6 +116,11 @@ export const keys = {
     all: ['tasks'] as const,
     list: (filter?: string) => ['tasks', 'list', { filter }] as const,
   },
+  projects: {
+    all: ['projects'] as const,
+    list: () => ['projects', 'list'] as const,
+    detail: (id: number) => ['projects', 'detail', id] as const,
+  },
   cameras: {
     all: ['cameras'] as const,
     list: () => ['cameras', 'list'] as const,

--- a/src/frontend/src/api/resources/brain.ts
+++ b/src/frontend/src/api/resources/brain.ts
@@ -107,6 +107,8 @@ export interface FeatureFlags {
   room_handoff_enabled: boolean;
   /** Gates the chat message-branching UI (edit/regenerate per-message fork actions). */
   chat_branching_enabled: boolean;
+  /** Gates the /projects nav + page (business-instance Phase 1). */
+  projects_enabled: boolean;
   /** True when the Reva-only Wissensbasis surface (/trace + /me/mix) is mounted.
    *  Standalone Renfield => false. Lets the frontend hide the Reva-only side
    *  panels without probing an endpoint that 404s (console-noise fix). */

--- a/src/frontend/src/api/resources/projects.ts
+++ b/src/frontend/src/api/resources/projects.ts
@@ -1,0 +1,76 @@
+import { useQueryClient } from '@tanstack/react-query';
+
+import apiClient from '../../utils/axios';
+import { useApiQuery, useApiMutation } from '../hooks';
+import { keys, STALE } from '../keys';
+
+/** A business-instance project (Phase 1). Mirrors ProjectResponse in
+ *  api/routes/projects.py. Each project owns exactly one KnowledgeBase. */
+export interface Project {
+  id: number;
+  name: string;
+  description: string | null;
+  owner_id: number | null;
+  knowledge_base_id: number | null;
+  circle_tier: number;
+  status: string;
+  created_at: string;
+  document_count: number;
+}
+
+export interface ProjectInput {
+  name: string;
+  description?: string | null;
+  circle_tier?: number;
+}
+
+async function fetchProjects(): Promise<Project[]> {
+  const response = await apiClient.get<Project[]>('/api/projects');
+  return Array.isArray(response.data) ? response.data : [];
+}
+
+async function createProjectRequest(input: ProjectInput): Promise<Project> {
+  const response = await apiClient.post<Project>('/api/projects', input);
+  return response.data;
+}
+
+async function deleteProjectRequest(id: number): Promise<void> {
+  await apiClient.delete(`/api/projects/${id}`);
+}
+
+export function useProjectsQuery() {
+  return useApiQuery(
+    {
+      queryKey: keys.projects.list(),
+      queryFn: fetchProjects,
+      staleTime: STALE.DEFAULT,
+    },
+    'projects.failedToLoad',
+  );
+}
+
+export function useCreateProject() {
+  const queryClient = useQueryClient();
+  return useApiMutation(
+    {
+      mutationFn: createProjectRequest,
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: keys.projects.all });
+      },
+    },
+    'projects.failedToSave',
+  );
+}
+
+export function useDeleteProject() {
+  const queryClient = useQueryClient();
+  return useApiMutation(
+    {
+      mutationFn: deleteProjectRequest,
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: keys.projects.all });
+      },
+    },
+    'projects.failedToDelete',
+  );
+}

--- a/src/frontend/src/components/Layout.tsx
+++ b/src/frontend/src/components/Layout.tsx
@@ -39,6 +39,7 @@ import {
   ClipboardList,
   Hammer,
   Radar,
+  FolderKanban,
 } from 'lucide-react';
 import DeviceStatus from './DeviceStatus';
 import ThemeToggle from './ThemeToggle';
@@ -180,8 +181,12 @@ export default function Layout({ children }: LayoutProps) {
   // legacy flat nav. The flag resolving late just reveals the collapse once.
   const { data: featureFlags } = useFeatureFlags();
   const wissenWorkspace = featureFlags?.wissen_workspace_enabled ?? false;
+  // Business-instance Phase 1: append the Projects entry only when the runtime flag is on.
+  // Gated off the typed /api/config/features flag (NOT item.feature — the
+  // AuthContext feature map defaults missing keys to true, so it can't hide it).
+  const projectsEnabled = featureFlags?.projects_enabled ?? false;
 
-  const mainNavSource: NavItemConfig[] = wissenWorkspace
+  const baseMainNav: NavItemConfig[] = wissenWorkspace
     ? (() => {
         const out: NavItemConfig[] = [];
         let inserted = false;
@@ -198,6 +203,10 @@ export default function Layout({ children }: LayoutProps) {
         return out;
       })()
     : mainNavigationConfig;
+
+  const mainNavSource: NavItemConfig[] = projectsEnabled
+    ? [...baseMainNav, { nameKey: 'nav.projects', href: '/projects', icon: FolderKanban }]
+    : baseMainNav;
 
   const mainNavigation: NavItem[] = mainNavSource.map((item) => ({
     ...item,

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -35,6 +35,7 @@
     "chat": "Chat",
     "knowledge": "Wissen",
     "tasks": "Aufgaben",
+    "projects": "Projekte",
     "cameras": "Kameras",
     "rooms": "Räume",
     "speakers": "Sprecher",
@@ -572,6 +573,24 @@
     "reviewBucketFailed": "Überprüfungs-Warteschlange konnte nicht geladen werden.",
     "promoteFailed": "Übernahme fehlgeschlagen.",
     "dismissFailed": "Verwerfen fehlgeschlagen."
+  },
+  "projects": {
+    "title": "Projekte",
+    "subtitle": "Projekte anlegen und deren Wissensbasis verwalten",
+    "createTitle": "Neues Projekt anlegen",
+    "namePlaceholder": "Projektname",
+    "descriptionPlaceholder": "Beschreibung (optional)",
+    "create": "Projekt anlegen",
+    "creating": "Wird angelegt...",
+    "loading": "Lade Projekte...",
+    "noProjects": "Keine Projekte vorhanden",
+    "noProjectsDesc": "Lege ein Projekt an, um eine eigene Wissensbasis und Verlauf zu erhalten.",
+    "documentCount": "{{count}} Dokumente",
+    "documentCount_one": "{{count}} Dokument",
+    "created": "Erstellt",
+    "failedToLoad": "Projekte konnten nicht geladen werden",
+    "failedToSave": "Projekt konnte nicht gespeichert werden",
+    "failedToDelete": "Projekt konnte nicht gelöscht werden"
   },
   "tasks": {
     "title": "Aufgaben",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -35,6 +35,7 @@
     "chat": "Chat",
     "knowledge": "Knowledge",
     "tasks": "Tasks",
+    "projects": "Projects",
     "cameras": "Cameras",
     "rooms": "Rooms",
     "speakers": "Speakers",
@@ -572,6 +573,24 @@
     "reviewBucketFailed": "Could not load the review queue.",
     "promoteFailed": "Promotion failed.",
     "dismissFailed": "Dismiss failed."
+  },
+  "projects": {
+    "title": "Projects",
+    "subtitle": "Create projects and manage their knowledge base",
+    "createTitle": "Create a new project",
+    "namePlaceholder": "Project name",
+    "descriptionPlaceholder": "Description (optional)",
+    "create": "Create project",
+    "creating": "Creating...",
+    "loading": "Loading projects...",
+    "noProjects": "No projects yet",
+    "noProjectsDesc": "Create a project to give it its own knowledge base and history.",
+    "documentCount": "{{count}} documents",
+    "documentCount_one": "{{count}} document",
+    "created": "Created",
+    "failedToLoad": "Could not load projects",
+    "failedToSave": "Could not save project",
+    "failedToDelete": "Could not delete project"
   },
   "tasks": {
     "title": "Tasks",

--- a/src/frontend/src/pages/ProjectsPage.tsx
+++ b/src/frontend/src/pages/ProjectsPage.tsx
@@ -1,0 +1,125 @@
+import { useState, type FormEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { FolderKanban, FileText, Loader, XCircle, Plus } from 'lucide-react';
+
+import PageHeader from '../components/PageHeader';
+import TierBadge from '../components/TierBadge';
+import { useProjectsQuery, useCreateProject } from '../api/resources/projects';
+
+export default function ProjectsPage() {
+  const { t } = useTranslation();
+  const projectsQuery = useProjectsQuery();
+  const createProject = useCreateProject();
+  const projects = projectsQuery.data ?? [];
+
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed || createProject.isPending) return;
+    try {
+      await createProject.mutateAsync({ name: trimmed, description: description.trim() || null });
+      setName('');
+      setDescription('');
+    } catch {
+      // Error is surfaced via createProject.errorMessage; keep the form filled.
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        icon={FolderKanban}
+        title={t('projects.title')}
+        subtitle={t('projects.subtitle')}
+      />
+
+      {/* Create form */}
+      <form onSubmit={handleSubmit} className="card space-y-3">
+        <h2 className="text-base font-semibold text-gray-900 dark:text-white">
+          {t('projects.createTitle')}
+        </h2>
+        <input
+          className="input"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder={t('projects.namePlaceholder')}
+          aria-label={t('projects.namePlaceholder')}
+          maxLength={255}
+        />
+        <textarea
+          className="input"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder={t('projects.descriptionPlaceholder')}
+          aria-label={t('projects.descriptionPlaceholder')}
+          rows={2}
+        />
+        {createProject.errorMessage && (
+          <p className="text-sm text-red-600 dark:text-red-400">{createProject.errorMessage}</p>
+        )}
+        <button
+          type="submit"
+          className="btn-primary inline-flex items-center gap-2"
+          disabled={!name.trim() || createProject.isPending}
+        >
+          {createProject.isPending ? (
+            <Loader className="w-4 h-4 animate-spin" />
+          ) : (
+            <Plus className="w-4 h-4" />
+          )}
+          {createProject.isPending ? t('projects.creating') : t('projects.create')}
+        </button>
+      </form>
+
+      {/* List */}
+      <div className="space-y-4">
+        {projectsQuery.isLoading ? (
+          <div className="card text-center py-12">
+            <Loader className="w-8 h-8 animate-spin mx-auto text-gray-500 dark:text-gray-400 mb-2" />
+            <p className="text-gray-500 dark:text-gray-400">{t('projects.loading')}</p>
+          </div>
+        ) : projectsQuery.errorMessage ? (
+          <div className="card text-center py-12">
+            <XCircle className="w-12 h-12 mx-auto text-red-500 mb-3" />
+            <p className="font-medium text-gray-700 dark:text-gray-300">{projectsQuery.errorMessage}</p>
+          </div>
+        ) : projects.length === 0 ? (
+          <div className="card text-center py-12">
+            <FolderKanban className="w-12 h-12 mx-auto text-gray-400 dark:text-gray-600 mb-3" />
+            <p className="font-medium text-gray-700 dark:text-gray-300">{t('projects.noProjects')}</p>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('projects.noProjectsDesc')}</p>
+          </div>
+        ) : (
+          projects.map((project) => (
+            <div key={project.id} className="card">
+              <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0">
+                  <h3 className="text-base font-semibold text-gray-900 dark:text-white mb-1 truncate">
+                    {project.name}
+                  </h3>
+                  {project.description && (
+                    <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">
+                      {project.description}
+                    </p>
+                  )}
+                  <div className="flex items-center gap-3 text-xs text-gray-500 dark:text-gray-400">
+                    <span className="inline-flex items-center gap-1">
+                      <FileText className="w-3.5 h-3.5" />
+                      {t('projects.documentCount', { count: project.document_count })}
+                    </span>
+                    <span>{t('projects.created')}: {new Date(project.created_at).toLocaleDateString()}</span>
+                  </div>
+                </div>
+                <TierBadge tier={project.circle_tier} />
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/tests/backend/test_config_features.py
+++ b/tests/backend/test_config_features.py
@@ -56,6 +56,21 @@ async def test_features_reports_role_surfacing_flag(monkeypatch, enabled):
     assert resp.json()["role_surfacing_enabled"] is enabled
 
 
+@pytest.mark.parametrize("enabled", [True, False])
+async def test_features_reports_projects_flag(monkeypatch, enabled):
+    """Business-instance Phase 1: the /projects nav is frontend-gated on this allowlisted flag."""
+    monkeypatch.setattr(settings, "projects_enabled", enabled)
+    from main import app
+    _auth_default(app)
+    try:
+        async with await _client(app) as c:
+            resp = await c.get("/api/config/features")
+    finally:
+        app.dependency_overrides.clear()
+    assert resp.status_code == 200
+    assert resp.json()["projects_enabled"] is enabled
+
+
 async def test_features_wissensbasis_reva_false_in_standalone():
     """Standalone Renfield does NOT mount the Reva-only /me/mix route, so the
     flag is False — the frontend then hides the Reva panels WITHOUT probing an

--- a/tests/backend/test_projects.py
+++ b/tests/backend/test_projects.py
@@ -1,0 +1,165 @@
+"""Route tests for /api/projects (business-instance Phase 1).
+
+Covers the feature-flag gate, the create-project-creates-linked-KB invariant,
+owner-scoping under auth, and delete-keeps-the-KB. Pure route validation on the
+default SQLite harness — no Postgres semantics needed (the shared `db_session`
+is what `override_get_db` yields, so seeding + the route hit the same DB).
+
+The migration itself is exercised by a real `alembic upgrade` on the .159 build
+box (create_all skips the migration body — see memory
+feedback_alembic_test_real_upgrade), not here.
+"""
+from __future__ import annotations
+
+import pytest
+
+from models.database import KnowledgeBase, Project, User
+from utils.config import settings
+
+pytestmark = [pytest.mark.asyncio]
+
+
+def _override_user(user: User | None) -> None:
+    """Force get_optional_user to resolve to `user` (or anonymous) for the app."""
+    from main import app
+    from services.auth_service import get_optional_user
+
+    app.dependency_overrides[get_optional_user] = lambda: user
+
+
+def _enable(monkeypatch, *, auth: bool) -> None:
+    monkeypatch.setattr(settings, "projects_enabled", True)
+    monkeypatch.setattr(settings, "auth_enabled", auth)
+
+
+# ---------------------------------------------------------------------------
+# Feature-flag gate
+# ---------------------------------------------------------------------------
+
+async def test_all_routes_404_when_flag_off(async_client, monkeypatch):
+    monkeypatch.setattr(settings, "projects_enabled", False)
+    assert (await async_client.post("/api/projects", json={"name": "X"})).status_code == 404
+    assert (await async_client.get("/api/projects")).status_code == 404
+    assert (await async_client.get("/api/projects/1")).status_code == 404
+    assert (await async_client.delete("/api/projects/1")).status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Create → dedicated 1:1 KnowledgeBase
+# ---------------------------------------------------------------------------
+
+async def test_create_project_creates_linked_kb(async_client, db_session, monkeypatch):
+    _enable(monkeypatch, auth=False)
+    resp = await async_client.post(
+        "/api/projects", json={"name": "Alpha", "description": "d"}
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["name"] == "Alpha"
+    assert body["description"] == "d"
+    assert body["status"] == "active"
+    assert body["circle_tier"] == 2
+    assert body["document_count"] == 0
+    assert body["knowledge_base_id"] is not None
+
+    # The KB really exists, is tier-scoped to the project, and is distinct per project.
+    kb = await db_session.get(KnowledgeBase, body["knowledge_base_id"])
+    assert kb is not None
+    assert kb.default_circle_tier == 2
+
+    # A second project gets its OWN fresh KB (1:1, unique name).
+    resp2 = await async_client.post("/api/projects", json={"name": "Alpha"})
+    assert resp2.status_code == 200
+    assert resp2.json()["knowledge_base_id"] != body["knowledge_base_id"]
+
+
+async def test_create_honors_explicit_tier(async_client, db_session, monkeypatch):
+    _enable(monkeypatch, auth=False)
+    resp = await async_client.post(
+        "/api/projects", json={"name": "Tiered", "circle_tier": 4}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["circle_tier"] == 4
+    kb = await db_session.get(KnowledgeBase, body["knowledge_base_id"])
+    assert kb.default_circle_tier == 4
+
+
+# ---------------------------------------------------------------------------
+# List / get / delete (auth off = single-user sees all)
+# ---------------------------------------------------------------------------
+
+async def test_list_get_delete_lifecycle_auth_off(async_client, db_session, monkeypatch):
+    _enable(monkeypatch, auth=False)
+    created = (await async_client.post("/api/projects", json={"name": "Beta"})).json()
+    pid = created["id"]
+    kb_id = created["knowledge_base_id"]
+
+    listing = await async_client.get("/api/projects")
+    assert listing.status_code == 200
+    assert any(p["id"] == pid for p in listing.json())
+
+    got = await async_client.get(f"/api/projects/{pid}")
+    assert got.status_code == 200
+    assert got.json()["id"] == pid
+
+    deleted = await async_client.delete(f"/api/projects/{pid}")
+    assert deleted.status_code == 200
+    assert deleted.json()["knowledge_base_retained"] is True
+    assert deleted.json()["knowledge_base_id"] == kb_id
+
+    # Project row gone; the KB is deliberately retained.
+    assert (await async_client.get(f"/api/projects/{pid}")).status_code == 404
+    assert await db_session.get(KnowledgeBase, kb_id) is not None
+
+
+async def test_get_missing_project_404(async_client, monkeypatch):
+    _enable(monkeypatch, auth=False)
+    assert (await async_client.get("/api/projects/999999")).status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Owner scoping under auth
+# ---------------------------------------------------------------------------
+
+async def test_owner_scoping_under_auth(async_client, monkeypatch):
+    _enable(monkeypatch, auth=True)
+    user_a = User(id=1, username="a", password_hash="x", is_active=True, role_id=1)
+    user_b = User(id=2, username="b", password_hash="x", is_active=True, role_id=1)
+
+    _override_user(user_a)
+    created = await async_client.post("/api/projects", json={"name": "Gamma"})
+    assert created.status_code == 200
+    assert created.json()["owner_id"] == 1
+    pid = created.json()["id"]
+
+    # User B cannot see A's project (owner-gated 404 + absent from list).
+    _override_user(user_b)
+    assert (await async_client.get(f"/api/projects/{pid}")).status_code == 404
+    assert all(p["id"] != pid for p in (await async_client.get("/api/projects")).json())
+
+    # Owner A can.
+    _override_user(user_a)
+    assert (await async_client.get(f"/api/projects/{pid}")).status_code == 200
+    assert any(p["id"] == pid for p in (await async_client.get("/api/projects")).json())
+
+
+async def test_create_requires_auth_when_enabled(async_client, monkeypatch):
+    _enable(monkeypatch, auth=True)
+    _override_user(None)
+    assert (await async_client.post("/api/projects", json={"name": "X"})).status_code == 401
+
+
+async def test_delete_owner_gated_under_auth(async_client, monkeypatch):
+    _enable(monkeypatch, auth=True)
+    user_a = User(id=1, username="a", password_hash="x", is_active=True, role_id=1)
+    user_b = User(id=2, username="b", password_hash="x", is_active=True, role_id=1)
+
+    _override_user(user_a)
+    pid = (await async_client.post("/api/projects", json={"name": "Delta"})).json()["id"]
+
+    _override_user(user_b)
+    assert (await async_client.delete(f"/api/projects/{pid}")).status_code == 404
+
+    _override_user(user_a)
+    assert (await async_client.delete(f"/api/projects/{pid}")).status_code == 200

--- a/tests/frontend/react/mocks/handlers.ts
+++ b/tests/frontend/react/mocks/handlers.ts
@@ -362,6 +362,7 @@ export const handlers: HttpHandler[] = [
       artifacts_typed_enabled: false,
       room_handoff_enabled: false,
       chat_branching_enabled: false,
+      projects_enabled: false,
     });
   }),
   // MCP API

--- a/tests/frontend/react/pages/ProjectsPage.test.tsx
+++ b/tests/frontend/react/pages/ProjectsPage.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+
+import { server } from '../mocks/server';
+import { BASE_URL } from '../mocks/handlers';
+import ProjectsPage from '../../../../src/frontend/src/pages/ProjectsPage';
+import { renderWithProviders } from '../test-utils';
+import i18n from '../../../../src/frontend/src/i18n';
+import type { Project } from '../../../../src/frontend/src/api/resources/projects';
+
+function mkProject(over: Partial<Project>): Project {
+  return {
+    id: 1,
+    name: 'Project',
+    description: null,
+    owner_id: null,
+    knowledge_base_id: 10,
+    circle_tier: 2,
+    status: 'active',
+    created_at: '2026-07-13T10:00:00Z',
+    document_count: 0,
+    ...over,
+  };
+}
+
+describe('ProjectsPage', () => {
+  it('renders the list of projects', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/projects`, () =>
+        HttpResponse.json([
+          mkProject({ id: 1, name: 'Alpha', document_count: 3 }),
+          mkProject({ id: 2, name: 'Beta' }),
+        ]),
+      ),
+    );
+
+    renderWithProviders(<ProjectsPage />);
+
+    await waitFor(() => expect(screen.getByText('Alpha')).toBeInTheDocument());
+    expect(screen.getByText('Beta')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when there are no projects', async () => {
+    server.use(http.get(`${BASE_URL}/api/projects`, () => HttpResponse.json([])));
+
+    renderWithProviders(<ProjectsPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText(i18n.t('projects.noProjects'))).toBeInTheDocument(),
+    );
+  });
+
+  it('creates a project and shows it in the refreshed list', async () => {
+    const store: Project[] = [];
+    server.use(
+      http.get(`${BASE_URL}/api/projects`, () => HttpResponse.json(store)),
+      http.post(`${BASE_URL}/api/projects`, async ({ request }) => {
+        const body = (await request.json()) as { name: string; description: string | null };
+        const created = mkProject({ id: 99, name: body.name, description: body.description });
+        store.push(created);
+        return HttpResponse.json(created);
+      }),
+    );
+
+    renderWithProviders(<ProjectsPage />);
+    const user = userEvent.setup();
+
+    // The create form's name field is the first textbox; the submit is the only button.
+    const [nameInput] = screen.getAllByRole('textbox');
+    await user.type(nameInput, 'Gamma');
+    await user.click(screen.getByRole('button', { name: i18n.t('projects.create') }));
+
+    await waitFor(() => expect(screen.getByText('Gamma')).toBeInTheDocument());
+  });
+});


### PR DESCRIPTION
## What this delivers (Phase 1)

Phase 1 of the business-instance plan: a **minimal `Project` model + one dedicated `KnowledgeBase` per project (1:1) + CRUD**, all behind the `projects_enabled` feature flag. Dark by default → the household instance is byte-identical. This is conventional CRUD on the existing Renfield substrate — a project becomes usable for chat/doc-based history immediately (ingest targets the project's KB via the existing knowledge routes). No codebase fork: everything is additive behind the flag.

### Backend
- **`Project` model** (`models/database.py`): `id, name, description, owner_id (FK users, SET NULL), knowledge_base_id (FK knowledge_bases, SET NULL — 1:1), circle_tier (default 2 = household/team), status (default 'active'), created_at`.
- **Migration `pc20260713_projects`** — chained on the live head `pc20260712_federation_user_links`. Idempotent (inspector-guarded create, so `Base.metadata.create_all` at boot + a re-run are both no-ops), fully transactional, `ON DELETE SET NULL` FKs, indexes on both FKs.
- **`services/project_service.py`** — `create_project` enforces the 1:1 project→KB invariant: a fresh KB, owner-scoped, tier-scoped (`default_circle_tier` = project tier), unique name via the project id.
- **`api/routes/projects.py`** (registered in `main.py`):
  - `POST /api/projects` — create project + its KB (auth on → creator owns both; auth off → owner NULL, mirrors `POST /api/knowledge/bases`).
  - `GET /api/projects` — list, owner-scoped; auth-off single-user sees all.
  - `GET /api/projects/{id}` — owner-gated 404.
  - `DELETE /api/projects/{id}` — deletes the project row only; **deliberately keeps the KB + documents** (no silent corpus data-loss), reported as `knowledge_base_retained: true`.
  - Every route 404s when `projects_enabled` is off. `document_count` returned on responses.
- **Feature flag** `projects_enabled: bool = False` in `utils/config.py`, exposed in the `/api/config/features` allowlist for the frontend.

### Frontend (behind the same flag)
- `/projects` page — list + create-project form, using DESIGN.md tokens (`.card`, `.input`, `.btn-primary`), `TierBadge`, dark-mode variants, `useTranslation()` with keys in **both** `de.json` + `en.json`.
- `api/resources/projects.ts` hook (list/create/delete), query keys, `projects_enabled` added to the typed `FeatureFlags`.
- Flag-gated route in `App.tsx` + sidebar nav entry in `Layout.tsx` (gated off the typed `/api/config/features` flag, not the AuthContext feature map which defaults missing keys to `true`).

## Deferred to later phases (NOT in this PR)
Meeting transcription + diarization, the `Meeting` model, the project timeline view, the minutes pipeline (summary/decisions/action-items), and the Notes feature — see the business-instance plan phases 2–4.

## Test evidence
- **Backend, on the .159 build box:** `tests/backend/test_projects.py` + `tests/backend/test_config_features.py` → **16 passed, 0 failed**. Cases: flag-off 404 on all routes, create-creates-linked-KB (+ second project gets its own fresh KB), explicit-tier honored, list/get/delete lifecycle (auth off), missing-project 404, owner scoping under auth (user B can't see/delete user A's project), create requires auth when enabled, delete owner-gated, and the `/api/config/features` flag exposure.
- **Migration exercised for REAL** (not just `create_all`, which skips the migration body): built the base schema, dropped `projects`, stamped to the prior head, ran the actual `alembic upgrade` on a fresh Postgres. Verified the resulting schema (server defaults `circle_tier=2` / `status='active'` / `created_at=now()`, `ON DELETE SET NULL` FKs, both indexes), plus **downgrade** drops it cleanly and the **idempotency guard** makes a re-run over an existing table a no-op.
- **Frontend:** `npm run typecheck` clean for all touched files (2 remaining errors are pre-existing in `RoomOutputSettings.test.tsx`, a file this PR does not touch — confirmed by stashing this branch); `npm run build` (real Tailwind gate) clean; `ProjectsPage.test.tsx` **3/3** vitest pass.

## Notes
- Migration head chained onto: **`pc20260712_federation_user_links`** (verified as the live head via `alembic heads` against the private cluster).
- Do NOT merge / deploy — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)