### PR TITLE
fix(agent): include the date (with year) in build_time_context

### DIFF
--- a/src/backend/services/daypart_service.py
+++ b/src/backend/services/daypart_service.py
@@ -148,10 +148,14 @@ def get_daypart_info(_now: datetime | None = None) -> dict:
 
 
 def build_time_context(lang: str = "de") -> str:
-    """Build a short prompt string describing the current time-of-day.
+    """Build a short prompt string describing the current date + time-of-day.
 
-    Example (de): ``"ZEITKONTEXT: Aktuelle Zeit: 22:14 Uhr (Nacht, Donnerstag)"``
-    Example (en): ``"TIME CONTEXT: Current time: 22:14 (Night, Thursday)"``
+    Example (de): ``"ZEITKONTEXT: Heute ist Donnerstag, der 2026-06-11. Aktuelle Zeit: 22:14 Uhr (Nacht)."``
+    Example (en): ``"TIME CONTEXT: Today is Thursday, 2026-06-11. Current time: 22:14 (Night)."``
+
+    The **date (with year)** is included, not just the time-of-day: without it
+    the LLM invents a year from its training cutoff when asked "what's today"
+    or when reasoning about relative dates ("next week", scheduling windows).
 
     Wraps everything in try/except and returns "" on ANY error so the agent
     path can never be broken by this helper.
@@ -163,9 +167,16 @@ def build_time_context(lang: str = "de") -> str:
         label = _DAYPART_LABELS[lang_key][daypart]
         weekday = _WEEKDAYS[lang_key][now.weekday()]
         hhmm = now.strftime("%H:%M")
+        iso_date = now.strftime("%Y-%m-%d")
         if lang_key == "en":
-            return f"TIME CONTEXT: Current time: {hhmm} ({label}, {weekday})"
-        return f"ZEITKONTEXT: Aktuelle Zeit: {hhmm} Uhr ({label}, {weekday})"
+            return (
+                f"TIME CONTEXT: Today is {weekday}, {iso_date}. "
+                f"Current time: {hhmm} ({label})."
+            )
+        return (
+            f"ZEITKONTEXT: Heute ist {weekday}, der {iso_date}. "
+            f"Aktuelle Zeit: {hhmm} Uhr ({label})."
+        )
     except Exception as e:  # noqa: BLE001 — must never break the agent
         logger.warning(f"build_time_context failed, returning empty: {e}")
         return ""

--- a/tests/backend/test_daypart_service.py
+++ b/tests/backend/test_daypart_service.py
@@ -134,6 +134,7 @@ def test_build_time_context_de_contains_label():
         assert "Nacht" in out
         assert "Donnerstag" in out
         assert "22:14" in out
+        assert "2026-06-11" in out  # the date (with year) must be present
 
 
 def test_build_time_context_en_contains_label():
@@ -148,6 +149,7 @@ def test_build_time_context_en_contains_label():
         assert "Night" in out
         assert "Thursday" in out
         assert "22:14" in out
+        assert "2026-06-11" in out  # the date (with year) must be present
 
 
 def test_build_time_context_day_label_de():


### PR DESCRIPTION
## Problem

The `{time_context}` line injected into every agent prompt (`build_time_context` in `services/daypart_service.py`) carried only the **time-of-day + weekday**, not the **date**:

> `ZEITKONTEXT: Aktuelle Zeit: 22:14 Uhr (Nacht, Donnerstag)`

So when the agent is asked "what's today?" or reasons about relative dates ("next week", scheduling/deploy windows), it has nothing to anchor on and **invents a year from its training cutoff**. Observed downstream in Reva (a release/deploy assistant): it answered **"14. Juli 2025" on 2026-08-17**.

## Fix

Include the ISO date (with year) in the string:

- de: `ZEITKONTEXT: Heute ist Donnerstag, der 2026-06-11. Aktuelle Zeit: 22:14 Uhr (Nacht).`
- en: `TIME CONTEXT: Today is Thursday, 2026-06-11. Current time: 22:14 (Night).`

Still best-effort — returns `""` on any error, so the agent path can never be broken by this helper. The existing weekday/time/daypart substrings are preserved (backward-compatible for any consumer keying on them).

## Tests

`test_daypart_service.py` now asserts the date (`2026-06-11`) is present in both the de and en output; the empty-on-error and daypart-label tests are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)