### PR TITLE
fix(mcp-health): accept either ingest token (folder OR email) on /report

### DIFF
--- a/src/backend/api/routes/mcp_health.py
+++ b/src/backend/api/routes/mcp_health.py
@@ -14,10 +14,20 @@ from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from services.database import get_db
+from services.email_ingest import verify_email_ingest_token
 from services.folder_ingest import verify_folder_ingest_token
 from services.mcp_health_monitor import ingest_report
 
 router = APIRouter()
+
+
+async def _verify_any_ingest_token(db: AsyncSession, token: str) -> bool:
+    """A health report is not a data path — the token only proves the caller is a
+    legit renfield ingest MCP. Accept EITHER provisioned ingest token so the
+    filesystem MCP (folder token) AND the email-ingest MCP (email token) can report."""
+    return await verify_folder_ingest_token(db, token) or await verify_email_ingest_token(
+        db, token
+    )
 
 
 @router.post("/report")
@@ -27,12 +37,13 @@ async def report_mcp_health(
     db: AsyncSession = Depends(get_db),
 ):
     """Record an ingest MCP's OPERATOR-NOTIFY (``{source, event, reason, root?}``) →
-    surface + proactively alert. Bearer-auth (folder-ingest token). Never raises into
-    the MCP's notify path beyond the auth gate — a malformed body is just ignored."""
+    surface + proactively alert. Bearer-auth (any provisioned ingest token — folder
+    or email). Never raises into the MCP's notify path beyond the auth gate — a
+    malformed body is just ignored."""
     if not authorization or not authorization.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
     token = authorization.removeprefix("Bearer ").strip()
-    if not await verify_folder_ingest_token(db, token):
+    if not await _verify_any_ingest_token(db, token):
         raise HTTPException(status_code=403, detail="Invalid token")
     try:
         await ingest_report(payload if isinstance(payload, dict) else {})


### PR DESCRIPTION
Follow-up to #1048. The `/api/mcp-health/report` endpoint verified only the
folder-ingest token, but the **email-ingest MCP holds the email ingest token** —
its `OPERATOR-NOTIFY` pushes would 403. A health report is not a data path; the
token only proves the caller is a legit renfield ingest MCP. Accept either
provisioned ingest token (`verify_folder_ingest_token` OR `verify_email_ingest_token`).

Needed to wire the xidra email-ingest MCP's `EMAIL_NOTIFY_WEBHOOK_URL` at the
health endpoint. Requires a backend rebuild before the email-ingest webhook works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)