### PR TITLE
feat(voice-server): chunked meeting transcription — bounded GPU peak, multi-hour

### DIFF
--- a/voice-server/CHANGELOG.md
+++ b/voice-server/CHANGELOG.md
@@ -3,6 +3,23 @@
 Releases via `bin/release-voice-server.sh` — the script refuses to release a
 version without a section here. Pushed digests live in `RELEASES.md`.
 
+## [0.3.5] — 2026-07-20
+
+- **Chunked meeting transcription (bounded GPU peak, multi-hour).** A recording
+  longer than `meeting_chunk_seconds` (default 480 s) is diarized + ASR'd in
+  bounded time-windows, so peak VRAM is ∝ the window, not the whole recording —
+  the real fix for the CUDA-OOM: an 8-min window peaks ~3–4 GB, so a multi-hour
+  meeting fits a shared GPU AND CTranslate2 never retains a 14 GB workspace that
+  starves the next meeting / live STT (v0.3.4's `empty_cache` only freed the torch
+  side; the whisper peak still ballooned with recording length). Each window is
+  diarized independently, so chunk-local speakers are stitched into GLOBAL
+  speakers by ECAPA cosine ≥ `meeting_speaker_match_threshold` (0.55) via a
+  running-centroid `SpeakerRegistry`. Short recordings stay a single pass
+  (pyannote labels used directly — byte-identical to before). New pure,
+  fixture-tested cores: `SpeakerRegistry`, `_chunk_bounds`,
+  `_merge_adjacent_same_speaker`. New config: `meeting_chunk_seconds`,
+  `meeting_speaker_match_threshold`.
+
 ## [0.3.4] — 2026-07-20
 
 - **Meeting transcription: free the CUDA cache between diarization and ASR.**

--- a/voice-server/tests/test_meeting_alignment.py
+++ b/voice-server/tests/test_meeting_alignment.py
@@ -1,9 +1,15 @@
 """Unit tests for the meeting word→speaker alignment (pure logic, no GPU)."""
 
+import numpy as np
+
 from voice_server.services.meeting_service import (
     MeetingDiarizationService,
+    MeetingSegment,
+    SpeakerRegistry,
     Turn,
     Word,
+    _chunk_bounds,
+    _merge_adjacent_same_speaker,
     align_words_to_segments,
 )
 
@@ -12,6 +18,60 @@ def test_free_cuda_cache_is_safe_without_gpu():
     """The OOM-mitigation cache free is best-effort: it must never raise when
     there's no CUDA (build/test box), so it can't break a transcription."""
     MeetingDiarizationService._free_cuda_cache()  # no exception = pass
+
+
+# --- chunked transcription: pure stitching/boundary logic (no GPU) ---
+
+def test_chunk_bounds_covers_recording_with_short_last_window():
+    assert _chunk_bounds(1000, 400) == [(0, 400), (400, 800), (800, 1000)]
+    assert _chunk_bounds(300, 400) == [(0, 300)]      # shorter than a chunk → one pass
+    assert _chunk_bounds(1000, 0) == [(0, 1000)]      # chunking disabled → one pass
+
+
+def _emb(*vals):
+    return np.asarray(vals, dtype=np.float32)
+
+
+def test_speaker_registry_stitches_same_voice_across_chunks():
+    """A voice that reappears in a later chunk (near-identical embedding) maps to
+    the SAME global speaker; a distinct voice gets its own."""
+    reg = SpeakerRegistry(threshold=0.7)
+    a1 = reg.assign(_emb(1.0, 0.0, 0.0))   # voice A, chunk 1
+    b1 = reg.assign(_emb(0.0, 1.0, 0.0))   # voice B, chunk 1
+    a2 = reg.assign(_emb(0.98, 0.02, 0.0)) # voice A again, chunk 2 (cos≈1)
+    c = reg.assign(_emb(0.0, 0.0, 1.0))    # voice C
+    assert a1 == a2         # stitched
+    assert b1 != a1 and c != a1 and c != b1
+    assert {a1, b1, c} == {"SPEAKER_00", "SPEAKER_01", "SPEAKER_02"}
+
+
+def test_speaker_registry_below_threshold_makes_new_speaker():
+    reg = SpeakerRegistry(threshold=0.9)
+    x = reg.assign(_emb(1.0, 0.0))
+    y = reg.assign(_emb(0.6, 0.8))   # cos 0.6 < 0.9 → distinct
+    assert x != y
+
+
+def test_speaker_registry_none_embedding_never_merges():
+    """A silent/too-short local speaker (no embedding) always gets its own label
+    — never mis-merged into someone else."""
+    reg = SpeakerRegistry(threshold=0.5)
+    a = reg.assign(_emb(1.0, 0.0))
+    n1 = reg.assign(None)
+    n2 = reg.assign(None)
+    assert len({a, n1, n2}) == 3
+    assert reg.centroid(n1) is None
+
+
+def test_merge_adjacent_same_speaker_joins_across_boundary():
+    segs = [
+        MeetingSegment("SPEAKER_00", 0.0, 5.0, "hallo"),
+        MeetingSegment("SPEAKER_00", 5.0, 8.0, "welt"),   # same speaker, next chunk
+        MeetingSegment("SPEAKER_01", 8.0, 9.0, "ja"),
+    ]
+    merged = _merge_adjacent_same_speaker(segs)
+    assert [s.speaker for s in merged] == ["SPEAKER_00", "SPEAKER_01"]
+    assert merged[0].text == "hallo welt" and merged[0].end_s == 8.0
 
 
 def _w(text, a, b):

