### PR TITLE
feat(ocr): bake Tesseract into the backend image for the OCR-engine eval

### DIFF
--- a/docs/design/ocr-engine-eval.md
+++ b/docs/design/ocr-engine-eval.md
@@ -159,17 +159,22 @@ a partial comparison even on an incompletely-provisioned host.
   `src/backend/requirements.txt` (baseline + `docling_full_page_ocr`).
 - `poppler-utils` (the `pdftotext` binary) — already required by the
   `poppler_text_layer` path in production.
-- **Tesseract** (the new dependency for `docling_tesseract`), one of:
-  - `tesseract-ocr` + the `deu`/`eng` language data
-    (`apt-get install tesseract-ocr tesseract-ocr-deu tesseract-ocr-eng`) for the
-    CLI variant (`TesseractCliOcrOptions`, preferred — most portable), **or**
-  - the `tesserocr` Python binding + libtesseract for `TesseractOcrOptions`.
-  - docling's Tesseract extra: `pip install "docling[tesserocr]"` (the option
-    classes ship with docling 2.x; the harness imports them defensively and skips
-    the engine if the installed docling version lacks them).
+- **Tesseract** (for `docling_tesseract`) — **now baked into the backend image**:
+  `tesseract-ocr` + `tesseract-ocr-deu` + `tesseract-ocr-eng` are installed in the
+  runtime stage of `src/backend/Dockerfile` (alongside `poppler-utils`). The harness
+  uses docling's `TesseractCliOcrOptions` (ships with docling 2.x, shells out to the
+  `tesseract` binary — no `tesserocr` C-binding needed). So after the next backend
+  build, the full comparison runs with no manual install; **on a pod running an
+  older image**, `apt-get install tesseract-ocr tesseract-ocr-deu tesseract-ocr-eng`
+  provides it ephemerally.
   - **Language codes differ:** Tesseract uses ISO 639-2 (`deu`/`eng`); EasyOcr
-    uses `de`/`en`. The `deu`/`eng` traineddata must be installed or Tesseract
+    uses `de`/`en`. The `deu`/`eng` traineddata must be present or Tesseract
     OCR produces nothing.
+- **The harness itself** (`bin/run_ocr_engine_eval.py`) is not baked into the image
+  (`bin/` is outside the `src/backend` build context, per convention with the other
+  `bin/*` scripts). Run it by `kubectl cp`-ing it into a pod that has the uploads
+  PVC mounted (e.g. `document-worker`) — the document bytes live at
+  `Document.file_path` on that PVC, so the harness must run where it's mounted.
 
 These deps are needed **only to run the benchmark**. A `docling_tesseract` swap
 would additionally require adding Tesseract to the backend image and wiring a

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -117,6 +117,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgomp1 \
     espeak-ng \
     poppler-utils \
+    # Tesseract + DE/EN language data — used ONLY by the OCR-engine eval harness
+    # (bin/run_ocr_engine_eval.py, TODOS.md "OCR engine evaluation / swap") via
+    # docling's TesseractCliOcrOptions, which shells out to the `tesseract`
+    # binary. NOT used by the live ingest path (that stays docling-EasyOcr). The
+    # `deu`/`eng` traineddata is ISO 639-2 (not EasyOcr's `de`/`en`) and must be
+    # present or Tesseract yields nothing. ~15 MB; drop if a swap is ruled out.
+    tesseract-ocr \
+    tesseract-ocr-deu \
+    tesseract-ocr-eng \
     wget \
     curl \
     ca-certificates \


### PR DESCRIPTION
Follow-up to #1028 (OCR-engine eval harness). To actually answer the harness's core question — is **Tesseract** better than docling-EasyOcr on the low-quality corpus — Tesseract has to be available where the harness runs.

**Change:** add `tesseract-ocr` + `tesseract-ocr-deu` + `tesseract-ocr-eng` to the backend runtime image (next to `poppler-utils`). The harness uses docling's `TesseractCliOcrOptions` (shells out to the `tesseract` binary, ships with docling 2.x) — so **only the apt packages** are needed, no `tesserocr` C-binding. ~15 MB.

- **Not** wired into the live ingest path — that stays docling-EasyOcr. This only makes the `docling_tesseract` benchmark engine runnable. A real swap is a separate migration the eval's decision rule gates.
- After the next backend build, the eval runs with no ephemeral install. On an older-image pod, `apt-get install tesseract-ocr tesseract-ocr-deu tesseract-ocr-eng` still works ephemerally.
- Design doc updated (deps section: tesseract now image-provided; the harness still gets `kubectl cp`'d into a PVC-mounted pod since `bin/` is outside the `src/backend` build context).

Latent until the next backend build — no redeploy needed for this PR itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)