### PR TITLE
fix(voice-server): decode one-shot uploads from a seekable file so m4a works (v0.3.3)

### DIFF
--- a/voice-server/CHANGELOG.md
+++ b/voice-server/CHANGELOG.md
@@ -3,6 +3,24 @@
 Releases via `bin/release-voice-server.sh` — the script refuses to release a
 version without a section here. Pushed digests live in `RELEASES.md`.
 
+## [0.3.3] — 2026-07-19
+
+- **One-shot decode reads a seekable file, not a stdin pipe.** `/api/voice/stt`
+  and `/transcribe-meeting` streamed the whole upload into RAM and fed it to
+  `ffmpeg -i pipe:0`. A pipe is not seekable, so a normal phone/Mac **m4a**
+  (AAC in MP4 with the `moov` index atom at the END of the file, past ffmpeg's
+  ~5 MB probe window) decoded to zero PCM — `offset 0x2c: partial file /
+  Invalid data` — and failed every meeting uploaded from an iPhone/Mac. The
+  one-shot decoder now streams the upload to a seekable temp file in fixed-size
+  chunks and runs `ffmpeg -i <file>`; MP4/m4a decode correctly and a multi-hour
+  meeting no longer sits whole in RAM on the media layer. Every other container
+  (wav/webm/opus/mp3/flac) is unaffected — they decode from a file just as well.
+  New `decode_upload_to_pcm` (preferred, chunked-stream entry); `decode_audio_to_pcm`
+  kept for byte-callers, now also file-backed. `VOICE_ONESHOT_SPOOL_DIR` steers
+  the temp file onto a disk-backed volume (keep multi-hour spools off a tmpfs).
+  Regression test synthesizes a >6 MB moov-at-end m4a. Streaming WS path
+  (`audio_decoder.py`) is unchanged (live chunks are inherently non-seekable).
+
 ## [0.3.2] — 2026-07-19
 
 - **`anon_default_client`** (household migration T31): on the anon listener

--- a/voice-server/RELEASES.md
+++ b/voice-server/RELEASES.md
@@ -10,3 +10,4 @@ that enforceable.
 | v0.3.0 | 2026-07-18 | f3aab0dc | `registry.treehouse.x-idra.de/renfield/voice-server@sha256:a252cd9294827705f4ecd419280ac19a962d30d1266aaafda61dc0fe0a3b7396` |
 | v0.3.1 | 2026-07-18 | b5d8373a | `registry.treehouse.x-idra.de/renfield/voice-server@sha256:e93a2b46491054964fe72330884550c502181b681e0249eb3a1f7fcf96982e41` |
 | v0.3.2 | 2026-07-19 | b16e04c3 | `registry.treehouse.x-idra.de/renfield/voice-server@sha256:733e96566b6a599796c4150f329ea6e106c0eeaeb946e52941f46f7f811e3ba4` |
+| v0.3.3 | 2026-07-19 | d929420c | `registry.treehouse.x-idra.de/renfield/voice-server@sha256:2e977a367522561431435c4b412fcaefe9f62463ae52c89ef7c67a2484ff2a30` |

