### PR TITLE
fix(orchestrator): drop no-data sources from combined answer (structural, no regex)

### DIFF
--- a/src/backend/services/orchestrator.py
+++ b/src/backend/services/orchestrator.py
@@ -41,6 +41,26 @@ def _strip_source_line(answer: str) -> str:
     """Remove any trailing ``_Quelle: ..._`` / ``_Source: ..._`` line."""
     return _SOURCE_LINE_RE.sub("", answer).rstrip()
 
+
+def _sub_agent_returned_data(result: dict) -> bool:
+    """Structural check: did this sub-agent's tools actually return data?
+
+    Grounded in the data flow, not the LLM's prose: True iff at least one
+    ``tool_result`` step succeeded AND carried a non-null ``data`` payload
+    (``AgentStep.data`` = the tool result's ``data``, which is ``None`` for an
+    empty/"no results" tool response — see agent_service, and the dup-guard's
+    stop-directive which carries no data). Used to drop a legitimately-empty
+    source (e.g. Digital.ai Release queried for konfigure-only entities) from
+    the combined answer instead of pattern-matching "the tool returned no data"
+    out of its narration.
+
+    ``has_data`` is captured on the sub_result in ``_run_sub_agent`` BEFORE the
+    sub_agent_role tag is written into ``step.data`` (which would otherwise mask
+    the null). This reader just trusts that flag; default True so a missing
+    signal never drops a source.
+    """
+    return bool(result.get("has_data", True))
+
 if TYPE_CHECKING:
     from services.action_executor import ActionExecutor
     from services.agent_router import AgentRole, AgentRouter
@@ -82,6 +102,7 @@ def _failed_sub_result(role: str, query: str, error: str | None = None) -> dict:
         "steps": [],
         "plugin_data": {},
         "error": error,
+        "has_data": False,
     }
 
 
@@ -446,6 +467,13 @@ class QueryOrchestrator:
 
             steps: list = []
             final_answer: str | None = None
+            # Structural "did this sub-agent's tools return data?" — captured
+            # from the raw step BEFORE the sub_agent_role tag is written into
+            # step.data below (which would replace a null payload with a dict
+            # and mask the signal). A tool_result step carries the tool's own
+            # success flag + data payload (data is None for an empty response),
+            # so this reflects the data flow, not the LLM's wording.
+            has_data = False
             try:
                 async for step in agent.run(
                     message=query,
@@ -454,6 +482,12 @@ class QueryOrchestrator:
                     lang=lang,
                     **agent_kwargs,
                 ):
+                    if (
+                        step.step_type == "tool_result"
+                        and getattr(step, "success", False)
+                        and step.data is not None
+                    ):
+                        has_data = True
                     # Tag step with sub-agent role for frontend grouping.
                     # Only inject when data is dict-shaped or unset — list
                     # data (JQL results) and scalars must stay as-is so
@@ -483,6 +517,7 @@ class QueryOrchestrator:
                 "steps": steps,
                 "plugin_data": {},
                 "error": agent_run_error,
+                "has_data": has_data,
             }
 
             # post_sub_agent: fire even on agent.run crash so plugins can
@@ -673,8 +708,17 @@ class QueryOrchestrator:
 
         non_empty = [r for r in sub_results if r.get("answer")]
 
