### PR TITLE
feat(paperless-audit): review overlay — per-field apply selection + manual edits (backend, PR1/2)

### DIFF
--- a/src/backend/alembic/versions/pc20260726_audit_review.py
+++ b/src/backend/alembic/versions/pc20260726_audit_review.py
@@ -1,0 +1,50 @@
+"""paperless_audit_results: user review overlay (manual edits + field selection)
+
+Revision ID: pc20260726_audit_review
+Revises: pc20260722d_fingerprint_person_name
+Create Date: 2026-07-26
+
+Two additive nullable JSON columns on ``paperless_audit_results`` backing the
+audit-flow review overlay:
+  - ``user_overrides``  {field: edited_value} — manual edits to the suggested_*
+    values (kept separate from suggested_* so the LLM proposal stays as
+    provenance and "reset to suggestion" is trivial).
+  - ``field_selection`` [field, ...] — which fields to apply; NULL = all changed
+    (legacy behavior, byte-identical when no review was made).
+
+Idempotent + inspector-guarded (``Base.metadata.create_all`` adds the columns on
+a fresh install, so upgrade guards against them already existing). Fully
+transactional.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "pc20260726_audit_review"
+down_revision = "pc20260722d_fingerprint_person_name"
+branch_labels = None
+depends_on = None
+
+_TABLE = "paperless_audit_results"
+_COLUMNS = ("user_overrides", "field_selection")
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if _TABLE not in inspector.get_table_names():
+        return  # fresh install without the table yet; create_all owns it
+    cols = {c["name"] for c in inspector.get_columns(_TABLE)}
+    for name in _COLUMNS:
+        if name not in cols:
+            op.add_column(_TABLE, sa.Column(name, sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if _TABLE not in inspector.get_table_names():
+        return
+    cols = {c["name"] for c in inspector.get_columns(_TABLE)}
+    for name in _COLUMNS:
+        if name in cols:
+            op.drop_column(_TABLE, name)

--- a/src/backend/ha_glue/api/routes/paperless_audit.py
+++ b/src/backend/ha_glue/api/routes/paperless_audit.py
@@ -6,6 +6,7 @@ Paperless MCP server is configured. See lifecycle.py.
 """
 
 import logging
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
@@ -34,6 +35,14 @@ class ApplyRequest(BaseModel):
 
 class SkipRequest(BaseModel):
     result_ids: list[int]
+
+
+class ReviewRequest(BaseModel):
+    """Manual review overlay for one audit result. Each field REPLACES the stored
+    value; omit (None) to leave that overlay untouched. Field names/types are
+    validated server-side against PaperlessAuditService.EDITABLE_FIELDS."""
+    overrides: dict[str, Any] | None = None
+    field_selection: list[str] | None = None
 
 
 class ReOcrRequest(BaseModel):