--- a/voice-server/contracts/openapi-v0.3.3.json
+++ b/voice-server/contracts/openapi-v0.3.3.json
@@ -1,0 +1,610 @@
+
+==========
+== CUDA ==
+==========
+
+CUDA Version 12.6.3
+
+Container image Copyright (c) 2016-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+This container image and its contents are governed by the NVIDIA Deep Learning Container License.
+By pulling and using the container, you accept the terms and conditions of this license:
+https://developer.nvidia.com/ngc/nvidia-deep-learning-container-license
+
+A copy of this license is made available in this container at /NGC-DL-CONTAINER-LICENSE for your convenience.
+
+WARNING: The NVIDIA Driver was not detected.  GPU functionality will not be available.
+   Use the NVIDIA Container Toolkit to start this container with GPU support; see
+   https://docs.nvidia.com/datacenter/cloud-native/ .
+
+{
+  "components": {
+    "schemas": {
+      "Body_stt_endpoint_api_voice_stt_post": {
+        "properties": {
+          "audio": {
+            "contentMediaType": "application/octet-stream",
+            "title": "Audio",
+            "type": "string"
+          },
+          "language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Language"
+          }
+        },
+        "required": [
+          "audio"
+        ],
+        "title": "Body_stt_endpoint_api_voice_stt_post",
+        "type": "object"
+      },
+      "Body_stt_opus_endpoint_api_voice_stt_opus_post": {
+        "properties": {
+          "audio": {
+            "contentMediaType": "application/octet-stream",
+            "title": "Audio",
+            "type": "string"
+          },
+          "language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Language"
+          }
+        },
+        "required": [
+          "audio"
+        ],
+        "title": "Body_stt_opus_endpoint_api_voice_stt_opus_post",
+        "type": "object"
+      },
+      "Body_transcribe_meeting_endpoint_transcribe_meeting_post": {
+        "properties": {
+          "audio": {
+            "contentMediaType": "application/octet-stream",
+            "title": "Audio",
+            "type": "string"
+          },
+          "whisper_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Whisper Model"
+          }
+        },
+        "required": [
+          "audio"
+        ],
+        "title": "Body_transcribe_meeting_endpoint_transcribe_meeting_post",
+        "type": "object"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "MeetingSegmentOut": {
+        "properties": {
+          "embedding": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Embedding"
+          },
+          "end_s": {
+            "title": "End S",
+            "type": "number"
+          },
+          "speaker": {
+            "title": "Speaker",
+            "type": "string"
+          },
+          "start_s": {
+            "title": "Start S",
+            "type": "number"
+          },
+          "text": {
+            "title": "Text",
+            "type": "string"
+          }
+        },
+        "required": [
+          "speaker",
+          "start_s",
+          "end_s",
+          "text"
+        ],
+        "title": "MeetingSegmentOut",
+        "type": "object"
+      },
+      "MeetingTranscribeResponse": {
+        "properties": {
+          "duration_s": {
+            "title": "Duration S",
+            "type": "number"
+          },
+          "num_speakers": {
+            "title": "Num Speakers",
+            "type": "integer"
+          },
+          "segments": {
+            "items": {
+              "$ref": "#/components/schemas/MeetingSegmentOut"
+            },
+            "title": "Segments",
+            "type": "array"
+          }
+        },
+        "required": [
+          "segments",
+          "num_speakers",
+          "duration_s"
+        ],
+        "title": "MeetingTranscribeResponse",
+        "type": "object"
+      },
+      "STTResponse": {
+        "properties": {
+          "audio_duration_s": {
+            "title": "Audio Duration S",
+            "type": "number"
+          },
+          "language": {
+            "title": "Language",
+            "type": "string"
+          },
+          "speaker_embedding": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "number"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Speaker Embedding"
+          },
+          "text": {
+            "title": "Text",
+            "type": "string"
+          }
+        },
+        "required": [
+          "text",
+          "language",
+          "audio_duration_s"
+        ],
+        "title": "STTResponse",
+        "type": "object"
+      },
+      "TTSRequest": {
+        "properties": {
+          "language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Language"
+          },
+          "text": {
+            "title": "Text",
+            "type": "string"
+          },
+          "voice": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Voice"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "title": "TTSRequest",
+        "type": "object"
+      },
+      "ValidationError": {
+        "properties": {
+          "ctx": {
+            "title": "Context",
+            "type": "object"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "title": "Location",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError",
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "title": "renfield-voice-server",
+    "version": "0.3.3"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/api/voice/stt": {
+      "post": {
+        "description": "Transcribe a single audio file. One-shot (not streaming).",
+        "operationId": "stt_endpoint_api_voice_stt_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Voice-Client",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Voice-Client"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_stt_endpoint_api_voice_stt_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/STTResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Stt Endpoint"
+      }
+    },
+    "/api/voice/stt-opus": {
+      "post": {
+        "description": "Transcribe a satellite's raw Opus packets (C1 transport).\n\nThe satellite ships bare libopus packets (no container) that ffmpeg can't\nparse, so /api/voice/stt (ffmpeg auto-detect) can't take them. This sibling\ndecodes the C1 `[uint16 len][packet]\u2026` framing with opuslib, then runs the\nsame STT + embed path. Decode moved here (media layer) from the backend\n(voice-identity C2 Phase 1, design D6).",
+        "operationId": "stt_opus_endpoint_api_voice_stt_opus_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Voice-Client",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Voice-Client"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_stt_opus_endpoint_api_voice_stt_opus_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/STTResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Stt Opus Endpoint"
+      }
+    },
+    "/api/voice/tts": {
+      "post": {
+        "description": "Synthesize text to a single WAV file (one-shot \u2014 full text in one go).",
+        "operationId": "tts_endpoint_api_voice_tts_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Voice-Client",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Voice-Client"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TTSRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Tts Endpoint"
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "health_health_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Health Health Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Health"
+      }
+    },
+    "/transcribe-meeting": {
+      "post": {
+        "description": "Batch diarization + ASR over a whole meeting recording (\u00a72).\n\nReturns raw speaker-CLUSTER-attributed segments (SPEAKER_00\u2026) + a per-cluster\nECAPA embedding. The backend applies pseudonyms / human labels \u2014 voice-server\nstays stateless (same contract boundary as /stt).",
+        "operationId": "transcribe_meeting_endpoint_transcribe_meeting_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Voice-Client",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Voice-Client"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_transcribe_meeting_endpoint_transcribe_meeting_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeetingTranscribeResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Transcribe Meeting Endpoint"
+      }
+    }
+  }
+}

