### PR TITLE
feat(projects): Phase 4A — project timeline (/projects/{id})

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -110,9 +110,13 @@ Ein minimales **Projekt**-Modell für Business-Instanzen (Phase 1): jedes Projek
 - **Dark by default**: `PROJECTS_ENABLED=false` → alle Routen 404, kein Nav-Eintrag, Household-Instanz byte-identisch. Kein Codebase-Fork — rein additiv hinter dem Flag.
 - **Owner-scoped**: Auth an → nur eigene Projekte; `AUTH_ENABLED=false` (Single-User) sieht alle. Der Anleger besitzt Projekt und KB.
 - **1:1-Invariante** in `services/project_service.py`: frische KB pro Projekt, kollisionssichere KB-Namen über die Projekt-ID, Projekt + KB in einer Transaktion.
-- **Später (nicht Teil dieser Phase)**: Projekt-Timeline, Protokoll-Pipeline (Zusammenfassung/Entscheidungen/Action-Items), Notizen. (Meeting-Transkription + `Meeting`-Modell sind inzwischen gebaut — siehe unten.)
+- **Später (nicht Teil dieser Phase)**: Notizen (als 5. atom_type geplant). Protokoll-Pipeline (Zusammenfassung/Entscheidungen/Action-Items) + Meeting-Transkription sind inzwischen gebaut — siehe unten.
 
 Migration `pc20260713_projects`.
+
+### Projekt-Timeline (Phase 4A, `projects_enabled`, migration `pc20260719_project_links`)
+
+Jedes Projekt hat unter `/projects/{id}` einen **chronologischen Verlauf** (neueste zuerst), der die projekt-zugehörigen Artefakte zu EINEM Feed zusammenführt: **Dokumente** (aus der 1:1-KB des Projekts), **Besprechungen** (`Meeting.project_id`), **Entscheidungen** (aus den bestätigten Minutes eines Meetings flach gezogen) und **Chats** (`Conversation.project_id`). `GET /api/projects/{id}/timeline` (owner-gated 404, paginiert) fragt jede Quelle einzeln ab und merge-sortiert in Python (heterogene Zeilen teilen keine SQL-Projektion), per-Quelle gedeckelt — spiegelt das Presence-Analytics-Single-Scan-Muster als Multi-Source-Merge. Migration `pc20260719_project_links` fügt ein nullable `project_id` (FK `ON DELETE SET NULL`) an `meetings` + `conversations`. Meeting-Upload akzeptiert ein optionales owner-validiertes `project_id`. **Frontend**: `ProjectDetailPage` (Klick-Durchgriff aus der Projektliste, Timeline-Zeilen mit Icon je Typ + Deep-Links nach `/knowledge?doc=` / `/meetings`). Dokumente füllen die Timeline heute schon (Ingest in die Projekt-KB); ein Projekt-Picker in der Meetings/Chat-UI zum Setzen von `project_id` ist ein kleiner Follow-up. Dark by default.
 
 ## Meeting-Transkription + Diarisierung (§2, `MEETING_TRANSCRIPTION_ENABLED` / voice-server `MEETING_ENABLED`, dark by default)
 

