### PR TITLE
feat(voice-server): §2 meeting diarization endpoint + cu128/pyannote image — PR 2/3

### DIFF
--- a/k8s/voice-server.yaml
+++ b/k8s/voice-server.yaml
@@ -106,6 +106,19 @@ spec:
                 secretKeyRef:
                   name: renfield-secrets
                   key: secret-key
+            # §2 meeting diarization. Dark by default — MEETING_ENABLED=false
+            # means the pyannote pipeline is never loaded, so a non-meeting
+            # deployment is byte-identical. Flip to "true" (+ the meeting image)
+            # to turn it on. HF_TOKEN backs a cold-cache pyannote download
+            # (the model is baked into the image; optional at runtime).
+            - name: MEETING_ENABLED
+              value: "false"
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token
+                  key: HF_TOKEN
+                  optional: true
           resources:
             requests:
               cpu: "2"

--- a/voice-server/Dockerfile
+++ b/voice-server/Dockerfile
@@ -51,16 +51,17 @@ ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:/opt/venv/lib/python3.12/site-packages
 WORKDIR /app
 COPY requirements.txt /app/requirements.txt
 
-# torch is used ONLY for speechbrain's compute_features +
-# mean_var_norm CPU preproc (per design § B.1.0 — ECAPA features
-# run on CPU before the ONNX call). STT uses CTranslate2; ECAPA
-# inference uses onnxruntime-gpu. So we install CPU torch
-# (~150 MB) instead of the cu124 wheel (~5 GB) — keeps every
-# layer well below Harbor's ~2.5 GB practical limit.
 RUN pip install --upgrade pip wheel
 
-RUN pip install --index-url https://download.pytorch.org/whl/cpu \
-        torch>=2.4 torchaudio>=2.4
+# GPU torch (cu128). Historically this was CPU-only torch (~150 MB) because torch
+# served only speechbrain's CPU ECAPA preproc. §2 meeting diarization runs
+# pyannote's neural pipeline ON THE GPU, which needs GPU torch. cu128 runs on
+# both the gpu-3 Ada card (sm_89) and Blackwell (sm_120) — one pyannote
+# integration for §2 + the planned streaming-diarization feature. This is a
+# ~6 GB layer (over Harbor's ~2.5 GB comfort limit, same as the backend image's
+# large layers — the push is slow but works); kept in its OWN layer.
+RUN pip install --index-url https://download.pytorch.org/whl/cu128 \
+        torch==2.7.1 torchaudio==2.7.1
 
 RUN pip install \
         numpy>=1.26 \
@@ -70,6 +71,30 @@ RUN pip install \
 # speechbrain pulls in plain `onnxruntime` (CPU) as a transitive. Install
 # it BEFORE onnxruntime-gpu so the GPU wheel wins the final import path.
 RUN pip install speechbrain>=1.0
+
+# pyannote.audio for §2 meeting diarization. Pin huggingface_hub<0.26: pyannote
+# 3.x internally calls hf_hub_download(use_auth_token=...) which hub 0.26+
+# removed (validated in the spike). Own layer, BEFORE the final onnxruntime-gpu
+# cleanup because pyannote transitively pulls CPU onnxruntime.
+RUN pip install "pyannote.audio>=3.1,<4" "huggingface_hub<0.26"
+
+# Bake the gated pyannote diarization model into the image (offline-first). Uses
+# a BuildKit secret so the HF token never lands in image history. Skipped (with
+# a loud echo) when no secret is passed — the runtime then downloads on warmup
+# if MEETING_ENABLED + HF_TOKEN are set and the cache is cold.
+ENV HF_HOME=/opt/hf-cache
+RUN --mount=type=secret,id=hf_token \
+    HF_TOKEN="$(cat /run/secrets/hf_token 2>/dev/null || true)"; \
+    if [ -n "$HF_TOKEN" ]; then \
+      python - "$HF_TOKEN" <<'PY' || echo "[bake] pyannote model bake FAILED — will download on warmup"; \
+import sys, torch
+_o = torch.load
+torch.load = lambda *a, **k: _o(*a, **{**k, "weights_only": False})
+from pyannote.audio import Pipeline
+p = Pipeline.from_pretrained("pyannote/speaker-diarization-3.1", use_auth_token=sys.argv[1])
+print("[bake] pyannote model cached:", p is not None)
+PY
+    else echo "[bake] no hf_token build secret — pyannote model not baked"; fi
 
 # cuDNN is required by onnxruntime-gpu's CUDAExecutionProvider but is
 # NOT included in nvidia/cuda:12.6-runtime base. Pull it via pip wheel.

