### PR TITLE
chore(k8s): reconcile in-cluster LLM fallback flags into household ConfigMap

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -99,6 +99,17 @@ data:
   LLM_OPENAI_EMBED_BASE_URL: "http://ollama:11434/v1"
   LLM_OPENAI_EMBED_MODEL: "qwen3-embedding:4b"
 
+  # In-cluster LLM fallback (PR #1083). When the cuda.local OpenAI-compat
+  # chat/agent tier is unreachable (connection-down or cold-model 5xx), the
+  # backend fails the turn over to the in-cluster Ollama (OLLAMA_URL) using
+  # LLM_OPENAI_FALLBACK_MODEL, and the wait-for-deps init boot-gate becomes
+  # time-bounded (WAIT_CUDA_MAX_SECONDS) so the backend still boots during a
+  # cuda outage. Enabled here after the 2026-08-09 cuda outages; the in-code
+  # default is false (dark).
+  LLM_OPENAI_FALLBACK_ENABLED: "true"
+  LLM_OPENAI_FALLBACK_MODEL: "qwen3:14b"
+  WAIT_CUDA_MAX_SECONDS: "30"
+
   # Voice-server (B.4): when set, backend's /api/voice/voice-chat
   # orchestrator delegates STT + TTS to the voice-server pod
   # (k8s-gpu-3) instead of running them in-process. Backend retains


### PR DESCRIPTION
## What

Commits the three in-cluster LLM fallback flags (PR #1083) into the household `k8s/configmap.yaml` so git matches the live state:

```yaml
LLM_OPENAI_FALLBACK_ENABLED: "true"
LLM_OPENAI_FALLBACK_MODEL:   "qwen3:14b"
WAIT_CUDA_MAX_SECONDS:       "30"
```

## Why

These were applied **live via `kubectl patch`** during the 2026-08-09 `cuda.local` outage recovery (cuda moved to `.15`, but `cuda.local` still resolved to the dead `.227`). Per the *"flip flags in git, never kubectl-patch"* rule, this reconciles the drift back into version control.

## Effect

With the flags on:
- an unreachable `cuda.local` chat/agent tier **fails the turn over to the in-cluster Ollama** (`qwen3:14b`) at runtime, and
- the `wait-for-deps` init boot-gate becomes **time-bounded** (`WAIT_CUDA_MAX_SECONDS`) so the backend still boots during a cuda outage.

The in-code default stays `false` (dark) — this only turns it on for the household deploy.

## Verification

Both instances (`renfield` + `renfield-xidra`) already run image `2026-08-09-llmfallback` with these flags live and verified:
- backend booted `1/1` through the bounded init while cuda was fully unreachable;
- a synthetic `get_default_client().chat(...)` logged `primary failed (APIConnectionError); falling back to Ollama (model=qwen3:14b)` and returned a real completion.

## Follow-ups (not in this PR)

- Private **xidra** config repo needs the same three flags (separate repo).
- Router DNS `cuda.local` → `.15` to restore the primary (`qwen3.6`-35B); switchback is automatic once resolution is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vEy3T6JbZ1yEtH1VWT4Lp