### PR TITLE
fix(meeting-worker): use voice-server FQDN so it resolves cross-namespace

### DIFF
--- a/k8s/meeting-worker.yaml
+++ b/k8s/meeting-worker.yaml
@@ -51,7 +51,10 @@ spec:
               echo "waiting for postgres..."; until nc -z postgres 5432; do sleep 1; done
               echo "waiting for redis...";    until nc -z redis 6379;    do sleep 1; done
               # The meeting worker's downstream is the voice-server (diarization+ASR).
-              echo "waiting for voice-server..."; until nc -z voice-server 8080; do sleep 2; done
+              # Use the FQDN so this resolves from ANY namespace — the household
+              # runs the voice-server in `renfield`, and other instances (e.g.
+              # renfield-xidra) reach it cross-namespace via the same name.
+              echo "waiting for voice-server..."; until nc -z voice-server.renfield 8080; do sleep 2; done
               echo "deps ready"
           resources:
             requests: {cpu: 10m, memory: 16Mi}


### PR DESCRIPTION
The meeting-worker's `wait-for-deps` init container hardcoded a bare `voice-server` hostname, which only resolves inside the `renfield` namespace. Instances that share the household voice-server cross-namespace (e.g. `renfield-xidra`, `VOICE_SERVER_URL=http://voice-server.renfield:8080`) got their meeting-worker stuck forever in init on `nc: bad address 'voice-server'`.

Fix: use the FQDN `voice-server.renfield` — resolves identically from the household's own namespace and from any consumer namespace. Verified: xidra meeting-worker got past init after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)