### PR TITLE
feat(frontend): Connections page — per-user tool credentials

### DIFF
--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -33,6 +33,7 @@ const MemoryPage = lazy(() => import('./pages/MemoryPage'));
 const UsersPage = lazy(() => import('./pages/UsersPage'));
 const RolesPage = lazy(() => import('./pages/RolesPage'));
 const IntegrationsPage = lazy(() => import('./pages/IntegrationsPage'));
+const ConnectionsPage = lazy(() => import('./pages/ConnectionsPage'));
 const SettingsPage = lazy(() => import('./pages/SettingsPage'));
 const SatellitesPage = lazy(() => import('./pages/SatellitesPage'));
 const IntentsPage = lazy(() => import('./pages/IntentsPage'));
@@ -101,6 +102,7 @@ function AppRoutes() {
             } />
             <Route path="/chat" element={<Navigate to="/" replace />} />
             <Route path="/tasks" element={<TasksPage />} />
+            <Route path="/connections" element={<ConnectionsPage />} />
             {projectsEnabled && (
               <Route path="/projects" element={
                 <ProtectedRoute>

--- a/src/frontend/src/api/keys.ts
+++ b/src/frontend/src/api/keys.ts
@@ -19,6 +19,10 @@ export const STALE = {
  * key that starts with `['foo', ...]` (RQ uses prefix-match on tuples).
  */
 export const keys = {
+  connections: {
+    all: ['connections'] as const,
+    list: () => ['connections', 'list'] as const,
+  },
   memories: {
     all: ['memories'] as const,
     list: (category: string | null) => ['memories', 'list', { category }] as const,

--- a/src/frontend/src/api/resources/connections.ts
+++ b/src/frontend/src/api/resources/connections.ts
@@ -1,0 +1,69 @@
+/**
+ * Connections — per-user tool credentials (per-user data scoping).
+ *
+ * Talks to Reva's /api/connections. Secrets are write-only: the list never
+ * returns a token, only a `connected` boolean per provider.
+ */
+import { useQueryClient } from '@tanstack/react-query';
+import apiClient from '../../utils/axios';
+import { useApiQuery, useApiMutation } from '../hooks';
+import { keys, STALE } from '../keys';
+
+export interface ConnectionProvider {
+  provider_key: string;
+  display_name?: string;
+  descriptor?: string;
+  credential_type?: string;
+  read_only?: boolean;
+  mint_url?: string;
+  help?: string;
+  connected: boolean;
+}
+
+async function fetchConnections(): Promise<ConnectionProvider[]> {
+  const response = await apiClient.get<ConnectionProvider[]>('/api/connections');
+  return response.data ?? [];
+}
+
+async function connectRequest(input: { providerKey: string; secret: string }): Promise<void> {
+  await apiClient.put(`/api/connections/${encodeURIComponent(input.providerKey)}`, {
+    secret: input.secret,
+  });
+}
+
+async function disconnectRequest(providerKey: string): Promise<void> {
+  await apiClient.delete(`/api/connections/${encodeURIComponent(providerKey)}`);
+}
+
+export function useConnections() {
+  return useApiQuery<ConnectionProvider[]>(
+    {
+      queryKey: keys.connections.list(),
+      queryFn: fetchConnections,
+      staleTime: STALE.DEFAULT,
+    },
+    'connections.errors.load',
+  );
+}
+
+export function useConnect() {
+  const queryClient = useQueryClient();
+  return useApiMutation<void, { providerKey: string; secret: string }>(
+    {
+      mutationFn: connectRequest,
+      onSuccess: () => queryClient.invalidateQueries({ queryKey: keys.connections.all }),
+    },
+    'connections.errors.connect',
+  );
+}
+
+export function useDisconnect() {
+  const queryClient = useQueryClient();
+  return useApiMutation<void, string>(
+    {
+      mutationFn: disconnectRequest,
+      onSuccess: () => queryClient.invalidateQueries({ queryKey: keys.connections.all }),
+    },
+    'connections.errors.disconnect',
+  );
+}

--- a/src/frontend/src/components/Layout.tsx
+++ b/src/frontend/src/components/Layout.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import type { LucideIcon } from 'lucide-react';
 import {
   MessageSquare,
+  Plug,
   CheckSquare,
   Camera,
   Lightbulb,
@@ -90,6 +91,7 @@ const mainNavigationConfig: NavItemConfig[] = [
   // unified 3D scene with built-in search (D23, Option 3). Old chip
   // URLs and ?focus= deep-links redirect via App.tsx Route.
   { nameKey: 'nav.tasks', href: '/tasks', icon: CheckSquare, feature: 'tasks' },
+  { nameKey: 'nav.connections', href: '/connections', icon: Plug },
   { nameKey: 'nav.cameras', href: '/camera', icon: Camera, permission: ['cam.view', 'cam.full'], feature: 'cameras' },
 ];
 

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -34,8 +34,38 @@
     "clear": "Leeren",
     "daysShort": "{{days}}d"
   },
+  "connections": {
+    "title": "Verbindungen",
+    "subtitle": "Verbinde deine Werkzeuge, damit Reva in deinem Namen handelt — mit deinen eigenen Rechten, nicht mit einem geteilten Konto.",
+    "loading": "Verbindungen werden geladen…",
+    "empty": "Es sind keine verbindbaren Werkzeuge konfiguriert.",
+    "connect": "Verbinden",
+    "manage": "Verwalten",
+    "connectTitle": "{{name}} verbinden",
+    "manageTitle": "{{name}} verwalten",
+    "manageBody": "{{name}} ist verbunden. Token ersetzen oder Verbindung trennen.",
+    "defaultHelp": "Füge dein Zugriffstoken ein. Reva speichert es verschlüsselt und nutzt es nur, um in deinem Namen zu handeln.",
+    "mintLink": "Token erstellen",
+    "tokenLabel": "Zugriffstoken",
+    "tokenHint": "Reva zeigt es nach dem Speichern nicht wieder an. Du kannst es jederzeit im Werkzeug widerrufen.",
+    "save": "Verbindung speichern",
+    "saving": "Speichern…",
+    "disconnect": "Trennen",
+    "disconnecting": "Wird getrennt…",
+    "rotate": "Token ersetzen",
+    "status": {
+      "connected": "Verbunden",
+      "notConnected": "Nicht verbunden"
+    },
+    "errors": {
+      "load": "Deine Verbindungen konnten nicht geladen werden.",
+      "connect": "Die Verbindung konnte nicht gespeichert werden.",
+      "disconnect": "Die Verbindung konnte nicht getrennt werden."
+    }
+  },
   "nav": {
     "chat": "Chat",
+    "connections": "Verbindungen",
     "knowledge": "Wissen",
     "tasks": "Aufgaben",
     "projects": "Projekte",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -34,8 +34,38 @@
     "clear": "Clear",
     "daysShort": "{{days}}d"
   },
+  "connections": {
+    "title": "Connections",
+    "subtitle": "Connect your tools so Reva can act as you — with your own permissions, not a shared account.",
+    "loading": "Loading connections…",
+    "empty": "No connectable tools are configured.",
+    "connect": "Connect",
+    "manage": "Manage",
+    "connectTitle": "Connect {{name}}",
+    "manageTitle": "Manage {{name}}",
+    "manageBody": "{{name}} is connected. Replace the token or disconnect it.",
+    "defaultHelp": "Paste your access token. Reva stores it encrypted and only uses it to act as you.",
+    "mintLink": "Create a token",
+    "tokenLabel": "Access token",
+    "tokenHint": "Reva never shows it again after saving. You can revoke it anytime in the tool.",
+    "save": "Save connection",
+    "saving": "Saving…",
+    "disconnect": "Disconnect",
+    "disconnecting": "Disconnecting…",
+    "rotate": "Replace token",
+    "status": {
+      "connected": "Connected",
+      "notConnected": "Not connected"
+    },
+    "errors": {
+      "load": "Could not load your connections.",
+      "connect": "Could not save the connection.",
+      "disconnect": "Could not disconnect."
+    }
+  },
   "nav": {
     "chat": "Chat",
+    "connections": "Connections",
     "knowledge": "Knowledge",
     "tasks": "Tasks",
     "projects": "Projects",

--- a/src/frontend/src/pages/ConnectionsPage.tsx
+++ b/src/frontend/src/pages/ConnectionsPage.tsx
@@ -1,0 +1,204 @@
+/**
+ * Connections — per-user tool credentials (per-user data scoping).
+ *
+ * Lists connectable tools; the user pastes a per-user token so Reva acts as
+ * them (not a shared account). Secrets are write-only — the list only shows a
+ * connected/not-connected status. See docs/architecture/connections-ui-spec.md.
+ */
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Plug, ExternalLink, Loader2, CheckCircle2, Circle } from 'lucide-react';
+import PageHeader from '../components/PageHeader';
+import Modal from '../components/Modal';
+import Badge from '../components/Badge';
+import Alert from '../components/Alert';
+import {
+  useConnections,
+  useConnect,
+  useDisconnect,
+  type ConnectionProvider,
+} from '../api/resources/connections';
+
+export default function ConnectionsPage() {
+  const { t } = useTranslation();
+  const { data: providers, isLoading, isError, errorMessage } = useConnections();
+  const connect = useConnect();
+  const disconnect = useDisconnect();
+
+  // modal state: the provider being connected/managed, and the paste field
+  const [active, setActive] = useState<ConnectionProvider | null>(null);
+  const [mode, setMode] = useState<'connect' | 'manage'>('connect');
+  const [secret, setSecret] = useState('');
+
+  const open = (p: ConnectionProvider) => {
+    setActive(p);
+    setMode(p.connected ? 'manage' : 'connect');
+    setSecret('');
+    connect.reset?.();
+  };
+  const close = () => {
+    setActive(null);
+    setSecret('');
+  };
+
+  const submit = async () => {
+    if (!active || !secret.trim()) return;
+    await connect.mutateAsync({ providerKey: active.provider_key, secret: secret.trim() });
+    close();
+  };
+  const remove = async () => {
+    if (!active) return;
+    await disconnect.mutateAsync(active.provider_key);
+    close();
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <PageHeader
+        icon={Plug}
+        title={t('connections.title')}
+        subtitle={t('connections.subtitle')}
+      />
+
+      {isError && <Alert variant="error" className="mb-4">{errorMessage}</Alert>}
+
+      {isLoading ? (
+        <div className="flex items-center gap-2 text-gray-500 py-10 justify-center">
+          <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
+          {t('connections.loading')}
+        </div>
+      ) : (
+        <div className="card divide-y divide-gray-100 dark:divide-gray-700 p-0 overflow-hidden">
+          {(providers ?? []).map((p) => (
+            <div key={p.provider_key} className="flex items-center gap-4 px-5 py-4">
+              <div className="flex-1 min-w-0">
+                <div className="font-semibold text-gray-900 dark:text-gray-100">
+                  {p.display_name ?? p.provider_key}
+                </div>
+                {p.descriptor && (
+                  <div className="text-sm text-gray-500 dark:text-gray-400 truncate">
+                    {p.descriptor}
+                  </div>
+                )}
+              </div>
+              {p.connected ? (
+                <Badge color="green" icon={CheckCircle2}>{t('connections.status.connected')}</Badge>
+              ) : (
+                <Badge color="gray" icon={Circle}>{t('connections.status.notConnected')}</Badge>
+              )}
+              <button
+                type="button"
+                onClick={() => open(p)}
+                className={p.connected ? 'btn-secondary' : 'btn-primary'}
+              >
+                {p.connected ? t('connections.manage') : t('connections.connect')}
+              </button>
+            </div>
+          ))}
+          {(providers ?? []).length === 0 && (
+            <div className="px-5 py-10 text-center text-gray-500 dark:text-gray-400">
+              {t('connections.empty')}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Connect / manage modal */}
+      <Modal
+        isOpen={active !== null}
+        onClose={close}
+        title={
+          active
+            ? t(mode === 'manage' ? 'connections.manageTitle' : 'connections.connectTitle', {
+                name: active.display_name ?? active.provider_key,
+              })
+            : ''
+        }
+      >
+        {active && (
+          <div className="space-y-4">
+            {mode === 'connect' ? (
+              <>
+                <p className="text-sm text-gray-600 dark:text-gray-300">
+                  {active.help ?? t('connections.defaultHelp')}
+                  {active.mint_url && (
+                    <>
+                      {' '}
+                      <a
+                        href={active.mint_url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-primary-600 dark:text-primary-400 font-medium inline-flex items-center gap-1"
+                      >
+                        {t('connections.mintLink')}
+                        <ExternalLink className="w-3.5 h-3.5" aria-hidden="true" />
+                      </a>
+                    </>
+                  )}
+                </p>
+                <div>
+                  <label
+                    htmlFor="connection-token"
+                    className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+                  >
+                    {t('connections.tokenLabel')}
+                  </label>
+                  <input
+                    id="connection-token"
+                    type="password"
+                    autoComplete="off"
+                    className="input w-full"
+                    value={secret}
+                    onChange={(e) => setSecret(e.target.value)}
+                    aria-describedby="connection-token-hint"
+                  />
+                  <p id="connection-token-hint" className="text-xs text-gray-500 dark:text-gray-400 mt-1.5">
+                    {t('connections.tokenHint')}
+                  </p>
+                </div>
+                {connect.errorMessage && <Alert variant="error">{connect.errorMessage}</Alert>}
+                <div className="flex justify-end gap-2 pt-1">
+                  <button type="button" className="btn-secondary" onClick={close}>
+                    {t('common.cancel')}
+                  </button>
+                  <button
+                    type="button"
+                    className="btn-primary"
+                    disabled={!secret.trim() || connect.isPending}
+                    onClick={submit}
+                  >
+                    {connect.isPending ? t('connections.saving') : t('connections.save')}
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <p className="text-sm text-gray-600 dark:text-gray-300">
+                  {t('connections.manageBody', { name: active.display_name ?? active.provider_key })}
+                </p>
+                {disconnect.errorMessage && <Alert variant="error">{disconnect.errorMessage}</Alert>}
+                <div className="flex justify-between gap-2 pt-1">
+                  <button
+                    type="button"
+                    className="btn-danger"
+                    disabled={disconnect.isPending}
+                    onClick={remove}
+                  >
+                    {disconnect.isPending ? t('connections.disconnecting') : t('connections.disconnect')}
+                  </button>
+                  <button
+                    type="button"
+                    className="btn-primary"
+                    onClick={() => setMode('connect')}
+                  >
+                    {t('connections.rotate')}
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+      </Modal>
+    </div>
+  );
+}


### PR DESCRIPTION
## What
Adds the **`/connections`** page — where a user provisions their own per-user credential for a tool (per-user data scoping) so the agent acts **as them**, not a shared service account. Talks to the consumer's `/api/connections`.

## Design
Reviewed via `/plan-design-review` + `/plan-eng-review` (spec lives in the Reva repo: `docs/architecture/connections-ui-spec.md`):
- A **calm provider list** (not a card mosaic — App-UI rule), each row: name + descriptor, a status **Badge** (Connected / Not connected), and Connect/Manage.
- A **connect modal** (paste-token): masked **write-only** token field with a **visible label** + `aria-describedby` hint, a mint-link, and trust copy ("stored encrypted", "never shown again", "revoke anytime").
- **Manage**: replace token / disconnect.
- Loading / error / empty states; dark-mode; de/en i18n.
- Secrets are **write-only end to end** — the list API only returns a `connected` boolean, never a token.

## Files
- `api/resources/connections.ts` — `useConnections` / `useConnect` / `useDisconnect` + a `keys.connections` factory.
- `pages/ConnectionsPage.tsx` — the page.
- `App.tsx` route `/connections`; `Layout.tsx` nav (Plug icon); `en.json`/`de.json`.

Type-clean (`tsc --noEmit`: 0 errors in these files).

## Notes
- Backend is a Reva plugin (`/api/connections`, self-scoped, secrets in an AES-256-GCM vault). This PR is the platform-side page.
- Follow-ons: OAuth-redirect providers (P2); an **Expired** row state once the backend exposes `expires_at`; a Vitest/RTL test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)