### PR TITLE
feat(satellite): sunxi GPIO backend for the SPI display (Orange Pi A733)

### DIFF
--- a/docs/design/a733-satellite-display.md
+++ b/docs/design/a733-satellite-display.md
@@ -1,0 +1,71 @@
+# A733 (Orange Pi Zero 3W) satellite SPI display — bring-up reference
+
+**Status: software port DONE, hardware not yet attached (2026-08-10).** The satellite's
+`ST7789Display` driver is now Orange-Pi-capable; attaching a small SPI TFT needs the
+physical wiring + the pin/overlay values filled in and an on-board test. Mirrors the camera
+bring-up (`a733-satellite-camera.md`): the *hardware* fits (Pi-compatible header), the
+*driver/GPIO layer* is where the Pi ecosystem stops.
+
+## Why it's mostly reuse
+
+- The board's 40-pin header is **Pi-pin-function-compatible** (schematic sheet 18): SPI0 on
+  pins 19/21/23/24/26, I2C on 3/5, plenty of GPIO, 3V3/5V/GND on the Pi positions. A Pi SPI
+  display HAT mates mechanically and the signals land on the right pins.
+- The satellite already ships an **`ST7789Display`** SPI driver (Whisplay HAT). It's now
+  **config-driven** (`gpio_backend`, `spi_bus/device/speed`, `dc/rst/bl` pins, `gpiochip`).
+
+## The one real gap: GPIO backend (gpiozero → libgpiod)
+
+gpiozero is Raspberry-Pi / **BCM-numbered** and can't drive Allwinner pins. So `display.py`
+gained a **`sunxi` backend**: DC/RST/BL via **`python-periphery`** (libgpiod) by `(gpiochip,
+line-offset)`, exposing the same `.on()/.off()/.value` surface — the rest of the driver is
+unchanged. `spidev` + `python-periphery` are in the satellite image (Dockerfile). Backlight
+is **on/off** on sunxi (no dimming — a PWM pin + overlay would be needed for that).
+
+## Attaching a display — steps
+
+1. **Pick a display:** a small SPI TFT — ST7789 240×280 (same as Whisplay, zero-code) or
+   ILI9341 320×240 (needs an ILI9341 init sequence variant). 4-wire SPI + DC + RST + BL.
+2. **Wire to the 40-pin header:** SCLK→23, MOSI→19, CS0→24, plus 3V3→1 (or 5V→2 per panel),
+   GND→any GND. Choose GPIO header pins for **DC**, **RST**, **BL** (e.g. 22/13/12) — note
+   which Allwinner pin each is (from schematic sheet 18: e.g. pin 22 = a `PD0/PE0` line).
+3. **Enable SPI (device-tree overlay):** the BSP ships `spi1-cs0-spidev` / `spi2-cs0-spidev`
+   overlays. Add the matching one to `overlays=` in `/boot/orangepiEnv.txt`, reboot, confirm
+   `/dev/spidevX.Y` appears. Set `spi_bus`/`spi_device` to X/Y.
+4. **Find the GPIO line offsets:** on the board, `gpiodetect` + `gpioinfo` — the main pinctrl
+   is one `gpiochipN`. A line offset ≈ `bank_index*32 + pin` (PA=0,PB=1,…PE=4,…), e.g. `PE2`
+   = 4*32+2 = 130 — **verify against `gpioinfo` line names on the actual board.** Put the
+   offsets in `dc_pin`/`rst_pin`/`bl_pin` and the chip in `gpiochip`.
+5. **Mount into the pod** (`k8s/satellite-esszimmer.yaml`, like the camera): hostPath
+   `/dev/spidevX.Y` (CharDevice) + `/dev/gpiochipN` (CharDevice).
+6. **Config** — the Esszimmer ConfigMap `display:` section:
+   ```yaml
+   display:
+     enabled: true
+     gpio_backend: sunxi
+     width: 240
+     height: 280
+     spi_bus: 1            # the /dev/spidevX.Y from step 3
+     spi_device: 0
+     dc_pin: 130          # gpiochip line offsets from step 4
+     rst_pin: 131
+     bl_pin: 132
+     gpiochip: "/dev/gpiochip0"
+   ```
+   (Bare-metal Pi satellites keep `gpio_backend: rpi` + BCM pins — byte-identical default.)
+7. **Rebuild the satellite image (v9→v10)** with the updated code, `ctr` import, apply,
+   restart — then verify the render on the panel.
+
+## Host provisioning (reproducible)
+
+The spidev overlay + gpio access are host-side — fold into `provision-camera.yml`'s pattern
+(a `display`/`spidev` task branch) or add a small `provision-display.yml`, driven off
+`display_enabled` + `display_gpio_backend` (already in the Ansible template + group_vars
+model). The `python-periphery`/`spidev` runtime is in the image, not the host.
+
+## What's done vs pending
+
+- ✅ Driver config-driven + sunxi (libgpiod) GPIO backend; `spidev`+`periphery` in the image;
+  config fields + parse + Ansible template. `gpio_backend` defaults to `rpi` (Pi unaffected).
+- ⏳ Physical display + wiring + the exact `/dev/spidevX.Y` + gpiochip line offsets + overlay,
+  the ConfigMap `display:` block, and an on-board render test. ILI9341 needs its init variant.

