### PR TITLE
chore(voice-server): record v0.3.1 digest row (follow-up to #992)

### DIFF
--- a/voice-server/RELEASES.md
+++ b/voice-server/RELEASES.md
@@ -8,3 +8,4 @@ that enforceable.
 | tag | date | git | digest |
 |-----|------|-----|--------|
 | v0.3.0 | 2026-07-18 | f3aab0dc | `registry.treehouse.x-idra.de/renfield/voice-server@sha256:a252cd9294827705f4ecd419280ac19a962d30d1266aaafda61dc0fe0a3b7396` |
+| v0.3.1 | 2026-07-18 | b5d8373a | `registry.treehouse.x-idra.de/renfield/voice-server@sha256:e93a2b46491054964fe72330884550c502181b681e0249eb3a1f7fcf96982e41` |


### PR DESCRIPTION
The v0.3.1 RELEASES.md digest row was lost in a stash during #992 (which committed only the OpenAPI contract). Image `@sha256:e93a2b46...` and tag `voice-server-v0.3.1` were published correctly; this just records the bookkeeping row.