### PR TITLE
chore(voice-server): v0.3.7 — per-meeting ASR language release

### DIFF
--- a/voice-server/CHANGELOG.md
+++ b/voice-server/CHANGELOG.md
@@ -3,6 +3,16 @@
 Releases via `bin/release-voice-server.sh` — the script refuses to release a
 version without a section here. Pushed digests live in `RELEASES.md`.
 
+## [0.3.7] — 2026-07-22
+
+- **Per-meeting ASR language.** `/transcribe-meeting` gains an optional `language`
+  Form param, threaded `transcribe → _process_window → _transcribe_words_sync`.
+  Pure `resolve_meeting_language()`: unset → `whisper_language_default` (backward-
+  compat), `"auto"`/`"detect"` → whisper autodetect, else the forced code. The
+  meeting path had hardcoded German, so English meetings were transcribed as
+  hallucinated German — this fixes it for the mixed EN/DE customer base. No dep
+  change (pure-Python layer). (renfield #1018)
+
 ## [0.3.6] — 2026-07-20
 
 - **THE meeting-OOM root fix: cap the ECAPA embedding input.** Traced the 14 GB

--- a/voice-server/voice_server/__init__.py
+++ b/voice-server/voice_server/__init__.py
@@ -13,4 +13,4 @@ See docs/VOICE_PIPELINE_DESIGN.md § "Phase B" for the full architecture.
 # uploads from a seekable file (m4a); 0.3.4 = free CUDA cache between diarize/ASR;
 # 0.3.5 = chunked meeting transcription (backstop); 0.3.6 = cap ECAPA embedding
 # input (THE meeting-OOM root fix).
-__version__ = "0.3.6"
+__version__ = "0.3.7"


### PR DESCRIPTION
Version bump + CHANGELOG for the v0.3.7 voice-server release (the `/transcribe-meeting` `language` param from #1018). Enables `bin/release-voice-server.sh v0.3.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)