### PR TITLE
feat(meetings): §2 Phase 3 minutes pipeline — backend (PR-A)

### DIFF
--- a/docs/design/meeting-minutes.md
+++ b/docs/design/meeting-minutes.md
@@ -1,0 +1,145 @@
+# §2 Phase 3 — Meeting Minutes Pipeline (PLAN)
+
+> Status: **PLAN / not started.** Builds on Phase 2 (meeting transcription + diarization,
+> live on household + xidra). Turns a completed, speaker-attributed transcript into
+> structured **minutes** — summary + decisions + action-items — with a **human-confirm**
+> gate before anything is finalized or ingested. Flag-gated, dark by default.
+
+## Goal & scope
+
+From a `completed` `Meeting` (segments + `transcript_document_id` already exist), one LLM
+pass produces a draft **minutes** object:
+
+- **summary** — a few sentences.
+- **decisions[]** — each `{ text, made_by? }` (speaker attribution optional).
+- **action_items[]** — each `{ text, owner?, due_hint? }` — meeting-scoped, human-confirmed.
+
+The draft is **proposed, never auto-committed**. The owner reviews/edits, then confirms;
+the confirmed minutes render into the transcript document (or a sibling doc) in the KB.
+
+### Explicit non-goals (locked in the §2 design)
+- **Action-items are NOT obligations.** §2 already gates Schicht-A **off** on transcripts
+  (D14 — "no phantom obligations from small talk"). Minutes action-items stay meeting-scoped
+  and human-confirmed; they do **not** feed the obligation notifier / calendar sync. (A future
+  "promote this action-item to an obligation" affordance could be added deliberately, later.)
+- **Satellite recording** ("Renfield, starte Meeting-Aufnahme") is a separate later phase,
+  out of the numbered Phases 1–4.
+- **Auto-confirm** — out. Human-in-the-loop is the whole point of this phase.
+
+## Data model (additive migration)
+
+The `meetings` table has no minutes fields today. Add them additively (migration
+`pc2026XXXX_meeting_minutes`, chain off the current head):
+
+```
+minutes            JSONB  NULL   -- {summary, decisions[], action_items[]} (draft or confirmed)
+minutes_status     VARCHAR(20) NOT NULL DEFAULT 'none'
+                    -- none → draft → confirmed  (mirrors the meeting status machine)
+minutes_generated_at  DateTime NULL
+minutes_confirmed_at  DateTime NULL
+```
+
+- One JSONB column keeps it cross-dialect (same pattern as `segments`), avoids N child tables
+  for v1, and rehydrates trivially. If decisions/action-items later need per-row state
+  (e.g. individual action-item completion), promote to a `meeting_minutes_items` table then —
+  not now (YAGNI).
+- `minutes_status` is the gate: `none` (not generated) → `draft` (LLM produced, awaiting
+  confirm) → `confirmed`. The UI and ingest key off this.
+
+## Extraction service (`services/meeting_minutes.py`)
+
+Mirror the Schicht-A extractor pattern (`services/schicht_a_extractor.py`):
+
+- `class MinutesExtractor` with `async def extract(segments, *, lang="de") -> MinutesDraft`.
+- Build the prompt from the **attributed** segments (speaker labels + text), so decisions/
+  action-items can carry `made_by`/`owner` when the transcript names a person.
+- Use the **thinking-model-aware** chat kwargs helper (`get_classification_chat_kwargs`) —
+  the same one Schicht-A uses — so a qwen3-style thinking model doesn't return empty `content`
+  (known failure mode: `reference_person_names_embedding_cluster` sibling — thinking models +
+  `content` handling).
+- **Structured output**: request strict JSON (`{summary, decisions, action_items}`); validate
+  the shape server-side before storing (kind/size caps like `artifact_service`), fall back to
+  a warm empty draft on a malformed response rather than persisting garbage.
+- New prompt file `prompts/meeting_minutes.yaml` (de + en variants), version-hashed like the
+  other prompts (shows up in `/health` prompt_hashes).
+
+## Pipeline: when it runs
+
+**Decision D-M1 — on-demand, not auto.** After a meeting completes, `minutes_status='none'`.
+The user clicks **"Protokoll erstellen"** on a completed meeting → `POST
+/api/meetings/{id}/minutes/generate` enqueues (or runs inline for short meetings) the extractor
+→ stores `minutes` + `minutes_status='draft'`. Rationale: avoids an LLM pass on every meeting
+(cost), and many recordings won't need minutes. (Auto-draft-on-complete is a trivial later
+flip if wanted — a follow-on step in `meeting_worker` after ingest.)
+
+For long transcripts the generate call routes through the **meeting worker** (reuse the queue
++ heartbeat guard) rather than blocking the request; short ones can run inline. Start inline
+with a size threshold; add the queue path only if needed.
+
+## API surface (routes on `api/routes/meetings.py`, owner-gated like the rest)
+
+```
+POST   /api/meetings/{id}/minutes/generate   -> 202/200, sets minutes_status=draft (409 if not completed)
+GET    /api/meetings/{id}/minutes            -> {minutes, minutes_status, ...}
+PUT    /api/meetings/{id}/minutes            -> owner edits the draft (summary/decisions/action_items)
+POST   /api/meetings/{id}/minutes/confirm    -> minutes_status=confirmed + render into KB (409 unless draft)
+DELETE /api/meetings/{id}/minutes            -> back to none (discard draft)
+```
+
+All `_require_enabled()` + `_get_owned_meeting()` gated, same as the existing meeting routes.
+
+## Human-confirm + ingest
+
+- Minutes are their **own** confirm surface (a REST confirm on the meeting), **not** the chat
+  `paperless_confirm` WS-frame path — meetings live on their own page/API, not in the chat flow.
+- On **confirm**: render the confirmed minutes as markdown and **append/prepend to the transcript
+  document** via the same stable-doc reindex path re-attribution uses
+  (`meeting_pipeline._reindex_transcript`, stable `transcript_document_id`) — OR ingest a sibling
+  "Protokoll" doc. **Decision D-M2:** append to the transcript doc (one KB artifact per meeting,
+  simpler retention — the existing retention job already purges the transcript doc). Keep
+  Schicht-A **off** on it (same `source="meeting_transcript"` gate).
+
+## Frontend (`pages/MeetingsPage.tsx`)
+
+Extend the expanded completed-meeting view (below the transcript / relabel section):
+
+- If `minutes_status === 'none'`: a **"Protokoll erstellen"** button → generate.
+- If `draft`: render summary + decisions + action-items as **editable** fields (typed inputs,
+  add/remove rows) + **"Bestätigen"** / **"Verwerfen"**. Reuse the inline-confirm affordance
+  style already on the card (relabel/delete).
+- If `confirmed`: read-only minutes + a link to the KB doc (already have `transcript_document_id`).
+- New `api/resources/meetings.ts` hooks (`useMeetingMinutes`, `useGenerateMinutes`,
+  `useUpdateMinutes`, `useConfirmMinutes`) — same `useApiQuery`/`useApiMutation` idiom.
+- i18n `meetings.minutes.*` in **de + en**. Typed shapes (no `any`).
+
+## Config / flag
+
+`MEETING_MINUTES_ENABLED` (default **false**, dark). Gate the routes (404 when off) + the
+frontend affordance (surface via `/api/config/features`, like `meeting_transcription_enabled`).
+Needs a chat model (already available); no new infra.
+
+## Build sequence (PR breakdown)
+
+1. **PR-A (backend):** migration (additive minutes fields) + `MinutesExtractor` +
+   `prompts/meeting_minutes.yaml` + the 5 routes + flag. Tests: extractor (fixture transcript →
+   shaped minutes, malformed-LLM fallback), route owner-gating + status transitions
+   (none→draft→confirmed, 409s), confirm→reindex. `test_meetings.py`.
+2. **PR-B (frontend):** minutes section on MeetingsPage + hooks + i18n + RTL tests
+   (generate/edit/confirm/discard, flag-gated render). Expose the flag in `/api/config/features`.
+3. **Docs sweep + deploy** (backend then frontend, **pre-seed images over LAN** — the Recreate
+   WAN-pull outage bit us 3× in the Phase 2 rollout).
+4. **Flag flip** per instance + browser E2E (generate → edit → confirm → KB doc updated).
+
+## Open decisions to confirm before building
+
+- **D-M1** on-demand vs auto-draft-on-complete (plan: on-demand). 
+- **D-M2** append-to-transcript-doc vs sibling Protokoll doc (plan: append).
+- **D-M3** action-item → obligation promotion: **out of v1** (keep the D14 wall); revisit as its
+  own opt-in later.
+- **Language**: extract in the transcript's language (de default), like the transcript.
+
+## Ties into
+Phase 2 design `docs/design/meeting-transcription.md` (the transcript this consumes);
+`services/schicht_a_extractor.py` (extraction pattern); the additive-migration discipline in
+`CLAUDE.md` (Alembic transaction model). Phase 4 (Notes + project timeline) builds on top:
+confirmed minutes are a natural timeline event + a note source.

