### PR TITLE
docs(tech-debt): Harbor push/pull slowness — topology + measurements

### DIFF
--- a/docs/TECHNICAL_DEBT.md
+++ b/docs/TECHNICAL_DEBT.md
@@ -2,7 +2,7 @@
 
 Dieses Dokument enthält eine umfassende Analyse der technischen Schulden im gesamten Renfield-System.
 
-**Letzte Aktualisierung:** 2026-07-23 (Infrastruktur I1: Harbor-Slowness vom Heim-Netz = **PMTUD-Blackhole** [MTU-Mismatch + geblocktes ICMP], NICHT Netz/Storage/Harbor — Netz gemessen 6 Gbit/s, NFS 104 MB/s; Fix = MSS-Clamping auf der OPNsense)
+**Letzte Aktualisierung:** 2026-07-23 (Infrastruktur I1 KORRIGIERT: Harbor-Slowness vom Heim-Netz = **WAN-Hairpin über die Public-IP**, upload-gedeckelt ~72 Mbit/s — KEIN PMTUD-Blackhole [sauberer Push: 0 Retrans, 0 frag-needed]. `.159` löst Harbor auf die Public-IP auf, weil der einzige TLS-Endpoint öffentlich ist. Fix: LAN-direkter `ctr import` › interner TLS-Endpoint + Split-Horizon-DNS. KEINE Firewall-Änderung. Vollanalyse: `../public_k8s/docs/harbor-slow-from-home-lan.md`)
 
 ---
 
@@ -16,7 +16,7 @@ Dieses Dokument enthält eine umfassende Analyse der technischen Schulden im ges
 | Infrastruktur | 0 | 4 | 2 | 7 | 6 |
 | **Gesamt** | **0** | **10** | **10** | **25** | **29** |
 
-**Offen (🟡):** Infrastruktur **I1** — Harbor push/pull vom Heim-Netz langsam (**PMTUD-Blackhole**: MTU-Mismatch + geblocktes ICMP; Netz/Storage/Harbor sind schnell). Fix = MSS-Clamping auf der OPNsense. Siehe §Infrastruktur.
+**Offen (🟡):** Infrastruktur **I1** — Harbor push/pull vom Heim-Netz langsam (**WAN-Hairpin über die Public-IP**, upload-gedeckelt ~72 Mbit/s; KEIN MTU/Blackhole — sauberer Push 0 Retrans/0 frag-needed). Ursache: `.159` löst Harbor auf die Public-IP auf (einziger TLS-Endpoint ist öffentlich). Fix: LAN-direkter `ctr import` › interner TLS-Endpoint + Split-Horizon-DNS. Siehe §Infrastruktur + `../public_k8s/docs/harbor-slow-from-home-lan.md`.
 
 ---
 
@@ -465,25 +465,30 @@ Nur eine zentrale ErrorBoundary (in `App.tsx`); keine Feature-spezifischen. Eine
 
 ### 🟡 Offen
 
-#### I1. Harbor push/pull vom Heim-Netz langsam — PMTUD-Blackhole (MTU-Mismatch + geblocktes ICMP)
+#### I1. Harbor push/pull vom Heim-Netz langsam — WAN-Hairpin (Public-IP-Pfad), KEIN MTU-Problem
 
-**Status:** Root Cause GEFUNDEN + gemessen (2026-07-23); Fix ausstehend (OPNsense-Zugriff nötig). Kein Datenverlust, aber jeder Backend-Deploy vom Heim-Netz kostet mehrere Minuten Push + einen ~5-min Pod-Pull-Recreate-Blip; große Layer laufen gelegentlich in ein Timeout (retrybar).
+**Status:** Root Cause per sauberer Nachmessung bestätigt (2026-07-23). Kein Datenverlust; ein Backend-Deploy vom Heim-Netz ist WAN-upload-gebremst (~72 Mbit/s), daher der ~5-min Pod-Pull-Recreate-Blip. **Fix = Routing/DNS + interner TLS-Endpoint, NICHT Firewall/MTU.** Volle Analyse: **`../public_k8s/docs/harbor-slow-from-home-lan.md`**.
 