--- a/src/satellite/Dockerfile
+++ b/src/satellite/Dockerfile
@@ -64,7 +64,12 @@ RUN pip3 install --break-system-packages \
         cryptography \
         Pillow \
         "opuslib>=3.0.1" \
+        spidev \
+        python-periphery \
     && pip3 install --break-system-packages --no-deps openwakeword
+# spidev + python-periphery: SPI TFT display support on the A733 (sunxi gpio_backend
+# drives DC/RST/BL via libgpiod/periphery, not gpiozero/BCM). No-op unless a display is
+# configured + wired. See docs/design/a733-satellite-display.md.
 
 # --- Wake word + VAD models (baked) ---
 # openWakeWord base feature models + a builtin keyword, plus Silero VAD.

--- a/src/satellite/provisioning/templates/satellite.yaml.j2
+++ b/src/satellite/provisioning/templates/satellite.yaml.j2
@@ -108,8 +108,16 @@ led:
 
 display:
   enabled: {{ display_enabled | default(false) | lower }}
-  width: 240
-  height: 280
+  width: {{ display_width | default(240) }}
+  height: {{ display_height | default(280) }}
+  gpio_backend: {{ display_gpio_backend | default('rpi') }}   # rpi (gpiozero/BCM) | sunxi (libgpiod)
+  spi_bus: {{ display_spi_bus | default(0) }}
+  spi_device: {{ display_spi_device | default(0) }}
+  spi_speed_hz: {{ display_spi_speed_hz | default(80000000) }}
+  dc_pin: {{ display_dc_pin | default(27) }}     # BCM (rpi) | gpiochip line offset (sunxi)
+  rst_pin: {{ display_rst_pin | default(4) }}
+  bl_pin: {{ display_bl_pin | default(22) }}
+  gpiochip: "{{ display_gpiochip | default('/dev/gpiochip0') }}"
 
 camera:
   enabled: {{ camera_enabled | default(false) | lower }}

--- a/src/satellite/renfield_satellite/config.py
+++ b/src/satellite/renfield_satellite/config.py
@@ -177,10 +177,20 @@ class ButtonConfig:
 
 @dataclass
 class DisplayConfig:
-    """Display settings (Whisplay HAT ST7789)"""
+    """Display settings (SPI TFT — ST7789/ILI9341). gpio_backend selects the pin
+    driver: 'rpi' (gpiozero/BCM, Whisplay on a Pi) or 'sunxi' (libgpiod, Orange Pi
+    A733 — dc/rst/bl are line offsets on `gpiochip`)."""
     enabled: bool = False
     width: int = 240
     height: int = 280
+    gpio_backend: str = "rpi"
+    spi_bus: int = 0
+    spi_device: int = 0
+    spi_speed_hz: int = 80_000_000
+    dc_pin: int = 27
+    rst_pin: int = 4
+    bl_pin: int = 22
+    gpiochip: str = "/dev/gpiochip0"
 
 
 @dataclass