--- a/src/backend/alembic/versions/pc20260719_project_links.py
+++ b/src/backend/alembic/versions/pc20260719_project_links.py
@@ -1,0 +1,59 @@
+"""project links — Phase 4A: project_id on meetings + conversations
+
+Revision ID: pc20260719_project_links
+Revises: pc20260718_meeting_minutes
+Create Date: 2026-07-19
+
+Adds a nullable ``project_id`` FK (ON DELETE SET NULL) to ``meetings`` and
+``conversations`` so a meeting / chat can be scoped to a Project and surface on
+its ``/projects/{id}`` timeline (documents already reach a project via its 1:1
+KB). SET NULL mirrors the owner/KB FK convention — deleting a project never
+blocks; the row just de-scopes.
+
+Idempotency: ``Base.metadata.create_all`` (backend boot) already carries these
+columns for a fresh install, so every op is inspector-guarded to a no-op re-run
+(same pattern as pc20260713_projects). Fully transactional
+(transaction_per_migration).
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "pc20260719_project_links"
+down_revision = "pc20260718_meeting_minutes"
+branch_labels = None
+depends_on = None
+
+
+def _cols(inspector, table: str) -> set[str]:
+    return {c["name"] for c in inspector.get_columns(table)}
+
+
+def _idx(inspector, table: str) -> set[str]:
+    return {ix["name"] for ix in inspector.get_indexes(table)}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = set(inspector.get_table_names())
+
+    for table in ("meetings", "conversations"):
+        if table not in tables:
+            continue  # create_all will build it with the column already present
+        if "project_id" not in _cols(inspector, table):
+            op.add_column(
+                table,
+                sa.Column(
+                    "project_id", sa.Integer(),
+                    sa.ForeignKey("projects.id", ondelete="SET NULL"), nullable=True,
+                ),
+            )
+        idx = f"ix_{table}_project_id"
+        if idx not in _idx(inspector, table):
+            op.create_index(idx, table, ["project_id"])
+
+
+def downgrade() -> None:
+    for table in ("conversations", "meetings"):
+        op.drop_index(f"ix_{table}_project_id", table_name=table)
+        op.drop_column(table, "project_id")

--- a/src/backend/api/routes/meetings.py
+++ b/src/backend/api/routes/meetings.py
@@ -90,6 +90,7 @@ class MeetingResponse(BaseModel):
     date: str | None
     error: str | None
     transcript_document_id: int | None
+    project_id: int | None
     created_at: str
 
 
@@ -101,6 +102,7 @@ def _to_response(m: Meeting) -> MeetingResponse:
         date=m.date.isoformat() if m.date else None,
         error=m.error,
         transcript_document_id=m.transcript_document_id,
+        project_id=m.project_id,
         created_at=m.created_at.isoformat() if m.created_at else "",
     )
 
@@ -113,13 +115,26 @@ async def transcribe_meeting(
     title: str | None = Form(None),
     date: str | None = Form(None),
     consent_note: str | None = Form(None),
+    project_id: int | None = Form(None),
     user: User | None = Depends(get_optional_user),
     db: AsyncSession = Depends(get_db),
 ) -> MeetingResponse:
-    """Upload a recording for transcription. Returns 202 with the meeting id to poll."""
+    """Upload a recording for transcription. Returns 202 with the meeting id to poll.
+
+    Optional ``project_id`` (Phase 4A) scopes the meeting to a Project so it
+    surfaces on ``/projects/{id}/timeline``; owner-validated when provided."""
     _require_enabled()
     if settings.auth_enabled and not user:
         raise HTTPException(status_code=401, detail="Authentication required")
+
+    # Validate an optional project scope: it must exist and (auth on) be the
+    # caller's, so a meeting can't be attached to someone else's project.
+    if project_id is not None:
+        from models.database import Project
+
+        project = await db.get(Project, project_id)
+        if project is None or (settings.auth_enabled and user and project.owner_id != user.id):
+            raise HTTPException(status_code=404, detail="Project not found")
 
     # Consent is mandatory from day one (DE workplace recording — designed in).
     if not consent_confirmed:
@@ -162,6 +177,7 @@ async def transcribe_meeting(
         consent_confirmed=True,
         consent_note=consent_note,
         retention_until=retention_until,
+        project_id=project_id,
     )
     db.add(meeting)
     await db.commit()

--- a/src/backend/api/routes/projects.py
+++ b/src/backend/api/routes/projects.py
@@ -14,7 +14,7 @@ plan §7) and are NOT here.
 """
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -151,6 +151,35 @@ async def get_project_route(
     _require_enabled()
     project = await _get_owned_project(project_id, user, db)
     return await _to_response(db, project)
+
+
+class TimelineEvent(BaseModel):
+    kind: str  # document | meeting | decision | chat
+    id: str    # kind-scoped stable id (e.g. "meeting-3", "decision-3-0")
+    ts: str    # ISO timestamp (empty when the source row is undated)
+    title: str
+    subtitle: str | None = None
+    document_id: int | None = None            # deep-link → /knowledge?doc=
+    meeting_id: int | None = None             # deep-link → /meetings
+    conversation_session_id: str | None = None
+
+
+@router.get("/{project_id}/timeline", response_model=list[TimelineEvent])
+async def project_timeline_route(
+    project_id: int,
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    user: User | None = Depends(get_optional_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[TimelineEvent]:
+    """Chronological (newest-first) merged feed for the project — its documents,
+    meetings, confirmed-minutes decisions, and scoped chat. Owner-gated 404."""
+    _require_enabled()
+    project = await _get_owned_project(project_id, user, db)
+    from services.project_timeline import get_project_timeline
+
+    events = await get_project_timeline(db, project, limit=limit, offset=offset)
+    return [TimelineEvent(**e) for e in events]
 
 
 @router.delete("/{project_id}")

--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -39,6 +39,13 @@ class Conversation(Base):
     user_id = Column(Integer, ForeignKey("users.id"), nullable=True, index=True)
     speaker_id = Column(Integer, ForeignKey("speakers.id", ondelete="SET NULL"), nullable=True, index=True)
 
+    # Optional business-instance Project scope (Phase 4A). SET NULL so deleting a
+    # project de-scopes the chat rather than cascading it away. Lets a
+    # conversation surface on the project's /projects/{id} timeline.
+    project_id = Column(
+        Integer, ForeignKey("projects.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+
     # Conversation state (survives history truncation)
     context_vars = Column(JSON, nullable=True)   # Pinned structured state (entities, focus)
     summary = Column(Text, nullable=True)         # LLM-generated summary of older messages
@@ -354,7 +361,6 @@ class Meeting(Base):
     ingested into the target KB as ``transcript_document_id``. Gated by
     ``settings.meeting_transcription_enabled``; both instances leave it off.
 
-    NO ``project_id`` / minutes fields yet — those are additive later phases.
     ``consent_confirmed`` is REQUIRED at upload from day one (DE workplace
     recording — designed in, not bolted on).
     """
@@ -364,6 +370,12 @@ class Meeting(Base):
 
     # Ownership (nullable for auth-disabled single-user deploys, mirrors Project).
     owner_user_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True)
+
+    # Optional business-instance Project scope (Phase 4A). SET NULL so deleting a
+    # project de-scopes the meeting. Surfaces the meeting on /projects/{id} timeline.
+    project_id = Column(
+        Integer, ForeignKey("projects.id", ondelete="SET NULL"), nullable=True, index=True
+    )
 
     # Circles v1 tier. Default 2 = household/team — a meeting is a shared artifact.
     circle_tier = Column(Integer, nullable=False, default=2)

--- a/src/backend/services/project_timeline.py
+++ b/src/backend/services/project_timeline.py
@@ -1,0 +1,156 @@
+"""Project timeline (Phase 4A).
+
+Merges the time-ordered artifacts that belong to a Project into ONE chronological
+feed for ``GET /api/projects/{id}/timeline``:
+
+- **documents** ingested into the project's 1:1 KB (already project-scoped)
+- **meetings** scoped via ``Meeting.project_id``
+- **decisions** flattened out of a completed meeting's confirmed minutes JSON
+  (no per-decision timestamp exists → stamped with the parent meeting's
+  ``minutes_confirmed_at`` / date)
+- **chat** conversations scoped via ``Conversation.project_id``
+
+Shape mirrors the presence-analytics timeline (single ordered scan per source),
+generalised to a multi-source merge: each source is queried independently, then
+merge-sorted in Python (heterogeneous rows can't share one SQL projection
+cleanly) newest-first and offset-sliced. Owner scoping + the feature gate live in
+the route; this service only reads.
+"""
+from __future__ import annotations
+
+from datetime import date as date_cls
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import Conversation, Document, Meeting, Project
+
+# Per-source fetch cap (offset + limit, bounded) so a huge corpus can't pull
+# everything into memory for a paged view. A timeline is a browse surface, not a
+# bulk export; deep paging past this is intentionally not supported.
+_SOURCE_CAP = 500
+
+
+def _as_dt(value: datetime | date_cls | None) -> datetime | None:
+    """Normalise a Date or DateTime to a comparable datetime (Date → midnight)."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, date_cls):
+        return datetime(value.year, value.month, value.day)
+    return None
+
+
+def _doc_title(doc: Document) -> str:
+    return (
+        getattr(doc, "generated_title", None)
+        or doc.title
+        or doc.filename
+        or f"Dokument {doc.id}"
+    )
+
+
+async def get_project_timeline(
+    db: AsyncSession, project: Project, *, limit: int, offset: int
+) -> list[dict]:
+    """Return the project's merged timeline events, newest-first, offset-sliced."""
+    fetch = min(offset + limit, _SOURCE_CAP)
+    events: list[dict] = []
+
+    # --- documents (project KB) -------------------------------------------- #
+    if project.knowledge_base_id is not None:
+        docs = (
+            await db.execute(
+                select(Document)
+                .where(Document.knowledge_base_id == project.knowledge_base_id)
+                .order_by(Document.created_at.desc())
+                .limit(fetch)
+            )
+        ).scalars().all()
+        for d in docs:
+            ts = _as_dt(d.created_at)
+            events.append({
+                "_ts": ts,
+                "kind": "document",
+                "id": f"document-{d.id}",
+                "ts": ts.isoformat() if ts else "",
+                "title": _doc_title(d),
+                "subtitle": d.status if d.status != "completed" else None,
+                "document_id": d.id,
+                "meeting_id": None,
+                "conversation_session_id": None,
+            })
+
+    # --- meetings + their decisions ---------------------------------------- #
+    meetings = (
+        await db.execute(
+            select(Meeting)
+            .where(Meeting.project_id == project.id)
+            .order_by(Meeting.created_at.desc())
+            .limit(fetch)
+        )
+    ).scalars().all()
+    for m in meetings:
+        m_ts = _as_dt(m.date) or _as_dt(m.created_at)
+        events.append({
+            "_ts": m_ts,
+            "kind": "meeting",
+            "id": f"meeting-{m.id}",
+            "ts": m_ts.isoformat() if m_ts else "",
+            "title": m.title or f"Besprechung {m.id}",
+            "subtitle": m.status if m.status != "completed" else None,
+            "document_id": m.transcript_document_id,
+            "meeting_id": m.id,
+            "conversation_session_id": None,
+        })
+        # Flatten CONFIRMED decisions into their own events.
+        if m.minutes_status == "confirmed" and isinstance(m.minutes, dict):
+            d_ts = _as_dt(m.minutes_confirmed_at) or m_ts
+            for idx, dec in enumerate(m.minutes.get("decisions") or []):
+                text = (dec or {}).get("text") if isinstance(dec, dict) else None
+                if not text:
+                    continue
+                events.append({
+                    "_ts": d_ts,
+                    "kind": "decision",
+                    "id": f"decision-{m.id}-{idx}",
+                    "ts": d_ts.isoformat() if d_ts else "",
+                    "title": text,
+                    "subtitle": (dec.get("made_by") or None),
+                    "document_id": m.transcript_document_id,
+                    "meeting_id": m.id,
+                    "conversation_session_id": None,
+                })
+
+    # --- chat conversations ------------------------------------------------ #
+    convs = (
+        await db.execute(
+            select(Conversation)
+            .where(Conversation.project_id == project.id)
+            .order_by(Conversation.updated_at.desc())
+            .limit(fetch)
+        )
+    ).scalars().all()
+    for c in convs:
+        c_ts = _as_dt(c.updated_at) or _as_dt(c.created_at)
+        summary = (c.summary or "").strip()
+        events.append({
+            "_ts": c_ts,
+            "kind": "chat",
+            "id": f"chat-{c.id}",
+            "ts": c_ts.isoformat() if c_ts else "",
+            "title": (summary[:120] if summary else f"Unterhaltung {c.id}"),
+            "subtitle": None,
+            "document_id": None,
+            "meeting_id": None,
+            "conversation_session_id": c.session_id,
+        })
+
+    # Merge-sort newest-first (undated rows sink to the bottom), then slice.
+    events.sort(key=lambda e: (e["_ts"] is not None, e["_ts"] or datetime.min), reverse=True)
+    window = events[offset:offset + limit]
+    for e in window:
+        e.pop("_ts", None)
+    return window

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import { queryClient } from './api/queryClient';
 // Lazy-loaded admin/secondary pages
 const TasksPage = lazy(() => import('./pages/TasksPage'));
 const ProjectsPage = lazy(() => import('./pages/ProjectsPage'));
+const ProjectDetailPage = lazy(() => import('./pages/ProjectDetailPage'));
 const MeetingsPage = lazy(() => import('./pages/MeetingsPage'));
 const CameraPage = lazy(() => import('./pages/CameraPage'));
 const HomeAssistantPage = lazy(() => import('./pages/HomeAssistantPage'));
@@ -98,6 +99,13 @@ function AppRoutes() {
               <Route path="/projects" element={
                 <ProtectedRoute>
                   <ProjectsPage />
+                </ProtectedRoute>
+              } />
+            )}
+            {projectsEnabled && (
+              <Route path="/projects/:id" element={
+                <ProtectedRoute>
+                  <ProjectDetailPage />
                 </ProtectedRoute>
               } />
             )}

--- a/src/frontend/src/api/keys.ts
+++ b/src/frontend/src/api/keys.ts
@@ -120,6 +120,7 @@ export const keys = {
     all: ['projects'] as const,
     list: () => ['projects', 'list'] as const,
     detail: (id: number) => ['projects', 'detail', id] as const,
+    timeline: (id: number) => ['projects', id, 'timeline'] as const,
   },
   meetings: {
     all: ['meetings'] as const,

--- a/src/frontend/src/api/resources/projects.ts
+++ b/src/frontend/src/api/resources/projects.ts
@@ -24,8 +24,31 @@ export interface ProjectInput {
   circle_tier?: number;
 }
 
+/** One merged project-timeline event (Phase 4A). Mirrors TimelineEvent in
+ *  api/routes/projects.py — a document/meeting/decision/chat, newest-first. */
+export interface TimelineEvent {
+  kind: 'document' | 'meeting' | 'decision' | 'chat';
+  id: string;
+  ts: string;
+  title: string;
+  subtitle: string | null;
+  document_id: number | null;
+  meeting_id: number | null;
+  conversation_session_id: string | null;
+}
+
 async function fetchProjects(): Promise<Project[]> {
   const response = await apiClient.get<Project[]>('/api/projects');
+  return Array.isArray(response.data) ? response.data : [];
+}
+
+async function fetchProject(id: number): Promise<Project> {
+  const response = await apiClient.get<Project>(`/api/projects/${id}`);
+  return response.data;
+}
+
+async function fetchTimeline(id: number): Promise<TimelineEvent[]> {
+  const response = await apiClient.get<TimelineEvent[]>(`/api/projects/${id}/timeline`);
   return Array.isArray(response.data) ? response.data : [];
 }
 
@@ -46,6 +69,30 @@ export function useProjectsQuery() {
       staleTime: STALE.DEFAULT,
     },
     'projects.failedToLoad',
+  );
+}
+
+export function useProjectQuery(id: number | null) {
+  return useApiQuery(
+    {
+      queryKey: keys.projects.detail(id ?? 0),
+      queryFn: () => fetchProject(id as number),
+      staleTime: STALE.DEFAULT,
+      enabled: id != null,
+    },
+    'projects.failedToLoad',
+  );
+}
+
+export function useProjectTimeline(id: number | null) {
+  return useApiQuery(
+    {
+      queryKey: keys.projects.timeline(id ?? 0),
+      queryFn: () => fetchTimeline(id as number),
+      staleTime: STALE.DEFAULT,
+      enabled: id != null,
+    },
+    'projects.failedToLoadTimeline',
   );
 }
 

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -591,7 +591,22 @@
     "created": "Erstellt",
     "failedToLoad": "Projekte konnten nicht geladen werden",
     "failedToSave": "Projekt konnte nicht gespeichert werden",
-    "failedToDelete": "Projekt konnte nicht gelöscht werden"
+    "failedToDelete": "Projekt konnte nicht gelöscht werden",
+    "failedToLoadTimeline": "Verlauf konnte nicht geladen werden",
+    "backToList": "Zurück zu den Projekten",
+    "notFound": "Projekt nicht gefunden",
+    "timeline": {
+      "title": "Verlauf",
+      "subtitle": "Dokumente, Besprechungen, Entscheidungen und Chats dieses Projekts",
+      "empty": "Noch keine Aktivität",
+      "emptyDesc": "Sobald Dokumente ingestiert, Besprechungen aufgenommen oder Chats zugeordnet werden, erscheinen sie hier.",
+      "kind": {
+        "document": "Dokument",
+        "meeting": "Besprechung",
+        "decision": "Entscheidung",
+        "chat": "Chat"
+      }
+    }
   },
   "meetings": {
     "title": "Besprechungen",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -591,7 +591,22 @@
     "created": "Created",
     "failedToLoad": "Could not load projects",
     "failedToSave": "Could not save project",
-    "failedToDelete": "Could not delete project"
+    "failedToDelete": "Could not delete project",
+    "failedToLoadTimeline": "Could not load the timeline",
+    "backToList": "Back to projects",
+    "notFound": "Project not found",
+    "timeline": {
+      "title": "Timeline",
+      "subtitle": "This project's documents, meetings, decisions and chats",
+      "empty": "No activity yet",
+      "emptyDesc": "Once documents are ingested, meetings recorded, or chats scoped to this project, they show up here.",
+      "kind": {
+        "document": "Document",
+        "meeting": "Meeting",
+        "decision": "Decision",
+        "chat": "Chat"
+      }
+    }
   },
   "meetings": {
     "title": "Meetings",

--- a/src/frontend/src/pages/ProjectDetailPage.tsx
+++ b/src/frontend/src/pages/ProjectDetailPage.tsx
@@ -1,0 +1,126 @@
+import { useTranslation } from 'react-i18next';
+import { Link, useParams } from 'react-router';
+import {
+  FolderKanban, FileText, Mic, Gavel, MessageSquare, Loader, XCircle, ArrowLeft,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
+import PageHeader from '../components/PageHeader';
+import TierBadge from '../components/TierBadge';
+import { formatDateTime } from '../utils/datetime';
+import {
+  useProjectQuery, useProjectTimeline, type TimelineEvent,
+} from '../api/resources/projects';
+
+/** Per-kind icon + accent for a timeline event. */
+const KIND_META: Record<TimelineEvent['kind'], { Icon: LucideIcon; cls: string }> = {
+  document: { Icon: FileText, cls: 'text-blue-600 dark:text-blue-400' },
+  meeting: { Icon: Mic, cls: 'text-primary-600 dark:text-primary-400' },
+  decision: { Icon: Gavel, cls: 'text-amber-600 dark:text-amber-400' },
+  chat: { Icon: MessageSquare, cls: 'text-green-600 dark:text-green-400' },
+};
+
+/** A single timeline row; deep-links to the underlying artifact where one exists. */
+function TimelineRow({ event }: { event: TimelineEvent }) {
+  const { t } = useTranslation();
+  const { Icon, cls } = KIND_META[event.kind];
+
+  const href =
+    event.document_id != null
+      ? `/knowledge?doc=${event.document_id}`
+      : event.meeting_id != null
+        ? '/meetings'
+        : null;
+
+  const body = (
+    <div className="flex items-start gap-3">
+      <Icon className={`w-4 h-4 mt-0.5 shrink-0 ${cls}`} aria-hidden="true" />
+      <div className="min-w-0 flex-1">
+        <p className="text-sm text-gray-900 dark:text-white break-words">{event.title}</p>
+        <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+          <span className="uppercase tracking-wide">{t(`projects.timeline.kind.${event.kind}`)}</span>
+          {event.subtitle && <span>· {event.subtitle}</span>}
+          {event.ts && <span>· {formatDateTime(event.ts)}</span>}
+        </div>
+      </div>
+    </div>
+  );
+
+  return href ? (
+    <Link to={href} className="block card hover:border-primary-300 dark:hover:border-primary-700 transition-colors">
+      {body}
+    </Link>
+  ) : (
+    <div className="card">{body}</div>
+  );
+}
+
+export default function ProjectDetailPage() {
+  const { t } = useTranslation();
+  const params = useParams();
+  const projectId = params.id ? Number(params.id) : null;
+
+  const projectQuery = useProjectQuery(projectId);
+  const timelineQuery = useProjectTimeline(projectId);
+  const project = projectQuery.data;
+  const events = timelineQuery.data ?? [];
+
+  return (
+    <div className="space-y-6">
+      <Link
+        to="/projects"
+        className="inline-flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-primary-600 dark:hover:text-primary-400"
+      >
+        <ArrowLeft className="w-4 h-4" />
+        {t('projects.backToList')}
+      </Link>
+
+      {projectQuery.isLoading ? (
+        <div className="card text-center py-12">
+          <Loader className="w-8 h-8 animate-spin mx-auto text-gray-500 dark:text-gray-400" />
+        </div>
+      ) : projectQuery.errorMessage || !project ? (
+        <div className="card text-center py-12">
+          <XCircle className="w-12 h-12 mx-auto text-red-500 mb-3" />
+          <p className="font-medium text-gray-700 dark:text-gray-300">
+            {projectQuery.errorMessage || t('projects.notFound')}
+          </p>
+        </div>
+      ) : (
+        <>
+          <PageHeader
+            icon={FolderKanban}
+            title={project.name}
+            subtitle={project.description || t('projects.timeline.subtitle')}
+          >
+            <TierBadge tier={project.circle_tier} />
+          </PageHeader>
+
+          <div>
+            <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-3">
+              {t('projects.timeline.title')}
+            </h2>
+            {timelineQuery.isLoading ? (
+              <div className="card text-center py-10">
+                <Loader className="w-6 h-6 animate-spin mx-auto text-gray-400" />
+              </div>
+            ) : timelineQuery.errorMessage ? (
+              <div className="card text-center py-10">
+                <p className="text-sm text-red-600 dark:text-red-400">{timelineQuery.errorMessage}</p>
+              </div>
+            ) : events.length === 0 ? (
+              <div className="card text-center py-10">
+                <p className="font-medium text-gray-700 dark:text-gray-300">{t('projects.timeline.empty')}</p>
+                <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('projects.timeline.emptyDesc')}</p>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {events.map((e) => <TimelineRow key={e.id} event={e} />)}
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/pages/ProjectsPage.tsx
+++ b/src/frontend/src/pages/ProjectsPage.tsx
@@ -1,6 +1,7 @@
 import { useState, type FormEvent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { FolderKanban, FileText, Loader, XCircle, Plus } from 'lucide-react';
+import { Link } from 'react-router';
+import { FolderKanban, FileText, Loader, XCircle, Plus, ChevronRight } from 'lucide-react';
 
 import PageHeader from '../components/PageHeader';
 import { formatDate } from '../utils/datetime';
@@ -96,7 +97,11 @@ export default function ProjectsPage() {
           </div>
         ) : (
           projects.map((project) => (
-            <div key={project.id} className="card">
+            <Link
+              key={project.id}
+              to={`/projects/${project.id}`}
+              className="card block hover:border-primary-300 dark:hover:border-primary-700 transition-colors"
+            >
               <div className="flex items-start justify-between gap-4">
                 <div className="min-w-0">
                   <h3 className="text-base font-semibold text-gray-900 dark:text-white mb-1 truncate">
@@ -115,9 +120,12 @@ export default function ProjectsPage() {
                     <span>{t('projects.created')}: {formatDate(project.created_at)}</span>
                   </div>
                 </div>
-                <TierBadge tier={project.circle_tier} />
+                <div className="flex items-center gap-2 shrink-0">
+                  <TierBadge tier={project.circle_tier} />
+                  <ChevronRight className="w-4 h-4 text-gray-400" />
+                </div>
               </div>
-            </div>
+            </Link>
           ))
         )}
       </div>

--- a/tests/backend/test_projects.py
+++ b/tests/backend/test_projects.py
@@ -119,6 +119,60 @@ async def test_get_missing_project_404(async_client, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Timeline (Phase 4A) — merged doc + meeting + decision + chat feed
+# ---------------------------------------------------------------------------
+
+async def test_timeline_merges_sources_newest_first(async_client, db_session, monkeypatch):
+    from datetime import datetime
+
+    from models.database import Conversation, Meeting
+
+    _enable(monkeypatch, auth=False)
+    created = (await async_client.post("/api/projects", json={"name": "TL"})).json()
+    pid, kb_id = created["id"], created["knowledge_base_id"]
+
+    # A document in the project KB.
+    db_session.add(Document(
+        filename="spec.pdf", title="Spec", file_path="/x/spec.pdf", knowledge_base_id=kb_id,
+        status="completed", created_at=datetime(2026, 7, 10, 9, 0),
+    ))
+    # A completed meeting scoped to the project, with one confirmed decision.
+    db_session.add(Meeting(
+        id=501, title="Kickoff", status="completed", project_id=pid,
+        created_at=datetime(2026, 7, 12, 10, 0),
+        minutes_status="confirmed",
+        minutes={"summary": "s", "decisions": [{"text": "Ship it", "made_by": "Anna"}],
+                 "action_items": []},
+        minutes_confirmed_at=datetime(2026, 7, 12, 11, 0),
+    ))
+    # A chat conversation scoped to the project (newest).
+    db_session.add(Conversation(
+        session_id="sess-tl", project_id=pid, summary="planning chat",
+        created_at=datetime(2026, 7, 13, 8, 0), updated_at=datetime(2026, 7, 13, 8, 0),
+    ))
+    await db_session.commit()
+
+    resp = await async_client.get(f"/api/projects/{pid}/timeline")
+    assert resp.status_code == 200
+    events = resp.json()
+    kinds = [e["kind"] for e in events]
+    assert set(kinds) == {"document", "meeting", "decision", "chat"}
+    # Newest-first: the 07-13 chat leads; the 07-10 document is last.
+    assert kinds[0] == "chat"
+    assert kinds[-1] == "document"
+    # The decision carries its text + attribution and links back to the meeting.
+    dec = next(e for e in events if e["kind"] == "decision")
+    assert dec["title"] == "Ship it" and dec["subtitle"] == "Anna" and dec["meeting_id"] == 501
+
+
+async def test_timeline_owner_gated_and_flag_gated(async_client, monkeypatch):
+    _enable(monkeypatch, auth=False)
+    assert (await async_client.get("/api/projects/999999/timeline")).status_code == 404
+    monkeypatch.setattr(settings, "projects_enabled", False)
+    assert (await async_client.get("/api/projects/1/timeline")).status_code == 404
+
+
+# ---------------------------------------------------------------------------
 # Owner scoping under auth
 # ---------------------------------------------------------------------------
 

--- a/tests/frontend/react/pages/ProjectDetailPage.test.tsx
+++ b/tests/frontend/react/pages/ProjectDetailPage.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+
+import { server } from '../mocks/server';
+import { BASE_URL } from '../mocks/handlers';
+import ProjectDetailPage from '../../../../src/frontend/src/pages/ProjectDetailPage';
+import { renderWithProviders } from '../test-utils';
+import i18n from '../../../../src/frontend/src/i18n';
+
+// The page reads the route param; pin it to project 5 (renderWithProviders uses
+// BrowserRouter, which doesn't supply a matched :id to a directly-rendered page).
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
+  return { ...actual, useParams: () => ({ id: '5' }) };
+});
+
+const PROJECT = {
+  id: 5, name: 'Apollo', description: 'Rocket project', owner_id: 1,
+  knowledge_base_id: 9, circle_tier: 2, status: 'active',
+  created_at: '2026-07-10T09:00:00Z', document_count: 1,
+};
+
+describe('ProjectDetailPage', () => {
+  it('renders the project header + a merged, newest-first timeline with deep-links', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/projects/5`, () => HttpResponse.json(PROJECT)),
+      http.get(`${BASE_URL}/api/projects/5/timeline`, () =>
+        HttpResponse.json([
+          { kind: 'chat', id: 'chat-1', ts: '2026-07-13T08:00:00Z', title: 'planning chat',
+            subtitle: null, document_id: null, meeting_id: null, conversation_session_id: 'sess-1' },
+          { kind: 'decision', id: 'decision-3-0', ts: '2026-07-12T11:00:00Z', title: 'Ship it',
+            subtitle: 'Anna', document_id: 20, meeting_id: 3, conversation_session_id: null },
+          { kind: 'meeting', id: 'meeting-3', ts: '2026-07-12T10:00:00Z', title: 'Kickoff',
+            subtitle: null, document_id: 20, meeting_id: 3, conversation_session_id: null },
+          { kind: 'document', id: 'document-20', ts: '2026-07-10T09:00:00Z', title: 'Spec',
+            subtitle: null, document_id: 20, meeting_id: null, conversation_session_id: null },
+        ]),
+      ),
+    );
+
+    renderWithProviders(<ProjectDetailPage />);
+
+    // Header shows the project name.
+    await waitFor(() => expect(screen.getByText('Apollo')).toBeInTheDocument());
+
+    // All four event kinds render with their titles.
+    expect(screen.getByText('planning chat')).toBeInTheDocument();
+    expect(screen.getByText('Ship it')).toBeInTheDocument();
+    expect(screen.getByText('Kickoff')).toBeInTheDocument();
+    expect(screen.getByText('Spec')).toBeInTheDocument();
+
+    // The decision carries its attribution.
+    expect(screen.getByText(/Anna/)).toBeInTheDocument();
+
+    // A document event deep-links into the knowledge base.
+    const specLink = screen.getByText('Spec').closest('a');
+    expect(specLink).toHaveAttribute('href', '/knowledge?doc=20');
+  });
+
+  it('shows the empty state when the timeline has no events', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/projects/5`, () => HttpResponse.json(PROJECT)),
+      http.get(`${BASE_URL}/api/projects/5/timeline`, () => HttpResponse.json([])),
+    );
+
+    renderWithProviders(<ProjectDetailPage />);
+    await waitFor(() =>
+      expect(screen.getByText(i18n.t('projects.timeline.empty'))).toBeInTheDocument(),
+    );
+  });
+
+  it('shows an error state when the project 404s', async () => {
+    // A 404 surfaces through the query wrapper as the localized load-error; the
+    // page renders the error card rather than the timeline.
+    server.use(
+      http.get(`${BASE_URL}/api/projects/5`, () => HttpResponse.json({}, { status: 404 })),
+      http.get(`${BASE_URL}/api/projects/5/timeline`, () => HttpResponse.json({}, { status: 404 })),
+    );
+
+    renderWithProviders(<ProjectDetailPage />);
+    await waitFor(
+      () => expect(screen.getByText(i18n.t('projects.failedToLoad'))).toBeInTheDocument(),
+      { timeout: 3000 },
+    );
+    // The timeline heading is NOT rendered in the error state.
+    expect(screen.queryByText(i18n.t('projects.timeline.title'))).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Phase 4A of the business-instance Projects feature: a per-project **chronological timeline** at `/projects/{id}`.

## What it delivers
A merged, newest-first feed of everything that belongs to a project:
- **documents** ingested into the project's 1:1 KB (already project-scoped today)
- **meetings** scoped via a new `Meeting.project_id`
- **decisions** flattened out of a completed meeting's confirmed minutes JSON
- **chat** conversations scoped via a new `Conversation.project_id`

## Backend
- **Migration `pc20260719_project_links`**: nullable `project_id` FK (`ON DELETE SET NULL`) on `meetings` + `conversations`, inspector-guarded idempotent (create_all-safe). **Real-upgrade tested on Postgres** (create_all → drop cols → stamp prior head → `alembic upgrade head` → columns present).
- **`services/project_timeline.py`**: queries each source independently then merge-sorts newest-first in Python (heterogeneous rows can't share one SQL projection), offset-sliced, per-source-capped. Mirrors the presence-analytics single-scan pattern generalized to a multi-source merge.
- **`GET /api/projects/{id}/timeline`** — owner-gated 404, `projects_enabled`, paginated (`limit`/`offset`).
- Meeting upload accepts an optional owner-validated `project_id`; `MeetingResponse` surfaces it.

## Frontend
- **`ProjectDetailPage`** at `/projects/:id`: header + timeline with per-kind icons and deep-links (`document`/`meeting` → `/knowledge?doc` / `/meetings`). `ProjectsPage` cards are now click-through.
- `useProjectQuery` / `useProjectTimeline` hooks + query keys, i18n de+en (`projects.timeline.*`).

## Tests
- Backend `test_projects` **12/12** (`.159`): timeline merge/ordering, decision flattening + attribution + meeting deep-link, owner+flag gating.
- RTL `ProjectDetailPage` **3/3**: 4-kind merge + newest-first + doc deep-link, empty state, error state.
- `tsc` + prod build + eslint clean.

## Scope / follow-ups
- **Dark by default** (`projects_enabled` off on household). No behavior change there.
- Documents populate the timeline today; a **project-picker in the meetings/chat UI** to *set* `project_id` from the front end is a small deliberate follow-up.
- **Phase 4B** (Notes as a 5th atom_type + `[[bidirectional links]]`) is a separate, larger effort — its own design pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)