### PR TITLE
feat(orchestrator): deterministic merge + typed domain contracts (typed-contracts Phases 0+2)

### DIFF
--- a/src/backend/services/domain_contract.py
+++ b/src/backend/services/domain_contract.py
@@ -1,0 +1,105 @@
+"""Typed domain contracts for the cross-MCP orchestrator (typed-contracts plan,
+Phase 2). Platform-generic: Renfield owns the ``DomainEnvelope`` shape + the
+registry; plugins (Reva) register a per-domain contract that produces / verifies
+/ renders an envelope from a sub-agent's result.
+
+The orchestrator merge uses the registry as the top of the degradation ladder:
+
+    Tier 1  registered contract → produce → verify → render   (this module)
+       │ (no contract, produce=None, or verify fails)
+    Tier 2  prose juxtaposition of the sub-agent's own answer  (orchestrator.py)
+       │ (kill-switch)
+    Tier 3  LLM synthesizer                                    (orchestrator.py)
+
+A contract NEVER raises into the merge — the orchestrator wraps produce/verify/
+render in try/except and demotes to Tier 2 on any failure, so a buggy plugin
+contract degrades gracefully instead of breaking the turn.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+from loguru import logger
+
+# Cross-repo contract version. A plugin registering a contract built against a
+# different major version is refused (fail-closed to Tier 2) — there is no
+# coordinated two-repo CI, so version safety is a runtime guard (plan finding #6).
+DOMAIN_CONTRACT_VERSION = 1
+
+# status values (supersedes 3-lite's bool `incomplete` — plan finding A4)
+STATUS_COMPLETE = "complete"
+STATUS_PARTIAL = "partial"
+STATUS_EMPTY = "empty"
+STATUS_ERROR = "error"
+_VALID_STATUS = frozenset({STATUS_COMPLETE, STATUS_PARTIAL, STATUS_EMPTY, STATUS_ERROR})
+
+
+@dataclass
+class DomainEnvelope:
+    """The typed result of one domain's sub-agent, produced deterministically
+    from its tool results (or, later, constrained-decoded reasoning)."""
+
+    domain: str
+    status: str = STATUS_COMPLETE
+    items: list[Any] = field(default_factory=list)
+    summary: str | None = None
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.status not in _VALID_STATUS:
+            raise ValueError(f"invalid DomainEnvelope status: {self.status!r}")
+
+
+@runtime_checkable
+class DomainContract(Protocol):
+    """A plugin-provided per-domain contract. All three methods run inside the
+    orchestrator's try/except demotion guard — raising demotes to Tier 2."""
+
+    version: int
+
+    def produce(self, sub_result: dict) -> DomainEnvelope | None:
+        """Build the envelope from the sub-agent result (tool data). Return None
+        to decline (→ Tier 2), e.g. when the expected tool result isn't present."""
+        ...
+
+    def verify(self, envelope: DomainEnvelope, sub_result: dict) -> bool:
+        """Cross-check the envelope against ground-truth tool data. False → demote."""
+        ...
+
+    def render(self, envelope: DomainEnvelope, lang: str) -> str:
+        """Render the envelope to a prose section body (no header — the merge
+        adds the role-keyed header)."""
+        ...
+
+
+_REGISTRY: dict[str, DomainContract] = {}
+
+
+def register_domain_contract(domain: str, contract: DomainContract) -> None:
+    """Register a per-domain contract. Version-mismatched contracts are refused
+    (fail-closed to Tier 2 + a warning) rather than risking a skewed render."""
+    ver = getattr(contract, "version", None)
+    if ver != DOMAIN_CONTRACT_VERSION:
+        logger.warning(
+            f"domain contract '{domain}' version {ver} != {DOMAIN_CONTRACT_VERSION} "
+            "— refused (fails closed to Tier 2). Bump both repos in lockstep."
+        )
+        try:
+            from utils.metrics import record_contract_version_mismatch
+            record_contract_version_mismatch(domain)
+        except Exception:  # noqa: BLE001
+            pass
+        return
+    _REGISTRY[domain] = contract
+    logger.info(f"domain contract registered: {domain} (v{ver})")
+
+
+def get_domain_contract(domain: str) -> DomainContract | None:
+    return _REGISTRY.get(domain)
+
+
+def clear_domain_contracts() -> None:
+    """Test hook — reset the registry."""
+    _REGISTRY.clear()

