### PR TITLE
fix(deps): pin mcp<2.0 (2.0.0 renamed streamablehttp_client)

### DIFF
--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -81,7 +81,7 @@ python-dateutil>=2.8.2
 rapidfuzz>=3.9.0              # Fuzzy string matching (Paperless taxonomy resolution)
 
 # MCP Client (Model Context Protocol)
-mcp>=1.26.0
+mcp>=1.26.0,<2.0        # <2.0: mcp 2.0.0 renamed streamablehttp_client → streamable_http_client (breaks services/mcp_client.py)
 jsonschema>=4.21.0            # JSON Schema validation for MCP tool inputs
 
 # MCP Servers (standalone packages)


### PR DESCRIPTION
mcp 2.0.0 renamed `streamablehttp_client` → `streamable_http_client`, breaking `services/mcp_client.py:1048` → all MCP servers failed to connect, /api/health 503. `mcp>=1.26.0` had no upper cap so a fresh pip resolve jumped to 2.0.0. Cap `<2.0` (resolves to mcp 1.29.0, which has `streamablehttp_client`) until the 2.0 API migration is done separately. Verified live: mcp 1.29.0, all MCP up, health 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)