-        if len(non_empty) >= 2:
-            synthesized = await self._synthesize(message, sub_results, ollama, lang)
+        # Prefer sources that actually returned data: drop a legitimately-empty
+        # source's "found nothing" narration when at least one data-bearing
+        # source remains (e.g. a konfigure release-calendar question that also
+        # fans to Digital.ai Release, which holds none of those entities). Only
+        # applies to the mixed case — if EVERY source is empty, answer_sources
+        # stays == non_empty and the existing behavior is unchanged.
+        with_data = [r for r in non_empty if _sub_agent_returned_data(r)]
+        answer_sources = with_data if with_data else non_empty
+
+        if len(answer_sources) >= 2:
+            synthesized = await self._synthesize(message, answer_sources, ollama, lang)
             if synthesized:
                 yield AgentStep(
                     step_number=99,
@@ -684,11 +728,11 @@ class QueryOrchestrator:
                 return
             # Synthesizer returned nothing — fall through to fallback.
 
-        if non_empty:
+        if answer_sources:
             yield AgentStep(
                 step_number=99,
                 step_type="final_answer",
-                content=non_empty[0]["answer"],
+                content=answer_sources[0]["answer"],
             )
             return
 

--- a/tests/backend/test_orchestrator.py
+++ b/tests/backend/test_orchestrator.py
@@ -1340,6 +1340,7 @@ class TestParallelExecution:
         assert result == {
             "role": "release", "query": "test",
             "answer": "", "steps": [], "plugin_data": {}, "error": None,
+            "has_data": False,
         }
 
 
@@ -2358,3 +2359,75 @@ class TestSynthesisHooks:
 # ============================================================================
 # Phase 1 (orchestrator-uplift) — backwards compat: vanilla Renfield deploy
 # ============================================================================
+
+
+class TestEmitCombinedAnswerNoDataFilter:
+    """Structurally drop a legitimately-empty source from the combined answer
+    when a data-bearing source remains — via the has_data flag captured from
+    each sub-agent's actual tool results, NOT prose pattern-matching."""
+
+    @pytest.mark.asyncio
+    async def test_drops_no_data_source_when_data_source_remains(self):
+        orch = QueryOrchestrator(_make_router([]), MagicMock())
+        sub_results = [
+            {"role": "konfigure", "answer": "Freeze windows for OMS-01: ...",
+             "has_data": True, "steps": [], "plugin_data": {}},
+            {"role": "release", "answer": "The tool did not return any data.",
+             "has_data": False, "steps": [], "plugin_data": {}},
+        ]
+        with patch.object(orch, "_synthesize",
+                          new=AsyncMock(return_value="SHOULD_NOT_BE_USED")) as syn:
+            steps = [s async for s in
+                     orch._emit_combined_answer("msg", sub_results, _make_ollama(""), "en")]
+        syn.assert_not_called()  # only one data-bearing source → single-survivor
+        finals = [s for s in steps if s.step_type == "final_answer"]
+        assert len(finals) == 1
+        assert "Freeze windows" in finals[0].content
+        assert "did not return" not in finals[0].content
+
+    @pytest.mark.asyncio
+    async def test_all_empty_keeps_existing_behavior(self):
+        orch = QueryOrchestrator(_make_router([]), MagicMock())
+        sub_results = [
+            {"role": "release", "answer": "No releases found.",
+             "has_data": False, "steps": [], "plugin_data": {}},
+        ]
+        with patch.object(orch, "_synthesize", new=AsyncMock(return_value=None)):
+            steps = [s async for s in
+                     orch._emit_combined_answer("msg", sub_results, _make_ollama(""), "en")]
+        finals = [s for s in steps if s.step_type == "final_answer"]
+        assert len(finals) == 1
+        # the only source is empty → NOT dropped (we never blank the answer)
+        assert "No releases found" in finals[0].content
+
+    @pytest.mark.asyncio
+    async def test_two_data_sources_both_synthesized(self):
+        orch = QueryOrchestrator(_make_router([]), MagicMock())
+        sub_results = [
+            {"role": "konfigure", "answer": "Freezes ...", "has_data": True,
+             "steps": [], "plugin_data": {}},
+            {"role": "jira", "answer": "Ticket RM27-4 ...", "has_data": True,
+             "steps": [], "plugin_data": {}},
+        ]
+        with patch.object(orch, "_synthesize",
+                          new=AsyncMock(return_value="COMBINED")) as syn:
+            steps = [s async for s in
+                     orch._emit_combined_answer("msg", sub_results, _make_ollama(""), "en")]
+        syn.assert_called_once()
+        assert len(syn.call_args.args[1]) == 2  # both data sources passed
+        finals = [s for s in steps if s.step_type == "final_answer"]
+        assert finals[0].content == "COMBINED"
+
+    @pytest.mark.asyncio
+    async def test_missing_has_data_flag_defaults_to_kept(self):
+        """Back-compat: a sub_result without has_data must never be dropped."""
+        orch = QueryOrchestrator(_make_router([]), MagicMock())
+        sub_results = [
+            {"role": "release", "answer": "Legacy answer with no flag.",
+             "steps": [], "plugin_data": {}},
+        ]
+        with patch.object(orch, "_synthesize", new=AsyncMock(return_value=None)):
+            steps = [s async for s in
+                     orch._emit_combined_answer("msg", sub_results, _make_ollama(""), "en")]
+        finals = [s for s in steps if s.step_type == "final_answer"]
+        assert "Legacy answer" in finals[0].content


### PR DESCRIPTION
A multi-domain query can fan out to a source that legitimately has nothing (e.g. a konfigure release-calendar question also routed to Digital.ai Release, which holds none of those entities). That sub-agent still narrates its empty result, and the synthesizer wove "the tool did not return data" into an otherwise-correct combined answer as an error-like caveat.

`_emit_combined_answer` now drops a sub-agent that returned no data **when at least one data-bearing source remains**. The signal is **structural**: `has_data` is captured in `_run_sub_agent` from each `tool_result` step's own `success` flag + `data` payload (`data` is `None` for an empty tool response), **before** the `sub_agent_role` tag is written into `step.data` and masks the null. No regex over the LLM's prose — that approach is incomplete now and drifts over time.

Scope is limited: the all-empty and all-data cases are byte-identical to before; a missing `has_data` flag defaults to kept, so it can never blank an answer. Verified against the prod image: test_orchestrator.py 70/70 (4 new tests for the mixed/all-empty/two-data/back-compat cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)