### PR TITLE
fix(paperless): decouple audit mount from ha_glue (reach HA-less deploys)

### DIFF
--- a/src/backend/api/lifecycle.py
+++ b/src/backend/api/lifecycle.py
@@ -1129,6 +1129,45 @@ async def _load_plugin_module():
         await _load_one_plugin(spec)
 
 
+async def _init_paperless_audit(app: "FastAPI") -> None:
+    """Mount the Paperless audit REST router + start its service, from PLATFORM CORE.
+
+    The audit code lives under ``ha_glue/`` for historical packaging reasons, but it
+    needs no Home Assistant — only the Paperless MCP + ``paperless_audit_enabled``.
+    Mounting it here (not inside the ha_glue plugin) makes it available on HA-less
+    instances (e.g. the business/xidra deploy that never loads ha_glue), which is
+    where it previously 404'd. This is the SINGLE owner of the mount — the ha_glue
+    plugin no longer mounts it, so there is no double-include on HA deploys.
+
+    Gated: no-op unless ``paperless_audit_enabled`` AND the Paperless MCP server is
+    configured. Stores the service on ``app.state.paperless_audit`` for the shutdown
+    path. Best-effort — a failure here must not break startup.
+    """
+    try:
+        from ha_glue.utils.config import ha_glue_settings
+
+        if not ha_glue_settings.paperless_audit_enabled:
+            return
+        mcp_manager = getattr(app.state, "mcp_manager", None)
+        if not mcp_manager or not mcp_manager.has_server("paperless"):
+            logger.info("Paperless MCP not configured — audit disabled")
+            return
+
+        from ha_glue.api.routes.paperless_audit import router as audit_router
+        from ha_glue.services.paperless_audit_service import PaperlessAuditService
+        from services.database import AsyncSessionLocal
+
+        app.include_router(audit_router)
+        audit_service = PaperlessAuditService(
+            mcp_manager=mcp_manager, db_factory=AsyncSessionLocal
+        )
+        app.state.paperless_audit = audit_service
+        await audit_service.start()
+        logger.info("✅ Paperless Audit: routes mounted + service started (platform-core)")
+    except Exception:  # noqa: BLE001 — never break startup on the audit mount
+        logger.opt(exception=True).warning("Paperless audit init failed")
+
+
 @asynccontextmanager
 async def lifespan(app: "FastAPI"):
     """
@@ -1329,6 +1368,11 @@ async def lifespan(app: "FastAPI"):
     from utils.hooks import run_hooks
     await run_hooks("startup", app=app)
     await run_hooks("register_routes", app=app)
+
+    # Paperless audit — mounted from platform core (not the ha_glue plugin) so it
+    # works on HA-less instances too. Runs after register_routes so it's the single
+    # mount owner regardless of whether ha_glue is loaded.
+    await _init_paperless_audit(app)
 
     yield
 

--- a/src/backend/ha_glue/bootstrap.py
+++ b/src/backend/ha_glue/bootstrap.py
@@ -164,12 +164,9 @@ async def ha_glue_on_startup(*, app: Any) -> None:
         )
 
     # --- Paperless audit ---
-    try:
-        await _init_paperless_audit(app)
-    except Exception:  # noqa: BLE001
-        logger.opt(exception=True).warning(
-            "ha_glue.bootstrap: paperless audit init failed"
-        )
+    # Moved to platform core (api/lifecycle.py::_init_paperless_audit) so it works on
+    # HA-less instances (business/xidra) that never load this plugin. Mounting it here
+    # would double-include on HA deploys.
 
     # --- HA keyword preload (background) ---
     try:
@@ -251,39 +248,6 @@ async def _init_zeroconf(app: Any) -> None:
     await zeroconf_service.start()
     app.state.zeroconf_service = zeroconf_service
     logger.info("✅ Zeroconf Service bereit")
-
-
-async def _init_paperless_audit(app: Any) -> None:
-    """Dynamically provision Paperless audit if MCP server is available.
-
-    Routes, service, and imports only happen inside this function. If
-    Paperless MCP is not configured, nothing is imported, no routes
-    exist. Stores the running service on `app.state.paperless_audit`
-    so the platform shutdown path can stop it.
-    """
-    from ha_glue.utils.config import ha_glue_settings
-
-    if not ha_glue_settings.paperless_audit_enabled:
-        return
-
-    mcp_manager = getattr(app.state, "mcp_manager", None)
-    if not mcp_manager or not mcp_manager.has_server("paperless"):
-        logger.info("Paperless MCP not configured — audit disabled")
-        return
-
-    from ha_glue.api.routes.paperless_audit import router as audit_router
-    from services.database import AsyncSessionLocal
-    from ha_glue.services.paperless_audit_service import PaperlessAuditService
-
-    app.include_router(audit_router)
-
-    audit_service = PaperlessAuditService(
-        mcp_manager=mcp_manager,
-        db_factory=AsyncSessionLocal,
-    )
-    app.state.paperless_audit = audit_service
-    await audit_service.start()
-    logger.info("Paperless Audit: Routes mounted, service started")
 
 
 def _schedule_ha_keywords_preload() -> None:
@@ -650,14 +614,9 @@ async def ha_glue_register_routes(*, app: Any) -> None:
         )
 
     # --- Paperless audit REST router ---
-    try:
-        from ha_glue.api.routes.paperless_audit import router as paperless_router
-        app.include_router(paperless_router)
-        logger.info("✅ ha_glue: mounted paperless_audit router")
-    except Exception:  # noqa: BLE001
-        logger.opt(exception=True).warning(
-            "ha_glue.bootstrap: paperless_audit router mount failed"
-        )
+    # Mounted from platform core (api/lifecycle.py::_init_paperless_audit), NOT here —
+    # the audit needs no Home Assistant, so it must reach HA-less deploys too. This
+    # plugin is the single-owner no more; mounting here would double-include.
 
     # --- Device WebSocket (/ws/device) — satellites + Renfield web panels ---
     try:

--- a/tests/backend/test_lifecycle_scheduler.py
+++ b/tests/backend/test_lifecycle_scheduler.py
@@ -114,3 +114,64 @@ async def test_cancel_during_boot_run_terminates_cleanly():
         pass
     assert task.done()
 
+
+
+# --- Platform-core Paperless audit mount (decoupled from the ha_glue plugin) ---
+# The audit REST router is mounted here, not inside the HA-only ha_glue plugin, so
+# it reaches HA-less deploys (business/xidra) instead of 404'ing.
+
+from unittest.mock import MagicMock  # noqa: E402
+
+
+async def test_init_paperless_audit_mounts_when_enabled(monkeypatch):
+    """Flag on + Paperless MCP present → router mounted + service started."""
+    from ha_glue.utils.config import ha_glue_settings
+
+    monkeypatch.setattr(ha_glue_settings, "paperless_audit_enabled", True)
+
+    started = {}
+
+    class _FakeService:
+        def __init__(self, **_kw):
+            started["init"] = True
+
+        async def start(self):
+            started["start"] = True
+
+    monkeypatch.setattr(
+        "ha_glue.services.paperless_audit_service.PaperlessAuditService", _FakeService
+    )
+
+    app = MagicMock()
+    app.state.mcp_manager = MagicMock()
+    app.state.mcp_manager.has_server = MagicMock(return_value=True)
+
+    await lifecycle._init_paperless_audit(app)
+
+    app.include_router.assert_called_once()
+    assert isinstance(app.state.paperless_audit, _FakeService)
+    assert started == {"init": True, "start": True}
+
+
+async def test_init_paperless_audit_noop_when_disabled(monkeypatch):
+    from ha_glue.utils.config import ha_glue_settings
+
+    monkeypatch.setattr(ha_glue_settings, "paperless_audit_enabled", False)
+    app = MagicMock()
+
+    await lifecycle._init_paperless_audit(app)
+
+    app.include_router.assert_not_called()
+
+
+async def test_init_paperless_audit_noop_without_paperless_mcp(monkeypatch):
+    from ha_glue.utils.config import ha_glue_settings
+
+    monkeypatch.setattr(ha_glue_settings, "paperless_audit_enabled", True)
+    app = MagicMock()
+    app.state.mcp_manager = MagicMock()
+    app.state.mcp_manager.has_server = MagicMock(return_value=False)
+
+    await lifecycle._init_paperless_audit(app)
+
+    app.include_router.assert_not_called()


### PR DESCRIPTION
**Bug:** Starting the Paperless audit on a business/HA-less instance (xidra) 404s.

**Root cause:** the audit REST router lives under `ha_glue/` and was mounted only by
the ha_glue **plugin**. HA-less deploys never load ha_glue (no Home Assistant), so
every ha_glue route — including paperless-audit, which needs no HA — 404s by design
(`ha_glue_register_routes` docstring: "Pro deploys … cleanly return 404").

**Fix:** move the mount to platform core so it reaches any instance with the Paperless
MCP + `PAPERLESS_AUDIT_ENABLED`, independent of ha_glue:
- `api/lifecycle.py::_init_paperless_audit` mounts the router + starts the service after
  the `register_routes` hook (single mount owner).
- `ha_glue/bootstrap.py`: removed the ha_glue-side mount (def + call + unconditional
  router include) so HA deploys don't double-mount. Audit code stays under `ha_glue/`;
  only the mount moved.

Household unchanged in effect (ha_glue still loaded; audit now mounts via platform core,
flag already `true`). The xidra `PAPERLESS_AUDIT_ENABLED=true` flag lives in the private
(gitignored) xidra configmap, applied to the cluster out-of-band.

Tests: 112 passed on .159, incl. 3 new mount tests. `import ha_glue.bootstrap` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)