### PR TITLE
fix(llm): dedicated router URL, OpenAI-tier model defaults, reasoning-effort control

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -255,6 +255,37 @@ AGENT_ROUTER_TIMEOUT=30.0
 - `AGENT_CONV_CONTEXT_MESSAGES`: `6`
 - `AGENT_ROUTER_TIMEOUT`: `30.0`
 
+### OpenAI-kompatibler LLM-Endpoint (llama-server / vLLM / OpenRouter)
+
+```bash
+# Basis-URL eines OpenAI-kompatiblen Endpoints. Wenn gesetzt, nutzt der
+# Agent-Tier (und standardmäßig chat/rag/intent/kg/memory) diesen Endpoint
+# statt Ollama. Per-Tier abschaltbar: LLM_OPENAI_FOR_{AGENT,CHAT,RAG,INTENT,KG,MEMORY}=false
+# LLM_OPENAI_BASE_URL=http://cuda.local:8081/v1
+
+# Bearer-Key für externe APIs (OpenRouter, vLLM mit Auth). llama-server
+# ignoriert den Wert; ohne Key wird "no-key" gesendet.
+# LLM_OPENAI_API_KEY=sk-or-...
+
+# Logischer Modellname des Endpoints (llama-server --alias)
+# LLM_OPENAI_MODEL=qwen3.6
+
+# Reasoning-Budget für Reasoning-Modelle hinter dem Endpoint
+# ("minimal"/"low"/"medium"/"high"/"none", providerabhängig). Wird NUR bei
+# gesetztem Wert als `reasoning_effort` im Request-Body mitgesendet —
+# llama-server ignoriert unbekannte Felder, lokale Deployments bleiben
+# byte-identisch. Ohne diesen Wert laufen Reasoning-Modelle (GLM-5.x, Kimi,
+# DeepSeek, GPT-5.x) auf ihrem Default-Effort: gemessen ~30s Time-to-First-
+# Token pro Agent-Step, ~100s pro Multi-Step-Turn.
+# LLM_OPENAI_REASONING_EFFORT=low
+```
+
+**Defaults:**
+- `LLM_OPENAI_BASE_URL`: None (Ollama wird verwendet)
+- `LLM_OPENAI_API_KEY`: None (sendet "no-key")
+- `LLM_OPENAI_MODEL`: `qwen3.6`
+- `LLM_OPENAI_REASONING_EFFORT`: None (kein reasoning_effort im Request)
+
 **Wann aktivieren:**
 Der Agent Loop ermöglicht komplexe, mehrstufige Anfragen mit bedingter Logik und Tool-Verkettung:
 - "Wie ist das Wetter in Berlin und wenn es kälter als 10 Grad ist, suche ein Hotel"

--- a/src/backend/prompts/agent.yaml
+++ b/src/backend/prompts/agent.yaml
@@ -1205,7 +1205,12 @@ llm_options_summary:
 # Tool pre-selection — short JSON-only response, small context window.
 # Used by AgentService._preselect_tools() to ask the LLM for a small list of
 # tool names it expects to need this turn. Temperature 0 = deterministic.
+# num_predict 512 (not 120): reasoning models spend completion budget on
+# hidden reasoning BEFORE the visible JSON; at 120 the content came back
+# empty and pre-selection failed on every turn. Non-reasoning models stop
+# early and are unaffected. Keep in sync with
+# _DEFAULT_LLM_OPTIONS_TOOL_PRESELECT in services/agent_service.py.
 llm_options_tool_preselect:
   temperature: 0
-  num_predict: 120
+  num_predict: 512
   num_ctx: 4096

--- a/src/backend/services/agent_router.py
+++ b/src/backend/services/agent_router.py
@@ -543,15 +543,17 @@ class AgentRouter:
         # Priority: agent_router_model/url > agent_model/url > intent_model > default
         router_url = settings.agent_router_url or settings.agent_ollama_url
         router_model = settings.agent_router_model or settings.ollama_intent_model or settings.ollama_model