--- a/voice-server/tests/test_audio_oneshot.py
+++ b/voice-server/tests/test_audio_oneshot.py
@@ -1,0 +1,139 @@
+"""One-shot decoder: MP4/m4a (moov-at-end) must decode.
+
+Regression for the phone/Mac m4a bug. A normal (non-faststart) m4a stores its
+`moov` index atom at the END of the file; ffmpeg must SEEK back to it to demux.
+The old decoder fed the upload over a stdin pipe (`pipe:0`), which is not
+seekable, so any m4a whose `moov` sits beyond ffmpeg's ~5 MB pipe-probe window
+decoded to zero PCM (`offset 0x2c: partial file`). Decoding from a seekable
+on-disk file fixes it.
+
+The fixture is generated at test time (the voice-server image always ships
+ffmpeg); the test skips where ffmpeg / the AAC encoder is unavailable. It is
+sized past the pipe-probe window on purpose — a tiny m4a would decode over a
+pipe too (ffmpeg buffers the whole small input) and would NOT catch the bug.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+import struct
+import subprocess
+
+import numpy as np
+import pytest
+
+from voice_server.services.audio_oneshot import (
+    OneshotDecodeError,
+    decode_audio_to_pcm,
+    decode_upload_to_pcm,
+)
+
+# Big enough that `moov` lands well past ffmpeg's default ~5 MB pipe probe window,
+# so this genuinely exercises the seek path (a small m4a would not).
+_MIN_TRIGGER_BYTES = 6 * 1024 * 1024
+
+
+def _have_ffmpeg_aac() -> bool:
+    if not shutil.which("ffmpeg"):
+        return False
+    try:
+        enc = subprocess.run(
+            ["ffmpeg", "-hide_banner", "-encoders"],
+            capture_output=True, text=True, timeout=10,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return " aac " in enc
+
+
+def _moov_after_mdat(data: bytes) -> bool:
+    pos, moov, mdat = 0, None, None
+    while pos + 8 <= len(data):
+        size = struct.unpack(">I", data[pos:pos + 4])[0]
+        typ = data[pos + 4:pos + 8]
+        if typ == b"moov":
+            moov = pos
+        elif typ == b"mdat":
+            mdat = pos
+        if size == 0:
+            break
+        pos += size
+    return moov is not None and mdat is not None and moov > mdat
+
+
+def _make_m4a_moov_at_end(tmp_path) -> bytes:
+    """A >6 MB single-channel 16 kHz AAC/m4a with moov at the end (not faststart).
+
+    White noise, not a tone: AAC compresses a pure sine to a fraction of the
+    nominal bitrate, so a tone can't reliably clear the ~5 MB pipe-probe window.
+    Incompressible noise actually spends the bits; 16 kHz mono AAC still caps
+    the effective rate well under the requested 128 k (~9 KB/s), so 1200 s lands
+    ≈ 11 MB — `moov` ends up well past where a stdin pipe could reach it.
+    """
+    out = tmp_path / "sample.m4a"
+    subprocess.run(
+        [
+            "ffmpeg", "-y", "-loglevel", "error",
+            "-f", "lavfi", "-i", "anoisesrc=color=white:duration=1200:sample_rate=16000",
+            "-ac", "1", "-c:a", "aac", "-b:a", "128k",
+            str(out),
+        ],
+        check=True, timeout=90,
+    )
+    return out.read_bytes()
+
+
+class _FakeUpload:
+    """Minimal Starlette-UploadFile stand-in: async chunked read."""
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+        self._pos = 0
+
+    async def read(self, size: int = -1) -> bytes:
+        if size is None or size < 0:
+            chunk, self._pos = self._data[self._pos:], len(self._data)
+            return chunk
+        chunk = self._data[self._pos:self._pos + size]
+        self._pos += len(chunk)
+        return chunk
+
+
+ffmpeg_aac = pytest.mark.skipif(not _have_ffmpeg_aac(), reason="ffmpeg+aac unavailable")
+
+
+@ffmpeg_aac
+async def test_decode_audio_to_pcm_handles_moov_at_end_m4a(tmp_path):
+    data = _make_m4a_moov_at_end(tmp_path)
+    assert len(data) >= _MIN_TRIGGER_BYTES, "fixture too small to exercise the seek path"
+    assert _moov_after_mdat(data), "fixture must have moov AFTER mdat to reproduce the bug"
+
+    pcm = await decode_audio_to_pcm(data)
+    assert pcm.dtype == np.float32
+    assert pcm.size > 16000  # >1 s of 16 kHz PCM — a piped decode would give 0
+
+
+@ffmpeg_aac
+async def test_decode_upload_to_pcm_streams_and_decodes_m4a(tmp_path):
+    data = _make_m4a_moov_at_end(tmp_path)
+    pcm = await decode_upload_to_pcm(_FakeUpload(data))
+    assert pcm.dtype == np.float32
+    assert pcm.size > 16000
+
+
+async def test_empty_upload_raises():
+    with pytest.raises(OneshotDecodeError):
+        await decode_upload_to_pcm(_FakeUpload(b""))
+
+
+async def test_empty_bytes_raise():
+    with pytest.raises(OneshotDecodeError):
+        await decode_audio_to_pcm(b"")
+
+
+@ffmpeg_aac
+async def test_garbage_is_terminal_not_hang(tmp_path):
+    # Non-audio bytes → a clean OneshotDecodeError (4xx), never a hang.
+    with pytest.raises(OneshotDecodeError):
+        await decode_audio_to_pcm(b"\x00\x01\x02not audio at all" * 100, timeout_s=15.0)

--- a/voice-server/voice_server/__init__.py
+++ b/voice-server/voice_server/__init__.py
@@ -10,4 +10,4 @@ See docs/VOICE_PIPELINE_DESIGN.md § "Phase B" for the full architecture.
 # Kept in sync with the image tag by bin/release-voice-server.sh (extraction
 # plan T4). 0.3.0 = registry auth mode; 0.3.1 = X-Verify-Secret header (T11);
 # 0.3.2 = anon_default_client (household migration T31).
-__version__ = "0.3.2"
+__version__ = "0.3.3"

--- a/voice-server/voice_server/api/rest_voice.py
+++ b/voice-server/voice_server/api/rest_voice.py
@@ -28,7 +28,7 @@ from pydantic import BaseModel
 
 from voice_server.auth import AuthError, authenticate
 from voice_server.config import settings
-from voice_server.services.audio_oneshot import OneshotDecodeError, decode_audio_to_pcm
+from voice_server.services.audio_oneshot import OneshotDecodeError, decode_upload_to_pcm
 from voice_server.services.opus_decode import (
     OpusDecodeError,
     OpusUnavailableError,
@@ -89,18 +89,13 @@ async def stt_endpoint(
     _user: dict = Depends(_require_token),
 ) -> STTResponse:
     """Transcribe a single audio file. One-shot (not streaming)."""
-    audio_bytes = await audio.read()
-    if not audio_bytes:
-        raise HTTPException(status_code=400, detail="empty audio")
-
-    # REST gives us a complete file — let ffmpeg auto-detect the container
-    # and codec. The streaming AudioDecoder pins -f to a codec hint
-    # because chunks can't be auto-detected, but that hint over-constrains
-    # full-file uploads (e.g. browser MediaRecorder webm/opus rejected by
-    # `-f webm`). The one-shot decoder also captures stderr so failures
-    # produce a real error message instead of silent 0 PCM.
+    # REST gives us a complete file — stream it to a seekable temp file and let
+    # ffmpeg auto-detect the container/codec. A seekable file (not a stdin pipe)
+    # is required for MP4/m4a (moov-at-end) and is harmless for every other
+    # container; the one-shot decoder also captures stderr so failures produce a
+    # real error message instead of silent 0 PCM.
     try:
-        pcm = await decode_audio_to_pcm(audio_bytes)
+        pcm = await decode_upload_to_pcm(audio)
     except OneshotDecodeError as e:
         logger.warning("STT decode failed: %s", e)
         raise HTTPException(status_code=400, detail=f"audio decode failed: {e}") from e
@@ -211,11 +206,13 @@ async def transcribe_meeting_endpoint(
     if meeting is None or not meeting.ready:
         raise HTTPException(status_code=503, detail="meeting diarization not available")
 
-    audio_bytes = await audio.read()
-    if not audio_bytes:
-        raise HTTPException(status_code=400, detail="empty audio")
+    # Stream the whole recording to a seekable temp file (never the whole file
+    # in RAM — a meeting can be multi-hour) and decode from there. The seekable
+    # file is what makes phone/Mac m4a (moov-at-end) decode at all. A generous
+    # decode budget covers long recordings (ffmpeg decode runs far faster than
+    # realtime, but a multi-hour file still needs headroom over the 30 s default).
     try:
-        pcm = await decode_audio_to_pcm(audio_bytes)
+        pcm = await decode_upload_to_pcm(audio, timeout_s=600.0)
     except OneshotDecodeError as e:
         # A recording the decoder can't parse is terminal (4xx) — the backend
         # worker maps 4xx to a failed meeting, not an infinite retry.

--- a/voice-server/voice_server/services/audio_oneshot.py
+++ b/voice-server/voice_server/services/audio_oneshot.py
@@ -7,6 +7,18 @@ the strict `-f webm` demuxer when the explicit codec hint doesn't
 match the Matroska track-codec inside; auto-detect handles webm/opus,
 ogg/opus, wav, mp3, flac, m4a transparently.
 
+**ffmpeg decodes from a real file on disk, NOT a stdin pipe.** MP4/m4a
+put the `moov` index atom at the END of the file (only faststart-remuxed
+files carry it up front), and ffmpeg must SEEK back to it to demux. A pipe
+(`pipe:0`) is not seekable, so a normal phone/Mac m4a decodes to zero PCM
+with `offset 0x2c: partial file / Invalid data`. Reading from a seekable
+file fixes it (and every other container is unaffected — WAV/webm/opus/mp3
+decode from a file just as well as from a pipe).
+
+The upload is streamed to that file in fixed-size chunks — never the whole
+recording in RAM — so a multi-hour meeting stays bounded on the media layer
+too (mirrors the backend's chunked upload).
+
 Stderr captured (not DEVNULL) so failures surface in logs instead of
 the silent "0 PCM bytes" mystery the streaming path produces.
 """