--- a/voice-server/voice_server/__init__.py
+++ b/voice-server/voice_server/__init__.py
@@ -10,4 +10,4 @@ See docs/VOICE_PIPELINE_DESIGN.md § "Phase B" for the full architecture.
 # Kept in sync with the image tag by bin/release-voice-server.sh (extraction
 # plan T4). 0.3.0 = registry auth mode; 0.3.1 = X-Verify-Secret header (T11);
 # 0.3.2 = anon_default_client (household migration T31).
-__version__ = "0.3.4"
+__version__ = "0.3.5"

--- a/voice-server/voice_server/config.py
+++ b/voice-server/voice_server/config.py
@@ -123,6 +123,13 @@ class Settings(BaseSettings):
     meeting_enabled: bool = False
     meeting_diarization_model: str = "pyannote/speaker-diarization-3.1"
     meeting_whisper_model: str = ""
+    # Chunked transcription: recordings longer than this are diarized + ASR'd in
+    # bounded time-windows (peak VRAM ∝ window, not whole recording — so a
+    # multi-hour meeting fits a shared GPU and CTranslate2 doesn't retain a huge
+    # workspace). Chunk-local speakers are stitched into global ones by ECAPA
+    # cosine ≥ meeting_speaker_match_threshold. 0 disables chunking (single pass).
+    meeting_chunk_seconds: int = 480          # 8 min → ~3-4 GB peak
+    meeting_speaker_match_threshold: float = 0.55
     # HF token for the gated pyannote model at warmup (offline-first: the model
     # is baked into the image, so this only matters if the cache is cold).
     hf_token: SecretStr | None = None