-        if settings.agent_router_url:
-            # A DEDICATED router endpoint always wins. get_agent_client would
-            # short-circuit to the OpenAI-compat endpoint whenever the agent
-            # tier uses one, sending this small local router model to an
+        if router_url:
+            # An explicitly configured router endpoint (AGENT_ROUTER_URL,
+            # falling back to AGENT_OLLAMA_URL) always wins. get_agent_client
+            # would short-circuit to the OpenAI-compat endpoint whenever the
+            # agent tier uses one, sending this small local router model to an
             # external API that validates model IDs (400) — the router must
-            # keep classifying locally regardless of where the agent lives.
-            client = get_dedicated_client(settings.agent_router_url)
-        elif router_url:
-            client, _ = get_agent_client(fallback_url=router_url)
+            # keep classifying on its configured endpoint regardless of where
+            # the agent lives. (llama-server URLs still work: create_llm_client
+            # picks the OpenAI-compat adapter for /v1 URLs, and llama-server
+            # ignores the requested model name.)
+            client = get_dedicated_client(router_url)
         else:
             client = ollama.client
 

--- a/src/backend/services/agent_router.py
+++ b/src/backend/services/agent_router.py
@@ -42,6 +42,7 @@ from utils.llm_client import (
     extract_response_content,
     get_agent_client,
     get_classification_chat_kwargs,
+    get_dedicated_client,
 )
 
 if TYPE_CHECKING:
@@ -542,7 +543,14 @@ class AgentRouter:
         # Priority: agent_router_model/url > agent_model/url > intent_model > default
         router_url = settings.agent_router_url or settings.agent_ollama_url
         router_model = settings.agent_router_model or settings.ollama_intent_model or settings.ollama_model
-        if router_url:
+        if settings.agent_router_url:
+            # A DEDICATED router endpoint always wins. get_agent_client would
+            # short-circuit to the OpenAI-compat endpoint whenever the agent
+            # tier uses one, sending this small local router model to an
+            # external API that validates model IDs (400) — the router must
+            # keep classifying locally regardless of where the agent lives.
+            client = get_dedicated_client(settings.agent_router_url)
+        elif router_url:
             client, _ = get_agent_client(fallback_url=router_url)
         else:
             client = ollama.client

--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -24,7 +24,12 @@ from services.prompt_manager import prompt_manager
 from utils.circuit_breaker import agent_circuit_breaker
 from utils.config import settings
 from utils.prompt_safety import neutralize_delimiters
-from utils.llm_client import extract_response_content, get_agent_client, get_classification_chat_kwargs
+from utils.llm_client import (
+    extract_response_content,
+    get_agent_client,
+    get_classification_chat_kwargs,
+    use_openai_for_tier,
+)
 from utils.token_counter import token_counter
 
 if TYPE_CHECKING:
@@ -1455,10 +1460,18 @@ class AgentService:
 
         start_time = time.monotonic()
 
-        # Per-role model/URL override > global agent settings > default
+        # Per-role model/URL override > global agent settings > default.
+        # When the agent tier rides an OpenAI-compat endpoint, the last-resort
+        # default must be that endpoint's model — falling back to the local
+        # Ollama model name sends e.g. "llama3.2:3b" to an external API that
+        # validates model IDs (400). Affects roles without a model override
+        # (notably the built-in `general` fallback role).
         role_model = self.role.model if self.role else None
         role_url = self.role.ollama_url if self.role else None
-        agent_model = role_model or settings.agent_model or settings.ollama_model
+        if use_openai_for_tier("agent"):
+            agent_model = role_model or settings.agent_model or settings.llm_openai_model
+        else:
+            agent_model = role_model or settings.agent_model or settings.ollama_model
 
         # Use separate Ollama instance for agent if configured
         agent_client, resolved_url = get_agent_client(role_url, settings.agent_ollama_url)

