### PR TITLE
chore(voice): v0.3.2 release records + household meeting-worker repoint (T31)

### DIFF
--- a/k8s/meeting-worker.yaml
+++ b/k8s/meeting-worker.yaml
@@ -50,11 +50,12 @@ spec:
             - |
               echo "waiting for postgres..."; until nc -z postgres 5432; do sleep 1; done
               echo "waiting for redis...";    until nc -z redis 6379;    do sleep 1; done
-              # The meeting worker's downstream is the voice-server (diarization+ASR).
-              # Use the FQDN so this resolves from ANY namespace — the household
-              # runs the voice-server in `renfield`, and other instances (e.g.
-              # renfield-xidra) reach it cross-namespace via the same name.
-              echo "waiting for voice-server..."; until nc -z voice-server.renfield 8080; do sleep 2; done
+              # The meeting worker's downstream is the SHARED voice-server
+              # (voice-server consolidation 2026-07). The household reaches it
+              # via the NetworkPolicy-fenced anon Service; /transcribe-meeting
+              # authenticates through anon_default_client (no X-Voice-Client
+              # needed). Matches the backend's VOICE_SERVER_URL.
+              echo "waiting for voice-server..."; until nc -z voice-server-anon.voice 8081; do sleep 2; done
               echo "deps ready"
           resources:
             requests: {cpu: 10m, memory: 16Mi}

--- a/voice-server/RELEASES.md
+++ b/voice-server/RELEASES.md
@@ -9,3 +9,4 @@ that enforceable.
 |-----|------|-----|--------|
 | v0.3.0 | 2026-07-18 | f3aab0dc | `registry.treehouse.x-idra.de/renfield/voice-server@sha256:a252cd9294827705f4ecd419280ac19a962d30d1266aaafda61dc0fe0a3b7396` |
 | v0.3.1 | 2026-07-18 | b5d8373a | `registry.treehouse.x-idra.de/renfield/voice-server@sha256:e93a2b46491054964fe72330884550c502181b681e0249eb3a1f7fcf96982e41` |
+| v0.3.2 | 2026-07-19 | b16e04c3 | `registry.treehouse.x-idra.de/renfield/voice-server@sha256:733e96566b6a599796c4150f329ea6e106c0eeaeb946e52941f46f7f811e3ba4` |

