### PR TITLE
fix(agent): abort ReAct loop on repeated invalid-tool calls

### DIFF
--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -147,6 +147,13 @@ class AgentContext:
 
     # Track tools that return empty results (for empty-result loop detection)
     empty_results_per_tool: dict[str, int] = field(default_factory=dict)
+    # Count of "unknown tool" attempts per requested name. detect_infinite_loop
+    # only inspects executed tool_call steps, so an agent repeatedly asking for a
+    # tool that isn't registered (e.g. one that pre-selection pruned, or a
+    # hallucinated name) produces only `error` steps and never trips the loop
+    # guard — it burns the whole step budget. Tracked here so the loop can abort
+    # to a summary early.
+    invalid_tool_attempts: dict[str, int] = field(default_factory=dict)
 
     # Extracted context variables from tool results (for follow-up queries)
     extracted_vars: dict[str, Any] = field(default_factory=dict)
@@ -276,6 +283,12 @@ class AgentContext:
         """Check if a tool has returned empty results repeatedly."""
         return self.empty_results_per_tool.get(tool, 0) >= threshold
 
+    def record_invalid_tool(self, tool: str) -> int:
+        """Record an attempt to call an unregistered/unknown tool. Returns the
+        running total of invalid attempts across the turn."""
+        self.invalid_tool_attempts[tool] = self.invalid_tool_attempts.get(tool, 0) + 1
+        return sum(self.invalid_tool_attempts.values())
+
     def detect_infinite_loop(self, min_repetitions: int = 3) -> bool:
         """
         Detect if the agent is stuck in an infinite loop.
@@ -402,6 +415,14 @@ def _serialize_for_prompt(data: any, budget_chars: int = 0) -> str:
 
     # Scalar or other — return as-is (already over budget but can't reduce structurally)
     return serialized
+
+
+# Abort the ReAct loop after this many total "unknown tool" attempts in a turn.
+# The regular infinite-loop guard only inspects executed tool_call steps, so
+# repeated requests for an unregistered tool (pruned by pre-selection, or
+# hallucinated) never trip it. 3 mirrors detect_infinite_loop's min_repetitions:
+# give the LLM a couple of chances to self-correct off the error, then summarize.
+_INVALID_TOOL_ABORT_THRESHOLD = 3
 
 
 # LLM option defaults — used as fallback if prompts/agent.yaml lacks the key.
@@ -1860,6 +1881,7 @@ class AgentService:
             resolved = self.tool_registry.resolve_tool_name(action)
             if not resolved:
                 logger.warning(f"⚠️ Agent step {step_num}: Invalid tool '{action}'")
+                total_invalid = context.record_invalid_tool(action)
                 error_content = f"Unknown tool: {action}" if lang == "en" else f"Unbekanntes Tool: {action}"
                 error_step = AgentStep(
                     step_number=step_num,
@@ -1869,6 +1891,23 @@ class AgentService:
                 )
                 context.steps.append(error_step)
                 yield error_step
+                # Loop guard: `detect_infinite_loop` only sees executed tool_call
+                # steps, so an agent fixated on a tool that isn't registered
+                # (pruned by pre-selection, or hallucinated) would spin here to
+                # max_steps producing nothing. Abort to a summary once it has
+                # wasted enough steps — same fail-fast contract as the empty /
+                # infinite-loop guards below.
+                if total_invalid >= _INVALID_TOOL_ABORT_THRESHOLD:
+                    logger.warning(
+                        f"🔄 Agent gave up: {total_invalid} invalid-tool attempts "
+                        f"(last '{action}') at step {step_num}"
+                    )
+                    summary_step = await self._build_summary_answer(
+                        context, step_num, message, ollama, agent_model,
+                        lang=lang, agent_client=agent_client,
+                    )
+                    yield summary_step
+                    return
                 # Continue loop — LLM will see the error in history
                 continue
             if resolved != action:

--- a/tests/backend/test_agent_service.py
+++ b/tests/backend/test_agent_service.py
@@ -476,6 +476,42 @@ class TestAgentContext:
         assert ctx.detect_infinite_loop(min_repetitions=3) is False
 
     @pytest.mark.unit
+    def test_record_invalid_tool_counts_and_totals(self):
+        """record_invalid_tool tracks per-name counts and returns the running total.
+
+        Invalid-tool attempts are `error` steps, invisible to detect_infinite_loop
+        (which only inspects executed tool_call steps). Without this counter an
+        agent fixated on an unregistered tool (e.g. one pre-selection pruned)
+        spins to max_steps producing nothing. See _INVALID_TOOL_ABORT_THRESHOLD.
+        """
+        from services.agent_service import _INVALID_TOOL_ABORT_THRESHOLD
+
+        ctx = AgentContext(original_message="test")
+        assert ctx.invalid_tool_attempts == {}
+
+        # detect_infinite_loop must NOT catch these (they never execute):
+        for _ in range(5):
+            ctx.steps.append(AgentStep(step_number=1, step_type="error", tool="mcp.konfigure.list_aktivities"))
+        assert ctx.detect_infinite_loop(min_repetitions=3) is False
+
+        # The dedicated counter does, and reaches the abort threshold.
+        total = 0
+        for _ in range(_INVALID_TOOL_ABORT_THRESHOLD):
+            total = ctx.record_invalid_tool("mcp.konfigure.list_aktivities")
+        assert total == _INVALID_TOOL_ABORT_THRESHOLD
+        assert total >= _INVALID_TOOL_ABORT_THRESHOLD  # loop would abort here
+
+    @pytest.mark.unit
+    def test_record_invalid_tool_total_across_different_names(self):
+        """The abort total spans different invalid names, not just repeats of one."""
+        ctx = AgentContext(original_message="test")
+        ctx.record_invalid_tool("foo")
+        ctx.record_invalid_tool("bar")
+        total = ctx.record_invalid_tool("baz")
+        assert total == 3
+        assert ctx.invalid_tool_attempts == {"foo": 1, "bar": 1, "baz": 1}
+
+    @pytest.mark.unit
     def test_history_prompt_with_steps(self):
         ctx = AgentContext(original_message="test")
         ctx.steps.append(AgentStep(


### PR DESCRIPTION
## Problem

`AgentContext.detect_infinite_loop` only inspects executed `tool_call` steps. When the agent repeatedly requests a tool that isn't in its registry — one that pre-selection pruned, or a hallucinated name — each attempt is an `error` step, invisible to the loop guard. The agent spins on the same invalid tool until `max_steps`, produces nothing, and returns `error_incomplete` ("Sorry, I could not fully process the request.").

Observed downstream (Reva): a konfigure sub-agent called `get_aktivity_by_name` → 404, correctly decided it needed `list_aktivities` to resolve the name→id, but that tool had been pruned by pre-selection → "Invalid tool" → looped 6× to max_steps. Token utilization was 8-11% throughout, so this is not the budget reducer.

## Fix

- `AgentContext.invalid_tool_attempts` + `record_invalid_tool()` track unknown-tool requests per turn.
- The ReAct loop aborts to `_build_summary_answer` once the running total reaches `_INVALID_TOOL_ABORT_THRESHOLD` (3), mirroring the existing empty-result and infinite-loop fail-fast guards. The agent summarizes what it has instead of burning the whole step budget.

No change to the happy path or to how valid tools resolve.

## Tests

`tests/backend/test_agent_service.py`: two new unit tests (`test_record_invalid_tool_counts_and_totals`, `test_record_invalid_tool_total_across_different_names`) assert the counter tracks totals and that `detect_infinite_loop` still does NOT catch invalid-tool `error` steps (proving the new counter is necessary).

Verified in the downstream reva image: `test_agent_service.py` → **121 passed**, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)