@@ -15,30 +27,75 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
+import tempfile
+from typing import Protocol
 
 import numpy as np
 
 logger = logging.getLogger(__name__)
+
+# Streamed to the on-disk temp file in 1 MiB chunks (never the whole file in RAM).
+_SPOOL_CHUNK = 1 << 20
+
+# Where the seekable temp file lands. tempfile default honours $TMPDIR; a
+# dedicated env lets the deployment steer it onto a disk-backed volume (a
+# multi-hour recording must NOT land on a tmpfs /tmp, which would be RAM again).
+_SPOOL_DIR = os.environ.get("VOICE_ONESHOT_SPOOL_DIR") or None
 
 
 class OneshotDecodeError(Exception):
     pass
 
 
-async def decode_audio_to_pcm(audio_bytes: bytes, *, timeout_s: float = 30.0) -> np.ndarray:
-    """Decode any common audio container to mono 16 kHz float32 PCM.
+class _UploadLike(Protocol):
+    """The slice of Starlette's UploadFile we depend on (async chunked read)."""
 
-    Fixed argv (no shell). ffmpeg auto-detects the input format from
-    the byte stream — works for the full set browsers / satellites
-    actually send (webm/opus, ogg/opus, wav, mp3, flac, m4a).
+    async def read(self, size: int = -1) -> bytes: ...
+
+
+async def _spool_upload_to_tempfile(upload: _UploadLike) -> tuple[str, int]:
+    """Stream an upload to a fresh seekable temp file in chunks; return (path, bytes).
+
+    Never buffers the whole upload in RAM. Caller owns the file and MUST unlink it.
     """
