### PR TITLE
fix(k8s): ollama requests both k8s-gpu-1 GPUs (was 1 → VRAM-starved router)

### DIFF
--- a/k8s/ollama.yaml
+++ b/k8s/ollama.yaml
@@ -96,11 +96,17 @@ spec:
             requests:
               cpu: "2"
               memory: 4Gi
-              nvidia.com/gpu: 1
+              # BOTH k8s-gpu-1 GPUs (5070 Ti + 5060 Ti = 32 GB). Previously 1,
+              # which pinned Ollama to a single card — so the vision model
+              # (qwen3-vl:8b, renfield PDF/paperless OCR) + embeddings filled it
+              # and the qwen3:14b agent-router load 500'd (VRAM), failing the
+              # Reva router over to the `general` role. Voice moved off gpu-1 to
+              # gpu-3 (renfield.io/role=voice-llm) to free the 2nd card. 2026-08-17.
+              nvidia.com/gpu: 2
             limits:
               cpu: "6"
               memory: 16Gi
-              nvidia.com/gpu: 1
+              nvidia.com/gpu: 2
       volumes:
         - name: models
           hostPath:


### PR DESCRIPTION
Requesting both k8s-gpu-1 GPUs (5070 Ti + 5060 Ti = 32 GB). The manifest's own comment already assumed 32 GB, but the request/limit was nvidia.com/gpu: 1 → Ollama got one card. Under load it filled with the vision model (qwen3-vl:8b, PDF/paperless OCR) + embeddings and the qwen3:14b agent-router load 500'd on OOM, failing the Reva router over to the general role. Freeing the 2nd card required moving voice-server off gpu-1 back to k8s-gpu-3 (its voice-llm home) after gpu-3's passthrough driver was recovered (proprietary 595). Verified live: ollama sees 2 GPUs; qwen3:14b loads (200, was 500).

🤖 Generated with [Claude Code](https://claude.com/claude-code)