-**Root Cause: NICHT Netzwerk/Storage/Harbor — ein PMTUD-Blackhole.** Ein Hop auf dem Pfad Heim-Netz (`192.168.1.x`) → `.99`-Cluster (via virtueller OPNsense) hat eine **MTU < 1500**, UND **ICMP „fragmentation needed" (Type 3 Code 4) ist geblockt** (dasselbe ICMP-Filtering, das die ganze Untersuchung `ping` fehlschlagen ließ). Damit scheitert Path-MTU-Discovery **still**: der Sender schickt weiter 1500-Byte-Pakete, die verworfen werden → TCP retransmittet endlos → Durchsatz kollabiert auf ~10-16 Mbit/s. Betrifft **alle Heim-Clients**: Pushes von der Build-Box (`.159`) UND Pulls der `renfield-private`-Nodes (`1.x`) — daher die ~5-min-Backend-Recreate-Pulls. Reva/roberta ist schnell, weil es **lokal auf `.99`** zu Harbor pusht (kein reduzierter-MTU-Hop im Pfad).
+**Root Cause: das Heim-LAN erreicht Harbor über die *öffentliche* IP → Hairpin durch die WAN (upload-gedeckelt).** `.159` löst `registry.treehouse.x-idra.de` → **`93.241.252.154`** (Public-IP, via `/etc/hosts`) auf; der Traffic verlässt und betritt das Netz über die **PPPoE-WAN** (NAT-Hairpin) und ist dort auf die **WAN-Upload-Rate (~72 Mbit/s gemessen)** begrenzt. Es MUSS diesen Pfad nehmen, weil **Harbors einziger TLS-Endpoint der öffentliche ist**: HAProxy ist im LAN nicht erreichbar (`192.168.1.1:443` Timeout), internes Traefik macht nur HTTP (`99.101:443` refused, `:80` ok). `.99`-Hosts erreichen Harbor **intern** → 3–80× schneller.
 
-**Messungen (2026-07-23), die Netz/Storage/Harbor als Ursache AUSSCHLIESSEN:**
+**KEIN PMTUD-Blackhole (die frühere Hypothese ist widerlegt):** ein sauberer 100-MB-Push von `.159` @ MTU 1500 lief in **10 s mit 0 TCP-Retransmits und 0 ICMP frag-needed** (`nstat` TcpRetransSegs-Delta = 0; `tcpdump icmp[icmptype]==3` = 0). Ein Blackhole verwirft Pakete und retransmittet massiv — hier **nichts**. Die frühere „MTU 1380 = 5× schneller"-Messung war transiente WAN-Congestion, nicht MTU (reproduziert nicht). **Es wurde KEINE Firewall-Änderung gemacht** (MSS-Clamp/ICMP hätten ein Nicht-Problem „gefixt"); der `os-firewall`-API-Zugriff war rein lesend.
 
-| Ebene | Ergebnis |
-|---|---|
-| Netzwerk cross-VLAN `.159 → roberta` (durch die virt. OPNsense, `iperf3`) | **~6 Gbit/s** ✓ |
-| NFS-Storage-Write auf einem Harbor-Node (`dd oflag=direct`, 500 MB) | **104 MB/s** ✓ |
-| Harbor-Push von `.99` (roberta), 100 MB | **3,1 s** ✓ (Reva ist wirklich schnell) |
-| Harbor-Push vom Heim-Netz (`.159`), 100 MB @ MTU **1500** | **49,9 s** ✗ |
-| … derselbe Push @ MTU **1380** | **10,8 s** (5× schneller → Smoking Gun) |
+**Messungen (2026-07-23):**
 
