### PR TITLE
feat(orchestrator): typed planner via constrained decoding (typed-contracts Phase 4b)

### DIFF
--- a/src/backend/services/orchestrator.py
+++ b/src/backend/services/orchestrator.py
@@ -80,6 +80,66 @@ def _role_label(role: str) -> str:
     return _ROLE_LABELS.get(role, (role or "?").replace("_", " ").title())
 
 
+def _build_plan_schema(enum_roles: list[str]) -> dict:
+    """JSON schema for the typed planner (Phase 4b): a strict object whose
+    sub_queries[].role is an ENUM of the eligible roles — so constrained decoding
+    guarantees valid, parseable JSON with only real roles. No minItems, so a
+    single-domain request can return {"sub_queries": []}."""
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["sub_queries"],
+        "properties": {
+            "sub_queries": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["role", "query"],
+                    "properties": {
+                        "role": {"type": "string", "enum": enum_roles},
+                        "query": {"type": "string"},
+                    },
+                },
+            }
+        },
+    }
+
+
+def _parse_plan(response_text: str) -> list | None:
+    """Parse an orchestrator plan response into a list of sub-query dicts.
+
+    Handles both shapes so the typed-planner flag can flip safely:
+    - typed (json_schema): a clean ``{"sub_queries": [...]}`` document;
+    - legacy free-text: a bare ``[...]`` array, sometimes wrapped in prose.
+
+    Returns the sub-query list, or None when nothing parseable is present.
+    """
+    import json as _json
+
+    text = (response_text or "").strip()
+    if not text or text.lower() in ("null", "none"):
+        return None
+    # Full-document parse first — always succeeds under json_schema.
+    try:
+        doc = _json.loads(text)
+        if isinstance(doc, dict):
+            return doc.get("sub_queries")
+        if isinstance(doc, list):
+            return doc
+    except _json.JSONDecodeError:
+        pass
+    # Legacy: extract the outermost [...] array from a prose-wrapped response.
+    start = text.find("[")
+    end = text.rfind("]") + 1
+    if start < 0 or end <= start:
+        return None
+    try:
+        return _json.loads(text[start:end])
+    except _json.JSONDecodeError:
+        return None
+
+
 if TYPE_CHECKING:
     from services.action_executor import ActionExecutor
     from services.agent_router import AgentRole, AgentRouter
@@ -249,13 +309,37 @@ class QueryOrchestrator:
                 client = ollama.client
 
             classification_kwargs = get_classification_chat_kwargs(planner_model)
+
+            # Phase 4b — typed planner. Constrain the plan to a JSON schema whose
+            # `role` is an ENUM of the eligible roles, so the planner can neither
+            # wrap the JSON in prose (parse failure → spurious single-role) nor
+            # invent a role name (the two failure modes noted above). Only used
+            # on the OpenAI-compat/llama-server path (json_schema isn't an Ollama
+            # concept); a small Ollama planner keeps the free-text prompt.
+            plan_prompt = detect_prompt
+            plan_format = None
+            _enum_roles = [n for n in sorted(eligible_names) if n in self.router.roles]
+            if (
+                settings.orchestrator_typed_planner
+                and use_openai_for_tier("agent")
+                and _enum_roles
+            ):
+                plan_format = _build_plan_schema(_enum_roles)
+                plan_prompt = (
+                    detect_prompt
+                    + '\n\nRespond ONLY with JSON: {"sub_queries": [{"role": <one '
+                    'of the roles above>, "query": <localized sub-query>}]}. For a '
+                    'single-domain request, return {"sub_queries": []}.'
+                )
+
             # num_predict=800 matches Reva's production planner budget — enough
             # for a 4-sub-agent plan with localized query strings.
             raw_response = await asyncio.wait_for(
                 client.chat(
                     model=planner_model,
-                    messages=[{"role": "user", "content": detect_prompt}],
+                    messages=[{"role": "user", "content": plan_prompt}],
                     options={"temperature": 0, "num_predict": 800, "num_ctx": 4096},
+                    format=plan_format,
                     **classification_kwargs,
                 ),
                 timeout=settings.agent_router_timeout,
@@ -266,20 +350,12 @@ class QueryOrchestrator:
             if response_text.lower() in ("null", "none", ""):
                 return None
 
-            # Extract the JSON array from a potentially-prose response.
-            # Even large models occasionally wrap the array in explanation.
-            start = response_text.find("[")
-            end = response_text.rfind("]") + 1
-            if start < 0 or end <= start:
-                logger.info(f"Orchestrator: no JSON array in response, single-role. Raw: {response_text[:200]}")
+            # Parse the plan (typed {"sub_queries":[...]} or legacy bare/prose
+            # array — see _parse_plan). None ⇒ unparseable ⇒ single-role.
+            sub_queries = _parse_plan(response_text)
+            if sub_queries is None:
+                logger.info(f"Orchestrator: no JSON plan in response, single-role. Raw: {response_text[:200]}")
                 return None
-
-            try:
-                sub_queries = json.loads(response_text[start:end])
-            except json.JSONDecodeError as e:
-                logger.info(f"Orchestrator: JSON parse failed ({e}), single-role. Raw: {response_text[start:end][:200]}")
-                return None
-
             if not isinstance(sub_queries, list) or len(sub_queries) < 2:
                 return None
 

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -338,6 +338,15 @@ class Settings(BaseSettings):
     dropped or mislabeled) and removes an LLM round-trip per multi-domain turn.
     Kill-switch: set False to revert to _synthesize (Tier 3 break-glass).
     See docs/architecture/orchestrator-typed-contracts-plan.md."""
+    orchestrator_typed_planner: bool = True
+    """Phase 4b of the typed-contracts plan. When True (default), detect_multi_domain
+    constrains the planner LLM to a typed plan schema (json_schema, role as an
+    ENUM of eligible roles) via constrained decoding — so the plan is always
+    valid parseable JSON with valid roles (eliminating the free-text parse
+    failures that silently collapsed a real multi-domain query to single-role,
+    and the invalid-role entries). Kill-switch: set False to use the legacy
+    free-text prompt + substring-JSON parse. The parser handles both shapes, so
+    a flip is safe either way."""
     orchestrator_typed_contracts: bool = True
     """Phase 2/3 of the typed-contracts plan. When True (default), a domain with
     a registered DomainContract (services.domain_contract) is rendered Tier 1 —