-    if not audio_bytes:
-        raise OneshotDecodeError("empty input")
+    fd, path = tempfile.mkstemp(suffix=".oneshot", dir=_SPOOL_DIR)
+    total = 0
+    try:
+        # Blocking file writes are fine here: the media host is I/O-light and the
+        # chunk loop yields to the event loop on every awaited upload.read().
+        with os.fdopen(fd, "wb") as fh:
+            while True:
+                chunk = await upload.read(_SPOOL_CHUNK)
+                if not chunk:
+                    break
+                total += len(chunk)
+                fh.write(chunk)
+    except BaseException:
+        _safe_unlink(path)
+        raise
+    return path, total
 
+
+def _safe_unlink(path: str) -> None:
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        pass
+    except OSError as e:  # noqa: BLE001 — cleanup best-effort
+        logger.warning("oneshot temp cleanup failed for %s: %s", path, e)
+
+
+async def _ffmpeg_file_to_pcm(path: str, *, timeout_s: float) -> np.ndarray:
+    """Decode a seekable on-disk audio file to mono 16 kHz float32 PCM.
+
+    Fixed argv (no shell). ffmpeg auto-detects the container from the file and
+    seeks freely (so MP4/m4a moov-at-end works). PCM is pulled over stdout.
+    """
     argv = [
         "ffmpeg",
         "-loglevel", "error",
-        "-i", "pipe:0",
+        "-i", path,          # seekable file — NOT pipe:0
         "-ac", "1",
         "-ar", "16000",
         "-f", "f32le",
@@ -46,14 +103,12 @@ async def decode_audio_to_pcm(audio_bytes: bytes, *, timeout_s: float = 30.0) ->
     ]
     proc = await asyncio.create_subprocess_exec(
         *argv,
-        stdin=asyncio.subprocess.PIPE,
+        stdin=asyncio.subprocess.DEVNULL,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
     try:
-        stdout, stderr = await asyncio.wait_for(
-            proc.communicate(audio_bytes), timeout=timeout_s
-        )
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout_s)
     except asyncio.TimeoutError:
         proc.kill()
         await proc.wait()