@@ -394,6 +404,14 @@ def load_config(config_path: Optional[str] = None) -> Config:
         config.display.enabled = disp.get("enabled", config.display.enabled)
         config.display.width = disp.get("width", config.display.width)
         config.display.height = disp.get("height", config.display.height)
+        config.display.gpio_backend = disp.get("gpio_backend", config.display.gpio_backend)
+        config.display.spi_bus = disp.get("spi_bus", config.display.spi_bus)
+        config.display.spi_device = disp.get("spi_device", config.display.spi_device)
+        config.display.spi_speed_hz = disp.get("spi_speed_hz", config.display.spi_speed_hz)
+        config.display.dc_pin = disp.get("dc_pin", config.display.dc_pin)
+        config.display.rst_pin = disp.get("rst_pin", config.display.rst_pin)
+        config.display.bl_pin = disp.get("bl_pin", config.display.bl_pin)
+        config.display.gpiochip = disp.get("gpiochip", config.display.gpiochip)
 
     if "camera" in config_data:
         cam = config_data["camera"]

--- a/src/satellite/renfield_satellite/hardware/display.py
+++ b/src/satellite/renfield_satellite/hardware/display.py
@@ -25,6 +25,50 @@ except ImportError:
     PWMLED = None
     GPIO_AVAILABLE = False
 
+
+# ── sunxi GPIO backend (Orange Pi A733 etc.) ──────────────────────────────────
+# gpiozero is Raspberry-Pi / BCM-numbered and does NOT map to Allwinner pins. On
+# a sunxi board the DC/RST/backlight lines are driven via libgpiod by (gpiochip,
+# line-offset) — python-periphery gives a clean, version-stable API. These shims
+# mimic the gpiozero OutputDevice/PWMLED surface the ST7789 driver uses
+# (.on()/.off()/.value/.close()), so the rest of the driver is backend-agnostic.
+# NOTE: backlight is on/off here (no dimming) — sunxi PWM dimming needs a hardware
+# PWM pin + overlay; wire BL to a plain GPIO for now. Validate pins on-board.
+class _SunxiOut:
+    """A single output line via python-periphery (libgpiod)."""
+    def __init__(self, gpiochip: str, line: int):
+        from periphery import GPIO
+        self._g = GPIO(gpiochip, int(line), "out")
+        self._g.write(False)
+
+    def on(self):
+        self._g.write(True)
+
+    def off(self):
+        self._g.write(False)
+
+    def close(self):
+        try:
+            self._g.close()
+        except Exception:
+            pass
+
+
+class _SunxiBacklight(_SunxiOut):
+    """Backlight line exposing a gpiozero-PWMLED-like `.value` (thresholded on/off)."""
+    def __init__(self, gpiochip: str, line: int):
+        super().__init__(gpiochip, line)
+        self._value = 0.0
+
+    @property
+    def value(self) -> float:
+        return self._value
+
+    @value.setter
+    def value(self, v: float):
+        self._value = max(0.0, min(1.0, float(v)))
+        self._g.write(self._value > 0.05)   # on/off (no dimming without a PWM pin)
+
 try:
     from PIL import Image, ImageDraw, ImageFont
     PIL_AVAILABLE = True
@@ -78,6 +122,8 @@ class ST7789Display:
         dc_pin: int = 27,
         rst_pin: int = 4,
         bl_pin: int = 22,
+        gpio_backend: str = "rpi",          # "rpi" (gpiozero/BCM) | "sunxi" (libgpiod)
+        gpiochip: str = "/dev/gpiochip0",   # sunxi backend: DC/RST/BL are line offsets on this chip
     ):
         self.width = width
         self.height = height
@@ -87,6 +133,8 @@ class ST7789Display:
         self.dc_pin = dc_pin
         self.rst_pin = rst_pin
         self.bl_pin = bl_pin
+        self.gpio_backend = gpio_backend
+        self.gpiochip = gpiochip
 
         self._spi: Optional["spidev.SpiDev"] = None
         self._dc: Optional["OutputDevice"] = None
@@ -95,14 +143,23 @@ class ST7789Display:
 
     def open(self) -> bool:
         """Initialize SPI and GPIO, run display init sequence."""
-        if not SPI_AVAILABLE or not GPIO_AVAILABLE:
-            print("Display: spidev or gpiozero not available")
+        if not SPI_AVAILABLE:
+            print("Display: spidev not available")
             return False
 
         try:
-            self._dc = OutputDevice(self.dc_pin)
-            self._rst = OutputDevice(self.rst_pin)
-            self._bl = PWMLED(self.bl_pin, initial_value=0)
+            if self.gpio_backend == "sunxi":
+                # Allwinner: DC/RST/BL are (gpiochip, line) via libgpiod/periphery.
+                self._dc = _SunxiOut(self.gpiochip, self.dc_pin)
+                self._rst = _SunxiOut(self.gpiochip, self.rst_pin)
+                self._bl = _SunxiBacklight(self.gpiochip, self.bl_pin)
+            else:
+                if not GPIO_AVAILABLE:
+                    print("Display: gpiozero not available (rpi backend)")
+                    return False
+                self._dc = OutputDevice(self.dc_pin)
+                self._rst = OutputDevice(self.rst_pin)
+                self._bl = PWMLED(self.bl_pin, initial_value=0)
 
             self._spi = spidev.SpiDev()
             self._spi.open(self.spi_bus, self.spi_device)
@@ -248,10 +305,14 @@ class DisplayController:
     ST7789 display. Uses a background thread to avoid blocking.
     """
 
-    def __init__(self, width: int = 240, height: int = 280, room: str = ""):
+    def __init__(self, width: int = 240, height: int = 280, room: str = "",
+                 hw: Optional[dict] = None):
         self.width = width
         self.height = height
         self.room = room
+        # Hardware settings passed to ST7789Display (gpio_backend/spi_bus/spi_device/
+        # spi_speed_hz/dc_pin/rst_pin/bl_pin/gpiochip). Empty = Pi/gpiozero defaults.
+        self._hw = hw or {}
 
         self._display: Optional[ST7789Display] = None
         self._lock = threading.Lock()
@@ -265,7 +326,7 @@ class DisplayController:
             print("Display: Pillow not installed")
             return False
 
-        self._display = ST7789Display(width=self.width, height=self.height)
+        self._display = ST7789Display(width=self.width, height=self.height, **self._hw)
         if not self._display.open():
             self._display = None
             return False

--- a/src/satellite/renfield_satellite/satellite.py
+++ b/src/satellite/renfield_satellite/satellite.py
@@ -195,6 +195,16 @@ class Satellite:
             self.display = DisplayController(
                 width=self.config.display.width,
                 height=self.config.display.height,
+                hw={
+                    "gpio_backend": self.config.display.gpio_backend,
+                    "spi_bus": self.config.display.spi_bus,
+                    "spi_device": self.config.display.spi_device,
+                    "spi_speed_hz": self.config.display.spi_speed_hz,
+                    "dc_pin": self.config.display.dc_pin,
+                    "rst_pin": self.config.display.rst_pin,
+                    "bl_pin": self.config.display.bl_pin,
+                    "gpiochip": self.config.display.gpiochip,
+                },
                 room=self.config.satellite.room,
             )
 

--- a/tests/satellite/test_display_backend.py
+++ b/tests/satellite/test_display_backend.py
@@ -1,0 +1,60 @@
+"""Tests for the config-driven SPI-display backend (rpi gpiozero vs sunxi libgpiod).
+
+The A733 (Orange Pi) drives the SPI TFT's DC/RST/BL via libgpiod (gpio_backend=sunxi),
+not gpiozero/BCM. These pin the config plumbing + back-compat so a Pi satellite stays
+byte-identical and the Orange Pi gets the right pins. No hardware: open() is not called
+(that's where periphery/spidev would touch /dev).
+"""
+
+import pytest
+
+from renfield_satellite.config import Config, load_config
+from renfield_satellite.hardware.display import ST7789Display, DisplayController
+
+
+class TestDisplayConfigDefaults:
+    @pytest.mark.satellite
+    def test_defaults_are_rpi_backcompat(self):
+        cfg = Config()
+        assert cfg.display.gpio_backend == "rpi"        # Pi satellites unchanged
+        assert cfg.display.spi_bus == 0 and cfg.display.spi_device == 0
+        assert (cfg.display.dc_pin, cfg.display.rst_pin, cfg.display.bl_pin) == (27, 4, 22)
+
+
+class TestDisplayConfigParse:
+    @pytest.mark.satellite
+    def test_parses_sunxi_display_block(self, tmp_path):
+        p = tmp_path / "satellite.yaml"
+        p.write_text(
+            "satellite:\n  id: sat-x\n  room: X\n"
+            "display:\n"
+            "  enabled: true\n  gpio_backend: sunxi\n  spi_bus: 1\n  spi_device: 0\n"
+            "  dc_pin: 130\n  rst_pin: 131\n  bl_pin: 132\n  gpiochip: /dev/gpiochip0\n"
+        )
+        cfg = load_config(str(p))
+        assert cfg.display.enabled is True
+        assert cfg.display.gpio_backend == "sunxi"
+        assert cfg.display.spi_bus == 1
+        assert (cfg.display.dc_pin, cfg.display.rst_pin, cfg.display.bl_pin) == (130, 131, 132)
+        assert cfg.display.gpiochip == "/dev/gpiochip0"
+
+
+class TestST7789Backend:
+    @pytest.mark.satellite
+    def test_construction_carries_sunxi_settings(self):
+        d = ST7789Display(width=240, height=280, gpio_backend="sunxi",
+                          gpiochip="/dev/gpiochip0", dc_pin=130, rst_pin=131, bl_pin=132,
+                          spi_bus=1, spi_device=0)
+        assert d.gpio_backend == "sunxi"
+        assert d.gpiochip == "/dev/gpiochip0"
+        assert (d.dc_pin, d.rst_pin, d.bl_pin) == (130, 131, 132)
+        assert d.spi_bus == 1
+
+    @pytest.mark.satellite
+    def test_controller_passes_hw_through(self):
+        # DisplayController must forward hw settings into ST7789Display at open() time.
+        ctrl = DisplayController(width=240, height=280,
+                                 hw={"gpio_backend": "sunxi", "gpiochip": "/dev/gpiochip1",
+                                     "dc_pin": 5})
+        assert ctrl._hw["gpio_backend"] == "sunxi"
+        assert ctrl._hw["gpiochip"] == "/dev/gpiochip1"


### PR DESCRIPTION
## What

Prepares the satellite app to drive a **small SPI TFT display on the Orange Pi A733** (Esszimmer). The board's 40-pin header is Pi-pin-compatible, and the satellite already has an `ST7789Display` SPI driver — the only real gap was the GPIO layer (gpiozero is BCM/Pi-specific). This is the software port; wiring + on-board test come when the display is attached.

## Changes

- **`display.py`** — `ST7789Display` is now config-driven (`gpio_backend`, `spi_bus/device/speed`, `dc/rst/bl`, `gpiochip`). New **`sunxi`** backend drives DC/RST/BL via **`python-periphery`** (libgpiod) by `(gpiochip, line-offset)`, same `.on()/.off()/.value` surface — rest of the driver unchanged. `rpi` (gpiozero) stays default → **Pi satellites byte-identical**. (Backlight on/off on sunxi; PWM dimming needs a hw PWM pin.)
- **`config.py`** — `DisplayConfig` fields + parse; **`satellite.py`** threads them via `hw={}`.
- **`Dockerfile`** — add `spidev` + `python-periphery` (Orange Pi image; no-op unless a display is wired).
- **`satellite.yaml.j2`** — render the display hw fields (default rpi).
- **`docs/design/a733-satellite-display.md`** — bring-up plan (wiring → spidev overlay → gpiochip line offsets → pod mounts → ConfigMap block → rebuild).
- **tests** — defaults/back-compat + sunxi config parse + hw threading (run on `.159`, like the config tests).

## Scope

Software port only. **Pending** (the "attach" stage): pick the SPI TFT, wire DC/RST/BL to header pins, enable the spidev overlay, find the `/dev/spidevX.Y` + gpiochip line offsets, add the ConfigMap `display:` block, rebuild the image, and test the render on-board. ILI9341 would need its init-sequence variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vEy3T6JbZ1yEtH1VWT4Lp