### PR TITLE
fix(orchestrator): pass agent_kwargs to the pre_sub_agent hook

### DIFF
--- a/src/backend/services/orchestrator.py
+++ b/src/backend/services/orchestrator.py
@@ -457,12 +457,17 @@ class QueryOrchestrator:
             agent = AgentService(tool_registry, role=role)
 
             # run_hooks never raises (utils/hooks.py contract) — direct call.
+            # `agent_kwargs` is the SAME dict spread into `agent.run(**agent_kwargs)`
+            # below, so a handler may scope it in place per sub-agent (e.g. drop a
+            # cross-domain `current_release_id` from `context_vars_text` so a jira
+            # sub-agent's prompt can't be misled by a release entity from a prior turn).
             await run_hooks(
                 "pre_sub_agent",
                 step=sq,
                 role=role_name,
                 tool_registry=tool_registry,
                 lang=lang,
+                agent_kwargs=agent_kwargs,
             )
 
             steps: list = []


### PR DESCRIPTION
Minimal seam so a plugin can scope a sub-agent's prompt per domain. `_run_sub_agent` already fires `pre_sub_agent` right before `agent.run(**agent_kwargs)`; this passes that same `agent_kwargs` dict to the hook, so a handler may filter `context_vars_text` (the prompt's "## Conversation Context" block) in place for the sub-agent's domain.

**Why:** a sub-agent inherited the parent turn's context vars unchanged, so a prior turn's `current_release_id` bled into a jira/confluence/itsm sub-agent and misled its prompt (part of the "F5" bleed found in an orchestrator deep-analysis). The consumer is Reva's `_on_pre_sub_agent`, which drops cross-domain entity vars.

No behaviour change without a handler that mutates `agent_kwargs`. One added kwarg; `run_hooks` never raises.

Consumer PR: X-idra-Systems-GmbH/reva `fix/f5-scope-context-vars-per-sub-agent`. Verified live (Reva e2e browser suite 13/13, orchestrated sub-agents clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)