@@ -68,3 +123,40 @@ async def decode_audio_to_pcm(audio_bytes: bytes, *, timeout_s: float = 30.0) ->
         raise OneshotDecodeError(f"ffmpeg produced no PCM (stderr: {msg})")
 
     return np.frombuffer(stdout, dtype=np.float32).copy()
+
+
+async def decode_upload_to_pcm(upload: _UploadLike, *, timeout_s: float = 30.0) -> np.ndarray:
+    """Decode a complete-file upload to mono 16 kHz float32 PCM.
+
+    Streams the upload to a seekable temp file (bounded RAM) and decodes from
+    there so MP4/m4a (moov-at-end, needs seek) works. Preferred entry for REST
+    endpoints — they hold an UploadFile and should never `.read()` a whole
+    multi-hour recording into memory.
+    """
+    path, total = await _spool_upload_to_tempfile(upload)
+    try:
+        if total == 0:
+            raise OneshotDecodeError("empty input")
+        return await _ffmpeg_file_to_pcm(path, timeout_s=timeout_s)
+    finally:
+        _safe_unlink(path)
+
+
+async def decode_audio_to_pcm(audio_bytes: bytes, *, timeout_s: float = 30.0) -> np.ndarray:
+    """Decode an in-memory audio blob to mono 16 kHz float32 PCM.
+
+    Kept for callers that already hold the bytes (raw-opus sibling, tests). The
+    bytes are written to a seekable temp file first — same reason as
+    ``decode_upload_to_pcm``: MP4/m4a need a seekable input, a pipe does not
+    work. Prefer ``decode_upload_to_pcm`` when you have an UploadFile so the
+    recording never sits in RAM.
+    """
+    if not audio_bytes:
+        raise OneshotDecodeError("empty input")
+    fd, path = tempfile.mkstemp(suffix=".oneshot", dir=_SPOOL_DIR)
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(audio_bytes)
+        return await _ffmpeg_file_to_pcm(path, timeout_s=timeout_s)
+    finally:
+        _safe_unlink(path)