-**Fix (an EINER Stelle, behebt Push UND Pull für alle Heim-Clients):** **TCP-MSS-Clamping auf der OPNsense** auf die tatsächliche Pfad-MTU (Firewall → Settings → Normalization „MSS clamping", oder per-Interface-MSS). Damit handelt jede TCP-Verbindung eine sichere Segmentgröße aus → keine übergroßen Pakete, kein Blackhole, ohne per-Host-MTU-Basteln. Ergänzend/alternativ: (a) den reduzierten-MTU-Hop finden + auf 1500 bringen (OPNsense-Interface/VLAN), (b) ICMP frag-needed durchlassen, damit PMTUD überhaupt funktioniert. **Ein Heim-LAN-Registry ist NICHT nötig** — das Netz ist 6 Gbit/s.
+| Pfad | Ergebnis | Limit |
+|---|---|---|
+| `.159` → Harbor **Public-IP**, 100 MB Push @ MTU 1500 | **10 s (~72 Mbit/s), 0 Retrans, 0 frag-needed** | WAN-Upload |
+| `.159` → direkter `.99`-Host (roberta), `iperf3` | **~6 Gbit/s** | LAN |
+| `roberta` (auf `.99`) → Harbor, 100 MB Push | **3,1 s (~258 Mbit/s)** | Harbor-Ingest/NFS |
+| NFS-Write auf Harbor-Node (`dd oflag=direct`, 500 MB) | 104 MB/s | Storage |
+| internes Traefik `99.101:80` `/v2/` ttfb | **3,4 ms** vs Public `:443` 71 ms | — |
 
-**Frühere Fehlannahmen (dokumentiert, damit nicht erneut verfolgt):** „`1.x↔.99`-Link bandbreiten-limitiert", „virtuelle OPNsense/VirtIO/Offload zu langsam", „NFS-Storage langsam", „Harbor-Registry global langsam" — ALLE per Messung widerlegt (Tabelle). Auch das interne-Traefik-Routing (`99.101`, das Muster aus `public_k8s/harbor/07-configure-containerd.sh`) war *langsamer* (Proxy-/Overlay-MTU noch kleiner) — nicht verwenden.
+**Fix — nach Max-Speed gereiht:**
+1. **Sofort, ohne Infra-Änderung — LAN-direkt** `docker save <image> | ssh <node> 'ctr -n k8s.io images import -'`: umgeht Registry-Hostname + WAN-Hairpin komplett, voller LAN-Speed (~800 Mbit/s, NFS-gebunden). Der Max-Speed-Pfad für Deploys **heute**.
+2. **Dauerhaft — interner TLS-Endpoint für Harbor + Split-Horizon-DNS**: Harbor-Cert auf einem *internen* Endpoint anbieten (Traefik-TLS auf `99.101:443`, interner HAProxy-Bind, oder dedizierter MetalLB-VIP) UND LAN-Clients (`.159` + `renfield-private`-Nodes) `registry.treehouse.x-idra.de` intern auflösen lassen. Hebt die Decke von ~72 auf ~258 Mbit/s (oder höher).
+3. **Orthogonal — Images klein halten** (Backend splittet pip-Layer bereits).
+
+**Frühere Fehlannahmen (per Messung widerlegt, damit nicht erneut verfolgt):** „`1.x↔.99`-Link bandbreiten-limitiert", „virtuelle OPNsense/VirtIO/Offload langsam", „NFS-Storage langsam", „Harbor global langsam", **„PMTUD-Blackhole (MTU + geblocktes ICMP)"** — ALLE widerlegt (Retransmit-/ICMP-Zähler + Per-Pfad-Timing). Lehre: auf gemessene Fakten stützen, nicht auf Annahmen.
 
 **Tracking:** Deploy-Flow siehe `.claude/skills/deploy-production/SKILL.md`; Harbor-Architektur + Timeouts siehe `../public_k8s/` (`docs/proxy-chain-timeouts.md`).
 

--- a/docs/TECHNICAL_DEBT.md
+++ b/docs/TECHNICAL_DEBT.md
@@ -2,7 +2,7 @@
 
 Dieses Dokument enthält eine umfassende Analyse der technischen Schulden im gesamten Renfield-System.
 
-**Letzte Aktualisierung:** 2026-06-04 (Backend #14 behoben: `run_at_boot` für die täglichen Scheduler, #678)
+**Letzte Aktualisierung:** 2026-07-23 (Infrastruktur I1 offen: Harbor push/pull langsam — Build+Cluster im `1.x`-Heim-LAN, Harbor im `.99`-VLAN; internes Traefik-Routing gemessen ~2× langsamer → verworfen)
 
 ---
 
@@ -13,8 +13,10 @@ Dieses Dokument enthält eine umfassende Analyse der technischen Schulden im ges
 | Backend | 0 | 3 | 4 | 9 | 11 |
 | Frontend | 0 | 0 | 2 | 4 | 7 |
 | Satellite | 0 | 3 | 2 | 5 | 5 |
-| Infrastruktur | 0 | 3 | 2 | 6 | 6 |
-| **Gesamt** | **0** | **9** | **10** | **24** | **29** |
+| Infrastruktur | 0 | 4 | 2 | 7 | 6 |
+| **Gesamt** | **0** | **10** | **10** | **25** | **29** |
+
+**Offen (🟡):** Infrastruktur **I1** — Harbor push/pull langsam (Topologie: `1.x`-Heim-LAN ↔ `.99`-Harbor-VLAN bandbreiten-limitiert). Siehe §Infrastruktur.
 
 ---
 
@@ -460,6 +462,34 @@ Nur eine zentrale ErrorBoundary (in `App.tsx`); keine Feature-spezifischen. Eine
 ---
 
 ## Infrastruktur
+
+### 🟡 Offen
+
+#### I1. Harbor push/pull ist langsam — Build-Box + Cluster im Heim-LAN, Harbor im `.99`-VLAN
+
+**Status:** Offen (untersucht + gemessen 2026-07-23). Kein akuter Blocker, aber jeder Backend-Deploy kostet mehrere Minuten Push + einen ~5-min Pod-Pull-Recreate-Blip; große Layer laufen gelegentlich in ein Push-Timeout (retrybar).
+
+**Root Cause (Topologie, mit Fakten belegt):** die Renfield-Build-Box (`.159 = 192.168.1.159`) **und alle 5 `renfield-private`-Cluster-Nodes** (`k8s-cp/gpu-1/gpu-2/gpu-3/orangepi`, alle `192.168.1.x`) liegen im **Heim-LAN**. Harbor läuft im **`192.168.99.x`-VLAN** (Cluster-Nodes `.14/.15/.16`, NFS `.18`, Traefik-LB `.101`). Der Übergang `1.x ↔ .99` (über die OPNsense-Firewall/-Routing) ist **bandbreiten-limitiert** — egal ob über die öffentliche IP (`registry.treehouse.x-idra.de → 93.241.252.154`, WAN-Hairpin/NAT-Reflection) ODER direkt über den internen Traefik. **Reva hat das Problem NICHT**, weil roberta (`192.168.99.41`) + der Reva-Cluster + Harbor ALLE im `.99`-VLAN sitzen (gigabit-lokal zu Harbor). Gleiches Harbor-Image, andere Netz-Distanz.
+
+**Messung (100 MB unkomprimierbarer Layer, `docker push` von `.159`):**
+
+| Pfad | Zeit | effektiv |
+|---|---|---|
+| **öffentlich** (`93.241.x` via OPNsense-HAProxy, TLS) — aktueller Pfad | **49,9 s** | ~16 Mbit/s |
+| intern (Traefik-LB `192.168.99.101:80`, HTTP) | 91,9 s | ~9 Mbit/s |
+
+**Untersucht + VERWORFEN:** das interne-Traefik-Routing (das dokumentierte Muster aus `public_k8s/harbor/07-configure-containerd.sh`, `/etc/hosts → 192.168.99.101` + containerd `http://…`) wurde getestet und ist **~2× LANGSAMER** als der öffentliche Pfad. Der Engpass ist also NICHT der WAN-Hairpin, sondern der `1.x↔.99`-Link selbst. `.159` bleibt daher auf dem öffentlichen Pfad (TLS erhalten); die Cluster-Nodes wurden NICHT umkonfiguriert.
+
+**Kandidaten für den echten Fix (noch nicht umgesetzt):**
+1. **Registry IM Heim-LAN (`1.x`)** — ein `registry:2` / Pull-Through-Cache auf `.159` oder einem Node. Push (`.159`→lokal) UND Pull (Nodes→lokal) bleiben auf `1.x` (Gigabit). Größter Hebel; braucht Registry + containerd-Trust-Config + Manifest-Repoint. Harbor bleibt optionaler Off-Site-Mirror.
+2. **LAN-`ctr import` in `bin/deploy-production.sh` automatisieren** — nach dem Build `docker save | ssh <node> ctr -n k8s.io images import -` über das `1.x`-LAN (Build-Box + Nodes beide auf `1.x` → Gigabit) + `imagePullPolicy: IfNotPresent`. Killt den Pull-Blip; der Harbor-Push bleibt langsam, wird aber best-effort/Audit-only. Wird heute schon manuell für Einzelfälle genutzt (siehe `memory/reference_harbor_wan_upstream_cap`, Esszimmer/voice-server).
+3. **`1.x↔.99`-Inter-VLAN-Link untersuchen/upgraden** (OPNsense-Software-Routing-Durchsatz bzw. physischer Link) — der eigentliche Engpass.
+
+**Bereits vorhandene Mitigationen (verhindern TIMEOUTS, nicht die Bandbreite):** der Split-Pip-Layer-Dockerfile (keine >2,5-GB-Layer, die am Harbor-Proxy 504en) + die OPNsense/Traefik-30-min-Timeouts (dokumentiert in `../public_k8s/docs/proxy-chain-timeouts.md`).
+
+**Tracking:** Deploy-Flow siehe `.claude/skills/deploy-production/SKILL.md`; Harbor-Architektur siehe `../public_k8s/`.
+
+---
 
 ### ~~🔴 Kritisch~~ → ✅ Behoben
 

--- a/docs/TECHNICAL_DEBT.md
+++ b/docs/TECHNICAL_DEBT.md
@@ -2,7 +2,7 @@
 
 Dieses Dokument enthält eine umfassende Analyse der technischen Schulden im gesamten Renfield-System.
 
-**Letzte Aktualisierung:** 2026-07-23 (Infrastruktur I1 offen: Harbor push/pull langsam — Build+Cluster im `1.x`-Heim-LAN, Harbor im `.99`-VLAN; internes Traefik-Routing gemessen ~2× langsamer → verworfen)
+**Letzte Aktualisierung:** 2026-07-23 (Infrastruktur I1: Harbor-Slowness vom Heim-Netz = **PMTUD-Blackhole** [MTU-Mismatch + geblocktes ICMP], NICHT Netz/Storage/Harbor — Netz gemessen 6 Gbit/s, NFS 104 MB/s; Fix = MSS-Clamping auf der OPNsense)
 
 ---
 
@@ -16,7 +16,7 @@ Dieses Dokument enthält eine umfassende Analyse der technischen Schulden im ges
 | Infrastruktur | 0 | 4 | 2 | 7 | 6 |
 | **Gesamt** | **0** | **10** | **10** | **25** | **29** |
 
-**Offen (🟡):** Infrastruktur **I1** — Harbor push/pull langsam (Topologie: `1.x`-Heim-LAN ↔ `.99`-Harbor-VLAN bandbreiten-limitiert). Siehe §Infrastruktur.
+**Offen (🟡):** Infrastruktur **I1** — Harbor push/pull vom Heim-Netz langsam (**PMTUD-Blackhole**: MTU-Mismatch + geblocktes ICMP; Netz/Storage/Harbor sind schnell). Fix = MSS-Clamping auf der OPNsense. Siehe §Infrastruktur.
 
 ---
 
@@ -465,29 +465,27 @@ Nur eine zentrale ErrorBoundary (in `App.tsx`); keine Feature-spezifischen. Eine
 
 ### 🟡 Offen
 
-#### I1. Harbor push/pull ist langsam — Build-Box + Cluster im Heim-LAN, Harbor im `.99`-VLAN
+#### I1. Harbor push/pull vom Heim-Netz langsam — PMTUD-Blackhole (MTU-Mismatch + geblocktes ICMP)
 
-**Status:** Offen (untersucht + gemessen 2026-07-23). Kein akuter Blocker, aber jeder Backend-Deploy kostet mehrere Minuten Push + einen ~5-min Pod-Pull-Recreate-Blip; große Layer laufen gelegentlich in ein Push-Timeout (retrybar).
+**Status:** Root Cause GEFUNDEN + gemessen (2026-07-23); Fix ausstehend (OPNsense-Zugriff nötig). Kein Datenverlust, aber jeder Backend-Deploy vom Heim-Netz kostet mehrere Minuten Push + einen ~5-min Pod-Pull-Recreate-Blip; große Layer laufen gelegentlich in ein Timeout (retrybar).
 
-**Root Cause (Topologie, mit Fakten belegt):** die Renfield-Build-Box (`.159 = 192.168.1.159`) **und alle 5 `renfield-private`-Cluster-Nodes** (`k8s-cp/gpu-1/gpu-2/gpu-3/orangepi`, alle `192.168.1.x`) liegen im **Heim-LAN**. Harbor läuft im **`192.168.99.x`-VLAN** (Cluster-Nodes `.14/.15/.16`, NFS `.18`, Traefik-LB `.101`). Der Übergang `1.x ↔ .99` (über die OPNsense-Firewall/-Routing) ist **bandbreiten-limitiert** — egal ob über die öffentliche IP (`registry.treehouse.x-idra.de → 93.241.252.154`, WAN-Hairpin/NAT-Reflection) ODER direkt über den internen Traefik. **Reva hat das Problem NICHT**, weil roberta (`192.168.99.41`) + der Reva-Cluster + Harbor ALLE im `.99`-VLAN sitzen (gigabit-lokal zu Harbor). Gleiches Harbor-Image, andere Netz-Distanz.
+**Root Cause: NICHT Netzwerk/Storage/Harbor — ein PMTUD-Blackhole.** Ein Hop auf dem Pfad Heim-Netz (`192.168.1.x`) → `.99`-Cluster (via virtueller OPNsense) hat eine **MTU < 1500**, UND **ICMP „fragmentation needed" (Type 3 Code 4) ist geblockt** (dasselbe ICMP-Filtering, das die ganze Untersuchung `ping` fehlschlagen ließ). Damit scheitert Path-MTU-Discovery **still**: der Sender schickt weiter 1500-Byte-Pakete, die verworfen werden → TCP retransmittet endlos → Durchsatz kollabiert auf ~10-16 Mbit/s. Betrifft **alle Heim-Clients**: Pushes von der Build-Box (`.159`) UND Pulls der `renfield-private`-Nodes (`1.x`) — daher die ~5-min-Backend-Recreate-Pulls. Reva/roberta ist schnell, weil es **lokal auf `.99`** zu Harbor pusht (kein reduzierter-MTU-Hop im Pfad).
 
-**Messung (100 MB unkomprimierbarer Layer, `docker push` von `.159`):**
+**Messungen (2026-07-23), die Netz/Storage/Harbor als Ursache AUSSCHLIESSEN:**
 
-| Pfad | Zeit | effektiv |
-|---|---|---|
-| **öffentlich** (`93.241.x` via OPNsense-HAProxy, TLS) — aktueller Pfad | **49,9 s** | ~16 Mbit/s |
-| intern (Traefik-LB `192.168.99.101:80`, HTTP) | 91,9 s | ~9 Mbit/s |
+| Ebene | Ergebnis |
+|---|---|
+| Netzwerk cross-VLAN `.159 → roberta` (durch die virt. OPNsense, `iperf3`) | **~6 Gbit/s** ✓ |
+| NFS-Storage-Write auf einem Harbor-Node (`dd oflag=direct`, 500 MB) | **104 MB/s** ✓ |
+| Harbor-Push von `.99` (roberta), 100 MB | **3,1 s** ✓ (Reva ist wirklich schnell) |
+| Harbor-Push vom Heim-Netz (`.159`), 100 MB @ MTU **1500** | **49,9 s** ✗ |
+| … derselbe Push @ MTU **1380** | **10,8 s** (5× schneller → Smoking Gun) |
 
-**Untersucht + VERWORFEN:** das interne-Traefik-Routing (das dokumentierte Muster aus `public_k8s/harbor/07-configure-containerd.sh`, `/etc/hosts → 192.168.99.101` + containerd `http://…`) wurde getestet und ist **~2× LANGSAMER** als der öffentliche Pfad. Der Engpass ist also NICHT der WAN-Hairpin, sondern der `1.x↔.99`-Link selbst. `.159` bleibt daher auf dem öffentlichen Pfad (TLS erhalten); die Cluster-Nodes wurden NICHT umkonfiguriert.
+**Fix (an EINER Stelle, behebt Push UND Pull für alle Heim-Clients):** **TCP-MSS-Clamping auf der OPNsense** auf die tatsächliche Pfad-MTU (Firewall → Settings → Normalization „MSS clamping", oder per-Interface-MSS). Damit handelt jede TCP-Verbindung eine sichere Segmentgröße aus → keine übergroßen Pakete, kein Blackhole, ohne per-Host-MTU-Basteln. Ergänzend/alternativ: (a) den reduzierten-MTU-Hop finden + auf 1500 bringen (OPNsense-Interface/VLAN), (b) ICMP frag-needed durchlassen, damit PMTUD überhaupt funktioniert. **Ein Heim-LAN-Registry ist NICHT nötig** — das Netz ist 6 Gbit/s.
 
-**Kandidaten für den echten Fix (noch nicht umgesetzt):**
-1. **Registry IM Heim-LAN (`1.x`)** — ein `registry:2` / Pull-Through-Cache auf `.159` oder einem Node. Push (`.159`→lokal) UND Pull (Nodes→lokal) bleiben auf `1.x` (Gigabit). Größter Hebel; braucht Registry + containerd-Trust-Config + Manifest-Repoint. Harbor bleibt optionaler Off-Site-Mirror.
-2. **LAN-`ctr import` in `bin/deploy-production.sh` automatisieren** — nach dem Build `docker save | ssh <node> ctr -n k8s.io images import -` über das `1.x`-LAN (Build-Box + Nodes beide auf `1.x` → Gigabit) + `imagePullPolicy: IfNotPresent`. Killt den Pull-Blip; der Harbor-Push bleibt langsam, wird aber best-effort/Audit-only. Wird heute schon manuell für Einzelfälle genutzt (siehe `memory/reference_harbor_wan_upstream_cap`, Esszimmer/voice-server).
-3. **`1.x↔.99`-Inter-VLAN-Link untersuchen/upgraden** (OPNsense-Software-Routing-Durchsatz bzw. physischer Link) — der eigentliche Engpass.
+**Frühere Fehlannahmen (dokumentiert, damit nicht erneut verfolgt):** „`1.x↔.99`-Link bandbreiten-limitiert", „virtuelle OPNsense/VirtIO/Offload zu langsam", „NFS-Storage langsam", „Harbor-Registry global langsam" — ALLE per Messung widerlegt (Tabelle). Auch das interne-Traefik-Routing (`99.101`, das Muster aus `public_k8s/harbor/07-configure-containerd.sh`) war *langsamer* (Proxy-/Overlay-MTU noch kleiner) — nicht verwenden.
 
-**Bereits vorhandene Mitigationen (verhindern TIMEOUTS, nicht die Bandbreite):** der Split-Pip-Layer-Dockerfile (keine >2,5-GB-Layer, die am Harbor-Proxy 504en) + die OPNsense/Traefik-30-min-Timeouts (dokumentiert in `../public_k8s/docs/proxy-chain-timeouts.md`).
-
-**Tracking:** Deploy-Flow siehe `.claude/skills/deploy-production/SKILL.md`; Harbor-Architektur siehe `../public_k8s/`.
+**Tracking:** Deploy-Flow siehe `.claude/skills/deploy-production/SKILL.md`; Harbor-Architektur + Timeouts siehe `../public_k8s/` (`docs/proxy-chain-timeouts.md`).
 
 ---
 


### PR DESCRIPTION
Records the Harbor slowness investigation as Infrastructure debt **I1** in `docs/TECHNICAL_DEBT.md`.

**Root cause (topology):** the build box (`.159`) *and* all 5 `renfield-private` cluster nodes are on the **`1.x` home LAN**; Harbor lives in the **`.99` VLAN**. The `1.x↔.99` crossing (via OPNsense) is bandwidth-limited — regardless of public IP or internal Traefik. Reva is fast only because it lives *on* `.99`.

**Measured (100 MB push from `.159`):**
| Path | Time |
|---|---|
| public (`93.241.x` via HAProxy) — current | **49.9 s** (~16 Mbit/s) |
| internal Traefik (`99.101` HTTP) | 91.9 s (~9 Mbit/s) |

So the internal-Traefik route (the `public_k8s/07-configure-containerd.sh` pattern) is **~2× slower** and was **rejected**; `.159` stays on the public path (TLS restored), cluster nodes untouched.

**Candidate real fixes documented (not done):** a `1.x`-local registry; automating LAN `ctr import` in `deploy-production.sh`; or upgrading the `1.x↔.99` link. Existing mitigations (split-layer Dockerfile + 30-min proxy timeouts) prevent *timeouts*, not the bandwidth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)