### PR TITLE
chore: activate MCP self-detection on household (flag flip)

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -151,6 +151,11 @@ data:
   SUPPORTED_LANGUAGES: "de,en,it"
   AGENT_ENABLED: "true"
   MCP_ENABLED: "true"
+  # MCP self-detection (Phase 1): surface MCP failures renfield already detects
+  # (Plane-A get_status() degrade/down + Plane-B ingest-MCP OPERATOR-NOTIFY pushes)
+  # as ONE deduped proactive admin alert + an internal.system_health entry, instead
+  # of dead-ending in logs. Needs PROACTIVE_ENABLED (on here) for the push.
+  MCP_HEALTH_MONITOR_ENABLED: "true"
   MEMORY_ENABLED: "true"
   MEMORY_EXTRACTION_ENABLED: "true"
   KNOWLEDGE_GRAPH_ENABLED: "true"


### PR DESCRIPTION
Flips `MCP_HEALTH_MONITOR_ENABLED=true` in the household `renfield-env` ConfigMap.
`PROACTIVE_ENABLED` is already true here, so this activates the full detect→alert
loop shipped dark in #1048.

xidra is activated separately via its private (gitignored) ConfigMap (both
`MCP_HEALTH_MONITOR_ENABLED` + `PROACTIVE_ENABLED` per operator decision).

Backend image `2026-07-25-mcp-health` (carrying the #1048 code) is already rolled
out to both namespaces; this is the config-only flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)