### PR TITLE
fix(paperless): distinguish resolve-or-create failure from guardrail-skip

### DIFF
--- a/src/backend/ha_glue/services/paperless_audit_service.py
+++ b/src/backend/ha_glue/services/paperless_audit_service.py
@@ -577,6 +577,7 @@ class PaperlessAuditService:
         resolver fetches its own (single-call callers / fallback).
         """
         from services.folder_ingest_paperless import (
+            PaperlessResolveError,
             resolve_or_create_correspondent,
             resolve_or_create_taxonomy,
         )
@@ -588,35 +589,50 @@ class PaperlessAuditService:
         if result.suggested_title and result.suggested_title != result.current_title:
             params["title"] = result.suggested_title
             has_changes = True
-        if result.suggested_correspondent and result.suggested_correspondent != result.current_correspondent:
-            corr = await resolve_or_create_correspondent(
-                self._mcp, result.suggested_correspondent, names=tax.get("correspondents")
-            )
-            if corr:  # None = a fuzzy-near match exists → guardrail, leave unset
-                params["correspondent"] = corr
-                has_changes = True
-        if result.suggested_document_type and result.suggested_document_type != result.current_document_type:
-            dt = result.suggested_document_type
-            if settings.paperless_autocreate_document_type:
-                # None on a fuzzy-near guardrail hit → skip (same as correspondent),
-                # rather than force the raw suggestion and risk a near-duplicate type.
-                dt = await resolve_or_create_taxonomy(
-                    self._mcp, "document_type", dt, names=tax.get("document_types")
+        # raise_on_error=True so a transient taxonomy read / create FAILURE is
+        # distinguishable from a legitimate guardrail-skip (None): on failure we
+        # abort this pass and leave the row pending for a clean retry, instead of
+        # dropping the fix silently and reporting it as applied.
+        try:
+            if result.suggested_correspondent and result.suggested_correspondent != result.current_correspondent:
+                corr = await resolve_or_create_correspondent(
+                    self._mcp, result.suggested_correspondent,
+                    names=tax.get("correspondents"), raise_on_error=True,
                 )
-            if dt:
-                params["document_type"] = dt
-                has_changes = True
-        if result.suggested_tags and result.suggested_tags != result.current_tags:
-            tags = result.suggested_tags
-            if settings.paperless_autocreate_tags:
-                resolved = [
-                    await resolve_or_create_taxonomy(self._mcp, "tag", t, names=tax.get("tags"))
-                    for t in tags
-                ]
-                tags = [t for t in resolved if t]  # drop guardrail-skipped (None) tags
-            if tags:
-                params["tags"] = tags
-                has_changes = True
+                if corr:  # None = a fuzzy-near match exists → guardrail, leave unset
+                    params["correspondent"] = corr
+                    has_changes = True
+            if result.suggested_document_type and result.suggested_document_type != result.current_document_type:
+                dt = result.suggested_document_type
+                if settings.paperless_autocreate_document_type:
+                    # None on a fuzzy-near guardrail hit → skip (same as correspondent),
+                    # rather than force the raw suggestion and risk a near-duplicate type.
+                    dt = await resolve_or_create_taxonomy(
+                        self._mcp, "document_type", dt,
+                        names=tax.get("document_types"), raise_on_error=True,
+                    )
+                if dt:
+                    params["document_type"] = dt
+                    has_changes = True
+            if result.suggested_tags and result.suggested_tags != result.current_tags:
+                tags = result.suggested_tags
+                if settings.paperless_autocreate_tags:
+                    resolved = [
+                        await resolve_or_create_taxonomy(
+                            self._mcp, "tag", t, names=tax.get("tags"), raise_on_error=True
+                        )
+                        for t in tags
+                    ]
+                    tags = [t for t in resolved if t]  # drop guardrail-skipped (None) tags
+                if tags:
+                    params["tags"] = tags
+                    has_changes = True
+        except PaperlessResolveError as e:
+            logger.warning(
+                f"_apply_fix: taxonomy resolve failed for doc {result.paperless_doc_id} "
+                f"({e}) — leaving pending for retry, not reporting as applied"
+            )
+            return False
         if result.suggested_date and result.suggested_date != result.current_date:
             params["created_date"] = result.suggested_date
             has_changes = True

--- a/src/backend/services/folder_ingest_paperless.py
+++ b/src/backend/services/folder_ingest_paperless.py
@@ -40,6 +40,16 @@ from models.database import (
 from services.folder_ingest import _PAPERLESS_SETTLED, IngestMeta, PaperlessLeg
 
 
+class PaperlessResolveError(Exception):
+    """A resolve-or-create FAILED (couldn't read the taxonomy, or the create call
+    errored) — as distinct from a legitimate ``None`` return (empty input or a
+    fuzzy-near guardrail skip). Only raised when a caller passes
+    ``raise_on_error=True`` (default off keeps the None-on-anything contract that
+    the folder-ingest / reextract / backfill callers rely on). Lets the audit's
+    ``_apply_fix`` tell "intentionally left unset" from "transiently failed" so it
+    doesn't report a dropped fix as applied."""
+
+
 def _parse_paperless_result(mcp_result: dict | None) -> dict:
     """Unwrap the MCPManager envelope to the paperless tool's own dict.
 
@@ -72,7 +82,8 @@ async def _fetch_correspondent_names(mcp_manager) -> list[str] | None:
 
 
 async def resolve_or_create_correspondent(
-    mcp_manager, extracted_value: str, *, names: list[str] | None = None, create: bool = True
+    mcp_manager, extracted_value: str, *, names: list[str] | None = None,
+    create: bool = True, raise_on_error: bool = False,
 ) -> str | None:
     """Option A + guardrail: map a confidently-new extracted sender to a Paperless
     correspondent NAME the upload can resolve, creating it ONLY when it has no
