### PR TITLE
feat(voice-server): anon_default_client for household migration (T31)

### DIFF
--- a/voice-server/CHANGELOG.md
+++ b/voice-server/CHANGELOG.md
@@ -3,6 +3,15 @@
 Releases via `bin/release-voice-server.sh` — the script refuses to release a
 version without a section here. Pushed digests live in `RELEASES.md`.
 
+## [0.3.2] — 2026-07-19
+
+- **`anon_default_client`** (household migration T31): on the anon listener
+  only, a request with no `X-Voice-Client` defaults to the configured client
+  id (must be an `anonymous: true` row). Lets a caller that predates the
+  X-Voice-Client header (the renfield household backend) use the shared
+  instance via the NetworkPolicy-fenced anon port without a rebuild. Empty =
+  off; never applies on the primary port.
+
 ## [0.3.1] — 2026-07-18
 
 - **X-Verify-Secret header** (extraction plan T11): registry rows gain an

--- a/voice-server/tests/test_auth_registry.py
+++ b/voice-server/tests/test_auth_registry.py
@@ -181,6 +181,32 @@ async def test_anonymous_row_rejected_on_primary_port(registry_mode):
 
 
 @pytest.mark.asyncio
+async def test_anon_default_client_fills_missing_id_on_anon_port(registry_mode, monkeypatch):
+    # Household migration T31: no X-Voice-Client on the anon port defaults to
+    # the configured client (an anonymous row) → accepted.
+    monkeypatch.setattr(settings, "anon_default_client", "renfield")
+    payload = await authenticate("", None, via_anon_port=True)
+    assert payload["user_id"] == "anonymous"
+    assert payload["client_id"] == "renfield"
+
+
+@pytest.mark.asyncio
+async def test_anon_default_client_does_not_apply_on_primary_port(registry_mode, monkeypatch):
+    # The default is anon-port-only: a missing client id on the primary
+    # (ingress-reachable) port is still rejected.
+    monkeypatch.setattr(settings, "anon_default_client", "renfield")
+    with pytest.raises(AuthError, match="client id"):
+        await authenticate("", None, via_anon_port=False)
+
+
+@pytest.mark.asyncio
+async def test_anon_default_client_unset_still_rejects_missing_id(registry_mode):
+    # Default off (empty) → missing client id rejected as before.
+    with pytest.raises(AuthError, match="client id"):
+        await authenticate("", None, via_anon_port=True)
+
+
+@pytest.mark.asyncio
 async def test_anonymous_row_ignores_supplied_token(registry_mode):
     # Household has no signing keys to validate against; a stray token is
     # ignored rather than routed anywhere.

--- a/voice-server/voice_server/__init__.py
+++ b/voice-server/voice_server/__init__.py
@@ -8,5 +8,6 @@ See docs/VOICE_PIPELINE_DESIGN.md § "Phase B" for the full architecture.
 """
 
 # Kept in sync with the image tag by bin/release-voice-server.sh (extraction
-# plan T4). 0.3.0 = registry auth mode; 0.3.1 = X-Verify-Secret header (T11).
-__version__ = "0.3.1"
+# plan T4). 0.3.0 = registry auth mode; 0.3.1 = X-Verify-Secret header (T11);
+# 0.3.2 = anon_default_client (household migration T31).
+__version__ = "0.3.2"

--- a/voice-server/voice_server/auth.py
+++ b/voice-server/voice_server/auth.py
@@ -137,6 +137,15 @@ async def _verify_via(url: str, token: str, secret: str | None = None) -> dict[s
 async def _validate_registry(
     token: str, client_id: str | None, via_anon_port: bool
 ) -> dict[str, Any]:
+    # On the anon listener only, a MISSING client id may default to a
+    # configured one — lets a caller that predates the X-Voice-Client header
+    # (e.g. the renfield household backend) use the shared instance. Safe
+    # because the anon port is NetworkPolicy-fenced; the defaulted id must be
+    # an `anonymous: true` row (checked below). Never applies on the primary
+    # (ingress-reachable) port.
+    if not client_id and via_anon_port and settings.anon_default_client:
+        client_id = settings.anon_default_client
+
     if not client_id:
         raise AuthError(
             "registry auth requires a client id "

--- a/voice-server/voice_server/config.py
+++ b/voice-server/voice_server/config.py
@@ -96,6 +96,12 @@ class Settings(BaseSettings):
     # with a NetworkPolicy; the primary port NEVER serves anonymous registry
     # clients, so an ingress-reachable request can't claim the anonymous row.
     anon_port: int = 8081
+    # On the anon listener, a request with NO X-Voice-Client defaults to this
+    # client id. Lets a caller that predates the X-Voice-Client header (e.g.
+    # the renfield household backend) use the shared instance via the fenced
+    # anon port. Must name an `anonymous: true` row. Empty = off (missing
+    # client id is rejected as usual).
+    anon_default_client: str = ""
 
     # STT (D1) — accepts a local path OR an HF model id (downloads to HF cache)
     whisper_model: str = "Systran/faster-whisper-medium"


### PR DESCRIPTION
On the anon listener only, a missing `X-Voice-Client` defaults to `ANON_DEFAULT_CLIENT` (must be an anonymous row). Lets the renfield household backend (predates the header) use the shared instance via the fenced anon port — no household rebuild, no migrations (runbook Approach B). Off by default; never applies on the primary port. v0.3.2, +3 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)