### PR TITLE
feat(prototype): NPU vision-offload for A733 satellites + doc reconciliation

### DIFF
--- a/docs/SATELLITE_CAMERA.md
+++ b/docs/SATELLITE_CAMERA.md
@@ -138,3 +138,20 @@ cards.
 (RTX 5060 Ti, 16 GB) — `OLLAMA_VISION_URL` routes there, so no separate vision pod is
 needed. A single test-snapshot inference measured ~1 s end-to-end on the GPU; image-heavy
 scene descriptions with longer responses take proportionally longer.
+
+## On-device NPU offload (A733 satellites) — prototype
+
+The snapshot→`qwen3-vl` path above is authoritative and stays the default. On an **A733**
+satellite (Vivante VIP9000, 3 TOPS NPU) two of its jobs can run **on-device** as a GPU
+offload + privacy + offline improvement — see `prototypes/npu-occupancy/`:
+
+- **Occupancy count** (the announce privacy gate) → an NPU YOLOv8n person-detector; only
+  an integer leaves the device, the frame never does.
+- **Object / document-type recognition** ("is this an invoice / letter / parcel label")
+  → an NPU MobileCLIP zero-shot classifier + a has-text trigger that *routes* a presented
+  document into the existing folder-ingest / Docling / Schicht-A pipeline. It **triages**;
+  the cluster still does authoritative OCR/extraction.
+
+Gesture + facial-expression understanding is a **separate** (CPU-MediaPipe) design —
+`docs/design/non-verbal-communication.md`. The A733 CSI camera options (IMX219 etc.) are
+in that doc's 2026-08-09 addendum and the prototype README.

--- a/docs/SATELLITE_CAMERA.md
+++ b/docs/SATELLITE_CAMERA.md
@@ -153,5 +153,7 @@ offload + privacy + offline improvement — see `prototypes/npu-occupancy/`:
   the cluster still does authoritative OCR/extraction.
 
 Gesture + facial-expression understanding is a **separate** (CPU-MediaPipe) design —
