### PR TITLE
docs(voice-server): record v0.3.7 release digest

### DIFF
--- a/voice-server/RELEASES.md
+++ b/voice-server/RELEASES.md
@@ -11,3 +11,4 @@ that enforceable.
 | v0.3.1 | 2026-07-18 | b5d8373a | `registry.treehouse.x-idra.de/renfield/voice-server@sha256:e93a2b46491054964fe72330884550c502181b681e0249eb3a1f7fcf96982e41` |
 | v0.3.2 | 2026-07-19 | b16e04c3 | `registry.treehouse.x-idra.de/renfield/voice-server@sha256:733e96566b6a599796c4150f329ea6e106c0eeaeb946e52941f46f7f811e3ba4` |
 | v0.3.3 | 2026-07-19 | d929420c | `registry.treehouse.x-idra.de/renfield/voice-server@sha256:2e977a367522561431435c4b412fcaefe9f62463ae52c89ef7c67a2484ff2a30` |
+| v0.3.7 | 2026-07-22 | ad403347 | `registry.treehouse.x-idra.de/renfield/voice-server@sha256:25ecbb757143978bdc03b4bbd781fe87bf795d00107ae36e952e1ed2aa29341c` |


### PR DESCRIPTION
Closes the audit loose end from the v0.3.7 deploy — the release script's RELEASES.md step was interrupted by the gpu-3 disk incident during the roll. Digest `sha256:25ecbb75` is live (deployed to the shared voice-server, pinned in private_k8s, git tag `voice-server-v0.3.7` pushed). v0.3.4–0.3.6 remain unrecorded (pre-existing drift; tags exist, digests never appended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)