@@ -137,6 +146,33 @@ async def get_result(result_id: int, request: Request, _user: User = Depends(req
     service = _get_service(request)
     result = await service.get_result_by_id(result_id)
     if not result:
+        raise HTTPException(status_code=404, detail="Result not found")
+    return result
+
+
+@router.patch("/results/{result_id}")
+async def update_review(
+    result_id: int,
+    body: ReviewRequest,
+    request: Request,
+    _user: User = Depends(require_permission(Permission.ADMIN)),
+):
+    """Persist a manual review: edited values + per-field apply selection.
+
+    Apply (`POST /apply`) reads the persisted overlay off the row, so no payload
+    threading is needed there. Returns the updated result; 400 on invalid
+    field/type, 404 if the result id is unknown.
+    """
+    service = _get_service(request)
+    try:
+        result = await service.update_review(
+            result_id,
+            overrides=body.overrides,
+            field_selection=body.field_selection,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    if result is None:
         raise HTTPException(status_code=404, detail="Result not found")
     return result
 

--- a/src/backend/ha_glue/models/database.py
+++ b/src/backend/ha_glue/models/database.py
@@ -542,6 +542,13 @@ class PaperlessAuditResult(Base):
 
     status = Column(String, default="pending")
 
+    # User review overlay: manual edits to the suggested values + a per-field
+    # apply selection. Both NULL = no review → apply uses ALL suggested_* changes
+    # (legacy behavior, byte-identical). See PaperlessAuditService.EDITABLE_FIELDS
+    # for the canonical field names used as keys/entries here.
+    user_overrides = Column(JSON, nullable=True)   # {field: edited_value}
+    field_selection = Column(JSON, nullable=True)  # [field, ...] to apply; NULL = all changed
+
     renfield_ocr_text = Column(Text, nullable=True)
 
     audited_at = Column(DateTime, default=_utcnow)

--- a/src/backend/ha_glue/services/paperless_audit_service.py
+++ b/src/backend/ha_glue/services/paperless_audit_service.py
@@ -562,6 +562,125 @@ class PaperlessAuditService:
             "tags": await _fetch_taxonomy_names(self._mcp, "tag"),
         }
 
+    # Canonical field names for the review overlay (user_overrides keys /
+    # field_selection entries). "date" maps to the MCP `created_date` param in
+    # _apply_fix; the rest match the suggested_*/current_* column stems.
+    EDITABLE_FIELDS = (
+        "title", "correspondent", "document_type", "tags",
+        "date", "storage_path", "custom_fields",
+    )
+
+    def _validate_overrides(self, overrides: dict) -> dict:
+        """Validate a manual-edit map against EDITABLE_FIELDS + per-field types.
+        A None value drops that field's override. Empty values are REJECTED (not
+        silently accepted): _apply_fix's truthiness gate would skip them, so a
+        blank edit would look saved but never apply — clearing a field is not
+        supported here. Raises ValueError on bad input (→ 400 at the route)."""
+        import datetime as _dt
+
+        if not isinstance(overrides, dict):
+            raise ValueError("overrides must be an object")
+        clean: dict = {}
+        for k, v in overrides.items():
+            if k not in self.EDITABLE_FIELDS:
+                raise ValueError(f"unknown field: {k!r}")
+            if v is None:
+                continue  # explicit drop of this override
+            if k == "tags":
+                if not (isinstance(v, list) and v and all(isinstance(t, str) and t.strip() for t in v)):
+                    raise ValueError("tags override must be a non-empty list of non-empty strings")
+            elif k == "custom_fields":
+                # Shape (field ids / values) is authoritative on the Paperless side;
+                # we only guard the outer type + non-emptiness here.
+                if not isinstance(v, dict) or not v:
+                    raise ValueError("custom_fields override must be a non-empty object")
+            elif k == "date":
+                if not isinstance(v, str):
+                    raise ValueError("date override must be a string")
+                try:
+                    _dt.date.fromisoformat(v)
+                except ValueError:
+                    raise ValueError("date override must be an ISO date (YYYY-MM-DD)")
+            elif not isinstance(v, str) or not v.strip():
+                raise ValueError(f"{k} override must be a non-empty string")
+            clean[k] = v
+        return clean
+
+    def _validate_selection(self, selection: list) -> list:
+        """Validate the apply-selection against EDITABLE_FIELDS; dedupe, keep order."""
+        if not isinstance(selection, list):
+            raise ValueError("field_selection must be a list")
+        seen: set = set()
+        out: list = []
+        for f in selection:
+            if f not in self.EDITABLE_FIELDS:
+                raise ValueError(f"unknown field: {f!r}")
+            if f not in seen:
+                seen.add(f)
+                out.append(f)
+        return out
+
+    async def update_review(
+        self,
+        result_id: int,
+        overrides: dict | None = None,
+        field_selection: list | None = None,
+    ) -> dict | None:
+        """Persist a manual review overlay: edited values (``overrides``) and/or
+        the subset of fields to apply (``field_selection``). Each param REPLACES
+        the whole stored value (not a merge); pass None to leave that overlay
+        untouched. Validates against EDITABLE_FIELDS + per-field types (raises
+        ValueError). Returns the updated result dict, or None if the id is unknown
+        (→ 404 at the route). Status is left as-is (apply reads the overlay later).
+        """
+        from models.database import PaperlessAuditResult
+
+        if overrides is not None:
+            overrides = self._validate_overrides(overrides)
+        if field_selection is not None:
+            field_selection = self._validate_selection(field_selection)
+
+        async with self._db_factory() as db:
+            stmt = select(PaperlessAuditResult).where(
+                PaperlessAuditResult.id == result_id
+            )
+            row = (await db.execute(stmt)).scalar_one_or_none()
+            if row is None:
+                return None
+            if overrides is not None:
+                row.user_overrides = overrides or None  # {} → NULL (no overlay)
+            if field_selection is not None:
+                # [] is meaningful (apply nothing); only None means "leave as-is".
+                row.field_selection = field_selection
+            # A manual review RE-OPENS the row for apply: editing an already
+            # applied/skipped/failed row must take effect on the next apply
+            # (apply_results only processes 'pending' rows). Reset so the edit
+            # isn't silently a no-op.
+            if overrides is not None or field_selection is not None:
+                row.status = "pending"
+                row.applied_at = None
+            await db.commit()
+            await db.refresh(row)
+            return self._result_to_dict(row)
+
+    async def _persist_status(self, result_id: int, status: str) -> None:
+        """Set a terminal status on a result row (and applied_at for 'applied')."""
+        from models.database import PaperlessAuditResult
+
+        async with self._db_factory() as db:
+            row = (
+                await db.execute(
+                    select(PaperlessAuditResult).where(
+                        PaperlessAuditResult.id == result_id
+                    )
+                )
+            ).scalar_one_or_none()
+            if row:
+                row.status = status
+                if status == "applied":
+                    row.applied_at = datetime.now(UTC).replace(tzinfo=None)
+                await db.commit()
+
     async def _apply_fix(self, result, taxonomy: dict | None = None) -> bool:
         """Apply suggested fix via MCP update_document tool.
 
@@ -586,24 +705,44 @@ class PaperlessAuditService:
         params = {"document_id": result.paperless_doc_id}
         has_changes = False
 
-        if result.suggested_title and result.suggested_title != result.current_title:
-            params["title"] = result.suggested_title
+        # Review overlay. ``user_overrides`` replaces the LLM suggestion per field
+        # (manual edit); ``field_selection`` limits which fields apply (None = all
+        # changed, the legacy path). Effective value = override if the user edited
+        # that field, else the suggested_* value. isinstance-guards keep the legacy
+        # path byte-identical when the columns are NULL (and tolerate mock rows).
+        overrides = result.user_overrides if isinstance(result.user_overrides, dict) else {}
+        selection = result.field_selection if isinstance(result.field_selection, list) else None
+
+        def _eff(field, suggested):
+            return overrides[field] if field in overrides else suggested
+
+        def _sel(field):
+            # A manual override IS an explicit intent to apply that field, so it
+            # always applies (never silently dropped by field_selection). Otherwise
+            # field_selection decides (None = all changed, the legacy path).
+            return field in overrides or selection is None or field in selection
+
+        title = _eff("title", result.suggested_title)
+        if _sel("title") and title and title != result.current_title:
+            params["title"] = title
             has_changes = True
         # raise_on_error=True so a transient taxonomy read / create FAILURE is
         # distinguishable from a legitimate guardrail-skip (None): on failure we
         # abort this pass and leave the row pending for a clean retry, instead of
         # dropping the fix silently and reporting it as applied.
         try:
-            if result.suggested_correspondent and result.suggested_correspondent != result.current_correspondent:
+            corr_val = _eff("correspondent", result.suggested_correspondent)
+            if _sel("correspondent") and corr_val and corr_val != result.current_correspondent:
                 corr = await resolve_or_create_correspondent(
-                    self._mcp, result.suggested_correspondent,
+                    self._mcp, corr_val,
                     names=tax.get("correspondents"), raise_on_error=True,
                 )
                 if corr:  # None = a fuzzy-near match exists → guardrail, leave unset
                     params["correspondent"] = corr
                     has_changes = True
-            if result.suggested_document_type and result.suggested_document_type != result.current_document_type:
-                dt = result.suggested_document_type
+            dt_val = _eff("document_type", result.suggested_document_type)
+            if _sel("document_type") and dt_val and dt_val != result.current_document_type:
+                dt = dt_val
                 if settings.paperless_autocreate_document_type:
                     # None on a fuzzy-near guardrail hit → skip (same as correspondent),
                     # rather than force the raw suggestion and risk a near-duplicate type.
@@ -614,8 +753,9 @@ class PaperlessAuditService:
                 if dt:
                     params["document_type"] = dt
                     has_changes = True
-            if result.suggested_tags and result.suggested_tags != result.current_tags:
-                tags = result.suggested_tags
+            tags_val = _eff("tags", result.suggested_tags)
+            if _sel("tags") and tags_val and tags_val != result.current_tags:
+                tags = tags_val
                 if settings.paperless_autocreate_tags:
                     resolved = [
                         await resolve_or_create_taxonomy(
@@ -633,17 +773,28 @@ class PaperlessAuditService:
                 f"({e}) — leaving pending for retry, not reporting as applied"
             )
             return False
-        if result.suggested_date and result.suggested_date != result.current_date:
-            params["created_date"] = result.suggested_date
+        date_val = _eff("date", result.suggested_date)
+        if _sel("date") and date_val and date_val != result.current_date:
+            params["created_date"] = date_val
             has_changes = True
-        if result.suggested_storage_path and result.suggested_storage_path != result.current_storage_path:
-            params["storage_path"] = result.suggested_storage_path
+        # storage_path: a manual override is applied as-is (trusted admin input),
+        # unlike an LLM suggestion which _analyze_document guards against the valid
+        # -paths list. A non-existent path is rejected by Paperless → row 'failed'.
+        sp_val = _eff("storage_path", result.suggested_storage_path)
+        if _sel("storage_path") and sp_val and sp_val != result.current_storage_path:
+            params["storage_path"] = sp_val
             has_changes = True
-        if result.suggested_custom_fields:
-            params["custom_fields"] = result.suggested_custom_fields
+        cf_val = _eff("custom_fields", result.suggested_custom_fields)
+        if _sel("custom_fields") and cf_val:
+            params["custom_fields"] = cf_val
             has_changes = True
 
         if not has_changes:
+            # Nothing to write (e.g. field_selection deselected every change, or an
+            # override equals the current value). Still mark the row processed so it
+            # does not reappear as pending and get re-counted "applied" on every
+            # subsequent apply (the deselect-all stuck-row bug).
+            await self._persist_status(result.id, "applied")
             return True
 
         mcp_result = await self._mcp.execute_tool("mcp.paperless.update_document", params)
@@ -673,11 +824,19 @@ class PaperlessAuditService:
         applied = 0
         failed = 0
 
+        from sqlalchemy import or_
+
         async with self._db_factory() as db:
             stmt = select(PaperlessAuditResult).where(
                 PaperlessAuditResult.id.in_(result_ids),
                 PaperlessAuditResult.status == "pending",
-                PaperlessAuditResult.changes_needed.is_(True),
+                # changes_needed OR a manual edit: a user override makes a row
+                # applicable even when the LLM flagged no change (they chose to
+                # fix it by hand).
+                or_(
+                    PaperlessAuditResult.changes_needed.is_(True),
+                    PaperlessAuditResult.user_overrides.isnot(None),
+                ),
             )
             results = (await db.execute(stmt)).scalars().all()
 
@@ -1689,6 +1848,8 @@ class PaperlessAuditService:
             "changes_needed": r.changes_needed,
             "reasoning": r.reasoning,
             "status": r.status,
+            "user_overrides": r.user_overrides,
+            "field_selection": r.field_selection,
             "audited_at": r.audited_at.isoformat() if r.audited_at else None,
             "applied_at": r.applied_at.isoformat() if r.applied_at else None,
             "audit_run_id": r.audit_run_id,

--- a/tests/backend/test_paperless_audit.py
+++ b/tests/backend/test_paperless_audit.py
@@ -961,8 +961,9 @@ class TestApplyFix:
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_apply_fix_no_changes(self, service, mock_mcp_manager):
-        """Should skip MCP call when all suggested values match current."""
+    async def test_apply_fix_no_changes(self, service, mock_mcp_manager, mock_db_factory):
+        """Should skip MCP call when all suggested values match current (the row is
+        still marked processed via _persist_status so it can't loop as pending)."""
         mock_result = MagicMock()
         mock_result.id = 1
         mock_result.paperless_doc_id = 42
@@ -979,6 +980,9 @@ class TestApplyFix:
         mock_result.current_storage_path = "path/a"
         mock_result.suggested_storage_path = "path/a"
         mock_result.suggested_custom_fields = None
+        mock_db_factory._mock_session.execute.return_value = MagicMock(
+            scalar_one_or_none=MagicMock(return_value=MagicMock())
+        )
 
         result = await service._apply_fix(mock_result)
 
@@ -987,8 +991,8 @@ class TestApplyFix:
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_apply_fix_none_suggested(self, service, mock_mcp_manager):
-        """Should skip when suggested values are None."""
+    async def test_apply_fix_none_suggested(self, service, mock_mcp_manager, mock_db_factory):
+        """Should skip when suggested values are None (row still marked processed)."""
         mock_result = MagicMock()
         mock_result.id = 1
         mock_result.paperless_doc_id = 42
@@ -1005,6 +1009,9 @@ class TestApplyFix:
         mock_result.current_storage_path = "path"
         mock_result.suggested_storage_path = None
         mock_result.suggested_custom_fields = None
+        mock_db_factory._mock_session.execute.return_value = MagicMock(
+            scalar_one_or_none=MagicMock(return_value=MagicMock())
+        )
 
         result = await service._apply_fix(mock_result)
 
@@ -1274,6 +1281,228 @@ class TestRunAudit:
 # ============================================================================
 # Apply/Skip/Reprocess Operations
 # ============================================================================
+
+
+class TestReviewOverlay:
+    """The manual-review overlay: user_overrides (edited values) + field_selection
+    (per-field apply subset), plus its validation. Exercises _apply_fix's overlay
+    handling and update_review persistence."""
+
+    @staticmethod
+    def _base_result():
+        """A result with title AND date changed, no overlay (legacy defaults)."""
+        r = MagicMock()
+        r.id = 1
+        r.paperless_doc_id = 42
+        r.current_title = "Old"
+        r.suggested_title = "New"
+        r.current_correspondent = None
+        r.suggested_correspondent = None
+        r.current_document_type = None
+        r.suggested_document_type = None
+        r.current_tags = None
+        r.suggested_tags = None
+        r.current_date = "2024-01-01"
+        r.suggested_date = "2024-02-02"
+        r.current_storage_path = None
+        r.suggested_storage_path = None
+        r.suggested_custom_fields = None
+        r.user_overrides = None
+        r.field_selection = None
+        return r
+
+    @staticmethod
+    def _wire_status_db(mock_db_factory):
+        """Wire the post-apply status-update lookup to a truthy row."""
+        s = mock_db_factory._mock_session
+        s.execute.return_value = MagicMock(
+            scalar_one_or_none=MagicMock(return_value=MagicMock())
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_override_replaces_suggested_value(self, service, mock_mcp_manager, mock_db_factory):
+        """A manual edit (user_overrides) is applied instead of the LLM suggestion."""
+        r = self._base_result()
+        r.user_overrides = {"title": "Hand Edited"}
+        self._wire_status_db(mock_db_factory)
+        assert await service._apply_fix(r) is True
+        params = mock_mcp_manager.execute_tool.call_args[0][1]
+        assert params["title"] == "Hand Edited"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_field_selection_limits_applied_fields(self, service, mock_mcp_manager, mock_db_factory):
+        """Only fields in field_selection are applied; other changed fields skip."""
+        r = self._base_result()  # title AND date both changed
+        r.field_selection = ["title"]
+        self._wire_status_db(mock_db_factory)
+        assert await service._apply_fix(r) is True
+        params = mock_mcp_manager.execute_tool.call_args[0][1]
+        assert params["title"] == "New"
+        assert "created_date" not in params  # date changed but not selected
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_override_applies_when_llm_flagged_no_change(self, service, mock_mcp_manager, mock_db_factory):
+        """A manual edit on a field the LLM did NOT change (suggested == current) is
+        still applied — the whole point of manual adjustment."""
+        r = self._base_result()
+        r.suggested_title = "Old"       # LLM: no title change
+        r.suggested_date = "2024-01-01"  # LLM: no date change
+        r.user_overrides = {"title": "Manually Set"}
+        self._wire_status_db(mock_db_factory)
+        assert await service._apply_fix(r) is True
+        params = mock_mcp_manager.execute_tool.call_args[0][1]
+        assert params["title"] == "Manually Set"
+        assert "created_date" not in params
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_none_overlay_is_legacy_behavior(self, service, mock_mcp_manager, mock_db_factory):
+        """Explicit None overlay → identical to the pre-feature apply (all changed)."""
+        r = self._base_result()
+        self._wire_status_db(mock_db_factory)
+        assert await service._apply_fix(r) is True
+        params = mock_mcp_manager.execute_tool.call_args[0][1]
+        assert params["title"] == "New"
+        assert params["created_date"] == "2024-02-02"
+
+    # --- validation ---
+
+    @pytest.mark.unit
+    def test_validate_overrides_accepts_known_fields(self, service):
+        out = service._validate_overrides({"title": "X", "tags": ["a"], "custom_fields": {"k": "v"}})
+        assert out == {"title": "X", "tags": ["a"], "custom_fields": {"k": "v"}}
+
+    @pytest.mark.unit
+    def test_validate_overrides_rejects_unknown_field(self, service):
+        with pytest.raises(ValueError):
+            service._validate_overrides({"nope": "x"})
+
+    @pytest.mark.unit
+    def test_validate_overrides_rejects_bad_types(self, service):
+        with pytest.raises(ValueError):
+            service._validate_overrides({"tags": "notalist"})
+        with pytest.raises(ValueError):
+            service._validate_overrides({"custom_fields": ["notadict"]})
+        with pytest.raises(ValueError):
+            service._validate_overrides({"title": 123})
+
+    @pytest.mark.unit
+    def test_validate_overrides_drops_none_value(self, service):
+        assert service._validate_overrides({"title": None}) == {}
+
+    @pytest.mark.unit
+    def test_validate_selection_dedupes_and_validates(self, service):
+        assert service._validate_selection(["title", "title", "tags"]) == ["title", "tags"]
+        with pytest.raises(ValueError):
+            service._validate_selection(["bogus"])
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_update_review_persists_overlay(self, service, mock_db_factory):
+        """update_review writes the validated overlay onto the row and commits."""
+        row = MagicMock()
+        s = mock_db_factory._mock_session
+        s.execute.return_value = MagicMock(scalar_one_or_none=MagicMock(return_value=row))
+        out = await service.update_review(1, overrides={"title": "Z"}, field_selection=["title"])
+        assert row.user_overrides == {"title": "Z"}
+        assert row.field_selection == ["title"]
+        s.commit.assert_awaited()
+        assert out is not None  # serialized row
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_update_review_unknown_id_returns_none(self, service, mock_db_factory):
+        s = mock_db_factory._mock_session
+        s.execute.return_value = MagicMock(scalar_one_or_none=MagicMock(return_value=None))
+        assert await service.update_review(999, overrides={"title": "Z"}) is None
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_update_review_empty_overrides_stored_as_none(self, service, mock_db_factory):
+        row = MagicMock()
+        s = mock_db_factory._mock_session
+        s.execute.return_value = MagicMock(scalar_one_or_none=MagicMock(return_value=row))
+        await service.update_review(1, overrides={})
+        assert row.user_overrides is None
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_update_review_invalid_field_raises(self, service, mock_db_factory):
+        with pytest.raises(ValueError):
+            await service.update_review(1, overrides={"bogus": "x"})
+
+    # --- review-fix regressions (from /review) ---
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_override_outside_selection_still_applies(self, service, mock_mcp_manager, mock_db_factory):
+        """A manual edit applies even when field_selection omits that field — an
+        override is an explicit intent to apply and must never be silently dropped."""
+        r = self._base_result()
+        r.current_correspondent = "Old Corr"
+        r.field_selection = ["title"]                    # correspondent NOT selected
+        r.user_overrides = {"correspondent": "Finanzamt"}
+
+        async def _execute(tool, params, **_kw):
+            if tool == "mcp.paperless.list_correspondents":
+                return {"success": True, "message": json.dumps({"items": []})}
+            if tool == "mcp.paperless.create_correspondent":
+                return {"success": True, "message": json.dumps({"id": 1, "name": params["name"]})}
+            return {"success": True}
+
+        mock_mcp_manager.execute_tool.side_effect = _execute
+        self._wire_status_db(mock_db_factory)
+        assert await service._apply_fix(r) is True
+        params = mock_mcp_manager.execute_tool.call_args[0][1]  # last = update_document
+        assert params["correspondent"] == "Finanzamt"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_deselect_all_marks_processed_not_stuck(self, service, mock_mcp_manager, mock_db_factory):
+        """field_selection=[] → no params → row is marked 'applied' (not left
+        pending and re-counted applied on every subsequent apply)."""
+        r = self._base_result()  # title + date changed
+        r.field_selection = []
+        status_row = MagicMock()
+        s = mock_db_factory._mock_session
+        s.execute.return_value = MagicMock(scalar_one_or_none=MagicMock(return_value=status_row))
+        assert await service._apply_fix(r) is True
+        tools = [c[0][0] for c in mock_mcp_manager.execute_tool.call_args_list]
+        assert "mcp.paperless.update_document" not in tools  # nothing written
+        assert status_row.status == "applied"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_update_review_reopens_non_pending_row(self, service, mock_db_factory):
+        """Editing an already-applied row resets it to pending so the correction
+        takes effect on the next apply (apply only processes pending rows)."""
+        row = MagicMock()
+        row.status = "applied"
+        row.applied_at = "2024-01-01T00:00:00"
+        s = mock_db_factory._mock_session
+        s.execute.return_value = MagicMock(scalar_one_or_none=MagicMock(return_value=row))
+        await service.update_review(1, overrides={"title": "Fixed"})
+        assert row.status == "pending"
+        assert row.applied_at is None
+
+    @pytest.mark.unit
+    def test_validate_overrides_rejects_empty_values(self, service):
+        """Empty values are rejected at the boundary (would be a silent no-op in
+        _apply_fix's truthiness gate — clearing a field is not supported here)."""
+        for bad in [{"title": ""}, {"title": "   "}, {"tags": []},
+                    {"tags": [""]}, {"custom_fields": {}}, {"storage_path": ""}]:
+            with pytest.raises(ValueError):
+                service._validate_overrides(bad)
+
+    @pytest.mark.unit
+    def test_validate_overrides_date_must_be_iso(self, service):
+        assert service._validate_overrides({"date": "2024-02-14"}) == {"date": "2024-02-14"}
+        for bad in [{"date": "not-a-date"}, {"date": "14.02.2024"}, {"date": ""}]:
+            with pytest.raises(ValueError):
+                service._validate_overrides(bad)
 
 
 class TestApplyResults:

--- a/tests/backend/test_paperless_audit_routes.py
+++ b/tests/backend/test_paperless_audit_routes.py
@@ -1,0 +1,94 @@
+"""HTTP route tests for the Paperless-audit review-overlay endpoint.
+
+PATCH /api/admin/paperless-audit/results/{id} is ADMIN-gated; these cover the
+status-code contract (200 / 400 / 404) and the auth gate at the HTTP boundary.
+The service internals (update_review / _validate_*) are unit-tested in
+test_paperless_audit.py — here the service is mocked so we exercise only the
+route wiring, error mapping, and permission dependency.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from ha_glue.api.routes.paperless_audit import router
+from models.permissions import Permission
+from services.auth_service import get_current_user
+from services.database import get_db
+
+pytestmark = [pytest.mark.backend]
+
+_PATH = "/api/admin/paperless-audit/results/5"
+
+
+class _FakeUser:
+    """Avoids ORM lazy-load: exposes has_permission directly (mirrors the
+    tool-health route tests)."""
+
+    def __init__(self, is_admin: bool):
+        self.id = 1
+        self.username = "u"
+        self._admin = is_admin
+
+    def has_permission(self, perm: str) -> bool:
+        return self._admin and perm == Permission.ADMIN.value
+
+
+def _app(service, *, is_admin: bool, monkeypatch) -> FastAPI:
+    # auth_enabled must be True or require_permission short-circuits to allow.
+    monkeypatch.setattr("services.auth_service.settings.auth_enabled", True)
+    app = FastAPI()
+    app.include_router(router)
+    app.state.paperless_audit = service
+    app.dependency_overrides[get_current_user] = lambda: _FakeUser(is_admin)
+    app.dependency_overrides[get_db] = lambda: None  # unused by permission_checker
+    return app
+
+
+def _client(app: FastAPI) -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://t")
+
+
+@pytest.mark.asyncio
+async def test_patch_review_200_on_success(monkeypatch):
+    svc = AsyncMock()
+    svc.update_review.return_value = {"id": 5, "user_overrides": {"title": "X"}}
+    app = _app(svc, is_admin=True, monkeypatch=monkeypatch)
+    async with _client(app) as c:
+        r = await c.patch(_PATH, json={"overrides": {"title": "X"}, "field_selection": ["title"]})
+    assert r.status_code == 200
+    assert r.json()["id"] == 5
+    svc.update_review.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_patch_review_400_on_validation_error(monkeypatch):
+    svc = AsyncMock()
+    svc.update_review.side_effect = ValueError("unknown field: 'x'")
+    app = _app(svc, is_admin=True, monkeypatch=monkeypatch)
+    async with _client(app) as c:
+        r = await c.patch(_PATH, json={"overrides": {"x": "y"}})
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_patch_review_404_on_unknown_id(monkeypatch):
+    svc = AsyncMock()
+    svc.update_review.return_value = None
+    app = _app(svc, is_admin=True, monkeypatch=monkeypatch)
+    async with _client(app) as c:
+        r = await c.patch("/api/admin/paperless-audit/results/999", json={"field_selection": ["title"]})
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_patch_review_requires_admin(monkeypatch):
+    svc = AsyncMock()
+    app = _app(svc, is_admin=False, monkeypatch=monkeypatch)
+    async with _client(app) as c:
+        r = await c.patch(_PATH, json={"overrides": {"title": "X"}})
+    assert r.status_code in (401, 403)
+    svc.update_review.assert_not_awaited()


### PR DESCRIPTION
Backend (PR1 of 2) for two Paperless-audit capabilities requested by the operator; the frontend follows in PR2.

## What
1. **Apply only SELECTED metadata fields** per document (not all suggested changes at once) — `field_selection`.
2. **Manually edit the suggested values** before applying — `user_overrides`.

## Design
- **Persisted** (operator choice): additive nullable JSON columns `user_overrides {field: value}` + `field_selection [field, …]` on `paperless_audit_results` (migration `pc20260726_audit_review`, inspector-guarded, chains onto `pc20260722d`). Both NULL = legacy (apply all suggested_* changes), **byte-identical**.
- Overrides kept **separate** from `suggested_*` so the LLM proposal stays as provenance and reset-to-suggestion is trivial.
- New `PATCH /api/admin/paperless-audit/results/{id}` (ADMIN) → `update_review`, validated against `EDITABLE_FIELDS` + per-field types (400 bad input, 404 unknown id). **`POST /apply` is unchanged** — it reads the persisted overlay off the row.
- Canonical fields: title/correspondent/document_type/tags/date/storage_path/custom_fields (date→`created_date` at the MCP call).

## Review fixes (from workflow-backed /review, all 7 confirmed findings addressed)
- An override on a field outside `field_selection` no longer silently drops (override ⇒ applied).
- A deselect-all / no-op row is marked processed (was stuck `pending` + miscounted applied).
- Editing an already applied/skipped row re-opens it (`status=pending`) so the edit takes effect.
- Empty overrides rejected at the boundary (400) instead of a silent no-op.
- `date` override ISO-validated; `storage_path` admin-override asymmetry documented.
- HTTP route tests added (200/400/404 + ADMIN gate) — `test_paperless_audit_routes.py`.

## Tests
136 passed on `.159` (service overlay behavior, validation, `update_review` persistence/re-open, route contract). Migration DDL verified on real Postgres (add/drop, rolled back); alembic chain single-head.

Dark until PR2 wires the UI; behavior byte-identical when the columns are NULL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)