### PR TITLE
fix(security): pentest findings — 401 on list routes, HSTS, action-confirmation guard

### DIFF
--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -10,6 +10,9 @@ For earlier history (v1.2.0 - v2.5.0), see [CHANGELOG.md](CHANGELOG.md) (German 
 
 ## [Unreleased]
 
+### Security
+- **Pentest fixes (x-ren.local, authorized)** (#1037). Three Low findings fixed: **(F1)** `/api/notes`, `/api/meetings`, `/api/projects` now return **401** for unauthenticated requests when auth is enabled (previously `200 + []` — empirically NO data leak, owner-filter + owner-gated 404 hold, but missing auth enforcement; auth-off/single-user unchanged). **(F3)** **HSTS** (`Strict-Transport-Security`, `max-age=15768000`) in `nginx.conf`. **(F5)** prompt guard (DE+EN) against fabricated action confirmations in the `general.conversation` path. Confirmed hardened: login break-in, IDOR, circle isolation, mass-assignment, prompt injection. Report: `docs/private/security/pentest-report-x-ren-local-2026-07-23.md`.
+
 ### Changed
 - **Default OCR engine → Tesseract** (#1033). The `force_full_page_ocr` re-run converter (which re-OCRs garbled/scanned documents) now uses **Tesseract** (deu+eng) by default instead of docling-EasyOcr. A 148-document eval over the flagged corpus (`bin/run_ocr_engine_eval.py --all-flagged`) showed Tesseract clearly better: **111/148 improved, only 8 regressed**, quality-gate drop 0.68→0.30, no speed penalty. Switchable via `RAG_OCR_ENGINE` (`Literal["tesseract","easyocr"]`); **fail-safe** — it verifies the tesseract runtime (CLI + deu/eng, or the tesserocr binding) and falls back to EasyOcr if absent, so ingest never crashes. `tesseract-ocr`+deu/eng ship in the backend image. Design/outcome: `docs/design/ocr-engine-eval.md`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Alle markanten Änderungen an Renfield, seit Release `v1.2.0`. Format lehnt sich
 
 ## [Unreleased]
 
+### Sicherheit
+- **Pentest-Fixes (x-ren.local, autorisiert)** (#1037). Drei Low-Findings behoben: **(F1)** `/api/notes`, `/api/meetings`, `/api/projects` erzwingen jetzt **401** für unauthentifizierte Requests bei aktivierter Auth (vorher `200 + []` — empirisch KEIN Datenabfluss, da Owner-Filter + owner-gated 404 greifen, aber fehlende Auth-Durchsetzung; auth-off/Single-User unverändert). **(F3)** **HSTS** (`Strict-Transport-Security`, `max-age=15768000`) in `nginx.conf`. **(F5)** Prompt-Guard (DE+EN) gegen halluzinierte Aktions-Bestätigungen im `general.conversation`-Pfad. Gehärtet bestätigt: Login-Break-in, IDOR, Circle-Isolation, Mass-Assignment, Prompt-Injection. Report: `docs/private/security/pentest-report-x-ren-local-2026-07-23.md`.
+
 ### Geändert
 - **OCR-Engine-Standard → Tesseract** (#1033). Der `force_full_page_ocr`-Re-Run-Converter (der garbled/gescannte Dokumente neu-OCRt) nutzt jetzt standardmäßig **Tesseract** (deu+eng) statt docling-EasyOcr. Ein 148-Dokument-Eval über den Flagged-Korpus (`bin/run_ocr_engine_eval.py --all-flagged`) zeigte Tesseract klar überlegen: **111/148 verbessert, nur 8 verschlechtert**, Quality-Gate-Drop 0.68→0.30, kein Speed-Nachteil. Umschaltbar via `RAG_OCR_ENGINE` (`Literal["tesseract","easyocr"]`); **fail-safe** — verifiziert die Tesseract-Runtime (CLI+deu/eng oder tesserocr-Binding) und fällt auf EasyOcr zurück, wenn sie fehlt, sodass Ingest nie abstürzt. `tesseract-ocr`+deu/eng im Backend-Image. Design/Ergebnis: `docs/design/ocr-engine-eval.md`.
 

--- a/src/backend/api/routes/meetings.py
+++ b/src/backend/api/routes/meetings.py
@@ -270,7 +270,7 @@ async def list_meetings(
     stmt = select(Meeting).order_by(Meeting.created_at.desc()).limit(limit)
     if settings.auth_enabled:
         if not user:
-            return []
+            raise HTTPException(status_code=401, detail="Authentication required")
         stmt = stmt.where(Meeting.owner_user_id == user.id)
 
     result = await db.execute(stmt)

--- a/src/backend/api/routes/meetings.py
+++ b/src/backend/api/routes/meetings.py
@@ -262,9 +262,9 @@ async def list_meetings(
     user: User | None = Depends(get_optional_user),
     db: AsyncSession = Depends(get_db),
 ) -> list[MeetingResponse]:
-    """List the caller's meetings, newest first (owner-scoped 404-free — an
-    unauthenticated caller under auth just gets an empty list). Backs the
-    Meetings page; the frontend polls it while any row is pending/processing."""
+    """List the caller's meetings, newest first (owner-scoped; an unauthenticated
+    caller under auth gets 401). Backs the Meetings page; the frontend polls it
+    while any row is pending/processing."""
     _require_enabled()
 
     stmt = select(Meeting).order_by(Meeting.created_at.desc()).limit(limit)

--- a/src/backend/api/routes/notes.py
+++ b/src/backend/api/routes/notes.py
@@ -136,7 +136,7 @@ async def list_notes_route(
     stmt = select(Note).order_by(Note.updated_at.desc()).limit(limit)
     if settings.auth_enabled:
         if not user:
-            return []
+            raise HTTPException(status_code=401, detail="Authentication required")
         stmt = stmt.where(Note.owner_user_id == user.id)
     result = await db.execute(stmt)
     return [_to_response(n) for n in result.scalars().all()]

--- a/src/backend/api/routes/projects.py
+++ b/src/backend/api/routes/projects.py
@@ -113,7 +113,7 @@ async def list_projects_route(
     stmt = select(Project).order_by(Project.created_at.desc())
     if settings.auth_enabled:
         if not user:
-            return []
+            raise HTTPException(status_code=401, detail="Authentication required")
         stmt = stmt.where(Project.owner_id == user.id)
 
     result = await db.execute(stmt)

--- a/src/backend/prompts/chat.yaml
+++ b/src/backend/prompts/chat.yaml
@@ -21,7 +21,7 @@ de:
     1. Antworte IMMER in natürlicher deutscher Sprache
     2. Gib NIEMALS JSON, Code oder technische Details aus
     3. Sei kurz, freundlich und direkt
-    4. Bestätige eine Aktion NUR, wenn sie WIRKLICH ausgeführt wurde (ein "System: Aktion ausgeführt"-Kontext liegt vor). Erfinde NIEMALS eine Erfolgsmeldung (z. B. "Das Licht ist an") für eine Aktion, die nicht tatsächlich ausgeführt wurde — sag dann, dass du sie gerade nicht ausführen kannst.
+    4. Bestätige eine ausgeführte Aktion einfach — aber NUR, wenn im Gesprächskontext tatsächlich ein Aktions-/Tool-Ergebnis vorliegt. Erfinde NIEMALS eine Erfolgsmeldung (z. B. "Das Licht ist an") für eine Aktion, die gar nicht ausgeführt wurde; sag dann ehrlich, dass du sie gerade nicht ausführen kannst.
     5. Bei Wissensfragen: Nutze den bereitgestellten Kontext
 
     GUTE Beispiele:
@@ -96,7 +96,7 @@ en:
     1. ALWAYS respond in natural English language
     2. NEVER output JSON, code, or technical details
     3. Be brief, friendly, and direct
-    4. Confirm an action ONLY if it was ACTUALLY executed (a "System: action executed" context is present). NEVER fabricate a success message (e.g. "the light is on") for an action that was not actually performed — instead say you cannot perform it right now.
+    4. Simply confirm an executed action — but ONLY when an action/tool result is actually present in the conversation context. NEVER fabricate a success message (e.g. "the light is on") for an action that was not performed; instead honestly say you cannot perform it right now.
     5. For knowledge questions: Use the provided context
 
     GOOD examples:

--- a/src/backend/prompts/chat.yaml
+++ b/src/backend/prompts/chat.yaml
@@ -21,7 +21,7 @@ de:
     1. Antworte IMMER in natürlicher deutscher Sprache
     2. Gib NIEMALS JSON, Code oder technische Details aus
     3. Sei kurz, freundlich und direkt
-    4. Wenn eine Aktion ausgeführt wurde, bestätige dies einfach
+    4. Bestätige eine Aktion NUR, wenn sie WIRKLICH ausgeführt wurde (ein "System: Aktion ausgeführt"-Kontext liegt vor). Erfinde NIEMALS eine Erfolgsmeldung (z. B. "Das Licht ist an") für eine Aktion, die nicht tatsächlich ausgeführt wurde — sag dann, dass du sie gerade nicht ausführen kannst.
     5. Bei Wissensfragen: Nutze den bereitgestellten Kontext
 
     GUTE Beispiele:
@@ -96,7 +96,7 @@ en:
     1. ALWAYS respond in natural English language
     2. NEVER output JSON, code, or technical details
     3. Be brief, friendly, and direct
-    4. If an action was executed, simply confirm it
+    4. Confirm an action ONLY if it was ACTUALLY executed (a "System: action executed" context is present). NEVER fabricate a success message (e.g. "the light is on") for an action that was not actually performed — instead say you cannot perform it right now.
     5. For knowledge questions: Use the provided context
 
     GOOD examples:

--- a/src/frontend/nginx.conf
+++ b/src/frontend/nginx.conf
@@ -131,6 +131,7 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
     # Baseline CSP — ENFORCING (v1 shipped Report-Only, verified clean, then flipped).
     add_header Content-Security-Policy $csp always;
+    add_header Strict-Transport-Security "max-age=15768000" always;
 
     # Service worker + its registration script have STABLE names (sw.js,
     # registerSW.js), so the immutable rule below would HTTP-cache them for a
@@ -148,6 +149,7 @@ server {
         add_header Cache-Control "no-cache, no-store, must-revalidate" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Content-Security-Policy $csp always;
+        add_header Strict-Transport-Security "max-age=15768000" always;
         expires off;
     }
 
@@ -161,12 +163,14 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
         add_header Content-Security-Policy $csp always;
+        add_header Strict-Transport-Security "max-age=15768000" always;
         expires off;
     }
     location = /manifest.webmanifest {
         add_header Cache-Control "no-cache, must-revalidate" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Content-Security-Policy $csp always;
+        add_header Strict-Transport-Security "max-age=15768000" always;
         expires off;
     }
 
@@ -180,6 +184,7 @@ server {
         add_header Cache-Control "no-cache, must-revalidate" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Content-Security-Policy $csp always;
+        add_header Strict-Transport-Security "max-age=15768000" always;
         expires off;
     }
 
@@ -216,6 +221,7 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
         add_header Content-Security-Policy $csp always;
+        add_header Strict-Transport-Security "max-age=15768000" always;
         expires off;
     }
 

--- a/src/frontend/nginx.conf
+++ b/src/frontend/nginx.conf
@@ -113,6 +113,13 @@ map $host $csp {
     default "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' blob: 'sha256-punQmGiNS8da81PCRuSsjEAS5CzAnZcWK/ykEF4Wg4A='; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; media-src 'self' blob: data:; worker-src 'self' blob:; manifest-src 'self'; frame-src 'self'; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; form-action 'self'";
 }
 
+# HSTS policy — single source (same pattern as $csp) to avoid per-location drift.
+# Conservative: no includeSubDomains/preload yet. Applied in every location that
+# declares its own add_header (they don't inherit the server block).
+map $host $hsts {
+    default "max-age=15768000";
+}
+
 server {
     listen 80;
     server_name localhost;
@@ -131,7 +138,7 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
     # Baseline CSP — ENFORCING (v1 shipped Report-Only, verified clean, then flipped).
     add_header Content-Security-Policy $csp always;
-    add_header Strict-Transport-Security "max-age=15768000" always;
+    add_header Strict-Transport-Security $hsts always;
 
     # Service worker + its registration script have STABLE names (sw.js,
     # registerSW.js), so the immutable rule below would HTTP-cache them for a
@@ -149,7 +156,7 @@ server {
         add_header Cache-Control "no-cache, no-store, must-revalidate" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Content-Security-Policy $csp always;
-        add_header Strict-Transport-Security "max-age=15768000" always;
+        add_header Strict-Transport-Security $hsts always;
         expires off;
     }
 
@@ -163,14 +170,14 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
         add_header Content-Security-Policy $csp always;
-        add_header Strict-Transport-Security "max-age=15768000" always;
+        add_header Strict-Transport-Security $hsts always;
         expires off;
     }
     location = /manifest.webmanifest {
         add_header Cache-Control "no-cache, must-revalidate" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Content-Security-Policy $csp always;
-        add_header Strict-Transport-Security "max-age=15768000" always;
+        add_header Strict-Transport-Security $hsts always;
         expires off;
     }
 
@@ -184,7 +191,7 @@ server {
         add_header Cache-Control "no-cache, must-revalidate" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Content-Security-Policy $csp always;
-        add_header Strict-Transport-Security "max-age=15768000" always;
+        add_header Strict-Transport-Security $hsts always;
         expires off;
     }
 
@@ -193,12 +200,14 @@ server {
         default_type application/javascript;
         expires 1y;
         add_header Cache-Control "public, immutable";
+        add_header Strict-Transport-Security $hsts always;
     }
 
     # Cache static assets (content-hashed bundles → safe to cache forever)
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|wasm|onnx|mjs)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        add_header Strict-Transport-Security $hsts always;
     }
 
     # /api and /ws are backend routes (ingress-routed). If one ever reaches the
@@ -221,7 +230,7 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
         add_header Content-Security-Policy $csp always;
-        add_header Strict-Transport-Security "max-age=15768000" always;
+        add_header Strict-Transport-Security $hsts always;
         expires off;
     }
 

--- a/tests/backend/test_meetings.py
+++ b/tests/backend/test_meetings.py
@@ -1323,3 +1323,10 @@ class TestMeetingProjectPatch:
                 user=intruder, db=db_session,
             )
         assert exc.value.status_code == 404
+
+
+async def test_list_meetings_requires_auth_when_enabled(async_client, monkeypatch, tmp_path):
+    """Regression (pentest F1): unauth GET /api/meetings on auth-enabled must 401."""
+    _enable(monkeypatch, tmp_path, auth=True)
+    _override_user(None)
+    assert (await async_client.get("/api/meetings")).status_code == 401

--- a/tests/backend/test_notes.py
+++ b/tests/backend/test_notes.py
@@ -261,3 +261,11 @@ async def test_note_retrieval_finds_and_circle_filters(async_client, db_session,
 
     # A thin query returns nothing.
     assert await NoteRetrieval(db_session).search("", asker_id=None, top_k=10) == []
+
+
+async def test_list_notes_requires_auth_when_enabled(async_client, monkeypatch):
+    """Regression (pentest F1): unauth GET /api/notes on an auth-enabled instance
+    must 401, not 200+[] (missing-auth enforcement)."""
+    _enable(monkeypatch, auth=True)
+    _override_user(None)
+    assert (await async_client.get("/api/notes")).status_code == 401

--- a/tests/backend/test_projects.py
+++ b/tests/backend/test_projects.py
@@ -255,3 +255,10 @@ async def test_list_reports_document_count(async_client, db_session, monkeypatch
     assert listing.status_code == 200
     row = next(p for p in listing.json() if p["id"] == created["id"])
     assert row["document_count"] == 2
+
+
+async def test_list_projects_requires_auth_when_enabled(async_client, monkeypatch):
+    """Regression (pentest F1): unauth GET /api/projects on auth-enabled must 401."""
+    _enable(monkeypatch, auth=True)
+    _override_user(None)
+    assert (await async_client.get("/api/projects")).status_code == 401


### PR DESCRIPTION
Fixes from an **authorized black-box pentest** of the auth-on xidra instance (`x-ren.local`). Full report: `docs/private/security/pentest-report-x-ren-local-2026-07-23.md` (gitignored). **No Critical/High** — 3 Low findings, all fixed.

## Fixes
- **F1 — missing 401 on list routes.** `/api/notes`, `/api/meetings`, `/api/projects` returned `200 + []` for an unauthenticated request under `auth_enabled` instead of `401`. **Empirically NO data leak** (seeded a note; unauth *and* a foreign user still got `[]`, owner-gated 404 by-id) — it's missing-auth enforcement / API hygiene. `return []` → `raise HTTPException(401)`; auth-off (single-user) unchanged. **+3 regression tests** (`test_list_*_requires_auth_when_enabled`).
- **F3 — no HSTS.** Added `Strict-Transport-Security: max-age=15768000` after every CSP `add_header` in `nginx.conf` (server + all header-locations → avoids the `add_header` inheritance trap). Conservative (no `includeSubDomains`/`preload`).
- **F5 — fabricated action confirmations.** The agent said "the light is on" without any tool call (`general.conversation`, **no** HA_CONTROL bypass). Prompt guard (DE+EN) in `chat.yaml`: only confirm an action on a real execution context, never fabricate.

Retracted as false-positive/by-design: F2 (`/docs` = SPA fallback), F4 (`/api/federation/peers` intentionally user-visible, empty).

## Tests
83/83 pass on `.159` (the 3 affected files), including the 3 new regression tests.

## Deploy notes
- Backend (F1/F5): standard rollout.
- Frontend (F3, nginx header-only): needs a **build-stamp bump** for PWA cache propagation (per the deploy skill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)