### PR TITLE
fix: MCP request-wrap for flat args + don't override high-confidence entity-id route

### DIFF
--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -1825,8 +1825,36 @@ async def websocket_endpoint(
 
                     # Step 2 — if no plan, run the LLM planner. Skip the
                     # ~3-10s planner round-trip for chitchat roles.
+                    #
+                    # Also skip it when the router took a high-confidence entity-id
+                    # route (Layer 1, conf 0.9): a specific named entity matched and
+                    # ALL matches were in ONE domain (reference_resolver only sets
+                    # inferred_domain for single-domain entity sets), so the query is
+                    # about that entity. Letting the speculative multi-domain planner
+                    # override it over-fans single-entity lookups — e.g. "Zeige mir
+                    # REVA-1" fanned to release+jira, where the release sub-agent then
+                    # hallucinated a "Release REVA-1" and bled a stale current_release_id.
+                    # Genuine cross-domain queries either match entities in multiple
+                    # domains (inferred_domain stays None → not gated) or route to a
+                    # non-entity layer / "general" (→ not gated); and release↔jira
+                    # bridging is still covered by the single agent's own bridge tools
+                    # (find_jira_issues_for_release / find_release_for_jira_issue).
+                    _entity_id_routed = bool(
+                        _resolved
+                        and getattr(_resolved, "entity_matches", None)
+                        and getattr(_resolved, "inferred_domain", None) == role.name
+                    )
+                    if _entity_id_routed:
+                        logger.info(
+                            f"🎼 Orchestrator: skipping planner — entity-id route to "
+                            f"'{role.name}' (conf 0.9) is authoritative for a single-entity query"
+                        )
                     orchestrator = None
-                    if sub_queries is None and role.name not in ("conversation", "knowledge"):
+                    if (
+                        sub_queries is None
+                        and role.name not in ("conversation", "knowledge")
+                        and not _entity_id_routed
+                    ):
                         from services.orchestrator import QueryOrchestrator
                         orchestrator = QueryOrchestrator(agent_router, mcp_manager)
                         try:

--- a/src/backend/services/mcp_client.py
+++ b/src/backend/services/mcp_client.py
@@ -250,6 +250,38 @@ def _coerce_arguments(arguments: dict, input_schema: dict) -> dict:
         logger.info(f"🔄 Unwrapping 'request' wrapper: {list(coerced['request'].keys())}")
         coerced = coerced["request"]
 
+    # Wrap flat LLM args INTO a single required object property the schema expects
+    # (the inverse of the unwrap above). Some MCP servers — notably the Digital.ai
+    # Release MCP — take every tool's parameters as one required `request` object,
+    # so a flat {"active": true} from the LLM fails validation with
+    # "'request' is a required property". When the schema has exactly one property,
+    # it is an object and required, and the LLM's keys are NOT top-level schema
+    # properties (i.e. they belong inside the wrapper), nest them. Handles the empty
+    # {} → {"request": {}} case too. Skipped when the wrapper key is already present,
+    # so a correctly-wrapped call is never double-wrapped.
+    if len(properties) == 1:
+        (wrap_key, wrap_schema), = properties.items()
+        # A single required "wrapper" property is object-like when it declares an
+        # object type OR references a model — FastMCP renders a Pydantic model
+        # parameter (e.g. release-mcp's `request: ListReleasesRequest`) as a bare
+        # $ref with no inline "type", so keying only on type=="object" misses it.
+        wrap_is_object = (
+            wrap_schema.get("type") == "object"
+            or "$ref" in wrap_schema
+            or "allOf" in wrap_schema
+            or "anyOf" in wrap_schema
+            or "oneOf" in wrap_schema
+            or "properties" in wrap_schema
+        )
+        if (
+            wrap_key not in coerced
+            and wrap_is_object
+            and wrap_key in input_schema.get("required", [])
+            and all(k not in properties for k in coerced)
+        ):
+            logger.info(f"🔄 Wrapping flat args into '{wrap_key}': {list(coerced.keys())}")
+            coerced = {wrap_key: coerced}
+
     # Strip invalid values: null for non-nullable fields, wrong types
     required = set(input_schema.get("required", []))
     _type_map = {"string": str, "integer": (int,), "number": (int, float), "boolean": (bool,),


### PR DESCRIPTION
Two platform fixes surfaced while hardening Reva's web-chat e2e suite (both verified live against the Reva plugin: browser suite 11/13 → 13/13, plus targeted probes).

## 1. `_coerce_arguments`: wrap flat LLM args into a required single-object param (`46eae155`)
`_coerce_arguments` already **unwraps** an extraneous `{"request": …}` envelope but had no inverse. The Digital.ai Release MCP takes every tool's params as one required `request` object, which FastMCP renders as a **`$ref`** to a `$defs` model (no inline `type: object`). So a flat `{"active": true}` from the LLM was rejected with `'request' is a required property` — silently breaking `list_releases` in the orchestrated sub-agent path.

Add the inverse coercion: when the schema has exactly one required property that is object-like (`type==object` **or** `$ref`/`allOf`/`anyOf`/`oneOf`/`properties`), the wrapper key is absent, and the args' keys aren't top-level props → nest them under it. Idempotent (a correctly-wrapped call is untouched); the pre-existing unwrap and flat-schema tools are unaffected.

## 2. Orchestrator: don't override a high-confidence entity-id route (`04521f73`)
`detect_multi_domain` ran even when the router had already taken its **Layer-1 entity-id route** (confidence 0.9) — a specific named entity matched and, because `reference_resolver` only sets `inferred_domain` for a **single-domain** entity set, the query is unambiguously about that one entity. The speculative planner then over-fanned single-entity lookups (e.g. a Jira-key lookup fanning to release+jira, the release sub-agent hallucinating a matching "release" and bleeding a stale `current_release_id`).

Skip the planner when the router entity-id-routed to the resolved role. Genuine cross-domain queries are unaffected — entities spanning multiple domains leave `inferred_domain` None (not gated), and queries with no entity match route via a non-entity layer / "general" (not gated).

## Verification
- Unit tests (run against the Reva prod image): `$ref` wrap, empty-args wrap, no-double-wrap, unwrap-preserved, flat-schema-untouched.
- Live: `list_releases({"active":true})` now succeeds; a single-entity Jira lookup stays single-role and returns the issue; the multi-domain status report AND a konfigure+jira cross-domain query still orchestrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)