### PR TITLE
feat(satellite): sunxi_isp camera backend — wire A733 ISP capture into the app

### DIFF
--- a/k8s/satellite-esszimmer.yaml
+++ b/k8s/satellite-esszimmer.yaml
@@ -62,6 +62,11 @@ data:
       brightness: 20
       idle_color: "yellow"        # Esszimmer identity colour (continuity w/ old sat)
       xvf_host_path: "/opt/renfield-satellite/bin/xvf_host"
+    camera:
+      enabled: true              # IMX219 on CAM1 (see docs/design/a733-satellite-camera.md)
+      backend: sunxi_isp         # Orange Pi A733 AW-ISP capture (/opt/awisp/renfield_isp_capture)
+      resolution: "1920x1080"
+      quality: 85
     button:
       gpio_pin: 17                # no button wired; degrades to no-op without GPIO libs
     ble:

--- a/src/satellite/provisioning/templates/satellite.yaml.j2
+++ b/src/satellite/provisioning/templates/satellite.yaml.j2
@@ -113,6 +113,9 @@ display:
 
 camera:
   enabled: {{ camera_enabled | default(false) | lower }}
+  backend: {{ camera_backend | default('rpicam') }}
+  resolution: "{{ camera_resolution | default('1280x720') }}"
+  quality: {{ camera_quality | default(85) }}
 
 button:
   gpio_pin: {{ button_gpio_pin }}

--- a/src/satellite/renfield_satellite/config.py
+++ b/src/satellite/renfield_satellite/config.py
@@ -189,6 +189,7 @@ class CameraConfig:
     enabled: bool = False
     resolution: str = "1280x720"
     quality: int = 85
+    backend: str = "rpicam"  # "rpicam" (Pi) | "sunxi_isp" (Orange Pi A733 + AW ISP)
 
 
 @dataclass
@@ -399,6 +400,7 @@ def load_config(config_path: Optional[str] = None) -> Config:
         config.camera.enabled = cam.get("enabled", config.camera.enabled)
         config.camera.resolution = cam.get("resolution", config.camera.resolution)
         config.camera.quality = cam.get("quality", config.camera.quality)
+        config.camera.backend = cam.get("backend", config.camera.backend)
 
     if "ble" in config_data:
         ble = config_data["ble"]

--- a/src/satellite/renfield_satellite/hardware/camera.py
+++ b/src/satellite/renfield_satellite/hardware/camera.py
@@ -1,52 +1,67 @@
 """
 Camera Controller for Renfield Satellite
 
-Captures JPEG snapshots via rpicam-still subprocess.
-Used for visual queries — snapshot taken at wakeword detection,
-sent alongside transcription to backend for Vision-LLM processing.
+Captures JPEG snapshots for visual queries + backend occupancy checks — snapshot
+taken on a backend `capture_snapshot` request, sent for Vision-LLM processing.
+
+Two capture backends, selected by config (`camera.backend`):
+  * "rpicam"    Raspberry Pi + Pi Camera via `rpicam-still` (the OS libcamera stack).
+  * "sunxi_isp" Orange Pi A733 (Esszimmer) + MIPI-CSI camera. Plain V4L2/OpenCV can't
+                capture on sunxi-vin (the Allwinner ISP must run), so this shells out to
+                `/opt/awisp/renfield_isp_capture` (which starts the AW ISP + does the
+                mplane grab → raw I420) and converts I420 → JPEG here. The tool + AW ISP
+                libs are hostPath-mounted into the pod at /opt/awisp
+                (k8s/satellite-esszimmer.yaml). See docs/design/a733-satellite-camera.md.
+
+Both return JPEG bytes, so the caller (`_capture_snapshot_for_request` → the WS
+`snapshot_result`) is backend-agnostic.
 """
 
 import asyncio
+import os
 import shutil
 import tempfile
 from pathlib import Path
 from typing import Optional
 
+# A733 sunxi_isp backend: the capture tool + Allwinner ISP libs (hostPath-mounted).
+_ISP_BIN = "/opt/awisp/renfield_isp_capture"
+_ISP_LIBS = "/opt/awisp/lib"
+_ISP_WARMUP = 8  # frames skipped for ISP 3A (auto-exposure/white-balance) to settle
+
 
 class CameraController:
-    """
-    Camera controller using rpicam-still subprocess.
+    """open() -> bool init, close() cleanup, capture() -> JPEG bytes | None. Graceful
+    degradation when the camera/tooling is absent (capture returns None)."""
 
-    Follows the same pattern as DisplayController/LEDController:
-    open() -> bool for initialization, close() for cleanup,
-    graceful degradation when hardware is not available.
-    """
-
-    def __init__(self, resolution: str = "1280x720", quality: int = 85):
+    def __init__(self, resolution: str = "1280x720", quality: int = 85,
+                 backend: str = "rpicam"):
         self.resolution = resolution
         self.quality = quality
+        self.backend = backend
         self._available = False
         self._tmp_dir: Optional[str] = None
 
     def open(self) -> bool:
-        """Check if rpicam-still is available on this system."""
-        if shutil.which("rpicam-still") is None:
+        """Verify the selected backend is usable + set up a scratch dir."""
+        if self.backend == "sunxi_isp":
+            if not os.path.exists(_ISP_BIN):
+                print(f"Camera: sunxi_isp backend but {_ISP_BIN} not found "
+                      "(is /opt/awisp mounted? see a733-satellite-camera.md)")
+                return False
+        elif shutil.which("rpicam-still") is None:
             print("Camera: rpicam-still not found")
             return False
 
         self._tmp_dir = tempfile.mkdtemp(prefix="renfield-cam-")
         self._available = True
-        print(f"Camera initialized (resolution={self.resolution}, quality={self.quality})")
+        print(f"Camera initialized (backend={self.backend}, resolution={self.resolution}, "
+              f"quality={self.quality})")
         return True
 
     def close(self):
-        """Clean up temporary directory."""
         if self._tmp_dir:
-            try:
-                import shutil as _shutil
-                _shutil.rmtree(self._tmp_dir, ignore_errors=True)
-            except Exception:
-                pass
+            shutil.rmtree(self._tmp_dir, ignore_errors=True)
             self._tmp_dir = None
         self._available = False
 
@@ -55,53 +70,91 @@ class CameraController:
         return self._available
 
     async def capture(self) -> Optional[bytes]:
-        """
-        Capture a JPEG snapshot.
-
-        Runs rpicam-still in a subprocess (non-blocking).
-        Returns JPEG bytes on success, None on failure.
-        """
+        """Capture a JPEG snapshot (non-blocking). Returns JPEG bytes or None."""
         if not self._available or not self._tmp_dir:
             return None
+        if self.backend == "sunxi_isp":
+            return await self._capture_isp()
+        return await self._capture_rpicam()
 
+    # ── rpicam (Raspberry Pi) ─────────────────────────────────────────────────
+    async def _capture_rpicam(self) -> Optional[bytes]:
         output_path = str(Path(self._tmp_dir) / "snapshot.jpg")
         width, height = self.resolution.split("x")
-
         cmd = [
-            "rpicam-still",
-            "--immediate",
-            "--nopreview",
-            "--width", width,
-            "--height", height,
-            "--quality", str(self.quality),
-            "-o", output_path,
+            "rpicam-still", "--immediate", "--nopreview",
+            "--width", width, "--height", height,
+            "--quality", str(self.quality), "-o", output_path,
         ]
-
         try:
             proc = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdout=asyncio.subprocess.DEVNULL,
-                stderr=asyncio.subprocess.PIPE,
-            )
+                *cmd, stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.PIPE)
             _, stderr = await asyncio.wait_for(proc.communicate(), timeout=10.0)
-
             if proc.returncode != 0:
-                err_msg = stderr.decode(errors="replace").strip() if stderr else "unknown error"
-                print(f"Camera capture failed (rc={proc.returncode}): {err_msg}")
+                err = stderr.decode(errors="replace").strip() if stderr else "unknown error"
+                print(f"Camera capture failed (rc={proc.returncode}): {err}")
                 return None
-
             path = Path(output_path)
             if not path.exists():
                 print("Camera capture failed: output file not created")
                 return None
-
             jpeg_bytes = path.read_bytes()
-            print(f"Camera captured {len(jpeg_bytes)} bytes")
+            print(f"Camera captured {len(jpeg_bytes)} bytes (rpicam)")
             return jpeg_bytes
-
         except asyncio.TimeoutError:
             print("Camera capture timed out (10s)")
             return None
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             print(f"Camera capture error: {e}")
             return None
+
+    # ── sunxi_isp (Orange Pi A733) ────────────────────────────────────────────
+    async def _capture_isp(self) -> Optional[bytes]:
+        raw = str(Path(self._tmp_dir) / "frame.i420")
+        width, height = self.resolution.split("x")
+        env = {**os.environ, "LD_LIBRARY_PATH": _ISP_LIBS}
+        cmd = [_ISP_BIN, "/dev/video0", width, height, raw, str(_ISP_WARMUP)]
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd, env=env, stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.PIPE)
+            _, stderr = await asyncio.wait_for(proc.communicate(), timeout=20.0)
+            path = Path(raw)
+            if proc.returncode != 0 or not path.exists() or path.stat().st_size == 0:
+                err = stderr.decode(errors="replace").strip() if stderr else ""
+                print(f"Camera capture failed (isp rc={proc.returncode}): {err[-200:]}")
+                return None
+            jpeg_bytes = await asyncio.to_thread(
+                self._i420_to_jpeg, path.read_bytes(), int(width), int(height), self.quality)
+            if jpeg_bytes:
+                print(f"Camera captured {len(jpeg_bytes)} bytes (sunxi_isp {width}x{height})")
+            return jpeg_bytes
+        except asyncio.TimeoutError:
+            print("Camera capture timed out (20s, isp)")
+            return None
+        except Exception as e:  # noqa: BLE001
+            print(f"Camera capture error (isp): {e}")
+            return None
+
+    @staticmethod
+    def _i420_to_jpeg(buf: bytes, w: int, h: int, quality: int) -> Optional[bytes]:
+        """Raw I420 (Y, then U, then V at w/2×h/2) → JPEG bytes (BT.601)."""
+        import io
+        import numpy as np
+        from PIL import Image
+        ysz, csz = w * h, (w // 2) * (h // 2)
+        if len(buf) < ysz + 2 * csz:
+            return None
+        a = np.frombuffer(buf, dtype=np.uint8)
+        Y = a[:ysz].reshape(h, w).astype(np.float32)
+        U = a[ysz:ysz + csz].reshape(h // 2, w // 2).astype(np.float32) - 128.0
+        V = a[ysz + csz:ysz + 2 * csz].reshape(h // 2, w // 2).astype(np.float32) - 128.0
+        U = np.repeat(np.repeat(U, 2, 0), 2, 1)
+        V = np.repeat(np.repeat(V, 2, 0), 2, 1)
+        R = (Y + 1.402 * V).clip(0, 255)
+        G = (Y - 0.344 * U - 0.714 * V).clip(0, 255)
+        B = (Y + 1.772 * U).clip(0, 255)
+        rgb = np.stack([R, G, B], axis=2).astype(np.uint8)
+        out = io.BytesIO()
+        Image.fromarray(rgb, "RGB").save(out, format="JPEG", quality=quality)
+        return out.getvalue()

--- a/src/satellite/renfield_satellite/satellite.py
+++ b/src/satellite/renfield_satellite/satellite.py
@@ -204,6 +204,7 @@ class Satellite:
             self.camera = CameraController(
                 resolution=self.config.camera.resolution,
                 quality=self.config.camera.quality,
+                backend=self.config.camera.backend,
             )
 
         # Enviro pHAT sensor (optional)

--- a/tests/satellite/test_camera_backend.py
+++ b/tests/satellite/test_camera_backend.py
@@ -1,0 +1,68 @@
+"""Tests for the satellite CameraController capture backends (rpicam vs sunxi_isp).
+
+The A733 (Esszimmer) can't capture via rpicam — it uses the sunxi_isp backend
+(/opt/awisp/renfield_isp_capture → I420 → JPEG). These pin the config-driven backend
+selection + the I420→JPEG conversion so a regression is caught here, not by a dark camera.
+No hardware: open() only checks tool availability; capture() is not exercised.
+"""
+
+import io
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from renfield_satellite.hardware.camera import CameraController
+
+
+class TestBackendSelection:
+    @pytest.mark.satellite
+    def test_rpicam_unavailable_when_binary_missing(self):
+        with patch("shutil.which", return_value=None):
+            assert CameraController(backend="rpicam").open() is False
+
+    @pytest.mark.satellite
+    def test_rpicam_available_when_binary_present(self):
+        with patch("shutil.which", return_value="/usr/bin/rpicam-still"):
+            cam = CameraController(backend="rpicam")
+            assert cam.open() is True
+            assert cam.available is True
+            cam.close()
+
+    @pytest.mark.satellite
+    def test_isp_unavailable_when_tool_missing(self):
+        # sunxi_isp must NOT fall back to rpicam — it checks the ISP tool path.
+        with patch("os.path.exists", return_value=False):
+            assert CameraController(backend="sunxi_isp").open() is False
+
+    @pytest.mark.satellite
+    def test_isp_available_when_tool_present(self):
+        with patch("os.path.exists", return_value=True):
+            cam = CameraController(backend="sunxi_isp")
+            assert cam.open() is True
+            cam.close()
+
+
+class TestI420ToJpeg:
+    @staticmethod
+    def _synthetic_i420(w: int, h: int) -> bytes:
+        y = np.tile(np.linspace(0, 255, w, dtype=np.uint8), (h, 1)).tobytes()
+        u = np.full((h // 2, w // 2), 128, dtype=np.uint8).tobytes()
+        v = np.full((h // 2, w // 2), 96, dtype=np.uint8).tobytes()
+        return y + u + v
+
+    @pytest.mark.satellite
+    def test_produces_valid_jpeg_of_right_size(self):
+        pytest.importorskip("PIL")
+        from PIL import Image
+        w, h = 64, 48
+        jpeg = CameraController._i420_to_jpeg(self._synthetic_i420(w, h), w, h, 85)
+        assert jpeg is not None
+        assert jpeg[:2] == b"\xff\xd8"          # JPEG SOI marker
+        assert Image.open(io.BytesIO(jpeg)).size == (w, h)
+
+    @pytest.mark.satellite
+    def test_short_buffer_returns_none(self):
+        pytest.importorskip("PIL")
+        # a truncated frame must fail safe (None), never raise into the capture path
+        assert CameraController._i420_to_jpeg(b"\x00" * 10, 64, 48, 85) is None


### PR DESCRIPTION
## What

Wires the A733 camera **capture** into the satellite app, so the existing `capture_snapshot` flow (backend occupancy checks + visual queries) works on the Esszimmer — which can't use rpicam.

`CameraController` gains a **config-selected backend** (same `open()`/`capture()->JPEG` contract):
- **`rpicam`** (default, Pi) — unchanged `rpicam-still` path.
- **`sunxi_isp`** (Orange Pi A733) — shells out to `/opt/awisp/renfield_isp_capture` (starts the AW ISP + mplane grab → raw I420) and converts **I420→JPEG** (numpy + Pillow). The WS `snapshot_result` path stays backend-agnostic.

## Changes

- `config.py`: `CameraConfig.backend` (`rpicam`|`sunxi_isp`) + yaml parse.
- `satellite.py`: pass `backend` to `CameraController`.
- `templates/satellite.yaml.j2`: render `camera.backend/resolution/quality` (matches the `camera_backend` var from `provision-camera.yml`).
- `k8s/satellite-esszimmer.yaml` ConfigMap: **enable the camera** (`backend: sunxi_isp`, 1920×1080) — the pod's config source.
- `tests/satellite/test_camera_backend.py`: backend selection (no cross-fallback) + I420→JPEG (valid JPEG of the right size; short buffer → None).

## Scope

This is the **capture** path — immediately useful via the backend's existing vision-LLM occupancy/visual-query features. On-device **NPU occupancy/gesture detection** stays prototype (needs the NBG model + the `non-verbal-communication.md` rollout).

## Deploy (activates it)

Rebuild the esszimmer satellite image (v8→v9) natively on the node + `ctr` import, apply the ConfigMap, restart the pod. Camera hardware/ISP/mounts are already live (#1085–#1087).

## Tests

4 pass locally; the 2 I420→JPEG cases run on `.159` (Pillow). `@pytest.mark.satellite`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vEy3T6JbZ1yEtH1VWT4Lp