### PR TITLE
feat(voice): X-Voice-Client header for shared voice-server registry auth (T8)

### DIFF
--- a/src/backend/services/voice_server_client.py
+++ b/src/backend/services/voice_server_client.py
@@ -58,8 +58,16 @@ def _auth_headers(auth_token: str) -> dict[str, str]:
     """Bearer header — omitted entirely when the token is empty, so a voice-server
     running auth_required=false treats the call as anonymous instead of trying
     (and failing) to validate an empty/foreign token. Callers gate the token on
-    ``settings.voice_server_auth_enabled``."""
-    return {"Authorization": f"Bearer {auth_token}"} if auth_token else {}
+    ``settings.voice_server_auth_enabled``.
+
+    Also carries the registry client id (X-Voice-Client) when configured, so the
+    shared multi-tenant voice-server can route this call to the right product's
+    verify endpoint / anonymous row. Omitted when unset → legacy single-tenant
+    (local/callback) voice-servers are unaffected."""
+    headers = {"Authorization": f"Bearer {auth_token}"} if auth_token else {}
+    if settings.voice_client_id:
+        headers["X-Voice-Client"] = settings.voice_client_id
+    return headers
 
 
 async def stt(

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -128,6 +128,14 @@ class Settings(BaseSettings):
     # Interim until the shared voice-server gets real multi-tenant auth.
     voice_server_auth_enabled: bool = True
 
+    # Client id for the shared voice-server's registry auth (AUTH_MODE=registry).
+    # When set, the backend sends it as the X-Voice-Client header on every
+    # voice-server call so the server routes token verification to THIS product's
+    # backend (or honors its anonymous row). Empty = omit the header, which keeps
+    # the legacy local/callback single-tenant voice-servers working unchanged.
+    # Each deployment sets its own: reva=reva, xidra=xidra, household=renfield.
+    voice_client_id: str = ""
+
     # Home Assistant / Frigate settings moved to ha_glue/utils/config.py
     # (see `HaGlueSettings`). Access via:
     #     from ha_glue.utils.config import ha_glue_settings

--- a/tests/backend/test_voice_server_client.py
+++ b/tests/backend/test_voice_server_client.py
@@ -82,6 +82,46 @@ async def test_stt_posts_multipart_with_bearer(monkeypatch) -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_stt_sends_x_voice_client_when_configured(monkeypatch) -> None:
+    # Registry auth: the shared voice-server routes verification by client id.
+    from utils.config import settings
+    monkeypatch.setattr(settings, "voice_client_id", "reva")
+
+    captured: dict = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured["client"] = request.headers.get("x-voice-client")
+        captured["auth"] = request.headers.get("authorization")
+        return httpx.Response(200, json={"text": "x", "language": "de", "audio_duration_s": 0.1})
+
+    _patch_async_client(monkeypatch, handler)
+    from services.voice_server_client import stt
+    await stt(_make_silence_wav(), auth_token="tok")
+    assert captured["client"] == "reva"
+    assert captured["auth"] == "Bearer tok"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_stt_omits_x_voice_client_when_unset(monkeypatch) -> None:
+    # Legacy single-tenant (local/callback) voice-servers must be unaffected.
+    from utils.config import settings
+    monkeypatch.setattr(settings, "voice_client_id", "")
+
+    captured: dict = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured["has_client"] = "x-voice-client" in request.headers
+        return httpx.Response(200, json={"text": "x", "language": "de", "audio_duration_s": 0.1})
+
+    _patch_async_client(monkeypatch, handler)
+    from services.voice_server_client import stt
+    await stt(_make_silence_wav(), auth_token="tok")
+    assert captured["has_client"] is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_stt_raises_on_non_2xx(monkeypatch) -> None:
     async def handler(_: httpx.Request) -> httpx.Response:
         return httpx.Response(503, text="model loading")


### PR DESCRIPTION
Client-side half of the voice-server consolidation registry auth (server side: #987). The shared instance (AUTH_MODE=registry) requires every caller to name its client id; the renfield thin-client previously sent only the bearer token, so it would be rejected.

- New `voice_client_id` (env `VOICE_CLIENT_ID`); `_auth_headers` adds `X-Voice-Client: <id>` when set. Empty = omitted → legacy local/callback voice-servers unaffected (backward compatible).
- Each deployment sets its own: reva=reva, xidra=xidra, household=renfield.
- Unblocks the extraction-plan **cutover (Phase 3.1)**. The `voice_server_auth_enabled` flag removal (D9) is deliberately deferred to Phase 3.5 (after migrations).
- +2 focused tests (header sent when configured / omitted when unset). Note: the full renfield backend suite needs the .159/container harness (a dev `.env` trips the base Settings locally); these two run clean in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)