### PR TITLE
fix(orchestrator): never silently drop a requested domain + deterministic pre_orchestration handoff

### DIFF
--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -1789,6 +1789,47 @@ async def websocket_endpoint(
                         session_id=msg_session_id,
                     )
                     for hr in hook_results:
+                        # A plugin may fully own a cross-domain turn
+                        # DETERMINISTICALLY (a fixed-shape deliverable — e.g. a
+                        # portfolio status report the LLM planner + ReAct
+                        # sub-agents render unreliably) by returning a
+                        # ``{"handled": True, "answer", "card", "replace_text"}``
+                        # dict instead of a sub-query plan. Short-circuit the
+                        # planner + orchestration entirely — same effect as a
+                        # sub-intent dispatch, but reachable even when the router
+                        # classified a plain role (no sub_intent) for the turn.
+                        if isinstance(hr, dict) and hr.get("handled"):
+                            agent_used = True
+                            sub_intent_handled = True
+                            full_response = hr.get("answer", "") or ""
+                            card = hr.get("card")
+                            replace_text = hr.get("replace_text")
+                            intent = {
+                                "intent": "plugin.pre_orchestration",
+                                "confidence": 1.0,
+                                "parameters": {},
+                            }
+                            # Emit the assistant bubble + card NOW (mirrors the
+                            # sub-intent dispatch block). The shared persistence
+                            # block below only emits the ``done`` marker — without
+                            # these frames the deterministic answer/card is built
+                            # but never reaches the browser.
+                            if full_response:
+                                await websocket.send_json({
+                                    "type": "stream",
+                                    "content": full_response,
+                                })
+                            if card:
+                                _pre_card_msg: dict = {"type": "card", "card": card}
+                                if replace_text:
+                                    _pre_card_msg["replace_text"] = replace_text
+                                await websocket.send_json(_pre_card_msg)
+                            await _emit_turn_artifacts(hr.get("artifacts"))
+                            logger.info(
+                                "🎼 pre_orchestration: plugin handled the turn "
+                                "deterministically — skipping planner + orchestration"
+                            )
+                            break
                         if not (isinstance(hr, list) and hr):
                             continue
                         # Validate per-element shape — plugin plans are
