### PR TITLE
fix(frontend): derive build stamp from deploy tag (kill the stale __BUILD_STAMP__)

### DIFF
--- a/bin/deploy-production.sh
+++ b/bin/deploy-production.sh
@@ -114,7 +114,7 @@ fi
 if [[ $SKIP_FRONTEND == 0 ]]; then
   log "build + push frontend:$FRONTEND_TAG"
   on_build "set -e; cd $STAGING/src/frontend && \
-    docker build -q --build-arg VITE_FEATURE_VOICE_STREAM=true -t $REGISTRY/frontend:latest -t $REGISTRY/frontend:$FRONTEND_TAG -f Dockerfile . && \
+    docker build -q --build-arg VITE_FEATURE_VOICE_STREAM=true --build-arg VITE_BUILD_STAMP=$FRONTEND_TAG -t $REGISTRY/frontend:latest -t $REGISTRY/frontend:$FRONTEND_TAG -f Dockerfile . && \
     docker push -q $REGISTRY/frontend:$FRONTEND_TAG && docker push -q $REGISTRY/frontend:latest"
 fi
 

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -86,8 +86,15 @@ ARG VITE_APP_TENANT_NAME=
 # false — community deploys don't ship OIDC and the button stays hidden.
 ARG VITE_OIDC_ENABLED=false
 
+# Build stamp — set from the deploy's frontend tag (bin/deploy-production.sh
+# passes --build-arg VITE_BUILD_STAMP=$FRONTEND_TAG). Surfaced in the startup
+# console log + doubles as the PWA cache-propagation lever (see main.tsx).
+# Defaults to 'dev' for a plain `docker build` without the arg.
+ARG VITE_BUILD_STAMP=dev
+
 # Set environment variables for build
 ENV VITE_API_URL=${VITE_API_URL}
+ENV VITE_BUILD_STAMP=${VITE_BUILD_STAMP}
 ENV VITE_WS_URL=${VITE_WS_URL}
 ENV VITE_APP_NAME=${VITE_APP_NAME}
 ENV VITE_APP_LOGO_URL=${VITE_APP_LOGO_URL}

--- a/src/frontend/src/main.tsx
+++ b/src/frontend/src/main.tsx
@@ -8,17 +8,22 @@ import './index.css';
 import './i18n';
 
 // Build stamp — also the PWA service-worker propagation lever.
-// The SW (vite-plugin-pwa, registerType:autoUpdate) PRECACHES index.html via
-// globPatterns, storing its response INCLUDING the CSP header captured at fetch
-// time. A change that touches only a non-bundled asset (e.g. the nginx CSP
-// header) leaves every built file byte-identical → the precache manifest and
-// sw.js don't change → autoUpdate never fires → existing clients keep serving
-// the stale-CSP shell. Bumping this string changes the JS bundle hash → rewrites
-// index.html's <script src> → index.html's revision changes → the SW re-precaches
-// it (re-fetching the current CSP) and propagates. So: when you change a served
-// HTTP header (CSP etc.) without any other frontend change, BUMP THIS so the fix
-// reaches existing PWA clients. See reference_pwa_sw_nocache_nginx.
-const __BUILD_STAMP__ = '2026-06-21.device-widgets-round2';
+// Injected at build time from the deploy's frontend tag via
+// `--build-arg VITE_BUILD_STAMP=<tag>` (Dockerfile → ENV → import.meta.env; see
+// bin/deploy-production.sh). Every deploy uses a unique tag, so the stamp is
+// always fresh — no more hand-editing a literal that silently rots.
+//
+// It's also the PWA propagation lever: the SW (vite-plugin-pwa,
+// registerType:autoUpdate) PRECACHES index.html via globPatterns, storing its
+// response INCLUDING the CSP header captured at fetch time. A change that touches
+// only a non-bundled asset (e.g. the nginx CSP header) would leave every built
+// file byte-identical → sw.js unchanged → autoUpdate never fires. But the nginx
+// CSP lives in THIS frontend image, so a header change rebuilds the image under a
+// new tag → the stamp changes → the JS bundle hash changes → index.html's
+// revision changes → the SW re-precaches (re-fetching the current CSP) and
+// propagates. So a header-only change reaches existing PWA clients automatically,
+// as long as the deploy uses a fresh tag. See reference_pwa_sw_nocache_nginx.
+const __BUILD_STAMP__ = (import.meta.env.VITE_BUILD_STAMP as string | undefined) ?? 'dev';
 console.info(`Renfield frontend build ${__BUILD_STAMP__}`);
 
 // Edition selector for theme tokens. When VITE_APP_EDITION=pro, the


### PR DESCRIPTION
The frontend startup log showed a months-stale build id (`2026-06-21.device-widgets-round2`) because `main.tsx` hardcoded `__BUILD_STAMP__` as a literal nobody updates. That string also doubles as the PWA cache-propagation lever (see the comment there), so a stale value undermines header-only cache busting too.

**Fix:** derive it from the deploy's frontend tag.
- `main.tsx` → `import.meta.env.VITE_BUILD_STAMP` (fallback `dev`)
- `Dockerfile` → `ARG VITE_BUILD_STAMP` → `ENV` (mirrors the other `VITE_*` args)
- `bin/deploy-production.sh` → `--build-arg VITE_BUILD_STAMP=$FRONTEND_TAG`

Every deploy uses a unique tag → the stamp is always fresh; a CSP/header change (nginx.conf lives in this image → new tag) now propagates to PWA clients automatically. Verified locally: a build with `VITE_BUILD_STAMP` set injects the value into the bundle; `tsc` + build green.

Latent until the next frontend deploy (no redeploy needed for this PR itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)