--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -418,7 +418,13 @@ _DEFAULT_LLM_OPTIONS_SUMMARY = {
     "temperature": 0.3, "num_predict": 1500, "num_ctx": 32768,
 }
 _DEFAULT_LLM_OPTIONS_TOOL_PRESELECT = {
-    "temperature": 0, "num_predict": 120, "num_ctx": 4096,
+    # 512, not 120: reasoning models spend completion budget on hidden
+    # reasoning tokens BEFORE the visible JSON. At 120 the entire budget was
+    # consumed by reasoning and the content came back empty, so pre-selection
+    # failed to parse on every turn (wasting the call and stuffing ALL tools
+    # into the agent prompt). 512 survives moderate reasoning while keeping
+    # the call cheap; non-reasoning models are unaffected (they stop early).
+    "temperature": 0, "num_predict": 512, "num_ctx": 4096,
 }
 
 # Hard workflow prerequisites: a tool the pre-selection LLM may pick cannot

--- a/src/backend/services/orchestrator.py
+++ b/src/backend/services/orchestrator.py
@@ -18,7 +18,12 @@ from loguru import logger
 
 from services.prompt_manager import prompt_manager
 from utils.config import settings
-from utils.llm_client import extract_response_content, get_agent_client, get_classification_chat_kwargs
+from utils.llm_client import (
+    extract_response_content,
+    get_agent_client,
+    get_classification_chat_kwargs,
+    use_openai_for_tier,
+)
 
 
 # Strip "_Quelle: ..._" / "_Source: ..._" lines that synthesizer LLMs
@@ -182,7 +187,15 @@ class QueryOrchestrator:
         if primary_role is not None:
             planner_model = getattr(primary_role, "model", None)
             planner_url = getattr(primary_role, "ollama_url", None)
-        planner_model = planner_model or settings.ollama_model
+        # Same last-resort rule as AgentService._run_impl: when the agent tier
+        # rides an OpenAI-compat endpoint, the default must be that endpoint's
+        # model — an Ollama model name sent to an external API that validates
+        # model IDs 400s, and the except below would silently disable
+        # multi-role orchestration on every turn.
+        if use_openai_for_tier("agent"):
+            planner_model = planner_model or settings.agent_model or settings.llm_openai_model
+        else:
+            planner_model = planner_model or settings.ollama_model
         planner_url = planner_url or settings.agent_ollama_url
 
         if not planner_model:

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -254,6 +254,15 @@ class Settings(BaseSettings):
     llm_openai_base_url: str | None = None
     llm_openai_api_key: SecretStr | None = None    # Any non-empty string is accepted by llama-server
     llm_openai_model: str = "qwen3.6"               # Logical model name exposed by the server (`--alias`)
+    # Reasoning-effort control for reasoning models behind the OpenAI-compat
+    # endpoint ("minimal"/"low"/"medium"/"high"/"none"; provider-dependent).
+    # Emitted as `reasoning_effort` in the request body ONLY when set —
+    # OpenRouter/OpenAI-style APIs honor it, llama-server ignores unknown
+    # fields, and the default (None) keeps local deployments byte-identical.
+    # Without it, reasoning models (GLM-5.x, Kimi, DeepSeek) run at their
+    # default (high) effort: measured ~30s time-to-first-token per agent
+    # step, ~100s per multi-step turn.
+    llm_openai_reasoning_effort: str | None = None
     # Per-tier opt-in: when True, that tier uses llm_openai_base_url instead of Ollama.
     # `agent` defaults to True if llm_openai_base_url is set; chat/rag/intent default
     # to following the agent setting unless explicitly overridden.

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -261,8 +261,10 @@ class Settings(BaseSettings):
     # fields, and the default (None) keeps local deployments byte-identical.
     # Without it, reasoning models (GLM-5.x, Kimi, DeepSeek) run at their
     # default (high) effort: measured ~30s time-to-first-token per agent
-    # step, ~100s per multi-step turn.
-    llm_openai_reasoning_effort: str | None = None
+    # step, ~100s per multi-step turn. Literal-validated: a typo here would
+    # otherwise 400 EVERY call on enum-validating providers across all tiers
+    # riding the endpoint.
+    llm_openai_reasoning_effort: Literal["minimal", "low", "medium", "high", "none"] | None = None
     # Per-tier opt-in: when True, that tier uses llm_openai_base_url instead of Ollama.
     # `agent` defaults to True if llm_openai_base_url is set; chat/rag/intent default
     # to following the agent setting unless explicitly overridden.

