### PR TITLE
feat(voice): voice_server_auth_enabled flag — send no token to a shared voice-server

### DIFF
--- a/src/backend/services/meeting_pipeline.py
+++ b/src/backend/services/meeting_pipeline.py
@@ -28,7 +28,16 @@ _MEETINGS_KB_NAME = "Meetings"
 
 
 def _service_token() -> str:
-    """Mint a short-lived service-account JWT for the pod-to-pod voice-server call."""
+    """Mint a short-lived service-account JWT for the pod-to-pod voice-server call.
+
+    Returns "" when ``voice_server_auth_enabled`` is off (this instance shares
+    another instance's voice-server, so our SECRET_KEY-signed token would 401 on
+    signature verification) — the client then sends no token and the
+    auth_required=false voice-server treats the call as anonymous."""
+    from utils.config import settings
+
+    if not settings.voice_server_auth_enabled:
+        return ""
     from services.auth_service import create_access_token
 
     return create_access_token({"sub": "service:meeting", "scope": "voice"})

--- a/src/backend/services/piper_service.py
+++ b/src/backend/services/piper_service.py
@@ -273,9 +273,14 @@ class PiperService:
         from services.auth_service import create_access_token
         from services.voice_server_client import VoiceServerError, tts as vs_tts
 
-        # Service-account token signed with the platform SECRET_KEY,
-        # which voice-server validates in local mode.
-        token = create_access_token({"sub": "service:piper", "scope": "voice"})
+        # Service-account token signed with the platform SECRET_KEY, which the
+        # voice-server validates in local mode. "" when voice_server_auth_enabled
+        # is off (shared/foreign voice-server) → client sends no token → anonymous.
+        token = (
+            create_access_token({"sub": "service:piper", "scope": "voice"})
+            if settings.voice_server_auth_enabled
+            else ""
+        )
         try:
             return await vs_tts(text, language=language, auth_token=token)
         except VoiceServerError as e:

--- a/src/backend/services/voice_server_client.py
+++ b/src/backend/services/voice_server_client.py
@@ -54,6 +54,14 @@ def _base_url() -> str:
     return settings.voice_server_url.rstrip("/")
 
 