--- a/src/backend/alembic/versions/pc20260718_meeting_minutes.py
+++ b/src/backend/alembic/versions/pc20260718_meeting_minutes.py
@@ -1,0 +1,52 @@
+"""meeting minutes — §2 Phase 3 (summary / decisions / action-items)
+
+Revision ID: pc20260718_meeting_minutes
+Revises: pc20260714b_document_source
+Create Date: 2026-07-18
+
+Adds the additive minutes columns to ``meetings``: a ``minutes`` JSONB blob
+({summary, decisions[], action_items[]}) plus a ``minutes_status`` gate
+(none -> draft -> confirmed) and generated/confirmed timestamps. NULL/'none'
+for every existing meeting, so this is behaviourally a no-op until Phase 3 is
+used.
+
+Idempotency: inspector-guarded per column — Base.metadata.create_all (backend
+boot) already adds these for the model, so re-running is a no-op. Fully
+transactional (transaction_per_migration).
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "pc20260718_meeting_minutes"
+down_revision = "pc20260714b_document_source"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    cols = {c["name"] for c in inspector.get_columns("meetings")}
+    dialect = bind.dialect.name
+    json_type = sa.dialects.postgresql.JSONB() if dialect == "postgresql" else sa.JSON()
+
+    if "minutes" not in cols:
+        op.add_column("meetings", sa.Column("minutes", json_type, nullable=True))
+    if "minutes_status" not in cols:
+        op.add_column(
+            "meetings",
+            sa.Column(
+                "minutes_status", sa.String(20), nullable=False, server_default="none"
+            ),
+        )
+    if "minutes_generated_at" not in cols:
+        op.add_column("meetings", sa.Column("minutes_generated_at", sa.DateTime(), nullable=True))
+    if "minutes_confirmed_at" not in cols:
+        op.add_column("meetings", sa.Column("minutes_confirmed_at", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("meetings", "minutes_confirmed_at")
+    op.drop_column("meetings", "minutes_generated_at")
+    op.drop_column("meetings", "minutes_status")
+    op.drop_column("meetings", "minutes")

--- a/src/backend/api/routes/config.py
+++ b/src/backend/api/routes/config.py
@@ -78,6 +78,9 @@ class FeatureFlags(BaseModel):
     # labeling). Off => no Meetings nav/page. See utils/config.py::
     # meeting_transcription_enabled + docs/design/meeting-transcription.md.
     meeting_transcription_enabled: bool
+    # Gates the §2 Phase 3 minutes UI (generate/edit/confirm on a completed
+    # meeting). Off => no minutes affordance. See utils/config.py::meeting_minutes_enabled.
+    meeting_minutes_enabled: bool
     # True when the Reva-only Wissensbasis surface (/trace + /me/mix) is mounted
     # (Reva adapter present). Standalone Renfield => False. Lets the frontend
     # hide the Reva-only side panels without probing an endpoint that 404s.
@@ -101,5 +104,6 @@ async def get_features(
         chat_branching_enabled=settings.chat_branching_enabled,
         projects_enabled=settings.projects_enabled,
         meeting_transcription_enabled=settings.meeting_transcription_enabled,
+        meeting_minutes_enabled=settings.meeting_minutes_enabled,
         wissensbasis_reva_available=_reva_wissensbasis_mounted(request),
     )

--- a/src/backend/api/routes/meetings.py
+++ b/src/backend/api/routes/meetings.py
@@ -322,3 +322,137 @@ async def relabel_speaker(
     if not ok:
         raise HTTPException(status_code=404, detail="speaker not found")
     return _to_response(meeting)
+
+
+# --------------------------------------------------------------------------- #
+# §2 Phase 3 — minutes (summary / decisions / action-items with human confirm)
+# --------------------------------------------------------------------------- #
+
+class _Decision(BaseModel):
+    text: str = Field(min_length=1, max_length=1000)
+    made_by: str = Field(default="", max_length=200)
+
+
+class _ActionItem(BaseModel):
+    text: str = Field(min_length=1, max_length=1000)
+    owner: str = Field(default="", max_length=200)
+    due_hint: str = Field(default="", max_length=200)
+
+
+class MinutesBody(BaseModel):
+    summary: str = Field(default="", max_length=4000)
+    decisions: list[_Decision] = Field(default_factory=list, max_length=100)
+    action_items: list[_ActionItem] = Field(default_factory=list, max_length=200)
+
+
+class MinutesResponse(BaseModel):
+    id: int
+    minutes_status: str
+    minutes: dict | None
+
+
+def _require_minutes_enabled() -> None:
+    _require_enabled()
+    if not settings.meeting_minutes_enabled:
+        raise HTTPException(status_code=404, detail="Meeting minutes are not enabled")
+
+
+def _minutes_response(m: Meeting) -> MinutesResponse:
+    return MinutesResponse(id=m.id, minutes_status=m.minutes_status, minutes=m.minutes)
+
+
+@router.post("/{meeting_id}/minutes/generate", response_model=MinutesResponse)
+async def generate_minutes(
+    meeting_id: int,
+    user: User | None = Depends(get_optional_user),
+    db: AsyncSession = Depends(get_db),
+) -> MinutesResponse:
+    """Extract DRAFT minutes from a completed meeting's transcript (owner-gated).
+    409 if the meeting isn't completed. Re-running overwrites the draft."""
+    _require_minutes_enabled()
+    meeting = await _get_owned_meeting(meeting_id, user, db)
+    if meeting.status != "completed":
+        raise HTTPException(status_code=409, detail="meeting not completed")
+
+    from services.meeting_minutes import MinutesExtractor
+
+    draft = await MinutesExtractor().extract(meeting.segments or [])
+    meeting.minutes = draft
+    meeting.minutes_status = "draft"
+    meeting.minutes_generated_at = datetime.utcnow()
+    meeting.minutes_confirmed_at = None
+    await db.commit()
+    return _minutes_response(meeting)
+
+
+@router.get("/{meeting_id}/minutes", response_model=MinutesResponse)
+async def get_minutes(
+    meeting_id: int,
+    user: User | None = Depends(get_optional_user),
+    db: AsyncSession = Depends(get_db),
+) -> MinutesResponse:
+    """Current minutes + status (owner-gated 404)."""
+    _require_minutes_enabled()
+    meeting = await _get_owned_meeting(meeting_id, user, db)
+    return _minutes_response(meeting)
+
+
+@router.put("/{meeting_id}/minutes", response_model=MinutesResponse)
+async def update_minutes(
+    meeting_id: int,
+    body: MinutesBody,
+    user: User | None = Depends(get_optional_user),
+    db: AsyncSession = Depends(get_db),
+) -> MinutesResponse:
+    """Owner edits the draft. 409 unless status is draft (confirmed minutes are
+    re-opened by editing → back to draft, so a re-confirm re-renders)."""
+    _require_minutes_enabled()
+    meeting = await _get_owned_meeting(meeting_id, user, db)
+    if meeting.minutes_status not in ("draft", "confirmed"):
+        raise HTTPException(status_code=409, detail="no minutes to edit — generate first")
+    meeting.minutes = body.model_dump()
+    meeting.minutes_status = "draft"
+    meeting.minutes_confirmed_at = None
+    await db.commit()
+    return _minutes_response(meeting)
+
+
+@router.post("/{meeting_id}/minutes/confirm", response_model=MinutesResponse)
+async def confirm_minutes(
+    meeting_id: int,
+    user: User | None = Depends(get_optional_user),
+    db: AsyncSession = Depends(get_db),
+) -> MinutesResponse:
+    """Confirm the draft → renders the minutes into the transcript document (same
+    stable-doc reindex path as re-attribution). 409 unless status is draft."""
+    _require_minutes_enabled()
+    meeting = await _get_owned_meeting(meeting_id, user, db)
+    if meeting.minutes_status != "draft":
+        raise HTTPException(status_code=409, detail="minutes not in draft state")
+
+    meeting.minutes_status = "confirmed"
+    meeting.minutes_confirmed_at = datetime.utcnow()
+    # Re-render the transcript doc WITH the confirmed minutes + reindex in place
+    # (commits meeting + doc status). No new ingest — stable transcript_document_id.
+    from services.meeting_pipeline import _overwrite_transcript_and_reindex
+
+    await _overwrite_transcript_and_reindex(db, meeting, meeting.segments or [])
+    return _minutes_response(meeting)
+
+
+@router.delete("/{meeting_id}/minutes", response_model=MinutesResponse)
+async def delete_minutes(
+    meeting_id: int,
+    user: User | None = Depends(get_optional_user),
+    db: AsyncSession = Depends(get_db),
+) -> MinutesResponse:
+    """Discard minutes → back to none. Does NOT strip already-confirmed minutes
+    from the transcript document (a subsequent relabel/reindex would drop them)."""
+    _require_minutes_enabled()
+    meeting = await _get_owned_meeting(meeting_id, user, db)
+    meeting.minutes = None
+    meeting.minutes_status = "none"
+    meeting.minutes_generated_at = None
+    meeting.minutes_confirmed_at = None
+    await db.commit()
+    return _minutes_response(meeting)

