### PR TITLE
fix(chat): answer web-chat turns in the user's language (Teams parity)

### DIFF
--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -73,6 +73,40 @@ _ROOM_PATTERN = re.compile(
     r'\b(?:im|in\s+(?:der|dem|die|das)?)\s+(\w+)', re.I | re.UNICODE,
 )
 
+# Per-turn chat language detection. The web agent otherwise runs EVERY turn
+# under ``ollama.default_lang`` regardless of the message language, so an
+# English question gets the German system prompt and a German answer. The
+# Teams path already detects per-message; this brings the web path to parity.
+# ``detect_document_language`` (rag_service) bails under 50 chars, useless for
+# short chat turns, so this is a light stopword heuristic instead: German
+# chars/stopwords → "de", a clear English signal → "en", otherwise the
+# configured ``default`` (so a German-default deployment never regresses on an
+# ambiguous message; only a confident English signal flips the turn).
+_DE_STOPWORDS = re.compile(
+    r"\b(der|die|das|den|dem|des|und|oder|ich|mir|mich|mein|meine|welche|welcher|"
+    r"sind|ist|war|haben|hat|hatte|wurde|werden|zeige|zeig|bitte|gibt|für|nach|"
+    r"mit|im|am|beim|vom|zum|zur|auf|aus|ein|eine|einen|was|wie|wo|wann|warum|"
+    r"kann|soll|muss|nicht|kein|keine|alle|aktiv|aktiven|aktive|zwischen|über|"
+    r"unter|wir|unser|unsere|diese|dieser|dieses)\b", re.I)
+_EN_STOPWORDS = re.compile(
+    r"\b(the|is|are|was|were|show|list|give|what|which|when|where|why|how|who|"
+    r"can|could|should|would|do|does|did|deploy|release|releases|depend|depends|"
+    r"dependency|dependencies|freeze|window|windows|conflict|conflicts|earliest|"
+    r"safe|governance|active|all|between|for|with|about|there|any|our|approved|"
+    r"exceptions)\b", re.I)
+
+
+def detect_message_language(text: str, default: str) -> str:
+    """de/en for a short chat message; falls back to ``default`` when unclear."""
+    t = text or ""
+    if re.search(r"[äöüßÄÖÜ]", t):
+        return "de"
+    if _DE_STOPWORDS.search(t):
+        return "de"
+    if _EN_STOPWORDS.search(t):
+        return "en"
+    return default
+
 
 def _detect_media_transport(message: str) -> tuple[str, str | None] | None:
     """Detect simple media transport commands (stop/pause/resume/next/previous).
@@ -1099,6 +1133,10 @@ async def websocket_endpoint(
                 msg = WSChatMessage(**data)
                 message_type = msg.type
                 content = msg.content
+                # Answer in the language the user wrote in (parity with the
+                # Teams path). Falls back to ollama.default_lang when unclear,
+                # so German-default deployments are unchanged for German input.
+                turn_lang = detect_message_language(content, ollama.default_lang)
                 msg_session_id = msg.session_id
                 use_rag = msg.use_rag
                 knowledge_base_id = msg.knowledge_base_id
@@ -1468,7 +1506,7 @@ async def websocket_endpoint(
             document_context = ""
             if not media_shortcut_handled and not paperless_confirm_handled:
                 memory_context = await _retrieve_memory_context(
-                    content, user_id=user_id, lang=ollama.default_lang
+                    content, user_id=user_id, lang=turn_lang
                 )
                 if attachment_ids:
                     document_context = await _fetch_document_context(
@@ -1492,14 +1530,14 @@ async def websocket_endpoint(
             if user_personality_style:
                 from services.ollama_service import _build_personality_context
                 personality_context = _build_personality_context(
-                    user_personality_style, user_personality_prompt, ollama.default_lang
+                    user_personality_style, user_personality_prompt, turn_lang
                 )
 
             # Build time-of-day context for agent prompts (day/evening/night).
             # build_time_context wraps everything in try/except and returns ""
             # on any error, so this can never break the agent path.
             from services.daypart_service import build_time_context
-            time_context = build_time_context(lang=ollama.default_lang)
+            time_context = build_time_context(lang=turn_lang)
 
             # Get router from app state (initialized at startup if agent_enabled)
             agent_router = getattr(app.state, 'agent_router', None)
@@ -1829,7 +1867,7 @@ async def websocket_endpoint(
                             message=content,
                             ollama=ollama,
                             executor=executor,
-                            lang=ollama.default_lang,
+                            lang=turn_lang,
                             typing_callback=_typing_callback,
                             conversation_history=session_state.conversation_history if session_state.conversation_history else None,
                             room_context=room_context,
@@ -2057,6 +2095,7 @@ async def websocket_endpoint(
                     async for step in agent.run(
                         message=content,
                         ollama=ollama,
+                        lang=turn_lang,
                         executor=executor,
                         conversation_history=session_state.conversation_history if session_state.conversation_history else None,
                         room_context=room_context,

--- a/tests/backend/test_message_language.py
+++ b/tests/backend/test_message_language.py
@@ -1,0 +1,46 @@
+"""Per-turn chat language detection (web-chat answers in the user's language).
+
+The web agent used to run every turn under ``ollama.default_lang``, so an
+English question got the German system prompt and a German answer. These tests
+lock the heuristic: German chars/stopwords → "de", a clear English signal →
+"en", otherwise the configured default (so a German-default deployment never
+regresses on an ambiguous message).
+"""
+import pytest
+
+from api.websocket.chat_handler import detect_message_language
+
+pytestmark = pytest.mark.backend
+
+
+@pytest.mark.parametrize("text", [
+    "Show me all active releases",
+    "Which freeze windows are active in January 2027?",
+    "Are there any dependency conflicts across the programme?",
+    "What depends on Major Release R27.4? Show me the applications and Jira tickets.",
+    "I want to deploy OrderMgmt to production on 10 January — when is the earliest safe date?",
+    "Where can we improve freeze governance? Back it up with KPIs.",
+    "Are there any approved freeze exceptions?",
+])
+def test_english_questions_detect_en(text):
+    # default is German; a confident English signal must still flip to en.
+    assert detect_message_language(text, "de") == "en"
+
+
+@pytest.mark.parametrize("text", [
+    "Zeige mir alle aktiven Releases",
+    "Welche Freeze-Fenster sind im Januar 2027 aktiv?",
+    "Gibt es Abhängigkeitskonflikte im Programm?",
+    "Wo haben wir bei der Freeze-Governance Verbesserungspotenzial?",
+    "Ich möchte OrderMgmt nach Prod deployen",  # umlaut ö
+    "Was hängt alles am Major Release R27.4?",   # umlaut ä
+])
+def test_german_questions_detect_de(text):
+    assert detect_message_language(text, "de") == "de"
+
+
+def test_ambiguous_falls_back_to_default():
+    # No German or English signal → keep the deployment default (no regression).
+    assert detect_message_language("R27.4?", "de") == "de"
+    assert detect_message_language("R27.4?", "en") == "en"
+    assert detect_message_language("", "de") == "de"


### PR DESCRIPTION
## Problem
The web agent ran every turn under `ollama.default_lang`, so an **English question got the German system prompt → a German answer**. The Teams path already detects the message language per turn (`_detect_language`); the web path never did. Reva even ships an English prompt — it was just never selected on web.

## Fix
- New `detect_message_language(text, default)` in `chat_handler` — German chars/stopwords → `de`, a clear English signal → `en`, otherwise the configured **default** (so German-default deployments never regress on an ambiguous message; only a confident English signal flips the turn). `detect_document_language` couldn't be reused — it bails under 50 chars.
- Compute `turn_lang` from the message and thread it into `agent.run(lang=…)`, `orchestrator.run_orchestrated(lang=…)`, and the per-turn context builders (memory / personality / time).

## Tests
`tests/backend/test_message_language.py`: English demo questions → `en`, German → `de`, ambiguous → default. `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)