--- a/voice-server/tests/test_meeting_alignment.py
+++ b/voice-server/tests/test_meeting_alignment.py
@@ -1,0 +1,64 @@
+"""Unit tests for the meeting word→speaker alignment (pure logic, no GPU)."""
+
+from voice_server.services.meeting_service import (
+    Turn,
+    Word,
+    align_words_to_segments,
+)
+
+
+def _w(text, a, b):
+    return Word(text=text, start_s=a, end_s=b)
+
+
+def test_overlap_assignment_and_merge():
+    """Words are assigned to the most-overlapping turn; consecutive same-speaker
+    words merge into one segment."""
+    turns = [Turn("SPEAKER_00", 0.0, 2.0), Turn("SPEAKER_01", 2.0, 4.0)]
+    words = [_w("hallo", 0.0, 0.5), _w("welt", 0.6, 1.5),
+             _w("guten", 2.1, 2.6), _w("tag", 2.7, 3.2)]
+    segs = align_words_to_segments(words, turns)
+    assert [s.speaker for s in segs] == ["SPEAKER_00", "SPEAKER_01"]
+    assert segs[0].text == "hallo welt"
+    assert segs[1].text == "guten tag"
+    assert segs[0].start_s == 0.0 and segs[0].end_s == 1.5
+
+
+def test_word_in_gap_goes_to_nearest_turn():
+    """A word overlapping NO turn (diarization gap) attaches to the nearest one."""
+    turns = [Turn("SPEAKER_00", 0.0, 1.0), Turn("SPEAKER_01", 3.0, 4.0)]
+    words = [_w("gap", 1.4, 1.6)]  # closer to SPEAKER_00 (ends 1.0) than SPEAKER_01 (starts 3.0)
+    segs = align_words_to_segments(words, turns)
+    assert len(segs) == 1 and segs[0].speaker == "SPEAKER_00"
+
+
+def test_no_diarization_single_speaker():
+    turns: list[Turn] = []
+    words = [_w("a", 0.0, 0.5), _w("b", 0.5, 1.0)]
+    segs = align_words_to_segments(words, turns)
+    assert len(segs) == 1
+    assert segs[0].speaker == "SPEAKER_00"
+    assert segs[0].text == "a b"
+
+
+def test_empty_words_yields_no_segments():
+    assert align_words_to_segments([], [Turn("SPEAKER_00", 0, 1)]) == []
+    assert align_words_to_segments([_w("  ", 0, 1)], [Turn("SPEAKER_00", 0, 1)]) == []
+
+
+def test_speaker_alternation_splits_segments():
+    """A→B→A alternation produces three segments (no cross-speaker merge)."""
+    turns = [Turn("SPEAKER_00", 0.0, 1.0), Turn("SPEAKER_01", 1.0, 2.0),
+             Turn("SPEAKER_00", 2.0, 3.0)]
+    words = [_w("one", 0.1, 0.5), _w("two", 1.1, 1.5), _w("three", 2.1, 2.5)]
+    segs = align_words_to_segments(words, turns)
+    assert [s.speaker for s in segs] == ["SPEAKER_00", "SPEAKER_01", "SPEAKER_00"]
+    assert [s.text for s in segs] == ["one", "two", "three"]
+
+
+def test_word_partial_overlap_picks_max_overlap_turn():
+    """A word straddling two turns lands with the one it overlaps MORE."""
+    turns = [Turn("SPEAKER_00", 0.0, 1.0), Turn("SPEAKER_01", 1.0, 3.0)]
+    # word 0.8–1.6: 0.2 s in SPEAKER_00, 0.6 s in SPEAKER_01 → SPEAKER_01
+    segs = align_words_to_segments([_w("straddle", 0.8, 1.6)], turns)
+    assert segs[0].speaker == "SPEAKER_01"