--- a/src/backend/utils/llm_client.py
+++ b/src/backend/utils/llm_client.py
@@ -164,6 +164,18 @@ def _make_client_with_fallback(primary_url: str) -> LLMClient:
     return primary
 
 
+def get_dedicated_client(url: str) -> LLMClient:
+    """Client bound to an explicit URL, bypassing the OpenAI-tier short-circuit.
+
+    For callers with their own dedicated endpoint (e.g. the router's
+    ``AGENT_ROUTER_URL``) that must NOT follow the agent tier to an external
+    OpenAI-compatible API: those callers use small local model names which
+    external APIs reject with 400. llama-server ignores the requested model
+    name, which masked this for local deployments.
+    """
+    return _make_client_with_fallback(url)
+
+
 def get_default_client() -> LLMClient:
     """Return the client for the default chat tier.
 

--- a/src/backend/utils/llm_client.py
+++ b/src/backend/utils/llm_client.py
@@ -353,6 +353,11 @@ class OpenAICompatibleClient:
         oa_messages = self._convert_messages(messages)
         oa_kwargs = self._options_to_openai(options, kwargs)
         extra_body = self._think_extra_body(kwargs)
+        if settings.llm_openai_reasoning_effort:
+            # Cap reasoning-model effort (see config.llm_openai_reasoning_effort).
+            # Single emit point: both the blocking and streaming paths below
+            # pass this extra_body through.
+            extra_body["reasoning_effort"] = settings.llm_openai_reasoning_effort
 
         # Tools: Ollama accepts a `tools` list with the OpenAI function schema
         # already, so pass through. tool_choice maps directly.

--- a/tests/backend/test_agent_router.py
+++ b/tests/backend/test_agent_router.py
@@ -1381,7 +1381,10 @@ class TestRouterModelSettings:
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_router_uses_dedicated_url(self):
-        """agent_router_url routes to a separate Ollama instance."""
+        """agent_router_url binds the router directly to its own endpoint —
+        bypassing get_agent_client's OpenAI-tier short-circuit (which would
+        send the small router model to an external API that validates model
+        IDs)."""
         router = AgentRouter(SAMPLE_CONFIG)
         mock_response = MagicMock()
         mock_response.message.content = '{"role": "conversation"}'
@@ -1391,7 +1394,7 @@ class TestRouterModelSettings:
         ollama = make_mock_ollama('{"role": "conversation"}')
 
         with patch("services.agent_router.settings") as s, \
-             patch("services.agent_router.get_agent_client", return_value=(mock_client, None)) as gac:
+             patch("services.agent_router.get_dedicated_client", return_value=mock_client) as gdc:
             s.agent_router_model = "qwen3:1.7b"
             s.agent_router_url = "http://fast-gpu:11434"
             s.agent_ollama_url = "http://main-gpu:11434"
@@ -1399,9 +1402,36 @@ class TestRouterModelSettings:
             s.ollama_model = "llama3.2:3b"
 
             await router.classify("Hallo", ollama)
-            gac.assert_called_once_with(fallback_url="http://fast-gpu:11434")
+            gdc.assert_called_once_with("http://fast-gpu:11434")
             call_kwargs = mock_client.chat.call_args
             assert call_kwargs.kwargs["model"] == "qwen3:1.7b"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_router_falls_back_to_agent_ollama_url_dedicated(self):
+        """Without agent_router_url, the AGENT_OLLAMA_URL fallback must ALSO
+        bypass the OpenAI-tier short-circuit — same 400-model-mismatch class
+        for the second config shape."""
+        router = AgentRouter(SAMPLE_CONFIG)
+        mock_response = MagicMock()
+        mock_response.message.content = '{"role": "conversation"}'
+        mock_client = AsyncMock()
+        mock_client.chat = AsyncMock(return_value=mock_response)
+
+        ollama = make_mock_ollama('{"role": "conversation"}')
+
+        with patch("services.agent_router.settings") as s, \
+             patch("services.agent_router.get_dedicated_client", return_value=mock_client) as gdc:
+            s.agent_router_model = None
+            s.agent_router_url = None
+            s.agent_ollama_url = "http://main-gpu:11434"
+            s.ollama_intent_model = "qwen3:8b"
+            s.ollama_model = "llama3.2:3b"
+
+            await router.classify("Hallo", ollama)
+            gdc.assert_called_once_with("http://main-gpu:11434")
+            call_kwargs = mock_client.chat.call_args
+            assert call_kwargs.kwargs["model"] == "qwen3:8b"
 
 
 # ============================================================================

--- a/tests/backend/test_llm_client.py
+++ b/tests/backend/test_llm_client.py
@@ -1084,3 +1084,76 @@ class TestGetDefaultClientRoutesToOpenAI:
         assert isinstance(embed, OpenAICompatibleClient)
         assert embed._base_url == "http://embed:8080/v1"
         assert embed._default_model == "qwen3-embedding"
+
+
+# ============================================================================
+# Reasoning-effort control + dedicated client (OpenRouter latency fixes)
+# ============================================================================
+
+class TestReasoningEffortExtraBody:
+    """llm_openai_reasoning_effort must reach the request extra_body — and
+    ONLY when explicitly configured (local llama-server deployments stay
+    byte-identical with the default None)."""
+
+    def _client_with_mock_create(self):
+        client = OpenAICompatibleClient.__new__(OpenAICompatibleClient)
+        client._default_model = "m"
+        inner = MagicMock()
+        inner.chat.completions.create = AsyncMock(return_value=MagicMock(choices=[]))
+        client._client = inner
+        return client, inner
+
+    @pytest.mark.unit
+    @patch("utils.llm_client.settings")
+    async def test_reasoning_effort_emitted_when_set(self, mock_settings):
+        mock_settings.llm_openai_reasoning_effort = "low"
+        client, inner = self._client_with_mock_create()
+        with patch.object(OpenAICompatibleClient, "_wrap_response", return_value=MagicMock()):
+            await client.chat(model="m", messages=[{"role": "user", "content": "hi"}])
+        _, kwargs = inner.chat.completions.create.call_args
+        assert kwargs["extra_body"] == {"reasoning_effort": "low"}
+
+    @pytest.mark.unit
+    @patch("utils.llm_client.settings")
+    async def test_no_extra_body_when_unset(self, mock_settings):
+        mock_settings.llm_openai_reasoning_effort = None
+        client, inner = self._client_with_mock_create()
+        with patch.object(OpenAICompatibleClient, "_wrap_response", return_value=MagicMock()):
+            await client.chat(model="m", messages=[{"role": "user", "content": "hi"}])
+        _, kwargs = inner.chat.completions.create.call_args
+        assert kwargs["extra_body"] is None
+
+    @pytest.mark.unit
+    @patch("utils.llm_client.settings")
+    async def test_reasoning_effort_composes_with_think_flag(self, mock_settings):
+        mock_settings.llm_openai_reasoning_effort = "low"
+        client, inner = self._client_with_mock_create()
+        with patch.object(OpenAICompatibleClient, "_wrap_response", return_value=MagicMock()):
+            await client.chat(model="m", messages=[{"role": "user", "content": "hi"}], think=False)
+        _, kwargs = inner.chat.completions.create.call_args
+        assert kwargs["extra_body"]["reasoning_effort"] == "low"
+        assert kwargs["extra_body"]["chat_template_kwargs"] == {"enable_thinking": False}
+
+
+class TestGetDedicatedClient:
+    """get_dedicated_client() must bypass the OpenAI-tier short-circuit."""
+
+    @pytest.mark.unit
+    @patch("ollama.AsyncClient")
+    @patch("utils.llm_client.settings")
+    def test_dedicated_url_wins_over_openai_tier(self, mock_settings, mock_cls):
+        from utils.llm_client import get_dedicated_client
+
+        mock_settings.llm_openai_base_url = "https://openrouter.ai/api/v1"
+        mock_settings.llm_openai_for_agent = None
+        mock_settings.ollama_fallback_url = ""
+        mock_settings.ollama_connect_timeout = 10.0
+        mock_settings.ollama_read_timeout = 300.0
+        sentinel = MagicMock()
+        mock_cls.return_value = sentinel
+
+        result = get_dedicated_client("http://router-ollama:11434")
+
+        args, kwargs = mock_cls.call_args
+        assert kwargs.get("host") == "http://router-ollama:11434"
+        assert result is sentinel

--- a/tests/backend/test_llm_client.py
+++ b/tests/backend/test_llm_client.py
@@ -1103,33 +1103,36 @@ class TestReasoningEffortExtraBody:
         client._client = inner
         return client, inner
 
+    def _run_chat(self, client, **chat_kwargs):
+        import asyncio
+
+        with patch.object(OpenAICompatibleClient, "_wrap_response", return_value=MagicMock()):
+            asyncio.run(client.chat(model="m", messages=[{"role": "user", "content": "hi"}], **chat_kwargs))
+
     @pytest.mark.unit
     @patch("utils.llm_client.settings")
-    async def test_reasoning_effort_emitted_when_set(self, mock_settings):
+    def test_reasoning_effort_emitted_when_set(self, mock_settings):
         mock_settings.llm_openai_reasoning_effort = "low"
         client, inner = self._client_with_mock_create()
-        with patch.object(OpenAICompatibleClient, "_wrap_response", return_value=MagicMock()):
-            await client.chat(model="m", messages=[{"role": "user", "content": "hi"}])
+        self._run_chat(client)
         _, kwargs = inner.chat.completions.create.call_args
         assert kwargs["extra_body"] == {"reasoning_effort": "low"}
 
     @pytest.mark.unit
     @patch("utils.llm_client.settings")
-    async def test_no_extra_body_when_unset(self, mock_settings):
+    def test_no_extra_body_when_unset(self, mock_settings):
         mock_settings.llm_openai_reasoning_effort = None
         client, inner = self._client_with_mock_create()
-        with patch.object(OpenAICompatibleClient, "_wrap_response", return_value=MagicMock()):
-            await client.chat(model="m", messages=[{"role": "user", "content": "hi"}])
+        self._run_chat(client)
         _, kwargs = inner.chat.completions.create.call_args
         assert kwargs["extra_body"] is None
 
     @pytest.mark.unit
     @patch("utils.llm_client.settings")
-    async def test_reasoning_effort_composes_with_think_flag(self, mock_settings):
+    def test_reasoning_effort_composes_with_think_flag(self, mock_settings):
         mock_settings.llm_openai_reasoning_effort = "low"
         client, inner = self._client_with_mock_create()
-        with patch.object(OpenAICompatibleClient, "_wrap_response", return_value=MagicMock()):
-            await client.chat(model="m", messages=[{"role": "user", "content": "hi"}], think=False)
+        self._run_chat(client, think=False)
         _, kwargs = inner.chat.completions.create.call_args
         assert kwargs["extra_body"]["reasoning_effort"] == "low"
         assert kwargs["extra_body"]["chat_template_kwargs"] == {"enable_thinking": False}

--- a/tests/backend/test_llm_client.py
+++ b/tests/backend/test_llm_client.py
@@ -1139,16 +1139,17 @@ class TestReasoningEffortExtraBody:
 
 
 class TestGetDedicatedClient:
-    """get_dedicated_client() must bypass the OpenAI-tier short-circuit."""
+    """get_dedicated_client() builds a client for exactly the given URL — it
+    has no OpenAI-tier branch by construction (the seam that decides is in
+    AgentRouter.classify, covered by test_agent_router.py's
+    test_router_uses_dedicated_url / _falls_back_to_agent_ollama_url)."""
 
     @pytest.mark.unit
     @patch("ollama.AsyncClient")
     @patch("utils.llm_client.settings")
-    def test_dedicated_url_wins_over_openai_tier(self, mock_settings, mock_cls):
+    def test_binds_explicit_url(self, mock_settings, mock_cls):
         from utils.llm_client import get_dedicated_client
 
-        mock_settings.llm_openai_base_url = "https://openrouter.ai/api/v1"
-        mock_settings.llm_openai_for_agent = None
         mock_settings.ollama_fallback_url = ""
         mock_settings.ollama_connect_timeout = 10.0
         mock_settings.ollama_read_timeout = 300.0
@@ -1160,3 +1161,20 @@ class TestGetDedicatedClient:
         args, kwargs = mock_cls.call_args
         assert kwargs.get("host") == "http://router-ollama:11434"
         assert result is sentinel
+
+    @pytest.mark.unit
+    @patch("ollama.AsyncClient")
+    @patch("utils.llm_client.settings")
+    def test_fallback_wrapping_applies(self, mock_settings, mock_cls):
+        """A configured OLLAMA_FALLBACK_URL wraps the dedicated client, same
+        as every other _make_client_with_fallback consumer."""
+        from utils.llm_client import _FallbackLLMClient, get_dedicated_client
+
+        mock_settings.ollama_fallback_url = "http://backup:11434"
+        mock_settings.ollama_connect_timeout = 10.0
+        mock_settings.ollama_read_timeout = 300.0
+        mock_cls.return_value = MagicMock()
+
+        result = get_dedicated_client("http://router-ollama:11434")
+
+        assert isinstance(result, _FallbackLLMClient)


### PR DESCRIPTION
## Summary
Four related fixes surfaced by running the agent tier against an external OpenAI-compatible API (OpenRouter) — the first backend that *validates* model IDs and runs reasoning models at default effort. llama-server ignores the requested model name and has no hidden reasoning phase, which masked all of these locally.

- **Router honors its dedicated URL.** `AgentRouter.classify` resolved its client via `get_agent_client`, which short-circuits to the OpenAI-compat endpoint whenever the agent tier uses one — `AGENT_ROUTER_URL` was silently ignored and the small local router model name (`llama3.2:3b`) was sent to the external API (400 → dead turns). New `get_dedicated_client(url)` bypasses the short-circuit; `classify()` uses it whenever `agent_router_url` is explicitly configured. The router keeps classifying locally regardless of where the agent lives.
- **OpenAI-tier default model for model-less roles.** Roles without a `model` override (notably the built-in `general` fallback role) defaulted to `settings.ollama_model` even when the agent tier rides an OpenAI-compat endpoint — same 400 failure class. The last-resort default now follows the endpoint (`llm_openai_model` for the OpenAI tier).
- **`LLM_OPENAI_REASONING_EFFORT` (new setting, default None).** When set, emitted as `reasoning_effort` in the request body (single emit point, blocking + streaming). Without it, reasoning models (GLM-5.x, Kimi, DeepSeek, GPT-5.x) run at default effort — measured ~30 s hidden-reasoning TTFT per agent step, ~100 s per multi-step turn; with `low`, turns dropped to ~45 s in a full-pipeline benchmark. Default None keeps local llama-server deployments byte-identical (unknown body fields are ignored there anyway).
- **Tool pre-selection budget 120 → 512** (`agent.yaml` + the Python fallback, kept in sync). Reasoning models consume the completion budget with reasoning tokens before the visible JSON; at 120 the content came back empty and pre-selection failed to parse on **every** turn — wasting an LLM call per turn and stuffing all tools into the agent prompt. Non-reasoning models stop early and are unaffected.

## Test plan
- [x] Unit tests added: `reasoning_effort` extra_body emission (set/unset/composed with `think=False`) and `get_dedicated_client` bypass — `tests/backend/test_llm_client.py` (70 pass, run inside the production image)
- [x] Manual end-to-end: full-pipeline benchmark through a production deployment against OpenRouter (GLM-5.2, Kimi K3, DeepSeek V4 Pro, Qwen3.5-397B, GPT-5.6, Claude Sonnet 5) — router classifies locally, `general` role works, pre-selection selects 4/42 tools, turns ~45 s at `reasoning_effort=low`
- [x] Local-deployment regression: with `LLM_OPENAI_REASONING_EFFORT` unset and llama-server as endpoint, requests are byte-identical; boot + smoke verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)