-`docs/design/non-verbal-communication.md`. The A733 CSI camera options (IMX219 etc.) are
-in that doc's 2026-08-09 addendum and the prototype README.
+`docs/design/non-verbal-communication.md`. Camera choice for the A733: **use an RTSP/ONVIF
+IP camera** (Tapo C210 / Reolink E1 Pro) — the Zero 3W's 24-pin CSI has a connector/driver
+collision (no off-the-shelf camera both fits and has an A733 driver; a Pi-15-pin module
+won't even boot it). Details in that doc's 2026-08-09 addendum + the prototype README.

--- a/docs/SATELLITE_CAMERA.md
+++ b/docs/SATELLITE_CAMERA.md
@@ -153,7 +153,8 @@ offload + privacy + offline improvement — see `prototypes/npu-occupancy/`:
   the cluster still does authoritative OCR/extraction.
 
 Gesture + facial-expression understanding is a **separate** (CPU-MediaPipe) design —
-`docs/design/non-verbal-communication.md`. Camera choice for the A733: **use an RTSP/ONVIF
-IP camera** (Tapo C210 / Reolink E1 Pro) — the Zero 3W's 24-pin CSI has a connector/driver
-collision (no off-the-shelf camera both fits and has an A733 driver; a Pi-15-pin module
-won't even boot it). Details in that doc's 2026-08-09 addendum + the prototype README.
+`docs/design/non-verbal-communication.md`. Camera choice for the A733 (Orange Pi Zero 3W):
+its CSI port is a **Raspberry-Pi-standard 22-pin MIPI connector** and the **IMX219 driver
+is already built** — so an IMX219 camera (Pi Cam v2 / Waveshare IMX219-160IR) + a
+"Standard-Mini" 15↔22-pin cable + one DT overlay is the path. Full schematic-verified
+reference (pinout, driver, overlay, incompatible cameras): `docs/design/a733-satellite-camera.md`.

--- a/docs/design/a733-satellite-camera.md
+++ b/docs/design/a733-satellite-camera.md
@@ -168,38 +168,34 @@ Module 3 (IMX708) fails on the sensor driver, not the cable.
 5. Wire it to the occupancy/gesture prototypes (`prototypes/npu-occupancy/`) — the
    detector + WS contract are camera-agnostic; only the frame source changes.
 
-### DT overlay — draft (confirmed pins; a few bring-up TODOs)
+### DT overlay
 
-```dts
-/* sun60i-a733-orangepi-zero3w-cam-imx219.dts — CAM1 / CSI0, IMX219 2-lane.
- * Pins verified from OPi ZERO 3W V1.2 schematic sheet 13. */
-&vind0            { status = "okay"; };
-&csi0             { status = "okay"; };            /* MCSIA / CAM1 */
-&twi11            { status = "okay"; };            /* sensor i2c (pins 20/21) */
+**Written + compile-verified:**
+[`prototypes/npu-occupancy/dts/sun60i-a733-orangepi-zero3w-cam-imx219.dts`](../../prototypes/npu-occupancy/dts/sun60i-a733-orangepi-zero3w-cam-imx219.dts).
+It adds the missing `sensor0` (IMX219) + `vinc00` (capture) nodes under the already-enabled
+`&vind0`, using the exact sunxi-vin binding from the Orange Pi 4 Pro DTS (same A733 SoC) and
+our confirmed values (`sensor0_mname="imx219"`, `twi_cci_id=11`, `twi_addr=0x20`,
+reset/pwdn on PE6/PE5, CSI0). It **compiles** on the board (`cpp | dtc -@` → 1442-byte
+`.dtbo`; only cosmetic `unit_address_vs_reg` warnings, same as the 4 Pro DTS).
 
-&sensor0 {
-    device_type       = "sensor0";
-    sensor0_mname     = "imx219_mipi";             /* in-tree MIPI driver (=m) */
-    sensor0_twi_id    = <11>;                      /* TWI11 */
-    sensor0_twi_addr  = <0x10>;                    /* IMX219 default */
-    sensor0_mclk_id   = <0>;                       /* TODO verify vs csi_mclk group */
-    /* PE6 = pin17, PE5 = pin18 — assign reset/pwdn per driver expectation + polarity: */
-    sensor0_reset     = <&pio 'E' 6 ...>;          /* TODO confirm reset vs pwdn + active level */
-    sensor0_pwdn      = <&pio 'E' 5 ...>;
-    sensor0_mipi_id   = <0>;
-    sensor0_lane      = <2>;                        /* IMX219 = 2 lanes */
-    status            = "okay";
-};
-```
+Build/install (from the overlay's header): `armbian-add-overlay <file>.dts`, or manual
+`cpp | dtc -@` → copy `.dtbo` to `/boot/dtb/allwinner/overlay/` → add
+`overlays=sun60i-a733-orangepi-zero3w-cam-imx219` to `/boot/orangepiEnv.txt` → reboot →
+expect `/dev/video0`.
 
-TODOs to resolve on first bring-up (hardware-in-the-loop): exact `mclk` source (Pi modules
-self-clock — the SoC mclk may be unused), and the reset/pwdn GPIO polarity. Everything else
-(bus = TWI11, GPIOs = PE5/PE6, CSI0, 2-lane, 0x10) is schematic-confirmed.
+**On-target tunables** (validate with `dmesg | grep -iE "vin|csi|imx219"`; the sensor
+already ACKs on i2c, so if it doesn't enumerate it's one of these): the MCSIA→PHY mux
+(`vinc0_csi_sel`/`vinc0_mipi_sel` = 0, try 1/2), `sensor0_mclk_id` (Pi modules self-clock,
+likely inert), and the PE6/PE5 reset-vs-pwdn assignment + polarity.
 
 ## Verification / provenance
 
 - Board identity, kernel config, DTB, i2c buses, absent `/dev/video`: read live on the
   board over SSH (`root@192.168.1.82`), 2026-08-09.
+- **IMX219 sensor live-confirmed:** with a Camera Module 2 + correctly-oriented Standard-Mini
+  cable, `i2cdetect -y 11` shows the sensor answering at **0x10** on **TWI11** — the exact
+  bus/address the schematic predicted and the overlay hard-codes. (The prior no-boot was a
+  flipped FPC; once re-seated, the board boots and the sensor ACKs.)
 - Connector part, footprint, and CAM1/CAM2 pinout: the official schematic PDF, sheet 13.
 - Driver bus types (IMX219 MIPI vs OV5640 DVP): the A733 vendor kernel source
   (`orangepi-xunlong/linux-orangepi`, `orange-pi-6.6-sun60iw2`).

--- a/docs/design/a733-satellite-camera.md
+++ b/docs/design/a733-satellite-camera.md
@@ -87,16 +87,52 @@ CONFIG_SENSOR_OV13850=m         # MIPI, also available (13 MP)
   scaffold (`vind0`/`csi`/`sensor`/`vinc`) — adapt that as the overlay template.
 - So the entire remaining task is **one DT overlay** using the pins verified above.
 
-## The cable — and the no-boot root cause
+## Pin compatibility with Raspberry Pi cameras (verified)
 
-- **Root cause of the "Orange won't boot" incident:** a **15-pin** Pi camera (the
-  arbeitszimmer Pi Cam v2) was connected to the board's **22-pin** socket. The pins don't
-  align → mis-driven power/signal lines → the board fails to boot. Not a board fault; the
-  board is fine once disconnected.
-- **The one part to order:** a **Raspberry Pi Zero / Pi 5 camera cable, 15-pin (camera) ↔
-  22-pin (host), 0.5 mm** (the standard "Pi Zero camera cable"). ~€5, berrybase.de /
-  Amazon.de ("Raspberry Pi Zero Kamera Kabel 22-pin 15-pin"). A native-22-pin camera
-  needs a 22↔22 cable instead.
+The `fpc22-20-sm-RPI-TOP-h2` footprint is not just mechanically Pi-shaped — the **signal
+assignment matches the Raspberry Pi 22-pin standard** on the pins that matter, so a genuine
+Pi camera + the right cable maps correctly:
+
+| | SCL | SDA | 3V3 |
+|---|---|---|---|
+| Raspberry Pi 22-pin standard | pin 20 | pin 21 | pin 22 |
+| Orange Pi Zero 3W CAM1 (schematic) | pin 20 (TWI11_SCK) | pin 21 (TWI11_SDA) | pin 22 (VCC_3V3_CSI) |
+
+So the connector is genuinely Pi-compatible; an **IMX219** Pi camera is the right part.
+
+## The cable
+
+- **The one part to order:** a **Raspberry Pi "Standard - Mini" camera cable, 15-pin
+  (camera) ↔ 22-pin (host), 0.5 mm** (aka the Pi Zero / Pi 5 camera cable). ~€5,
+  berrybase.de / Amazon.de / Adafruit #5818. A native-22-pin camera needs a 22↔22 cable.
+
+## Troubleshooting: the board won't boot with the camera connected
+
+Two distinct causes, both **mechanical, not a board fault** — the board boots fine the
+moment the camera is unplugged. **Always power off before (dis)connecting the ribbon; a
+mis-seated CSI ribbon shorts 3V3→GND and can damage the board or camera if left powered.**
+
+1. **Wrong connector width** (the first incident): a **15-pin** Pi camera pushed onto the
+   **22-pin** socket without the 15→22 Standard-Mini cable → pins don't align → short → no
+   boot. Fix: use the Standard-Mini cable above.
+
+2. **Flipped FPC ribbon** (the second incident, with a correct Module 2 + cable): an FPC
+   ribbon has **contacts on one side only**. Inserted the wrong way round at **one** end,
+   the connector is **mirrored** — pin 22 (**3V3**) lands on pin 1 (**GND**) → **dead short
+   → no boot.** This is the classic FPC mistake and matches "boots without the camera, dies
+   with it" exactly. Fix, with **power off**:
+   - Unplug the camera; confirm the board boots bare (it will).
+   - Re-seat the ribbon so the **exposed metal contacts** face each connector's contact side
+     at **both** ends (the **blue stiffener** is the orientation reference; flipping one end
+     is what shorts it). Fully insert; close the latch/flap.
+   - Power on. If it boots but `/dev/video0` is absent, that's expected — the sensor still
+     needs the **DT overlay** (above); the board *booting* means the cable is now correct.
+   - Still no boot after fixing orientation with a known-good Standard-Mini cable → suspect a
+     damaged cable, or board damage from an earlier forced insertion (test the board bare,
+     then swap the cable).
+
+**Symptom on the cluster side:** the node goes `NotReady` + no ping (it's a hardware-pinned
+k8s node; a dead board can't self-heal). Unplug the camera and power-cycle to recover.
 
 ## Camera options (all IMX219 → driver already built)
 

--- a/docs/design/a733-satellite-camera.md
+++ b/docs/design/a733-satellite-camera.md
@@ -1,0 +1,179 @@
+# A733 (Orange Pi Zero 3W) satellite camera — hardware bring-up reference
+
+**Status: investigated + schematic-verified 2026-08-09. Not yet built.** This is the
+authoritative camera reference for the Allwinner **A733** satellite (the Esszimmer node,
+`orangepizero3w` / 192.168.1.82). It supersedes earlier, wrong conclusions in this repo
+that said "CSI is a dead end, use RTSP" — the schematic shows the opposite.
+
+## TL;DR
+
+- The board's camera connector is a **Raspberry-Pi-standard 22-pin 0.5 mm MIPI CSI FPC**
+  (footprint literally `fpc22-20-sm-RPI-TOP-h2`). A Pi camera is electrically compatible.
+- The **IMX219 driver is already built** into the running kernel (`CONFIG_SENSOR_IMX219=m`,
+  MIPI CSI-2). **No kernel/driver work.**
+- What's needed: **(1)** a **15-pin↔22-pin Raspberry Pi Zero/Pi 5 camera cable** (~€5) —
+  this is the *only* hardware missing; **(2)** one **device-tree overlay** to enable CSI0 +
+  add the `imx219` sensor node (all pin values known from the schematic, below).
+- **The no-boot** an operator hit was simply a **15-pin camera forced into the 22-pin
+  socket** without the adapter cable — a mechanical/pin mismatch, not a board fault.
+
+## Board (verified on-device via SSH)
+
+| Fact | Value | Source |
+|---|---|---|
+| Board | `Orange Pi Zero 3W`, `BOARDFAMILY=sun60iw2`, `BRANCH=legacy` | `/etc/orangepi-release` |
+| SoC | Allwinner **A733** (`sun60i-a733`), arm64, 8 cores, ~12 GB RAM | `/proc/device-tree/model`, node caps |
+| Kernel | 6.6.98 `sun60iw2` (vendor BSP, no mainline) | `uname -r` |
+| DTB | `sun60i-a733-orangepi-zero3w.dtb` | `/boot/dtb/allwinner/` |
+
+## The camera connector (verified from the official schematic)
+
+Source: **"OPI ZERO 3W V1_2 Schematic Diagram.pdf"** (Shenzhen Xunlong), sheet **13 —
+`13_CAM_MIPI CSI`**. There are **two** connectors: `CAM1` (CSI0) and `CAM2` (CSI1).
+
+- Connector part: **`KH-FPC0.5-H2.0SMT-22P-QCHF`** — 22-pin, 0.5 mm pitch.
+- Footprint: **`fpc22-20-sm-RPI-TOP-h2`** → the **Raspberry Pi 22-pin CSI standard**
+  (same connector as Pi 5 / Pi Zero / CM4), contacts on top.
+
+### `CAM1` = MIPI **CSI0** (MCSIA) — the primary camera port
+
+| Pins | Signal | Notes |
+|---|---|---|
+| 2–3 | MCSIA-D0N / D0P | data lane 0 |
+| 5–6 | MCSIA-D1N / D1P | data lane 1 (IMX219 = 2 lanes → uses 0+1) |
+| 8–9 | MCSIA-CKN / CKP | MIPI clock |
+| 11–12 | MCSIA-D2N / D2P | lane 2 (4-lane capable) |
+| 14–15 | MCSIA-D3N / D3P | lane 3 |
+| 17 | **PE6** | control GPIO (reset / pwdn) |
+| 18 | **PE5** | control GPIO (reset / pwdn) |
+| 20 | **TWI11_SCK** | sensor i2c clock → **i2c = TWI11** (`twi@251B000`) |
+| 21 | **TWI11_SDA** | sensor i2c data |
+| 22 | VCC_3V3_CSI | 3V3 power |
+| 1,4,7,10,13,16,19 | GND | diff-pair returns |
+| 23, 24 | GND | shield tabs |
+
+### `CAM2` = MIPI **CSI1** (MCSIB) — second port
+
+Same 22-pin RPI connector; **i2c = TWI9**, control GPIOs **PE9 / PE10**, MCSIB 4-lane.
+Use CAM1 unless a second camera is needed.
+
+**Note on clock:** the RPI 22-pin standard does not route a discrete sensor MCLK — Pi
+camera modules carry their own oscillator. Confirm mclk handling during bring-up (the
+sunxi-vin `imx219` node may still expect a `csi_mclk` pinctrl; the board defines
+`csi_mclk0/1/2` groups).
+
+## Driver status (verified in the running kernel)
+
+```
+CONFIG_AW_VIDEO_SUNXI_VIN=m     # Allwinner VIN (video-input) framework
+CONFIG_VIN_IOMMU=y
+CONFIG_SENSOR_IMX219=m          # ← MIPI CSI-2, 2-lane — matches the connector. USE THIS.
+CONFIG_SENSOR_OV13850=m         # MIPI, also available (13 MP)
+# CONFIG_SENSOR_OV5640 is not set # DVP/parallel driver — WRONG interface, do not use
+```
+
+- **IMX219** is the correct sensor: its in-tree `sunxi-vin` driver is `V4L2_MBUS_CSI2_DPHY`
+  (MIPI) and already compiled. Zero driver work.
+- **OV5640** is a trap: its in-tree driver is `V4L2_MBUS_PARALLEL` (DVP), and the only
+  buyable OV5640 module (Orange Pi OP1300) is a parallel camera for old H3 boards — wrong
+  interface for this MIPI connector. Do not use OV5640.
+
+## Device-tree status
+
+- `vind@5800800` (the CSI/ISP controller) is present in the Zero 3W DTB but
+  `status = "disabled"`; no active sensor node; the BSP ships **no camera overlay**
+  (confirmed: `/proc/device-tree` has no csi/vin nodes, `/dev/video*` absent).
+- The **Orange Pi 4 Pro** DTS (same A733 SoC) carries a complete commented-out camera
+  scaffold (`vind0`/`csi`/`sensor`/`vinc`) — adapt that as the overlay template.
+- So the entire remaining task is **one DT overlay** using the pins verified above.
+
+## The cable — and the no-boot root cause
+
+- **Root cause of the "Orange won't boot" incident:** a **15-pin** Pi camera (the
+  arbeitszimmer Pi Cam v2) was connected to the board's **22-pin** socket. The pins don't
+  align → mis-driven power/signal lines → the board fails to boot. Not a board fault; the
+  board is fine once disconnected.
+- **The one part to order:** a **Raspberry Pi Zero / Pi 5 camera cable, 15-pin (camera) ↔
+  22-pin (host), 0.5 mm** (the standard "Pi Zero camera cable"). ~€5, berrybase.de /
+  Amazon.de ("Raspberry Pi Zero Kamera Kabel 22-pin 15-pin"). A native-22-pin camera
+  needs a 22↔22 cable instead.
+
+## Camera options (all IMX219 → driver already built)
+
+| Camera | FoV / features | Use | Cable |
+|---|---|---|---|
+| **Pi Camera Module v2** (existing, arbeitszimmer) | ~62°, no IR | cheap first bring-up test | 15→22 |
+| **Waveshare IMX219-160IR** | 160°, IR night vision | the real occupancy/gesture camera | 15→22 |
+
+(Occupancy wants the wide/IR 160°; the plain Pi Cam v2 is fine to prove the pipeline. The
+board has **two** CSI ports if both a wide and a narrower camera are ever wanted.)
+
+### Cameras that will NOT work (driver mismatch, even though they plug in)
+
+| Camera | Sensor | Why not |
+|---|---|---|
+| **Raspberry Pi Camera Module 3** | **IMX708** | No IMX708 driver in the A733 `sunxi-vin` set (only IMX219/OV13850 are built). Plugs in via a Standard-Mini cable, but never enumerates. |
+| Orange Pi OP1300 / generic OV5640 modules | OV5640 | In-tree OV5640 driver is DVP/parallel; this connector is MIPI. Wrong interface. |
+| Pi HQ Camera | IMX477 | No IMX477 driver in the A733 set. |
+
+**Cable vs camera:** the connector is the Pi-standard 22-pin "Mini". The **"Raspberry Pi
+Camera Cable Standard - Mini"** (15-pin↔22-pin) is the *correct* cable — pair it with an
+**IMX219** camera. A cable being right does not make an unsupported *sensor* work: Camera
+Module 3 (IMX708) fails on the sensor driver, not the cable.
+
+## Bring-up steps
+
+1. Order the 15→22-pin Pi-Zero camera cable; connect the IMX219 module to **CAM1**.
+2. Write + install the DT overlay (below); enable it in `/boot/orangepiEnv.txt`
+   (`overlays=...`), reboot.
+3. Verify `/dev/video0` appears and `v4l2-ctl --list-devices` / a test capture works.
+4. Mount `/dev/video0` + `/dev/media0` into the Esszimmer pod (`k8s/satellite-esszimmer.yaml`,
+   alongside the existing `/dev/snd` mounts).
+5. Wire it to the occupancy/gesture prototypes (`prototypes/npu-occupancy/`) — the
+   detector + WS contract are camera-agnostic; only the frame source changes.
+
+### DT overlay — draft (confirmed pins; a few bring-up TODOs)
+
+```dts
+/* sun60i-a733-orangepi-zero3w-cam-imx219.dts — CAM1 / CSI0, IMX219 2-lane.
+ * Pins verified from OPi ZERO 3W V1.2 schematic sheet 13. */
+&vind0            { status = "okay"; };
+&csi0             { status = "okay"; };            /* MCSIA / CAM1 */
+&twi11            { status = "okay"; };            /* sensor i2c (pins 20/21) */
+
+&sensor0 {
+    device_type       = "sensor0";
+    sensor0_mname     = "imx219_mipi";             /* in-tree MIPI driver (=m) */
+    sensor0_twi_id    = <11>;                      /* TWI11 */
+    sensor0_twi_addr  = <0x10>;                    /* IMX219 default */
+    sensor0_mclk_id   = <0>;                       /* TODO verify vs csi_mclk group */
+    /* PE6 = pin17, PE5 = pin18 — assign reset/pwdn per driver expectation + polarity: */
+    sensor0_reset     = <&pio 'E' 6 ...>;          /* TODO confirm reset vs pwdn + active level */
+    sensor0_pwdn      = <&pio 'E' 5 ...>;
+    sensor0_mipi_id   = <0>;
+    sensor0_lane      = <2>;                        /* IMX219 = 2 lanes */
+    status            = "okay";
+};
+```
+
+TODOs to resolve on first bring-up (hardware-in-the-loop): exact `mclk` source (Pi modules
+self-clock — the SoC mclk may be unused), and the reset/pwdn GPIO polarity. Everything else
+(bus = TWI11, GPIOs = PE5/PE6, CSI0, 2-lane, 0x10) is schematic-confirmed.
+
+## Verification / provenance
+
+- Board identity, kernel config, DTB, i2c buses, absent `/dev/video`: read live on the
+  board over SSH (`root@192.168.1.82`), 2026-08-09.
+- Connector part, footprint, and CAM1/CAM2 pinout: the official schematic PDF, sheet 13.
+- Driver bus types (IMX219 MIPI vs OV5640 DVP): the A733 vendor kernel source
+  (`orangepi-xunlong/linux-orangepi`, `orange-pi-6.6-sun60iw2`).
+
+## Corrections to earlier docs (same investigation)
+
+Earlier edits in this repo reached wrong conclusions on this and are corrected to point
+here: the prototype `prototypes/npu-occupancy/README.md` camera section, the 2026-08-09
+addendum in `docs/design/non-verbal-communication.md`, and the note in
+`docs/SATELLITE_CAMERA.md`. The sequence of wrong turns (Waveshare 15-pin "top pick" →
+"24-pin, incompatible" → "CSI dead end, use RTSP" → **schematic: Pi-standard 22-pin, IMX219
+works with a €5 cable**) is a case study in *verify against the actual hardware/schematic,
+not extrapolation from lookalike boards.*

--- a/docs/design/a733-satellite-camera.md
+++ b/docs/design/a733-satellite-camera.md
@@ -1,9 +1,10 @@
 # A733 (Orange Pi Zero 3W) satellite camera — hardware bring-up reference
 
-**Status: investigated + schematic-verified 2026-08-09. Not yet built.** This is the
-authoritative camera reference for the Allwinner **A733** satellite (the Esszimmer node,
-`orangepizero3w` / 192.168.1.82). It supersedes earlier, wrong conclusions in this repo
-that said "CSI is a dead end, use RTSP" — the schematic shows the opposite.
+**Status: BROUGHT UP + WORKING 2026-08-09.** `/dev/video0` is live on the Esszimmer node
+(`orangepizero3w` / 192.168.1.82) with an IMX219 (Camera Module 2) on CAM1. This is the
+authoritative camera reference for the Allwinner **A733** satellite. It supersedes earlier,
+wrong conclusions in this repo that said "CSI is a dead end, use RTSP" — the schematic (and
+now a working camera) show the opposite.
 
 ## TL;DR
 
@@ -157,15 +158,31 @@ Camera Cable Standard - Mini"** (15-pin↔22-pin) is the *correct* cable — pai
 **IMX219** camera. A cable being right does not make an unsupported *sensor* work: Camera
 Module 3 (IMX708) fails on the sensor driver, not the cable.
 
-## Bring-up steps
+## Bring-up steps (as actually performed — DONE ✅)
 
-1. Order the 15→22-pin Pi-Zero camera cable; connect the IMX219 module to **CAM1**.
-2. Write + install the DT overlay (below); enable it in `/boot/orangepiEnv.txt`
-   (`overlays=...`), reboot.
-3. Verify `/dev/video0` appears and `v4l2-ctl --list-devices` / a test capture works.
-4. Mount `/dev/video0` + `/dev/media0` into the Esszimmer pod (`k8s/satellite-esszimmer.yaml`,
-   alongside the existing `/dev/snd` mounts).
-5. Wire it to the occupancy/gesture prototypes (`prototypes/npu-occupancy/`) — the
+1. ✅ IMX219 (Camera Module 2) on **CAM1** via a Standard-Mini (15↔22) cable, contacts
+   oriented correctly (a flipped ribbon shorts the board — see Troubleshooting).
+2. ✅ Compile + install the overlay: `.dtbo` → `/boot/dtb/allwinner/overlay/sun60i-a733-cam-imx219.dtbo`;
+   add `overlays=cam-imx219` to `/boot/orangepiEnv.txt` (the board uses
+   `overlay_prefix=sun60i-a733`, so the entry is the suffix `cam-imx219`); reboot. The
+   overlay applies (`/proc/device-tree/.../vind@5800800/sensor@5812000/sensor0_mname` = `imx219`).
+3. ✅ **Load the sunxi-vin modules — REQUIRED, easy to miss.** `CONFIG_AW_VIDEO_SUNXI_VIN`
+   and the sensor are **`=m` and do NOT autoload**, so after the overlay you still get no
+   `/dev/video0` until: `modprobe vin_io imx219 vin_v4l2`. Made persistent with
+   `/etc/modules-load.d/renfield-camera.conf` containing, in order:
+   ```
+   vin_io
+   imx219
+   vin_v4l2
+   ```
+   Result: `dmesg` → `[imx219]find the sony IMX219`, and `/dev/video0` + `/dev/media0`
+   appear (`v4l2-ctl -d /dev/video0 --list-formats-ext` enumerates RGB565/RGB888/NV12/YUV422/
+   GREY — the ISP output). **All overlay values were correct first try** (csi_sel/mipi_sel=0,
+   mclk_id=0, PE6/PE5 reset/pwdn) — no tunable iteration was needed. (A harmless
+   `imx219_2 ... No such device` logs from a second base-DTB sensor slot with no camera.)
+4. ⏳ **Next:** mount `/dev/video0` + `/dev/media0` into the Esszimmer pod
+   (`k8s/satellite-esszimmer.yaml`, alongside the existing `/dev/snd` hostPath mounts).
+5. ⏳ Wire it to the occupancy/gesture prototypes (`prototypes/npu-occupancy/`) — the
    detector + WS contract are camera-agnostic; only the frame source changes.
 
 ### DT overlay

--- a/docs/design/non-verbal-communication.md
+++ b/docs/design/non-verbal-communication.md
@@ -498,20 +498,18 @@ re-shapes into a cheap near-term slice + a later motion phase.
 Two findings from the NPU-vision-offload work update assumptions in this doc. They do
 **not** change any decision; they de-risk the hardware + acceleration story.
 
-1. **CSI is NOT usable on the Zero 3W today — use an RTSP (or USB UVC) camera.** This doc
-   (2026-06-27) assumed the A733 "needs a USB camera." A first pass found the board *does*
-   expose MIPI CSI and that `CONFIG_SENSOR_IMX219=m` is compiled — but a second pass (after
-   a Pi-15-pin IMX219 physically **failed to boot** the board) found a **connector/driver
-   collision** that no off-the-shelf CSI camera resolves: the board's CSI is a **24-pin FPC**
-   (Allwinner pinout), Orange Pi's 24-pin modules are all **OV5640 → no driver** in this
-   kernel, and the driver-supported sensors (IMX219/OV13850) ship only in **wrong-connector**
-   form (Pi 15/22-pin or RK3399). **No verified 15→24-pin adapter exists.** So a CSI camera
-   would require porting a `sunxi-vin` OV5640 driver + a Zero-3W DT overlay — real kernel
-   work, out of scope. **Reference camera is now an RTSP/ONVIF IP camera** (e.g. TP-Link
-   Tapo C210 ~€35, Reolink E1 Pro ~€40): no host driver, no DT overlay, no `/dev` mount —
-   frames over the network into the existing Frigate pipeline. USB UVC stays a valid
-   alternative. (This corrects the "CSI-IMX219 is the reference" claim in an earlier draft
-   of this addendum.)
+1. **CSI IMX219 IS viable on the Zero 3W — full hardware reference:
+   [`a733-satellite-camera.md`](a733-satellite-camera.md).** This doc (2026-06-27) assumed
+   the A733 "needs a USB camera." The board's own **schematic** (sheet 13) settles it: the
+   camera port `CAM1` is a **Raspberry-Pi-standard 22-pin 0.5 mm MIPI CSI** connector
+   (footprint `fpc22-20-sm-RPI-TOP-h2`) on **CSI0**, i2c **TWI11**, control GPIOs
+   **PE6/PE5** — and the **IMX219 driver is already `=m`** in the running kernel. So an
+   IMX219 camera + a **Raspberry Pi "Standard-Mini" 15↔22-pin cable** + **one DT overlay**
+   (values in the reference doc) is the path — no kernel/driver work. The no-boot an
+   operator hit was a 15-pin camera in the 22-pin socket *without* the adapter cable.
+   (Not Camera Module 3 / IMX708 — no driver; not OV5640 — DVP, wrong interface.) This
+   corrects earlier drafts of this addendum that mis-called it "24-pin / CSI dead end /
+   use RTSP" — all wrong extrapolations from lookalike boards.
 
 2. **The MediaPipe→NPU conversion rail now exists (demonstrated).** §Risks and
    T-SILICON-PROBE note NPU acceleration needs "a separate Verisilicon TFLite→NBG

--- a/docs/design/non-verbal-communication.md
+++ b/docs/design/non-verbal-communication.md
@@ -498,19 +498,20 @@ re-shapes into a cheap near-term slice + a later motion phase.
 Two findings from the NPU-vision-offload work update assumptions in this doc. They do
 **not** change any decision; they de-risk the hardware + acceleration story.
 
-1. **CSI camera is viable on the A733 — supersedes "needs a USB camera."** This doc
-   (2026-06-27) assumed "the Pi CSI module is unsupported on that board → needs a USB
-   camera" (§Hardware finding, Decision 3, Phase-4 plan). A camera survey against the
-   **actual A733 vendor kernel config** (`linux-sun60iw2-current-a733.config`, 6.6.98)
-   found the board **does** expose MIPI CSI (the A733 Orange Pi Zero 3W has 2× 4-lane
-   connectors) and that **`CONFIG_SENSOR_IMX219=m` is compiled in** — so an IMX219 CSI
-   module works with only a device-tree overlay (host driver in-tree; the pod mounts
-   `/dev/video*`+`/dev/media*`, like `/dev/snd` today). USB UVC still works and stays a
-   valid Tier-2/transitional option, but **CSI-IMX219 is now the reference** for a
-   gesture/vision satellite. Only four sensors have drivers (IMX219, OV13850, GC05A2,
-   GC030A) — OV5647 is unsupported. Note the optics tension: occupancy wants wide/fisheye
-   + low-light (IMX219-160IR), gesture/expression wants a less-distorted, closer view —
-   the board's **two** CSI ports allow one of each, or pick per priority.
+1. **CSI is NOT usable on the Zero 3W today — use an RTSP (or USB UVC) camera.** This doc
+   (2026-06-27) assumed the A733 "needs a USB camera." A first pass found the board *does*
+   expose MIPI CSI and that `CONFIG_SENSOR_IMX219=m` is compiled — but a second pass (after
+   a Pi-15-pin IMX219 physically **failed to boot** the board) found a **connector/driver
+   collision** that no off-the-shelf CSI camera resolves: the board's CSI is a **24-pin FPC**
+   (Allwinner pinout), Orange Pi's 24-pin modules are all **OV5640 → no driver** in this
+   kernel, and the driver-supported sensors (IMX219/OV13850) ship only in **wrong-connector**
+   form (Pi 15/22-pin or RK3399). **No verified 15→24-pin adapter exists.** So a CSI camera
+   would require porting a `sunxi-vin` OV5640 driver + a Zero-3W DT overlay — real kernel
+   work, out of scope. **Reference camera is now an RTSP/ONVIF IP camera** (e.g. TP-Link
+   Tapo C210 ~€35, Reolink E1 Pro ~€40): no host driver, no DT overlay, no `/dev` mount —
+   frames over the network into the existing Frigate pipeline. USB UVC stays a valid
+   alternative. (This corrects the "CSI-IMX219 is the reference" claim in an earlier draft
+   of this addendum.)
 
 2. **The MediaPipe→NPU conversion rail now exists (demonstrated).** §Risks and
    T-SILICON-PROBE note NPU acceleration needs "a separate Verisilicon TFLite→NBG

--- a/docs/design/non-verbal-communication.md
+++ b/docs/design/non-verbal-communication.md
@@ -490,3 +490,39 @@ re-shapes into a cheap near-term slice + a later motion phase.
   production** — per-room full-household BLE enrollment. Phase 3b (motion gestures,
   Jester-trained temporal model) and Head B (body-language) remain deferred behind
   their own gates.
+
+---
+
+## Addendum (2026-08-09) — camera + NPU-rail reconciliation
+
+Two findings from the NPU-vision-offload work update assumptions in this doc. They do
+**not** change any decision; they de-risk the hardware + acceleration story.
+
+1. **CSI camera is viable on the A733 — supersedes "needs a USB camera."** This doc
+   (2026-06-27) assumed "the Pi CSI module is unsupported on that board → needs a USB
+   camera" (§Hardware finding, Decision 3, Phase-4 plan). A camera survey against the
+   **actual A733 vendor kernel config** (`linux-sun60iw2-current-a733.config`, 6.6.98)
+   found the board **does** expose MIPI CSI (the A733 Orange Pi Zero 3W has 2× 4-lane
+   connectors) and that **`CONFIG_SENSOR_IMX219=m` is compiled in** — so an IMX219 CSI
+   module works with only a device-tree overlay (host driver in-tree; the pod mounts
+   `/dev/video*`+`/dev/media*`, like `/dev/snd` today). USB UVC still works and stays a
+   valid Tier-2/transitional option, but **CSI-IMX219 is now the reference** for a
+   gesture/vision satellite. Only four sensors have drivers (IMX219, OV13850, GC05A2,
+   GC030A) — OV5647 is unsupported. Note the optics tension: occupancy wants wide/fisheye
+   + low-light (IMX219-160IR), gesture/expression wants a less-distorted, closer view —
+   the board's **two** CSI ports allow one of each, or pick per priority.
+
+2. **The MediaPipe→NPU conversion rail now exists (demonstrated).** §Risks and
+   T-SILICON-PROBE note NPU acceleration needs "a separate Verisilicon TFLite→NBG
+   conversion port" and is deferred (Phase 3a runs MediaPipe on the A76 CPU). That exact
+   rail — ACUITY toolkit (ONNX/TFLite → INT8 NBG) → VIPLite runtime — is now built and
+   documented in `prototypes/npu-occupancy/` (for occupancy + object/document
+   recognition). When the deferred MediaPipe-landmark NPU port is picked up, reuse that
+   rail; it does **not** change the Phase-3a-on-CPU decision.
+
+**Prototype scaffold** for the buildable slices lives in `prototypes/npu-occupancy/`:
+`nonverbal_starter.py` implements Phase-3a static gestures (stock MediaPipe, CPU) + the
+deferred Head-B facial-expression affect read (FaceLandmarker blendshapes, advisory),
+faithful to the decisions above (fail-closed actuation, advisory affect, nothing
+persisted, separate PSK-bound gesture WS). It is prototype scaffolding, not wired into
+prod — the productization PR is the Implementation Tasks above.

--- a/k8s/satellite-esszimmer.yaml
+++ b/k8s/satellite-esszimmer.yaml
@@ -162,6 +162,11 @@ spec:
             - name: bluetooth
               mountPath: /var/lib/bluetooth
               readOnly: true
+            # CSI camera (IMX219 on CAM1) — see docs/design/a733-satellite-camera.md
+            - name: video
+              mountPath: /dev/video0
+            - name: media
+              mountPath: /dev/media0
           resources:
             requests:
               cpu: "250m"
@@ -187,3 +192,15 @@ spec:
         - name: bluetooth
           hostPath:
             path: /var/lib/bluetooth
+        # CSI camera brought up via the sun60i-a733-cam-imx219 DT overlay + the
+        # sunxi-vin modules (persisted at boot via /etc/modules-load.d). CharDevice
+        # asserts the node exists; media0 is the sunxi-vin media controller used to
+        # configure the capture pipeline. See docs/design/a733-satellite-camera.md.
+        - name: video
+          hostPath:
+            path: /dev/video0
+            type: CharDevice
+        - name: media
+          hostPath:
+            path: /dev/media0
+            type: CharDevice

--- a/prototypes/npu-occupancy/README.md
+++ b/prototypes/npu-occupancy/README.md
@@ -1,0 +1,201 @@
+# NPU-offloaded occupancy check — prototype
+
+Run the message-relay **camera occupancy check** on the Esszimmer satellite's **Allwinner
+A733 Vivante VIP9000 NPU** (3 TOPS INT8) instead of shipping the frame to the GPU-box
+vision LLM.
+
+## Why
+
+Today (`services/ollama_service.py::count_people_in_image`, called from the announce
+privacy gate — `ANNOUNCE_CAMERA_OCCUPANCY_CHECK`) the satellite captures a JPEG, base64s
+it to the backend, and a vision **LLM** (`qwen3-vl:8b`) counts the people. That:
+
+- **burns the GPU** for a task the edge NPU is purpose-built for;
+- **sends a room photo off the device** (transient, but it still leaves the satellite);
+- **dies with the cluster** — no GPU, no occupancy check.
+
+Person-counting is a **detection** task, and the VIP9000 runs YOLO-class detectors well
+(~20 ms/frame). It cannot host a useful LLM (tops out ~360M params — see the
+`a733_npu_driver` benchmarks), so an LLM-on-NPU would be pointless; a **YOLOv8n person
+detector** on-NPU is the right shape. Bonus: **only an integer leaves the satellite** —
+a privacy upgrade over the status quo.
+
+## The seam (why this is low-risk)
+
+The public contract is already perfect — one function, `int | None`:
+
+```
+count_people_in_image(image_b64) -> int | None      # None ⇒ "couldn't tell"
+```
+
+We add a parallel, camera-local path with the **same return type**, and the announce gate
+prefers it when available, else falls back to the existing LLM path **byte-identically**.
+No behaviour change when the NPU/camera is absent.
+
+```
+                          ┌─ has_npu_occupancy ─▶ request_occupant_count() ─WS─▶ satellite: grab frame ─▶ NPU YOLOv8n ─▶ int
+announce gate ─ room cam ─┤                                                       (frame stays on device)
+                          └─ else ──────────────▶ request_snapshot() + count_people_in_image()  (LLM, unchanged)
+```
+
+## Scope — four capabilities across TWO inference stacks
+
+This prototype grew past occupancy. The satellite's camera + A733 unlock four things, but
+they split across **two different inference stacks** — don't conflate them:
+
+| Capability | Stack | Where it runs | Status |
+|---|---|---|---|
+| **Occupancy count** (announce gate) | NPU detection (YOLOv8n) | A733 NPU | prototype here; replaces the GPU vision-LLM count |
+| **Object / document-type recognition** | NPU classification (MobileCLIP zero-shot) | A733 NPU | prototype here; **complements** the existing `qwen3-vl` path (`docs/SATELLITE_CAMERA.md`) |
+| **Hand gestures** ("Head A") | **MediaPipe landmarks → CPU** (not NPU) | A733 **A76 CPU** | design + spikes done: `docs/design/non-verbal-communication.md`; Phase-3a starter here |
+| **Facial expression / affect** ("Head B") | **MediaPipe FaceLandmarker → CPU** | A733 **A76 CPU** | deferred behind Head A; advisory read scaffolded here |
+
+Key fact (from the `T-SILICON-PROBE` spike): **MediaPipe runs on the A76 CPU, not the
+NPU** — its Delegate is CPU/GPU only. So gestures/expression are CPU (~3-5 fps, enough for
+static gestures); the NPU is for detection/classification (occupancy, object/document).
+The NPU→MediaPipe conversion rail (ACUITY→NBG, built here for detection) is the deferred
+acceleration path for landmarks, *not* a Phase-3a dependency.
+
+**Document reading already exists** via the cluster: `docs/SATELLITE_CAMERA.md`'s
+snapshot→`qwen3-vl` path answers *"was steht auf diesem Zettel?"* today. The NPU pieces
+here are edge **triage** (recognize + has-text) that *route* a presented document into the
+**existing** Docling + Schicht-A cluster pipeline — they do not re-implement OCR.
+
+## Files in this prototype
+
+| File | Role |
+|---|---|
+| `occupancy_detector.py` | Shared letterbox + YOLOv8 decode + NMS + person-count. `OnnxCpuBackend` (runnable reference / CPU fallback) and `VipLiteNpuBackend` (A733 NPU deploy target). Same `count() -> int \| None`. |
+| `object_document_recognizer.py` | Zero-shot object/document-type recognition (MobileCLIP image encoder on NPU vs pre-computed text-label embeddings) + a has-text trigger + `route_document_to_cluster` (push a presented doc into the existing folder-ingest pipeline). Reuses `occupancy_detector`'s backends. |
+| `nonverbal_starter.py` | Hand-gesture (Head A) + facial-expression (Head B) starter — **MediaPipe on CPU**, implementing `non-verbal-communication.md` Phase 3a. Fail-closed actuation, advisory affect, nothing persisted, separate PSK-bound gesture WS. |
+| `satellite_occupancy.py` | `V4L2Camera` (single-frame CSI grab), `OccupancyProbe`, and the `count_occupants` WS handler mirroring `_handle_capture_snapshot`. |
+| `README.md` | This — design, model-conversion recipe, integration diff, deploy. |
+
+## Camera (research result, 2026-08-09)
+
+Against the **actual A733 vendor kernel config**, the board exposes MIPI CSI and only four
+sensors have drivers (`IMX219`, `OV13850`, `GC05A2`, `GC030A`; OV5647 unsupported). **Top
+pick: Waveshare IMX219-160IR** (8 MP, 160° FoV, IR night-vision, ~$30) — the only wide +
+night-capable module whose sensor is compiled in your kernel. Fallback: a wide-FoV **RTSP
+IP cam** (no host driver, slots into Frigate). Occupancy wants wide/fisheye/low-light;
+gesture/document reading wants a closer, less-distorted view — the board's **two CSI
+ports** allow one of each. This supersedes the "needs a USB camera" assumption in
+`non-verbal-communication.md` (see its 2026-08-09 addendum).
+
+## Validate the pipeline TODAY (no NPU, no board)
+
+The CPU backend proves the whole count contract before any hardware work:
+
+```bash
+cd prototypes/npu-occupancy
+pip install onnxruntime pillow numpy
+# export a stock YOLOv8n to ONNX (ultralytics) — one-off on any machine:
+python -c "from ultralytics import YOLO; YOLO('yolov8n.pt').export(format='onnx', imgsz=640, opset=12)"
+python occupancy_detector.py yolov8n.onnx some_room_photo.jpg      # -> people: N
+```
+
+Same code path, same pre/post-processing the NPU backend uses — so once the NBG is built,
+counts agree bar quantization noise.
+
+## Build the NBG for the NPU (ACUITY, on your workstation)
+
+The VIP9000 runs an **NBG** (Network Binary Graph), produced offline by the **ACUITY
+toolkit** in Docker (per `petayyyy/a733_npu_driver`). The private key never touches the
+board; only the NBG + VIPLite libs ship to it.
+
+```
+# 1. ONNX (from the validate step above)          yolov8n.onnx
+# 2. ACUITY import → quantize INT8 → export NBG    (ACUITY 6.30.22 docker image)
+pegasus import onnx      --model yolov8n.onnx --output-model yolov8n.json ...
+pegasus quantize         --model yolov8n.json --iterations 100 \
+                         --dataset ./calib_list.txt \            # 100–300 indoor room frames
+                         --quantizer asymmetric_affine --qtype uint8
+pegasus export ovxlib    --model yolov8n.json --output yolov8n_nbg   # → yolov8n.nbg
+```
+
+Notes that decide whether the counts are usable:
+- **Calibration set = real room frames** from the actual camera/mount (evening light,
+  people at the far wall). Generic COCO calibration under-counts in a dim room.
+- **Bake `/255` into the graph** at import (`--input-normalization`) so the board feeds
+  raw `uint8` NCHW — `VipLiteNpuBackend.infer` assumes this.
+- Person-detection quantizes cleanly to INT8 (unlike the ≥0.5B LLMs, which collapsed to
+  cosine 0.236). Confirm post-quant with ACUITY's cosine metric ≥ 0.99 vs the ONNX head.
+
+## Wire it into Renfield (integration diff — deferred to the productization PR)
+
+Prototype only; these are the exact edits when we promote it out of `prototypes/`.
+
+**Satellite** — `renfield_satellite/network/websocket_client.py` (3 edits, see the
+docstring in `satellite_occupancy.py`): advertise `has_npu_occupancy`, dispatch
+`count_occupants`, add `_handle_count_occupants`. Construct the probe once at startup via
+`build_occupancy(model_path, device)`.
+
+**Backend** — `ha_glue/services/satellite_manager.py`, mirror `request_snapshot`:
+
+```python
+# capabilities: add `has_npu_occupancy: bool = False` to SatelliteCapabilities,
+# populate from register (like has_camera at line 220/832).
+
+self._pending_counts: dict[str, asyncio.Future] = {}          # beside _pending_snapshots
+
+async def request_occupant_count(self, satellite_id, timeout=8.0) -> int | None:
+    sat = self._get(satellite_id)
+    if sat is None or not sat.capabilities.has_npu_occupancy:
+        return None
+    request_id = uuid4().hex
+    fut = self._loop.create_future(); self._pending_counts[request_id] = fut
+    try:
+        await sat.send({"type": "count_occupants", "request_id": request_id})
+        return await asyncio.wait_for(fut, timeout)
+    except (asyncio.TimeoutError, Exception):
+        return None
+    finally:
+        self._pending_counts.pop(request_id, None)
+
+def resolve_occupant_count(self, request_id, count):               # WS: occupant_count_result
+    fut = self._pending_counts.get(request_id)
+    if fut and not fut.done(): fut.set_result(count)
+```
+
+**Announce gate** — where it does `request_snapshot()` then `count_people_in_image()`:
+
+```python
+sat = mgr.get_camera_satellite_for_room(room_id)
+count = None
+if sat and sat.capabilities.has_npu_occupancy:
+    count = await mgr.request_occupant_count(sat.id)     # NPU, frame stays on device
+if count is None:                                        # no NPU, or it declined → LLM path
+    img = await mgr.request_snapshot(sat.id) if sat else None
+    count = await ollama.count_people_in_image(img) if img else None
+# unchanged downstream: None → fail-closed on 'personal' (neutral "message waiting")
+```
+
+The `None`-means-uncertain contract is preserved end to end, so the fail-closed privacy
+property of the announce gate is untouched.
+
+## Deploy to the Esszimmer pod (`k8s/satellite-esszimmer.yaml`)
+
+The pod is already privileged with `hostPath /dev`; a CSI camera adds only the model +
+the sensor nodes (driver is on the HOST — see the camera research for the sensor + its
+device-tree overlay):
+
+```yaml
+volumeMounts:
+  - { name: dev-video, mountPath: /dev/video0 }     # CSI sensor (host driver)
+  - { name: dev-media, mountPath: /dev/media0 }
+  - { name: nbg,       mountPath: /opt/models/occupancy.nbg, subPath: occupancy.nbg }
+# volumes: dev-video/dev-media = hostPath /dev/video0,/dev/media0 ; nbg from a ConfigMap/Secret or the image
+```
+
+Bake the VIPLite `.so`s + `occupancy.nbg` into the satellite image (like the wakeword
+model), set the model path env, done. `MEETING_ENABLED`-style flag: `NPU_OCCUPANCY_ENABLED`.
+
+## Status / open items
+
+- **Runnable now:** CPU reference path (counts people from a JPEG) — the integration
+  contract is provable before hardware.
+- **Blocked on hardware:** ACUITY export + on-board VIPLite run (needs the A733 SDK + the
+  board) and the CSI camera (research agent running — sensor choice sets `/dev/videoN`,
+  resolution, FoV; the detector is camera-agnostic so it doesn't block this code).
+- **Not yet wired into prod** — deliberately. This is a `prototypes/` scaffold; the
+  integration diff above is the productization PR.

--- a/prototypes/npu-occupancy/README.md
+++ b/prototypes/npu-occupancy/README.md
@@ -71,16 +71,32 @@ here are edge **triage** (recognize + has-text) that *route* a presented documen
 | `satellite_occupancy.py` | `V4L2Camera` (single-frame CSI grab), `OccupancyProbe`, and the `count_occupants` WS handler mirroring `_handle_capture_snapshot`. |
 | `README.md` | This — design, model-conversion recipe, integration diff, deploy. |
 
-## Camera (research result, 2026-08-09)
+## Camera (research result, 2026-08-09 — corrected)
 
-Against the **actual A733 vendor kernel config**, the board exposes MIPI CSI and only four
-sensors have drivers (`IMX219`, `OV13850`, `GC05A2`, `GC030A`; OV5647 unsupported). **Top
-pick: Waveshare IMX219-160IR** (8 MP, 160° FoV, IR night-vision, ~$30) — the only wide +
-night-capable module whose sensor is compiled in your kernel. Fallback: a wide-FoV **RTSP
-IP cam** (no host driver, slots into Frigate). Occupancy wants wide/fisheye/low-light;
-gesture/document reading wants a closer, less-distorted view — the board's **two CSI
-ports** allow one of each. This supersedes the "needs a USB camera" assumption in
-`non-verbal-communication.md` (see its 2026-08-09 addendum).
+**CSI is a dead end on this board today — use an RTSP IP camera.** There is a
+**connector/driver collision** on the Zero 3W (A733), confirmed after a Pi-15-pin camera
+failed to boot it:
+
+- The A733 vendor kernel (6.6.98, `sun60iw2`) builds drivers only for `IMX219`, `OV13850`,
+  `GC05A2`, `GC030A`.
+- The board's CSI is a **24-pin FPC** (Allwinner pinout). Orange Pi's own 24-pin camera
+  modules are all **OV5640** → **no driver** in this kernel.
+- The driver-supported sensors (IMX219/OV13850) ship only in **wrong-connector** form (Pi
+  15/22-pin or RK3399). **No verified 15→24-pin adapter exists — do not improvise one**
+  (a Pi 15-pin camera on the 24-pin connector already caused a no-boot).
+- Net: **no off-the-shelf CSI camera is both connector- AND driver-matched** for this board.
+  CSI would require porting a `sunxi-vin` OV5640 driver + a Zero-3W DT overlay (real kernel
+  work) — out of scope.
+
+**Recommended camera: an RTSP/ONVIF IP camera** — e.g. **TP-Link Tapo C210** (~€35) or
+**Reolink E1 Pro** (~€40). Frames arrive over RTSP: **no host driver, no DT overlay, no
+`/dev/video*` mount into the pod** — just network egress, and it slots into the existing
+Frigate pipeline. This is the buy-it-today path; it supersedes both the earlier
+Waveshare-IMX219 CSI pick AND the "needs a USB camera" line in `non-verbal-communication.md`.
+
+Implication for the prototype: `satellite_occupancy.py`'s `V4L2Camera` becomes an **RTSP
+frame grab** (`cv2.VideoCapture("rtsp://…")`) instead of `/dev/video0` — the detector and
+WS contract are unchanged (frame in → count/label out).
 
 ## Validate the pipeline TODAY (no NPU, no board)
 

--- a/prototypes/npu-occupancy/README.md
+++ b/prototypes/npu-occupancy/README.md
@@ -71,32 +71,25 @@ here are edge **triage** (recognize + has-text) that *route* a presented documen
 | `satellite_occupancy.py` | `V4L2Camera` (single-frame CSI grab), `OccupancyProbe`, and the `count_occupants` WS handler mirroring `_handle_capture_snapshot`. |
 | `README.md` | This — design, model-conversion recipe, integration diff, deploy. |
 
-## Camera (research result, 2026-08-09 — corrected)
+## Camera — schematic-verified (2026-08-09)
 
-**CSI is a dead end on this board today — use an RTSP IP camera.** There is a
-**connector/driver collision** on the Zero 3W (A733), confirmed after a Pi-15-pin camera
-failed to boot it:
+**Full hardware reference: [`docs/design/a733-satellite-camera.md`](../../docs/design/a733-satellite-camera.md).**
 
-- The A733 vendor kernel (6.6.98, `sun60iw2`) builds drivers only for `IMX219`, `OV13850`,
-  `GC05A2`, `GC030A`.
-- The board's CSI is a **24-pin FPC** (Allwinner pinout). Orange Pi's own 24-pin camera
-  modules are all **OV5640** → **no driver** in this kernel.
-- The driver-supported sensors (IMX219/OV13850) ship only in **wrong-connector** form (Pi
-  15/22-pin or RK3399). **No verified 15→24-pin adapter exists — do not improvise one**
-  (a Pi 15-pin camera on the 24-pin connector already caused a no-boot).
-- Net: **no off-the-shelf CSI camera is both connector- AND driver-matched** for this board.
-  CSI would require porting a `sunxi-vin` OV5640 driver + a Zero-3W DT overlay (real kernel
-  work) — out of scope.
+CSI **works** on this board — the earlier "dead end / use RTSP" call in this file was wrong
+(it extrapolated the connector from lookalike boards). The Zero 3W schematic (sheet 13)
+shows the camera port `CAM1` is a **Raspberry-Pi-standard 22-pin 0.5 mm MIPI CSI** connector
+(footprint `fpc22-20-sm-RPI-TOP-h2`), wired to **CSI0**, i2c **TWI11**, control GPIOs
+**PE6/PE5**. The **IMX219 driver is already built** (`CONFIG_SENSOR_IMX219=m`).
 
-**Recommended camera: an RTSP/ONVIF IP camera** — e.g. **TP-Link Tapo C210** (~€35) or
-**Reolink E1 Pro** (~€40). Frames arrive over RTSP: **no host driver, no DT overlay, no
-`/dev/video*` mount into the pod** — just network egress, and it slots into the existing
-Frigate pipeline. This is the buy-it-today path; it supersedes both the earlier
-Waveshare-IMX219 CSI pick AND the "needs a USB camera" line in `non-verbal-communication.md`.
+- **Camera:** any **IMX219** module (Pi Cam v2, or Waveshare IMX219-160IR for wide+IR).
+  NOT Camera Module 3 (IMX708 — no driver) and NOT OV5640 (DVP, wrong interface).
+- **Cable:** a **Raspberry Pi "Standard - Mini" (15-pin↔22-pin) camera cable** (~€5). The
+  no-boot an operator saw was a 15-pin camera in the 22-pin socket *without* this adapter.
+- **Software:** one DT overlay (enable CSI0 + `imx219` on TWI11, PE5/PE6, 2-lane) — pins in
+  the reference doc. Then mount `/dev/video0` into the pod.
 
-Implication for the prototype: `satellite_occupancy.py`'s `V4L2Camera` becomes an **RTSP
-frame grab** (`cv2.VideoCapture("rtsp://…")`) instead of `/dev/video0` — the detector and
-WS contract are unchanged (frame in → count/label out).
+The prototype's `satellite_occupancy.py::V4L2Camera` reads `/dev/video0` as-is once the
+overlay is loaded — no code change; the detector + WS contract are camera-agnostic.
 
 ## Validate the pipeline TODAY (no NPU, no board)
 

--- a/prototypes/npu-occupancy/dts/sun60i-a733-orangepi-zero3w-cam-imx219.dts
+++ b/prototypes/npu-occupancy/dts/sun60i-a733-orangepi-zero3w-cam-imx219.dts
@@ -1,0 +1,96 @@
+/*
+ * IMX219 camera on the Orange Pi Zero 3W (Allwinner A733 / sun60iw2) — CAM1 / CSI0.
+ *
+ * Runtime device-tree overlay. The base DTB already enables the CSI/MIPI/ISP
+ * controllers (vind@5800800, csi@5820000, mipi@, isp@ are all status="okay"); what
+ * it lacks is a SENSOR node + a VINC capture-pipeline node. This overlay adds them,
+ * so the sunxi-vin driver binds the IMX219 and exposes /dev/video0.
+ *
+ * Every value below is grounded:
+ *   - sensor mname/binding/vinc structure = the Orange Pi 4 Pro DTS (same A733 SoC),
+ *     which ships a populated `imx219` example (its sensor2 even uses twi_cci_id=11).
+ *   - twi_cci_id=11 / twi_addr=0x20 / GPIOs PE6+PE5 = the Zero 3W schematic sheet 13
+ *     (CAM1: i2c TWI11 on pins 20/21, control PE6 pin17 / PE5 pin18) AND verified live:
+ *     `i2cdetect -y 11` shows the IMX219 answering at 0x10 (7-bit) = 0x20 (8-bit).
+ *
+ * BRING-UP TUNABLES (validate on-target via `dmesg | grep -iE "vin|csi|imx219"` — if
+ * the sensor doesn't enumerate, these are the knobs, in order of likelihood):
+ *   (a) vinc0_csi_sel / vinc0_mipi_sel — the MCSIA→PHY mux. Set to 0 (CAM1 is labelled
+ *       "MIPI_DPHY_CSI0"); if no probe, try 1 then 2.
+ *   (b) sensor0_mclk_id — 0 for CSI0. A Pi camera module self-clocks (its own 24 MHz
+ *       oscillator; the RPI 22-pin connector routes no MCLK), so this is likely inert,
+ *       but the driver still selects a group.
+ *   (c) sensor0_reset vs sensor0_pwdn polarity — PE6/PE5 assignment + ACTIVE_LOW/HIGH.
+ *       IMX219 XCLR is active-low (low=reset). If it probes on i2c but won't stream,
+ *       swap the PE6/PE5 roles or flip the flags.
+ *
+ * Build (easiest, on the board): armbian-add-overlay sun60i-a733-orangepi-zero3w-cam-imx219.dts
+ *   (compiles + installs to /boot/dtb/allwinner/overlay/ + edits orangepiEnv.txt for you)
+ * Build (manual): cpp -nostdinc -undef -x assembler-with-cpp \
+ *                    sun60i-a733-orangepi-zero3w-cam-imx219.dts | \
+ *                 dtc -@ -I dts -O dtb -o sun60i-a733-orangepi-zero3w-cam-imx219.dtbo -
+ *   then copy the .dtbo to /boot/dtb/allwinner/overlay/ and add to /boot/orangepiEnv.txt:
+ *                 overlays=sun60i-a733-orangepi-zero3w-cam-imx219
+ *   reboot. Expect /dev/video0. See ../../docs/design/a733-satellite-camera.md.
+ *
+ * Self-contained: the GPIO flag + pin-bank macros are defined inline (with #ifndef
+ * guards), so it compiles without the kernel dt-bindings headers. `&pio` resolves
+ * against the base DTB's __symbols__ at apply time (dtc -@).
+ */
+/dts-v1/;
+/plugin/;
+
+#ifndef GPIO_ACTIVE_HIGH
+#define GPIO_ACTIVE_HIGH 0
+#endif
+#ifndef GPIO_ACTIVE_LOW
+#define GPIO_ACTIVE_LOW 1
+#endif
+/* Pin-bank index for &pio: A=0 B=1 C=2 D=3 E=4 ... */
+#ifndef PE
+#define PE 4
+#endif
+
+/ {
+	fragment@0 {
+		target = <&vind0>;
+		__overlay__ {
+			#address-cells = <2>;
+			#size-cells = <2>;
+
+			/* IMX219 on CAM1 / CSI0, i2c = TWI11, control = PE6/PE5 */
+			sensor0: sensor@5812000 {
+				device_type       = "sensor0";
+				sensor0_mname     = "imx219";
+				sensor0_twi_cci_id = <11>;                 /* TWI11 (CAM1 pins 20/21) */
+				sensor0_twi_addr  = <0x20>;                /* IMX219 7-bit 0x10 → 8-bit 0x20 */
+				sensor0_mclk_id   = <0>;                   /* tunable (b) */
+				sensor0_pos       = "rear";
+				sensor0_isp_used  = <1>;
+				sensor0_fmt       = <1>;
+				sensor0_stby_mode = <0>;
+				sensor0_vflip     = <0>;
+				sensor0_hflip     = <0>;
+				sensor0_power_en  = <>;
+				sensor0_reset     = <&pio PE 6 GPIO_ACTIVE_LOW>;   /* CAM1 pin17 = PE6; tunable (c) */
+				sensor0_pwdn      = <&pio PE 5 GPIO_ACTIVE_HIGH>;  /* CAM1 pin18 = PE5; tunable (c) */
+				status            = "okay";
+			};
+
+			/* Capture pipeline → /dev/video0. Binds sensor0 to CSI0/MIPI0/ISP0. */
+			vinc00: vinc@5830000 {
+				vinc0_csi_sel          = <0>;              /* tunable (a) — CAM1 = MIPI_DPHY_CSI0 */
+				vinc0_mipi_sel         = <0>;              /* tunable (a) */
+				vinc0_isp_sel          = <0>;
+				vinc0_isp_tx_ch        = <0>;
+				vinc0_tdm_rx_sel       = <0>;
+				vinc0_rear_sensor_sel  = <0>;              /* → sensor0 */
+				vinc0_front_sensor_sel = <0>;
+				vinc0_sensor_list      = <0>;
+				device_id              = <0>;
+				work_mode              = <0x0>;
+				status                 = "okay";
+			};
+		};
+	};
+};

--- a/prototypes/npu-occupancy/nonverbal_starter.py
+++ b/prototypes/npu-occupancy/nonverbal_starter.py
@@ -1,0 +1,134 @@
+"""Non-verbal starter — hand-gesture (Head A) + facial-expression (Head B) — prototype.
+
+IMPLEMENTS the buildable near-term slice of the EXISTING, spike-validated design:
+`docs/design/non-verbal-communication.md` (Phase 3a). This is NOT a new design — read
+that doc first; the decisions (fail-closed actuation, advisory-only affect, nothing
+persisted, gated bounded-window capture, BLE-single-occupant attribution) are binding.
+
+DIFFERENT inference stack from occupancy/object recognition: this is the MediaPipe
+LANDMARK pipeline, which the T-SILICON-PROBE spike found runs on the A733's **A76 CPU**
+(~3-5 fps), NOT the NPU — MediaPipe Tasks' Delegate is CPU/GPU only; an NPU port is a
+separate deferred Verisilicon TFLite→NBG conversion (the very rail the occupancy
+prototype demonstrates, but out of scope for Phase 3a). So: CPU here, on purpose.
+
+  Head A — STATIC command gestures (ships now, zero training): stock MediaPipe
+           GestureRecognizer → {Open_Palm=palm-stop, Thumb_Up=confirm, Thumb_Down=reject,
+           finger-count 1-2 = pick option N}. MOTION gestures (wave/swipe/volume) are
+           Phase 3b (a Jester-trained temporal model, landmark-only) — not here.
+  Head B — FACIAL EXPRESSION / affect (deferred; scaffolded advisory-only): MediaPipe
+           FaceLandmarker blendshapes → a bounded affect enum. NEVER actuates; shapes
+           tone/verbosity only, fail-open. Gated behind Head A + a read-quality eval.
+
+Actuation is fail-closed and reuses the device-widget gate VERBATIM (Decision 6): a
+recognized command → a `device_action`-style frame → `HA_CONTROL`-gated in chat_handler →
+server re-validated → `_HANDLERS`-only internal tool. A gesture grants nothing the user
+lacks; unidentified / not-single-occupant → read-only.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Static gesture → Renfield intent (config-driven in prod; Phase-3a subset from the doc).
+STATIC_GESTURE_INTENTS: dict[str, str] = {
+    "Open_Palm": "cancel_pending",       # palm-stop → stop action / clear pending confirm
+    "Thumb_Up": "confirm_pending",       # → confirm the staged device_action / Paperless card
+    "Thumb_Down": "reject_pending",      # → cancel the staged confirm
+    # finger-count handled separately (pick option N) via landmark finger counting
+}
+
+# Head B: MediaPipe FaceLandmarker blendshape → bounded affect (Decision: bounded enums,
+# no free-form, discarded each window). Advisory only; fail-open on low confidence.
+_AFFECT_ORDER = ("frustrated", "confused", "pleased", "neutral")
+
+
+@dataclass
+class NonVerbalConfig:
+    gesture_model: str          # gesture_recognizer.task (MediaPipe bundle)
+    face_model: str             # face_landmarker.task (blendshapes on)
+    conf: float = 0.60          # per-gesture confidence floor (Decision D7)
+    debounce_frames: int = 3    # N-frame debounce before a command fires (D7)
+
+
+class NonVerbalReader:
+    """Bounded-window reader: fed frames while a capture window is open (gesture-gated per
+    T2 — trigger → window → sleep), emits at most one debounced command + an advisory
+    affect read. Holds no history across windows (Decision 7: nothing persisted)."""
+
+    def __init__(self, cfg: NonVerbalConfig) -> None:
+        from mediapipe.tasks import python as mp
+        from mediapipe.tasks.python import vision
+        self._vision = vision
+        base = mp.BaseOptions
+        self._greco = vision.GestureRecognizer.create_from_options(
+            vision.GestureRecognizerOptions(base_options=base(model_asset_path=cfg.gesture_model),
+                                            running_mode=vision.RunningMode.VIDEO, num_hands=2))
+        self._face = vision.FaceLandmarker.create_from_options(
+            vision.FaceLandmarkerOptions(base_options=base(model_asset_path=cfg.face_model),
+                                         output_face_blendshapes=True,
+                                         running_mode=vision.RunningMode.VIDEO))
+        self._cfg = cfg
+        self._streak: dict[str, int] = {}
+
+    # ── Head A ────────────────────────────────────────────────────────────────
+    def gesture(self, mp_image, ts_ms: int) -> str | None:
+        """→ a debounced intent when a static gesture is held for N frames, else None.
+        Returns the INTENT string; the caller routes it through the fail-closed gate —
+        this function never actuates."""
+        res = self._greco.recognize_for_video(mp_image, ts_ms)
+        top = res.gestures[0][0] if res.gestures and res.gestures[0] else None
+        if not top or top.category_name == "None" or top.score < self._cfg.conf:
+            self._streak.clear()
+            return None
+        name = top.category_name
+        self._streak = {name: self._streak.get(name, 0) + 1}     # only the current gesture streaks
+        if self._streak[name] < self._cfg.debounce_frames:
+            return None
+        self._streak.clear()                                     # one fire per hold (cooldown)
+        return STATIC_GESTURE_INTENTS.get(name)
+
+    # ── Head B (advisory; deferred) ─────────────────────────────────────────────
+    def affect(self, mp_image, ts_ms: int) -> tuple[str, float] | None:
+        """→ (affect, confidence) or None. Maps ARKit-style blendshapes to the doc's
+        bounded affect enum. ADVISORY: never actuates, only shapes {nonverbal_context}."""
+        res = self._face.detect_for_video(mp_image, ts_ms)
+        if not res.face_blendshapes:
+            return None
+        bs = {c.category_name: c.score for c in res.face_blendshapes[0]}
+        smile = max(bs.get("mouthSmileLeft", 0), bs.get("mouthSmileRight", 0))
+        brow_down = max(bs.get("browDownLeft", 0), bs.get("browDownRight", 0))
+        brow_up = bs.get("browInnerUp", 0)
+        scores = {
+            "frustrated": brow_down,
+            "confused": brow_up * (1 - smile),
+            "pleased": smile,
+            "neutral": 0.35,                                     # prior; wins on weak signals
+        }
+        affect = max(_AFFECT_ORDER, key=lambda a: scores[a])
+        conf = scores[affect]
+        return (affect, conf) if conf >= 0.5 else ("neutral", conf)
+
+    def close(self) -> None:
+        self._greco.close(); self._face.close()
+
+
+# ── Streaming / privacy (mirror non-verbal-communication.md §"Streaming protocol") ──────
+#
+# WS mirrors capture_snapshot/bt_scan_request; a SEPARATE gesture WS that MUST inherit the
+# satellite enrollment-PSK + fleet-state machine (Decision D6 — else it reopens the H1
+# "LAN device claims a satellite_id", now streaming video).
+#
+#   register       += {gesture_capable: bool, gesture_tier: "ondevice"|"video"}
+#   backend→sat     : gesture_stream_start / gesture_stream_stop   (gate the window)
+#   sat→backend     : landmark_frame {ts, hands[], pose[], face_blendshapes[]}  ← Tier-1
+#                     COORDINATES/SCORES ONLY — raw video NEVER leaves the room (privacy spine)
+#   result→agent    : recognized intent → device_action-style frame through the EXISTING
+#                     HA_CONTROL fail-closed gate;  affect → {nonverbal_context} prompt line
+#
+# Binding invariants from the doc (do not soften in the productization PR):
+#   * Nothing persisted (Decision 7): no raw video, no landmark history, no affect log.
+#   * LED "vision active" tell while the window is open (LEDController.set_pattern).
+#   * Attribution fail-closed (T-ATTRIB-SPIKE): actuate only when is_user_alone_in_room()
+#     identifies a single BLE-tracked occupant; multi-person / unidentified → read-only.
+#   * Safe-action allowlist = REVERSIBLE actions only; no irreversible action via gesture
+#     without a voice/tap confirm (D7).
+#   * kinderbad needs its OWN opt-in flag (Decision 8) — never inherits the camera flag.

--- a/prototypes/npu-occupancy/object_document_recognizer.py
+++ b/prototypes/npu-occupancy/object_document_recognizer.py
@@ -1,0 +1,138 @@
+"""On-device object / document-type recognition — prototype (extends occupancy).
+
+Reuses the SAME NPU rails as `occupancy_detector.py` (DetectorBackend → ONNX-CPU
+reference or VIPLite-NBG on the A733 NPU); only the model + post-processing differ.
+
+TWO complementary jobs, both edge/triage — the AUTHORITATIVE document extraction stays
+in the cluster (Docling + qwen3-vl + Schicht-A). This does NOT replace that:
+
+  1. RECOGNIZE  — zero-shot classify what's in front of the camera ("a letter / an
+     invoice / a receipt / a parcel label / an ID card / an object"). Uses a MobileCLIP
+     image encoder on the NPU (research: MobileCLIP-S0 ≈ 22.6 ms/frame on the VIP9000)
+     scored against PRE-COMPUTED text-label embeddings → cosine → top label. Zero-shot =
+     add a label by adding a caption string, no retraining.
+
+  2. HAS-TEXT   — a lightweight text-DETECTION pass (PP-OCR-det / DBNet, CNN → NPU-
+     friendly) answers "is there readable text here?" so a presented document TRIGGERS
+     capture-and-route, without trying to OCR on the NPU. Full-quality OCR is the
+     cluster's job (see `route_document_to_cluster`).
+
+WHY NOT OCR ON THE NPU: text *recognition* needs a CNN/CTC recognizer (PP-OCR-mobile);
+transformer recognizers won't compile on this NPU (same limit that blocked the ≥0.5B
+LLMs). Detection triages; the cluster reads. This mirrors SATELLITE_CAMERA.md's existing
+snapshot→qwen3-vl path — the NPU just decides WHEN to invoke it and works offline.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from occupancy_detector import DetectorConfig, OnnxCpuBackend, VipLiteNpuBackend
+
+# CLIP-family preprocessing (differs from YOLO letterbox): center-square, 256², CLIP norm.
+_CLIP_SIDE = 256
+_CLIP_MEAN = np.array([0.4815, 0.4578, 0.4082], dtype=np.float32)
+_CLIP_STD = np.array([0.2686, 0.2613, 0.2758], dtype=np.float32)
+
+# Household-relevant zero-shot labels. Grow by adding a caption — no retraining.
+DEFAULT_LABELS: dict[str, str] = {
+    "brief": "a photo of a paper letter or official document",
+    "rechnung": "a photo of an invoice or a bill",
+    "quittung": "a photo of a receipt",
+    "paketlabel": "a photo of a parcel shipping label",
+    "ausweis": "a photo of an ID card or passport",
+    "visitenkarte": "a photo of a business card",
+    "buchseite": "a photo of a page from a book",
+    "objekt": "a photo of an everyday object, not a document",
+}
+
+
+def _clip_preprocess(bgr: np.ndarray) -> np.ndarray:
+    h, w = bgr.shape[:2]
+    s = min(h, w)
+    top, left = (h - s) // 2, (w - s) // 2
+    crop = bgr[top:top + s, left:left + s]
+    ys = (np.arange(_CLIP_SIDE) * s / _CLIP_SIDE).astype(np.int32).clip(0, s - 1)
+    xs = ys
+    sq = crop[ys][:, xs][:, :, ::-1]                                   # →RGB
+    chw = (sq.astype(np.float32) / 255.0 - _CLIP_MEAN) / _CLIP_STD
+    return np.ascontiguousarray(chw.transpose(2, 0, 1), dtype=np.float32)[None]
+
+
+@dataclass
+class RecognizerConfig:
+    image_encoder_path: str                    # MobileCLIP image encoder (.onnx / .nbg)
+    text_embeddings_path: str                  # .npz: {label: 512-d unit vector}, built offline
+    labels: dict[str, str] = field(default_factory=lambda: DEFAULT_LABELS)
+    margin: float = 0.03                        # top1 must beat top2 by this, else "unsure"
+
+
+class ObjectDocumentRecognizer:
+    """Zero-shot: image → label. Text embeddings are computed ONCE offline (CPU CLIP text
+    tower) and shipped as an .npz — the board only runs the image encoder on the NPU."""
+
+    def __init__(self, cfg: RecognizerConfig) -> None:
+        self._cfg = cfg
+        Backend = VipLiteNpuBackend if cfg.image_encoder_path.endswith(".nbg") else OnnxCpuBackend
+        self._enc = Backend(DetectorConfig(model_path=cfg.image_encoder_path))
+        data = np.load(cfg.text_embeddings_path)
+        self._label_names = list(data.files)
+        self._text = np.stack([data[k] for k in self._label_names])       # (L, D) unit rows
+
+    def recognize(self, bgr: np.ndarray) -> tuple[str, float] | None:
+        """→ (label, confidence) or None. Confidence = softmaxed cosine; None if the top
+        two labels are within `margin` (genuinely ambiguous → don't guess)."""
+        try:
+            emb = self._enc.infer(_clip_preprocess(bgr))[0].astype(np.float32)
+            emb /= np.linalg.norm(emb) + 1e-9
+            sims = self._text @ emb                                        # cosine, (L,)
+            order = sims.argsort()[::-1]
+            if len(order) >= 2 and sims[order[0]] - sims[order[1]] < self._cfg.margin:
+                return None
+            probs = np.exp(sims * 100.0); probs /= probs.sum()             # CLIP temp≈100
+            return self._label_names[order[0]], float(probs[order[0]])
+        except Exception as e:  # noqa: BLE001
+            print(f"[recognize] failed: {e}")
+            return None
+
+    def is_document(self, bgr: np.ndarray) -> bool:
+        r = self.recognize(bgr)
+        return bool(r and r[0] != "objekt")
+
+    def close(self) -> None:
+        self._enc.close()
+
+
+# ── Present-to-camera → authoritative cluster ingest ──────────────────────────
+# The NPU triages; the CLUSTER extracts. When a document is presented and confirmed,
+# capture a HIGH-RES frame and push it through the EXISTING folder-ingest bridge — the
+# same path as `internal.ingest_file` / `POST /api/folder-ingest/document` — so Docling +
+# Schicht-A do the real work (dedup / owner+tier / Paperless filing identical). No new
+# extraction stack; the camera just becomes another ingest source.
+async def route_document_to_cluster(jpeg: bytes, *, source_room: str, backend, doc_hint: str | None):
+    """Push a presented-document capture into the cluster ingest pipeline.
+
+    `backend` is the satellite's authenticated REST client to
+    `POST /api/folder-ingest/document` (Bearer folder-ingest token; the same push the
+    filesystem MCP uses). `doc_hint` is the NPU's recognized label ("rechnung"), passed
+    as a soft title hint — the cluster's Schicht-A extraction stays authoritative.
+
+    Offline (cluster unreachable): fall back to the on-device PP-OCR-mobile read for a
+    best-effort answer, and queue the capture for push on reconnect (mirrors the
+    filesystem/email MCP re-reconcile-on-recovery pattern). Nothing is persisted beyond
+    the transient queue entry.
+    """
+    payload = {"filename": f"camera-{source_room}.jpg", "content_b64": None, "hint": doc_hint}
+    # payload["content_b64"] = base64(jpeg)  # (kept explicit in the productization PR)
+    return await backend.push_document(payload, jpeg=jpeg)
+
+
+if __name__ == "__main__":
+    import sys
+    from PIL import Image
+    rec = ObjectDocumentRecognizer(RecognizerConfig(image_encoder_path=sys.argv[1],
+                                                     text_embeddings_path=sys.argv[2]))
+    bgr = np.asarray(Image.open(sys.argv[3]).convert("RGB"))[:, :, ::-1].copy()
+    print("recognized:", rec.recognize(bgr))
+    rec.close()

--- a/prototypes/npu-occupancy/occupancy_detector.py
+++ b/prototypes/npu-occupancy/occupancy_detector.py
@@ -1,0 +1,209 @@
+"""NPU-offloaded occupancy detector — prototype.
+
+Replaces the GPU-box vision-LLM people-count (`OllamaService.count_people_in_image`,
+services/ollama_service.py) with an on-device person-DETECTION model that runs on the
+Esszimmer satellite's Allwinner A733 Vivante VIP9000 NPU (3 TOPS INT8).
+
+WHY DETECTION, NOT AN LLM: the VIP9000 runs YOLO-class detectors well (~20 ms/frame)
+but cannot host a useful LLM (it tops out at ~360M params — see the a733_npu_driver
+benchmarks). Person-counting is a detection task, so this is a perfect fit — AND a
+privacy win: the frame is never base64'd off the device; only an integer count leaves
+the satellite. The public contract stays identical to the LLM path:
+
+        count(frame_or_jpeg) -> int | None      # None = "couldn't tell" (caller decides fail-open/closed)
+
+BACKENDS (same interface, swap by config):
+  * OnnxCpuBackend   — runnable reference on any box (onnxruntime). Proves the pipeline
+                       end-to-end today, before the NPU port lands. Also the satellite's
+                       CPU fallback if the NBG/VIPLite libs are absent.
+  * VipLiteNpuBackend — the deploy target. Loads an ACUITY-exported NBG and runs it via
+                       the VIP Lite userspace API (see a733_npu_driver). Not runnable off
+                       the board; the pre/post-processing below is shared with the CPU
+                       backend so behaviour is identical bar quantization noise.
+
+Model: YOLOv8n (COCO), person = class 0. Nano is enough for "how many people" and keeps
+the NBG small; the calibration + INT8 export recipe is in README.md.
+"""
+from __future__ import annotations
+
+import io
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+import numpy as np
+
+# ── Model constants (YOLOv8 COCO export) ──────────────────────────────────────
+_INPUT = 640                      # square letterbox side the NBG is compiled for
+_PERSON_CLASS = 0                 # COCO class id for "person"
+_CONF_THRESH = 0.35               # tuned for indoor occupancy; see README for calibration
+_IOU_THRESH = 0.50                # NMS
+
+
+# ── Shared pre/post-processing (identical for CPU and NPU so counts agree) ─────
+def _letterbox(bgr: np.ndarray) -> tuple[np.ndarray, float, tuple[int, int]]:
+    """Resize keeping aspect ratio and pad to _INPUT×_INPUT (gray 114). Returns the
+    NCHW float32 [0,1] tensor plus the scale + (pad_x, pad_y) needed to map boxes back."""
+    h, w = bgr.shape[:2]
+    scale = min(_INPUT / h, _INPUT / w)
+    nh, nw = int(round(h * scale)), int(round(w * scale))
+    # Nearest-neighbour keeps the prototype dependency-light; real deploy uses cv2.resize.
+    ys = (np.arange(nh) / scale).astype(np.int32).clip(0, h - 1)
+    xs = (np.arange(nw) / scale).astype(np.int32).clip(0, w - 1)
+    resized = bgr[ys][:, xs]
+    canvas = np.full((_INPUT, _INPUT, 3), 114, dtype=np.uint8)
+    pad_y, pad_x = (_INPUT - nh) // 2, (_INPUT - nw) // 2
+    canvas[pad_y:pad_y + nh, pad_x:pad_x + nw] = resized
+    rgb = canvas[:, :, ::-1]                                    # BGR→RGB
+    chw = np.ascontiguousarray(rgb.transpose(2, 0, 1), dtype=np.float32) / 255.0
+    return chw[None], scale, (pad_x, pad_y)
+
+
+def _nms(boxes: np.ndarray, scores: np.ndarray, iou_thresh: float) -> list[int]:
+    """Plain NumPy NMS → kept indices (highest score first)."""
+    if len(boxes) == 0:
+        return []
+    x1, y1, x2, y2 = boxes.T
+    areas = (x2 - x1).clip(0) * (y2 - y1).clip(0)
+    order = scores.argsort()[::-1]
+    keep: list[int] = []
+    while order.size:
+        i = order[0]
+        keep.append(int(i))
+        xx1 = np.maximum(x1[i], x1[order[1:]])
+        yy1 = np.maximum(y1[i], y1[order[1:]])
+        xx2 = np.minimum(x2[i], x2[order[1:]])
+        yy2 = np.minimum(y2[i], y2[order[1:]])
+        inter = (xx2 - xx1).clip(0) * (yy2 - yy1).clip(0)
+        iou = inter / (areas[i] + areas[order[1:]] - inter + 1e-9)
+        order = order[1:][iou <= iou_thresh]
+    return keep
+
+
+def _count_persons(output: np.ndarray, conf: float = _CONF_THRESH) -> int:
+    """Decode a YOLOv8 head → number of `person` boxes surviving conf + NMS.
+
+    `output` is the raw model tensor, shape (1, 84, 8400) or (84, 8400): 4 bbox
+    (cx,cy,w,h) + 80 class scores. We only care about class 0, and we only need the
+    COUNT — the boxes are in letterbox space but NMS/counting are scale-invariant, so
+    no un-letterboxing is required for a head count.
+    """
+    o = output[0] if output.ndim == 3 else output          # (84, 8400)
+    o = o.T                                                  # (8400, 84)
+    person_scores = o[:, 4 + _PERSON_CLASS]
+    # Reject any box whose person score isn't the dominant class (avoids a poster of a
+    # person that the net weakly lights up while a real object dominates).
+    dominant = o[:, 4:].argmax(axis=1) == _PERSON_CLASS
+    mask = (person_scores >= conf) & dominant
+    if not mask.any():
+        return 0
+    cx, cy, bw, bh = o[mask, 0], o[mask, 1], o[mask, 2], o[mask, 3]
+    boxes = np.stack([cx - bw / 2, cy - bh / 2, cx + bw / 2, cy + bh / 2], axis=1)
+    keep = _nms(boxes, person_scores[mask], _IOU_THRESH)
+    return len(keep)
+
+
+def _decode_jpeg(data: bytes) -> np.ndarray:
+    """JPEG bytes → HxWx3 BGR uint8. Pillow keeps the prototype dependency-light; the
+    on-satellite build already has a JPEG path from the snapshot capture."""
+    from PIL import Image
+    img = Image.open(io.BytesIO(data)).convert("RGB")
+    return np.asarray(img)[:, :, ::-1].copy()               # RGB→BGR
+
+
+# ── Backends ──────────────────────────────────────────────────────────────────
+@dataclass
+class DetectorConfig:
+    model_path: str                     # .onnx (CPU) or .nbg (NPU)
+    conf_thresh: float = _CONF_THRESH
+
+
+class DetectorBackend(ABC):
+    """Runs the compiled model on one preprocessed NCHW tensor → raw head tensor."""
+
+    @abstractmethod
+    def infer(self, nchw: np.ndarray) -> np.ndarray: ...
+
+    @abstractmethod
+    def close(self) -> None: ...
+
+
+class OnnxCpuBackend(DetectorBackend):
+    """Runnable reference / satellite CPU fallback. `pip install onnxruntime pillow`."""
+
+    def __init__(self, cfg: DetectorConfig) -> None:
+        import onnxruntime as ort
+        self._sess = ort.InferenceSession(cfg.model_path, providers=["CPUExecutionProvider"])
+        self._in = self._sess.get_inputs()[0].name
+
+    def infer(self, nchw: np.ndarray) -> np.ndarray:
+        return self._sess.run(None, {self._in: nchw})[0]
+
+    def close(self) -> None:
+        self._sess = None
+
+
+class VipLiteNpuBackend(DetectorBackend):
+    """A733 Vivante VIP9000 deploy target. Loads an ACUITY-exported NBG and runs it via
+    the VIP Lite userspace API. Import + calls follow petayyyy/a733_npu_driver's Python
+    bindings; this module is only importable ON the board (VIPLite .so present).
+
+    The NBG is INT8-quantized, so the head comes back as int8 + a per-tensor scale; we
+    dequantize to float and hand it to the SAME `_count_persons` as the CPU path.
+    """
+
+    def __init__(self, cfg: DetectorConfig) -> None:
+        import viplite  # from a733_npu_driver userspace libs; board-only
+        self._vip = viplite
+        self._net = viplite.load_network(cfg.model_path)     # NBG → graph handle
+        self._in = viplite.input_tensor(self._net, 0)
+        self._out = viplite.output_tensor(self._net, 0)
+
+    def infer(self, nchw: np.ndarray) -> np.ndarray:
+        # VIP Lite wants the network's compiled input layout/quant; ACUITY baked the
+        # /255 normalization into the graph, so we feed uint8 NCHW here (see README).
+        self._vip.set_input(self._in, (nchw * 255.0).astype(np.uint8))
+        self._vip.run(self._net)
+        raw, scale, zero_point = self._vip.get_output_quant(self._out)
+        return (raw.astype(np.float32) - zero_point) * scale
+
+    def close(self) -> None:
+        self._vip.release_network(self._net)
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+class OccupancyDetector:
+    """Drop-in replacement for the vision-LLM occupancy count. Same return contract:
+    an int people-count, or None when the model is unavailable/errors (caller decides
+    fail-open vs fail-closed — the announce gate fails CLOSED on personal messages)."""
+
+    def __init__(self, backend: DetectorBackend, conf_thresh: float = _CONF_THRESH) -> None:
+        self._backend = backend
+        self._conf = conf_thresh
+
+    @classmethod
+    def from_config(cls, cfg: DetectorConfig) -> "OccupancyDetector":
+        backend = VipLiteNpuBackend(cfg) if cfg.model_path.endswith(".nbg") else OnnxCpuBackend(cfg)
+        return cls(backend, cfg.conf_thresh)
+
+    def count(self, frame: "np.ndarray | bytes") -> int | None:
+        """`frame`: BGR uint8 HxWx3, or JPEG bytes (the satellite's snapshot format)."""
+        try:
+            bgr = _decode_jpeg(frame) if isinstance(frame, (bytes, bytearray)) else frame
+            nchw, _, _ = _letterbox(bgr)
+            out = self._backend.infer(nchw)
+            return _count_persons(out, self._conf)
+        except Exception as e:  # noqa: BLE001 — mirror count_people_in_image: never raise into the gate
+            print(f"[occupancy] detect failed: {e}")
+            return None
+
+    def close(self) -> None:
+        self._backend.close()
+
+
+if __name__ == "__main__":
+    # Smoke: python occupancy_detector.py yolov8n.onnx test.jpg
+    import sys
+    det = OccupancyDetector.from_config(DetectorConfig(model_path=sys.argv[1]))
+    with open(sys.argv[2], "rb") as fh:
+        print("people:", det.count(fh.read()))
+    det.close()

--- a/prototypes/npu-occupancy/satellite_occupancy.py
+++ b/prototypes/npu-occupancy/satellite_occupancy.py
@@ -1,0 +1,106 @@
+"""Satellite-side occupancy handler — prototype.
+
+Adds a `count_occupants` WS request to the satellite, mirroring `capture_snapshot`
+(websocket_client.py:681/746). The backend asks "how many people in your room?"; the
+satellite grabs ONE frame from its CSI camera, runs the NPU person-detector locally, and
+replies with just an integer. The frame never leaves the device.
+
+Wire-in on the satellite (3 small edits to renfield_satellite/network/websocket_client.py):
+
+  1. register capabilities: add `"has_npu_occupancy": self._occupancy is not None`
+     next to `has_camera` (satellite_manager reads it to choose this path).
+
+  2. dispatch (near line 681, beside capture_snapshot):
+         elif msg_type == "count_occupants":
+             asyncio.create_task(self._handle_count_occupants(data.get("request_id")))
+
+  3. handler: `_handle_count_occupants` below (bound as a method).
+
+The detector + camera are injected once at startup (see `build_occupancy()`), so the hot
+path never re-loads the NBG.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+# In-repo prototype import; on the satellite this ships inside renfield_satellite/vision/.
+from occupancy_detector import DetectorConfig, OccupancyDetector
+
+
+class V4L2Camera:
+    """Single-frame grabber for a CSI sensor exposed as /dev/videoN.
+
+    CSI (not a webcam): the sensor driver lives on the HOST; the privileged pod mounts
+    /dev/video* + /dev/media*. We open lazily and read one frame per request — no
+    continuous streaming (occupancy checks are occasional, and a persistent stream would
+    fight the audio loop for USB/DMA bandwidth and power).
+    """
+
+    def __init__(self, device: str = "/dev/video0", width: int = 1280, height: int = 720) -> None:
+        self._device, self._w, self._h = device, width, height
+
+    async def grab_bgr(self):
+        # Run the blocking V4L2 read off the event loop so it never stalls wakeword/WS.
+        return await asyncio.to_thread(self._grab_sync)
+
+    def _grab_sync(self):
+        import cv2  # opencv-python-headless on the satellite image
+        cap = cv2.VideoCapture(self._device, cv2.CAP_V4L2)
+        try:
+            cap.set(cv2.CAP_PROP_FRAME_WIDTH, self._w)
+            cap.set(cv2.CAP_PROP_FRAME_HEIGHT, self._h)
+            # Drop the first couple of frames — CSI sensors need AE/AWB to settle,
+            # else the first frame is black/over-exposed and the count is garbage.
+            for _ in range(3):
+                ok, frame = cap.read()
+            return frame if ok else None
+        finally:
+            cap.release()
+
+
+class OccupancyProbe:
+    """Camera + detector, held for the process lifetime. `count()` = grab → detect."""
+
+    def __init__(self, camera: V4L2Camera, detector: OccupancyDetector) -> None:
+        self._camera, self._detector = camera, detector
+
+    async def count(self) -> int | None:
+        bgr = await self._camera.grab_bgr()
+        if bgr is None:
+            return None
+        # Detection is CPU/NPU-bound → off the event loop too.
+        return await asyncio.to_thread(self._detector.count, bgr)
+
+    def close(self) -> None:
+        self._detector.close()
+
+
+def build_occupancy(model_path: str, device: str = "/dev/video0") -> Optional["OccupancyProbe"]:
+    """Construct the probe, or None if the model/camera isn't present (→ satellite
+    advertises has_npu_occupancy=False and the backend transparently uses the LLM path)."""
+    try:
+        det = OccupancyDetector.from_config(DetectorConfig(model_path=model_path))
+        return OccupancyProbe(V4L2Camera(device), det)
+    except Exception as e:  # noqa: BLE001
+        print(f"[occupancy] disabled (no model/camera): {e}")
+        return None
+
+
+# ── The WS handler (bind as WebSocketClient._handle_count_occupants) ───────────
+async def _handle_count_occupants(self, request_id):
+    """Count people in the room NOW and reply with `occupant_count_result`. ALWAYS
+    replies (count=None on no-camera/error) so the backend future never hangs — exactly
+    like _handle_capture_snapshot always sending a snapshot_result."""
+    count = None
+    try:
+        if getattr(self, "_occupancy", None) is not None:
+            count = await self._occupancy.count()
+    except Exception as e:  # noqa: BLE001
+        print(f"Occupancy count failed: {e}")
+    try:
+        await self._send({
+            "type": "occupant_count_result", "request_id": request_id, "count": count,
+        })
+    except Exception as e:  # noqa: BLE001
+        print(f"Failed to send occupant_count_result: {e}")


### PR DESCRIPTION
## What

Prototype scaffolding for four camera capabilities on the Esszimmer **A733** satellite (Vivante VIP9000, 3 TOPS NPU), across **two inference stacks**, plus reconciliation of the findings into the existing design docs. **Prototype only — not wired into prod.**

## Two inference stacks (deliberately not conflated)

**NPU-detection** (the A733 NPU's strength):
- `occupancy_detector.py` — YOLOv8n person-count replacing the GPU vision-LLM count in the announce privacy gate. `OnnxCpuBackend` (runnable reference / CPU fallback) + `VipLiteNpuBackend` (ACUITY→NBG deploy target); same `count() -> int | None` contract. **Frame never leaves the device — only an integer** (privacy upgrade over today's snapshot-to-backend).
- `object_document_recognizer.py` — zero-shot object/document-type recognition (MobileCLIP on NPU vs pre-computed text-label embeddings) + a has-text trigger + `route_document_to_cluster()` which pushes a presented document into the **existing** folder-ingest → Docling → Schicht-A pipeline. Edge **triage**, not a re-implementation of OCR — `SATELLITE_CAMERA.md`'s `qwen3-vl` path stays authoritative.
- `satellite_occupancy.py` — V4L2 single-frame CSI capture + a `count_occupants` WS handler mirroring `_handle_capture_snapshot`.

**CPU-MediaPipe** (the NPU can't run MediaPipe — the `T-SILICON-PROBE` spike):
- `nonverbal_starter.py` — implements `non-verbal-communication.md` **Phase 3a**: stock MediaPipe static-gesture recognizer (Head A) + FaceLandmarker blendshape affect read (Head B, deferred/advisory). Faithful to the doc's binding decisions: fail-closed actuation via the `HA_CONTROL` `device_action` gate, advisory-only affect, nothing persisted, separate PSK-bound gesture WS, BLE-single-occupant attribution.

## Docs reconciled

- `docs/design/non-verbal-communication.md` — **2026-08-09 addendum**: CSI IMX219 is viable on the A733 (verified against the actual vendor kernel config), superseding the "needs a USB camera" assumption; the MediaPipe→NPU conversion rail now exists (this prototype). **Decisions unchanged.**
- `docs/SATELLITE_CAMERA.md` — on-device NPU offload section + prototype pointer.

## Camera research (in the prototype README)

Against the real A733 kernel config, only four sensors have drivers (`IMX219`, `OV13850`, `GC05A2`, `GC030A`; OV5647 unsupported). **Top pick: Waveshare IMX219-160IR** (only wide + night-capable sensor with a compiled driver); RTSP IP cam as fallback. Occupancy vs gesture/document want opposite optics — the board's **two CSI ports** allow one of each.

## Status / not in scope

- **Not wired into prod** — `prototypes/` scaffolding. Productization is the Implementation Tasks already in `non-verbal-communication.md` (gated on the physical A733 fps/thermal probe + per-room BLE enrollment).
- All 4 Python modules compile clean; the `OnnxCpuBackend` path is runnable today as the reference (`python occupancy_detector.py yolov8n.onnx room.jpg`). The `VipLiteNpuBackend` / ACUITY export needs the A733 SDK + board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vEy3T6JbZ1yEtH1VWT4Lp