### PR TITLE
fix(frontend): render block markdown in AdaptiveCard TextBlocks

### DIFF
--- a/src/frontend/src/components/AdaptiveCardRenderer.tsx
+++ b/src/frontend/src/components/AdaptiveCardRenderer.tsx
@@ -231,6 +231,75 @@ function renderFormattedText(text?: string): ReactNode {
   return parts;
 }
 
+/**
+ * Render a TextBlock's text as block-level markdown → real React elements.
+ *
+ * The synthesizer (and any multi-line tool result) emits markdown with
+ * `### headings`, `-`/`*` bullet lists, and blank-line paragraph breaks.
+ * `renderFormattedText` only parses INLINE marks (bold/italic/<cite>) and a
+ * plain `<p>` collapses the source newlines, so that content used to render
+ * as a run-on wall. This splits on newlines and emits headings, `<ul>` lists,
+ * and paragraphs, delegating each line's inline marks to renderFormattedText.
+ * No raw HTML — every node is a React element through the escape boundary,
+ * same security model as the inline path.
+ */
+function renderMarkdownBlocks(text: string, keyBase: string): ReactNode {
+  const lines = text.split('\n');
+  const blocks: ReactNode[] = [];
+  let bullets: ReactNode[] = [];
+  let k = 0;
+
+  const flushBullets = () => {
+    if (bullets.length > 0) {
+      blocks.push(
+        <ul key={`${keyBase}-ul-${k++}`} className="list-disc pl-5 space-y-0.5">
+          {bullets}
+        </ul>,
+      );
+      bullets = [];
+    }
+  };
+
+  for (const raw of lines) {
+    const line = raw.replace(/\s+$/, '');
+    // Bullet: leading `-` or `*` followed by whitespace (single marker, so
+    // `**bold**` at line start is NOT mistaken for a bullet).
+    const bulletMatch = line.match(/^\s*[-*]\s+(.*)$/);
+    if (bulletMatch) {
+      bullets.push(
+        <li key={`${keyBase}-li-${k++}`}>{renderFormattedText(bulletMatch[1])}</li>,
+      );
+      continue;
+    }
+    flushBullets();
+
+    const headingMatch = line.match(/^\s*#{1,6}\s+(.*)$/);
+    if (headingMatch) {
+      blocks.push(
+        <p key={`${keyBase}-h-${k++}`} className="font-semibold mt-2 first:mt-0">
+          {renderFormattedText(headingMatch[1])}
+        </p>,
+      );
+    } else if (line.trim() === '') {
+      // Blank line → small paragraph gap.
+      blocks.push(<div key={`${keyBase}-sp-${k++}`} className="h-2" aria-hidden="true" />);
+    } else {
+      blocks.push(<p key={`${keyBase}-p-${k++}`}>{renderFormattedText(line)}</p>);
+    }
+  }
+  flushBullets();
+  return blocks;
+}
+
+/**
+ * A TextBlock needs block rendering when it carries newlines or opens with a
+ * heading / bullet marker. Single-line titles and labels stay on the cheap
+ * inline `<p>` path (backward-compatible).
+ */
+function isBlockText(text: string): boolean {
+  return /\n/.test(text) || /^\s*(#{1,6}\s|[-*]\s)/.test(text);
+}
+
 function renderElement(element: AcElement | undefined, index: number | string = 0): ReactNode {
   if (!element) return null;
   // The recursive call from ColumnSet sets `type: 'Column'` on bare column
@@ -251,11 +320,19 @@ function renderElement(element: AcElement | undefined, index: number | string = 
       const align = tb.horizontalAlignment === 'Center' ? 'text-center'
         : tb.horizontalAlignment === 'Right' ? 'text-right' : '';
 
+      const tbClassName = `${size} ${weight} ${color} ${subtle} ${wrap} ${align} ${spacing} ${separator}`.trim();
+      const tbText = tb.text ?? '';
+      // Multi-line / block markdown → real heading/list/paragraph elements so
+      // newlines and bullets survive. Single-line text keeps the inline <p>.
+      if (isBlockText(tbText)) {
+        return (
+          <div key={key} className={tbClassName}>
+            {renderMarkdownBlocks(tbText, key)}
+          </div>
+        );
+      }
       return (
-        <p
-          key={key}
-          className={`${size} ${weight} ${color} ${subtle} ${wrap} ${align} ${spacing} ${separator}`.trim()}
-        >
+        <p key={key} className={tbClassName}>
           {renderFormattedText(tb.text)}
         </p>
       );

--- a/tests/frontend/react/components/AdaptiveCardRendererMarkdown.test.tsx
+++ b/tests/frontend/react/components/AdaptiveCardRendererMarkdown.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * Block-level markdown in TextBlocks. The synthesizer (and multi-line tool
+ * results) emit `### headings`, `-`/`*` bullet lists, and blank-line
+ * paragraph breaks. Before this, a plain <p> collapsed the newlines and the
+ * inline parser left `###`/`*` as literal text, so orchestrated answers
+ * rendered as a run-on wall (Reva Q4 "R27.4 + Jira", Q3 "deploy date").
+ * These assert headings/lists/paragraphs become real elements, that inline
+ * bold still works inside them, and that single-line TextBlocks stay on the
+ * cheap inline <p> path.
+ */
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+
+import AdaptiveCardRenderer from '../../../../src/frontend/src/components/AdaptiveCardRenderer';
+import { renderWithRouter } from '../test-utils';
+
+describe('AdaptiveCardRenderer — block markdown in TextBlocks', () => {
+  it('renders headings, bullet lists and paragraphs from multi-line markdown', () => {
+    const card = {
+      body: [
+        {
+          type: 'TextBlock' as const,
+          text:
+            'Basierend auf den Daten:\n' +
+            '### Betroffene Anwendungen\n' +
+            '- ERP-Core\n' +
+            '* OrderMgmt\n' +
+            '\n' +
+            'Status: **Backlog**',
+        },
+      ],
+    };
+    const { container } = renderWithRouter(<AdaptiveCardRenderer card={card} />);
+
+    // Both bullet markers (`-` and `*`) become list items.
+    const items = screen.getAllByRole('listitem');
+    expect(items.map((li) => li.textContent)).toEqual(['ERP-Core', 'OrderMgmt']);
+    expect(container.querySelectorAll('ul')).toHaveLength(1);
+
+    // Heading text survives; the `###` marker does not leak as literal text.
+    expect(screen.getByText('Betroffene Anwendungen')).toBeInTheDocument();
+    expect(screen.queryByText(/###/)).toBeNull();
+
+    // Inline bold still parses inside a paragraph → <strong>, no literal `**`.
+    const strong = screen.getByText('Backlog');
+    expect(strong.tagName).toBe('STRONG');
+    expect(screen.queryByText(/\*\*/)).toBeNull();
+  });
+
+  it('keeps single-line text on the inline <p> path (no list)', () => {
+    const card = {
+      body: [{ type: 'TextBlock' as const, text: 'Release Details' }],
+    };
+    const { container } = renderWithRouter(<AdaptiveCardRenderer card={card} />);
+
+    expect(screen.getByText('Release Details')).toBeInTheDocument();
+    expect(container.querySelectorAll('ul')).toHaveLength(0);
+    expect(container.querySelectorAll('li')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Problem

Multi-line tool/synthesis text in an Adaptive Card `TextBlock` rendered as a run-on wall with literal `###`/`*`. Two causes in `AdaptiveCardRenderer.tsx`:

- `renderFormattedText` only parses **inline** marks (`**bold**`/`_italic_`/`<cite>`).
- The `TextBlock` `<p>` has no `whitespace-pre-wrap`, so source newlines collapse to spaces.

So block markdown (`### headings`, `-`/`*` bullet lists, blank-line paragraph breaks) became one line. This surfaced on **orchestrated (multi-role) answers**, whose synthesizer output is placed into a single card `TextBlock` (via the Reva `post_orchestration` path) with a generic replace_text lede that swallows the cleanly-streamed prose bubble. Single-role answers with no card were unaffected (their streamed prose keeps its newlines in a `whitespace-pre-wrap` `<p>`).

## Fix

`renderMarkdownBlocks()` splits a `TextBlock`'s text into **real React elements** — headings, `<ul>/<li>` lists, and paragraphs — delegating each line's inline marks to the existing `renderFormattedText`. Single-line titles/labels stay on the cheap inline `<p>` path (backward-compatible). No raw HTML; every node crosses React's escape boundary, same security model as the inline path.

## Tests

- New `tests/frontend/react/components/AdaptiveCardRendererMarkdown.test.tsx` (2 tests): block markdown → heading + `<ul>/<li>` + paragraph, inline bold preserved inside them, `###`/`**` not leaked as literal text; single-line text stays a `<p>` with no list.
- Existing `AdaptiveCardRendererUrlSafety` (4) + `wissensbasis/AdaptiveCardRendererCite` (3) pass — no regression.
- `AdaptiveCardRenderer.tsx` is typecheck-clean and eslint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)