--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -396,6 +396,16 @@ class Meeting(Base):
     # Retention mechanism (not a status): a daily job deletes meetings past this.
     retention_until = Column(DateTime, nullable=True)
 
+    # === Phase 3: minutes (summary / decisions / action-items), additive ===
+    # Draft or confirmed minutes as {summary, decisions[], action_items[]} — one
+    # JSONB blob (v1; promote to a child table only if per-item state is needed).
+    # minutes_status gates the UI + ingest: none -> draft (LLM produced, awaiting
+    # human confirm) -> confirmed (rendered into the transcript document).
+    minutes = Column(JSON().with_variant(JSONB(), "postgresql"), nullable=True)
+    minutes_status = Column(String(20), nullable=False, default="none", server_default="none")
+    minutes_generated_at = Column(DateTime, nullable=True)
+    minutes_confirmed_at = Column(DateTime, nullable=True)
+
     created_at = Column(DateTime, default=_utcnow)
 
 

--- a/src/backend/prompts/meeting_minutes.yaml
+++ b/src/backend/prompts/meeting_minutes.yaml
@@ -1,0 +1,59 @@
+# Meeting minutes extraction prompts (§2 Phase 3).
+#
+# Used by MinutesExtractor.extract() to turn a speaker-attributed meeting
+# transcript into DRAFT minutes: a short summary, the decisions taken, and the
+# action-items agreed. The draft is human-confirmed before anything is finalized.
+#
+# Rules: extract only what the transcript says (no invention). Attribute
+# made_by/owner ONLY when the transcript names a person; leave empty otherwise.
+# Action-items are meeting-scoped — NOT obligations/deadlines for the Fristen
+# agenda. Respond with JSON only.
+
+de:
+  system: |
+    Du erstellst ein praegnantes Besprechungsprotokoll aus einem sprecher-
+    attribuierten Transkript. Gib AUSSCHLIESSLICH ein JSON-Objekt zurueck, keinen
+    Fliesstext, kein Markdown.
+
+    Schema:
+    {
+      "summary": "2-5 Saetze, worum es ging und die wichtigsten Ergebnisse",
+      "decisions": [{"text": "getroffene Entscheidung", "made_by": "Name oder leer"}],
+      "action_items": [{"text": "vereinbarte Aufgabe", "owner": "Name oder leer", "due_hint": "Termin wie genannt oder leer"}]
+    }
+
+    Regeln:
+    - Extrahiere nur, was im Transkript steht. Erfinde nichts.
+    - "made_by"/"owner" nur setzen, wenn eine Person klar benannt ist (aus dem
+      Sprecherlabel oder namentlich), sonst leer lassen.
+    - "due_hint" ist ein WORTLAUT-Hinweis (z.B. "bis Freitag", "naechste Woche") —
+      KEIN berechnetes Datum.
+    - Nur echte Entscheidungen/Aufgaben aufnehmen, keinen Smalltalk.
+    - Leere Listen sind erlaubt, wenn nichts entschieden/vereinbart wurde.
+  user: |
+    Transkript:
+    {transcript}
+
+en:
+  system: |
+    You produce concise meeting minutes from a speaker-attributed transcript.
+    Respond with a JSON object ONLY — no prose, no markdown.
+
+    Schema:
+    {
+      "summary": "2-5 sentences: what it was about and the key outcomes",
+      "decisions": [{"text": "the decision made", "made_by": "name or empty"}],
+      "action_items": [{"text": "the agreed task", "owner": "name or empty", "due_hint": "the deadline as stated, or empty"}]
+    }
+
+    Rules:
+    - Only extract what the transcript states. Invent nothing.
+    - Set "made_by"/"owner" only when a person is clearly named (from the speaker
+      label or by name); otherwise leave empty.
+    - "due_hint" is a VERBATIM hint (e.g. "by Friday", "next week") — NOT a
+      computed date.
+    - Include only real decisions/tasks, not small talk.
+    - Empty lists are fine when nothing was decided/agreed.
+  user: |
+    Transcript:
+    {transcript}

