### PR TITLE
fix(proactive): per-user suppression scope + tenant-neutral enrich prompt

### DIFF
--- a/src/backend/services/notification_service.py
+++ b/src/backend/services/notification_service.py
@@ -13,7 +13,7 @@ import secrets
 from datetime import UTC, datetime, timedelta
 
 from loguru import logger
-from sqlalchemy import delete, select, text
+from sqlalchemy import delete, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.database import (
@@ -258,8 +258,8 @@ class NotificationService:
                 context = f"\nZusätzliche Daten: {data}"
 
             prompt = (
-                "Du bist ein Smart-Home-Assistent. Formuliere die folgende Benachrichtigung "
-                "als natürlich-sprachliche, hilfreiche Nachricht für den Bewohner. "
+                "Du bist ein digitaler Assistent. Formuliere die folgende Benachrichtigung "
+                "als natürlich-sprachliche, hilfreiche Nachricht für den Nutzer. "
                 "Halte dich kurz (1-2 Sätze). Antworte NUR mit der formulierten Nachricht.\n\n"
                 f"Event: {event_type}\n"
                 f"Titel: {title}\n"
@@ -284,17 +284,35 @@ class NotificationService:
     # ------------------------------------------------------------------
 
     async def _is_suppressed(
-        self, event_type: str, embedding: list[float] | None = None,
+        self,
+        event_type: str,
+        embedding: list[float] | None = None,
+        target_user_id: int | None = None,
     ) -> bool:
-        """Check if this notification type is suppressed via feedback learning."""
+        """Check if this notification type is suppressed via feedback learning.
+
+        Scoped to the TARGET user: a suppression applies only when it was created by
+        that user (``user_id == target_user_id``) OR it is a GLOBAL rule
+        (``user_id IS NULL`` — single-user/auth-off mode, or an intentionally
+        instance-wide suppression). Without this scope, one user dismissing a
+        notification type would suppress it for EVERY user on a multi-user instance.
+        For a broadcast (``target_user_id is None``) only global rules apply, since
+        ``user_id == None`` compiles to ``user_id IS NULL``.
+        """
         if not settings.proactive_feedback_learning_enabled:
             return False
+
+        user_scope = or_(
+            NotificationSuppression.user_id == target_user_id,
+            NotificationSuppression.user_id.is_(None),
+        )
 
         # Exact event_type match
         result = await self.db.execute(
             select(NotificationSuppression.id).where(
                 NotificationSuppression.event_pattern == event_type,
                 NotificationSuppression.is_active.is_(True),
+                user_scope,
             ).limit(1)
         )
         if result.scalar_one_or_none() is not None:
@@ -312,10 +330,11 @@ class NotificationService:
                         FROM notification_suppressions
                         WHERE is_active = true
                           AND embedding IS NOT NULL
+                          AND (user_id = :uid OR user_id IS NULL)
                         ORDER BY embedding <=> CAST(:embedding AS vector)
                         LIMIT 1
                     """),
-                    {"embedding": str(embedding)},
+                    {"embedding": str(embedding), "uid": target_user_id},
                 )
                 row = result.first()
                 if row and row.similarity >= threshold:
@@ -455,8 +474,8 @@ class NotificationService:
             except Exception as e:
                 logger.warning(f"⚠️ Embedding generation failed: {e}")
 
-        # 3. Suppression check (feedback learning)
-        if await self._is_suppressed(event_type, embedding):
+        # 3. Suppression check (feedback learning) — scoped to the target user
+        if await self._is_suppressed(event_type, embedding, target_user_id=target_user_id):
             raise ValueError("Notification suppressed by feedback rule")
 
         # 4. Semantic dedup check

--- a/tests/backend/test_notifications.py
+++ b/tests/backend/test_notifications.py
@@ -673,6 +673,69 @@ class TestSuppressionLearning:
             assert result is False
 
     @pytest.mark.database
+    async def test_suppression_scoped_to_creating_user(self, notification_service, db_session, test_user):
+        """A PER-USER suppression blocks only that user's notifications — NOT other
+        users' (the multi-tenant bug: one user's dismissal must not suppress for all)."""
+        db_session.add(NotificationSuppression(
+            event_pattern="ha_automation.washer", is_active=True, user_id=test_user.id,
+        ))
+        await db_session.commit()
+        with patch("services.notification_service.settings") as mock_settings:
+            mock_settings.proactive_feedback_learning_enabled = True
+            mock_settings.proactive_feedback_similarity_threshold = 0.80
+            # same target user → suppressed
+            assert await notification_service._is_suppressed(
+                "ha_automation.washer", target_user_id=test_user.id) is True
+            # a DIFFERENT user → NOT suppressed (this is what the fix protects)
+            assert await notification_service._is_suppressed(
+                "ha_automation.washer", target_user_id=test_user.id + 999) is False
+            # a broadcast (no target user) → NOT suppressed by a per-user rule
+            assert await notification_service._is_suppressed(
+                "ha_automation.washer", target_user_id=None) is False
+
+    @pytest.mark.database
+    async def test_global_suppression_blocks_all_targets(self, notification_service, db_session, test_user):
+        """A GLOBAL suppression (user_id NULL) still blocks for any target user."""
+        db_session.add(NotificationSuppression(
+            event_pattern="ha_automation.washer", is_active=True, user_id=None,
+        ))
+        await db_session.commit()
+        with patch("services.notification_service.settings") as mock_settings:
+            mock_settings.proactive_feedback_learning_enabled = True
+            mock_settings.proactive_feedback_similarity_threshold = 0.80
+            assert await notification_service._is_suppressed(
+                "ha_automation.washer", target_user_id=test_user.id) is True
+            assert await notification_service._is_suppressed(
+                "ha_automation.washer", target_user_id=None) is True
+
+    @pytest.mark.database
+    async def test_enrichment_prompt_is_tenant_neutral(self, notification_service):
+        """The enrichment prompt must not use household 'Smart-Home'/'Bewohner' phrasing
+        (wrong for a business tenant)."""
+        captured = {}
+
+        async def _fake_generate(**kw):
+            captured["prompt"] = kw.get("prompt", "")
+
+            class _R:
+                response = "Formulierte Nachricht."
+
+            return _R()
+
+        mock_client = MagicMock()
+        mock_client.generate = _fake_generate
+        with patch("services.notification_service.settings") as ms, \
+             patch("utils.llm_client.get_default_client", return_value=mock_client):
+            ms.proactive_enrichment_enabled = True
+            ms.proactive_enrichment_model = ""
+            ms.ollama_model = "m"
+            await notification_service._enrich_message("evt", "Titel", "Nachricht")
+
+        assert "Smart-Home" not in captured["prompt"]
+        assert "Bewohner" not in captured["prompt"]
+        assert "digitaler Assistent" in captured["prompt"]
+
+    @pytest.mark.database
     async def test_list_suppressions(self, notification_service, db_session):
         """Test: List active suppressions."""
         db_session.add(NotificationSuppression(event_pattern="type_a", is_active=True))


### PR DESCRIPTION
Fixes the two bugs that kept proactive_feedback_learning + proactive_enrichment dark. (1) Notification suppression now scoped to the target user (user_id == target OR NULL) on exact + semantic queries — previously one user's dismissal suppressed a notification type for all users on multi-user instances. (2) Enrichment prompt genericized from household 'Smart-Home-Assistent/Bewohner' to 'digitaler Assistent/Nutzer'. 10 tests pass (per-user scoping, global, tenant-neutral prompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)