--- a/voice-server/voice_server/services/meeting_service.py
+++ b/voice-server/voice_server/services/meeting_service.py
@@ -1,12 +1,23 @@
 """Meeting diarization + ASR (§2).
 
 Runs pyannote.audio speaker diarization + faster-whisper word-level ASR over a
-whole meeting recording and aligns them into speaker-attributed segments, with a
-per-cluster ECAPA embedding (same ONNX space as ``/api/voice/stt``).
+meeting recording and aligns them into speaker-attributed segments, with a
+per-speaker ECAPA embedding (same ONNX space as ``/api/voice/stt``).
 
-The alignment is a PURE function (``align_words_to_segments``) — fixture-unit
-tested with no GPU. The GPU glue (pyannote pipeline load + diarize, faster-whisper
-word timestamps) lives in ``MeetingDiarizationService``.
+**Chunked for long recordings.** A recording longer than ``meeting_chunk_seconds``
+is diarized + transcribed in bounded time-windows so peak VRAM is ∝ the window,
+not the whole recording — a multi-hour meeting fits a shared GPU, and CTranslate2
+never retains a huge workspace that starves the next meeting or live STT. Each
+window is diarized independently (chunk-local speaker labels), so the local
+speakers are stitched into GLOBAL speakers by ECAPA cosine similarity
+(``SpeakerRegistry``). A short recording is a single pass (pyannote labels used
+directly, byte-identical to the pre-chunking behaviour).
+
+The correctness cores are PURE and fixture-unit-tested with no GPU:
+``align_words_to_segments`` (word→turn), ``SpeakerRegistry`` (cross-chunk speaker
+stitching), ``_chunk_bounds``, ``_merge_adjacent_same_speaker``. The GPU glue
+(pyannote load + diarize, faster-whisper words, per-window orchestration) lives in
+``MeetingDiarizationService``.
 
 Model loading: the pyannote pipeline is baked into the image (offline-first) and
 loaded once at warmup when ``meeting_enabled``. The ASR model is the resident STT
@@ -109,6 +120,91 @@ def align_words_to_segments(words: list[Word], turns: list[Turn]) -> list[Meetin
     return segments
 
 
+def _l2norm(v: np.ndarray) -> np.ndarray:
+    """Unit-normalize (so dot product == cosine); safe on a zero vector."""
+    n = float(np.linalg.norm(v))
+    return v / n if n > 0 else v
+
+
+class SpeakerRegistry:
+    """Online cross-chunk speaker stitching (PURE — no GPU/IO, fixture-tested).
+
+    Chunked transcription diarizes each window independently, so the same person
+    is a different chunk-local label per window. This maps each chunk-local
+    speaker (via its ECAPA embedding) to a GLOBAL speaker: greedy nearest-centroid
+    match if cosine ≥ ``threshold``, else a new global speaker. Centroids are a
+    running mean over the matched embeddings (re-normalized), so a speaker's
+    identity firms up across the meeting. A local speaker with no embedding
+    (silent/too-short clip) always gets its own global label (never mis-merged)."""
+
+    def __init__(self, threshold: float) -> None:
+        self.threshold = threshold
+        self._centroids: list[np.ndarray] = []
+        self._counts: list[int] = []
+        self._labels: list[str] = []
+
+    def _new_label(self) -> str:
+        label = f"SPEAKER_{len(self._labels):02d}"
+        return label
+
+    def assign(self, embedding: np.ndarray | None) -> str:
+        if embedding is None:
+            label = self._new_label()
+            self._centroids.append(np.zeros(0, dtype=np.float32))
+            self._counts.append(0)
+            self._labels.append(label)
+            return label
+        v = _l2norm(np.asarray(embedding, dtype=np.float32))
+        best_i, best_sim = -1, -1.0
+        for i, c in enumerate(self._centroids):
+            if c.size == 0:
+                continue
+            sim = float(np.dot(v, c))
+            if sim > best_sim:
+                best_sim, best_i = sim, i
+        if best_i >= 0 and best_sim >= self.threshold:
+            n = self._counts[best_i]
+            self._centroids[best_i] = _l2norm((self._centroids[best_i] * n + v) / (n + 1))
+            self._counts[best_i] = n + 1
+            return self._labels[best_i]
+        label = self._new_label()
+        self._centroids.append(v)
+        self._counts.append(1)
+        self._labels.append(label)
+        return label
+
+    def centroid(self, label: str) -> list[float] | None:
+        try:
+            i = self._labels.index(label)
+        except ValueError:
+            return None
+        c = self._centroids[i]
+        return c.tolist() if c.size else None
+
+
+def _chunk_bounds(total_samples: int, chunk_samples: int) -> list[tuple[int, int]]:
+    """Non-overlapping [start, end) sample windows covering the whole recording
+    (last window is short). PURE. ``chunk_samples <= 0`` → one window (no chunking)."""
+    if chunk_samples <= 0 or total_samples <= chunk_samples:
+        return [(0, total_samples)]
+    return [(s, min(s + chunk_samples, total_samples))
+            for s in range(0, total_samples, chunk_samples)]
+
+
+def _merge_adjacent_same_speaker(segments: list[MeetingSegment]) -> list[MeetingSegment]:
+    """Merge consecutive segments with the same (global) speaker — e.g. a turn
+    split across a chunk boundary. PURE. Assumes segments are time-ordered."""
+    merged: list[MeetingSegment] = []
+    for s in segments:
+        if merged and merged[-1].speaker == s.speaker:
+            prev = merged[-1]
+            prev.text = (prev.text + " " + s.text).strip()
+            prev.end_s = s.end_s
+        else:
+            merged.append(s)
+    return merged
+
+
 class MeetingDiarizationService:
     """Loads pyannote at warmup (when meeting_enabled); runs the batch pipeline."""
 
@@ -197,50 +293,92 @@ class MeetingDiarizationService:
         except Exception:  # noqa: BLE001 — never let cleanup break a transcription
             pass
 
-    async def transcribe(self, pcm: np.ndarray, *, whisper_model, speaker_service) -> list[dict]:
-        """Diarize + transcribe + align + per-cluster embed. Returns a list of
-        segment dicts: {speaker(cluster id), start_s, end_s, text, embedding}."""
-        if not self.ready or self._pipeline is None:
-            raise RuntimeError("MeetingDiarizationService not ready")
+    async def _process_window(
+        self, pcm: np.ndarray, *, whisper_model, speaker_service
+    ) -> tuple[list[MeetingSegment], dict[str, np.ndarray | None]]:
+        """Diarize + ASR + align ONE audio window → window-local segments (labels
+        + timestamps relative to the window) + a per-local-speaker ECAPA embedding.
+        Peak VRAM is bounded by the window length. Caller offsets timestamps and
+        stitches local→global speakers (chunked path) or uses labels as-is."""
         loop = asyncio.get_running_loop()
-        async with self._lock:  # one batch job at a time (semaphore=1)
-            turns = await loop.run_in_executor(None, self._diarize_sync, pcm)
-            # Release pyannote's torch cache BEFORE whisper so CTranslate2's
-            # (separate-pool) encode has room — this is the OOM fix.
-            self._free_cuda_cache()
-            words = await loop.run_in_executor(
-                None, self._transcribe_words_sync, pcm, whisper_model
-            )
-        # Release the job's allocations so they don't accumulate across meetings
-        # (and starve the other services sharing this GPU).
+        turns = await loop.run_in_executor(None, self._diarize_sync, pcm)
+        # Release pyannote's torch cache BEFORE whisper so CTranslate2's
+        # (separate-pool) encode has room — the OOM guard, per window.
+        self._free_cuda_cache()
+        words = await loop.run_in_executor(None, self._transcribe_words_sync, pcm, whisper_model)
         self._free_cuda_cache()
 
         segments = align_words_to_segments(words, turns)
-
-        # Per-cluster ECAPA embedding: concatenate each speaker's audio windows.
-        embeddings: dict[str, list[float] | None] = {}
+        embeddings: dict[str, np.ndarray | None] = {}
         for speaker in {s.speaker for s in segments}:
             clip = _concat_speaker_audio(pcm, [s for s in segments if s.speaker == speaker])
             if clip.size == 0:
                 embeddings[speaker] = None
                 continue
             try:
-                emb = await speaker_service.embed(clip)
-                embeddings[speaker] = emb.tolist()
-            except Exception as e:  # noqa: BLE001 - embedding is best-effort
+                embeddings[speaker] = await speaker_service.embed(clip)
+            except Exception as e:  # noqa: BLE001 — embedding is best-effort
                 logger.warning("cluster embed failed for %s: %s", speaker, e)
                 embeddings[speaker] = None
+        return segments, embeddings
 
-        return [
-            {
-                "speaker": s.speaker,
-                "start_s": round(s.start_s, 3),
-                "end_s": round(s.end_s, 3),
-                "text": s.text,
-                "embedding": embeddings.get(s.speaker),
-            }
-            for s in segments
-        ]
+    @staticmethod
+    def _seg_dict(s: MeetingSegment, embedding) -> dict:
+        emb = embedding.tolist() if isinstance(embedding, np.ndarray) else embedding
+        return {
+            "speaker": s.speaker,
+            "start_s": round(s.start_s, 3),
+            "end_s": round(s.end_s, 3),
+            "text": s.text,
+            "embedding": emb,
+        }
+
+    async def transcribe(self, pcm: np.ndarray, *, whisper_model, speaker_service) -> list[dict]:
+        """Diarize + transcribe + align + per-speaker embed → segment dicts
+        {speaker, start_s, end_s, text, embedding}.
+
+        Recordings longer than ``meeting_chunk_seconds`` are processed in bounded
+        windows (peak VRAM ∝ window, not the whole recording) and the chunk-local
+        speakers are stitched into GLOBAL speakers by ECAPA cosine — so a
+        multi-hour meeting fits a shared GPU and repeated meetings don't starve
+        it. A short recording is a single pass (pyannote's labels used directly)."""
+        if not self.ready or self._pipeline is None:
+            raise RuntimeError("MeetingDiarizationService not ready")
+
+        chunk_samples = max(0, int(settings.meeting_chunk_seconds)) * SAMPLE_RATE
+        bounds = _chunk_bounds(int(pcm.size), chunk_samples)
+
+        async with self._lock:  # one meeting job monopolises the GPU
+            if len(bounds) == 1:
+                segments, embeddings = await self._process_window(
+                    pcm, whisper_model=whisper_model, speaker_service=speaker_service
+                )
+                return [self._seg_dict(s, embeddings.get(s.speaker)) for s in segments]
+
+            # Chunked: process each window, stitch local speakers → global.
+            registry = SpeakerRegistry(float(settings.meeting_speaker_match_threshold))
+            all_segments: list[MeetingSegment] = []
+            for idx, (a, b) in enumerate(bounds):
+                offset_s = a / SAMPLE_RATE
+                segments, embeddings = await self._process_window(
+                    pcm[a:b], whisper_model=whisper_model, speaker_service=speaker_service
+                )
+                # Assign in a deterministic order so stitching is reproducible.
+                local_to_global = {
+                    loc: registry.assign(embeddings.get(loc)) for loc in sorted(embeddings)
+                }
+                for s in segments:
+                    s.speaker = local_to_global.get(s.speaker, s.speaker)
+                    s.start_s += offset_s
+                    s.end_s += offset_s
+                all_segments.extend(segments)
+                logger.info(
+                    "meeting chunk %d/%d done (%.0f–%.0fs, %d segments)",
+                    idx + 1, len(bounds), offset_s, b / SAMPLE_RATE, len(segments),
+                )
+
+            all_segments = _merge_adjacent_same_speaker(all_segments)
+            return [self._seg_dict(s, registry.centroid(s.speaker)) for s in all_segments]
 
 
 def _concat_speaker_audio(pcm: np.ndarray, segments: list[MeetingSegment]) -> np.ndarray:


### PR DESCRIPTION
## The real fix for the meeting CUDA-OOM
v0.3.4's `empty_cache()` freed pyannote's torch memory (so the *first* meeting on a fresh GPU succeeded), but the **whisper (CTranslate2) peak still scaled with recording length** (~14 GB for 32 min) and CTranslate2's caching allocator **retained** it — so the peak persisted and the *next* meeting starved (`batch_size 32 too large`). Chunking bounds the peak at the root.

## What
A recording longer than `meeting_chunk_seconds` (default **480 s / 8 min**) is diarized + ASR'd in **bounded time-windows** → peak VRAM ∝ the window (~3–4 GB), not the whole recording. So a multi-hour meeting fits a shared GPU **and** CTranslate2 never retains a huge workspace that starves the next meeting / live STT.

Each window is diarized independently (chunk-local speaker labels), so chunk-local speakers are **stitched into global speakers** by ECAPA cosine ≥ `meeting_speaker_match_threshold` (0.55) via a running-centroid `SpeakerRegistry`. A local speaker with no embedding never mis-merges. **Short recordings stay a single pass — byte-identical to before.**

## Tests
Pure, fixture-tested cores (no GPU): `SpeakerRegistry` stitching (reappearing voice → same global; below-threshold → new; None → own), `_chunk_bounds`, `_merge_adjacent_same_speaker`. **12 pass** on the cu128 image.

## Deploy
v0.3.5 image; env `meeting_chunk_seconds`/`meeting_speaker_match_threshold` default in-code (no manifest env needed). Rolls the shared voice-server (`ns voice`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)