--- a/src/backend/services/meeting_minutes.py
+++ b/src/backend/services/meeting_minutes.py
@@ -1,0 +1,200 @@
+"""Meeting minutes extraction (§2 Phase 3).
+
+From a completed meeting's speaker-attributed segments, one LLM pass produces a
+DRAFT minutes object — ``{summary, decisions[], action_items[]}`` — which the
+owner reviews/edits/confirms before it is finalized (never auto-committed).
+
+Mirrors ``schicht_a_extractor`` (thinking-model-aware chat kwargs, strict-JSON
+response, best-effort — a malformed response yields an empty draft rather than
+raising). Action-items are meeting-scoped and human-confirmed; they deliberately
+do NOT feed the obligation notifier (D14 — no phantom obligations from small
+talk). See docs/design/meeting-minutes.md.
+"""
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from loguru import logger
+
+from services.prompt_manager import prompt_manager
+from utils.config import settings
+from utils.llm_client import (
+    extract_response_content,
+    get_classification_chat_kwargs,
+    get_default_client,
+)
+
+# Shape caps (DoS / runaway-generation guard, mirrors artifact_service).
+_MAX_SUMMARY = 4000
+_MAX_ITEM_TEXT = 1000
+_MAX_NAME = 200
+_MAX_DECISIONS = 100
+_MAX_ACTION_ITEMS = 200
+# Cap the transcript fed to the model (very long meetings) — head is where the
+# agenda/decisions usually land; keep generous.
+_MAX_TRANSCRIPT_CHARS = 24000
+
+
+def _parse_llm_json(raw: str) -> dict | None:
+    """Best-effort JSON out of an LLM reply (tolerates ```json fences / prose)."""
+    if not raw:
+        return None
+    raw = raw.strip()
+    fence = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", raw, re.DOTALL)
+    candidate = fence.group(1) if fence else raw
+    m = re.search(r"\{.*\}", candidate, re.DOTALL)
+    if not m:
+        return None
+    try:
+        obj = json.loads(m.group(0))
+        return obj if isinstance(obj, dict) else None
+    except (ValueError, TypeError):
+        return None
+
+
+def _clean(value: Any, cap: int) -> str:
+    return (str(value).strip())[:cap] if value is not None else ""
+
+
+def _normalize_minutes(payload: dict) -> dict:
+    """Coerce a raw LLM payload into the validated minutes shape, dropping junk.
+    Always returns the full shape (empty lists rather than missing keys)."""
+    summary = _clean(payload.get("summary"), _MAX_SUMMARY)
+
+    decisions: list[dict] = []
+    for d in (payload.get("decisions") or [])[:_MAX_DECISIONS]:
+        if isinstance(d, str):
+            text = _clean(d, _MAX_ITEM_TEXT)
+            made_by = ""
+        elif isinstance(d, dict):
+            text = _clean(d.get("text"), _MAX_ITEM_TEXT)
+            made_by = _clean(d.get("made_by"), _MAX_NAME)
+        else:
+            continue
+        if text:
+            decisions.append({"text": text, "made_by": made_by})
+
+    action_items: list[dict] = []
+    for a in (payload.get("action_items") or [])[:_MAX_ACTION_ITEMS]:
+        if isinstance(a, str):
+            text, owner, due = _clean(a, _MAX_ITEM_TEXT), "", ""
+        elif isinstance(a, dict):
+            text = _clean(a.get("text"), _MAX_ITEM_TEXT)
+            owner = _clean(a.get("owner"), _MAX_NAME)
+            due = _clean(a.get("due_hint"), _MAX_NAME)
+        else:
+            continue
+        if text:
+            action_items.append({"text": text, "owner": owner, "due_hint": due})
+
+    return {"summary": summary, "decisions": decisions, "action_items": action_items}
+
+
+def empty_minutes() -> dict:
+    return {"summary": "", "decisions": [], "action_items": []}
+
+
+def _segments_to_text(segments: list[dict]) -> str:
+    lines: list[str] = []
+    for seg in segments or []:
+        speaker = seg.get("speaker", "Sprecher ?")
+        text = (seg.get("text") or "").strip()
+        if text:
+            lines.append(f"{speaker}: {text}")
+    return "\n".join(lines)[:_MAX_TRANSCRIPT_CHARS]
+
+
+class MinutesExtractor:
+    """One per request; ``llm_client`` injectable for tests."""
+
+    def __init__(self, llm_client: Any = None):
+        self._llm_client = llm_client
+
+    async def extract(self, segments: list[dict], *, lang: str = "de") -> dict:
+        """Return validated minutes ``{summary, decisions[], action_items[]}``.
+        Never raises — a missing model / malformed response yields empty minutes."""
+        transcript = _segments_to_text(segments)
+        if not transcript.strip():
+            return empty_minutes()
+
+        model = settings.ollama_chat_model or settings.ollama_model
+        if not model:
+            logger.warning("meeting minutes: no chat model configured")
+            return empty_minutes()
+
+        system = prompt_manager.get(
+            "meeting_minutes", "system",
+            default=(
+                "Du erstellst ein Besprechungsprotokoll aus einem Transkript. "
+                "Antworte AUSSCHLIESSLICH als JSON: "
+                '{"summary": "...", "decisions": [{"text": "...", "made_by": "..."}], '
+                '"action_items": [{"text": "...", "owner": "...", "due_hint": "..."}]}. '
+                "made_by/owner/due_hint nur wenn im Transkript genannt, sonst leer."
+            ),
+            lang=lang,
+        )
+        user = prompt_manager.get(
+            "meeting_minutes", "user", default="Transkript:\n{transcript}",
+            lang=lang, transcript=transcript,
+        )
+
+        try:
+            client = self._llm_client or get_default_client()
+            response = await client.chat(
+                model=model,
+                messages=[
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": user},
+                ],
+                options={"temperature": 0.2},
+                **get_classification_chat_kwargs(model),
+            )
+            payload = _parse_llm_json(extract_response_content(response) or "")
+            if payload is None:
+                raise ValueError("unparseable minutes response")
+            return _normalize_minutes(payload)
+        except Exception as e:  # noqa: BLE001 — best-effort; never break the request
+            logger.warning(f"meeting minutes extraction failed: {e}")
+            return empty_minutes()
+
+
+def render_minutes_markdown(minutes: dict, *, lang: str = "de") -> str:
+    """Render confirmed minutes as a markdown section appended to the transcript
+    document. Returns "" for empty minutes (nothing to append)."""
+    minutes = minutes or {}
+    summary = (minutes.get("summary") or "").strip()
+    decisions = minutes.get("decisions") or []
+    action_items = minutes.get("action_items") or []
+    if not summary and not decisions and not action_items:
+        return ""
+
+    de = lang.startswith("de")
+    h_min = "Protokoll" if de else "Minutes"
+    h_sum = "Zusammenfassung" if de else "Summary"
+    h_dec = "Entscheidungen" if de else "Decisions"
+    h_act = "Aufgaben" if de else "Action items"
+
+    out = [f"\n## {h_min}\n"]
+    if summary:
+        out.append(f"### {h_sum}\n\n{summary}\n")
+    if decisions:
+        out.append(f"### {h_dec}\n")
+        for d in decisions:
+            who = (d.get("made_by") or "").strip()
+            out.append(f"- {d.get('text', '').strip()}" + (f" — _{who}_" if who else ""))
+        out.append("")
+    if action_items:
+        out.append(f"### {h_act}\n")
+        for a in action_items:
+            owner = (a.get("owner") or "").strip()
+            due = (a.get("due_hint") or "").strip()
+            suffix = ""
+            if owner:
+                suffix += f" — **{owner}**"
+            if due:
+                suffix += f" ({due})"
+            out.append(f"- [ ] {a.get('text', '').strip()}{suffix}")
+        out.append("")
+    return "\n".join(out).rstrip() + "\n"

