### PR TITLE
fix(meetings): disable the 30s upload timeout — large recordings failed to upload

### DIFF
--- a/src/frontend/src/api/resources/meetings.ts
+++ b/src/frontend/src/api/resources/meetings.ts
@@ -55,7 +55,8 @@ async function fetchMeetings(): Promise<Meeting[]> {
   return Array.isArray(response.data) ? response.data : [];
 }
 
-async function uploadMeetingRequest(input: MeetingUploadInput): Promise<Meeting> {
+// Exported for the timeout regression test (see meetings.upload.test.ts).
+export async function uploadMeetingRequest(input: MeetingUploadInput): Promise<Meeting> {
   const formData = new FormData();
   formData.append('audio', input.audio);
   formData.append('consent_confirmed', String(input.consentConfirmed));
@@ -64,6 +65,11 @@ async function uploadMeetingRequest(input: MeetingUploadInput): Promise<Meeting>
   if (input.consentNote) formData.append('consent_note', input.consentNote);
   const response = await apiClient.post<Meeting>('/api/meetings/transcribe', formData, {
     headers: { 'Content-Type': 'multipart/form-data' },
+    // Meeting recordings are large (multi-hour → hundreds of MB). The shared
+    // apiClient default (30s) aborts a big/slow upload client-side before it
+    // finishes — no request completes, no meeting row, no server error. Disable
+    // the timeout for THIS request so the upload runs to completion.
+    timeout: 0,
   });
   return response.data;
 }

--- a/tests/frontend/react/api/meetings.upload.test.ts
+++ b/tests/frontend/react/api/meetings.upload.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the shared axios instance so we can inspect the request config.
+vi.mock('../../../../src/frontend/src/utils/axios', () => ({
+  default: { post: vi.fn().mockResolvedValue({ data: { id: 1, status: 'pending' } }) },
+}));
+
+import apiClient from '../../../../src/frontend/src/utils/axios';
+import { uploadMeetingRequest } from '../../../../src/frontend/src/api/resources/meetings';
+
+describe('meeting upload request', () => {
+  beforeEach(() => vi.mocked(apiClient.post).mockClear());
+
+  it('disables the request timeout so large recordings are not cut off at 30s', async () => {
+    const audio = new File([new Uint8Array(10)], 'besprechung.m4a', { type: 'audio/mp4' });
+    await uploadMeetingRequest({ audio, consentConfirmed: true, title: 'x' });
+
+    expect(apiClient.post).toHaveBeenCalledTimes(1);
+    const [url, body, config] = vi.mocked(apiClient.post).mock.calls[0];
+    expect(url).toBe('/api/meetings/transcribe');
+    expect(body).toBeInstanceOf(FormData);
+    // The load-bearing bit: no 30s cap on the (potentially hundreds-of-MB) upload.
+    expect(config?.timeout).toBe(0);
+  });
+
+  it('sends the consent flag and audio in the multipart body', async () => {
+    const audio = new File([new Uint8Array(10)], 'a.wav', { type: 'audio/wav' });
+    await uploadMeetingRequest({ audio, consentConfirmed: true });
+    const body = vi.mocked(apiClient.post).mock.calls[0][1] as FormData;
+    expect(body.get('consent_confirmed')).toBe('true');
+    expect(body.get('audio')).toBeInstanceOf(File);
+  });
+});


### PR DESCRIPTION
## Symptom
Uploading a Besprechung (meeting) failed with no Meeting row created and no server-side error.

## Root cause
The upload used `apiClient.post(...)` without a timeout override → inherited the shared **30s default**. Meeting recordings are large (multi-hour → hundreds of MB); a big/slow upload aborts client-side at 30s before completing, so nothing reaches the backend logic (no row, no error).

## Verified during diagnosis
- Backend endpoint returns **202** and creates the row (in-pod test).
- Traefik ingress passes a **160MB** authenticated body fine (15.7s on LAN, HTTP 202) — no size limit.
- Frontend sends `consent_confirmed` + audio correctly.
- → The only weakness for a large/slow upload is the 30s client timeout.

## Fix
`timeout: 0` on the transcribe upload only (other requests keep 30s). Regression test asserts the config carries `timeout: 0`.

Frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)