### PR TITLE
feat(meetings): §2 Track A — surface merge-on-enroll propagation in the UI

### DIFF
--- a/src/backend/api/routes/meetings.py
+++ b/src/backend/api/routes/meetings.py
@@ -360,6 +360,14 @@ class RelabelRequest(BaseModel):
     label: str = Field(min_length=1, max_length=100)
 
 
+class RelabelResponse(MeetingResponse):
+    # §2 Track A merge-on-enroll: how many OTHER meetings this relabel also renamed
+    # (same anonymous fingerprint). Lets the UI say "also applied to N meetings" so
+    # cross-meeting propagation is visible, not a surprise. 0 when the flag is off
+    # or the cluster has no cross-meeting fingerprint.
+    cross_meeting_applied: int = 0
+
+
 @router.get("/{meeting_id}/segments")
 async def get_segments(
     meeting_id: int,
@@ -372,13 +380,13 @@ async def get_segments(
     return {"id": meeting.id, "status": meeting.status, "segments": meeting.segments or []}
 
 
-@router.post("/{meeting_id}/relabel", response_model=MeetingResponse)
+@router.post("/{meeting_id}/relabel", response_model=RelabelResponse)
 async def relabel_speaker(
     meeting_id: int,
     data: RelabelRequest,
     user: User | None = Depends(get_optional_user),
     db: AsyncSession = Depends(get_db),
-) -> MeetingResponse:
+) -> RelabelResponse:
     """Relabel one speaker cluster (pseudonym → person). Re-renders + reindexes
     the transcript in place (stable transcript_document_id). Owner-gated 404."""
     _require_enabled()
@@ -394,15 +402,20 @@ async def relabel_speaker(
     # Merge-on-enroll (§2 Track A): propagate the human name to other meetings
     # sharing this cluster's fingerprint. Best-effort — the primary relabel above
     # already committed, so a propagation hiccup must not fail the request.
+    cross_meeting_applied = 0
     if settings.meeting_fingerprints_enabled:
         from services.meeting_pipeline import enroll_fingerprint_across_meetings
 
         try:
-            await enroll_fingerprint_across_meetings(db, meeting, data.speaker_key, data.label)
+            affected = await enroll_fingerprint_across_meetings(
+                db, meeting, data.speaker_key, data.label
+            )
+            cross_meeting_applied = len(affected)
         except Exception as e:  # noqa: BLE001
             logger.warning(f"meeting {meeting_id}: merge-on-enroll propagation failed: {e}")
 
-    return _to_response(meeting)
+    return RelabelResponse(**_to_response(meeting).model_dump(),
+                           cross_meeting_applied=cross_meeting_applied)
 
 
 # --------------------------------------------------------------------------- #

--- a/src/frontend/src/api/resources/meetings.ts
+++ b/src/frontend/src/api/resources/meetings.ts
@@ -28,7 +28,14 @@ export interface MeetingSegment {
   start_s: number;
   end_s: number;
   text: string;
+  /** §2 Track A cross-meeting anonymous fingerprint (only when the flag is on). */
+  fingerprint_id?: number | null;
+  fingerprint_label?: string | null;
 }
+
+/** Relabel result — Meeting fields plus how many OTHER meetings the name
+ *  propagated to via merge-on-enroll (§2 Track A). */
+export type RelabelResult = Meeting & { cross_meeting_applied: number };
 
 interface MeetingSegmentsResponse {
   id: number;
@@ -94,8 +101,8 @@ async function deleteMeetingRequest(meetingId: number): Promise<void> {
   await apiClient.delete(`/api/meetings/${meetingId}`);
 }
 
-async function relabelRequest(input: RelabelInput): Promise<Meeting> {
-  const response = await apiClient.post<Meeting>(
+async function relabelRequest(input: RelabelInput): Promise<RelabelResult> {
+  const response = await apiClient.post<RelabelResult>(
     `/api/meetings/${input.meetingId}/relabel`,
     { speaker_key: input.speakerKey, label: input.label },
   );

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -669,6 +669,8 @@
     "relabelPlaceholder": "Name der Person",
     "relabelAria": "{{speaker}} umbenennen",
     "relabelSave": "Speichern",
+    "crossMeetingApplied_one": "Auch in 1 weiterer Besprechung angewendet (dieselbe Stimme).",
+    "crossMeetingApplied_other": "Auch in {{count}} weiteren Besprechungen angewendet (dieselbe Stimme).",
     "delete": "Löschen",
     "confirmDelete": "Löschen bestätigen",
     "cancelDelete": "Abbrechen",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -669,6 +669,8 @@
     "relabelPlaceholder": "Person's name",
     "relabelAria": "Rename {{speaker}}",
     "relabelSave": "Save",
+    "crossMeetingApplied_one": "Also applied to 1 other meeting (same voice).",
+    "crossMeetingApplied_other": "Also applied to {{count}} other meetings (same voice).",
     "delete": "Delete",
     "confirmDelete": "Confirm delete",
     "cancelDelete": "Cancel",

--- a/src/frontend/src/pages/MeetingsPage.tsx
+++ b/src/frontend/src/pages/MeetingsPage.tsx
@@ -57,14 +57,17 @@ function SpeakerLabels({ meetingId, segments }: { meetingId: number; segments: M
 
   const [drafts, setDrafts] = useState<Record<string, string>>({});
   const [savedKey, setSavedKey] = useState<string | null>(null);
+  // §2 Track A merge-on-enroll: how many OTHER meetings the last relabel renamed.
+  const [crossApplied, setCrossApplied] = useState(0);
 
   const submit = async (speakerKey: string) => {
     const label = (drafts[speakerKey] ?? '').trim();
     if (!label || relabel.isPending) return;
     try {
-      await relabel.mutateAsync({ meetingId, speakerKey, label });
+      const res = await relabel.mutateAsync({ meetingId, speakerKey, label });
       setDrafts((d) => ({ ...d, [speakerKey]: '' }));
       setSavedKey(speakerKey);
+      setCrossApplied(res.cross_meeting_applied ?? 0);
     } catch {
       // Error surfaced via relabel.errorMessage; keep the draft.
     }
@@ -88,7 +91,7 @@ function SpeakerLabels({ meetingId, segments }: { meetingId: number; segments: M
             value={drafts[sp.key] ?? ''}
             onChange={(e) => {
               setDrafts((d) => ({ ...d, [sp.key]: e.target.value }));
-              if (savedKey === sp.key) setSavedKey(null);
+              if (savedKey === sp.key) { setSavedKey(null); setCrossApplied(0); }
             }}
             placeholder={t('meetings.relabelPlaceholder')}
             aria-label={t('meetings.relabelAria', { speaker: sp.name })}
@@ -111,6 +114,11 @@ function SpeakerLabels({ meetingId, segments }: { meetingId: number; segments: M
       ))}
       {relabel.errorMessage && (
         <p className="text-sm text-red-600 dark:text-red-400">{relabel.errorMessage}</p>
+      )}
+      {savedKey && crossApplied > 0 && !relabel.isPending && (
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          {t('meetings.crossMeetingApplied', { count: crossApplied })}
+        </p>
       )}
     </div>
   );

--- a/tests/frontend/react/pages/MeetingsPage.test.tsx
+++ b/tests/frontend/react/pages/MeetingsPage.test.tsx
@@ -244,6 +244,35 @@ describe('MeetingsPage', () => {
 
     await waitFor(() => expect(relabeled).toEqual({ speaker_key: 'S1', label: 'Anna' }));
   });
+
+  it('shows the merge-on-enroll message when a relabel propagates across meetings', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/meetings`, () =>
+        HttpResponse.json([mkMeeting({ id: 5, title: 'Planning', status: 'completed' })]),
+      ),
+      http.get(`${BASE_URL}/api/meetings/5/segments`, () =>
+        HttpResponse.json({
+          id: 5, status: 'completed',
+          segments: [{ speaker: 'Sprecher 1', speaker_key: 'S1', start_s: 0, end_s: 2, text: 'Hi.', fingerprint_id: 3, fingerprint_label: 'Speaker AB' }],
+        }),
+      ),
+      // §2 Track A: relabel propagated to 2 other meetings sharing the fingerprint.
+      http.post(`${BASE_URL}/api/meetings/5/relabel`, () =>
+        HttpResponse.json({ ...mkMeeting({ id: 5 }), cross_meeting_applied: 2 }),
+      ),
+    );
+
+    renderWithProviders(<MeetingsPage />);
+    const user = userEvent.setup();
+    await user.click(await screen.findByText('Planning'));
+    await waitFor(() => expect(screen.getByText('Hi.')).toBeInTheDocument());
+    await user.type(screen.getByLabelText(i18n.t('meetings.relabelAria', { speaker: 'Sprecher 1' })), 'Anna');
+    await user.click(screen.getAllByRole('button', { name: i18n.t('meetings.relabelSave') })[0]);
+
+    await waitFor(() =>
+      expect(screen.getByText(i18n.t('meetings.crossMeetingApplied', { count: 2 }))).toBeInTheDocument(),
+    );
+  });
 });
 
 /** Enable the minutes feature flag and stub the transcript segments so a


### PR DESCRIPTION
First step toward activating `meeting_fingerprints_enabled`: make the cross-meeting merge VISIBLE before it's turned on.

- **relabel route** returns `cross_meeting_applied` — how many other meetings the name propagated to via merge-on-enroll (was discarded).
- **frontend** types the fingerprint fields on segments + shows *"Also applied to N other meetings (same voice)"* on relabel (i18n de+en, pluralized).
- **Flag-off = byte-identical** (count always 0 → message never shows). Dark until `meeting_fingerprints_enabled` + real-meeting calibration.
- Tests: frontend message test; 70 backend meeting/fingerprint tests green on .159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)