### PR TITLE
chore(k8s): bump Esszimmer satellite image to v9 (sunxi_isp camera)

### DIFF
--- a/k8s/satellite-esszimmer.yaml
+++ b/k8s/satellite-esszimmer.yaml
@@ -127,7 +127,7 @@ spec:
                     values: ["arm64"]
       containers:
         - name: satellite
-          image: renfield/satellite:esszimmer-v8
+          image: renfield/satellite:esszimmer-v9
           imagePullPolicy: Never   # imported into node containerd (k8s.io ns)
           securityContext:
             privileged: true        # raw /dev access for USB audio + xvf_host


### PR DESCRIPTION
Reconciles the live image tag (v8→v9) into git after the sunxi_isp camera deploy (#1088). v9 is built on the node + ctr-imported; verified in-pod (1080p JPEG capture, 33999 bytes). 🤖 Generated with [Claude Code](https://claude.com/claude-code)