--- a/src/backend/utils/llm_client.py
+++ b/src/backend/utils/llm_client.py
@@ -329,8 +329,18 @@ class OpenAICompatibleClient:
             oa["seed"] = opts["seed"]
         if "stop" in opts:
             oa["stop"] = opts["stop"]
-        if kwargs.get("format") == "json":
+        fmt = kwargs.get("format")
+        if fmt == "json":
             oa["response_format"] = {"type": "json_object"}
+        elif isinstance(fmt, dict):
+            # A JSON Schema → constrained decoding. llama-server enforces the
+            # schema (verified: json_object is NOT enforced on this build, but
+            # json_schema IS — see the typed-contracts Phase-1 spike). Guarantees
+            # a schema-conforming, always-parseable response.
+            oa["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {"name": "schema", "schema": fmt, "strict": True},
+            }
         return oa
 
     @staticmethod


### PR DESCRIPTION
Platform side of Phase 4b. Fixes the orchestrator's cross-domain **split** stage — the planner (`detect_multi_domain`) that decomposes a multi-domain query into per-domain sub-queries. Paired with X-idra reva `feat/orchestrator-typed-planner` (unit tests).

## Problem (named in the code's own comment)
The planner is a small-ish LLM emitting free-text JSON that gets substring-parsed. Its two failure modes — "they wrap JSON in prose and invent role names" — either collapse a real multi-domain query to single-role (parse failure) or emit an unusable role.

## Fix — constrained decoding
- `utils/llm_client.py::_options_to_openai`: a **dict** `format` now maps to `response_format {type: json_schema, json_schema: {name, schema, strict: True}}`. (`json_object` is NOT enforced on the prod llama-server build; `json_schema` IS — verified in the Phase-1 spike. A `"json"` string still → `json_object`.)
- `orchestrator.py::_build_plan_schema`: a strict object whose `sub_queries[].role` is an **enum** of the eligible roles (no `minItems`, so single-domain returns `{"sub_queries": []}`). So the plan is always valid, parseable JSON with only real roles.
- `_parse_plan` handles BOTH the typed `{"sub_queries":[...]}` object and the legacy bare/prose `[...]` array, so the flag flips safely.
- Gated `settings.orchestrator_typed_planner` (default True); only on the OpenAI-compat/llama-server planner path. Off / Ollama planner → legacy behavior, byte-identical.

## Verification (prod)
- Deployed; `detect_multi_domain` cleanly detects domains with valid roles and **zero planner parse-failures** on the multi-domain probe.
- Review: no functional bugs (fallback safety, parse edge cases, strict-schema shape all verified).
- Tests (reva repo `test_typed_planner.py`, 12): `_parse_plan` all shapes, `_build_plan_schema`, and the `json_schema` client mapping.

## Note
`response_format: json_schema` is now a reusable constrained-decoding seam for any renfield caller (structured planning, typed sub-agent output, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)