### PR TITLE
fix(auth): attach bearer token in a module-scope interceptor (feature-flag race)

### DIFF
--- a/src/frontend/src/context/AuthContext.tsx
+++ b/src/frontend/src/context/AuthContext.tsx
@@ -6,6 +6,7 @@
  */
 import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react';
 import apiClient from '../utils/axios';
+import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from '../utils/authTokens';
 import type { User, LoginResponse } from '../types/api';
 
 // Auth user with permissions
@@ -34,10 +35,6 @@ export interface AuthContextValue {
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);
-
-// Token storage keys
-const ACCESS_TOKEN_KEY = 'renfield_access_token';
-const REFRESH_TOKEN_KEY = 'renfield_refresh_token';
 
 interface AuthProviderProps {
   children: ReactNode;
@@ -222,22 +219,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }, [fetchUser]);
 
   // Setup axios interceptor for auth header
-  useEffect(() => {
-    const interceptor = apiClient.interceptors.request.use(
-      (config) => {
-        const token = getAccessToken();
-        if (token && !config.headers.Authorization) {
-          config.headers.Authorization = `Bearer ${token}`;
-        }
-        return config;
-      },
-      (error) => Promise.reject(error)
-    );
-
-    return () => {
-      apiClient.interceptors.request.eject(interceptor);
-    };
-  }, [getAccessToken]);
+  // NOTE: the request interceptor that attaches the access token now lives at
+  // module scope in utils/axios.ts, so it is registered before any component
+  // mounts and cannot race the app's first authenticated queries. (It used to
+  // be registered here in a useEffect, which children's query effects could
+  // beat → 401 → feature flags cached false on auth-on instances.)
 
   // Setup response interceptor for token refresh
   useEffect(() => {

--- a/src/frontend/src/utils/authTokens.ts
+++ b/src/frontend/src/utils/authTokens.ts
@@ -1,0 +1,8 @@
+// Shared localStorage keys for the JWT auth tokens.
+//
+// Defined here — NOT in AuthContext — so the axios request interceptor can read
+// the access token without importing AuthContext (which imports apiClient, so
+// that would be a circular import). Both AuthContext and utils/axios.ts import
+// these constants.
+export const ACCESS_TOKEN_KEY = 'renfield_access_token';
+export const REFRESH_TOKEN_KEY = 'renfield_refresh_token';

--- a/src/frontend/src/utils/axios.ts
+++ b/src/frontend/src/utils/axios.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosInstance, InternalAxiosRequestConfig, AxiosResponse, AxiosError } from 'axios';
 
 import { getApiBaseUrl } from './env';
+import { ACCESS_TOKEN_KEY } from './authTokens';
 
 // Axios Instance mit Base URL
 const apiClient: AxiosInstance = axios.create({
@@ -11,10 +12,23 @@ const apiClient: AxiosInstance = axios.create({
   }
 });
 
-// Request Interceptor
+// Request Interceptor — attach the bearer token from localStorage on EVERY
+// request. This is registered at module scope (when apiClient is created,
+// before any React component mounts), so it CANNOT race the app's first
+// authenticated queries. Previously the token was attached only by an
+// interceptor AuthContext registered inside a useEffect; a child component's
+// query effect (e.g. useFeatureFlags → /api/config/features) runs before the
+// parent AuthContext's effect, so on an auth-on instance with a token already
+// in localStorage that first request went out unauthenticated → 401 → and
+// because react-query does not retry 401s, the feature flags cached as `false`
+// (hiding e.g. the Meetings/Wissen nav). Reading from localStorage here removes
+// that ordering dependency entirely.
 apiClient.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
-    // Hier könnte Auth-Token hinzugefügt werden
+    const token = localStorage.getItem(ACCESS_TOKEN_KEY);
+    if (token && !config.headers.Authorization) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
     return config;
   },
   (error: AxiosError) => {

--- a/tests/frontend/react/utils/axios.test.ts
+++ b/tests/frontend/react/utils/axios.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+
+import { server } from '../mocks/server';
+import { BASE_URL } from '../mocks/handlers';
+import apiClient from '../../../../src/frontend/src/utils/axios';
+import { ACCESS_TOKEN_KEY } from '../../../../src/frontend/src/utils/authTokens';
+
+// Regression guard for the feature-flag auth race: the bearer token is attached
+// by a module-scope request interceptor (registered when apiClient is created),
+// NOT by an interceptor AuthContext registers in a useEffect. So a request that
+// fires before any component mounts (e.g. the first /api/config/features query)
+// still carries the token — no 401, no feature flags cached false.
+describe('apiClient auth interceptor', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('attaches the bearer token from localStorage on every request', async () => {
+    localStorage.setItem(ACCESS_TOKEN_KEY, 'tok-abc');
+    let auth: string | null = 'MISSING';
+    server.use(
+      http.get(`${BASE_URL}/api/_probe`, ({ request }) => {
+        auth = request.headers.get('authorization');
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    await apiClient.get('/api/_probe');
+    expect(auth).toBe('Bearer tok-abc');
+  });
+
+  it('sends no Authorization header when no token is stored', async () => {
+    let auth: string | null = 'MISSING';
+    server.use(
+      http.get(`${BASE_URL}/api/_probe2`, ({ request }) => {
+        auth = request.headers.get('authorization');
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    await apiClient.get('/api/_probe2');
+    expect(auth).toBeNull();
+  });
+
+  it('does not overwrite an explicit Authorization header', async () => {
+    localStorage.setItem(ACCESS_TOKEN_KEY, 'tok-abc');
+    let auth: string | null = 'MISSING';
+    server.use(
+      http.get(`${BASE_URL}/api/_probe3`, ({ request }) => {
+        auth = request.headers.get('authorization');
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    await apiClient.get('/api/_probe3', { headers: { Authorization: 'Bearer explicit' } });
+    expect(auth).toBe('Bearer explicit');
+  });
+});


### PR DESCRIPTION
## The bug (found during the xidra meetings bring-up)
On an **auth-on** instance with a token already in `localStorage`, the app's first authenticated queries can fire **before** `AuthContext` registers its token interceptor — a child component's react-query effect (`useFeatureFlags` → `/api/config/features`) runs before the parent `AuthContext`'s `useEffect`. That first request goes out **unauthenticated → 401**, and since react-query doesn't retry 401s, the feature flags cache as **all-false**. Effect: flag-gated nav/routes (Meetings, Wissen workspace, …) are **hidden from real users** even though the backend has the flags on. (Observed live: xidra rendered the legacy nav + no Besprechungen despite `meeting_transcription_enabled=true`.)

## The fix
Attach the bearer token from `localStorage` in the `apiClient` request interceptor at **module scope** (`utils/axios.ts`) — registered when the client is created, before any component mounts, so it can't be raced. Token keys move to `utils/authTokens.ts` (shared, avoids a circular import). `AuthContext`'s now-redundant request-interceptor `useEffect` is removed; its response/refresh interceptor stays.

## Tests
- +3 `utils/axios.test.ts`: token attached from localStorage / no token → no header / explicit `Authorization` not overwritten.
- `AuthContext` 14 tests still pass. tsc clean, build ok, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)