--- a/src/backend/services/meeting_pipeline.py
+++ b/src/backend/services/meeting_pipeline.py
@@ -83,7 +83,17 @@ def render_transcript_markdown(meeting: Meeting, segments: list[dict]) -> str:
         if not text:
             continue
         lines.append(f"**{speaker}:** {text}")
-    return "\n".join(lines).strip() + "\n"
+    body = "\n".join(lines).strip() + "\n"
+
+    # Phase 3: append CONFIRMED minutes to the same document (D-M2 — one KB
+    # artifact per meeting). Draft minutes are never rendered into the doc.
+    if getattr(meeting, "minutes_status", "none") == "confirmed" and meeting.minutes:
+        from services.meeting_minutes import render_minutes_markdown
+
+        section = render_minutes_markdown(meeting.minutes)
+        if section:
+            body = body.rstrip() + "\n\n" + section
+    return body
 
 
 async def _resolve_meetings_kb(db) -> KnowledgeBase:

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -489,6 +489,9 @@ class Settings(BaseSettings):
     # /api/config/features). Off => both instances are byte-identical.
     # See docs/design/meeting-transcription.md.
     meeting_transcription_enabled: bool = False
+    # §2 Phase 3: minutes pipeline (summary/decisions/action-items with human
+    # confirm) on a completed transcript. Dark by default; needs a chat model.
+    meeting_minutes_enabled: bool = False
     # faster-whisper model for meeting batch ASR ("" => reuse the STT default).
     # A larger model (e.g. large-v3-turbo) trades GPU-seconds for accuracy; set
     # from the spike results. Loaded/unloaded per job on the voice-server.

