### PR TITLE
feat(paperless-audit): editable review UI — per-field selection + inline edits (frontend, PR2/2)

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -619,6 +619,12 @@ Die „Re-OCR"-Aktion läuft **nicht** mehr blind über Paperless' eigene OCR (d
 
 Tabs: Audit Control (Start/Status), Review Queue (Sortierung, Suche, Freigabe), OCR Issues (Re-OCR-Angebot), **Niedrige OCR-Qualität** (siehe unten), Vollständigkeit, Duplikate, Ansprechpartner, Statistics.
 
+### Editierbare Review-Queue (selektive + manuelle Freigabe)
+
+Die Review-Queue ist nicht mehr „alles-oder-nichts": jeder vorgeschlagene Wert ist ein **inline editierbares Feld** (Auto-Save beim Verlassen des Feldes), und pro geändertem Feld gibt es eine **Übernehmen-Checkbox** — so lässt sich pro Dokument auswählen, *welche* der vorgeschlagenen Änderungen angewendet werden, und ein Vorschlag vor der Freigabe von Hand korrigieren. Tags haben einen Chip-Editor (hinzufügen/entfernen), benutzerdefinierte Felder einen Key/Value-Editor in einer pro-Zeile ausklappbaren Lade.
+
+Das Review-Overlay wird **persistiert** — zwei additive JSON-Spalten auf `paperless_audit_results` (Migration `pc20260726_audit_review`): `user_overrides` (`{Feld: editierter Wert}`, getrennt von `suggested_*`, damit der LLM-Vorschlag als Provenance erhalten bleibt) und `field_selection` (anzuwendende Felder; beide `NULL` = Legacy „alle vorgeschlagenen Änderungen", byte-identisch). Neuer Endpunkt `PATCH /api/admin/paperless-audit/results/{id}` (ADMIN, validiert Feldnamen/Typen → 400/404); `POST /apply` bleibt unverändert und liest das persistierte Overlay von der Zeile. In `_apply_fix` ist der effektive Wert pro Feld = Override ?? Vorschlag, angewendet nur wenn ausgewählt **und** ≠ aktuell (ein manueller Override gilt immer, ein Feld auf den aktuellen Wert editiert ist ein No-op). Die Frontend-Freigabe (einzeln + Sammel) flusht ausstehende Feld-Speicherungen, bevor angewendet wird.
+
 ### Niedrige OCR-Qualität (Triage statt SQL)
 
 Eigener Tab, der Dokumente sichtbar macht, deren **Ingest** an der Qualität gescheitert ist — damit der Operator sie in der UI statt per SQL bearbeitet. Ein Dokument gilt als „niedrige OCR-Qualität", wenn **eines** zutrifft:

--- a/src/backend/alembic/versions/pc20260726_audit_review.py
+++ b/src/backend/alembic/versions/pc20260726_audit_review.py
@@ -1,0 +1,50 @@
+"""paperless_audit_results: user review overlay (manual edits + field selection)
+
+Revision ID: pc20260726_audit_review
+Revises: pc20260722d_fingerprint_person_name
+Create Date: 2026-07-26
+
+Two additive nullable JSON columns on ``paperless_audit_results`` backing the
+audit-flow review overlay:
+  - ``user_overrides``  {field: edited_value} — manual edits to the suggested_*
+    values (kept separate from suggested_* so the LLM proposal stays as
+    provenance and "reset to suggestion" is trivial).
+  - ``field_selection`` [field, ...] — which fields to apply; NULL = all changed
+    (legacy behavior, byte-identical when no review was made).
+
+Idempotent + inspector-guarded (``Base.metadata.create_all`` adds the columns on
+a fresh install, so upgrade guards against them already existing). Fully
+transactional.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "pc20260726_audit_review"
+down_revision = "pc20260722d_fingerprint_person_name"
+branch_labels = None
+depends_on = None
+
+_TABLE = "paperless_audit_results"
+_COLUMNS = ("user_overrides", "field_selection")
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if _TABLE not in inspector.get_table_names():
+        return  # fresh install without the table yet; create_all owns it
+    cols = {c["name"] for c in inspector.get_columns(_TABLE)}
+    for name in _COLUMNS:
+        if name not in cols:
+            op.add_column(_TABLE, sa.Column(name, sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if _TABLE not in inspector.get_table_names():
+        return
+    cols = {c["name"] for c in inspector.get_columns(_TABLE)}
+    for name in _COLUMNS:
+        if name in cols:
+            op.drop_column(_TABLE, name)

--- a/src/backend/ha_glue/api/routes/paperless_audit.py
+++ b/src/backend/ha_glue/api/routes/paperless_audit.py
@@ -6,6 +6,7 @@ Paperless MCP server is configured. See lifecycle.py.
 """
 
 import logging
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
@@ -34,6 +35,14 @@ class ApplyRequest(BaseModel):
 
 class SkipRequest(BaseModel):
     result_ids: list[int]
+
+
+class ReviewRequest(BaseModel):
+    """Manual review overlay for one audit result. Each field REPLACES the stored
+    value; omit (None) to leave that overlay untouched. Field names/types are
+    validated server-side against PaperlessAuditService.EDITABLE_FIELDS."""
+    overrides: dict[str, Any] | None = None
+    field_selection: list[str] | None = None
 
 
 class ReOcrRequest(BaseModel):
@@ -137,6 +146,33 @@ async def get_result(result_id: int, request: Request, _user: User = Depends(req
     service = _get_service(request)
     result = await service.get_result_by_id(result_id)
     if not result:
+        raise HTTPException(status_code=404, detail="Result not found")
+    return result
+
+
+@router.patch("/results/{result_id}")
+async def update_review(
+    result_id: int,
+    body: ReviewRequest,
+    request: Request,
+    _user: User = Depends(require_permission(Permission.ADMIN)),
+):
+    """Persist a manual review: edited values + per-field apply selection.
+
+    Apply (`POST /apply`) reads the persisted overlay off the row, so no payload
+    threading is needed there. Returns the updated result; 400 on invalid
+    field/type, 404 if the result id is unknown.
+    """
+    service = _get_service(request)
+    try:
+        result = await service.update_review(
+            result_id,
+            overrides=body.overrides,
+            field_selection=body.field_selection,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    if result is None:
         raise HTTPException(status_code=404, detail="Result not found")
     return result
 

--- a/src/backend/ha_glue/models/database.py
+++ b/src/backend/ha_glue/models/database.py
@@ -542,6 +542,13 @@ class PaperlessAuditResult(Base):
 
     status = Column(String, default="pending")
 
+    # User review overlay: manual edits to the suggested values + a per-field
+    # apply selection. Both NULL = no review → apply uses ALL suggested_* changes
+    # (legacy behavior, byte-identical). See PaperlessAuditService.EDITABLE_FIELDS
+    # for the canonical field names used as keys/entries here.
+    user_overrides = Column(JSON, nullable=True)   # {field: edited_value}
+    field_selection = Column(JSON, nullable=True)  # [field, ...] to apply; NULL = all changed
+
     renfield_ocr_text = Column(Text, nullable=True)
 
     audited_at = Column(DateTime, default=_utcnow)

--- a/src/backend/ha_glue/services/paperless_audit_service.py
+++ b/src/backend/ha_glue/services/paperless_audit_service.py
@@ -562,6 +562,125 @@ class PaperlessAuditService:
             "tags": await _fetch_taxonomy_names(self._mcp, "tag"),
         }
 
+    # Canonical field names for the review overlay (user_overrides keys /
+    # field_selection entries). "date" maps to the MCP `created_date` param in
+    # _apply_fix; the rest match the suggested_*/current_* column stems.
+    EDITABLE_FIELDS = (
+        "title", "correspondent", "document_type", "tags",
+        "date", "storage_path", "custom_fields",
+    )
+
+    def _validate_overrides(self, overrides: dict) -> dict:
+        """Validate a manual-edit map against EDITABLE_FIELDS + per-field types.
+        A None value drops that field's override. Empty values are REJECTED (not
+        silently accepted): _apply_fix's truthiness gate would skip them, so a
+        blank edit would look saved but never apply — clearing a field is not
+        supported here. Raises ValueError on bad input (→ 400 at the route)."""
+        import datetime as _dt
+
+        if not isinstance(overrides, dict):
+            raise ValueError("overrides must be an object")
+        clean: dict = {}
+        for k, v in overrides.items():
+            if k not in self.EDITABLE_FIELDS:
+                raise ValueError(f"unknown field: {k!r}")
+            if v is None:
+                continue  # explicit drop of this override
+            if k == "tags":
+                if not (isinstance(v, list) and v and all(isinstance(t, str) and t.strip() for t in v)):
+                    raise ValueError("tags override must be a non-empty list of non-empty strings")
+            elif k == "custom_fields":
+                # Shape (field ids / values) is authoritative on the Paperless side;
+                # we only guard the outer type + non-emptiness here.
+                if not isinstance(v, dict) or not v:
+                    raise ValueError("custom_fields override must be a non-empty object")
+            elif k == "date":
+                if not isinstance(v, str):
+                    raise ValueError("date override must be a string")
+                try:
+                    _dt.date.fromisoformat(v)
+                except ValueError:
+                    raise ValueError("date override must be an ISO date (YYYY-MM-DD)")
+            elif not isinstance(v, str) or not v.strip():
+                raise ValueError(f"{k} override must be a non-empty string")
+            clean[k] = v
+        return clean
+
+    def _validate_selection(self, selection: list) -> list:
+        """Validate the apply-selection against EDITABLE_FIELDS; dedupe, keep order."""
+        if not isinstance(selection, list):
+            raise ValueError("field_selection must be a list")
+        seen: set = set()
+        out: list = []
+        for f in selection:
+            if f not in self.EDITABLE_FIELDS:
+                raise ValueError(f"unknown field: {f!r}")
+            if f not in seen:
+                seen.add(f)
+                out.append(f)
+        return out
+
+    async def update_review(
+        self,
+        result_id: int,
+        overrides: dict | None = None,
+        field_selection: list | None = None,
+    ) -> dict | None:
+        """Persist a manual review overlay: edited values (``overrides``) and/or
+        the subset of fields to apply (``field_selection``). Each param REPLACES
+        the whole stored value (not a merge); pass None to leave that overlay
+        untouched. Validates against EDITABLE_FIELDS + per-field types (raises
+        ValueError). Returns the updated result dict, or None if the id is unknown
+        (→ 404 at the route). Status is left as-is (apply reads the overlay later).
+        """
+        from models.database import PaperlessAuditResult
+
+        if overrides is not None:
+            overrides = self._validate_overrides(overrides)
+        if field_selection is not None:
+            field_selection = self._validate_selection(field_selection)
+
+        async with self._db_factory() as db:
+            stmt = select(PaperlessAuditResult).where(
+                PaperlessAuditResult.id == result_id
+            )
+            row = (await db.execute(stmt)).scalar_one_or_none()
+            if row is None:
+                return None
+            if overrides is not None:
+                row.user_overrides = overrides or None  # {} → NULL (no overlay)
+            if field_selection is not None:
+                # [] is meaningful (apply nothing); only None means "leave as-is".
+                row.field_selection = field_selection
+            # A manual review RE-OPENS the row for apply: editing an already
+            # applied/skipped/failed row must take effect on the next apply
+            # (apply_results only processes 'pending' rows). Reset so the edit
+            # isn't silently a no-op.
+            if overrides is not None or field_selection is not None:
+                row.status = "pending"
+                row.applied_at = None
+            await db.commit()
+            await db.refresh(row)
+            return self._result_to_dict(row)
+
+    async def _persist_status(self, result_id: int, status: str) -> None:
+        """Set a terminal status on a result row (and applied_at for 'applied')."""
+        from models.database import PaperlessAuditResult
+
+        async with self._db_factory() as db:
+            row = (
+                await db.execute(
+                    select(PaperlessAuditResult).where(
+                        PaperlessAuditResult.id == result_id
+                    )
+                )
+            ).scalar_one_or_none()
+            if row:
+                row.status = status
+                if status == "applied":
+                    row.applied_at = datetime.now(UTC).replace(tzinfo=None)
+                await db.commit()
+
     async def _apply_fix(self, result, taxonomy: dict | None = None) -> bool:
         """Apply suggested fix via MCP update_document tool.
 
@@ -586,24 +705,44 @@ class PaperlessAuditService:
         params = {"document_id": result.paperless_doc_id}
         has_changes = False
 
-        if result.suggested_title and result.suggested_title != result.current_title:
-            params["title"] = result.suggested_title
+        # Review overlay. ``user_overrides`` replaces the LLM suggestion per field
+        # (manual edit); ``field_selection`` limits which fields apply (None = all
+        # changed, the legacy path). Effective value = override if the user edited
+        # that field, else the suggested_* value. isinstance-guards keep the legacy
+        # path byte-identical when the columns are NULL (and tolerate mock rows).
+        overrides = result.user_overrides if isinstance(result.user_overrides, dict) else {}
+        selection = result.field_selection if isinstance(result.field_selection, list) else None
+
+        def _eff(field, suggested):
+            return overrides[field] if field in overrides else suggested
+
+        def _sel(field):
+            # A manual override IS an explicit intent to apply that field, so it
+            # always applies (never silently dropped by field_selection). Otherwise
+            # field_selection decides (None = all changed, the legacy path).
+            return field in overrides or selection is None or field in selection
+
+        title = _eff("title", result.suggested_title)
+        if _sel("title") and title and title != result.current_title:
+            params["title"] = title
             has_changes = True
         # raise_on_error=True so a transient taxonomy read / create FAILURE is
         # distinguishable from a legitimate guardrail-skip (None): on failure we
         # abort this pass and leave the row pending for a clean retry, instead of
         # dropping the fix silently and reporting it as applied.
         try:
-            if result.suggested_correspondent and result.suggested_correspondent != result.current_correspondent:
+            corr_val = _eff("correspondent", result.suggested_correspondent)
+            if _sel("correspondent") and corr_val and corr_val != result.current_correspondent:
                 corr = await resolve_or_create_correspondent(
-                    self._mcp, result.suggested_correspondent,
+                    self._mcp, corr_val,
                     names=tax.get("correspondents"), raise_on_error=True,
                 )
                 if corr:  # None = a fuzzy-near match exists → guardrail, leave unset
                     params["correspondent"] = corr
                     has_changes = True
-            if result.suggested_document_type and result.suggested_document_type != result.current_document_type:
-                dt = result.suggested_document_type
+            dt_val = _eff("document_type", result.suggested_document_type)
+            if _sel("document_type") and dt_val and dt_val != result.current_document_type:
+                dt = dt_val
                 if settings.paperless_autocreate_document_type:
                     # None on a fuzzy-near guardrail hit → skip (same as correspondent),
                     # rather than force the raw suggestion and risk a near-duplicate type.
@@ -614,8 +753,9 @@ class PaperlessAuditService:
                 if dt:
                     params["document_type"] = dt
                     has_changes = True
-            if result.suggested_tags and result.suggested_tags != result.current_tags:
-                tags = result.suggested_tags
+            tags_val = _eff("tags", result.suggested_tags)
+            if _sel("tags") and tags_val and tags_val != result.current_tags:
+                tags = tags_val
                 if settings.paperless_autocreate_tags:
                     resolved = [
                         await resolve_or_create_taxonomy(
@@ -633,17 +773,28 @@ class PaperlessAuditService:
                 f"({e}) — leaving pending for retry, not reporting as applied"
             )
             return False
-        if result.suggested_date and result.suggested_date != result.current_date:
-            params["created_date"] = result.suggested_date
+        date_val = _eff("date", result.suggested_date)
+        if _sel("date") and date_val and date_val != result.current_date:
+            params["created_date"] = date_val
             has_changes = True
-        if result.suggested_storage_path and result.suggested_storage_path != result.current_storage_path:
-            params["storage_path"] = result.suggested_storage_path
+        # storage_path: a manual override is applied as-is (trusted admin input),
+        # unlike an LLM suggestion which _analyze_document guards against the valid
+        # -paths list. A non-existent path is rejected by Paperless → row 'failed'.
+        sp_val = _eff("storage_path", result.suggested_storage_path)
+        if _sel("storage_path") and sp_val and sp_val != result.current_storage_path:
+            params["storage_path"] = sp_val
             has_changes = True
-        if result.suggested_custom_fields:
-            params["custom_fields"] = result.suggested_custom_fields
+        cf_val = _eff("custom_fields", result.suggested_custom_fields)
+        if _sel("custom_fields") and cf_val:
+            params["custom_fields"] = cf_val
             has_changes = True
 
         if not has_changes:
+            # Nothing to write (e.g. field_selection deselected every change, or an
+            # override equals the current value). Still mark the row processed so it
+            # does not reappear as pending and get re-counted "applied" on every
+            # subsequent apply (the deselect-all stuck-row bug).
+            await self._persist_status(result.id, "applied")
             return True
 
         mcp_result = await self._mcp.execute_tool("mcp.paperless.update_document", params)
@@ -673,11 +824,19 @@ class PaperlessAuditService:
         applied = 0
         failed = 0
 
+        from sqlalchemy import or_
+
         async with self._db_factory() as db:
             stmt = select(PaperlessAuditResult).where(
                 PaperlessAuditResult.id.in_(result_ids),
                 PaperlessAuditResult.status == "pending",
-                PaperlessAuditResult.changes_needed.is_(True),
+                # changes_needed OR a manual edit: a user override makes a row
+                # applicable even when the LLM flagged no change (they chose to
+                # fix it by hand).
+                or_(
+                    PaperlessAuditResult.changes_needed.is_(True),
+                    PaperlessAuditResult.user_overrides.isnot(None),
+                ),
             )
             results = (await db.execute(stmt)).scalars().all()
 
@@ -1689,6 +1848,8 @@ class PaperlessAuditService:
             "changes_needed": r.changes_needed,
             "reasoning": r.reasoning,
             "status": r.status,
+            "user_overrides": r.user_overrides,
+            "field_selection": r.field_selection,
             "audited_at": r.audited_at.isoformat() if r.audited_at else None,
             "applied_at": r.applied_at.isoformat() if r.applied_at else None,
             "audit_run_id": r.audit_run_id,

--- a/src/frontend/src/api/resources/paperlessAudit.ts
+++ b/src/frontend/src/api/resources/paperlessAudit.ts
@@ -13,6 +13,29 @@ export interface AuditStatus {
   total?: number;
 }
 
+/** Canonical field names for the review overlay — must match the backend
+ *  PaperlessAuditService.EDITABLE_FIELDS. */
+export type EditableField =
+  | 'title'
+  | 'correspondent'
+  | 'document_type'
+  | 'tags'
+  | 'date'
+  | 'storage_path'
+  | 'custom_fields';
+
+/** Manual edits the user made to the suggested values, keyed by canonical field.
+ *  Scalar fields carry a string, tags a string[], custom_fields an object. */
+export type ReviewOverrides = Partial<{
+  title: string;
+  correspondent: string;
+  document_type: string;
+  date: string;
+  storage_path: string;
+  tags: string[];
+  custom_fields: Record<string, unknown>;
+}>;
+
 export interface AuditResult {
   id: number;
   paperless_doc_id: number;
@@ -26,6 +49,9 @@ export interface AuditResult {
   suggested_date?: string | null;
   current_storage_path?: string | null;
   suggested_storage_path?: string | null;
+  current_tags?: string[] | null;
+  current_custom_fields?: Record<string, unknown> | null;
+  suggested_custom_fields?: Record<string, unknown> | null;
   detected_language?: string | null;
   suggested_tags?: string[];
   missing_fields?: string[];
@@ -34,6 +60,11 @@ export interface AuditResult {
   ocr_issues?: string;
   content_completeness?: number;
   completeness_issues?: string;
+  status?: string;
+  // Review overlay (PR: selective + manual edits). Both null = no review →
+  // apply uses all suggested_* changes.
+  user_overrides?: ReviewOverrides | null;
+  field_selection?: EditableField[] | null;
   // Low-quality OCR signal (resolved from the renfield Document; null/false
   // for Paperless-only docs that were never ingested into the KB).
   low_quality_ocr?: boolean;
@@ -143,6 +174,22 @@ async function applyResultsRequest(ids: number[]): Promise<void> {
 
 async function skipResultsRequest(ids: number[]): Promise<void> {
   await apiClient.post('/api/admin/paperless-audit/skip', { result_ids: ids });
+}
+
+export interface UpdateReviewInput {
+  id: number;
+  // Each field REPLACES the stored overlay; pass null to leave it untouched.
+  overrides?: ReviewOverrides | null;
+  field_selection?: EditableField[] | null;
+}
+
+async function updateReviewRequest(input: UpdateReviewInput): Promise<AuditResult> {
+  const { id, overrides, field_selection } = input;
+  const { data } = await apiClient.patch<AuditResult>(
+    `/api/admin/paperless-audit/results/${id}`,
+    { overrides, field_selection },
+  );
+  return data;
 }
 
 async function reOcrRequest(ids: number[]): Promise<void> {
@@ -356,6 +403,19 @@ export function useSkipResults() {
     {
       mutationFn: skipResultsRequest,
       onSuccess: () => invalidateAudit(queryClient),
+    },
+    'paperlessAudit.error',
+  );
+}
+
+/** Persist a manual review overlay (edited values + per-field apply selection).
+ *  Deliberately does NOT invalidate the audit query: this fires on blur/toggle
+ *  while the user is editing, and a refetch would clobber in-progress local
+ *  drafts on other rows. apply/skip invalidate when the batch settles. */
+export function useUpdateReview() {
+  return useApiMutation(
+    {
+      mutationFn: updateReviewRequest,
     },
     'paperlessAudit.error',
   );

--- a/src/frontend/src/components/paperless/AuditReviewRow.tsx
+++ b/src/frontend/src/components/paperless/AuditReviewRow.tsx
@@ -11,7 +11,7 @@
  * explicit intent), so field_selection only needs to carry the fields the user
  * wants applied; untouched rows never PATCH and keep the legacy apply-all path.
  */
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { Check, X, Loader, ChevronDown, ChevronRight, Plus, Trash2 } from 'lucide-react';
@@ -95,6 +95,9 @@ interface AuditReviewRowProps {
   onApprove: (ids: number[]) => void | Promise<void>;
   onSkip: (ids: number[]) => void;
   actionLoading: boolean;
+  /** Register this row's latest in-flight save so the page can flush it before
+   *  apply (covers both single-row and bulk approve). */
+  onRegisterPending: (id: number, save: Promise<unknown>) => void;
   /** Total column count so the custom-fields drawer can span the full row. */
   colSpan: number;
 }
@@ -106,13 +109,36 @@ export default function AuditReviewRow({
   onApprove,
   onSkip,
   actionLoading,
+  onRegisterPending,
   colSpan,
 }: AuditReviewRowProps) {
   const { t } = useTranslation();
   const updateReview = useUpdateReview();
   const [draft, setDraft] = useState<Draft>(() => initDraft(r));
   const [expanded, setExpanded] = useState(false);
-  const pendingRef = useRef<Promise<unknown> | null>(null);
+  // draftRef mirrors `draft` so event handlers read the latest state without a
+  // stale closure (two interactions before a re-render can't clobber each other).
+  const draftRef = useRef<Draft>(draft);
+  // Serialize saves so out-of-order network delivery can't leave an older payload
+  // as the last server write; the tail settles when the row is fully persisted.
+  const chainRef = useRef<Promise<unknown>>(Promise.resolve());
+
+  // Re-seed the draft when the SERVER data changes (e.g. an apply/skip of another
+  // row invalidates the query and this still-pending row refetches with fresh
+  // suggested_* / persisted overlay). Keyed on a signature of the server fields —
+  // our own edits don't invalidate, so this never clobbers an in-progress draft.
+  const serverSig = JSON.stringify([
+    r.current_title, r.suggested_title, r.current_correspondent, r.suggested_correspondent,
+    r.current_document_type, r.suggested_document_type, r.current_date, r.suggested_date,
+    r.current_storage_path, r.suggested_storage_path, r.current_tags, r.suggested_tags,
+    r.current_custom_fields, r.suggested_custom_fields, r.user_overrides, r.field_selection,
+  ]);
+  useEffect(() => {
+    const seeded = initDraft(r);
+    draftRef.current = seeded;
+    setDraft(seeded);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [serverSig]);
 
   const effScalar = (f: ScalarField): string =>
     (draft.overrides[f] as string | undefined) ?? scalarSuggested(r, f);
@@ -120,6 +146,9 @@ export default function AuditReviewRow({
   const effCustom = (): Record<string, unknown> =>
     (draft.overrides.custom_fields ?? r.suggested_custom_fields ?? {}) as Record<string, unknown>;
 
+  // A field APPLIES iff its effective value differs from current (matches the
+  // backend `eff != current` guard). An override equal to current is a no-op, so
+  // it's not applicable — no stuck disabled checkbox.
   const isChanged = (f: EditableField): boolean => {
     if (f === 'tags') return effTags().length > 0 && !tagsEqual(effTags(), r.current_tags ?? []);
     if (f === 'custom_fields')
@@ -128,33 +157,44 @@ export default function AuditReviewRow({
     return !!v && v !== scalarCurrent(r, f as ScalarField);
   };
   const isOverridden = (f: EditableField): boolean => f in draft.overrides;
-  const isApplicable = (f: EditableField): boolean => isChanged(f) || isOverridden(f);
+  const isApplicable = (f: EditableField): boolean => isChanged(f);
 
   const persist = (next: Draft) => {
-    const p = updateReview.mutateAsync({
-      id: r.id,
-      overrides: next.overrides,
-      field_selection: [...next.selection],
-    });
-    pendingRef.current = p;
-    // Swallow — the mutation surfaces its own error toast; a failed save must not
-    // reject the row's approve flow below.
-    p.catch(() => undefined);
+    const run = () =>
+      updateReview.mutateAsync({
+        id: r.id,
+        overrides: next.overrides,
+        field_selection: [...next.selection],
+      });
+    // Chain after the previous save settles (run on both fulfil and reject so a
+    // transient failure doesn't wedge the queue). The mutation surfaces its own
+    // error toast; the tail never rejects so the page's flush can't throw.
+    const tail = chainRef.current.then(run, run).catch(() => undefined);
+    chainRef.current = tail;
+    onRegisterPending(r.id, tail);
   };
 
   const commit = (next: Draft) => {
+    draftRef.current = next;
     setDraft(next);
     persist(next);
   };
 
   // --- scalar editing ---
   const onScalarChange = (f: ScalarField, value: string) => {
-    setDraft((d) => ({ ...d, overrides: { ...d.overrides, [f]: value } }));
+    // Keystroke: update state + ref only (no persist until blur).
+    const next: Draft = {
+      ...draftRef.current,
+      overrides: { ...draftRef.current.overrides, [f]: value },
+    };
+    draftRef.current = next;
+    setDraft(next);
   };
   const onScalarBlur = (f: ScalarField) => {
-    const raw = (draft.overrides[f] as string | undefined) ?? '';
-    const overrides = { ...draft.overrides };
-    const selection = new Set(draft.selection);
+    const d = draftRef.current;
+    const raw = (d.overrides[f] as string | undefined) ?? '';
+    const overrides = { ...d.overrides };
+    const selection = new Set(d.selection);
     if (raw.trim() === '' || raw === scalarSuggested(r, f)) {
       // Empty or back-to-suggestion → not an override (clearing isn't supported).
       delete overrides[f];
@@ -170,16 +210,18 @@ export default function AuditReviewRow({
 
   // --- selection toggle (checkbox) ---
   const onToggleField = (f: EditableField) => {
-    const selection = new Set(draft.selection);
+    const d = draftRef.current;
+    const selection = new Set(d.selection);
     if (selection.has(f)) selection.delete(f);
     else selection.add(f);
-    commit({ ...draft, selection });
+    commit({ ...d, selection });
   };
 
   // --- tags editing ---
   const setTags = (tags: string[]) => {
-    const overrides = { ...draft.overrides };
-    const selection = new Set(draft.selection);
+    const d = draftRef.current;
+    const overrides = { ...d.overrides };
+    const selection = new Set(d.selection);
     if (tags.length === 0 || tagsEqual(tags, r.suggested_tags ?? [])) {
       delete overrides.tags; // revert to suggestion / can't clear
     } else {
@@ -193,8 +235,9 @@ export default function AuditReviewRow({
 
   // --- custom_fields editing ---
   const setCustom = (obj: Record<string, unknown>) => {
-    const overrides = { ...draft.overrides };
-    const selection = new Set(draft.selection);
+    const d = draftRef.current;
+    const overrides = { ...d.overrides };
+    const selection = new Set(d.selection);
     if (Object.keys(obj).length === 0 || objEqual(obj, r.suggested_custom_fields ?? {})) {
       delete overrides.custom_fields;
     } else {
@@ -205,19 +248,6 @@ export default function AuditReviewRow({
     else selection.delete('custom_fields');
     commit({ overrides, selection });
   };
-
-  const approve = async () => {
-    // Flush any in-flight save so the persisted overlay reflects the latest edit
-    // before apply reads it off the row.
-    if (pendingRef.current) await pendingRef.current;
-    await onApprove([r.id]);
-  };
-
-  const editedCount = useMemo(
-    () => [...draft.selection].filter((f) => isApplicable(f)).length,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [draft],
-  );
 
   return (
     <>
@@ -278,7 +308,7 @@ export default function AuditReviewRow({
         </td>
         <td className="py-3 px-2">
           <EditableScalar
-            field="date" current={scalarCurrent(r, 'date')} value={effScalar('date')} placeholder="YYYY-MM-DD"
+            field="date" current={scalarCurrent(r, 'date')} value={effScalar('date')} placeholder={t('paperlessAudit.review.datePlaceholder')}
             applicable={isApplicable('date')} selected={draft.selection.has('date')}
             overridden={isOverridden('date')}
             onChange={(v) => onScalarChange('date', v)} onBlur={() => onScalarBlur('date')}
@@ -320,8 +350,8 @@ export default function AuditReviewRow({
               {expanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
             </button>
             <button
-              onClick={approve}
-              disabled={actionLoading || editedCount === 0}
+              onClick={() => onApprove([r.id])}
+              disabled={actionLoading}
               className="btn-icon text-green-600 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-900/20 disabled:opacity-40"
               title={t('paperlessAudit.review.approve')}
             >
@@ -473,6 +503,21 @@ interface CustomFieldsEditorProps {
   onToggle: () => void;
   t: TFunction;
 }
+// Preserve JSON types (number/bool/null) round-tripping through a text input;
+// anything not valid JSON stays a plain string — so a numeric custom field
+// edited to "5" saves as 5, not "5" (no silent type corruption).
+function coerceCfValue(s: string): unknown {
+  const trimmed = s.trim();
+  if (trimmed === '') return s;
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (typeof parsed === 'number' || typeof parsed === 'boolean' || parsed === null) return parsed;
+  } catch {
+    /* not JSON → keep the raw string */
+  }
+  return s;
+}
+
 function CustomFieldsEditor({ value, applicable, selected, onChange, onToggle, t }: CustomFieldsEditorProps) {
   const [k, setK] = useState('');
   const [v, setV] = useState('');
@@ -480,7 +525,7 @@ function CustomFieldsEditor({ value, applicable, selected, onChange, onToggle, t
   const addPair = () => {
     const key = k.trim();
     if (!key) return;
-    onChange({ ...value, [key]: v });
+    onChange({ ...value, [key]: coerceCfValue(v) });
     setK('');
     setV('');
   };
@@ -503,7 +548,7 @@ function CustomFieldsEditor({ value, applicable, selected, onChange, onToggle, t
               <input
                 type="text"
                 value={typeof val === 'string' ? val : JSON.stringify(val)}
-                onChange={(e) => onChange({ ...value, [key]: e.target.value })}
+                onChange={(e) => onChange({ ...value, [key]: coerceCfValue(e.target.value) })}
                 className="input py-0.5 px-1.5 text-xs w-48"
               />
               <button onClick={() => removeKey(key)} className="btn-icon btn-icon-ghost" aria-label={t('common.remove')}>

--- a/src/frontend/src/components/paperless/AuditReviewRow.tsx
+++ b/src/frontend/src/components/paperless/AuditReviewRow.tsx
@@ -1,0 +1,525 @@
+/**
+ * One editable row in the Paperless-audit review queue.
+ *
+ * Two capabilities layered on the read-only diff:
+ *  1. per-field APPLY SELECTION — a checkbox on every applicable field
+ *     (suggested-changed or manually edited); checked ⟺ the field will apply.
+ *  2. manual EDIT — every suggested value is an inline input (auto-save on blur).
+ *
+ * State lives here as a per-row draft (overrides + selection) and is persisted
+ * via PATCH .../results/{id}. Overrides always apply server-side (an edit is an
+ * explicit intent), so field_selection only needs to carry the fields the user
+ * wants applied; untouched rows never PATCH and keep the legacy apply-all path.
+ */
+import { useMemo, useRef, useState } from 'react';
+import type { TFunction } from 'i18next';
+import { useTranslation } from 'react-i18next';
+import { Check, X, Loader, ChevronDown, ChevronRight, Plus, Trash2 } from 'lucide-react';
+
+import Badge from '../Badge';
+import {
+  useUpdateReview,
+  type AuditResult,
+  type EditableField,
+  type ReviewOverrides,
+} from '../../api/resources/paperlessAudit';
+import ConfidenceBadge from './ConfidenceBadge';
+
+const SCALAR_FIELDS = ['title', 'correspondent', 'document_type', 'date', 'storage_path'] as const;
+type ScalarField = (typeof SCALAR_FIELDS)[number];
+
+interface Draft {
+  overrides: ReviewOverrides;
+  selection: Set<EditableField>;
+}
+
+// --- value accessors -------------------------------------------------------
+
+function scalarCurrent(r: AuditResult, f: ScalarField): string {
+  const map: Record<ScalarField, string | null | undefined> = {
+    title: r.current_title,
+    correspondent: r.current_correspondent,
+    document_type: r.current_document_type,
+    date: r.current_date,
+    storage_path: r.current_storage_path,
+  };
+  return map[f] ?? '';
+}
+
+function scalarSuggested(r: AuditResult, f: ScalarField): string {
+  const map: Record<ScalarField, string | null | undefined> = {
+    title: r.suggested_title,
+    correspondent: r.suggested_correspondent,
+    document_type: r.suggested_document_type,
+    date: r.suggested_date,
+    storage_path: r.suggested_storage_path,
+  };
+  return map[f] ?? '';
+}
+
+function tagsEqual(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((x, i) => x === b[i]);
+}
+
+function objEqual(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
+  const ak = Object.keys(a).sort();
+  const bk = Object.keys(b).sort();
+  if (ak.length !== bk.length || ak.some((k, i) => k !== bk[i])) return false;
+  return ak.every((k) => JSON.stringify(a[k]) === JSON.stringify(b[k]));
+}
+
+// --- draft init ------------------------------------------------------------
+
+function initDraft(r: AuditResult): Draft {
+  const overrides: ReviewOverrides = { ...(r.user_overrides ?? {}) };
+  // Which fields "change" (would apply) given the current overrides.
+  const changed = new Set<EditableField>();
+  for (const f of SCALAR_FIELDS) {
+    const eff = (overrides[f] as string | undefined) ?? scalarSuggested(r, f);
+    if (eff && eff !== scalarCurrent(r, f)) changed.add(f);
+  }
+  const effTags = (overrides.tags ?? r.suggested_tags ?? []) as string[];
+  if (effTags.length && !tagsEqual(effTags, r.current_tags ?? [])) changed.add('tags');
+  const effCf = (overrides.custom_fields ?? r.suggested_custom_fields ?? {}) as Record<string, unknown>;
+  if (Object.keys(effCf).length && !objEqual(effCf, r.current_custom_fields ?? {})) changed.add('custom_fields');
+
+  // Persisted field_selection wins; else default to all changed fields.
+  const selection = r.field_selection ? new Set<EditableField>(r.field_selection) : changed;
+  return { overrides, selection };
+}
+
+interface AuditReviewRowProps {
+  result: AuditResult;
+  isBulkSelected: boolean;
+  onToggleBulkSelected: (id: number) => void;
+  onApprove: (ids: number[]) => void | Promise<void>;
+  onSkip: (ids: number[]) => void;
+  actionLoading: boolean;
+  /** Total column count so the custom-fields drawer can span the full row. */
+  colSpan: number;
+}
+
+export default function AuditReviewRow({
+  result: r,
+  isBulkSelected,
+  onToggleBulkSelected,
+  onApprove,
+  onSkip,
+  actionLoading,
+  colSpan,
+}: AuditReviewRowProps) {
+  const { t } = useTranslation();
+  const updateReview = useUpdateReview();
+  const [draft, setDraft] = useState<Draft>(() => initDraft(r));
+  const [expanded, setExpanded] = useState(false);
+  const pendingRef = useRef<Promise<unknown> | null>(null);
+
+  const effScalar = (f: ScalarField): string =>
+    (draft.overrides[f] as string | undefined) ?? scalarSuggested(r, f);
+  const effTags = (): string[] => (draft.overrides.tags ?? r.suggested_tags ?? []) as string[];
+  const effCustom = (): Record<string, unknown> =>
+    (draft.overrides.custom_fields ?? r.suggested_custom_fields ?? {}) as Record<string, unknown>;
+
+  const isChanged = (f: EditableField): boolean => {
+    if (f === 'tags') return effTags().length > 0 && !tagsEqual(effTags(), r.current_tags ?? []);
+    if (f === 'custom_fields')
+      return Object.keys(effCustom()).length > 0 && !objEqual(effCustom(), r.current_custom_fields ?? {});
+    const v = effScalar(f as ScalarField);
+    return !!v && v !== scalarCurrent(r, f as ScalarField);
+  };
+  const isOverridden = (f: EditableField): boolean => f in draft.overrides;
+  const isApplicable = (f: EditableField): boolean => isChanged(f) || isOverridden(f);
+
+  const persist = (next: Draft) => {
+    const p = updateReview.mutateAsync({
+      id: r.id,
+      overrides: next.overrides,
+      field_selection: [...next.selection],
+    });
+    pendingRef.current = p;
+    // Swallow — the mutation surfaces its own error toast; a failed save must not
+    // reject the row's approve flow below.
+    p.catch(() => undefined);
+  };
+
+  const commit = (next: Draft) => {
+    setDraft(next);
+    persist(next);
+  };
+
+  // --- scalar editing ---
+  const onScalarChange = (f: ScalarField, value: string) => {
+    setDraft((d) => ({ ...d, overrides: { ...d.overrides, [f]: value } }));
+  };
+  const onScalarBlur = (f: ScalarField) => {
+    const raw = (draft.overrides[f] as string | undefined) ?? '';
+    const overrides = { ...draft.overrides };
+    const selection = new Set(draft.selection);
+    if (raw.trim() === '' || raw === scalarSuggested(r, f)) {
+      // Empty or back-to-suggestion → not an override (clearing isn't supported).
+      delete overrides[f];
+    } else {
+      overrides[f] = raw;
+    }
+    const effNext = (overrides[f] as string | undefined) ?? scalarSuggested(r, f);
+    const nextChanged = !!effNext && effNext !== scalarCurrent(r, f);
+    if (nextChanged) selection.add(f);
+    else selection.delete(f);
+    commit({ overrides, selection });
+  };
+
+  // --- selection toggle (checkbox) ---
+  const onToggleField = (f: EditableField) => {
+    const selection = new Set(draft.selection);
+    if (selection.has(f)) selection.delete(f);
+    else selection.add(f);
+    commit({ ...draft, selection });
+  };
+
+  // --- tags editing ---
+  const setTags = (tags: string[]) => {
+    const overrides = { ...draft.overrides };
+    const selection = new Set(draft.selection);
+    if (tags.length === 0 || tagsEqual(tags, r.suggested_tags ?? [])) {
+      delete overrides.tags; // revert to suggestion / can't clear
+    } else {
+      overrides.tags = tags;
+    }
+    const eff = (overrides.tags ?? r.suggested_tags ?? []) as string[];
+    if (eff.length && !tagsEqual(eff, r.current_tags ?? [])) selection.add('tags');
+    else selection.delete('tags');
+    commit({ overrides, selection });
+  };
+
+  // --- custom_fields editing ---
+  const setCustom = (obj: Record<string, unknown>) => {
+    const overrides = { ...draft.overrides };
+    const selection = new Set(draft.selection);
+    if (Object.keys(obj).length === 0 || objEqual(obj, r.suggested_custom_fields ?? {})) {
+      delete overrides.custom_fields;
+    } else {
+      overrides.custom_fields = obj;
+    }
+    const eff = (overrides.custom_fields ?? r.suggested_custom_fields ?? {}) as Record<string, unknown>;
+    if (Object.keys(eff).length && !objEqual(eff, r.current_custom_fields ?? {})) selection.add('custom_fields');
+    else selection.delete('custom_fields');
+    commit({ overrides, selection });
+  };
+
+  const approve = async () => {
+    // Flush any in-flight save so the persisted overlay reflects the latest edit
+    // before apply reads it off the row.
+    if (pendingRef.current) await pendingRef.current;
+    await onApprove([r.id]);
+  };
+
+  const editedCount = useMemo(
+    () => [...draft.selection].filter((f) => isApplicable(f)).length,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [draft],
+  );
+
+  return (
+    <>
+      <tr className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50 align-top">
+        <td className="py-3 px-2">
+          <input
+            type="checkbox"
+            checked={isBulkSelected}
+            onChange={() => onToggleBulkSelected(r.id)}
+            className="rounded border-gray-300 dark:border-gray-600"
+            aria-label={t('paperlessAudit.review.selectRow')}
+          />
+        </td>
+        <td className="py-3 px-2 text-gray-900 dark:text-gray-100 font-mono text-xs">{r.paperless_doc_id}</td>
+
+        {/* title (+ tags editor) */}
+        <td className="py-3 px-2 max-w-xs">
+          <EditableScalar
+            field="title"
+            current={scalarCurrent(r, 'title')}
+            value={effScalar('title')}
+            applicable={isApplicable('title')}
+            selected={draft.selection.has('title')}
+            overridden={isOverridden('title')}
+            onChange={(v) => onScalarChange('title', v)}
+            onBlur={() => onScalarBlur('title')}
+            onToggle={() => onToggleField('title')}
+            t={t}
+          />
+          <TagsEditor
+            tags={effTags()}
+            current={r.current_tags ?? []}
+            applicable={isApplicable('tags')}
+            selected={draft.selection.has('tags')}
+            onChange={setTags}
+            onToggle={() => onToggleField('tags')}
+            t={t}
+          />
+        </td>
+
+        <td className="py-3 px-2">
+          <EditableScalar
+            field="correspondent" current={scalarCurrent(r, 'correspondent')} value={effScalar('correspondent')}
+            applicable={isApplicable('correspondent')} selected={draft.selection.has('correspondent')}
+            overridden={isOverridden('correspondent')}
+            onChange={(v) => onScalarChange('correspondent', v)} onBlur={() => onScalarBlur('correspondent')}
+            onToggle={() => onToggleField('correspondent')} t={t}
+          />
+        </td>
+        <td className="py-3 px-2">
+          <EditableScalar
+            field="document_type" current={scalarCurrent(r, 'document_type')} value={effScalar('document_type')}
+            applicable={isApplicable('document_type')} selected={draft.selection.has('document_type')}
+            overridden={isOverridden('document_type')}
+            onChange={(v) => onScalarChange('document_type', v)} onBlur={() => onScalarBlur('document_type')}
+            onToggle={() => onToggleField('document_type')} t={t}
+          />
+        </td>
+        <td className="py-3 px-2">
+          <EditableScalar
+            field="date" current={scalarCurrent(r, 'date')} value={effScalar('date')} placeholder="YYYY-MM-DD"
+            applicable={isApplicable('date')} selected={draft.selection.has('date')}
+            overridden={isOverridden('date')}
+            onChange={(v) => onScalarChange('date', v)} onBlur={() => onScalarBlur('date')}
+            onToggle={() => onToggleField('date')} t={t}
+          />
+        </td>
+        <td className="py-3 px-2">
+          {r.detected_language && (
+            <Badge color="blue" className="font-mono">{r.detected_language}</Badge>
+          )}
+        </td>
+        <td className="py-3 px-2">
+          <EditableScalar
+            field="storage_path" current={scalarCurrent(r, 'storage_path')} value={effScalar('storage_path')}
+            applicable={isApplicable('storage_path')} selected={draft.selection.has('storage_path')}
+            overridden={isOverridden('storage_path')}
+            onChange={(v) => onScalarChange('storage_path', v)} onBlur={() => onScalarBlur('storage_path')}
+            onToggle={() => onToggleField('storage_path')} t={t}
+          />
+        </td>
+        <td className="py-3 px-2">
+          {r.missing_fields && r.missing_fields.length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {r.missing_fields.map((f, i) => (
+                <Badge key={i} color="yellow">{f}</Badge>
+              ))}
+            </div>
+          )}
+        </td>
+        <td className="py-3 px-2"><ConfidenceBadge value={r.confidence} /></td>
+        <td className="py-3 px-2 text-right">
+          <div className="flex items-center justify-end gap-1">
+            <button
+              onClick={() => setExpanded((x) => !x)}
+              className="btn-icon btn-icon-ghost"
+              title={t('paperlessAudit.review.customFields')}
+              aria-expanded={expanded}
+            >
+              {expanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+            </button>
+            <button
+              onClick={approve}
+              disabled={actionLoading || editedCount === 0}
+              className="btn-icon text-green-600 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-900/20 disabled:opacity-40"
+              title={t('paperlessAudit.review.approve')}
+            >
+              {actionLoading ? <Loader className="w-4 h-4 animate-spin" /> : <Check className="w-4 h-4" />}
+            </button>
+            <button
+              onClick={() => onSkip([r.id])}
+              disabled={actionLoading}
+              className="btn-icon btn-icon-ghost"
+              title={t('paperlessAudit.review.skip')}
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+        </td>
+      </tr>
+      {expanded && (
+        <tr className="bg-gray-50 dark:bg-gray-800/40 border-b border-gray-100 dark:border-gray-800">
+          <td colSpan={colSpan} className="py-3 px-6">
+            <CustomFieldsEditor
+              value={effCustom()}
+              applicable={isApplicable('custom_fields')}
+              selected={draft.selection.has('custom_fields')}
+              onChange={setCustom}
+              onToggle={() => onToggleField('custom_fields')}
+              t={t}
+            />
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+// --- field sub-components ---------------------------------------------------
+
+interface SelectBoxProps {
+  applicable: boolean;
+  selected: boolean;
+  overridden?: boolean;
+  onToggle: () => void;
+  label: string;
+}
+function SelectBox({ applicable, selected, overridden, onToggle, label }: SelectBoxProps) {
+  if (!applicable) return null;
+  return (
+    <input
+      type="checkbox"
+      checked={selected}
+      disabled={overridden}
+      onChange={onToggle}
+      title={overridden ? label : undefined}
+      aria-label={label}
+      className="mt-1 rounded border-gray-300 dark:border-gray-600 disabled:opacity-60"
+    />
+  );
+}
+
+interface EditableScalarProps {
+  field: EditableField;
+  current: string;
+  value: string;
+  applicable: boolean;
+  selected: boolean;
+  overridden: boolean;
+  placeholder?: string;
+  onChange: (v: string) => void;
+  onBlur: () => void;
+  onToggle: () => void;
+  t: TFunction;
+}
+function EditableScalar({ current, value, applicable, selected, overridden, placeholder, onChange, onBlur, onToggle, t }: EditableScalarProps) {
+  return (
+    <div className="flex items-start gap-1.5">
+      <SelectBox applicable={applicable} selected={selected} overridden={overridden} onToggle={onToggle} label={t('paperlessAudit.review.applyField')} />
+      <div className="min-w-0 flex-1 space-y-0.5">
+        {current && current !== value && (
+          <div className="text-red-600 dark:text-red-400 line-through text-xs truncate">{current}</div>
+        )}
+        <input
+          type="text"
+          value={value}
+          placeholder={placeholder}
+          onChange={(e) => onChange(e.target.value)}
+          onBlur={onBlur}
+          className="input py-1 px-1.5 text-xs w-full"
+        />
+      </div>
+    </div>
+  );
+}
+
+interface TagsEditorProps {
+  tags: string[];
+  current: string[];
+  applicable: boolean;
+  selected: boolean;
+  onChange: (tags: string[]) => void;
+  onToggle: () => void;
+  t: TFunction;
+}
+function TagsEditor({ tags, current, applicable, selected, onChange, onToggle, t }: TagsEditorProps) {
+  const [entry, setEntry] = useState('');
+  const add = () => {
+    const v = entry.trim();
+    if (v && !tags.includes(v)) onChange([...tags, v]);
+    setEntry('');
+  };
+  return (
+    <div className="mt-1.5 flex items-start gap-1.5">
+      <SelectBox applicable={applicable} selected={selected} onToggle={onToggle} label={t('paperlessAudit.review.applyField')} />
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap gap-1">
+          {tags.map((tag) => (
+            <Badge key={tag} color="accent" className="inline-flex items-center gap-1">
+              {tag}
+              <button onClick={() => onChange(tags.filter((x) => x !== tag))} className="hover:text-red-500" aria-label={t('common.remove')}>
+                <X className="w-3 h-3" />
+              </button>
+            </Badge>
+          ))}
+          {current.length > 0 && !tagsEqual(tags, current) && (
+            <span className="text-red-500 dark:text-red-400 line-through text-[10px] self-center">{current.join(', ')}</span>
+          )}
+        </div>
+        <div className="mt-1 flex items-center gap-1">
+          <input
+            type="text"
+            value={entry}
+            onChange={(e) => setEntry(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); add(); } }}
+            placeholder={t('paperlessAudit.review.addTag')}
+            className="input py-0.5 px-1.5 text-xs w-24"
+          />
+          <button onClick={add} className="btn-icon btn-icon-ghost" aria-label={t('paperlessAudit.review.addTag')}>
+            <Plus className="w-3 h-3" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface CustomFieldsEditorProps {
+  value: Record<string, unknown>;
+  applicable: boolean;
+  selected: boolean;
+  onChange: (obj: Record<string, unknown>) => void;
+  onToggle: () => void;
+  t: TFunction;
+}
+function CustomFieldsEditor({ value, applicable, selected, onChange, onToggle, t }: CustomFieldsEditorProps) {
+  const [k, setK] = useState('');
+  const [v, setV] = useState('');
+  const entries = Object.entries(value);
+  const addPair = () => {
+    const key = k.trim();
+    if (!key) return;
+    onChange({ ...value, [key]: v });
+    setK('');
+    setV('');
+  };
+  const removeKey = (key: string) => {
+    const next = { ...value };
+    delete next[key];
+    onChange(next);
+  };
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <SelectBox applicable={applicable} selected={selected} onToggle={onToggle} label={t('paperlessAudit.review.applyField')} />
+        <span className="text-xs font-medium text-gray-600 dark:text-gray-300">{t('paperlessAudit.review.customFields')}</span>
+      </div>
+      {entries.length > 0 && (
+        <div className="space-y-1">
+          {entries.map(([key, val]) => (
+            <div key={key} className="flex items-center gap-2 text-xs">
+              <span className="font-mono text-gray-500 dark:text-gray-400">{key}</span>
+              <input
+                type="text"
+                value={typeof val === 'string' ? val : JSON.stringify(val)}
+                onChange={(e) => onChange({ ...value, [key]: e.target.value })}
+                className="input py-0.5 px-1.5 text-xs w-48"
+              />
+              <button onClick={() => removeKey(key)} className="btn-icon btn-icon-ghost" aria-label={t('common.remove')}>
+                <Trash2 className="w-3 h-3" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+      <div className="flex items-center gap-1">
+        <input type="text" value={k} onChange={(e) => setK(e.target.value)} placeholder={t('paperlessAudit.review.cfKey')} className="input py-0.5 px-1.5 text-xs w-32" />
+        <input type="text" value={v} onChange={(e) => setV(e.target.value)} placeholder={t('paperlessAudit.review.cfValue')} className="input py-0.5 px-1.5 text-xs w-48" />
+        <button onClick={addPair} className="btn-icon btn-icon-ghost" aria-label={t('paperlessAudit.review.cfAdd')}>
+          <Plus className="w-3 h-3" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/components/paperless/ConfidenceBadge.tsx
+++ b/src/frontend/src/components/paperless/ConfidenceBadge.tsx
@@ -1,0 +1,17 @@
+/** LLM-confidence percentage badge (green ≥80 / yellow ≥60 / red below).
+ *  Shared between the audit page and the editable review row. */
+interface ConfidenceBadgeProps {
+  value: number | null | undefined;
+}
+
+export default function ConfidenceBadge({ value }: ConfidenceBadgeProps) {
+  if (value == null) return <span className="text-gray-400">-</span>;
+  const pct = (value * 100).toFixed(0);
+  const color =
+    value >= 0.8
+      ? 'text-green-600 dark:text-green-400'
+      : value >= 0.6
+        ? 'text-yellow-600 dark:text-yellow-400'
+        : 'text-red-600 dark:text-red-400';
+  return <span className={`text-xs font-medium ${color}`}>{pct}%</span>;
+}

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -3,6 +3,7 @@
     "save": "Speichern",
     "cancel": "Abbrechen",
     "delete": "Löschen",
+    "remove": "Entfernen",
     "edit": "Bearbeiten",
     "create": "Erstellen",
     "close": "Schließen",
@@ -1549,7 +1550,14 @@
       "skipSelected": "Ausgewählte überspringen",
       "noResults": "Keine ausstehenden Änderungen",
       "noSearchResults": "Keine Ergebnisse für diese Suche",
-      "searchPlaceholder": "Titel, Ansprechpartner, Typ suchen..."
+      "searchPlaceholder": "Titel, Ansprechpartner, Typ suchen...",
+      "selectRow": "Zeile auswählen",
+      "applyField": "Dieses Feld übernehmen",
+      "customFields": "Benutzerdefinierte Felder",
+      "addTag": "Tag hinzufügen",
+      "cfKey": "Feld",
+      "cfValue": "Wert",
+      "cfAdd": "Feld hinzufügen"
     },
     "ocr": {
       "quality": "OCR-Qualität",

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -1557,7 +1557,8 @@
       "addTag": "Tag hinzufügen",
       "cfKey": "Feld",
       "cfValue": "Wert",
-      "cfAdd": "Feld hinzufügen"
+      "cfAdd": "Feld hinzufügen",
+      "datePlaceholder": "JJJJ-MM-TT"
     },
     "ocr": {
       "quality": "OCR-Qualität",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -3,6 +3,7 @@
     "save": "Save",
     "cancel": "Cancel",
     "delete": "Delete",
+    "remove": "Remove",
     "edit": "Edit",
     "create": "Create",
     "close": "Close",
@@ -1549,7 +1550,14 @@
       "skipSelected": "Skip Selected",
       "noResults": "No pending changes",
       "noSearchResults": "No results for this search",
-      "searchPlaceholder": "Search title, correspondent, type..."
+      "searchPlaceholder": "Search title, correspondent, type...",
+      "selectRow": "Select row",
+      "applyField": "Apply this field",
+      "customFields": "Custom fields",
+      "addTag": "Add tag",
+      "cfKey": "Field",
+      "cfValue": "Value",
+      "cfAdd": "Add field"
     },
     "ocr": {
       "quality": "OCR Quality",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -1557,7 +1557,8 @@
       "addTag": "Add tag",
       "cfKey": "Field",
       "cfValue": "Value",
-      "cfAdd": "Add field"
+      "cfAdd": "Add field",
+      "datePlaceholder": "YYYY-MM-DD"
     },
     "ocr": {
       "quality": "OCR Quality",

--- a/src/frontend/src/pages/PaperlessAuditPage.tsx
+++ b/src/frontend/src/pages/PaperlessAuditPage.tsx
@@ -4,7 +4,7 @@
  * Admin page for auditing Paperless documents using LLM analysis.
  * Provides audit control, review queue, OCR issue tracking, and statistics.
  */
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import type { TFunction } from 'i18next';
 import type { AxiosError } from 'axios';
 import type { LucideIcon } from 'lucide-react';
@@ -84,6 +84,13 @@ export default function PaperlessAuditPage() {
   const [reviewSearch, setReviewSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
   const reviewSearchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Latest in-flight review-overlay save per row (registered by AuditReviewRow),
+  // flushed before apply so a not-yet-persisted edit isn't dropped — covers both
+  // single-row and bulk approve.
+  const pendingSaves = useRef<Map<number, Promise<unknown>>>(new Map());
+  const registerPendingSave = useCallback((id: number, save: Promise<unknown>) => {
+    pendingSaves.current.set(id, save);
+  }, []);
 
   // OCR tab state
   const [ocrPage, setOcrPage] = useState(0);
@@ -224,6 +231,11 @@ export default function PaperlessAuditPage() {
   const approveResults = async (ids: number[]) => {
     setActionLoading((prev) => new Set([...prev, ...ids]));
     try {
+      // Flush any in-flight per-row overlay saves so apply reads the latest edits
+      // off the DB (allSettled: a failed save must not block the apply — its own
+      // error toast already surfaced).
+      const flush = ids.map((id) => pendingSaves.current.get(id)).filter(Boolean) as Promise<unknown>[];
+      if (flush.length) await Promise.allSettled(flush);
       await applyMutation.mutateAsync(ids);
     } catch (err) {
       const status = (err as AxiosError | undefined)?.response?.status;
@@ -443,6 +455,7 @@ export default function PaperlessAuditPage() {
           onToggleSelectAll={toggleSelectAll}
           onApprove={approveResults}
           onSkip={skipResults}
+          onRegisterPending={registerPendingSave}
           sortBy={reviewSortBy}
           sortOrder={reviewSortOrder}
           onSort={handleReviewSort}
@@ -659,6 +672,7 @@ interface ReviewTabProps {
   onToggleSelectAll: () => void;
   onApprove: (ids: number[]) => void;
   onSkip: (ids: number[]) => void;
+  onRegisterPending: (id: number, save: Promise<unknown>) => void;
   sortBy: string | null;
   sortOrder: 'asc' | 'desc';
   onSort: (column: string) => void;
@@ -673,7 +687,7 @@ interface SortHeaderProps {
 }
 
 // --- Review Tab Component ---
-function ReviewTab({ t, results, loading, total, page, setPage, selectedIds, actionLoading, onToggleSelected, onToggleSelectAll, onApprove, onSkip, sortBy, sortOrder, onSort, search, onSearch }: ReviewTabProps) {
+function ReviewTab({ t, results, loading, total, page, setPage, selectedIds, actionLoading, onToggleSelected, onToggleSelectAll, onApprove, onSkip, onRegisterPending, sortBy, sortOrder, onSort, search, onSearch }: ReviewTabProps) {
   const totalPages = Math.ceil(total / PAGE_SIZE);
   const allSelected = selectedIds.size === results.length && results.length > 0;
 
@@ -777,6 +791,7 @@ function ReviewTab({ t, results, loading, total, page, setPage, selectedIds, act
                 onToggleBulkSelected={onToggleSelected}
                 onApprove={onApprove}
                 onSkip={onSkip}
+                onRegisterPending={onRegisterPending}
                 actionLoading={actionLoading.has(r.id)}
                 colSpan={11}
               />

--- a/src/frontend/src/pages/PaperlessAuditPage.tsx
+++ b/src/frontend/src/pages/PaperlessAuditPage.tsx
@@ -17,6 +17,7 @@ import {
 import PageHeader from '../components/PageHeader';
 import Alert from '../components/Alert';
 import Badge from '../components/Badge';
+import AuditReviewRow from '../components/paperless/AuditReviewRow';
 import {
   useAuditStatusQuery,
   useReviewResultsQuery,
@@ -768,81 +769,18 @@ function ReviewTab({ t, results, loading, total, page, setPage, selectedIds, act
             </tr>
           </thead>
           <tbody>
-            {results.map((r) => {
-              const isLoading = actionLoading.has(r.id);
-              return (
-                <tr key={r.id} className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50">
-                  <td className="py-3 px-2">
-                    <input
-                      type="checkbox"
-                      checked={selectedIds.has(r.id)}
-                      onChange={() => onToggleSelected(r.id)}
-                      className="rounded border-gray-300 dark:border-gray-600"
-                    />
-                  </td>
-                  <td className="py-3 px-2 text-gray-900 dark:text-gray-100 font-mono text-xs">{r.paperless_doc_id}</td>
-                  <td className="py-3 px-2 max-w-xs">
-                    <DiffValue current={r.current_title} suggested={r.suggested_title} />
-                    {r.suggested_tags && r.suggested_tags.length > 0 && (
-                      <div className="mt-1 flex flex-wrap gap-1">
-                        {r.suggested_tags.map((tag, i) => (
-                          <Badge key={i} color="accent">{tag}</Badge>
-                        ))}
-                      </div>
-                    )}
-                  </td>
-                  <td className="py-3 px-2">
-                    <DiffValue current={r.current_correspondent} suggested={r.suggested_correspondent} />
-                  </td>
-                  <td className="py-3 px-2">
-                    <DiffValue current={r.current_document_type} suggested={r.suggested_document_type} />
-                  </td>
-                  <td className="py-3 px-2">
-                    <DiffValue current={r.current_date} suggested={r.suggested_date} />
-                  </td>
-                  <td className="py-3 px-2">
-                    {r.detected_language && (
-                      <Badge color="blue" className="font-mono">{r.detected_language}</Badge>
-                    )}
-                  </td>
-                  <td className="py-3 px-2">
-                    <DiffValue current={r.current_storage_path} suggested={r.suggested_storage_path} />
-                  </td>
-                  <td className="py-3 px-2">
-                    {r.missing_fields && r.missing_fields.length > 0 && (
-                      <div className="flex flex-wrap gap-1">
-                        {r.missing_fields.map((f, i) => (
-                          <Badge key={i} color="yellow">{f}</Badge>
-                        ))}
-                      </div>
-                    )}
-                  </td>
-                  <td className="py-3 px-2">
-                    <ConfidenceBadge value={r.confidence} />
-                  </td>
-                  <td className="py-3 px-2 text-right">
-                    <div className="flex items-center justify-end gap-1">
-                      <button
-                        onClick={() => onApprove([r.id])}
-                        disabled={isLoading}
-                        className="btn-icon text-green-600 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-900/20"
-                        title={t('paperlessAudit.review.approve')}
-                      >
-                        {isLoading ? <Loader className="w-4 h-4 animate-spin" /> : <Check className="w-4 h-4" />}
-                      </button>
-                      <button
-                        onClick={() => onSkip([r.id])}
-                        disabled={isLoading}
-                        className="btn-icon btn-icon-ghost"
-                        title={t('paperlessAudit.review.skip')}
-                      >
-                        <X className="w-4 h-4" />
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-              );
-            })}
+            {results.map((r) => (
+              <AuditReviewRow
+                key={r.id}
+                result={r}
+                isBulkSelected={selectedIds.has(r.id)}
+                onToggleBulkSelected={onToggleSelected}
+                onApprove={onApprove}
+                onSkip={onSkip}
+                actionLoading={actionLoading.has(r.id)}
+                colSpan={11}
+              />
+            ))}
           </tbody>
         </table>
       </div>
@@ -1396,33 +1334,6 @@ function CorrespondentsTab({ t, clusters, loading, threshold, setThreshold, onSc
       )}
     </div>
   );
-}
-
-interface DiffValueProps {
-  current?: string | null;
-  suggested?: string | null;
-}
-
-// --- Shared Components ---
-function DiffValue({ current, suggested }: DiffValueProps) {
-  if (!suggested || current === suggested) {
-    return <span className="text-gray-900 dark:text-gray-100">{current || '-'}</span>;
-  }
-  return (
-    <div className="space-y-0.5">
-      {current && (
-        <div className="text-red-600 dark:text-red-400 line-through text-xs">{current}</div>
-      )}
-      <div className="text-green-600 dark:text-green-400 text-xs font-medium">{suggested}</div>
-    </div>
-  );
-}
-
-function ConfidenceBadge({ value }: { value: number | null | undefined }) {
-  if (value == null) return <span className="text-gray-400">-</span>;
-  const pct = (value * 100).toFixed(0);
-  const color = value >= 0.8 ? 'text-green-600 dark:text-green-400' : value >= 0.6 ? 'text-yellow-600 dark:text-yellow-400' : 'text-red-600 dark:text-red-400';
-  return <span className={`text-xs font-medium ${color}`}>{pct}%</span>;
 }
 
 interface PaginationProps {

--- a/tests/backend/test_paperless_audit.py
+++ b/tests/backend/test_paperless_audit.py
@@ -961,8 +961,9 @@ class TestApplyFix:
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_apply_fix_no_changes(self, service, mock_mcp_manager):
-        """Should skip MCP call when all suggested values match current."""
+    async def test_apply_fix_no_changes(self, service, mock_mcp_manager, mock_db_factory):
+        """Should skip MCP call when all suggested values match current (the row is
+        still marked processed via _persist_status so it can't loop as pending)."""
         mock_result = MagicMock()
         mock_result.id = 1
         mock_result.paperless_doc_id = 42
@@ -979,6 +980,9 @@ class TestApplyFix:
         mock_result.current_storage_path = "path/a"
         mock_result.suggested_storage_path = "path/a"
         mock_result.suggested_custom_fields = None
+        mock_db_factory._mock_session.execute.return_value = MagicMock(
+            scalar_one_or_none=MagicMock(return_value=MagicMock())
+        )
 
         result = await service._apply_fix(mock_result)
 
@@ -987,8 +991,8 @@ class TestApplyFix:
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_apply_fix_none_suggested(self, service, mock_mcp_manager):
-        """Should skip when suggested values are None."""
+    async def test_apply_fix_none_suggested(self, service, mock_mcp_manager, mock_db_factory):
+        """Should skip when suggested values are None (row still marked processed)."""
         mock_result = MagicMock()
         mock_result.id = 1
         mock_result.paperless_doc_id = 42
@@ -1005,6 +1009,9 @@ class TestApplyFix:
         mock_result.current_storage_path = "path"
         mock_result.suggested_storage_path = None
         mock_result.suggested_custom_fields = None
+        mock_db_factory._mock_session.execute.return_value = MagicMock(
+            scalar_one_or_none=MagicMock(return_value=MagicMock())
+        )
 
         result = await service._apply_fix(mock_result)
 
@@ -1274,6 +1281,228 @@ class TestRunAudit:
 # ============================================================================
 # Apply/Skip/Reprocess Operations
 # ============================================================================
+
+
+class TestReviewOverlay:
+    """The manual-review overlay: user_overrides (edited values) + field_selection
+    (per-field apply subset), plus its validation. Exercises _apply_fix's overlay
+    handling and update_review persistence."""
+
+    @staticmethod
+    def _base_result():
+        """A result with title AND date changed, no overlay (legacy defaults)."""
+        r = MagicMock()
+        r.id = 1
+        r.paperless_doc_id = 42
+        r.current_title = "Old"
+        r.suggested_title = "New"
+        r.current_correspondent = None
+        r.suggested_correspondent = None
+        r.current_document_type = None
+        r.suggested_document_type = None
+        r.current_tags = None
+        r.suggested_tags = None
+        r.current_date = "2024-01-01"
+        r.suggested_date = "2024-02-02"
+        r.current_storage_path = None
+        r.suggested_storage_path = None
+        r.suggested_custom_fields = None
+        r.user_overrides = None
+        r.field_selection = None
+        return r
+
+    @staticmethod
+    def _wire_status_db(mock_db_factory):
+        """Wire the post-apply status-update lookup to a truthy row."""
+        s = mock_db_factory._mock_session
+        s.execute.return_value = MagicMock(
+            scalar_one_or_none=MagicMock(return_value=MagicMock())
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_override_replaces_suggested_value(self, service, mock_mcp_manager, mock_db_factory):
+        """A manual edit (user_overrides) is applied instead of the LLM suggestion."""
+        r = self._base_result()
+        r.user_overrides = {"title": "Hand Edited"}
+        self._wire_status_db(mock_db_factory)
+        assert await service._apply_fix(r) is True
+        params = mock_mcp_manager.execute_tool.call_args[0][1]
+        assert params["title"] == "Hand Edited"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_field_selection_limits_applied_fields(self, service, mock_mcp_manager, mock_db_factory):
+        """Only fields in field_selection are applied; other changed fields skip."""
+        r = self._base_result()  # title AND date both changed
+        r.field_selection = ["title"]
+        self._wire_status_db(mock_db_factory)
+        assert await service._apply_fix(r) is True
+        params = mock_mcp_manager.execute_tool.call_args[0][1]
+        assert params["title"] == "New"
+        assert "created_date" not in params  # date changed but not selected
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_override_applies_when_llm_flagged_no_change(self, service, mock_mcp_manager, mock_db_factory):
+        """A manual edit on a field the LLM did NOT change (suggested == current) is
+        still applied — the whole point of manual adjustment."""
+        r = self._base_result()
+        r.suggested_title = "Old"       # LLM: no title change
+        r.suggested_date = "2024-01-01"  # LLM: no date change
+        r.user_overrides = {"title": "Manually Set"}
+        self._wire_status_db(mock_db_factory)
+        assert await service._apply_fix(r) is True
+        params = mock_mcp_manager.execute_tool.call_args[0][1]
+        assert params["title"] == "Manually Set"
+        assert "created_date" not in params
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_none_overlay_is_legacy_behavior(self, service, mock_mcp_manager, mock_db_factory):
+        """Explicit None overlay → identical to the pre-feature apply (all changed)."""
+        r = self._base_result()
+        self._wire_status_db(mock_db_factory)
+        assert await service._apply_fix(r) is True
+        params = mock_mcp_manager.execute_tool.call_args[0][1]
+        assert params["title"] == "New"
+        assert params["created_date"] == "2024-02-02"
+
+    # --- validation ---
+
+    @pytest.mark.unit
+    def test_validate_overrides_accepts_known_fields(self, service):
+        out = service._validate_overrides({"title": "X", "tags": ["a"], "custom_fields": {"k": "v"}})
+        assert out == {"title": "X", "tags": ["a"], "custom_fields": {"k": "v"}}
+
+    @pytest.mark.unit
+    def test_validate_overrides_rejects_unknown_field(self, service):
+        with pytest.raises(ValueError):
+            service._validate_overrides({"nope": "x"})
+
+    @pytest.mark.unit
+    def test_validate_overrides_rejects_bad_types(self, service):
+        with pytest.raises(ValueError):
+            service._validate_overrides({"tags": "notalist"})
+        with pytest.raises(ValueError):
+            service._validate_overrides({"custom_fields": ["notadict"]})
+        with pytest.raises(ValueError):
+            service._validate_overrides({"title": 123})
+
+    @pytest.mark.unit
+    def test_validate_overrides_drops_none_value(self, service):
+        assert service._validate_overrides({"title": None}) == {}
+
+    @pytest.mark.unit
+    def test_validate_selection_dedupes_and_validates(self, service):
+        assert service._validate_selection(["title", "title", "tags"]) == ["title", "tags"]
+        with pytest.raises(ValueError):
+            service._validate_selection(["bogus"])
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_update_review_persists_overlay(self, service, mock_db_factory):
+        """update_review writes the validated overlay onto the row and commits."""
+        row = MagicMock()
+        s = mock_db_factory._mock_session
+        s.execute.return_value = MagicMock(scalar_one_or_none=MagicMock(return_value=row))
+        out = await service.update_review(1, overrides={"title": "Z"}, field_selection=["title"])
+        assert row.user_overrides == {"title": "Z"}
+        assert row.field_selection == ["title"]
+        s.commit.assert_awaited()
+        assert out is not None  # serialized row
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_update_review_unknown_id_returns_none(self, service, mock_db_factory):
+        s = mock_db_factory._mock_session
+        s.execute.return_value = MagicMock(scalar_one_or_none=MagicMock(return_value=None))
+        assert await service.update_review(999, overrides={"title": "Z"}) is None
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_update_review_empty_overrides_stored_as_none(self, service, mock_db_factory):
+        row = MagicMock()
+        s = mock_db_factory._mock_session
+        s.execute.return_value = MagicMock(scalar_one_or_none=MagicMock(return_value=row))
+        await service.update_review(1, overrides={})
+        assert row.user_overrides is None
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_update_review_invalid_field_raises(self, service, mock_db_factory):
+        with pytest.raises(ValueError):
+            await service.update_review(1, overrides={"bogus": "x"})
+
+    # --- review-fix regressions (from /review) ---
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_override_outside_selection_still_applies(self, service, mock_mcp_manager, mock_db_factory):
+        """A manual edit applies even when field_selection omits that field — an
+        override is an explicit intent to apply and must never be silently dropped."""
+        r = self._base_result()
+        r.current_correspondent = "Old Corr"
+        r.field_selection = ["title"]                    # correspondent NOT selected
+        r.user_overrides = {"correspondent": "Finanzamt"}
+
+        async def _execute(tool, params, **_kw):
+            if tool == "mcp.paperless.list_correspondents":
+                return {"success": True, "message": json.dumps({"items": []})}
+            if tool == "mcp.paperless.create_correspondent":
+                return {"success": True, "message": json.dumps({"id": 1, "name": params["name"]})}
+            return {"success": True}
+
+        mock_mcp_manager.execute_tool.side_effect = _execute
+        self._wire_status_db(mock_db_factory)
+        assert await service._apply_fix(r) is True
+        params = mock_mcp_manager.execute_tool.call_args[0][1]  # last = update_document
+        assert params["correspondent"] == "Finanzamt"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_deselect_all_marks_processed_not_stuck(self, service, mock_mcp_manager, mock_db_factory):
+        """field_selection=[] → no params → row is marked 'applied' (not left
+        pending and re-counted applied on every subsequent apply)."""
+        r = self._base_result()  # title + date changed
+        r.field_selection = []
+        status_row = MagicMock()
+        s = mock_db_factory._mock_session
+        s.execute.return_value = MagicMock(scalar_one_or_none=MagicMock(return_value=status_row))
+        assert await service._apply_fix(r) is True
+        tools = [c[0][0] for c in mock_mcp_manager.execute_tool.call_args_list]
+        assert "mcp.paperless.update_document" not in tools  # nothing written
+        assert status_row.status == "applied"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_update_review_reopens_non_pending_row(self, service, mock_db_factory):
+        """Editing an already-applied row resets it to pending so the correction
+        takes effect on the next apply (apply only processes pending rows)."""
+        row = MagicMock()
+        row.status = "applied"
+        row.applied_at = "2024-01-01T00:00:00"
+        s = mock_db_factory._mock_session
+        s.execute.return_value = MagicMock(scalar_one_or_none=MagicMock(return_value=row))
+        await service.update_review(1, overrides={"title": "Fixed"})
+        assert row.status == "pending"
+        assert row.applied_at is None
+
+    @pytest.mark.unit
+    def test_validate_overrides_rejects_empty_values(self, service):
+        """Empty values are rejected at the boundary (would be a silent no-op in
+        _apply_fix's truthiness gate — clearing a field is not supported here)."""
+        for bad in [{"title": ""}, {"title": "   "}, {"tags": []},
+                    {"tags": [""]}, {"custom_fields": {}}, {"storage_path": ""}]:
+            with pytest.raises(ValueError):
+                service._validate_overrides(bad)
+
+    @pytest.mark.unit
+    def test_validate_overrides_date_must_be_iso(self, service):
+        assert service._validate_overrides({"date": "2024-02-14"}) == {"date": "2024-02-14"}
+        for bad in [{"date": "not-a-date"}, {"date": "14.02.2024"}, {"date": ""}]:
+            with pytest.raises(ValueError):
+                service._validate_overrides(bad)
 
 
 class TestApplyResults:

--- a/tests/backend/test_paperless_audit_routes.py
+++ b/tests/backend/test_paperless_audit_routes.py
@@ -1,0 +1,94 @@
+"""HTTP route tests for the Paperless-audit review-overlay endpoint.
+
+PATCH /api/admin/paperless-audit/results/{id} is ADMIN-gated; these cover the
+status-code contract (200 / 400 / 404) and the auth gate at the HTTP boundary.
+The service internals (update_review / _validate_*) are unit-tested in
+test_paperless_audit.py — here the service is mocked so we exercise only the
+route wiring, error mapping, and permission dependency.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from ha_glue.api.routes.paperless_audit import router
+from models.permissions import Permission
+from services.auth_service import get_current_user
+from services.database import get_db
+
+pytestmark = [pytest.mark.backend]
+
+_PATH = "/api/admin/paperless-audit/results/5"
+
+
+class _FakeUser:
+    """Avoids ORM lazy-load: exposes has_permission directly (mirrors the
+    tool-health route tests)."""
+
+    def __init__(self, is_admin: bool):
+        self.id = 1
+        self.username = "u"
+        self._admin = is_admin
+
+    def has_permission(self, perm: str) -> bool:
+        return self._admin and perm == Permission.ADMIN.value
+
+
+def _app(service, *, is_admin: bool, monkeypatch) -> FastAPI:
+    # auth_enabled must be True or require_permission short-circuits to allow.
+    monkeypatch.setattr("services.auth_service.settings.auth_enabled", True)
+    app = FastAPI()
+    app.include_router(router)
+    app.state.paperless_audit = service
+    app.dependency_overrides[get_current_user] = lambda: _FakeUser(is_admin)
+    app.dependency_overrides[get_db] = lambda: None  # unused by permission_checker
+    return app
+
+
+def _client(app: FastAPI) -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://t")
+
+
+@pytest.mark.asyncio
+async def test_patch_review_200_on_success(monkeypatch):
+    svc = AsyncMock()
+    svc.update_review.return_value = {"id": 5, "user_overrides": {"title": "X"}}
+    app = _app(svc, is_admin=True, monkeypatch=monkeypatch)
+    async with _client(app) as c:
+        r = await c.patch(_PATH, json={"overrides": {"title": "X"}, "field_selection": ["title"]})
+    assert r.status_code == 200
+    assert r.json()["id"] == 5
+    svc.update_review.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_patch_review_400_on_validation_error(monkeypatch):
+    svc = AsyncMock()
+    svc.update_review.side_effect = ValueError("unknown field: 'x'")
+    app = _app(svc, is_admin=True, monkeypatch=monkeypatch)
+    async with _client(app) as c:
+        r = await c.patch(_PATH, json={"overrides": {"x": "y"}})
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_patch_review_404_on_unknown_id(monkeypatch):
+    svc = AsyncMock()
+    svc.update_review.return_value = None
+    app = _app(svc, is_admin=True, monkeypatch=monkeypatch)
+    async with _client(app) as c:
+        r = await c.patch("/api/admin/paperless-audit/results/999", json={"field_selection": ["title"]})
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_patch_review_requires_admin(monkeypatch):
+    svc = AsyncMock()
+    app = _app(svc, is_admin=False, monkeypatch=monkeypatch)
+    async with _client(app) as c:
+        r = await c.patch(_PATH, json={"overrides": {"title": "X"}})
+    assert r.status_code in (401, 403)
+    svc.update_review.assert_not_awaited()

--- a/tests/frontend/react/components/AuditReviewRow.test.tsx
+++ b/tests/frontend/react/components/AuditReviewRow.test.tsx
@@ -57,6 +57,7 @@ function renderRow(r: AuditResult) {
           onToggleBulkSelected={vi.fn()}
           onApprove={vi.fn()}
           onSkip={vi.fn()}
+          onRegisterPending={vi.fn()}
           actionLoading={false}
           colSpan={11}
         />
@@ -121,6 +122,37 @@ describe('AuditReviewRow', () => {
       field_selection: string[];
     };
     expect(body.field_selection.length).toBe(initial - 1);
+  });
+
+  it('editing a scalar back to the current value does not freeze the row', async () => {
+    // only title changes (correspondent/date == current)
+    renderRow(row({ suggested_correspondent: 'Old Corp', suggested_date: '2024-01-01' }));
+    const titleInput = screen.getByDisplayValue('New Title');
+    fireEvent.change(titleInput, { target: { value: 'Old Title' } }); // == current
+    fireEvent.blur(titleInput);
+
+    await waitFor(() => expect(mockedPatch).toHaveBeenCalled());
+    const body = mockedPatch.mock.calls[mockedPatch.mock.calls.length - 1][1] as {
+      field_selection: string[];
+    };
+    // a no-op edit deselects the field (not applied); the row is not stuck.
+    expect(body.field_selection).not.toContain('title');
+    const approveBtn = screen.getByTitle('Übernehmen');
+    expect(approveBtn).not.toBeDisabled();
+  });
+
+  it('preserves the JSON type of an edited custom field (no string coercion)', async () => {
+    renderRow(row({ suggested_custom_fields: { amount: 5 } }));
+    // expand the custom-fields drawer
+    fireEvent.click(screen.getByTitle('Benutzerdefinierte Felder'));
+    const valueInput = screen.getByDisplayValue('5');
+    fireEvent.change(valueInput, { target: { value: '10' } });
+
+    await waitFor(() => {
+      const bodies = mockedPatch.mock.calls.map((c) => c[1] as { overrides: { custom_fields?: Record<string, unknown> } });
+      const withCf = bodies.find((b) => b.overrides.custom_fields);
+      expect(withCf?.overrides.custom_fields).toEqual({ amount: 10 }); // number, not "10"
+    });
   });
 
   it('adding a tag persists a tags override', async () => {

--- a/tests/frontend/react/components/AuditReviewRow.test.tsx
+++ b/tests/frontend/react/components/AuditReviewRow.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * AuditReviewRow — the editable Paperless-audit review row.
+ * Verifies: suggested values render as editable inputs; a manual edit persists
+ * via PATCH with the override; a per-field checkbox toggle persists the
+ * field_selection; adding a tag persists the tags override.
+ *
+ * apiClient is mocked directly (mirrors PaperlessAuditLowQuality.test.tsx).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
+
+import AuditReviewRow from '../../../../src/frontend/src/components/paperless/AuditReviewRow';
+import { renderWithProviders } from '../test-utils';
+import apiClient from '../../../../src/frontend/src/utils/axios';
+import type { AuditResult } from '../../../../src/frontend/src/api/resources/paperlessAudit';
+
+vi.mock('../../../../src/frontend/src/utils/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn().mockResolvedValue({ data: {} }),
+    patch: vi.fn().mockResolvedValue({ data: {} }),
+  },
+  extractApiError: (_e: unknown, fallback: string) => fallback,
+  extractFieldErrors: () => ({}),
+}));
+
+const mockedPatch = vi.mocked(apiClient.patch);
+
+function row(overrides: Partial<AuditResult> = {}): AuditResult {
+  return {
+    id: 7,
+    paperless_doc_id: 100,
+    current_title: 'Old Title',
+    suggested_title: 'New Title',
+    current_correspondent: 'Old Corp',
+    suggested_correspondent: 'New Corp',
+    current_document_type: 'Invoice',
+    suggested_document_type: 'Invoice',
+    current_date: '2024-01-01',
+    suggested_date: '2024-02-02',
+    current_storage_path: null,
+    suggested_storage_path: null,
+    current_tags: [],
+    suggested_tags: [],
+    confidence: 0.9,
+    ...overrides,
+  };
+}
+
+function renderRow(r: AuditResult) {
+  return renderWithProviders(
+    <table>
+      <tbody>
+        <AuditReviewRow
+          result={r}
+          isBulkSelected={false}
+          onToggleBulkSelected={vi.fn()}
+          onApprove={vi.fn()}
+          onSkip={vi.fn()}
+          actionLoading={false}
+          colSpan={11}
+        />
+      </tbody>
+    </table>,
+  );
+}
+
+describe('AuditReviewRow', () => {
+  beforeEach(() => {
+    mockedPatch.mockClear();
+    mockedPatch.mockResolvedValue({ data: {} });
+  });
+
+  it('renders suggested values as editable inputs', () => {
+    renderRow(row());
+    expect(screen.getByDisplayValue('New Title')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('New Corp')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('2024-02-02')).toBeInTheDocument();
+  });
+
+  it('persists a manual edit as an override on blur', async () => {
+    renderRow(row());
+    const titleInput = screen.getByDisplayValue('New Title');
+    fireEvent.change(titleInput, { target: { value: 'Hand Edited' } });
+    fireEvent.blur(titleInput);
+
+    await waitFor(() => {
+      expect(mockedPatch).toHaveBeenCalledWith(
+        '/api/admin/paperless-audit/results/7',
+        expect.objectContaining({
+          overrides: expect.objectContaining({ title: 'Hand Edited' }),
+        }),
+      );
+    });
+  });
+
+  it('reverting an edit back to the suggestion drops the override', async () => {
+    renderRow(row());
+    const titleInput = screen.getByDisplayValue('New Title');
+    fireEvent.change(titleInput, { target: { value: 'New Title' } });
+    fireEvent.blur(titleInput);
+
+    await waitFor(() => expect(mockedPatch).toHaveBeenCalled());
+    const lastBody = mockedPatch.mock.calls[mockedPatch.mock.calls.length - 1][1] as {
+      overrides: Record<string, unknown>;
+    };
+    expect(lastBody.overrides).not.toHaveProperty('title');
+  });
+
+  it('toggling a field checkbox persists field_selection', async () => {
+    renderRow(row());
+    // The apply-field checkboxes carry the "Apply this field" aria-label; all
+    // changed fields (title, correspondent, date here) start selected.
+    const applyBoxes = screen.getAllByLabelText('Dieses Feld übernehmen');
+    const initial = applyBoxes.length;
+    expect(initial).toBeGreaterThan(0);
+    fireEvent.click(applyBoxes[0]); // deselect the first changed field
+
+    await waitFor(() => expect(mockedPatch).toHaveBeenCalled());
+    const body = mockedPatch.mock.calls[mockedPatch.mock.calls.length - 1][1] as {
+      field_selection: string[];
+    };
+    expect(body.field_selection.length).toBe(initial - 1);
+  });
+
+  it('adding a tag persists a tags override', async () => {
+    renderRow(row());
+    const tagInput = screen.getByPlaceholderText('Tag hinzufügen');
+    fireEvent.change(tagInput, { target: { value: 'steuer' } });
+    fireEvent.keyDown(tagInput, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(mockedPatch).toHaveBeenCalledWith(
+        '/api/admin/paperless-audit/results/7',
+        expect.objectContaining({
+          overrides: expect.objectContaining({ tags: ['steuer'] }),
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
Frontend (PR2 of 2) for the Paperless-audit review overlay. **Stacked on #1053** (backend) — base is that branch; retarget to `main` after #1053 merges.

## What the UI now does
The read-only diff table in the Review tab becomes editable:
- **Inline edit**: every suggested value is a text input, auto-saved on blur; the current value shows struck-through when it differs.
- **Per-field apply selection**: a checkbox on each changed/overridden field controls whether it's applied (`field_selection`). Editing a field auto-includes it.
- **Tags editor**: add/remove chips.
- **custom_fields editor**: key/value pairs in a per-row expandable drawer.

## How it wires
- New `components/paperless/AuditReviewRow.tsx` owns the per-row draft (`overrides` + `selection`) and persists via `PATCH /results/{id}` through `useUpdateReview`. The hook deliberately does **not** invalidate the audit query on edit (a refetch would clobber in-progress drafts on other rows).
- Per-row **approve flushes its pending save** before applying, so the persisted overlay reflects the latest edit.
- Because the backend applies overrides regardless of `field_selection`, the UI only needs to carry the intended-to-apply fields; untouched rows never PATCH → legacy apply-all path (byte-identical).
- Extracted the shared `ConfidenceBadge`; `AuditResult` extended (`current_tags`/`current_custom_fields`/`suggested_custom_fields`/`status`/`user_overrides`/`field_selection`) + `updateReviewRequest`.

## Tests / gates
- `tests/frontend/react/components/AuditReviewRow.test.tsx` — 5 green (inputs render; edit→override PATCH; revert drops override; checkbox→field_selection; tag add→tags override).
- `tsc --noEmit` clean for the touched files; `npm run build` green. (2 pre-existing tsc errors in the unrelated `RoomOutputSettings.test.tsx` are not from this diff.)

## Known limitation
Bulk "approve selected" relies on per-field blur-saves having already fired; the last-focused field blurs when clicking the bulk button (async save vs immediate apply = a millisecond race). The primary per-row approve path is race-safe via flush. E2E verification pending #1053 deploy (the PATCH endpoint isn't live until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)