--- a/src/backend/services/orchestrator.py
+++ b/src/backend/services/orchestrator.py
@@ -844,12 +844,49 @@ class QueryOrchestrator:
         """
         sections: list[str] = []
         for r in answer_sources:
-            label = _role_label(r.get("role", "?"))
-            body = (r.get("answer") or "").strip()
+            role = r.get("role", "?")
+            label = _role_label(role)
+            body = self._render_section(r, role, lang)
             if not body:
                 continue
             sections.append(f"## {label}\n\n{body}")
         return "\n\n".join(sections)
+
+    def _render_section(self, sub_result: dict, role: str, lang: str) -> str:
+        """Render one domain's section body. Tier 1 (registered contract:
+        produce→verify→render) with graceful demotion to Tier 2 (the sub-agent's
+        own prose) on decline / verify-fail / raise. See services.domain_contract.
+        """
+        from services.domain_contract import get_domain_contract
+
+        contract = (
+            get_domain_contract(role)
+            if settings.orchestrator_typed_contracts else None
+        )
+        if contract is not None:
+            reason = None
+            try:
+                envelope = contract.produce(sub_result)
+                if envelope is None:
+                    reason = "declined"
+                elif not contract.verify(envelope, sub_result):
+                    reason = "verify"
+                else:
+                    rendered = (contract.render(envelope, lang) or "").strip()
+                    if rendered:
+                        return rendered
+                    reason = "empty_render"
+            except Exception as e:  # noqa: BLE001 — a buggy contract must not break the turn
+                logger.warning(f"domain contract '{role}' raised, demoting to Tier 2: {e}")
+                reason = "error"
+            if reason:
+                try:
+                    from utils.metrics import record_contract_demotion
+                    record_contract_demotion(role, reason)
+                except Exception:  # noqa: BLE001
+                    pass
+        # Tier 2 — the sub-agent's own answer, verbatim.
+        return (sub_result.get("answer") or "").strip()
 
     async def _synthesize(
         self,

--- a/src/backend/services/orchestrator.py
+++ b/src/backend/services/orchestrator.py
@@ -61,6 +61,25 @@ def _sub_agent_returned_data(result: dict) -> bool:
     """
     return bool(result.get("has_data", True))
 
+
+# Display labels for the deterministic per-domain section headers (Phase 0 of
+# the typed-contracts plan). Platform-generic: known roles get a pretty label,
+# anything else falls back to a title-cased role key. This is display text, not
+# domain logic — the sub-agent's own answer carries the substance.
+_ROLE_LABELS = {
+    "release": "Digital.ai Release",
+    "jira": "Jira",
+    "confluence": "Confluence",
+    "itsm": "ITSM",
+    "test": "Test Evidence",
+    "konfigure": "konfigure",
+}
+
+
+def _role_label(role: str) -> str:
+    return _ROLE_LABELS.get(role, (role or "?").replace("_", " ").title())
+
+
 if TYPE_CHECKING:
     from services.action_executor import ActionExecutor
     from services.agent_router import AgentRole, AgentRouter
@@ -748,13 +767,43 @@ class QueryOrchestrator:
             if r.get("incomplete") or (not r.get("answer") and not r.get("error"))
         ]
 
+        # Instrumentation (Phase 0 / outside-voice finding #1): requested =
+        # every domain the planner fanned out to; rendered = domains that
+        # contributed content. The persistent gap is the residual domain-drop
+        # rate that gates the per-domain Phase-3 rollout.
+        try:
+            from utils.metrics import record_orchestrator_render
+            record_orchestrator_render(len(sub_results), len(answer_sources))
+        except Exception:  # noqa: BLE001 — metrics must never break the turn
+            pass
+        _dropped = [
+            r.get("role", "?") for r in sub_results if r not in answer_sources
+        ]
+        logger.info(
+            f"🎼 orchestrator domain coverage: requested={len(sub_results)} "
+            f"rendered={len(answer_sources)} "
+            f"roles={[r.get('role') for r in answer_sources]} dropped={_dropped}"
+        )
+
         content: str | None = None
         if len(answer_sources) >= 2:
-            content = await self._synthesize(message, answer_sources, ollama, lang)
-        if content is None and answer_sources:
+            # Phase 0: assemble the combined answer DETERMINISTICALLY by
+            # juxtaposing each sub-agent's own answer under a role-keyed header
+            # — a section is bound to its own sub-agent, so a domain cannot be
+            # dropped or cross-labeled. The LLM synthesizer (Tier 3) stays
+            # behind the kill-switch for break-glass revert.
+            if settings.orchestrator_deterministic_merge:
+                content = self._assemble_deterministic(answer_sources, lang)
+            else:
+                content = await self._synthesize(message, answer_sources, ollama, lang)
+        # `not content` (not `is None`): the deterministic assembly strips each
+        # body, so a degenerate all-whitespace answer set yields "" — treat that
+        # like None so it can't be yielded as a silently-empty combined answer
+        # (defensive, per code review; closes the same silent-drop class).
+        if not content and answer_sources:
             content = answer_sources[0]["answer"]
 
-        if content is None:
+        if not content:
             # Every sub-agent failed/empty. Surface a localized error so the user
             # isn't left staring at an empty reply.
             roles = [r.get("role", "?") for r in sub_results]
@@ -779,6 +828,28 @@ class QueryOrchestrator:
             )
 
         yield AgentStep(step_number=99, step_type="final_answer", content=content)