+def _auth_headers(auth_token: str) -> dict[str, str]:
+    """Bearer header — omitted entirely when the token is empty, so a voice-server
+    running auth_required=false treats the call as anonymous instead of trying
+    (and failing) to validate an empty/foreign token. Callers gate the token on
+    ``settings.voice_server_auth_enabled``."""
+    return {"Authorization": f"Bearer {auth_token}"} if auth_token else {}
+
+
 async def stt(
     audio_bytes: bytes,
     *,
@@ -68,7 +76,7 @@ async def stt(
     Returns {text, language, speaker_embedding?, audio_duration_s}.
     """
     url = f"{_base_url()}/api/voice/stt"
-    headers = {"Authorization": f"Bearer {auth_token}"}
+    headers = _auth_headers(auth_token)
     files = {"audio": (filename, audio_bytes, content_type)}
     data: dict[str, Any] = {}
     if language:
@@ -102,7 +110,7 @@ async def stt_opus(
     shape as stt(): {text, language, speaker_embedding?, audio_duration_s}.
     """
     url = f"{_base_url()}/api/voice/stt-opus"
-    headers = {"Authorization": f"Bearer {auth_token}"}
+    headers = _auth_headers(auth_token)
     files = {"audio": ("satellite_audio.opus", opus_blob, "application/octet-stream")}
     data: dict[str, Any] = {}
     if language:
@@ -131,7 +139,7 @@ async def tts(
 ) -> bytes:
     """POST text to voice-server /api/voice/tts. Returns full WAV bytes."""
     url = f"{_base_url()}/api/voice/tts"
-    headers = {"Authorization": f"Bearer {auth_token}"}
+    headers = _auth_headers(auth_token)
     payload: dict[str, Any] = {"text": text}
     if language:
         payload["language"] = language
@@ -169,7 +177,7 @@ async def transcribe_meeting(
     if timeout_s is None:
         timeout_s = settings.meeting_max_duration_h * 3600 + _MEETING_TIMEOUT_MARGIN_S
     url = f"{_base_url()}/transcribe-meeting"
-    headers = {"Authorization": f"Bearer {auth_token}"}
+    headers = _auth_headers(auth_token)
     data: dict[str, Any] = {}
     if whisper_model:
         data["whisper_model"] = whisper_model

--- a/src/backend/services/whisper_service.py
+++ b/src/backend/services/whisper_service.py
@@ -51,7 +51,12 @@ from services.audio_preprocessor import AudioPreprocessor
 # worker, scheduled jobs) need a service-account token signed with the
 # same SECRET_KEY voice-server validates against.
 def _get_service_token() -> str:
-    """Mint a short-lived service-account JWT for cross-pod auth."""
+    """Mint a short-lived service-account JWT for cross-pod auth. Returns "" when
+    ``voice_server_auth_enabled`` is off (shared/foreign voice-server) so the
+    client sends no token and the call is treated as anonymous."""
+    from utils.config import settings
+    if not settings.voice_server_auth_enabled:
+        return ""
     from services.auth_service import create_access_token
     return create_access_token({"sub": "service:whisper", "scope": "voice"})
 

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -118,6 +118,16 @@ class Settings(BaseSettings):
     # voice-server deployment.
     voice_server_url: str | None = None
 
+    # When False, the backend sends NO bearer token to the voice-server, so a
+    # voice-server running auth_required=false treats the call as anonymous.
+    # Set False on an instance that shares ANOTHER instance's voice-server: its
+    # own SECRET_KEY differs, so a token it minted would fail signature
+    # verification (401) even though the voice-server is "unauthenticated" (that
+    # flag only skips auth for a MISSING token, not a present-but-invalid one).
+    # Default True = the normal same-instance path (local-mode JWT validation).
+    # Interim until the shared voice-server gets real multi-tenant auth.
+    voice_server_auth_enabled: bool = True
+
     # Home Assistant / Frigate settings moved to ha_glue/utils/config.py
     # (see `HaGlueSettings`). Access via:
     #     from ha_glue.utils.config import ha_glue_settings

--- a/tests/backend/test_meetings.py
+++ b/tests/backend/test_meetings.py
@@ -327,6 +327,26 @@ class TestMeetingRoutes:
 # Pipeline pure functions — pseudonyms + render (no GPU, no DB)
 # ---------------------------------------------------------------------------
 
+class TestVoiceServerAuthGate:
+    """voice_server_auth_enabled=False → no token sent → voice-server anonymous
+    (for an instance sharing another instance's voice-server)."""
+
+    def test_auth_headers_omit_empty_token(self):
+        from services.voice_server_client import _auth_headers
+
+        assert _auth_headers("") == {}
+        assert _auth_headers("tok") == {"Authorization": "Bearer tok"}
+
+    def test_service_token_empty_when_auth_disabled(self, monkeypatch):
+        from services import meeting_pipeline
+
+        monkeypatch.setattr(settings, "voice_server_auth_enabled", False)
+        assert meeting_pipeline._service_token() == ""
+
+        monkeypatch.setattr(settings, "voice_server_auth_enabled", True)
+        assert meeting_pipeline._service_token()  # a real (non-empty) JWT
+
+
 class TestPseudonyms:
     def test_stable_first_appearance_mapping(self):
         from services.meeting_pipeline import apply_pseudonyms


### PR DESCRIPTION
## Problem
An instance sharing **another** instance's voice-server (renfield-xidra → the household voice-server) can't authenticate: it mints service tokens with its **own** SECRET_KEY, but the voice-server validates against the **household** key → `401 Signature verification failed`. `auth_required=false` doesn't help — it only skips auth for a **missing** token, not a present-but-foreign one. (Caught by the live xidra meeting E2E.)

## Fix
New `voice_server_auth_enabled` (default **True**). When **False**, the backend sends **no** bearer token → an `auth_required=false` voice-server treats the call as anonymous. Applied to all callers (meeting / STT / TTS) via a shared `_auth_headers()` that omits the header on an empty token + the 3 token minters returning `""` when off.

- **Household unchanged** (default True → keeps signing).
- **Shared-voice-server tenant** sets `VOICE_SERVER_AUTH_ENABLED=false` → anonymous → meetings work, **without sharing the household SECRET_KEY**.
- Interim until the voice-server topology redesign gives real multi-tenant auth.

## Tests
test_meetings **41 passed** (.159), +2: `_auth_headers` omits empty token; `_service_token` returns `""` when auth disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF