### PR TITLE
feat(a733-camera): working ISP frame capture + reproducible host setup

### DIFF
--- a/docs/design/a733-satellite-camera.md
+++ b/docs/design/a733-satellite-camera.md
@@ -233,6 +233,19 @@ pod sees `/opt/awisp/*` and captures a frame in-container. The `.c` is in-repo; 
 `.so`s are Allwinner proprietary (from the OPi desktop image) — they live on the host, NOT in git.
 (A later hardening option is to bake them into the satellite image instead of the host hostPath.)
 
+### Reproducibility (how this survives a reflash) — NOT Ansible
+
+The Esszimmer host is **not** the bare-metal-satellite Ansible target (`src/satellite/provisioning/`
+is for the Pi Zero 2 W sats, which have no A733/ISP and no camera). Instead the HOST-side camera
+setup is captured in a committed, idempotent script — **`k8s/orangepi-esszimmer-camera-setup.sh`**
+(same pattern as `k8s/orangepi-node-resilience.sh`), run as root on the node from a repo checkout.
+It: (1) compiles+installs the DT overlay + enables it in `orangepiEnv.txt`, (2) writes
+`/etc/modules-load.d/renfield-camera.conf`, (3) builds `renfield_isp_capture` and installs the AW
+ISP libs into `/opt/awisp`. The AW `.so`s are proprietary → staged from `private/awisp/` (or
+extracted from the desktop image), never committed. So: reflash the node → run k8s node setup +
+this script → reboot → `kubectl apply` the pod manifest → camera back. The POD side is fully
+git-managed; only these host bits + the proprietary libs are out-of-band.
+
 ## Thermal note (observed during bring-up)
 
 The board runs **warm: ~72 °C** on the CPU cores at idle-ish load (1.3), driven by the

--- a/docs/design/a733-satellite-camera.md
+++ b/docs/design/a733-satellite-camera.md
@@ -180,10 +180,59 @@ Module 3 (IMX708) fails on the sensor driver, not the cable.
    GREY — the ISP output). **All overlay values were correct first try** (csi_sel/mipi_sel=0,
    mclk_id=0, PE6/PE5 reset/pwdn) — no tunable iteration was needed. (A harmless
    `imx219_2 ... No such device` logs from a second base-DTB sensor slot with no camera.)
-4. ⏳ **Next:** mount `/dev/video0` + `/dev/media0` into the Esszimmer pod
-   (`k8s/satellite-esszimmer.yaml`, alongside the existing `/dev/snd` hostPath mounts).
-5. ⏳ Wire it to the occupancy/gesture prototypes (`prototypes/npu-occupancy/`) — the
-   detector + WS contract are camera-agnostic; only the frame source changes.
+4. ✅ Mount `/dev/video0` + `/dev/media0` into the Esszimmer pod
+   (`k8s/satellite-esszimmer.yaml`, alongside `/dev/snd`; `type: CharDevice`). Verified
+   visible in-container.
+5. ⏳ **Frame capture — needs the Allwinner GStreamer plugin (see below).** The detector
+   + WS contract are camera-agnostic; only the frame source needs this dependency.
+
+## Frame capture — sunxi-vin needs Allwinner's GStreamer `en-awisp` (NOT plain V4L2)
+
+The hardest gotcha, verified on-board 2026-08-09: **the sensor is detected and `/dev/video0`
+exists, but you cannot capture with plain V4L2 or OpenCV.** The device is a media-controller,
+**multiplanar** node whose ISP/scaler pipeline
+(sensor → mipi.0 → csi.0 → tdm_rx.0 → isp.0 → scaler.0 → vin_cap.0) will not negotiate a
+format from userspace V4L2:
+
+- `cv2.VideoCapture` / `v4l2-ctl --stream-mmap` → `VIDIOC_REQBUFS Invalid argument`,
+  `vin_pipeline_try_format failed`, `v4l2 sub device scaler get_selection error`. Setting
+  the sensor subdev (`/dev/v4l-subdev0`, `SRGGB10_1X10`) does not fix it — the AW ISP/scaler
+  needs proprietary configuration that raw V4L2 doesn't do.
+- **The only working path** is Allwinner's **patched GStreamer `v4l2src` with `en-awisp=1`**
+  (drives the AW ISP internally). This is exactly what the board's own
+  `/usr/local/bin/test_camera.sh` uses:
+  ```
+  gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 num-buffers=1 \
+      ! video/x-raw,format=NV12,width=640,height=480 ! jpegenc ! filesink location=cam.jpg
+  ```
+
+**The blocker:** `en-awisp` is an **Allwinner patch** — it is NOT in stock GStreamer and NOT
+apt-installable (checked: `apt-cache search` finds only stock `gstreamer1.0-plugins-good`,
+whose `v4l2src` lacks `en-awisp`). It ships only in Allwinner's BSP GStreamer (the Orange Pi
+**desktop** image). The current satellite image has no GStreamer at all.
+
+**Remaining task → get the AW GStreamer v4l2 plugin into the satellite image:**
+- **Option A (extract):** pull `gst-launch-1.0` + the AW GStreamer libs/plugins from an Orange
+  Pi **desktop** rootfs for this exact board/kernel, bake them into the satellite image.
+- **Option B (build):** build the AW BSP GStreamer (the `en-awisp` v4l2 plugin) from
+  Allwinner's A733 source, cross- or native-compile on the board.
+- **Option C (raw-Bayer bypass):** investigate whether sunxi-vin exposes a raw-CSI capture
+  path (bypassing the ISP/scaler) → capture SRGGB10 + debayer in software. Unverified; avoids
+  the AW plugin but adds a debayer step and unknown driver support.
+
+`prototypes/npu-occupancy/satellite_occupancy.py::V4L2Camera` is written for the
+`en-awisp` GStreamer path (subprocess → JPEG → BGR) and degrades to "capture disabled" when
+`gst-launch-1.0` is absent — so the occupancy gate stays safe until the plugin ships.
+
+## Thermal note (observed during bring-up)
+
+The board runs **warm: ~72 °C** on the CPU cores at idle-ish load (1.3), driven by the
+baseline satellite ML workload (wakeword + BLE + audio) + k8s overhead — **not** the camera
+(idle vin draws ~nothing). It **has a PWM fan, already at max** (`pwm-fan cur=4/max=4`), and
+is not throttling (cores at 1794 MHz, no dmesg thermal warnings), skin only 38 °C. There is
+little cooling headroom left, so **continuous** vision inference would push it toward the
+throttle point — another reason the non-verbal design uses *gated, bounded-window* capture
+rather than a persistent stream.
 
 ### DT overlay
 

--- a/docs/design/a733-satellite-camera.md
+++ b/docs/design/a733-satellite-camera.md
@@ -186,43 +186,43 @@ Module 3 (IMX708) fails on the sensor driver, not the cable.
 5. ⏳ **Frame capture — needs the Allwinner GStreamer plugin (see below).** The detector
    + WS contract are camera-agnostic; only the frame source needs this dependency.
 
-## Frame capture — sunxi-vin needs Allwinner's GStreamer `en-awisp` (NOT plain V4L2)
+## Frame capture — WORKING via the Allwinner ISP userspace (verified 2026-08-09)
 
-The hardest gotcha, verified on-board 2026-08-09: **the sensor is detected and `/dev/video0`
-exists, but you cannot capture with plain V4L2 or OpenCV.** The device is a media-controller,
-**multiplanar** node whose ISP/scaler pipeline
-(sensor → mipi.0 → csi.0 → tdm_rx.0 → isp.0 → scaler.0 → vin_cap.0) will not negotiate a
-format from userspace V4L2:
+**The sensor is detected and `/dev/video0` exists, but you cannot capture with plain V4L2 /
+OpenCV** — the device is a multiplanar media-controller whose ISP/scaler pipeline
+(sensor → mipi.0 → csi.0 → tdm_rx.0 → isp.0 → scaler.0 → vin_cap.0) produces nothing unless
+**Allwinner's ISP userspace is running**. `cv2.VideoCapture` / `v4l2-ctl --stream-mmap` →
+`VIDIOC_REQBUFS Invalid argument`, `vin_pipeline_try_format failed`,
+`scaler get_selection error`.
 
-- `cv2.VideoCapture` / `v4l2-ctl --stream-mmap` → `VIDIOC_REQBUFS Invalid argument`,
-  `vin_pipeline_try_format failed`, `v4l2 sub device scaler get_selection error`. Setting
-  the sensor subdev (`/dev/v4l-subdev0`, `SRGGB10_1X10`) does not fix it — the AW ISP/scaler
-  needs proprietary configuration that raw V4L2 doesn't do.
-- **The only working path** is Allwinner's **patched GStreamer `v4l2src` with `en-awisp=1`**
-  (drives the AW ISP internally). This is exactly what the board's own
-  `/usr/local/bin/test_camera.sh` uses:
-  ```
-  gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 num-buffers=1 \
-      ! video/x-raw,format=NV12,width=640,height=480 ! jpegenc ! filesink location=cam.jpg
-  ```
+**Red herring:** the board's `/usr/local/bin/test_camera.sh` uses `gst-launch-1.0 v4l2src …
+en-awisp=1`, but `en-awisp` exists in **no binary** (grep of the whole desktop rootfs found it
+only in that script). It's not a real property. Don't chase GStreamer.
 
-**The blocker:** `en-awisp` is an **Allwinner patch** — it is NOT in stock GStreamer and NOT
-apt-installable (checked: `apt-cache search` finds only stock `gstreamer1.0-plugins-good`,
-whose `v4l2src` lacks `en-awisp`). It ships only in Allwinner's BSP GStreamer (the Orange Pi
-**desktop** image). The current satellite image has no GStreamer at all.
+**What actually works: the AW ISP userspace** — `libAWIspApi.so` + `libisp.so` + `libisp_ini.so`
+(pkg `libawispapi-isp-602`, extracted from the OPi Zero 3W **desktop** image; tuning is baked
+into `libisp_ini.so`, no `/vendor/camera/isp_tuning` needed). Start the ISP
+(`CreateAWIspApi → ispApiInit → ispGetIspId(0) → ispStart`), then do the sunxi V4L2 mplane grab
+(`S_INPUT`, `VIDIOC_SET_SENSOR_ISP_CFG {0,0}`, `S_PARM`, `S_FMT` `V4L2_PIX_FMT_YUV420M` @ 640×480,
+`REQBUFS`/`QUERYBUF`+mmap/`QBUF`, `STREAMON`, `DQBUF`). The ISP does debayer + 3A.
 
-**Remaining task → get the AW GStreamer v4l2 plugin into the satellite image:**
-- **Option A (extract):** pull `gst-launch-1.0` + the AW GStreamer libs/plugins from an Orange
-  Pi **desktop** rootfs for this exact board/kernel, bake them into the satellite image.
-- **Option B (build):** build the AW BSP GStreamer (the `en-awisp` v4l2 plugin) from
-  Allwinner's A733 source, cross- or native-compile on the board.
-- **Option C (raw-Bayer bypass):** investigate whether sunxi-vin exposes a raw-CSI capture
-  path (bypassing the ISP/scaler) → capture SRGGB10 + debayer in software. Unverified; avoids
-  the AW plugin but adds a debayer step and unknown driver support.
+Shipped tool: **`prototypes/npu-occupancy/isp_capture/renfield_isp_capture.c`** — grabs ONE frame
+(skips ~8 frames for 3A warmup) and writes raw **I420**. Built + run on the board:
+```
+gcc -O2 -o renfield_isp_capture renfield_isp_capture.c -I/opt/awisp -L/opt/awisp/lib -lAWIspApi -Wl,-rpath,/opt/awisp/lib
+LD_LIBRARY_PATH=/opt/awisp/lib ./renfield_isp_capture /dev/video0 640 480 /tmp/frame.i420 8
+```
+→ `/tmp/frame.i420` = **460800 bytes (640×480 I420)**, a real image (Y mean≈113, stddev≈22).
+`V4L2Camera` (satellite_occupancy.py) calls this tool → I420 → BGR (numpy, no cv2); degrades to
+"capture disabled" if the tool/libs are absent.
 
-`prototypes/npu-occupancy/satellite_occupancy.py::V4L2Camera` is written for the
-`en-awisp` GStreamer path (subprocess → JPEG → BGR) and degrades to "capture disabled" when
-`gst-launch-1.0` is absent — so the occupancy gate stays safe until the plugin ships.
+**Deploy dependency (remaining):** bake the tool + the AW ISP libs into the satellite image:
+```
+/opt/awisp/renfield_isp_capture                                   # gcc-built from the .c
+/opt/awisp/lib/{libAWIspApi.so, libisp.so, libisp_ini.so}        # from the OPi desktop image
+```
+The `.c` is in-repo; the three AW `.so`s are Allwinner proprietary binaries (extracted from the
+desktop rootfs) — stage them into the satellite image build context, do NOT commit to git.
 
 ## Thermal note (observed during bring-up)
 

--- a/docs/design/a733-satellite-camera.md
+++ b/docs/design/a733-satellite-camera.md
@@ -210,19 +210,28 @@ Shipped tool: **`prototypes/npu-occupancy/isp_capture/renfield_isp_capture.c`** 
 (skips ~8 frames for 3A warmup) and writes raw **I420**. Built + run on the board:
 ```
 gcc -O2 -o renfield_isp_capture renfield_isp_capture.c -I/opt/awisp -L/opt/awisp/lib -lAWIspApi -Wl,-rpath,/opt/awisp/lib
-LD_LIBRARY_PATH=/opt/awisp/lib ./renfield_isp_capture /dev/video0 640 480 /tmp/frame.i420 8
+LD_LIBRARY_PATH=/opt/awisp/lib ./renfield_isp_capture /dev/video0 1920 1080 /tmp/frame.i420 8
 ```
-→ `/tmp/frame.i420` = **460800 bytes (640×480 I420)**, a real image (Y mean≈113, stddev≈22).
+→ `/tmp/frame.i420` = **3110400 bytes (1920×1080 I420)**, a real image (Y mean≈128, stddev≈28).
 `V4L2Camera` (satellite_occupancy.py) calls this tool → I420 → BGR (numpy, no cv2); degrades to
-"capture disabled" if the tool/libs are absent.
+"capture disabled" if the tool/libs are absent. Also verified **from inside the pod** (see mount
+below): 1080p frame captured in-container.
 
-**Deploy dependency (remaining):** bake the tool + the AW ISP libs into the satellite image:
-```
-/opt/awisp/renfield_isp_capture                                   # gcc-built from the .c
-/opt/awisp/lib/{libAWIspApi.so, libisp.so, libisp_ini.so}        # from the OPi desktop image
-```
-The `.c` is in-repo; the three AW `.so`s are Allwinner proprietary binaries (extracted from the
-desktop rootfs) — stage them into the satellite image build context, do NOT commit to git.
+**Resolution ceiling = 1920×1080.** The IMX219 is 8 MP (3280×2464) and captures 1080p natively,
+but this ISP config's **scaler output caps at 1920×1080** — `S_FMT` clamps any higher request
+(2560×1440 / 3280×2464 all come back as 1080p). Full-sensor res needs the ISP "large image" path
+(large-scaler / tiled capture); the `sensor_isp_cfg.large_image` + `ispSetIspLargeImage()` flags
+alone do NOT unlock it (tested — still clamped, and broke the simple grab). Not worth pursuing:
+1080p is ample for occupancy/gesture (the YOLO detector letterboxes to 640 anyway) and good for
+document reading. 640×480 / 1280×720 also work (lighter/less heat). The tool caps requests at
+1920×1080.
+
+**Deploy — DONE via hostPath (not baked into the image).** `/opt/awisp` (the `renfield_isp_capture`
+binary + `lib/{libAWIspApi,libisp,libisp_ini}.so`) lives on the **host** and is hostPath-mounted
+read-only into the pod (`k8s/satellite-esszimmer.yaml`, `awisp` volume). Applied + verified: the
+pod sees `/opt/awisp/*` and captures a frame in-container. The `.c` is in-repo; the three AW
+`.so`s are Allwinner proprietary (from the OPi desktop image) — they live on the host, NOT in git.
+(A later hardening option is to bake them into the satellite image instead of the host hostPath.)
 
 ## Thermal note (observed during bring-up)
 

--- a/k8s/orangepi-esszimmer-camera-setup.sh
+++ b/k8s/orangepi-esszimmer-camera-setup.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Reproducible HOST-side camera bring-up for the Esszimmer A733 satellite node
+# (Orange Pi Zero 3W / sun60iw2). Run as root ON THE NODE from a repo checkout:
+#
+#     sudo ./k8s/orangepi-esszimmer-camera-setup.sh
+#
+# WHY THIS EXISTS
+# ---------------
+# The Esszimmer satellite runs as a k8s pod (k8s/satellite-esszimmer.yaml, git-managed).
+# But a CSI camera needs HOST-level pieces a pod can't provide — a device-tree overlay,
+# a kernel module autoload, and the Allwinner ISP userspace. Those were bring-up'd by hand
+# during development; this script makes them reproducible so a reflash/replacement of the
+# node restores the camera. It mirrors the committed-node-script pattern of
+# k8s/orangepi-node-resilience.sh (this node's host is NOT the bare-metal-satellite Ansible
+# target — those Pi Zero 2 W sats have no A733/ISP and no camera).
+#
+# Idempotent: safe to re-run. A reboot is required after first run (for the DT overlay).
+#
+# Layer split:
+#   HOST (this script):  DT overlay + module autoload + /opt/awisp (tool + AW ISP libs)
+#   POD (k8s manifest):  hostPath-mounts /dev/video0, /dev/media0, /opt/awisp (already in git)
+set -euo pipefail
+
+[[ $EUID -eq 0 ]] || { echo "run as root (sudo)"; exit 1; }
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+PROTO="$REPO/prototypes/npu-occupancy"
+OVL_DIR=/boot/dtb/allwinner/overlay
+ENVFILE=/boot/orangepiEnv.txt
+AWISP=/opt/awisp
+
+echo "== 1. Device-tree overlay (IMX219 on CAM1/CSI0) =="
+# Compile the in-repo .dts → .dtbo and install under the overlay_prefix convention.
+tmp=$(mktemp -d)
+cpp -nostdinc -undef -x assembler-with-cpp \
+    "$PROTO/dts/sun60i-a733-orangepi-zero3w-cam-imx219.dts" \
+  | dtc -@ -I dts -O dtb -o "$tmp/sun60i-a733-cam-imx219.dtbo" - 2>/dev/null
+install -D -m0644 "$tmp/sun60i-a733-cam-imx219.dtbo" "$OVL_DIR/sun60i-a733-cam-imx219.dtbo"
+rm -rf "$tmp"
+# Enable it (overlay_prefix=sun60i-a733 → entry is the suffix "cam-imx219"). Idempotent.
+if grep -q '^overlays=' "$ENVFILE"; then
+  grep -qw cam-imx219 "$ENVFILE" || sed -i 's/^overlays=\(.*\)/overlays=\1 cam-imx219/' "$ENVFILE"
+else
+  echo 'overlays=cam-imx219' >> "$ENVFILE"
+fi
+echo "   installed overlay + $(grep '^overlays=' "$ENVFILE")"
+
+echo "== 2. Module autoload (sunxi-vin is =m and does NOT autoload) =="
+cat > /etc/modules-load.d/renfield-camera.conf <<'EOF'
+vin_io
+imx219
+vin_v4l2
+EOF
+echo "   wrote /etc/modules-load.d/renfield-camera.conf"
+
+echo "== 3. Allwinner ISP userspace + capture tool (/opt/awisp) =="
+install -d "$AWISP/lib"
+# 3a. AW ISP libs — Allwinner PROPRIETARY, extracted from the OPi Zero 3W *desktop* image
+#     (pkg libawispapi-isp-602: libAWIspApi.so, libisp.so, libisp_ini.so + AWIspApi.h).
+#     They are NOT in git. Stage them next to this script (or already present in /opt/awisp/lib).
+need_libs=(libAWIspApi.so libisp.so libisp_ini.so)
+missing=0; for l in "${need_libs[@]}"; do [[ -f "$AWISP/lib/$l" ]] || missing=1; done
+if [[ $missing -eq 1 ]]; then
+  if [[ -d "$REPO/private/awisp/lib" ]]; then
+    cp -a "$REPO/private/awisp/lib/." "$AWISP/lib/"
+    [[ -f "$REPO/private/awisp/AWIspApi.h" ]] && cp "$REPO/private/awisp/AWIspApi.h" "$AWISP/"
+    echo "   installed AW ISP libs from private/awisp/"
+  else
+    echo "   !! AW ISP libs missing. Extract from the OPi Zero 3W desktop image:"
+    echo "      7z x <img.7z>; loop-mount; copy /usr/lib/aarch64-linux-gnu/{libAWIspApi,libisp,libisp_ini}.so"
+    echo "      + /usr/include/AWIspApi.h  →  $AWISP/lib/ and $AWISP/  (or repo private/awisp/)."
+    echo "      (proprietary — never commit to git). See docs/design/a733-satellite-camera.md."
+    exit 2
+  fi
+fi
+# 3b. Build the capture tool from the in-repo source against the AW header + lib.
+cp "$PROTO/isp_capture/renfield_isp_capture.c" "$AWISP/"
+gcc -O2 -o "$AWISP/renfield_isp_capture" "$AWISP/renfield_isp_capture.c" \
+    -I"$AWISP" -L"$AWISP/lib" -lAWIspApi -Wl,-rpath,"$AWISP/lib"
+echo "   built $AWISP/renfield_isp_capture"
+
+echo
+echo "DONE. If the overlay was newly added, REBOOT for /dev/video0 to appear:"
+echo "   reboot"
+echo "Then verify:  ls /dev/video0 ; LD_LIBRARY_PATH=$AWISP/lib $AWISP/renfield_isp_capture /dev/video0 1920 1080 /tmp/f.i420 8"
+echo "The pod already hostPath-mounts /dev/video0 + /dev/media0 + /opt/awisp (k8s/satellite-esszimmer.yaml)."

--- a/k8s/satellite-esszimmer.yaml
+++ b/k8s/satellite-esszimmer.yaml
@@ -167,6 +167,12 @@ spec:
               mountPath: /dev/video0
             - name: media
               mountPath: /dev/media0
+            # Allwinner ISP capture tool + libs (renfield_isp_capture + libAWIspApi/libisp)
+            # — required to actually pull frames from the CSI pipeline. See
+            # docs/design/a733-satellite-camera.md.
+            - name: awisp
+              mountPath: /opt/awisp
+              readOnly: true
           resources:
             requests:
               cpu: "250m"
@@ -204,3 +210,7 @@ spec:
           hostPath:
             path: /dev/media0
             type: CharDevice
+        - name: awisp
+          hostPath:
+            path: /opt/awisp
+            type: Directory

--- a/prototypes/npu-occupancy/isp_capture/renfield_isp_capture.c
+++ b/prototypes/npu-occupancy/isp_capture/renfield_isp_capture.c
@@ -1,0 +1,142 @@
+/*
+ * renfield_isp_capture — grab ONE frame from the Allwinner A733 sunxi-vin + ISP
+ * pipeline and write it as raw I420 (YUV420 planar) to a file.
+ *
+ * WHY: on the A733 (Orange Pi Zero 3W) the CSI camera only produces frames when the
+ * Allwinner ISP userspace is running (libAWIspApi/libisp). Plain V4L2/OpenCV can't
+ * capture (the ISP/scaler pipeline won't negotiate). This does the exact sequence the
+ * vendor AWISPdemo does, but non-interactively and writing a clean frame — so the
+ * satellite can grab occupancy/gesture frames. See docs/design/a733-satellite-camera.md.
+ *
+ * Build (on the board): gcc -O2 -o renfield_isp_capture renfield_isp_capture.c \
+ *                          -L/opt/awisp/lib -lAWIspApi -Wl,-rpath,/opt/awisp/lib
+ * Run:   renfield_isp_capture /dev/video0 640 480 /tmp/frame.i420 [warmup_frames=8]
+ * Output: raw I420 (Y w*h, then U w*h/4, then V w*h/4). Convert in Python.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/select.h>
+#include <linux/videodev2.h>
+#include "AWIspApi.h"
+
+/* sunxi private ioctl (from sunxi_camera_v2.h): BASE_VIDIOC_PRIVATE(192) + 15 */
+struct sensor_isp_cfg { unsigned char isp_wdr_mode; unsigned char large_image; };
+#define VIDIOC_SET_SENSOR_ISP_CFG _IOWR('V', BASE_VIDIOC_PRIVATE + 15, struct sensor_isp_cfg)
+
+#define NBUF 4
+#define MAXPLANES 3
+
+static int xioctl(int fd, unsigned long req, void *arg, const char *name, int fatal) {
+    int r = ioctl(fd, req, arg);
+    if (r < 0) {
+        fprintf(stderr, "[cap] %s failed: %s\n", name, strerror(errno));
+        if (fatal) exit(2);
+    }
+    return r;
+}
+
+int main(int argc, char **argv) {
+    const char *dev = argc > 1 ? argv[1] : "/dev/video0";
+    int W = argc > 2 ? atoi(argv[2]) : 640;
+    int H = argc > 3 ? atoi(argv[3]) : 480;
+    const char *out = argc > 4 ? argv[4] : "/tmp/frame.i420";
+    int warmup = argc > 5 ? atoi(argv[5]) : 8;   /* skip frames while 3A converges */
+
+    int fd = open(dev, O_RDWR | O_NONBLOCK, 0);
+    if (fd < 0) { fprintf(stderr, "[cap] open %s: %s\n", dev, strerror(errno)); return 2; }
+
+    int input = 0;
+    xioctl(fd, VIDIOC_S_INPUT, &input, "S_INPUT", 0);
+
+    struct sensor_isp_cfg icfg = {0, 0};
+    xioctl(fd, VIDIOC_SET_SENSOR_ISP_CFG, &icfg, "SET_SENSOR_ISP_CFG", 0);
+
+    struct v4l2_streamparm parm; memset(&parm, 0, sizeof parm);
+    parm.type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
+    parm.parm.capture.timeperframe.numerator = 1;
+    parm.parm.capture.timeperframe.denominator = 30;
+    xioctl(fd, VIDIOC_S_PARM, &parm, "S_PARM", 0);
+
+    struct v4l2_format fmt; memset(&fmt, 0, sizeof fmt);
+    fmt.type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
+    fmt.fmt.pix_mp.width = W;
+    fmt.fmt.pix_mp.height = H;
+    fmt.fmt.pix_mp.pixelformat = V4L2_PIX_FMT_YUV420M;  /* I420, 3 separate planes */
+    fmt.fmt.pix_mp.field = V4L2_FIELD_NONE;
+    fmt.fmt.pix_mp.num_planes = 3;
+    xioctl(fd, VIDIOC_S_FMT, &fmt, "S_FMT", 1);
+    xioctl(fd, VIDIOC_G_FMT, &fmt, "G_FMT", 0);
+    W = fmt.fmt.pix_mp.width; H = fmt.fmt.pix_mp.height;
+    int nplanes = fmt.fmt.pix_mp.num_planes;
+    fprintf(stderr, "[cap] fmt %dx%d planes=%d\n", W, H, nplanes);
+
+    struct v4l2_requestbuffers req; memset(&req, 0, sizeof req);
+    req.count = NBUF; req.type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE; req.memory = V4L2_MEMORY_MMAP;
+    xioctl(fd, VIDIOC_REQBUFS, &req, "REQBUFS", 1);
+
+    void  *pbuf[NBUF][MAXPLANES];
+    size_t plen[NBUF][MAXPLANES];
+    for (unsigned i = 0; i < req.count; i++) {
+        struct v4l2_buffer buf; struct v4l2_plane planes[MAXPLANES];
+        memset(&buf, 0, sizeof buf); memset(planes, 0, sizeof planes);
+        buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE; buf.memory = V4L2_MEMORY_MMAP;
+        buf.index = i; buf.length = nplanes; buf.m.planes = planes;
+        xioctl(fd, VIDIOC_QUERYBUF, &buf, "QUERYBUF", 1);
+        for (int p = 0; p < nplanes; p++) {
+            plen[i][p] = planes[p].length;
+            pbuf[i][p] = mmap(NULL, planes[p].length, PROT_READ | PROT_WRITE, MAP_SHARED,
+                              fd, planes[p].m.mem_offset);
+            if (pbuf[i][p] == MAP_FAILED) { perror("[cap] mmap"); return 2; }
+        }
+        xioctl(fd, VIDIOC_QBUF, &buf, "QBUF", 1);
+    }
+
+    /* Start the Allwinner ISP userspace — without this the pipeline produces nothing. */
+    AWIspApi *isp = CreateAWIspApi();
+    if (!isp) { fprintf(stderr, "[cap] CreateAWIspApi failed\n"); return 2; }
+    isp->ispApiInit();
+    int isp_id = isp->ispGetIspId(0);
+    isp->ispStart(isp_id);
+    fprintf(stderr, "[cap] isp started id=%d\n", isp_id);
+
+    int type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
+    xioctl(fd, VIDIOC_STREAMON, &type, "STREAMON", 1);
+
+    int got = 0;
+    for (int n = 0; n <= warmup; n++) {
+        fd_set fds; FD_ZERO(&fds); FD_SET(fd, &fds);
+        struct timeval tv = {2, 0};
+        if (select(fd + 1, &fds, NULL, NULL, &tv) <= 0) { fprintf(stderr, "[cap] select timeout\n"); break; }
+
+        struct v4l2_buffer buf; struct v4l2_plane planes[MAXPLANES];
+        memset(&buf, 0, sizeof buf); memset(planes, 0, sizeof planes);
+        buf.type = type; buf.memory = V4L2_MEMORY_MMAP; buf.length = nplanes; buf.m.planes = planes;
+        if (xioctl(fd, VIDIOC_DQBUF, &buf, "DQBUF", 0) < 0) { usleep(20000); continue; }
+
+        if (n == warmup) {                       /* keep the last (3A-settled) frame */
+            FILE *f = fopen(out, "wb");
+            if (!f) { fprintf(stderr, "[cap] fopen %s: %s\n", out, strerror(errno)); return 2; }
+            size_t ysz = (size_t)W * H, csz = ysz / 4;
+            fwrite(pbuf[buf.index][0], 1, ysz, f);
+            fwrite(pbuf[buf.index][1], 1, csz, f);
+            fwrite(pbuf[buf.index][2], 1, csz, f);
+            fclose(f);
+            got = 1;
+            fprintf(stderr, "[cap] wrote %s (%dx%d I420)\n", out, W, H);
+        }
+        xioctl(fd, VIDIOC_QBUF, &buf, "QBUF", 0);
+    }
+
+    xioctl(fd, VIDIOC_STREAMOFF, &type, "STREAMOFF", 0);
+    isp->ispStop(isp_id);
+    isp->ispApiUnInit();
+    DestroyAWIspApi(isp);
+    close(fd);
+    return got ? 0 : 1;
+}

--- a/prototypes/npu-occupancy/isp_capture/renfield_isp_capture.c
+++ b/prototypes/npu-occupancy/isp_capture/renfield_isp_capture.c
@@ -43,13 +43,20 @@ static int xioctl(int fd, unsigned long req, void *arg, const char *name, int fa
 
 int main(int argc, char **argv) {
     const char *dev = argc > 1 ? argv[1] : "/dev/video0";
-    int W = argc > 2 ? atoi(argv[2]) : 640;
-    int H = argc > 3 ? atoi(argv[3]) : 480;
+    int W = argc > 2 ? atoi(argv[2]) : 1920;
+    int H = argc > 3 ? atoi(argv[3]) : 1080;
     const char *out = argc > 4 ? argv[4] : "/tmp/frame.i420";
     int warmup = argc > 5 ? atoi(argv[5]) : 8;   /* skip frames while 3A converges */
 
     int fd = open(dev, O_RDWR | O_NONBLOCK, 0);
     if (fd < 0) { fprintf(stderr, "[cap] open %s: %s\n", dev, strerror(errno)); return 2; }
+
+    /* This ISP config's scaler output caps at 1920x1080 (S_FMT clamps anything higher).
+     * The sensor is 8 MP, but full-res needs the ISP "large image" path (large-scaler /
+     * tiled) which `sensor_isp_cfg.large_image` + ispSetIspLargeImage alone don't unlock —
+     * not worth it here; 1080p is the practical max. So cap the request at 1920x1080. */
+    if (W > 1920) W = 1920;
+    if (H > 1080) H = 1080;
 
     int input = 0;
     xioctl(fd, VIDIOC_S_INPUT, &input, "S_INPUT", 0);

--- a/prototypes/npu-occupancy/satellite_occupancy.py
+++ b/prototypes/npu-occupancy/satellite_occupancy.py
@@ -29,34 +29,68 @@ from occupancy_detector import DetectorConfig, OccupancyDetector
 
 
 class V4L2Camera:
-    """Single-frame grabber for a CSI sensor exposed as /dev/videoN.
+    """Single-frame grabber for the A733 CSI sensor exposed as /dev/videoN.
 
     CSI (not a webcam): the sensor driver lives on the HOST; the privileged pod mounts
-    /dev/video* + /dev/media*. We open lazily and read one frame per request — no
-    continuous streaming (occupancy checks are occasional, and a persistent stream would
-    fight the audio loop for USB/DMA bandwidth and power).
+    /dev/video* + /dev/media*. One frame per request — no continuous streaming (occupancy
+    checks are occasional; a persistent stream adds heat on the passively-hot A733).
+
+    IMPORTANT — sunxi-vin does NOT capture via plain V4L2 / OpenCV.
+    ---------------------------------------------------------------
+    Verified on the Esszimmer board (2026-08-09): the sensor is detected and /dev/video0
+    exists, but `cv2.VideoCapture` and raw `v4l2-ctl --stream-mmap` BOTH fail — the device
+    is a media-controller, MULTIPLANAR node, and its ISP/scaler pipeline
+    (sensor → mipi → csi → tdm → isp → scaler → vin_cap) will not negotiate a format from
+    userspace V4L2 alone (`vin_pipeline_try_format failed`, `scaler get_selection error`).
+    The ONLY working capture path is Allwinner's **patched GStreamer `v4l2src`** with the
+    `en-awisp=1` property, which drives the AW ISP internally (this is exactly what the
+    board's own /usr/local/bin/test_camera.sh uses):
+
+        gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 num-buffers=1 \
+            ! video/x-raw,format=NV12,width=640,height=480 ! jpegenc ! filesink location=...
+
+    That `en-awisp` v4l2src is an Allwinner patch — it is NOT in stock GStreamer and NOT
+    apt-installable; it ships only in Allwinner's BSP GStreamer (Orange Pi desktop image).
+    So enabling capture is a DEPENDENCY task: get the AW GStreamer v4l2 plugin into the
+    satellite image (extract from the Orange Pi desktop rootfs for this board, or build
+    from the A733 BSP GStreamer source). See docs/design/a733-satellite-camera.md.
     """
 
-    def __init__(self, device: str = "/dev/video0", width: int = 1280, height: int = 720) -> None:
+    # AW GStreamer capture → one NV12 frame → JPEG on stdout, decoded to BGR.
+    _GST = (
+        "gst-launch-1.0 -q v4l2src device={dev} en-awisp=1 en-largemode=0 num-buffers=1 "
+        "! video/x-raw,format=NV12,width={w},height={h} ! jpegenc ! fdsink fd=1"
+    )
+
+    def __init__(self, device: str = "/dev/video0", width: int = 640, height: int = 480) -> None:
         self._device, self._w, self._h = device, width, height
 
     async def grab_bgr(self):
-        # Run the blocking V4L2 read off the event loop so it never stalls wakeword/WS.
         return await asyncio.to_thread(self._grab_sync)
 
     def _grab_sync(self):
-        import cv2  # opencv-python-headless on the satellite image
-        cap = cv2.VideoCapture(self._device, cv2.CAP_V4L2)
+        """Capture one frame via the AW GStreamer pipeline → decode to BGR.
+
+        Returns None if gst / the en-awisp plugin is absent (the current satellite image),
+        so the occupancy gate degrades gracefully until the AW plugin ships. Requires
+        gst-launch-1.0 WITH Allwinner's en-awisp v4l2src on PATH inside the pod."""
+        import shutil, subprocess
+        import numpy as np
+        from PIL import Image
+        import io as _io
+        if shutil.which("gst-launch-1.0") is None:
+            print("[camera] gst-launch-1.0 (with AW en-awisp v4l2src) not present — capture disabled")
+            return None
+        cmd = self._GST.format(dev=self._device, w=self._w, h=self._h)
         try:
-            cap.set(cv2.CAP_PROP_FRAME_WIDTH, self._w)
-            cap.set(cv2.CAP_PROP_FRAME_HEIGHT, self._h)
-            # Drop the first couple of frames — CSI sensors need AE/AWB to settle,
-            # else the first frame is black/over-exposed and the count is garbage.
-            for _ in range(3):
-                ok, frame = cap.read()
-            return frame if ok else None
-        finally:
-            cap.release()
+            out = subprocess.run(cmd.split(), capture_output=True, timeout=15).stdout
+            if not out:
+                return None
+            rgb = np.asarray(Image.open(_io.BytesIO(out)).convert("RGB"))
+            return rgb[:, :, ::-1].copy()  # RGB→BGR
+        except Exception as e:  # noqa: BLE001
+            print(f"[camera] capture failed: {e}")
+            return None
 
 
 class OccupancyProbe:

--- a/prototypes/npu-occupancy/satellite_occupancy.py
+++ b/prototypes/npu-occupancy/satellite_occupancy.py
@@ -54,8 +54,11 @@ class V4L2Camera:
     _CAP = "/opt/awisp/renfield_isp_capture"
     _LIBS = "/opt/awisp/lib"
 
-    def __init__(self, device: str = "/dev/video0", width: int = 640, height: int = 480,
+    def __init__(self, device: str = "/dev/video0", width: int = 1920, height: int = 1080,
                  warmup: int = 8) -> None:
+        # IMX219 is 8 MP; the ISP downscales, so 1280x720 / 640x480 also work if a lighter
+        # frame is wanted (the occupancy YOLO letterboxes to 640 regardless — higher res
+        # mainly helps document-reading / gesture detail, at more capture time + heat).
         self._device, self._w, self._h, self._warmup = device, width, height, warmup
 
     async def grab_bgr(self):

--- a/prototypes/npu-occupancy/satellite_occupancy.py
+++ b/prototypes/npu-occupancy/satellite_occupancy.py
@@ -35,62 +35,74 @@ class V4L2Camera:
     /dev/video* + /dev/media*. One frame per request — no continuous streaming (occupancy
     checks are occasional; a persistent stream adds heat on the passively-hot A733).
 
-    IMPORTANT — sunxi-vin does NOT capture via plain V4L2 / OpenCV.
-    ---------------------------------------------------------------
-    Verified on the Esszimmer board (2026-08-09): the sensor is detected and /dev/video0
-    exists, but `cv2.VideoCapture` and raw `v4l2-ctl --stream-mmap` BOTH fail — the device
-    is a media-controller, MULTIPLANAR node, and its ISP/scaler pipeline
-    (sensor → mipi → csi → tdm → isp → scaler → vin_cap) will not negotiate a format from
-    userspace V4L2 alone (`vin_pipeline_try_format failed`, `scaler get_selection error`).
-    The ONLY working capture path is Allwinner's **patched GStreamer `v4l2src`** with the
-    `en-awisp=1` property, which drives the AW ISP internally (this is exactly what the
-    board's own /usr/local/bin/test_camera.sh uses):
+    HOW CAPTURE WORKS ON THE A733 (verified working on the Esszimmer board 2026-08-09).
+    ----------------------------------------------------------------------------------
+    sunxi-vin will NOT capture via plain V4L2 / OpenCV: the device is a multiplanar
+    media-controller whose ISP/scaler pipeline won't produce frames unless Allwinner's ISP
+    userspace (libAWIspApi/libisp) is running. So capture goes through
+    `renfield_isp_capture` — a small C tool (isp_capture/renfield_isp_capture.c) that starts
+    the AW ISP (`CreateAWIspApi → ispStart`), does the sunxi V4L2 mplane grab, and writes one
+    frame as raw I420. Confirmed: a real 640×480 frame (Y mean≈113, stddev≈22). The vendor
+    `test_camera.sh`'s `en-awisp` GStreamer property was a red herring (exists in no binary).
 
-        gst-launch-1.0 v4l2src device=/dev/video0 en-awisp=1 en-largemode=0 num-buffers=1 \
-            ! video/x-raw,format=NV12,width=640,height=480 ! jpegenc ! filesink location=...
-
-    That `en-awisp` v4l2src is an Allwinner patch — it is NOT in stock GStreamer and NOT
-    apt-installable; it ships only in Allwinner's BSP GStreamer (Orange Pi desktop image).
-    So enabling capture is a DEPENDENCY task: get the AW GStreamer v4l2 plugin into the
-    satellite image (extract from the Orange Pi desktop rootfs for this board, or build
-    from the A733 BSP GStreamer source). See docs/design/a733-satellite-camera.md.
+    Deploy dependency: the satellite image must contain the tool + the AW ISP libs:
+        /opt/awisp/renfield_isp_capture
+        /opt/awisp/lib/{libAWIspApi.so, libisp.so, libisp_ini.so}   (from the OPi desktop image)
+    See docs/design/a733-satellite-camera.md. Degrades to "capture disabled" when absent.
     """
 
-    # AW GStreamer capture → one NV12 frame → JPEG on stdout, decoded to BGR.
-    _GST = (
-        "gst-launch-1.0 -q v4l2src device={dev} en-awisp=1 en-largemode=0 num-buffers=1 "
-        "! video/x-raw,format=NV12,width={w},height={h} ! jpegenc ! fdsink fd=1"
-    )
+    _CAP = "/opt/awisp/renfield_isp_capture"
+    _LIBS = "/opt/awisp/lib"
 
-    def __init__(self, device: str = "/dev/video0", width: int = 640, height: int = 480) -> None:
-        self._device, self._w, self._h = device, width, height
+    def __init__(self, device: str = "/dev/video0", width: int = 640, height: int = 480,
+                 warmup: int = 8) -> None:
+        self._device, self._w, self._h, self._warmup = device, width, height, warmup
 
     async def grab_bgr(self):
         return await asyncio.to_thread(self._grab_sync)
 
     def _grab_sync(self):
-        """Capture one frame via the AW GStreamer pipeline → decode to BGR.
+        """Capture one frame via renfield_isp_capture → raw I420 → BGR (numpy, no cv2).
 
-        Returns None if gst / the en-awisp plugin is absent (the current satellite image),
-        so the occupancy gate degrades gracefully until the AW plugin ships. Requires
-        gst-launch-1.0 WITH Allwinner's en-awisp v4l2src on PATH inside the pod."""
-        import shutil, subprocess
+        Returns None if the ISP capture tool/libs aren't installed (so the occupancy gate
+        degrades gracefully), or on any capture error."""
+        import os, subprocess, tempfile
         import numpy as np
-        from PIL import Image
-        import io as _io
-        if shutil.which("gst-launch-1.0") is None:
-            print("[camera] gst-launch-1.0 (with AW en-awisp v4l2src) not present — capture disabled")
+        if not os.path.exists(self._CAP):
+            print("[camera] renfield_isp_capture not installed — capture disabled")
             return None
-        cmd = self._GST.format(dev=self._device, w=self._w, h=self._h)
+        out = tempfile.mktemp(suffix=".i420")
+        env = {**os.environ, "LD_LIBRARY_PATH": self._LIBS}
         try:
-            out = subprocess.run(cmd.split(), capture_output=True, timeout=15).stdout
-            if not out:
+            subprocess.run([self._CAP, self._device, str(self._w), str(self._h), out,
+                            str(self._warmup)], env=env, timeout=20, capture_output=True)
+            if not os.path.exists(out) or os.path.getsize(out) < self._w * self._h:
                 return None
-            rgb = np.asarray(Image.open(_io.BytesIO(out)).convert("RGB"))
-            return rgb[:, :, ::-1].copy()  # RGB→BGR
+            buf = np.fromfile(out, dtype=np.uint8)
+            return self._i420_to_bgr(buf, self._w, self._h)
         except Exception as e:  # noqa: BLE001
             print(f"[camera] capture failed: {e}")
             return None
+        finally:
+            try:
+                os.unlink(out)
+            except OSError:
+                pass
+
+    @staticmethod
+    def _i420_to_bgr(buf, w: int, h: int):
+        """Raw I420 (Y, then U, then V; chroma at w/2×h/2) → BGR uint8 (BT.601)."""
+        import numpy as np
+        ysz, csz = w * h, (w // 2) * (h // 2)
+        Y = buf[:ysz].reshape(h, w).astype(np.float32)
+        U = buf[ysz:ysz + csz].reshape(h // 2, w // 2).astype(np.float32) - 128.0
+        V = buf[ysz + csz:ysz + 2 * csz].reshape(h // 2, w // 2).astype(np.float32) - 128.0
+        U = np.repeat(np.repeat(U, 2, 0), 2, 1)          # upsample chroma to full res
+        V = np.repeat(np.repeat(V, 2, 0), 2, 1)
+        R = Y + 1.402 * V
+        G = Y - 0.344 * U - 0.714 * V
+        B = Y + 1.772 * U
+        return np.stack([B, G, R], axis=2).clip(0, 255).astype(np.uint8)
 
 
 class OccupancyProbe:


### PR DESCRIPTION
## What

Completes the A733 (Esszimmer) camera from "device present" to **working frame capture wired into the satellite pod**, and makes the host-side setup reproducible.

Builds on the merged camera-bring-up work (#1085: hardware/driver/overlay/pod-mount). This PR is the **capture** last mile.

## The capture path (hard-won)

sunxi-vin won't capture via plain V4L2/OpenCV (multiplanar media-controller; the ISP must run). The vendor `test_camera.sh`'s `en-awisp` GStreamer property is a **red herring** — it exists in no binary. The real mechanism is Allwinner's **ISP userspace** (`libAWIspApi`/`libisp`/`libisp_ini`, extracted from the OPi Zero 3W desktop image; tuning baked into `libisp_ini.so`).

- **`prototypes/npu-occupancy/isp_capture/renfield_isp_capture.c`** — small C tool: `CreateAWIspApi → ispApiInit → ispGetIspId(0) → ispStart`, then the sunxi V4L2 mplane grab → writes one raw **I420** frame (skips ~8 frames for 3A warmup).
- **`satellite_occupancy.py::V4L2Camera`** rewired to call the tool → I420 → BGR (numpy, no cv2); degrades to "capture disabled" if the tool/libs are absent.

**Verified end-to-end, incl. from inside the pod:** a real **1920×1080** frame (3110400 B, Y mean 128 / stddev 28).

## Resolution

Default **1920×1080** (also 1280×720 / 640×480). That's the ceiling: this ISP's scaler output clamps `S_FMT` above 1080p; the full-sensor "large image" path isn't unlocked by the flags alone (tested) and isn't worth it — 1080p is ample for occupancy/gesture (YOLO letterboxes to 640) and good for document reading.

## Deploy + reproducibility (the "how does this work with Ansible?" answer)

- **Pod (git-managed):** `k8s/satellite-esszimmer.yaml` hostPath-mounts `/dev/video0`, `/dev/media0`, and `/opt/awisp` (read-only) into the pod. Applied + verified live.
- **Host (was manual → now reproducible):** `k8s/orangepi-esszimmer-camera-setup.sh` (idempotent, run as root on the node) installs the DT overlay, the module autoload, and builds `renfield_isp_capture` + the AW ISP libs into `/opt/awisp`. Mirrors the existing `k8s/orangepi-node-resilience.sh` pattern.
- **Not Ansible:** the bare-metal Pi satellites use Ansible (`src/satellite/provisioning/`) and have **no camera** (no A733/ISP). The Esszimmer is a k8s-pod satellite; its host uses committed node scripts, not the satellite Ansible.
- The 3 AW ISP `.so` are Allwinner **proprietary** (from the desktop image) — staged host-side / `private/awisp/`, **never committed**.

## Status

Camera is **live and capturing** on the Esszimmer node (1080p, in-pod verified). Full reference + the capture failure-mode trail: `docs/design/a733-satellite-camera.md`.

Not wired into the satellite *app* yet (the occupancy/gesture prototype calls `V4L2Camera`, but the satellite image doesn't run that path in prod) — that's the next productization step, gated on the non-verbal-communication.md rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vEy3T6JbZ1yEtH1VWT4Lp