### PR TITLE
fix(orchestrator): surface truncated sub-agents (F6) + carry entity ids into sub-queries (F7)

### DIFF
--- a/src/backend/prompts/agent.yaml
+++ b/src/backend/prompts/agent.yaml
@@ -580,6 +580,10 @@ de:
     2. Wenn eine einzige Domaene ausreicht -> genau das Wort: null
     3. "role" MUSS exakt einer der oben gelisteten Domaenen-Namen sein.
     4. "query" ist ein knapper Satz, der diese Domaene allein erledigen kann.
+    5. Konkrete Bezeichner aus der Anfrage (Ticket-Keys wie REVA-1/REL-100,
+       Release-IDs, exakte Namen) MUESSEN WOERTLICH in jede betreffende Teilaufgabe
+       uebernommen werden — niemals paraphrasieren oder weglassen. Der Sub-Agent
+       braucht den exakten Bezeichner als Anker.
 
     Beispiele:
 
@@ -1170,6 +1174,10 @@ en:
     2. If a single domain is enough -> exactly the word: null
     3. "role" MUST be exactly one of the listed domain names above.
     4. "query" is a short sentence that domain alone can complete.
+    5. Concrete identifiers from the request (ticket keys like REVA-1/REL-100,
+       release IDs, exact names) MUST be carried VERBATIM into every relevant
+       sub-task — never paraphrase or drop them. The sub-agent needs the exact
+       identifier as an anchor.
 
     Examples:
 

--- a/src/backend/services/orchestrator.py
+++ b/src/backend/services/orchestrator.py
@@ -726,45 +726,46 @@ class QueryOrchestrator:
         with_data = [r for r in non_empty if _sub_agent_returned_data(r)]
         answer_sources = with_data if with_data else non_empty
 
+        # Sub-agents that ran but produced NO answer AND NO error — a max_steps
+        # abort or a degenerate loop yields answer="" with error=None. Without
+        # this, such a domain vanishes silently from the combined answer while the
+        # turn is presented as complete (F6). Surface it as a per-domain note.
+        truncated_roles = [
+            r.get("role", "?") for r in sub_results
+            if not r.get("answer") and not r.get("error")
+        ]
+
+        content: str | None = None
         if len(answer_sources) >= 2:
-            synthesized = await self._synthesize(message, answer_sources, ollama, lang)
-            if synthesized:
-                yield AgentStep(
-                    step_number=99,
-                    step_type="final_answer",
-                    content=synthesized,
-                )
-                return
-            # Synthesizer returned nothing — fall through to fallback.
+            content = await self._synthesize(message, answer_sources, ollama, lang)
+        if content is None and answer_sources:
+            content = answer_sources[0]["answer"]
 
-        if answer_sources:
-            yield AgentStep(
-                step_number=99,
-                step_type="final_answer",
-                content=answer_sources[0]["answer"],
-            )
-            return
-
-        # Every sub-agent failed. Surface a localized error so the user
-        # isn't left staring at an empty reply.
-        failed_roles = [r.get("role", "?") for r in sub_results]
-        if lang.startswith("de"):
-            msg = (
+        if content is None:
+            # Every sub-agent failed/empty. Surface a localized error so the user
+            # isn't left staring at an empty reply.
+            roles = [r.get("role", "?") for r in sub_results]
+            content = (
                 "Keine der angefragten Integrationen hat eine Antwort "
-                f"geliefert (betroffen: {', '.join(failed_roles)}). "
+                f"geliefert (betroffen: {', '.join(roles)}). "
                 "Bitte versuche es in einem Moment erneut."
-            )
-        else:
-            msg = (
+                if lang.startswith("de") else
                 "None of the requested integrations returned an answer "
-                f"(affected: {', '.join(failed_roles)}). "
-                "Please try again in a moment."
+                f"(affected: {', '.join(roles)}). Please try again in a moment."
             )
-        yield AgentStep(
-            step_number=99,
-            step_type="final_answer",
-            content=msg,
-        )
+        elif truncated_roles:
+            # Partial success: at least one domain answered, but others were
+            # truncated with no error. Tell the user so a domain isn't hidden.
+            content += (
+                f"\n\n_Hinweis: {', '.join(truncated_roles)} konnte in dieser "
+                "Anfrage nicht abgeschlossen werden — die Antwort deckt diesen "
+                "Bereich nicht ab._"
+                if lang.startswith("de") else
+                f"\n\n_Note: {', '.join(truncated_roles)} could not be completed "
+                "for this request — the answer does not cover that area._"
+            )
+
+        yield AgentStep(step_number=99, step_type="final_answer", content=content)
 
     async def _synthesize(
         self,


### PR DESCRIPTION
Two P1 fixes from the orchestrator deep-analysis.

## F6 — silent domain disappearance
A sub-agent that ran but produced **no answer AND no error** (a `max_steps` abort / degenerate loop yields `answer=""` with `error=None`) was neither in the combined answer nor surfaced as a failure — its whole domain vanished while the turn was presented as complete (e.g. release times out → user sees a jira-only answer as if complete).

`_emit_combined_answer` now detects such **truncated** sub-agents (empty answer, no error) and appends a localized per-domain *"could not be completed"* note. Refactored to one `content` var + one `yield`; the all-failed and single-answer paths are unchanged.

## F7 — lossy sub-queries
The detect prompt (DE+EN) now requires concrete identifiers from the request (ticket keys like `REVA-1`/`REL-100`, release ids, exact names) to be carried **VERBATIM** into every sub-task, so a sub-agent has a concrete anchor instead of re-deriving a broad free-text search.

## Verify
Reva `tests/test_f6_truncated_domain.py` (5, green vs prod image): truncated-surfaced-with-one-answer, no-note-when-all-answered, error-source-not-truncated, all-truncated→all-failed-message, synth-path-appends-note. Live e2e browser suite 12/13 (the 1 WEAK is the pre-existing flaky orchestrated-report — jira sub-agent looping on results it deems unsatisfactory — orthogonal to these fixes; F7 actually produced clean JQL that run).

Pairs with the reva jira JQL-guidance change (X-idra-Systems-GmbH/reva `fix/f7-jira-jql-guidance`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)