+
+    def _assemble_deterministic(self, answer_sources: list[dict], lang: str) -> str:
+        """Phase 0 deterministic merge (Tier 2): juxtapose each sub-agent's own
+        answer under a role-keyed header. No LLM.
+
+        ``answer_sources`` has already excluded incomplete/errored sub-agents
+        (the ``non_empty`` filter drops ``incomplete`` results, so an
+        error_incomplete apology never reaches here — outside-voice finding #10),
+        and preferred data-bearing sources. Each section is bound to its own
+        sub-agent's role, so a domain can neither be dropped (every source gets a
+        section) nor cross-labeled (the header comes from the source's own role,
+        not an LLM's guess). The per-domain truncation note is still appended by
+        the caller for domains that produced no answer.
+        """
+        sections: list[str] = []
+        for r in answer_sources:
+            label = _role_label(r.get("role", "?"))
+            body = (r.get("answer") or "").strip()
+            if not body:
+                continue
+            sections.append(f"## {label}\n\n{body}")
+        return "\n\n".join(sections)
 
     async def _synthesize(
         self,

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -329,6 +329,15 @@ class Settings(BaseSettings):
     Short JSON-only response, deterministic — keep low to fail fast."""
     orchestrator_synthesis_timeout: float = Field(default=30.0, ge=5.0, le=300.0)
     """Timeout for orchestrator's synthesis call (combine sub-agent results into one answer)."""
+    orchestrator_deterministic_merge: bool = True
+    """Phase 0 of the typed-contracts plan. When True (default), the combined
+    multi-domain answer is assembled DETERMINISTICALLY by juxtaposing each
+    sub-agent's own answer under a role-keyed header — instead of the LLM
+    synthesizer (_synthesize). This removes the drop / conflate / cross-label
+    failure surface (a section is bound to its own sub-agent and cannot be
+    dropped or mislabeled) and removes an LLM round-trip per multi-domain turn.
+    Kill-switch: set False to revert to _synthesize (Tier 3 break-glass).
+    See docs/architecture/orchestrator-typed-contracts-plan.md."""
 
     # MCP Client (Model Context Protocol)
     mcp_enabled: bool = False             # Opt-in, disabled by default

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -338,6 +338,14 @@ class Settings(BaseSettings):
     dropped or mislabeled) and removes an LLM round-trip per multi-domain turn.
     Kill-switch: set False to revert to _synthesize (Tier 3 break-glass).
     See docs/architecture/orchestrator-typed-contracts-plan.md."""
+    orchestrator_typed_contracts: bool = True
+    """Phase 2/3 of the typed-contracts plan. When True (default), a domain with
+    a registered DomainContract (services.domain_contract) is rendered Tier 1 —
+    the merge runs the contract's produce→verify→render on the sub-agent's tool
+    data, instead of juxtaposing its prose (Tier 2). Only affects domains that
+    have a registered contract; all others stay Tier 2. A contract that declines
+    (produce→None), fails verification, or raises demotes to Tier 2. Kill-switch:
+    set False to force every domain to Tier 2 (prose juxtaposition)."""
 
     # MCP Client (Model Context Protocol)
     mcp_enabled: bool = False             # Opt-in, disabled by default

--- a/src/backend/utils/metrics.py
+++ b/src/backend/utils/metrics.py
@@ -44,6 +44,8 @@ _login_failure_total = None
 _authz_denied_total = None
 _kg_conflation_candidates = None
 _speaker_inprocess_embedding_blocked_total = None
+_orchestrator_domains_requested_total = None
+_orchestrator_domains_rendered_total = None
 
 
 def _init_metrics():
@@ -61,6 +63,7 @@ def _init_metrics():
     global _login_failure_total, _authz_denied_total
     global _kg_conflation_candidates
     global _speaker_inprocess_embedding_blocked_total
+    global _orchestrator_domains_requested_total, _orchestrator_domains_rendered_total
 
     if _metrics_initialized:
         return
@@ -209,6 +212,21 @@ def _init_metrics():
             ["path"],
         )
 
+        # Orchestrator domain-coverage instrumentation (typed-contracts plan
+        # Phase 0 / outside-voice finding #1). requested = domains the planner
+        # fanned out to; rendered = domains that contributed content to the
+        # combined answer. The ratio rendered/requested over time is the
+        # measured residual domain-drop rate that gates the per-domain Phase-3
+        # rollout — so it's built on evidence, not speculation.
+        _orchestrator_domains_requested_total = Counter(
+            "renfield_orchestrator_domains_requested_total",
+            "Sub-agent domains the orchestrator planner fanned out to",
+        )
+        _orchestrator_domains_rendered_total = Counter(
+            "renfield_orchestrator_domains_rendered_total",
+            "Sub-agent domains that contributed content to the combined answer",
+        )
+
         _metrics_initialized = True
         logger.info("Prometheus metrics initialized")
 
@@ -253,6 +271,21 @@ def record_agent_steps(steps: int):
     if not _metrics_initialized:
         return
     _agent_steps_total.observe(steps)
+
+
+def record_orchestrator_render(requested: int, rendered: int):
+    """Record orchestrator domain coverage for a multi-domain turn.
+
+    requested = domains fanned out to; rendered = domains that contributed
+    content. A persistent gap (rendered < requested) is the residual
+    domain-drop rate the typed-contracts Phase-3 rollout is gated on.
+    """
+    if not _metrics_initialized:
+        return
+    if requested > 0:
+        _orchestrator_domains_requested_total.inc(requested)
+    if rendered > 0:
+        _orchestrator_domains_rendered_total.inc(rendered)
 
 
 def record_circuit_breaker_state(name: str, state: str):

--- a/src/backend/utils/metrics.py
+++ b/src/backend/utils/metrics.py
@@ -46,6 +46,8 @@ _kg_conflation_candidates = None
 _speaker_inprocess_embedding_blocked_total = None
 _orchestrator_domains_requested_total = None
 _orchestrator_domains_rendered_total = None
+_orchestrator_contract_version_mismatch_total = None
+_orchestrator_contract_demotions_total = None
 
 
 def _init_metrics():
@@ -64,6 +66,7 @@ def _init_metrics():
     global _kg_conflation_candidates
     global _speaker_inprocess_embedding_blocked_total
     global _orchestrator_domains_requested_total, _orchestrator_domains_rendered_total
+    global _orchestrator_contract_version_mismatch_total, _orchestrator_contract_demotions_total
 
     if _metrics_initialized:
         return
@@ -226,6 +229,18 @@ def _init_metrics():
             "renfield_orchestrator_domains_rendered_total",
             "Sub-agent domains that contributed content to the combined answer",
         )
+        _orchestrator_contract_version_mismatch_total = Counter(
+            "renfield_orchestrator_contract_version_mismatch_total",
+            "Domain contract registrations refused due to version skew "
+            "(fail-closed to Tier 2)",
+            ["domain"],
+        )
+        _orchestrator_contract_demotions_total = Counter(
+            "renfield_orchestrator_contract_demotions_total",
+            "Tier-1 typed-contract renders that demoted to Tier 2 "
+            "(declined / verify-fail / raised)",
+            ["domain", "reason"],
+        )
 
         _metrics_initialized = True
         logger.info("Prometheus metrics initialized")
@@ -286,6 +301,20 @@ def record_orchestrator_render(requested: int, rendered: int):
         _orchestrator_domains_requested_total.inc(requested)
     if rendered > 0:
         _orchestrator_domains_rendered_total.inc(rendered)
+
+
+def record_contract_version_mismatch(domain: str):
+    """A domain contract was refused due to version skew (fail-closed to Tier 2)."""
+    if not _metrics_initialized:
+        return
+    _orchestrator_contract_version_mismatch_total.labels(domain=domain).inc()
+
+
+def record_contract_demotion(domain: str, reason: str):
+    """A Tier-1 typed render demoted to Tier 2 (reason: declined/verify/error)."""
+    if not _metrics_initialized:
+        return
+    _orchestrator_contract_demotions_total.labels(domain=domain, reason=reason).inc()
 
 
 def record_circuit_breaker_state(name: str, state: str):


### PR DESCRIPTION
Platform side of the orchestrator typed-contracts effort. Paired with X-idra reva `feat/orchestrator-deterministic-merge`. Design + full plan: `docs/architecture/orchestrator-typed-contracts-plan.md` (in the reva repo).

## Phase 0 — deterministic merge (retire the prose synthesizer)
`_emit_combined_answer` now assembles the combined multi-domain answer **deterministically** — each sub-agent's answer under a role-keyed `## <label>` header (`_assemble_deterministic`) — instead of the LLM synthesizer. A section is bound to its own sub-agent's role, so a domain can neither be dropped (every source gets a section) nor cross-labeled. Removes the drop/conflate/cross-label failure surface **and** an LLM round-trip per multi-domain turn.
- Gated `settings.orchestrator_deterministic_merge` (default True); False → `_synthesize` (Tier-3 break-glass).
- Preserves the shipped 3-lite logic (incomplete-exclusion, with_data, truncated note). Empty assembled string treated like None (no silently-empty answer — from code review).
- Instrumentation: `record_orchestrator_render` + `orchestrator_domains_{requested,rendered}_total` — the residual domain-drop rate that gates the per-domain rollout.

## Phase 2 — typed domain contracts + Tier-1 dispatch
New `services/domain_contract.py`: platform-generic `DomainEnvelope` (status enum superseding 3-lite's `incomplete` bool), a `DomainContract` Protocol, and a **version-guarded registry**. `_render_section` runs a registered contract's produce→verify→render (Tier 1) with try/except **demotion to Tier 2** (the sub-agent's prose) on decline / verify-fail / raise — the degradation ladder. Gated `settings.orchestrator_typed_contracts` (default True); only affects domains with a registered contract.
- Cross-repo version skew **fails closed** (register refuses a mismatched version → Tier 2 + `orchestrator_contract_version_mismatch_total`) — there is no coordinated two-repo CI.
- Tier-1 demotions counted via `orchestrator_contract_demotions_total{domain,reason}`.

## The degradation ladder
```
Tier 1  registered typed contract → produce → verify → render
Tier 2  prose juxtaposition (Phase 0)
Tier 3  LLM synthesizer (kill-switch break-glass)
```

## Verification (prod)
- Deployed + verified: `_synthesize` gone from the default path; `requested=2 rendered=2 dropped=[]`; portfolio report 4/4 byte-identical (unaffected — bypasses via Option 1); e2e 12/13 (the 1 fail is a pre-existing flaky follow-up).
- Reva registers the jira contract (companion PR), which fires Tier-1 on the cross-domain path.
- Tests (reva repo, run on the prod image): 92+ across `test_f6_truncated_domain.py` (merge + Tier-1 dispatch + version guard) and `test_jira_contract.py`.

Phase-1 constrained-decoding spike (separate, not in this diff) came back **GO** on the live llama-server (`json_schema` enforced); details in the plan doc §8a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)