### PR TITLE
fix(security): F6 — Redis auth + Redis/Postgres NetworkPolicy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ secrets/
 # Real private-config Secret (mailbox/weather/twin values) — NEVER public git.
 # Only the redacted .example.yaml is committed. See k8s/configmap.yaml header.
 k8s/renfield-env-private.secret.yaml
+k8s/redis-auth.secret.yaml
 k8s/secrets.yaml
 # Real private registry overlay (maps the placeholder registry -> real host) — NEVER public git.
 # Only kustomization.yaml.example is committed. See its header.

--- a/k8s/alembic-upgrade-job.yaml
+++ b/k8s/alembic-upgrade-job.yaml
@@ -24,6 +24,9 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/part-of: renfield
+        # Lets the redis/postgres NetworkPolicy (redis-postgres-netpol.yaml) admit
+        # this backend-image Job to Postgres for migrations.
+        app.kubernetes.io/component: backend-job
     spec:
       restartPolicy: OnFailure
       imagePullSecrets:

--- a/k8s/backend.yaml
+++ b/k8s/backend.yaml
@@ -100,6 +100,12 @@ spec:
             - secretRef:
                 name: renfield-env-private
                 optional: true
+            # Redis auth (pentest F6). Its REDIS_URL (with password) overrides the
+            # public ConfigMap's passwordless redis://redis:6379. optional so a
+            # cluster without it stays passwordless (legacy/dark-safe).
+            - secretRef:
+                name: redis-auth
+                optional: true
           env:
             # Loader prefers this RO mounted key when present (see the
             # federation-identity volumeMount below); falls back to generating at

--- a/k8s/document-worker.yaml
+++ b/k8s/document-worker.yaml
@@ -78,6 +78,8 @@ spec:
             # Private per-instance config (out of public git); optional so the
             # pod boots without it. See k8s/renfield-env-private.secret.example.yaml.
             - secretRef: {name: renfield-env-private, optional: true}
+            # Redis auth (pentest F6) — REDIS_URL with password overrides the ConfigMap.
+            - secretRef: {name: redis-auth, optional: true}
           env:
             - name: POD_NAME
               valueFrom: {fieldRef: {fieldPath: metadata.name}}

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -23,6 +23,7 @@ resources:
   - backend-tts-cache-route.yaml
   - shared-pvcs.yaml
   - document-worker.yaml
+  - redis-postgres-netpol.yaml   # pentest F6: restrict Redis/PG ingress to app pods
 
 labels:
   - pairs:

--- a/k8s/meeting-worker.yaml
+++ b/k8s/meeting-worker.yaml
@@ -71,6 +71,8 @@ spec:
             # Private per-instance config (out of public git); optional so the
             # pod boots without it. See k8s/renfield-env-private.secret.example.yaml.
             - secretRef: {name: renfield-env-private, optional: true}
+            # Redis auth (pentest F6) — REDIS_URL with password overrides the ConfigMap.
+            - secretRef: {name: redis-auth, optional: true}
           env:
             - name: POD_NAME
               valueFrom: {fieldRef: {fieldPath: metadata.name}}

--- a/k8s/redis-auth.secret.example.yaml
+++ b/k8s/redis-auth.secret.example.yaml
@@ -1,0 +1,30 @@
+# Redis authentication (pentest F6 — Redis was passwordless + no NetworkPolicy).
+#
+# Copy to k8s/redis-auth.secret.yaml (gitignored), set a strong random password
+# in BOTH keys (same password), and apply BEFORE rolling redis + the consumers:
+#
+#   PW=$(openssl rand -base64 32 | tr -d '/+=' | head -c 40)
+#   sed -e "s#__REDIS_PASSWORD__#$PW#" -e "s#__REDIS_URL__#redis://:$PW@redis:6379#" \
+#     k8s/redis-auth.secret.example.yaml > k8s/redis-auth.secret.yaml
+#   kubectl -n renfield apply -f k8s/redis-auth.secret.yaml
+#   kubectl -n renfield rollout restart deploy/redis deploy/backend deploy/document-worker deploy/meeting-worker
+#
+# How it wires up (zero code change):
+#   - redis.yaml reads REDIS_PASSWORD (optional) -> --requirepass.
+#   - backend/document-worker/meeting-worker add `- secretRef: redis-auth` AFTER
+#     renfield-env-private, so this REDIS_URL (with password) overrides the
+#     public ConfigMap's passwordless redis://redis:6379.
+#   - optional:true everywhere => absent Secret = legacy passwordless (dark-safe).
+#
+# Pair with k8s/redis-postgres-netpol.yaml (restricts who can even reach Redis/PG).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis-auth
+  namespace: renfield
+  labels:
+    app.kubernetes.io/part-of: renfield
+type: Opaque
+stringData:
+  REDIS_PASSWORD: "__REDIS_PASSWORD__"
+  REDIS_URL: "__REDIS_URL__"   # redis://:<password>@redis:6379

