### PR TITLE
fix(agent): same-tool loop guard + synthesizer on the agent model

### DIFF
--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -315,6 +315,16 @@ class AgentContext:
         recent = tool_calls[-min_repetitions:]
         return len(set(recent)) == 1
 
+    def count_tool_calls(self, tool: str) -> int:
+        """How many times ``tool`` has been called this turn (any parameters).
+
+        Backs the same-tool loop guard for agents that retry one tool with
+        varied args — which detect_infinite_loop (identical-only) misses."""
+        return sum(
+            1 for s in self.steps
+            if s.step_type == "tool_call" and s.tool == tool
+        )
+
 
 def _is_empty_result(result: dict) -> bool:
     """Detect if a tool result is effectively empty (0 results).
@@ -423,6 +433,16 @@ def _serialize_for_prompt(data: any, budget_chars: int = 0) -> str:
 # hallucinated) never trip it. 3 mirrors detect_infinite_loop's min_repetitions:
 # give the LLM a couple of chances to self-correct off the error, then summarize.
 _INVALID_TOOL_ABORT_THRESHOLD = 3
+
+# Abort the ReAct loop after this many calls to the SAME tool in a turn,
+# REGARDLESS of parameters. detect_infinite_loop only catches identical
+# (tool + params) calls, so an agent that keeps re-calling one tool with
+# slightly-varied args — e.g. a jira sub-agent retrying jira_search with
+# tweaked JQL because it deems the (valid) results unsatisfactory — loops
+# right past it. Higher than detect_infinite_loop's 3 (varied args is a
+# weaker loop signal than identical), and the abort summarizes what was
+# already gathered, so the domain survives instead of returning nothing.
+_SAME_TOOL_ABORT_THRESHOLD = 5
 
 
 # LLM option defaults — used as fallback if prompts/agent.yaml lacks the key.
@@ -2107,9 +2127,27 @@ class AgentService:
                     yield summary_step
                     return
 
-            # Check for infinite loop (same tool called repeatedly)
+            # Check for infinite loop (same tool called repeatedly — identical args)
             if context.detect_infinite_loop(min_repetitions=3):
                 logger.warning(f"🔄 Agent infinite loop detected at step {step_num} (tool: {action})")
+                yield AgentStep(
+                    step_number=step_num,
+                    step_type="error",
+                    content=prompt_manager.get("agent", "error_loop_detected", lang=lang, tool=action),
+                    tool=action,
+                )
+                summary_step = await self._build_summary_answer(context, step_num, message, ollama, agent_model, lang=lang, agent_client=agent_client)
+                yield summary_step
+                return
+
+            # Same tool called too many times with VARYING args — a "retry for
+            # better data" loop the identical-only guard above misses. Abort to a
+            # summary of what was already gathered so the domain still answers.
+            if context.count_tool_calls(action) >= _SAME_TOOL_ABORT_THRESHOLD:
+                logger.warning(
+                    f"🔄 Agent called '{action}' {context.count_tool_calls(action)}× "
+                    f"(varied args) at step {step_num} — aborting to summary"
+                )
                 yield AgentStep(
                     step_number=step_num,
                     step_type="error",

--- a/src/backend/services/orchestrator.py
+++ b/src/backend/services/orchestrator.py
@@ -839,14 +839,35 @@ class QueryOrchestrator:
             return "\n\n".join(r["answer"] for r in sub_results if r["answer"])
 
         try:
-            router_model = settings.agent_router_model or settings.ollama_intent_model or settings.ollama_model
-            classification_kwargs = get_classification_chat_kwargs(router_model)
+            # Weaving ≥2 sub-agent answers into one coherent multi-domain report
+            # is dense composition — use the AGENT model (qwen3.6), not the tiny
+            # router model, which routinely dropped a whole domain from the
+            # combined answer (F4). Mirrors the planner's model/client selection
+            # in detect_multi_domain. On timeout the except below falls back to
+            # concatenation, which still shows every domain — strictly safer than
+            # a small model silently omitting one.
+            primary_role = next(
+                (r for r in self.router.roles.values() if r.has_agent_loop), None
+            )
+            synth_model = getattr(primary_role, "model", None) if primary_role else None
+            synth_url = getattr(primary_role, "ollama_url", None) if primary_role else None
+            if use_openai_for_tier("agent"):
+                synth_model = synth_model or settings.agent_model or settings.llm_openai_model
+            else:
+                synth_model = synth_model or settings.ollama_model
+            synth_url = synth_url or settings.agent_ollama_url
+
+            if synth_url:
+                client, _ = get_agent_client(fallback_url=synth_url)
+            else:
+                client = ollama.client
+            classification_kwargs = get_classification_chat_kwargs(synth_model)
 
             raw_response = await asyncio.wait_for(
-                ollama.client.chat(
-                    model=router_model,
+                client.chat(
+                    model=synth_model,
                     messages=[{"role": "user", "content": synthesize_prompt}],
-                    options={"temperature": 0.3, "num_predict": 500},
+                    options={"temperature": 0.3, "num_predict": 900},
                     **classification_kwargs,
                 ),
                 timeout=settings.orchestrator_synthesis_timeout,


### PR DESCRIPTION
Two orchestrator robustness fixes.

## Same-tool loop guard (`agent_service.py`)
`detect_infinite_loop` only catches **3 identical** consecutive calls, so an agent that re-calls one tool with slightly **varied** args loops past it — observed in prod: a jira sub-agent retrying `jira_search` with tweaked JQL (because it deemed valid results "unsatisfactory") burned **17 steps**. `AgentContext.count_tool_calls` + `_SAME_TOOL_ABORT_THRESHOLD` (5) abort to `_build_summary_answer` once one tool is called 5×, so the domain still answers from what it gathered. Verified: jira sub-agent dropped 17 → 4 steps.

## Synthesizer on the agent model (`orchestrator._synthesize`)
Weaving ≥2 sub-agent answers into one report was done by the tiny **router model** (`llama3.2:3b`), which routinely dropped a whole domain (F4). Switch to the **agent model** (qwen3.6), mirroring the planner's model/client selection; on timeout the existing fallback concatenates all answers (still shows every domain). Only runs on genuine multi-domain turns.

## Honest scope
The orchestrated status report's both-domain rate rose (1/4 → 3/4 in one probe) but **stays flaky** for a separate reason: it's a 2-of-2-must-succeed pipeline where one sub-agent (release `my_dashboard` / jira variance) unreliably produces no usable answer, so the synthesizer legitimately has only one domain. These fixes remove real failure modes but don't make the multi-agent report deterministic — that would need a dedicated deterministic sub-intent.

Tests: reva `tests/test_same_tool_loop_guard.py` (5, green). Verified: e2e browser suite 13/13, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)