--- a/voice-server/voice_server/api/rest_voice.py
+++ b/voice-server/voice_server/api/rest_voice.py
@@ -16,6 +16,7 @@ Until B.4.c lands, Traefik does NOT route `/api/voice/*` to voice-server
 
 from __future__ import annotations
 
+import asyncio
 import io
 import logging
 import wave
@@ -157,6 +158,98 @@ async def _transcribe_and_embed(
         audio_duration_s=float(pcm.size) / 16000.0,
         speaker_embedding=embedding,
     )
+
+
+class MeetingSegmentOut(BaseModel):
+    speaker: str  # raw diarization cluster id (SPEAKER_00…); backend applies pseudonyms
+    start_s: float
+    end_s: float
+    text: str
+    embedding: list[float] | None = None
+
+
+class MeetingTranscribeResponse(BaseModel):
+    segments: list[MeetingSegmentOut]
+    num_speakers: int
+    duration_s: float
+
+
+@router.post("/transcribe-meeting", response_model=MeetingTranscribeResponse)
+async def transcribe_meeting_endpoint(
+    request: Request,
+    audio: UploadFile = File(...),
+    whisper_model: str | None = Form(default=None),
+    _user: dict = Depends(_require_token),
+) -> MeetingTranscribeResponse:
+    """Batch diarization + ASR over a whole meeting recording (§2).
+
+    Returns raw speaker-CLUSTER-attributed segments (SPEAKER_00…) + a per-cluster
+    ECAPA embedding. The backend applies pseudonyms / human labels — voice-server
+    stays stateless (same contract boundary as /stt).
+    """
+    from voice_server.services.meeting_service import MeetingDiarizationService
+
+    meeting: MeetingDiarizationService | None = getattr(request.app.state, "meeting", None)
+    if meeting is None or not meeting.ready:
+        raise HTTPException(status_code=503, detail="meeting diarization not available")
+
+    audio_bytes = await audio.read()
+    if not audio_bytes:
+        raise HTTPException(status_code=400, detail="empty audio")
+    try:
+        pcm = await decode_audio_to_pcm(audio_bytes)
+    except OneshotDecodeError as e:
+        # A recording the decoder can't parse is terminal (4xx) — the backend
+        # worker maps 4xx to a failed meeting, not an infinite retry.
+        logger.warning("meeting decode failed: %s", e)
+        raise HTTPException(status_code=400, detail=f"audio decode failed: {e}") from e
+    if pcm.size == 0:
+        raise HTTPException(status_code=400, detail="empty PCM after decode")
+
+    # ASR model: a per-job model when requested/configured (kept off the resident
+    # slot so a larger model doesn't contend with live STT), else the resident one.
+    loop = asyncio.get_running_loop()
+    model_name = (whisper_model or "").strip() or _settings_meeting_model()
+    per_job_model = None
+    try:
+        if model_name:
+            from faster_whisper import WhisperModel
+
+            from voice_server.config import settings as _s
+
+            per_job_model = await loop.run_in_executor(
+                None,
+                lambda: WhisperModel(
+                    model_name, device=_s.whisper_device, compute_type=_s.whisper_compute_type
+                ),
+            )
+            asr_model = per_job_model
+        else:
+            asr_model = request.app.state.stt._model  # resident faster-whisper
+
+        segments = await meeting.transcribe(
+            pcm, whisper_model=asr_model, speaker_service=request.app.state.speaker
+        )
+    except HTTPException:
+        raise
+    except Exception as e:  # noqa: BLE001
+        logger.exception("meeting transcription failed")
+        raise HTTPException(status_code=500, detail=f"transcription failed: {e}") from e
+    finally:
+        if per_job_model is not None:
+            del per_job_model  # unload; free VRAM for the next job / live STT
+
+    return MeetingTranscribeResponse(
+        segments=[MeetingSegmentOut(**s) for s in segments],
+        num_speakers=len({s["speaker"] for s in segments}),
+        duration_s=round(float(pcm.size) / 16000.0, 3),
+    )
+
+
+def _settings_meeting_model() -> str:
+    from voice_server.config import settings as _s
+
+    return (_s.meeting_whisper_model or "").strip()
 
 
 class TTSRequest(BaseModel):