--- a/tests/backend/test_meetings.py
+++ b/tests/backend/test_meetings.py
@@ -961,3 +961,139 @@ class TestReviewFixes:
         m = (await db_session.execute(_sel(Meeting))).scalars().first()
         assert m is not None and m.status == "failed"
         assert _glob.glob(str(tmp_path / "meetings" / f"meeting-{m.id}.*")) == []  # audio cleaned
+
+
+# ---------------------------------------------------------------------------
+# §2 Phase 3 — minutes (pure functions + routes)
+# ---------------------------------------------------------------------------
+
+class TestMeetingMinutesUnit:
+    def test_render_minutes_markdown(self):
+        from services.meeting_minutes import empty_minutes, render_minutes_markdown
+
+        assert render_minutes_markdown(empty_minutes()) == ""
+        md = render_minutes_markdown({
+            "summary": "Kurzfassung.",
+            "decisions": [{"text": "X beschlossen", "made_by": "Anna"}],
+            "action_items": [{"text": "Doku fertig", "owner": "Bob", "due_hint": "Freitag"}],
+        })
+        for needle in ("Protokoll", "Kurzfassung.", "X beschlossen", "Anna", "Bob", "Freitag"):
+            assert needle in md
+
+    async def test_extractor_normalizes_good_json(self, monkeypatch):
+        from types import SimpleNamespace
+
+        from services.meeting_minutes import MinutesExtractor
+
+        monkeypatch.setattr(settings, "ollama_chat_model", "test-model")
+
+        class _FakeLLM:
+            async def chat(self, **k):
+                return SimpleNamespace(message=SimpleNamespace(content=(
+                    '{"summary":"S","decisions":["D1"],'
+                    '"action_items":[{"text":"A1","owner":"Bob","due_hint":"heute"}]}'
+                )))
+
+        m = await MinutesExtractor(llm_client=_FakeLLM()).extract(
+            [{"speaker": "Sprecher 1", "text": "Wir machen X."}]
+        )
+        assert m["summary"] == "S"
+        assert m["decisions"] == [{"text": "D1", "made_by": ""}]  # bare string coerced
+        assert m["action_items"][0] == {"text": "A1", "owner": "Bob", "due_hint": "heute"}
+
+    async def test_extractor_falls_back_to_empty(self, monkeypatch):
+        from types import SimpleNamespace
+
+        from services.meeting_minutes import MinutesExtractor
+
+        monkeypatch.setattr(settings, "ollama_chat_model", "test-model")
+
+        class _BadLLM:
+            async def chat(self, **k):
+                return SimpleNamespace(message=SimpleNamespace(content="not json at all"))
+
+        empty = {"summary": "", "decisions": [], "action_items": []}
+        assert await MinutesExtractor(llm_client=_BadLLM()).extract(
+            [{"speaker": "S1", "text": "x"}]
+        ) == empty
+        # empty transcript → empty, no LLM call needed
+        assert await MinutesExtractor().extract([]) == empty
+
+
+@pytest.mark.asyncio
+class TestMeetingMinutesRoutes:
+    async def _seed_completed(self, db_session):
+        from models.database import Meeting
+
+        m = Meeting(
+            status="completed", consent_confirmed=True,
+            segments=[{"speaker": "Sprecher 1", "speaker_key": "S1", "text": "Wir machen X."}],
+        )
+        db_session.add(m)
+        await db_session.commit()
+        await db_session.refresh(m)
+        return m
+
+    async def test_minutes_404_when_flag_off(self, async_client, monkeypatch, tmp_path):
+        # transcription on, minutes flag OFF (default)
+        _enable(monkeypatch, tmp_path, auth=False)
+        _override_user(None)
+        assert (await async_client.post("/api/meetings/1/minutes/generate")).status_code == 404
+
+    async def test_generate_409_when_not_completed(
+        self, async_client, db_session, monkeypatch, tmp_path
+    ):
+        from models.database import Meeting
+
+        _enable(monkeypatch, tmp_path, auth=False)
+        monkeypatch.setattr(settings, "meeting_minutes_enabled", True)
+        _override_user(None)
+        m = Meeting(status="pending", consent_confirmed=True)
+        db_session.add(m)
+        await db_session.commit()
+        await db_session.refresh(m)
+        assert (await async_client.post(f"/api/meetings/{m.id}/minutes/generate")).status_code == 409
+
+    async def test_generate_edit_confirm_flow(
+        self, async_client, db_session, monkeypatch, tmp_path
+    ):
+        _enable(monkeypatch, tmp_path, auth=False)
+        monkeypatch.setattr(settings, "meeting_minutes_enabled", True)
+        _override_user(None)
+        m = await self._seed_completed(db_session)
+
+        # mock the extractor (no LLM) + the reindex (no doc/redis)
+        from services import meeting_minutes, meeting_pipeline
+
+        async def _fake_extract(self, segs, *, lang="de"):
+            return {"summary": "S", "decisions": [{"text": "D", "made_by": ""}], "action_items": []}
+
+        async def _fake_reindex(db, meeting, segments):
+            return None
+
+        monkeypatch.setattr(meeting_minutes.MinutesExtractor, "extract", _fake_extract)
+        monkeypatch.setattr(meeting_pipeline, "_overwrite_transcript_and_reindex", _fake_reindex)
+
+        # generate -> draft
+        r = await async_client.post(f"/api/meetings/{m.id}/minutes/generate")
+        assert r.status_code == 200 and r.json()["minutes_status"] == "draft"
+        assert r.json()["minutes"]["summary"] == "S"
+
+        # edit -> stays draft, content replaced
+        r = await async_client.put(
+            f"/api/meetings/{m.id}/minutes",
+            json={"summary": "Edited", "decisions": [], "action_items": []},
+        )
+        assert r.status_code == 200 and r.json()["minutes"]["summary"] == "Edited"
+
+        # confirm -> confirmed
+        r = await async_client.post(f"/api/meetings/{m.id}/minutes/confirm")
+        assert r.status_code == 200 and r.json()["minutes_status"] == "confirmed"
+
+        # confirm again -> 409 (not draft)
+        assert (await async_client.post(f"/api/meetings/{m.id}/minutes/confirm")).status_code == 409
+
+        # delete -> none
+        r = await async_client.delete(f"/api/meetings/{m.id}/minutes")
+        assert r.status_code == 200 and r.json()["minutes_status"] == "none"
+        assert r.json()["minutes"] is None


### PR DESCRIPTION
First half of §2 Phase 3 (plan: `docs/design/meeting-minutes.md`, included). Turns a completed transcript into structured **minutes** (summary / decisions / action-items) with a **human-confirm** gate. Dark by default (`MEETING_MINUTES_ENABLED`).

## What
- **Model + migration `pc20260718`:** additive `minutes` (JSONB) + `minutes_status` (`none→draft→confirmed`) + timestamps. Inspector-guarded; **real-upgrade tested on Postgres**.
- **`services/meeting_minutes.py`:** `MinutesExtractor` (thinking-model-aware, strict-JSON, best-effort → empty draft) + `render_minutes_markdown`. Prompts `meeting_minutes.yaml` (de+en).
- **Routes** (owner-gated, flag-404): generate (409 unless completed) / get / put / confirm (renders into the transcript doc, no new ingest) / delete.
- Action-items stay meeting-scoped + human-confirmed — **not** obligations (D14 wall).

## Tests
test_meetings **47 passed** (.159, +6). Migration real-upgrade verified on Postgres.

## Next
PR-B: frontend minutes UI + hooks + i18n + RTL. A separate follow-up fixes the pre-existing fresh-DB alembic chain gap (`relation "rooms" does not exist`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF