### PR TITLE
feat(auth): internal token-verify endpoint for voice-server callback/registry auth (T6)

### DIFF
--- a/src/backend/api/routes/internal_auth.py
+++ b/src/backend/api/routes/internal_auth.py
@@ -1,0 +1,100 @@
+"""Internal token verification endpoint for downstream services.
+
+The shared voice-server is the consumer: in ``callback`` or ``registry``
+auth mode (voice-server PR #987) it POSTs every JWT it sees to this
+endpoint instead of holding a copy of the backend's ``SECRET_KEY``. The
+backend stays the single source of truth for token issuance + revocation —
+logout, blacklist, and user deactivation take effect on the next
+voice-server connection without rotating keys in two places.
+
+First deployment that needs it: renfield-xidra's row in the shared
+voice-server's ``AUTH_CLIENTS`` registry (voice-server extraction plan T6;
+the reference implementation shipped in Reva 2026-05-08 and this is its
+upstream port — posture mirrors ``services/websocket_auth.py`` so
+voice-server's strictness matches the existing webchat path):
+
+- JWT signature + ``type == "access"``
+- ``jti`` not in the revocation blacklist
+- For user tokens: User row exists and ``is_active`` is True
+- For service-account tokens (``sub="service:..."`` minted in-process by
+  whisper_service / piper_service / meeting-worker for non-route callers):
+  JWT validity alone, no DB lookup
+
+Contract (pinned by voice-server's ``_verify_via``):
+
+- ``POST {"token": "<jwt>"}``
+- ``200`` + JSON payload containing a ``user_id`` field on accept.
+- ``401`` with a single opaque ``"unauthorized"`` detail on reject —
+  rejection-reason strings would be a free oracle for anyone with network
+  reach. Voice-server reads only the status code.
+
+The endpoint is unauthenticated by design — voice-server has no other
+credential to present. Constrain network exposure (ingress allowlist /
+NetworkPolicy) at the deployment layer.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _unauthorized() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="unauthorized",
+    )
+
+
+class VerifyRequest(BaseModel):
+    token: str
+
+
+@router.post("/auth/verify")
+async def verify_token(request: VerifyRequest) -> dict:
+    # Imported lazily so this module can be imported during test collection
+    # without dragging the auth + Redis + DB stack into scope.
+    from services.auth_service import decode_token, get_user_by_id
+    from services.database import AsyncSessionLocal
+    from services.token_blacklist import token_blacklist
+
+    payload = decode_token(request.token)
+    if not payload or payload.get("type") != "access":
+        raise _unauthorized()
+
+    jti = payload.get("jti")
+    if jti and await token_blacklist.is_blacklisted(jti):
+        raise _unauthorized()
+
+    sub = payload.get("sub")
+    if not sub:
+        raise _unauthorized()
+
+    if not sub.startswith("service:"):
+        try:
+            user_id_int = int(sub)
+        except (TypeError, ValueError):
+            raise _unauthorized() from None
+
+        try:
+            async with AsyncSessionLocal() as db:
+                user = await get_user_by_id(db, user_id_int)
+        except Exception as e:  # noqa: BLE001 — DB outage closes voice fail-safe
+            logger.warning("verify_token: user lookup failed: %s", e)
+            raise _unauthorized() from e
+
+        if user is None or not user.is_active:
+            raise _unauthorized()
+
+    # ``jti`` is the revocation handle — voice-server doesn't need it and
+    # shouldn't store it. ``exp`` is irrelevant once validated. Everything
+    # else (username, scope) flows through.
+    response = {k: v for k, v in payload.items() if k not in {"exp", "jti"}}
+    response["user_id"] = str(sub)
+    return response

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -32,6 +32,7 @@ from api.routes import (
     feedback,
     folder_ingest,
     intents,
+    internal_auth,
     knowledge,
     meetings,
     memory,
@@ -175,6 +176,9 @@ setup_rate_limiter(app)
 
 # REST API Routers
 app.include_router(auth.router, prefix="/api/auth", tags=["Authentication"])
+# Unauthenticated-by-design token oracle for downstream services (voice-server
+# callback/registry auth) — opaque 401s; constrain reach at the network layer.
+app.include_router(internal_auth.router, prefix="/api/internal", tags=["Internal"])
 app.include_router(roles.router, prefix="/api/roles", tags=["Roles"])
 app.include_router(users.router, prefix="/api/users", tags=["Users"])
 app.include_router(chat.router, prefix="/api/chat", tags=["Chat"])

--- a/tests/backend/test_internal_auth_verify.py
+++ b/tests/backend/test_internal_auth_verify.py
@@ -1,0 +1,199 @@
+"""Tests for api/routes/internal_auth.py (voice-server verify callback).
+
+``POST /api/internal/auth/verify`` is voice-server's callback target in
+``callback``/``registry`` auth mode (voice-server PR #987). Voice-server's
+behaviour is fixed (``voice_server/auth.py::_verify_via``), so these tests
+pin the contract:
+
+- 200 + payload containing ``user_id`` on accept; ``jti`` and ``exp``
+  stripped.
+- 401 + opaque ``"unauthorized"`` detail on every rejection branch
+  (signature, type, blacklist, missing/non-numeric/unknown/inactive user).
+- Service-account tokens (``sub="service:whisper"``) accepted without a
+  DB lookup.
+
+The route imports its collaborators lazily at call time, so the tests
+swap ``services.{auth_service, token_blacklist, database}`` in
+``sys.modules`` — no Redis/DB needed, and it works whether or not the
+real modules were already imported by other tests.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+class _SessionStub:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+
+def _install_service_stubs(
+    monkeypatch,
+    *,
+    decode_return,
+    blacklisted=False,
+    user="__default__",
+):
+    """``user``: ``"__default__"`` → active user; ``None`` → row missing;
+    any object with ``is_active`` → that state."""
+    if user == "__default__":
+        user = SimpleNamespace(id=42, is_active=True)
+
+    auth_module = types.ModuleType("services.auth_service")
+    auth_module.decode_token = lambda token: decode_return  # noqa: ARG005
+
+    async def _get_user_by_id(_db, _user_id):
+        return user
+
+    auth_module.get_user_by_id = _get_user_by_id
+
+    blacklist_module = types.ModuleType("services.token_blacklist")
+
+    class _Blacklist:
+        async def is_blacklisted(self, _jti):
+            return blacklisted
+
+    blacklist_module.token_blacklist = _Blacklist()
+
+    db_module = types.ModuleType("services.database")
+    db_module.AsyncSessionLocal = _SessionStub
+
+    services_pkg = sys.modules.get("services") or types.ModuleType("services")
+    monkeypatch.setitem(sys.modules, "services", services_pkg)
+    monkeypatch.setitem(sys.modules, "services.auth_service", auth_module)
+    monkeypatch.setitem(sys.modules, "services.token_blacklist", blacklist_module)
+    monkeypatch.setitem(sys.modules, "services.database", db_module)
+
+
+def _client() -> TestClient:
+    from api.routes.internal_auth import router
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api/internal")
+    return TestClient(app)
+
+
+def test_verify_accepts_valid_access_token(monkeypatch):
+    _install_service_stubs(
+        monkeypatch,
+        decode_return={
+            "sub": "42",
+            "username": "alice",
+            "type": "access",
+            "jti": "abc",
+            "exp": 9999999999,
+        },
+    )
+    resp = _client().post("/api/internal/auth/verify", json={"token": "x"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["user_id"] == "42"
+    assert body["username"] == "alice"
+    # exp + jti stripped — jti is the revocation handle and must not leak
+    # past the boundary.
+    assert "exp" not in body
+    assert "jti" not in body
+
+
+def test_verify_rejects_invalid_signature(monkeypatch):
+    _install_service_stubs(monkeypatch, decode_return=None)
+    resp = _client().post("/api/internal/auth/verify", json={"token": "x"})
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "unauthorized"
+
+
+def test_verify_rejects_refresh_token(monkeypatch):
+    _install_service_stubs(
+        monkeypatch,
+        decode_return={"sub": "42", "type": "refresh", "jti": "abc"},
+    )
+    resp = _client().post("/api/internal/auth/verify", json={"token": "x"})
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "unauthorized"
+
+
+def test_verify_rejects_blacklisted_jti(monkeypatch):
+    _install_service_stubs(
+        monkeypatch,
+        decode_return={"sub": "42", "type": "access", "jti": "revoked"},
+        blacklisted=True,
+    )
+    resp = _client().post("/api/internal/auth/verify", json={"token": "x"})
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "unauthorized"
+
+
+def test_verify_rejects_missing_sub(monkeypatch):
+    _install_service_stubs(
+        monkeypatch,
+        decode_return={"type": "access", "jti": "abc"},
+    )
+    resp = _client().post("/api/internal/auth/verify", json={"token": "x"})
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "unauthorized"
+
+
+def test_verify_rejects_unknown_user(monkeypatch):
+    """JWT structurally valid but the User row is gone (deleted)."""
+    _install_service_stubs(
+        monkeypatch,
+        decode_return={"sub": "42", "type": "access", "jti": "abc"},
+        user=None,
+    )
+    resp = _client().post("/api/internal/auth/verify", json={"token": "x"})
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "unauthorized"
+
+
+def test_verify_rejects_inactive_user(monkeypatch):
+    """User row exists but admin set is_active=False."""
+    _install_service_stubs(
+        monkeypatch,
+        decode_return={"sub": "42", "type": "access", "jti": "abc"},
+        user=SimpleNamespace(id=42, is_active=False),
+    )
+    resp = _client().post("/api/internal/auth/verify", json={"token": "x"})
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "unauthorized"
+
+
+def test_verify_rejects_non_numeric_sub(monkeypatch):
+    """Non-numeric, non-service sub can't reach a User row — mirrors
+    websocket_auth.py's strictness."""
+    _install_service_stubs(
+        monkeypatch,
+        decode_return={"sub": "not-an-int", "type": "access", "jti": "abc"},
+    )
+    resp = _client().post("/api/internal/auth/verify", json={"token": "x"})
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "unauthorized"
+
+
+def test_verify_accepts_service_token(monkeypatch):
+    """service:* tokens (whisper/piper/meeting-worker) verify without a DB
+    lookup — they have no User row."""
+    _install_service_stubs(
+        monkeypatch,
+        decode_return={
+            "sub": "service:whisper",
+            "scope": "voice",
+            "type": "access",
+            "jti": "svc-abc",
+        },
+        user=None,  # proves the user-lookup branch is skipped
+    )
+    resp = _client().post("/api/internal/auth/verify", json={"token": "x"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["user_id"] == "service:whisper"
+    assert body["scope"] == "voice"
+    assert "jti" not in body


### PR DESCRIPTION
Upstream port of Reva's `/api/internal/auth/verify` (reference: reva `src/reva/auth/verify_route.py`, in prod since 2026-05-08). Consumer: the shared voice-server's `callback`/`registry` auth (#987) — the backend stays the single source of truth for issuance + revocation, the voice-server holds no signing keys.

Contract (pinned by voice-server `_verify_via`): `POST {"token"}` → `200 {user_id, ...}` with `jti`/`exp` stripped, or opaque `401 "unauthorized"` on every rejection branch (signature, non-access type, blacklisted jti, missing/non-numeric/unknown/inactive user). `service:*` subs verify without a DB lookup. Endpoint is unauthenticated by design; constrain reach at the network layer (the xidra deployment does this via the voice-namespace NetworkPolicies + in-cluster-only Service).

Unblocks the `xidra` row in the shared voice-server's `AUTH_CLIENTS` (extraction plan T6). 9 contract tests, runnable standalone (`--noconftest`, sys.modules stubs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)