--- a/voice-server/voice_server/config.py
+++ b/voice-server/voice_server/config.py
@@ -49,6 +49,19 @@ class Settings(BaseSettings):
     speaker_model_path: Path = Path("/mnt/llm/voice/ecapa_tdnn.onnx")
     speaker_providers: list[str] = ["CUDAExecutionProvider", "CPUExecutionProvider"]
 
+    # Meeting diarization (§2) — pyannote turns + faster-whisper words →
+    # speaker-attributed segments. The pyannote pipeline is loaded at warmup
+    # ONLY when meeting_enabled (it's ~2 GB VRAM and useless on a non-meeting
+    # deployment). meeting_whisper_model="" reuses the resident STT model; set a
+    # larger one (e.g. large-v3-turbo) to trade GPU-seconds for accuracy — loaded
+    # per job so it doesn't sit resident contending with live satellite STT.
+    meeting_enabled: bool = False
+    meeting_diarization_model: str = "pyannote/speaker-diarization-3.1"
+    meeting_whisper_model: str = ""
+    # HF token for the gated pyannote model at warmup (offline-first: the model
+    # is baked into the image, so this only matters if the cache is cold).
+    hf_token: SecretStr | None = None
+
     # TTS (B.1)
     piper_voices_dir: Path = Path("/mnt/llm/voice/piper")
     piper_default_voice_de: str = "de_DE-thorsten-medium"

--- a/voice-server/voice_server/main.py
+++ b/voice-server/voice_server/main.py
@@ -60,6 +60,14 @@ async def lifespan(app: FastAPI):
 
     await app.state.stt.warmup()
     await app.state.speaker.warmup()
+
+    # Meeting diarization (§2): only loads pyannote (~2 GB VRAM) when enabled, so
+    # a non-meeting deployment is unaffected. warmup() no-ops when off.
+    from voice_server.services.meeting_service import MeetingDiarizationService
+
+    app.state.meeting = MeetingDiarizationService()
+    await app.state.meeting.warmup()
+
     logger.info("voice-server ready")
     try:
         yield
@@ -78,11 +86,14 @@ app = FastAPI(
 async def health() -> dict[str, object]:
     stt_ready = getattr(app.state, "stt", None) is not None and app.state.stt.ready
     spk_ready = getattr(app.state, "speaker", None) is not None and app.state.speaker.ready
+    meeting = getattr(app.state, "meeting", None)
     return {
         "status": "ok" if (stt_ready and spk_ready) else "warming",
         "version": __version__,
         "stt_ready": stt_ready,
         "speaker_ready": spk_ready,
+        # informational — meeting diarization is off unless MEETING_ENABLED
+        "meeting_ready": meeting is not None and meeting.ready,
     }
 
 

--- a/voice-server/voice_server/services/meeting_service.py
+++ b/voice-server/voice_server/services/meeting_service.py
@@ -1,0 +1,236 @@
+"""Meeting diarization + ASR (§2).
+
+Runs pyannote.audio speaker diarization + faster-whisper word-level ASR over a
+whole meeting recording and aligns them into speaker-attributed segments, with a
+per-cluster ECAPA embedding (same ONNX space as ``/api/voice/stt``).
+
+The alignment is a PURE function (``align_words_to_segments``) — fixture-unit
+tested with no GPU. The GPU glue (pyannote pipeline load + diarize, faster-whisper
+word timestamps) lives in ``MeetingDiarizationService``.
+
+Model loading: the pyannote pipeline is baked into the image (offline-first) and
+loaded once at warmup when ``meeting_enabled``. The ASR model is the resident STT
+model unless ``meeting_whisper_model`` is set (then loaded per job so a larger
+model doesn't sit resident contending with live satellite STT).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from voice_server.config import settings
+
+logger = logging.getLogger(__name__)
+
+SAMPLE_RATE = 16000
+
+
+@dataclass
+class Word:
+    text: str
+    start_s: float
+    end_s: float
+
+
+@dataclass
+class Turn:
+    """One diarization turn: a speaker cluster label over a time span."""
+
+    speaker: str
+    start_s: float
+    end_s: float
+
+
+@dataclass
+class MeetingSegment:
+    speaker: str
+    start_s: float
+    end_s: float
+    text: str
+    embedding: list[float] | None = field(default=None)
+
+
+def _overlap(a0: float, a1: float, b0: float, b1: float) -> float:
+    """Overlap duration of [a0,a1] and [b0,b1] (0 if disjoint)."""
+    return max(0.0, min(a1, b1) - max(a0, b0))
+
+
+def _nearest_turn(mid: float, turns: list[Turn]) -> Turn:
+    """The turn whose span is closest to a midpoint (for words that overlap no
+    turn — e.g. in a diarization gap)."""
+    def dist(t: Turn) -> float:
+        if t.start_s <= mid <= t.end_s:
+            return 0.0
+        return min(abs(mid - t.start_s), abs(mid - t.end_s))
+
+    return min(turns, key=dist)
+
+
+def align_words_to_segments(words: list[Word], turns: list[Turn]) -> list[MeetingSegment]:
+    """Assign each ASR word to the diarization turn it overlaps most (nearest
+    turn on a gap), then merge consecutive same-speaker words into segments.
+
+    PURE — no GPU, no IO. This is the correctness core of the pipeline and is
+    fixture-unit-tested (overlaps, gaps, no-diarization, empty).
+    """
+    words = [w for w in words if (w.text or "").strip()]
+    if not words:
+        return []
+    if not turns:
+        # No diarization → a single unknown speaker over the whole transcript.
+        text = " ".join(w.text.strip() for w in words)
+        return [MeetingSegment("SPEAKER_00", words[0].start_s, words[-1].end_s, text)]
+
+    labeled: list[tuple[str, Word]] = []
+    for w in words:
+        best: Turn | None = None
+        best_ov = 0.0
+        for t in turns:
+            ov = _overlap(w.start_s, w.end_s, t.start_s, t.end_s)
+            if ov > best_ov:
+                best_ov = ov
+                best = t
+        if best is None:  # word falls in a diarization gap → nearest turn
+            best = _nearest_turn((w.start_s + w.end_s) / 2.0, turns)
+        labeled.append((best.speaker, w))
+
+    segments: list[MeetingSegment] = []
+    for speaker, w in labeled:
+        if segments and segments[-1].speaker == speaker:
+            segments[-1].text += " " + w.text.strip()
+            segments[-1].end_s = w.end_s
+        else:
+            segments.append(MeetingSegment(speaker, w.start_s, w.end_s, w.text.strip()))
+    return segments
+
+
+class MeetingDiarizationService:
+    """Loads pyannote at warmup (when meeting_enabled); runs the batch pipeline."""
+
+    def __init__(self) -> None:
+        self._pipeline = None
+        self.ready: bool = False
+        self._lock = asyncio.Lock()  # batch job monopolises the GPU (semaphore=1)
+
+    async def warmup(self) -> None:
+        if not settings.meeting_enabled:
+            logger.info("meeting diarization disabled — skipping pyannote load")
+            return
+        logger.info("loading pyannote pipeline: %s", settings.meeting_diarization_model)
+        loop = asyncio.get_running_loop()
+        self._pipeline = await loop.run_in_executor(None, self._load_pipeline)
+        self.ready = self._pipeline is not None
+        logger.info("meeting diarization warm (ready=%s)", self.ready)
+
+    def _load_pipeline(self):
+        import torch
+        from pyannote.audio import Pipeline
+
+        # torch 2.6+ defaults torch.load to weights_only=True; lightning passes it
+        # explicitly True and the pyannote checkpoint carries non-tensor globals.
+        # Force False — the model is the trusted official/baked checkpoint.
+        _orig_load = torch.load
+
+        def _patched(*a, **k):
+            k["weights_only"] = False
+            return _orig_load(*a, **k)
+
+        torch.load = _patched
+        try:
+            token = settings.hf_token.get_secret_value() if settings.hf_token else None
+            try:
+                pipeline = Pipeline.from_pretrained(settings.meeting_diarization_model, token=token)
+            except TypeError:
+                pipeline = Pipeline.from_pretrained(
+                    settings.meeting_diarization_model, use_auth_token=token
+                )
+        finally:
+            torch.load = _orig_load
+        if pipeline is None:
+            logger.error(
+                "pyannote pipeline load returned None (gated model license not "
+                "accepted / token missing / cache cold)"
+            )
+            return None
+        if settings.whisper_device == "cuda":
+            pipeline.to(torch.device("cuda"))
+        return pipeline
+
+    def _diarize_sync(self, pcm: np.ndarray) -> list[Turn]:
+        import torch
+
+        waveform = torch.from_numpy(np.ascontiguousarray(pcm, dtype=np.float32)).unsqueeze(0)
+        annotation = self._pipeline({"waveform": waveform, "sample_rate": SAMPLE_RATE})
+        turns: list[Turn] = []
+        for segment, _track, speaker in annotation.itertracks(yield_label=True):
+            turns.append(Turn(str(speaker), float(segment.start), float(segment.end)))
+        turns.sort(key=lambda t: t.start_s)
+        return turns
+
+    def _transcribe_words_sync(self, pcm: np.ndarray, whisper_model) -> list[Word]:
+        segments, _info = whisper_model.transcribe(
+            pcm, word_timestamps=True, beam_size=1,
+            language=settings.whisper_language_default,
+        )
+        words: list[Word] = []
+        for seg in segments:
+            for w in (seg.words or []):
+                words.append(Word(text=w.word, start_s=float(w.start), end_s=float(w.end)))
+        return words
+
+    async def transcribe(self, pcm: np.ndarray, *, whisper_model, speaker_service) -> list[dict]:
+        """Diarize + transcribe + align + per-cluster embed. Returns a list of
+        segment dicts: {speaker(cluster id), start_s, end_s, text, embedding}."""
+        if not self.ready or self._pipeline is None:
+            raise RuntimeError("MeetingDiarizationService not ready")
+        loop = asyncio.get_running_loop()
+        async with self._lock:  # one batch job at a time (semaphore=1)
+            turns = await loop.run_in_executor(None, self._diarize_sync, pcm)
+            words = await loop.run_in_executor(
+                None, self._transcribe_words_sync, pcm, whisper_model
+            )
+
+        segments = align_words_to_segments(words, turns)
+
+        # Per-cluster ECAPA embedding: concatenate each speaker's audio windows.
+        embeddings: dict[str, list[float] | None] = {}
+        for speaker in {s.speaker for s in segments}:
+            clip = _concat_speaker_audio(pcm, [s for s in segments if s.speaker == speaker])
+            if clip.size == 0:
+                embeddings[speaker] = None
+                continue
+            try:
+                emb = await speaker_service.embed(clip)
+                embeddings[speaker] = emb.tolist()
+            except Exception as e:  # noqa: BLE001 - embedding is best-effort
+                logger.warning("cluster embed failed for %s: %s", speaker, e)
+                embeddings[speaker] = None
+
+        return [
+            {
+                "speaker": s.speaker,
+                "start_s": round(s.start_s, 3),
+                "end_s": round(s.end_s, 3),
+                "text": s.text,
+                "embedding": embeddings.get(s.speaker),
+            }
+            for s in segments
+        ]
+
+
+def _concat_speaker_audio(pcm: np.ndarray, segments: list[MeetingSegment]) -> np.ndarray:
+    """Concatenate the PCM windows for one speaker's segments (for the embed)."""
+    parts: list[np.ndarray] = []
+    for s in segments:
+        a = max(0, int(s.start_s * SAMPLE_RATE))
+        b = min(pcm.size, int(s.end_s * SAMPLE_RATE))
+        if b > a:
+            parts.append(pcm[a:b])
+    if not parts:
+        return np.zeros(0, dtype=np.float32)
+    return np.concatenate(parts).astype(np.float32)


### PR DESCRIPTION
**PR 2 of 3** for §2 meeting transcription (`docs/design/meeting-transcription.md`). Adds the voice-server side that PR #973's backend worker calls. **Dark by default** (`MEETING_ENABLED=false` → pyannote never loads → a non-meeting deployment is byte-identical).

## What's in this PR
- **`POST /transcribe-meeting`** (`voice_server/api/rest_voice.py`): batch pyannote diarization + faster-whisper word-level ASR over a whole recording → speaker-**cluster**-attributed segments (`SPEAKER_00`…) + a per-cluster ECAPA embedding (same ONNX space as `/stt`). Stateless — the backend applies pseudonyms/labels. `503` when disabled; `400` on undecodable audio (so the worker fails-fast, doesn't loop — pairs with PR 1's 4xx-terminal classification).
- **Pure alignment core** (`services/meeting_service.py::align_words_to_segments`): each ASR word → the diarization turn it overlaps most (nearest turn on a gap), then merge consecutive same-speaker words. Fixture-unit-tested, **no GPU** — 6 tests green.
- **`MeetingDiarizationService`**: loads pyannote **only when `MEETING_ENABLED`** (warmup), batch semaphore=1, the torch-2.6+ `weights_only=False` shim validated in the diarization spike. ASR uses a per-job model when `MEETING_WHISPER_MODEL` is set (kept off the resident STT slot so a larger model doesn't contend with live satellite STT), else the resident one.
- **Dockerfile**: GPU **torch cu128** (was CPU-only — pyannote runs neural diarization on the GPU) + `pyannote.audio` + `huggingface_hub<0.26`, **baking the gated diarization model via a BuildKit secret** (token never in image history). This is the exact stack proven in the spike (cu128 runs on both the gpu-3 Ada card and Blackwell — one pyannote integration for §2 + the planned streaming-diarization feature).
- `main.py` warmup/health wiring; `k8s/voice-server.yaml` `MEETING_ENABLED` (dark) + optional `HF_TOKEN`.

## Not in this PR
- **Image build + deploy** — the ~14 GB cu128/pyannote build on `.159` + Harbor push + gpu-3 rollout is a deliberate deploy step (the GPU pipeline itself is validated by the spike).
- **PR 3**: frontend (upload + status + speaker labeling).

## Testing
6 alignment tests green on `.159`. Depends on PR #973 (the backend caller) for the end-to-end flow; both are dark until `MEETING_TRANSCRIPTION_ENABLED` / `MEETING_ENABLED` flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)