### PR TITLE
fix(followup-chips): disable thinking mode so qwen3 returns content

### DIFF
--- a/src/backend/services/followup_service.py
+++ b/src/backend/services/followup_service.py
@@ -98,7 +98,11 @@ async def generate_followups(
         return []
 
     try:
-        from utils.llm_client import extract_response_content, get_default_client
+        from utils.llm_client import (
+            extract_response_content,
+            get_classification_chat_kwargs,
+            get_default_client,
+        )
 
         lang_name = "Deutsch" if (lang or "de").startswith("de") else "English"
         system = (
@@ -123,6 +127,11 @@ async def generate_followups(
             ],
             format="json",
             options={"temperature": 0.4},
+            # Disable thinking mode for thinking-capable models (e.g. qwen3): the
+            # ollama-python 0.6.1 bug returns EMPTY content when thinking is on, so the
+            # chips silently never generate. Mirrors every other classification call
+            # site (schicht_a, KG, router, meeting-minutes, paperless-audit).
+            **get_classification_chat_kwargs(model),
         )
         raw = extract_response_content(response) or ""
         return _parse_followups(raw, count)

--- a/tests/backend/test_followup_service.py
+++ b/tests/backend/test_followup_service.py
@@ -72,3 +72,26 @@ async def test_generate_is_best_effort_on_failure():
     with patch("utils.llm_client.get_default_client", return_value=mock_client), \
          patch("utils.llm_client.extract_response_content", return_value=""):
         assert await generate_followups("q", "an answer", model="m") == []
+
+
+@pytest.mark.unit
+async def test_generate_disables_thinking_for_thinking_model():
+    """A thinking-capable model (e.g. qwen3) MUST be called with think=False, else the
+    ollama-python bug returns empty content and no chips are ever produced."""
+    mock_client = MagicMock()
+    mock_client.chat = AsyncMock(return_value={"message": {"content": '["X?"]'}})
+    with patch("utils.llm_client.get_default_client", return_value=mock_client), \
+         patch("utils.llm_client.extract_response_content", return_value='["X?"]'):
+        await generate_followups("q", "an answer long enough", model="qwen3:8b", count=3)
+    assert mock_client.chat.await_args.kwargs.get("think") is False  # thinking disabled
+
+
+@pytest.mark.unit
+async def test_generate_no_think_kwarg_for_non_thinking_model():
+    """A non-thinking model gets no `think` kwarg (get_classification_chat_kwargs → {})."""
+    mock_client = MagicMock()
+    mock_client.chat = AsyncMock(return_value={"message": {"content": '["X?"]'}})
+    with patch("utils.llm_client.get_default_client", return_value=mock_client), \
+         patch("utils.llm_client.extract_response_content", return_value='["X?"]'):
+        await generate_followups("q", "an answer long enough", model="llama3.1:8b", count=3)
+    assert "think" not in mock_client.chat.await_args.kwargs


### PR DESCRIPTION
followup_service was the only classification call site not passing get_classification_chat_kwargs. With a thinking model (qwen3:8b via OLLAMA_INTENT_MODEL) the ollama-python bug returns empty content, so the followups frame was never emitted and chips silently never appeared. Fix mirrors every sibling call site (schicht_a, KG, router, meeting-minutes, paperless-audit). +2 tests (think=False for thinking model, absent for non-thinking). 10 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)