### PR DESCRIPTION
Phone/Mac meeting recordings (**m4a/AAC**) failed transcription with `audio decode failed: ffmpeg produced no PCM (offset 0x2c: partial file / Invalid data)`.

## Root cause
`/api/voice/stt` and `/transcribe-meeting` read the whole upload into RAM and fed it to `ffmpeg -i pipe:0`. A non-faststart m4a stores its `moov` index atom at the **end** of the file; ffmpeg must **seek** back to it to demux. A stdin pipe isn't seekable, so any m4a whose `moov` sits past ffmpeg's ~5 MB pipe-probe window (i.e. any real recording) decoded to **zero PCM**.

Reproduced exactly:
```
cat "Neue Aufnahme.m4a" | ffmpeg -i pipe:0 ... → 0 bytes  (offset 0x2c: partial file)
ffmpeg -i "Neue Aufnahme.m4a" ...             → 79 MB PCM
```
The file's `moov` sits at offset 58,515,579 (after `mdat` at 28) — classic moov-at-end.

## Fix
Stream the upload to a **seekable temp file** in fixed-size chunks, then `ffmpeg -i <file>`. This:
1. Makes MP4/m4a decode correctly (ffmpeg can seek to the end `moov`).
2. Stops buffering a multi-hour meeting **whole in RAM** on the media layer — the §2 "never whole-file-in-RAM" rule.

Every other container (wav/webm/opus/mp3/flac) decodes from a file identically — no behavior change for existing callers. The **streaming WS decoder** (`audio_decoder.py`) is untouched (live chunks are inherently non-seekable).

## Changes
- `audio_oneshot.py`: new `decode_upload_to_pcm(upload)` (chunked-stream entry; both REST endpoints use it so they never `.read()` a whole recording). `decode_audio_to_pcm(bytes)` kept for byte-callers (raw-opus sibling / tests), now also file-backed. `VOICE_ONESHOT_SPOOL_DIR` steers the spool onto a disk-backed volume (keep multi-hour spools off a tmpfs).
- `rest_voice.py`: both one-shot endpoints → `decode_upload_to_pcm`; meeting gets a 600 s decode budget.
- `tests/test_audio_oneshot.py`: synthesizes a >6 MB moov-at-end m4a (white noise, past the probe window) and asserts non-empty PCM — **fails on the old pipe path, passes now**. Plus empty-input + garbage-is-terminal guards. **5/5 pass** (clean python:3.11 + ffmpeg).
- v0.3.3 + CHANGELOG.

## Verification
- Regression suite 5/5 in a clean ffmpeg container.
- Decoded the **real 58 MB / 20.7 min** `Neue Aufnahme.m4a` via both entry points → correct PCM.

Ships to the shared voice-server (ns `voice`); backward-compatible. Deploy via `bin/release-voice-server.sh v0.3.3` + digest-pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)