--- a/k8s/redis-postgres-netpol.yaml
+++ b/k8s/redis-postgres-netpol.yaml
@@ -1,0 +1,53 @@
+# NetworkPolicy — restrict who can reach the Redis + Postgres data stores
+# (pentest F6: no NetworkPolicies existed, so ANY pod in the namespace — incl. an
+# MCP/sidecar — could reach passwordless Redis and the DB port). Defense-in-depth
+# against lateral movement; complements the Redis password (redis-auth.secret).
+#
+# Ingress to redis/postgres is allowed ONLY from the renfield backend-image
+# workloads that legitimately use them. Everything else in the namespace (MCP
+# servers, frontend, paperless, etc.) is denied at the network layer.
+#
+# NB: requires a CNI that enforces NetworkPolicy (Calico here — see
+# private_k8s/calico-ippool.yaml). Egress is not restricted (kept minimal).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: redis-allow-app-only
+  namespace: renfield
+  labels:
+    app.kubernetes.io/part-of: renfield
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector: {matchLabels: {app.kubernetes.io/name: backend}}
+        - podSelector: {matchLabels: {app.kubernetes.io/name: document-worker}}
+        - podSelector: {matchLabels: {app.kubernetes.io/name: meeting-worker}}
+        # alembic-upgrade Job + any backend-image job carry this shared label.
+        - podSelector: {matchLabels: {app.kubernetes.io/part-of: renfield, app.kubernetes.io/component: backend-job}}
+      ports:
+        - {protocol: TCP, port: 6379}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: postgres-allow-app-only
+  namespace: renfield
+  labels:
+    app.kubernetes.io/part-of: renfield
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector: {matchLabels: {app.kubernetes.io/name: backend}}
+        - podSelector: {matchLabels: {app.kubernetes.io/name: document-worker}}
+        - podSelector: {matchLabels: {app.kubernetes.io/name: meeting-worker}}
+        - podSelector: {matchLabels: {app.kubernetes.io/part-of: renfield, app.kubernetes.io/component: backend-job}}
+      ports:
+        - {protocol: TCP, port: 5432}

--- a/k8s/redis.yaml
+++ b/k8s/redis.yaml
@@ -54,20 +54,35 @@ spec:
       containers:
         - name: redis
           image: redis:7-alpine
-          command: ["redis-server", "--appendonly", "yes", "--dir", "/data"]
+          # requirepass from the redis-auth Secret (pentest F6). Empty/absent
+          # password => passwordless (legacy/dark-safe), so a cluster without the
+          # Secret still boots unchanged. sh -c so $REDIS_PASSWORD expands.
+          command:
+            - sh
+            - -c
+            - exec redis-server --appendonly yes --dir /data --requirepass "$REDIS_PASSWORD"
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: redis-auth
+                  key: REDIS_PASSWORD
+                  optional: true
           ports:
             - containerPort: 6379
           volumeMounts:
             - name: data
               mountPath: /data
+          # Probes auth with the password when set; fall back to unauth ping when
+          # passwordless, so the probe works in both modes.
           livenessProbe:
             exec:
-              command: ["redis-cli", "ping"]
+              command: ["sh", "-c", "redis-cli -a \"$REDIS_PASSWORD\" --no-auth-warning ping || redis-cli ping"]
             initialDelaySeconds: 10
             periodSeconds: 10
           readinessProbe:
             exec:
-              command: ["redis-cli", "ping"]
+              command: ["sh", "-c", "redis-cli -a \"$REDIS_PASSWORD\" --no-auth-warning ping || redis-cli ping"]
             initialDelaySeconds: 5
             periodSeconds: 5
           resources:


### PR DESCRIPTION
Pentest **F6** (x-ren.local, grey-box round 2). Redis was **passwordless** (`PING` → `+PONG`) and there were **0 NetworkPolicies**, so any pod in the namespace (incl. an MCP/sidecar) could reach Redis — which holds **SSO one-time codes, sessions, rate-limit state, task streams** — and the DB port. Defense-in-depth gap for lateral movement (internal only; 6379 is not exposed externally).

## Fix (zero backend code change, dark-safe)
- **`redis-auth` Secret** (`REDIS_PASSWORD` + `REDIS_URL`-with-password) — real value gitignored, `.example` committed (mirrors `renfield-env-private`).
- **redis.yaml**: `--requirepass` from `REDIS_PASSWORD` (`optional` → empty = passwordless legacy); probes auth-with-fallback.
- **backend + 2 workers**: `secretRef: redis-auth` **after** `renfield-env-private`, so its `REDIS_URL` (with password) overrides the public ConfigMap's passwordless `redis://redis:6379`. `optional: true` → absent Secret = legacy passwordless.
- **redis-postgres-netpol.yaml**: restrict Redis(6379)/Postgres(5432) ingress to backend + workers + backend-image jobs; added a `component: backend-job` label to the **alembic job** so migrations still reach Postgres. Requires Calico (in use).
- **kustomization**: +netpol. The Secret is applied out-of-band (`apply -f`, like `renfield-env-private`), so a plain `kustomize build` stays passwordless/dark by default.

## Validation
`kubectl kustomize k8s/` builds clean (39 objects, 2 NetworkPolicies, `requirepass`, 3 `redis-auth` secretRefs). Rollout order documented in the `.example` header.

**Dark-safe:** without the `redis-auth` Secret, behavior is byte-identical to today (passwordless). Applies to household + xidra; **xidra picks it up on rebuild**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)