--- a/voice-server/contracts/openapi-v0.3.2.json
+++ b/voice-server/contracts/openapi-v0.3.2.json
@@ -1,0 +1,610 @@
+
+==========
+== CUDA ==
+==========
+
+CUDA Version 12.6.3
+
+Container image Copyright (c) 2016-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+This container image and its contents are governed by the NVIDIA Deep Learning Container License.
+By pulling and using the container, you accept the terms and conditions of this license:
+https://developer.nvidia.com/ngc/nvidia-deep-learning-container-license
+
+A copy of this license is made available in this container at /NGC-DL-CONTAINER-LICENSE for your convenience.
+
+WARNING: The NVIDIA Driver was not detected.  GPU functionality will not be available.
+   Use the NVIDIA Container Toolkit to start this container with GPU support; see
+   https://docs.nvidia.com/datacenter/cloud-native/ .
+
+{
+  "components": {
+    "schemas": {
+      "Body_stt_endpoint_api_voice_stt_post": {
+        "properties": {
+          "audio": {
+            "contentMediaType": "application/octet-stream",
+            "title": "Audio",
+            "type": "string"
+          },
+          "language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Language"
+          }
+        },
+        "required": [
+          "audio"
+        ],
+        "title": "Body_stt_endpoint_api_voice_stt_post",
+        "type": "object"
+      },
+      "Body_stt_opus_endpoint_api_voice_stt_opus_post": {
+        "properties": {
+          "audio": {
+            "contentMediaType": "application/octet-stream",
+            "title": "Audio",
+            "type": "string"
+          },
+          "language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Language"
+          }
+        },
+        "required": [
+          "audio"
+        ],
+        "title": "Body_stt_opus_endpoint_api_voice_stt_opus_post",
+        "type": "object"
+      },
+      "Body_transcribe_meeting_endpoint_transcribe_meeting_post": {
+        "properties": {
+          "audio": {
+            "contentMediaType": "application/octet-stream",
+            "title": "Audio",
+            "type": "string"
+          },
+          "whisper_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Whisper Model"
+          }
+        },
+        "required": [
+          "audio"
+        ],
+        "title": "Body_transcribe_meeting_endpoint_transcribe_meeting_post",
+        "type": "object"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "MeetingSegmentOut": {
+        "properties": {
+          "embedding": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Embedding"
+          },
+          "end_s": {
+            "title": "End S",
+            "type": "number"
+          },
+          "speaker": {
+            "title": "Speaker",
+            "type": "string"
+          },
+          "start_s": {
+            "title": "Start S",
+            "type": "number"
+          },
+          "text": {
+            "title": "Text",
+            "type": "string"
+          }
+        },
+        "required": [
+          "speaker",
+          "start_s",
+          "end_s",
+          "text"
+        ],
+        "title": "MeetingSegmentOut",
+        "type": "object"
+      },
+      "MeetingTranscribeResponse": {
+        "properties": {
+          "duration_s": {
+            "title": "Duration S",
+            "type": "number"
+          },
+          "num_speakers": {
+            "title": "Num Speakers",
+            "type": "integer"
+          },
+          "segments": {
+            "items": {
+              "$ref": "#/components/schemas/MeetingSegmentOut"
+            },
+            "title": "Segments",
+            "type": "array"
+          }
+        },
+        "required": [
+          "segments",
+          "num_speakers",
+          "duration_s"
+        ],
+        "title": "MeetingTranscribeResponse",
+        "type": "object"
+      },
+      "STTResponse": {
+        "properties": {
+          "audio_duration_s": {
+            "title": "Audio Duration S",
+            "type": "number"
+          },
+          "language": {
+            "title": "Language",
+            "type": "string"
+          },
+          "speaker_embedding": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Speaker Embedding"
+          },
+          "text": {
+            "title": "Text",
+            "type": "string"
+          }
+        },
+        "required": [
+          "text",
+          "language",
+          "audio_duration_s"
+        ],
+        "title": "STTResponse",
+        "type": "object"
+      },
+      "TTSRequest": {
+        "properties": {
+          "language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Language"
+          },
+          "text": {
+            "title": "Text",
+            "type": "string"
+          },
+          "voice": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Voice"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "title": "TTSRequest",
+        "type": "object"
+      },
+      "ValidationError": {
+        "properties": {
+          "ctx": {
+            "title": "Context",
+            "type": "object"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "title": "Location",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError",
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "title": "renfield-voice-server",
+    "version": "0.3.2"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/api/voice/stt": {
+      "post": {
+        "description": "Transcribe a single audio file. One-shot (not streaming).",
+        "operationId": "stt_endpoint_api_voice_stt_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Voice-Client",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Voice-Client"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_stt_endpoint_api_voice_stt_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/STTResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Stt Endpoint"
+      }
+    },
+    "/api/voice/stt-opus": {
+      "post": {
+        "description": "Transcribe a satellite's raw Opus packets (C1 transport).\n\nThe satellite ships bare libopus packets (no container) that ffmpeg can't\nparse, so /api/voice/stt (ffmpeg auto-detect) can't take them. This sibling\ndecodes the C1 `[uint16 len][packet]\u2026` framing with opuslib, then runs the\nsame STT + embed path. Decode moved here (media layer) from the backend\n(voice-identity C2 Phase 1, design D6).",
+        "operationId": "stt_opus_endpoint_api_voice_stt_opus_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Voice-Client",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Voice-Client"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_stt_opus_endpoint_api_voice_stt_opus_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/STTResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Stt Opus Endpoint"
+      }
+    },
+    "/api/voice/tts": {
+      "post": {
+        "description": "Synthesize text to a single WAV file (one-shot \u2014 full text in one go).",
+        "operationId": "tts_endpoint_api_voice_tts_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Voice-Client",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Voice-Client"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TTSRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Tts Endpoint"
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "health_health_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Health Health Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Health"
+      }
+    },
+    "/transcribe-meeting": {
+      "post": {
+        "description": "Batch diarization + ASR over a whole meeting recording (\u00a72).\n\nReturns raw speaker-CLUSTER-attributed segments (SPEAKER_00\u2026) + a per-cluster\nECAPA embedding. The backend applies pseudonyms / human labels \u2014 voice-server\nstays stateless (same contract boundary as /stt).",
+        "operationId": "transcribe_meeting_endpoint_transcribe_meeting_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Voice-Client",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Voice-Client"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_transcribe_meeting_endpoint_transcribe_meeting_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeetingTranscribeResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Transcribe Meeting Endpoint"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Records the v0.3.2 release (anon_default_client) and fixes the household meeting-worker's hardcoded init wait (`voice-server.renfield:8080` → `voice-server-anon.voice:8081`) now that the household uses the shared instance. Part of the household migration (T31, runbook Approach B).