@@ -110,7 +121,10 @@ async def resolve_or_create_correspondent(
     if names is None:
         names = await _fetch_correspondent_names(mcp_manager)
     if names is None:
-        return None  # couldn't read the taxonomy → don't risk a duplicate
+        # couldn't read the taxonomy → don't risk a duplicate (transport failure)
+        if raise_on_error:
+            raise PaperlessResolveError("could not read correspondent taxonomy")
+        return None
     # Reuse the extractor's own matchers so "existing" means the same thing here
     # as it does inside extraction.
     from services.paperless_metadata_extractor import _fuzzy_match, _fuzzy_top_candidates
@@ -139,6 +153,8 @@ async def resolve_or_create_correspondent(
         f"folder-ingest paperless: create_correspondent failed for {value!r}: "
         f"{created.get('error')}"
     )
+    if raise_on_error:
+        raise PaperlessResolveError(f"create_correspondent failed: {created.get('error')}")
     return None
 
 
@@ -176,7 +192,7 @@ async def _fetch_taxonomy_names(mcp_manager, kind: str) -> list[str] | None:
 
 async def resolve_or_create_taxonomy(
     mcp_manager, kind: str, extracted_value: str, *,
-    names: list[str] | None = None, create: bool = True,
+    names: list[str] | None = None, create: bool = True, raise_on_error: bool = False,
 ) -> str | None:
     """Map a confidently-new extracted document_type/tag to a Paperless NAME the
     upload can resolve, creating it ONLY when it has no fuzzy-near match in the
@@ -187,7 +203,10 @@ async def resolve_or_create_taxonomy(
     if names is None:
         names = await _fetch_taxonomy_names(mcp_manager, kind)
     if names is None:
-        return None  # couldn't read the taxonomy → don't risk a duplicate
+        # couldn't read the taxonomy → don't risk a duplicate (transport failure)
+        if raise_on_error:
+            raise PaperlessResolveError(f"could not read {kind} taxonomy")
+        return None
     from services.paperless_metadata_extractor import _fuzzy_match, _fuzzy_top_candidates
 
     existing = _fuzzy_match(value, names)
@@ -206,6 +225,8 @@ async def resolve_or_create_taxonomy(
         logger.info(f"folder-ingest paperless: auto-created {kind} {value!r} (id={created.get('id')})")
         return created.get("name") or value
     logger.warning(f"folder-ingest paperless: create {kind} failed for {value!r}: {created.get('error')}")
+    if raise_on_error:
+        raise PaperlessResolveError(f"create {kind} failed: {created.get('error')}")
     return None
 
 

--- a/tests/backend/test_paperless_audit.py
+++ b/tests/backend/test_paperless_audit.py
@@ -875,6 +875,56 @@ class TestApplyFix:
 
     @pytest.mark.unit
     @pytest.mark.asyncio
+    async def test_apply_fix_returns_false_on_resolve_failure_not_silent_success(
+        self, service, mock_mcp_manager, mock_db_factory
+    ):
+        """A transport/create FAILURE while resolving a taxonomy value must NOT be
+        reported as an applied fix — _apply_fix returns False so the row stays
+        pending for retry (distinct from a guardrail-skip, which is a success)."""
+        mock_result = MagicMock()
+        mock_result.id = 1
+        mock_result.paperless_doc_id = 42
+        mock_result.current_title = "Same"
+        mock_result.suggested_title = "Same"
+        mock_result.current_correspondent = "A"
+        mock_result.suggested_correspondent = "B"  # only change; create will fail
+        mock_result.current_document_type = None
+        mock_result.suggested_document_type = None
+        mock_result.current_tags = None
+        mock_result.suggested_tags = None
+        mock_result.current_date = None
+        mock_result.suggested_date = None
+        mock_result.current_storage_path = None
+        mock_result.suggested_storage_path = None
+        mock_result.suggested_custom_fields = None
+
+        update_called = []
+
+        async def _execute(tool, params, **_kw):
+            if tool == "mcp.paperless.list_correspondents":
+                return {"success": True, "message": json.dumps({"items": [{"name": "A"}]})}
+            if tool == "mcp.paperless.create_correspondent":
+                # transport/create failure — NOT already_exists, no id
+                return {"success": True, "message": json.dumps({"error": "boom"})}
+            if tool == "mcp.paperless.update_document":
+                update_called.append(params)
+                return {"success": True, "message": "{}"}
+            return {"success": True, "message": "{}"}
+
+        mock_mcp_manager.execute_tool.side_effect = _execute
+
+        mock_session = mock_db_factory._mock_session
+        mock_db_result = MagicMock()
+        mock_scalar = MagicMock(return_value=mock_db_result)
+        mock_session.execute.return_value = MagicMock(scalar_one_or_none=mock_scalar)
+
+        success = await service._apply_fix(mock_result)
+
+        assert success is False  # NOT a silent success
+        assert update_called == []  # no partial write
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
     async def test_apply_fix_with_v2_fields(self, service, mock_mcp_manager, mock_db_factory):
         """Should include date, storage_path, custom_fields in MCP call."""
         mock_result = MagicMock()


### PR DESCRIPTION
The `/review` P3 residual on PR #1039's audit consolidation.

`resolve_or_create_correspondent`/`_taxonomy` returned `None` on **both** a
fuzzy-near guardrail-skip and a transport/create **failure** — indistinguishable.
So an audit fix whose only change was a correspondent/type/tag with a transient
create failure was counted "applied" while nothing was written and the row stayed
`pending` (silent drop).

**Fix:** a `PaperlessResolveError` + `raise_on_error=False` param on both
resolvers. When `True` they raise on a taxonomy-read/create failure; a guardrail
skip still returns `None`. Default `False` keeps every existing caller
(folder-ingest upload leg, reextract, backfill) byte-for-byte unchanged. `_apply_fix`
passes `raise_on_error=True` and returns `False` on the error (no partial write) so
the row stays pending for a clean, self-healing retry.

Tests: 148 passed on .159 (112 audit incl. the new
`test_apply_fix_returns_false_on_resolve_failure_not_silent_success`, 36
folder_ingest unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)