### PR TITLE
feat(voice): webchat /ws/voice sends ?client= for shared registry voice-server (Phase 3.2)

### DIFF
--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -63,6 +63,10 @@ ARG VITE_CHAT_STARTERS=
 # /ws/voice WebSocket UI (live partial transcripts, sub-second TTS
 # first-byte). Default unset = legacy REST path (request-response).
 ARG VITE_FEATURE_VOICE_STREAM=
+# Registry client id for a shared multi-tenant voice-server. When set, the
+# webchat /ws/voice connection sends ?client=<id> so the server routes token
+# verification to this product. Unset = omitted (legacy single-tenant path).
+ARG VITE_VOICE_CLIENT_ID=
 # Edition selector for translation overlays. "community" (default) keeps
 # the household-flavored Circles vocabulary (tier 2 = "Household",
 # settings = "Circles & Members"). "pro" loads the de.pro.json /
@@ -89,6 +93,7 @@ ENV VITE_APP_NAME=${VITE_APP_NAME}
 ENV VITE_APP_LOGO_URL=${VITE_APP_LOGO_URL}
 ENV VITE_CHAT_STARTERS=${VITE_CHAT_STARTERS}
 ENV VITE_FEATURE_VOICE_STREAM=${VITE_FEATURE_VOICE_STREAM}
+ENV VITE_VOICE_CLIENT_ID=${VITE_VOICE_CLIENT_ID}
 ENV VITE_APP_EDITION=${VITE_APP_EDITION}
 ENV VITE_APP_TENANT_NAME=${VITE_APP_TENANT_NAME}
 ENV VITE_OIDC_ENABLED=${VITE_OIDC_ENABLED}

--- a/src/frontend/src/pages/ChatPage/hooks/useVoiceStream.ts
+++ b/src/frontend/src/pages/ChatPage/hooks/useVoiceStream.ts
@@ -128,11 +128,16 @@ function buildVoiceWsUrl(token: string | null): string {
   // append /ws/voice. Mirror useDeviceConnection's pattern.
   // Token is omitted entirely when null so voice-server's
   // auth_required=False path works for AUTH_ENABLED=false deployments.
+  // VITE_VOICE_CLIENT_ID (when set) is sent as ?client= so a shared
+  // multi-tenant voice-server (AUTH_MODE=registry) routes verification to
+  // this product; omitted → legacy single-tenant voice-servers unaffected.
   const base = getWebSocketUrl().replace(/\/ws$/, '');
-  if (token) {
-    return `${base}/ws/voice?token=${encodeURIComponent(token)}`;
-  }
-  return `${base}/ws/voice`;
+  const clientId = import.meta.env.VITE_VOICE_CLIENT_ID as string | undefined;
+  const params = new URLSearchParams();
+  if (token) params.set('token', token);
+  if (clientId) params.set('client', clientId);
+  const qs = params.toString();
+  return qs ? `${base}/ws/voice?${qs}` : `${base}/ws/voice`;
 }
 
 function bytesToUuid(bytes: Uint8Array): string {


### PR DESCRIPTION
Client-side half of the webchat WebSocket cutover to the shared voice-server (server already reads `?client=` since #987).

`buildVoiceWsUrl` now appends `?client=<VITE_VOICE_CLIENT_ID>` (via URLSearchParams, alongside the optional token). Unset = omitted → legacy single-tenant (local/callback) voice-servers unaffected. Dockerfile plumbs the `VITE_VOICE_CLIENT_ID` build arg (reva's build-frontend.sh will pass `=reva`).

Vite build validates the TS at frontend-image build time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)