### PR TITLE
fix(voice-server): cap ECAPA embedding input — THE meeting-OOM root cause

### DIFF
--- a/voice-server/CHANGELOG.md
+++ b/voice-server/CHANGELOG.md
@@ -3,6 +3,21 @@
 Releases via `bin/release-voice-server.sh` — the script refuses to release a
 version without a section here. Pushed digests live in `RELEASES.md`.
 
+## [0.3.6] — 2026-07-20
+
+- **THE meeting-OOM root fix: cap the ECAPA embedding input.** Traced the 14 GB
+  balloon by elimination — whisper peaks ~1 GB and frees on `del`; pyannote held
+  only 86 MB (per the OOM's own "86 MiB by PyTorch, 15.27 GiB non-PyTorch"). The
+  hog is **ECAPA on onnxruntime-CUDA**: a meeting concatenates a speaker's WHOLE
+  audio and feeds it to ECAPA, whose TDNN activations grow with length — a 15-min
+  clip needs **>3 GB in a single conv `Pad` node** (measured), retained by
+  onnxruntime's arena. Speaker embeddings gain nothing past ~30 s, so
+  `speaker_service` now caps the clip to a centered `speaker_embed_max_seconds`
+  (30 s) window — defense-in-depth in the shared service (live STT already sends
+  short clips). New pure `cap_clip` helper (fixture-tested). This, not v0.3.5's
+  chunking, is what stops the OOM; chunking stays as multi-hour hygiene for
+  pyannote/whisper.
+
 ## [0.3.5] — 2026-07-20
 
 - **Chunked meeting transcription (bounded GPU peak, multi-hour).** A recording

--- a/voice-server/tests/test_speaker_cap.py
+++ b/voice-server/tests/test_speaker_cap.py
@@ -1,0 +1,25 @@
+"""ECAPA input cap — the meeting-OOM root fix (pure, no GPU)."""
+
+import numpy as np
+
+from voice_server.services.speaker_service import cap_clip
+
+
+def test_short_clip_passes_through_unchanged():
+    a = np.arange(1000, dtype=np.float32)
+    out = cap_clip(a, 3000)
+    assert out is a  # no copy/slice when already within the cap
+
+
+def test_long_clip_is_centered_to_cap():
+    a = np.arange(100_000, dtype=np.float32)
+    out = cap_clip(a, 30_000)
+    assert out.size == 30_000
+    # centered window: starts at (100000-30000)//2 = 35000
+    assert out[0] == 35_000 and out[-1] == 64_999
+
+
+def test_zero_or_negative_cap_disables_capping():
+    a = np.arange(50_000, dtype=np.float32)
+    assert cap_clip(a, 0).size == 50_000
+    assert cap_clip(a, -1).size == 50_000

--- a/voice-server/voice_server/__init__.py
+++ b/voice-server/voice_server/__init__.py
@@ -10,4 +10,4 @@ See docs/VOICE_PIPELINE_DESIGN.md § "Phase B" for the full architecture.
 # Kept in sync with the image tag by bin/release-voice-server.sh (extraction
 # plan T4). 0.3.0 = registry auth mode; 0.3.1 = X-Verify-Secret header (T11);
 # 0.3.2 = anon_default_client (household migration T31).
-__version__ = "0.3.5"
+__version__ = "0.3.6"

--- a/voice-server/voice_server/config.py
+++ b/voice-server/voice_server/config.py
@@ -113,6 +113,12 @@ class Settings(BaseSettings):
     # Speaker (D4)
     speaker_model_path: Path = Path("/mnt/llm/voice/ecapa_tdnn.onnx")
     speaker_providers: list[str] = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    # Cap the audio fed to ECAPA. The embedding is trained on ~3 s utterances and
+    # doesn't improve past ~30 s, but the TDNN's GPU activations grow with input
+    # length (a 15-min clip needs >3 GB in a single conv node, retained by
+    # onnxruntime's arena → the meeting-transcription OOM). A meeting concatenates
+    # a speaker's WHOLE audio, so this cap is load-bearing, not just hygiene.
+    speaker_embed_max_seconds: float = 30.0
 
     # Meeting diarization (§2) — pyannote turns + faster-whisper words →
     # speaker-attributed segments. The pyannote pipeline is loaded at warmup
@@ -123,12 +129,14 @@ class Settings(BaseSettings):
     meeting_enabled: bool = False
     meeting_diarization_model: str = "pyannote/speaker-diarization-3.1"
     meeting_whisper_model: str = ""
-    # Chunked transcription: recordings longer than this are diarized + ASR'd in
-    # bounded time-windows (peak VRAM ∝ window, not whole recording — so a
-    # multi-hour meeting fits a shared GPU and CTranslate2 doesn't retain a huge
-    # workspace). Chunk-local speakers are stitched into global ones by ECAPA
-    # cosine ≥ meeting_speaker_match_threshold. 0 disables chunking (single pass).
-    meeting_chunk_seconds: int = 480          # 8 min → ~3-4 GB peak
+    # Chunked transcription BACKSTOP for pathologically-long recordings. With the
+    # ECAPA input cap (speaker_embed_max_seconds), single-pass is memory-safe for
+    # normal meetings — and pyannote's GLOBAL diarization is more accurate than
+    # per-chunk diarize + cross-chunk stitch. So chunking only kicks in past this
+    # threshold, where whole-recording pyannote/whisper could get unwieldy; then
+    # chunk-local speakers are stitched by ECAPA cosine ≥ the threshold below.
+    # 0 disables chunking entirely (always single pass).
+    meeting_chunk_seconds: int = 3600         # ≤1 h → accurate single pass
     meeting_speaker_match_threshold: float = 0.55
     # HF token for the gated pyannote model at warmup (offline-first: the model
     # is baked into the image, so this only matters if the cache is cold).

--- a/voice-server/voice_server/services/speaker_service.py
+++ b/voice-server/voice_server/services/speaker_service.py
@@ -25,6 +25,16 @@ from voice_server.config import settings
 logger = logging.getLogger(__name__)
 
 
+def cap_clip(audio: np.ndarray, max_samples: int) -> np.ndarray:
+    """Return a CENTERED window of at most ``max_samples`` (skips a noisy
+    intro/outro); passes a short clip through. PURE — fixture-tested. Bounds the
+    ECAPA input so its GPU activations can't balloon on a multi-minute clip."""
+    if max_samples <= 0 or audio.size <= max_samples:
+        return audio
+    start = (audio.size - max_samples) // 2
+    return audio[start:start + max_samples]
+
+
 class SpeakerService:
     def __init__(self) -> None:
         self._session = None
@@ -91,6 +101,12 @@ class SpeakerService:
             raise RuntimeError("SpeakerService not ready")
         if audio_pcm.size == 0:
             raise ValueError("empty audio")
+
+        # Cap the clip: ECAPA gains nothing past ~30 s but its TDNN activations
+        # grow with input length (a multi-minute clip needs GBs of GPU in a single
+        # conv node, retained by onnxruntime's arena — the meeting OOM). A meeting
+        # concatenates a speaker's WHOLE audio, so this cap is load-bearing.
+        audio_pcm = cap_clip(audio_pcm, int(settings.speaker_embed_max_seconds * 16000))
 
         wave = torch.from_numpy(audio_pcm.astype(np.float32)).unsqueeze(0)
         feats = self._encoder.mods.compute_features(wave)


### PR DESCRIPTION
## Root cause (traced by elimination, not assumed)
The 14 GB GPU balloon that OOM'd meeting transcription was **not** whisper and **not** pyannote:
- whisper-medium peaks **~1 GB** and frees on `del` (measured in-pod).
- pyannote held only **86 MB** — the OOM's own message said *"86 MiB by PyTorch, 15.27 GiB non-PyTorch"*.
- The hog is **ECAPA on onnxruntime-CUDA**: the meeting path concatenates a speaker's **entire** audio and embeds it, and ECAPA's TDNN activations grow with input length — a 15-min clip needs **>3 GB in a single conv `Pad` node** (measured), retained by onnxruntime's arena.

## Fix
Speaker embeddings gain nothing past ~30 s → cap the ECAPA input to a centered `speaker_embed_max_seconds` (30 s) window (`cap_clip`, pure/fixture-tested). Defense-in-depth in the shared service; live STT already sends short clips.

Also raise `meeting_chunk_seconds` 480 → 3600: with the cap, single-pass is memory-safe for normal meetings **and** pyannote's global diarization is more accurate than the v0.3.5 per-chunk-diarize + cross-chunk-stitch — so chunking is now only a backstop for pathologically-long recordings.

v0.3.5 → **v0.3.6**; **15 tests pass**. Deploy verification (repeated 32-min meetings on a bounded GPU) in the PR discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)