### PR TITLE
fix(voice-server): free CUDA cache between diarization and ASR (meeting OOM)

### DIFF
--- a/voice-server/CHANGELOG.md
+++ b/voice-server/CHANGELOG.md
@@ -3,6 +3,18 @@
 Releases via `bin/release-voice-server.sh` — the script refuses to release a
 version without a section here. Pushed digests live in `RELEASES.md`.
 
+## [0.3.4] — 2026-07-20
+
+- **Meeting transcription: free the CUDA cache between diarization and ASR.**
+  `MeetingDiarizationService.transcribe` ran pyannote (torch) then faster-whisper
+  (CTranslate2, a SEPARATE CUDA pool). On a busy shared GPU, pyannote's torch
+  caching-allocator memory left no room for whisper's `encode`, OOM-ing a ~32-min
+  recording (`CUDA failed with error out of memory`) even though the diarization
+  tensors were already dead. Added `torch.cuda.empty_cache()` after diarization
+  (before whisper) and after each job, so the cache doesn't starve whisper or the
+  other services sharing the GPU. Best-effort / CUDA-only. Pairs with
+  `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` on the deployment.
+
 ## [0.3.3] — 2026-07-19
 
 - **One-shot decode reads a seekable file, not a stdin pipe.** `/api/voice/stt`

--- a/voice-server/tests/test_meeting_alignment.py
+++ b/voice-server/tests/test_meeting_alignment.py
@@ -1,10 +1,17 @@
 """Unit tests for the meeting word→speaker alignment (pure logic, no GPU)."""
 
 from voice_server.services.meeting_service import (
+    MeetingDiarizationService,
     Turn,
     Word,
     align_words_to_segments,
 )
+
+
+def test_free_cuda_cache_is_safe_without_gpu():
+    """The OOM-mitigation cache free is best-effort: it must never raise when
+    there's no CUDA (build/test box), so it can't break a transcription."""
+    MeetingDiarizationService._free_cuda_cache()  # no exception = pass
 
 
 def _w(text, a, b):

--- a/voice-server/voice_server/__init__.py
+++ b/voice-server/voice_server/__init__.py
@@ -10,4 +10,4 @@ See docs/VOICE_PIPELINE_DESIGN.md § "Phase B" for the full architecture.
 # Kept in sync with the image tag by bin/release-voice-server.sh (extraction
 # plan T4). 0.3.0 = registry auth mode; 0.3.1 = X-Verify-Secret header (T11);
 # 0.3.2 = anon_default_client (household migration T31).
-__version__ = "0.3.3"
+__version__ = "0.3.4"

--- a/voice-server/voice_server/services/meeting_service.py
+++ b/voice-server/voice_server/services/meeting_service.py
@@ -183,6 +183,20 @@ class MeetingDiarizationService:
                 words.append(Word(text=w.word, start_s=float(w.start), end_s=float(w.end)))
         return words
 
+    @staticmethod
+    def _free_cuda_cache() -> None:
+        """Return torch's caching-allocator memory to CUDA. pyannote diarization
+        (torch) holds a large cache after running; faster-whisper (CTranslate2)
+        allocates from a SEPARATE CUDA pool, so without this the whisper `encode`
+        OOMs on a full GPU even though the diarization tensors are already dead —
+        the failure mode on a ~32-min recording. Best-effort / CUDA-only."""
+        try:
+            import torch
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+        except Exception:  # noqa: BLE001 — never let cleanup break a transcription
+            pass
+
     async def transcribe(self, pcm: np.ndarray, *, whisper_model, speaker_service) -> list[dict]:
         """Diarize + transcribe + align + per-cluster embed. Returns a list of
         segment dicts: {speaker(cluster id), start_s, end_s, text, embedding}."""
@@ -191,9 +205,15 @@ class MeetingDiarizationService:
         loop = asyncio.get_running_loop()
         async with self._lock:  # one batch job at a time (semaphore=1)
             turns = await loop.run_in_executor(None, self._diarize_sync, pcm)
+            # Release pyannote's torch cache BEFORE whisper so CTranslate2's
+            # (separate-pool) encode has room — this is the OOM fix.
+            self._free_cuda_cache()
             words = await loop.run_in_executor(
                 None, self._transcribe_words_sync, pcm, whisper_model
             )
+        # Release the job's allocations so they don't accumulate across meetings
+        # (and starve the other services sharing this GPU).
+        self._free_cuda_cache()
 
         segments = align_words_to_segments(words, turns)
 


### PR DESCRIPTION
## Symptom
A ~32-min meeting upload failed transcription: `voice-server transcribe-meeting returned 500: transcription failed: CUDA failed with error out of memory`.

## Root cause
`MeetingDiarizationService.transcribe()` runs **pyannote diarization (torch)** then **faster-whisper (CTranslate2 — a *separate* CUDA allocator)**. pyannote's torch caching-allocator memory is retained after diarization, so on a busy shared GPU CTranslate2's `encode` finds no room and OOMs — even though the diarization tensors are already dead. (Diagnostics: at idle, nothing transcribing, the voice-server held **15.9 / 16 GB** — accumulated cache, not model weights; a 20-min meeting worked right after a fresh start.)

## Fix
`torch.cuda.empty_cache()` after diarization (before whisper) and after each job, so the cache doesn't starve whisper or the other services sharing the GPU. Best-effort, CUDA-only (no-op without a GPU). v0.3.3 → **v0.3.4**.

Pairs with **`PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`** on the deployment (that env goes in the private shared-voice manifest, not this repo).

## Verified
Image built on the cu128 base; **7 tests pass** (incl. a no-GPU safety test for the cache-free helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)