@@ -1852,6 +1893,7 @@ async def websocket_endpoint(
                     orchestrator = None
                     if (
                         sub_queries is None
+                        and not sub_intent_handled
                         and role.name not in ("conversation", "knowledge")
                         and not _entity_id_routed
                     ):

--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -2185,11 +2185,17 @@ class AgentService:
 
         if not collected:
             reason_text = "No results collected" if lang == "en" else "Keine Ergebnisse gesammelt"
+            # Structural incomplete marker: the agent was force-summarized (max_steps
+            # / loop abort) with NO usable tool results, so this "answer" is the
+            # error_incomplete apology, not real content. Downstream (the orchestrator)
+            # keys on data["incomplete"] to surface the failed domain instead of
+            # silently accepting the apology as the answer — no prose matching.
             return AgentStep(
                 step_number=step_num,
                 step_type="final_answer",
                 content=prompt_manager.get("agent", "error_incomplete", lang=lang),
                 reason=reason_text,
+                data={"incomplete": True},
             )
 
         # Build a summary prompt from externalized template

--- a/src/backend/services/orchestrator.py
+++ b/src/backend/services/orchestrator.py
@@ -479,6 +479,7 @@ class QueryOrchestrator:
             # success flag + data payload (data is None for an empty response),
             # so this reflects the data flow, not the LLM's wording.
             has_data = False
+            incomplete = False
             try:
                 async for step in agent.run(
                     message=query,
@@ -511,6 +512,12 @@ class QueryOrchestrator:
                     steps.append(step)
                     if step.step_type == "final_answer":
                         final_answer = step.content
+                        # A max_steps/loop abort with no usable data tags the
+                        # summary step data["incomplete"] (set in _build_summary_answer);
+                        # surviving the sub_agent_role tagging above.
+                        incomplete = bool(
+                            isinstance(step.data, dict) and step.data.get("incomplete")
+                        )
                 agent_run_error: str | None = None
             except Exception as e:
                 logger.opt(exception=True).error(
@@ -527,6 +534,7 @@ class QueryOrchestrator:
                 "plugin_data": {},
                 "error": agent_run_error,
                 "has_data": has_data,
+                "incomplete": incomplete,
             }
 
             # post_sub_agent: fire even on agent.run crash so plugins can
@@ -715,7 +723,12 @@ class QueryOrchestrator:
         """
         from services.agent_service import AgentStep
 
-        non_empty = [r for r in sub_results if r.get("answer")]
+        # Exclude force-summarized (incomplete) sub-agents — their non-empty
+        # "answer" is the error_incomplete apology, not content. Without this the
+        # `with_data` filter below would silently erase that whole domain while the
+        # F6 note (which only checks empty answers) never fires — the report then
+        # looks complete but covers one domain (the silent-drop bug).
+        non_empty = [r for r in sub_results if r.get("answer") and not r.get("incomplete")]
 
         # Prefer sources that actually returned data: drop a legitimately-empty
         # source's "found nothing" narration when at least one data-bearing
@@ -732,7 +745,7 @@ class QueryOrchestrator:
         # turn is presented as complete (F6). Surface it as a per-domain note.
         truncated_roles = [
             r.get("role", "?") for r in sub_results
-            if not r.get("answer") and not r.get("error")
+            if r.get("incomplete") or (not r.get("answer") and not r.get("error"))
         ]
 
         content: str | None = None


### PR DESCRIPTION
Two related fixes making cross-domain orchestrated turns reliable. Paired with X-idra reva `feat/deterministic-portfolio-report`.

## 1. Silent-drop gate (3-lite)
An orchestrated cross-domain query (e.g. a status report spanning release + jira) is a 2-of-N-must-succeed pipeline. When a sub-agent burned its step budget, `_build_summary_answer` returned the localized `error_incomplete` apology as a **non-empty** `final_answer` with `has_data=False`. `_emit_combined_answer`'s `with_data` filter then dropped that whole domain, and since the domain *had* an answer, the F6 truncated-roles note never fired — the report came back covering one domain, **presented as complete, with no indication**.

Fixed **structurally** (no prose/sentinel matching):
- `agent_service._build_summary_answer` tags the no-data force-summary `AgentStep` with `data={"incomplete": True}`.
- `orchestrator._run_sub_agent` propagates the flag into the sub-result dict.
- `orchestrator._emit_combined_answer` excludes incomplete results from the answer sources AND counts them as truncated, so the "could not be completed" note fires instead of the domain being erased.

Makes every orchestrated query honest about partial failure.

## 2. Deterministic pre_orchestration handoff
A plugin can now fully own a cross-domain turn **deterministically** by returning a `{"handled": True, "answer", "card", "replace_text"}` dict from the `pre_orchestration` hook (instead of a sub-query plan). `chat_handler` emits the assistant bubble + card frames immediately and sets `sub_intent_handled`, and the `detect_multi_domain` guard also checks `not sub_intent_handled` so a handled turn never re-enters the planner. This is reachable even when the router classified a plain role (no sub_intent) for the turn — which is exactly the case for the portfolio status report ("aktive Releases und offene Jira-Tickets" routes to the jira role, so no status_report sub-intent fires). Reva rides this to replace the flaky orchestrated report with a deterministic two-call fan-out.

## Verification (prod)
- Report probe **4/4 both-domain, byte-identical 2119-char output** every run (was oscillating 1/4–3/4).
- e2e "Orchestrated: Report" case PASS, 5s deterministic (both runs).
- Tests (reva repo, prod image): `test_f6_truncated_domain.py` (7, incl. 3 incomplete cases), `test_portfolio_report.py` (22).

Background: `docs/architecture/orchestrator-report-reliability.md` in the reva repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)