### PR TITLE
feat(voice-server): X-Verify-Secret header to gate the verify oracle (T11)

### DIFF
--- a/voice-server/CHANGELOG.md
+++ b/voice-server/CHANGELOG.md
@@ -3,6 +3,17 @@
 Releases via `bin/release-voice-server.sh` — the script refuses to release a
 version without a section here. Pushed digests live in `RELEASES.md`.
 
+## [0.3.1] — 2026-07-18
+
+- **X-Verify-Secret header** (extraction plan T11): registry rows gain an
+  optional `verify_secret`, and `callback` mode an optional
+  `AUTH_CALLBACK_SECRET`; when set, voice-server sends the secret as the
+  `X-Verify-Secret` header on the verify POST. The client backend gates its
+  (unauthenticated-by-design, now cross-cluster-reachable) verify endpoint on
+  it — closes the token oracle without depending on source-IP allowlisting
+  (prod Traefik is externalTrafficPolicy: Cluster, so an IP allowlist would
+  match SNAT'd node IPs). Opt-in; unset = no header (backward compatible).
+
 ## [0.3.0] — 2026-07-18
 
 - **AUTH_MODE=registry**: one shared instance authenticates N client products.

--- a/voice-server/tests/test_auth_registry.py
+++ b/voice-server/tests/test_auth_registry.py
@@ -34,11 +34,12 @@ def registry_mode(monkeypatch):
 
 
 def _stub_verify(monkeypatch, responses):
-    """responses: url → (status, payload) or an Exception to raise."""
+    """responses: url → (status, payload) or an Exception to raise.
+    Records (url, token, secret) per call so tests can assert the header."""
     calls = []
 
-    async def fake_post_verify(url, token):
-        calls.append((url, token))
+    async def fake_post_verify(url, token, secret=None):
+        calls.append((url, token, secret))
         r = responses[url]
         if isinstance(r, Exception):
             raise r
@@ -114,7 +115,8 @@ async def test_token_routed_to_the_named_clients_verify_url(registry_mode, monke
     payload = await authenticate("tok-a", "reva")
     assert payload["user_id"] == "42"
     assert payload["client_id"] == "reva"
-    assert calls == [("http://reva.example/api/internal/auth/verify", "tok-a")]
+    # no verify_secret configured on this row → no header sent
+    assert calls == [("http://reva.example/api/internal/auth/verify", "tok-a", None)]
 
 
 @pytest.mark.asyncio
@@ -187,6 +189,44 @@ async def test_anonymous_row_ignores_supplied_token(registry_mode):
 
 
 # --------------------------------------------------- legacy-mode regression
+
+@pytest.mark.asyncio
+async def test_registry_row_verify_secret_sent_as_header_arg(monkeypatch):
+    from pydantic import SecretStr
+    reg = dict(_REGISTRY)
+    reg["reva"] = AuthClient(
+        verify_url="http://reva.example/api/internal/auth/verify",
+        verify_secret=SecretStr("shared-xyz"),
+    )
+    monkeypatch.setattr(settings, "auth_mode", "registry")
+    monkeypatch.setattr(settings, "auth_clients", reg)
+    monkeypatch.setattr(settings, "anon_port", 8081)
+    calls = _stub_verify(monkeypatch, {
+        "http://reva.example/api/internal/auth/verify": (200, {"user_id": "42"}),
+    })
+    await authenticate("tok-a", "reva")
+    # the per-client secret is threaded down to _post_verify (→ X-Verify-Secret)
+    assert calls == [("http://reva.example/api/internal/auth/verify", "tok-a", "shared-xyz")]
+
+
+def test_verify_secret_without_verify_url_rejected():
+    from pydantic import SecretStr
+    with pytest.raises(ValueError):
+        AuthClient(anonymous=True, verify_secret=SecretStr("x"))
+
+
+@pytest.mark.asyncio
+async def test_callback_mode_sends_configured_secret(monkeypatch):
+    from pydantic import SecretStr
+    monkeypatch.setattr(settings, "auth_mode", "callback")
+    monkeypatch.setattr(settings, "auth_callback_url", "http://backend.example/verify")
+    monkeypatch.setattr(settings, "auth_callback_secret", SecretStr("cb-secret"))
+    calls = _stub_verify(monkeypatch, {
+        "http://backend.example/verify": (200, {"user_id": "7"}),
+    })
+    await authenticate("tok")
+    assert calls[0] == ("http://backend.example/verify", "tok", "cb-secret")
+
 
 @pytest.mark.asyncio
 async def test_local_mode_ignores_client_id_and_port(monkeypatch):

--- a/voice-server/voice_server/__init__.py
+++ b/voice-server/voice_server/__init__.py
@@ -8,5 +8,5 @@ See docs/VOICE_PIPELINE_DESIGN.md § "Phase B" for the full architecture.
 """
 
 # Kept in sync with the image tag by bin/release-voice-server.sh (extraction
-# plan T4). 0.3.0 = registry auth mode (multi-client consolidation).
-__version__ = "0.3.0"
+# plan T4). 0.3.0 = registry auth mode; 0.3.1 = X-Verify-Secret header (T11).
+__version__ = "0.3.1"

--- a/voice-server/voice_server/auth.py
+++ b/voice-server/voice_server/auth.py
@@ -90,13 +90,14 @@ def _validate_local(token: str) -> dict[str, Any]:
         raise AuthError(f"invalid token: {e}") from e
 
 
-async def _post_verify(url: str, token: str) -> tuple[int, Any]:
+async def _post_verify(url: str, token: str, secret: str | None = None) -> tuple[int, Any]:
     """POST a token to a verify endpoint. Split out so tests can stub the
     network without an HTTP server. Returns (status_code, parsed_json);
     raises AuthError on transport failure."""
+    headers = {"X-Verify-Secret": secret} if secret else None
     async with httpx.AsyncClient(timeout=5.0) as client:
         try:
-            resp = await client.post(url, json={"token": token})
+            resp = await client.post(url, json={"token": token}, headers=headers)
         except httpx.HTTPError as e:
             logger.warning("auth callback HTTP error: %s", e)
             # Deliberately generic: the exception string embeds the verify
@@ -113,11 +114,16 @@ async def _post_verify(url: str, token: str) -> tuple[int, Any]:
 async def _validate_callback(token: str) -> dict[str, Any]:
     if not settings.auth_callback_url:
         raise AuthError("auth_mode=callback but auth_callback_url is empty")
-    return await _verify_via(settings.auth_callback_url, token)
+    secret = (
+        settings.auth_callback_secret.get_secret_value()
+        if settings.auth_callback_secret
+        else None
+    )
+    return await _verify_via(settings.auth_callback_url, token, secret)
 
 
-async def _verify_via(url: str, token: str) -> dict[str, Any]:
-    status_code, payload = await _post_verify(url, token)
+async def _verify_via(url: str, token: str, secret: str | None = None) -> dict[str, Any]:
+    status_code, payload = await _post_verify(url, token, secret)
     if status_code != 200:
         raise AuthError(f"auth callback rejected token: {status_code}")
     # Pinned contract: a verify endpoint returns a JSON object with user_id.
@@ -164,6 +170,7 @@ async def _validate_registry(
 
     if not token:
         raise AuthError("missing token")
-    payload = await _verify_via(row.verify_url, token)  # type: ignore[arg-type]
+    secret = row.verify_secret.get_secret_value() if row.verify_secret else None
+    payload = await _verify_via(row.verify_url, token, secret)  # type: ignore[arg-type]
     payload["client_id"] = client_id
     return payload

--- a/voice-server/voice_server/config.py
+++ b/voice-server/voice_server/config.py
@@ -30,6 +30,11 @@ class AuthClient(BaseModel):
 
     verify_url: str | None = None
     anonymous: bool = False
+    # Optional shared secret sent as the X-Verify-Secret header on this
+    # client's verify POST. The client's backend gates its (unauthenticated-
+    # by-design) verify endpoint on it — closes the token oracle to anyone who
+    # can merely reach the endpoint. Only meaningful with verify_url.
+    verify_secret: SecretStr | None = None
 
     @model_validator(mode="after")
     def _exactly_one_shape(self) -> "AuthClient":
@@ -43,6 +48,8 @@ class AuthClient(BaseModel):
             )
         if self.verify_url and not self.verify_url.startswith(("http://", "https://")):
             raise ValueError(f"verify_url must be http(s), got: {self.verify_url}")
+        if self.verify_secret and not self.verify_url:
+            raise ValueError("verify_secret is only valid with verify_url")
         return self
 
 
@@ -70,6 +77,10 @@ class Settings(BaseSettings):
     secret_key: SecretStr = SecretStr("changeme-in-production")
     jwt_algorithm: str = "HS256"
     auth_callback_url: str | None = None  # used when auth_mode=callback
+    # Shared secret sent as X-Verify-Secret on the callback POST (auth_mode=
+    # callback). The registry mode carries its own per-client verify_secret in
+    # each AuthClient row instead.
+    auth_callback_secret: SecretStr | None = None
 
     # Multi-client registry (auth_mode=registry). Env AUTH_CLIENTS is a JSON
     # object mapping client-id → row, e.g.


### PR DESCRIPTION
Third piece of the voice-server consolidation (extraction plan T11; follows #987/#988/#990).

The verify endpoint (`/api/internal/auth/verify`) is unauthenticated by design and now reachable cross-cluster. An IP allowlist at reva's prod Traefik is NOT viable — its LoadBalancer is `externalTrafficPolicy: Cluster`, so kube-proxy SNATs the source and an allowlist would match node IPs (the TD-21 trap). So the oracle is gated with a shared secret instead: SNAT-independent, app-enforced, opt-in.

- Registry `AuthClient` rows gain optional `verify_secret`; `callback` mode gains `AUTH_CALLBACK_SECRET`. When set, voice-server sends `X-Verify-Secret: <secret>` on the verify POST.
- Reva's verify route (separate reva PR) requires a matching header when `REVA_INTERNAL_VERIFY_SECRET` is set, collapsing failure into the same opaque 401 (no oracle for the secret either). Unset on both sides = no header (backward compatible → safe rollout ordering: caller sends first, enforcement flips after).
- v0.3.1; +3 tests, suite 55 pass / 1 skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)