### PR TITLE
fix(ingest): quality gate accepts numeric/financial content + embed reliability + force_ocr reindex

### DIFF
--- a/src/backend/services/kb_maintenance_tool.py
+++ b/src/backend/services/kb_maintenance_tool.py
@@ -165,6 +165,13 @@ KB_MAINTENANCE_TOOLS: dict = {
                 "docs are reindexed. Set true for 'auch die unlesbaren' / "
                 "'trotzdem alle neu indexieren'."
             ),
+            "force_ocr": (
+                "Re-run FULL-PAGE OCR (force_full_page_ocr) instead of reusing the "
+                "existing text layer. Optional; default false. Use for scanned "
+                "documents whose text extraction was garbled ('nochmal mit OCR', "
+                "'als Scan neu erkennen'). Pairs well with force=true to give the "
+                "unindexable docs a real second chance."
+            ),
         },
     },
     "internal.list_chunkless_documents": {
@@ -381,6 +388,7 @@ async def reindex_documents(
         except (ValueError, TypeError):
             pass
     force = _as_bool(params.get("force"))
+    force_ocr = _as_bool(params.get("force_ocr"))
 
     try:
         async with AsyncSessionLocal() as db:
@@ -464,7 +472,7 @@ async def reindex_documents(
                 await queue.enqueue(
                     {
                         "document_id": did,
-                        "force_ocr": False,
+                        "force_ocr": force_ocr,
                         "user_id": user_id,
                         "trigger": "user_reindex",
                     }

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -383,7 +383,12 @@ class Settings(BaseSettings):
     rag_hybrid_fts_config: str = "german"     # PostgreSQL FTS config: simple/german/english
 
     # Embedding
-    rag_embedding_timeout: float = 30.0       # Timeout in seconds for embedding calls
+    # Timeout for a single embedding call. Sized to survive a cold model load: the
+    # embed model can be evicted to CPU under GPU/VRAM pressure on a shared Ollama, so
+    # the FIRST embed after eviction cold-loads (~10s) and, under concurrent chat +
+    # bulk-ingest load, can queue further. A too-tight timeout silently DROPS the chunk
+    # (→ unsearchable / parent-only docs), so favour reliability over failing fast.
+    rag_embedding_timeout: float = 60.0
 
     # W5 — RAG eval LLM timeouts (previously hardcoded as 60 / 30 in rag_eval_service.py)
     rag_eval_answer_timeout: float = Field(default=60.0, ge=10.0, le=300.0)

--- a/src/backend/utils/content_quality.py
+++ b/src/backend/utils/content_quality.py
@@ -24,11 +24,21 @@ from __future__ import annotations
 
 import re
 
-# A word-like token: ≥3 letters from a German-Latin alphabet. The bar is
-# deliberately language-aware (ä/ö/ü/ß) so German OCR with diacritics
-# isn't mis-classified as garbage. Anything outside this charset (digits,
-# punctuation, control glyphs from broken OCR) is NOT counted.
-_WORD_LIKE_RE = re.compile(r"^[A-Za-zÄÖÜäöüß]{3,}$")
+# A MEANINGFUL token carries real content: a word OR a structured/numeric datum.
+# The garbage we filter is glyph noise — single-char runs, punctuation, control
+# glyphs from broken OCR (``- r . : ■ { - n ; ;``). A token is meaningful when it
+# holds ≥3 alphanumeric characters (letters incl. ä/ö/ü/ß, or digits): this counts
+# real words (``Rechnung``), amounts (``1.250,00``), dates (``01.02.2026``), IBANs
+# (``DE12345678``), and codes — legitimate financial/tabular content that a business
+# archive is full of — while glyph noise (0-1 alphanumerics per token) is not counted.
+# (Prior versions counted ONLY letters-only ≥3-char tokens, which FALSELY flagged
+# numeric-heavy financial documents as garbage and dropped them at ingest.)
+_MIN_MEANINGFUL_ALNUM = 3
+
+
+def _is_meaningful(token: str) -> bool:
+    """A token with real content (word / number / amount / date / code), not glyph noise."""
+    return sum(1 for c in token if c.isalnum()) >= _MIN_MEANINGFUL_ALNUM
 
 # Length floor: shorter inputs are dominated by noise statistics. A
 # 12-char chunk of valid text could trivially trip a ratio check that
@@ -36,10 +46,11 @@ _WORD_LIKE_RE = re.compile(r"^[A-Za-zÄÖÜäöüß]{3,}$")
 # — the wins come on the medium-to-long garbage chunks.
 _MIN_LEN_FOR_QUALITY_CHECK = 40
 
-# Word-like-token ratio floor: below this, the text is dominated by
+# Meaningful-token ratio floor: below this, the text is dominated by
 # single-character runs / glyphs / punctuation. Calibrated empirically
-# against the production corpus: real text (German + technical English)
-# clears 0.4 by a wide margin; OCR garbage from Paperless lands 0.0-0.2.
+# against the production corpus: real text (German + technical English,
+# and numeric/financial content) clears 0.4 by a wide margin; OCR garbage
+# from Paperless lands 0.0-0.2.
 #
 # THRESHOLD-VERSIONING NOTE (v2.10.4): this constant is shared between
 # two call sites:
@@ -65,9 +76,10 @@ def is_low_quality_text(text: str | None) -> bool:
     """True if the text reads as OCR garbage / glyph noise.
 
     Returns False for None, empty, short (<40 char), or text that clears
-    the word-like-token ratio threshold. Only flags the medium-to-long
-    chunks dominated by single-char runs and punctuation glyphs that
-    failed Paperless OCR produces.
+    the meaningful-token ratio threshold (words OR numeric/structured data).
+    Only flags the medium-to-long chunks dominated by single-char runs and
+    punctuation glyphs that failed Paperless OCR produces — NOT legitimate
+    numeric/financial content.
     """
     if not text:
         return False
@@ -79,8 +91,8 @@ def is_low_quality_text(text: str | None) -> bool:
     if not tokens:
         return False
 
-    wordlike = sum(1 for t in tokens if _WORD_LIKE_RE.fullmatch(t))
-    ratio = wordlike / len(tokens)
+    meaningful = sum(1 for t in tokens if _is_meaningful(t))
+    ratio = meaningful / len(tokens)
     return ratio < _MIN_WORDLIKE_RATIO
 
 

--- a/tests/backend/test_content_quality.py
+++ b/tests/backend/test_content_quality.py
@@ -33,9 +33,29 @@ CLEAN_SAMPLES = [
 ]
 
 
+# Legitimate financial/tabular content — numeric-heavy but REAL. The prior
+# letters-only heuristic FALSELY flagged these (dropping them at ingest → the
+# 2026-07 xidra unsearchable-financial-docs bug); they MUST pass now.
+FINANCIAL_SAMPLES = [
+    "IBAN: DE12 3456 7890 1234 56 BIC: GENODEF1XXX Betrag: 1.250,00 EUR "
+    "Datum: 01.02.2026 Rechnungsnr: 2024-00123 Kundennr: 44521",
+    "Pos 1 Menge 2 Einzelpreis 49,99 Gesamt 99,98 Pos 2 Menge 1 Einzelpreis "
+    "120,00 Gesamt 120,00 Zwischensumme 219,98 MwSt 19% 41,80 Summe 261,78 EUR",
+    "Steuernummer 123/456/78901 USt-IdNr DE123456789 Zeitraum 01.01.2026 bis "
+    "31.12.2026 Vorauszahlung 4.200,00 Nachzahlung 318,45",
+]
+
+
 @pytest.mark.parametrize("text", GARBAGE_SAMPLES)
 def test_garbage_flagged(text: str):
     assert is_low_quality_text(text) is True, f"Should flag garbage: {text!r}"
+
+
+@pytest.mark.parametrize("text", FINANCIAL_SAMPLES)
+def test_numeric_financial_content_passes(text: str):
+    """Numeric/financial content (amounts, IBANs, dates, codes) is legitimate — it
+    must NOT be flagged as garbage even though it has few letters-only words."""
+    assert is_low_quality_text(text) is False, f"legit financial content wrongly flagged: {text!r}"
 
 
 @pytest.mark.parametrize("text", CLEAN_SAMPLES)

--- a/tests/backend/test_kb_maintenance_tool.py
+++ b/tests/backend/test_kb_maintenance_tool.py
@@ -136,7 +136,22 @@ async def test_reindex_enqueues_user_reindex_for_chunkless(monkeypatch):
     assert {p["document_id"] for p in payloads} == {5, 9}
     assert all(p["trigger"] == "user_reindex" for p in payloads)
     assert all(p["user_id"] == 7 for p in payloads)
+    assert all(p["force_ocr"] is False for p in payloads)  # default: reuse text layer
     assert session.commit.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_reindex_force_ocr_threads_into_enqueue(monkeypatch):
+    """force_ocr=true enqueues force_full_page_ocr so garbled scans get re-OCR'd."""
+    cm, _ = _session([_scalar_result(0), _scalars_result([5, 9]), MagicMock()])
+    monkeypatch.setattr(kb, "AsyncSessionLocal", cm)
+    monkeypatch.setattr(kb.settings, "auth_enabled", False)
+    q = _patch_queue(monkeypatch)
+
+    out = await kb.reindex_documents({"force_ocr": True}, user_id=7)
+    assert out["success"] and out["data"]["reindexed"] == 2
+    payloads = [c.args[0] for c in q.enqueue.await_args_list]
+    assert all(p["force_ocr"] is True for p in payloads)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Makes Renfield able to index + repair financial/business documents.

**1. Quality-gate false-positive (root cause of ~31 of xidra's 47 unsearchable docs):** `is_low_quality_text` counted only letters-only ≥3-char tokens, so legitimate financial content (IBANs, amounts, dates, codes) scored ~0.09 and was dropped at ingest as garbage. Now counts MEANINGFUL tokens (≥3 alphanumeric); glyph noise still flagged.
**2. Embed reliability:** `rag_embedding_timeout` 30→60s (embed model cold-loads ~10s when evicted to CPU under shared-GPU pressure; tight timeout silently dropped chunks).
**3. `force_ocr` param on `internal.reindex_documents`** (worker already supported it) for genuinely garbled scans.

Destructive ingest gate → existing dropped chunks need a reindex (planned after deploy). 57 tests pass (financial passes, garbage flagged, no processor/rag regressions, force_ocr threads through).

🤖 Generated with [Claude Code](https://claude.com/claude-code)