### PR TITLE
test: 28 rotten Backend-Tests gefixt — Suite komplett grün (5969/0)

### DIFF
--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -27,11 +27,13 @@ Plan: `~/.claude/plans/harmonic-toasting-toucan.md` (approved 2026-08-16). Dark 
 - [x] Frontend: PdfSplitReviewSection (contiguity-by-construction editing, opt-in thumbs, prop re-sync), StatusBadge split states (DESIGN warning tone), polling terminal states, i18n de/en/it
 - [x] Tests: 16 route/service + 6 RTL; 2 review cycles (10+1 findings fixed); full suite baseline-identical; rotten MeetingsPage test fixed (undici/jsdom File)
 
-## PR3 — VLM slow path
-- [ ] `PdfSplitTaskQueue` (stream `renfield:tasks:pdfsplit`), `workers/pdf_split_worker.py` (meeting-worker template, row heartbeat, poison → treat-as-single)
-- [ ] VLM page-signal fill-in (plain-text transcription, per-call timeout, circuit breaker, NO page cap)
-- [ ] `k8s/pdf-split-worker.yaml` + kustomization + ConfigMap env
-- [ ] Tests: `test_pdf_split_worker.py`
+## PR3 — VLM slow path — DONE, merged #1100 (98348c07)
+- [x] All of it + 2 review cycles (incl. release-blocking inert-queue-defaults bug) — see design doc
+
+## Deployed 2026-08-18 (household)
+- [x] Images `2026-08-18-pdfsplit`, migration applied, flag ON, worker live, netpols enforced, E2E green (synthetic 3-doc split perfect)
+- [x] xidra rollout DONE 2026-08-20 (migration, flag, worker, netpols mit eigener privater Quelle k8s/xidra/redis-postgres-netpol.yaml; ~3-min Paperless-Netpol-Incident, behoben) ·
+- [ ] Follow-ups: deploy-script fix (sed registry for alembic job) · /verify-tests for the 28 rotten main tests · test docs 421-424 cleanup (user decision)
 
 ## Review / verification log
 (fill during implementation)

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -151,6 +151,48 @@ def _reset_rate_limiter():
 
 
 # ============================================================================
+# Redis client isolation
+# ============================================================================
+
+# The backend caches its async Redis clients per PROCESS (services.redis_client
+# ._client, used by login_lockout/task_queue/...; TokenBlacklist._redis). In
+# production that is one client on one event loop for the process lifetime. The
+# suite, however, runs every test on a FRESH function-scoped loop, so a client
+# built in test A's loop carries a pooled connection bound to a loop that is
+# already closed by the time test B borrows it — the command raises "Event loop
+# is closed". That surfaces as an unrelated-looking failure wherever a Redis
+# error is handled rather than raised: get_current_user's blacklist check fails
+# CLOSED and returns 401, so an authenticated request in test B gets rejected
+# purely because test A opened the connection.
+#
+# Drop the cached clients around every test so each one builds its own on the
+# loop it actually runs on. Teardown is best-effort: a test may have swapped in
+# a fake, and closing a client whose loop is gone is itself allowed to fail.
+@pytest.fixture(autouse=True)
+def _reset_shared_redis_clients():
+    def _drop():
+        try:
+            from services import redis_client as _rc
+        except ImportError:
+            pass
+        else:
+            _rc._client = None
+        try:
+            from services.token_blacklist import token_blacklist as _tb
+        except ImportError:
+            pass
+        else:
+            try:
+                _tb._redis = None
+            except Exception:
+                pass
+
+    _drop()
+    yield
+    _drop()
+
+
+# ============================================================================
 # Database Fixtures
 # ============================================================================
 

--- a/tests/backend/test_agent_parallel.py
+++ b/tests/backend/test_agent_parallel.py
@@ -136,16 +136,69 @@ async def test_orchestrator_parallel_runs_both_agents():
     ]
 
     steps = []
-    with patch.object(settings, "agent_orchestrator_parallel", True):
+    with patch.object(settings, "agent_orchestrator_parallel", True), \
+         patch.object(settings, "orchestrator_deterministic_merge", True):
         async for step in orch._run_parallel(sub_queries, "original", MagicMock(), MagicMock()):
             steps.append(step)
 
     final_answers = [s for s in steps if s.step_type == "final_answer"]
-    # Orchestrator now yields exactly ONE final_answer — the synthesized
-    # one. Per-sub-agent final_answer steps are suppressed so the web chat
-    # doesn't render multiple greetings / duplicated intro text.
+    # Orchestrator yields exactly ONE final_answer — the combined one.
+    # Per-sub-agent final_answer steps are suppressed so the web chat doesn't
+    # render multiple greetings / duplicated intro text.
+    assert len(final_answers) == 1
+    # Under the deterministic merge (Phase 0, default) that combined answer is
+    # assembled from the sub-agents' OWN answers under role-keyed headers — the
+    # LLM synthesizer is not consulted, so no domain can be dropped or
+    # cross-labeled.
+    orch._synthesize.assert_not_awaited()
+    assert final_answers[0].content == (
+        "## Role A\n\nResult for role_a\n\n## Role B\n\nResult for role_b"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_orchestrator_parallel_synthesizes_when_merge_disabled():
+    """With the deterministic-merge kill-switch off, the combined answer comes
+    from the LLM synthesizer (break-glass revert path)."""
+    from services.orchestrator import QueryOrchestrator
+
+    mock_router = MagicMock()
+    mock_role = MagicMock()
+    mock_role.has_agent_loop = True
+    mock_role.mcp_servers = []
+    mock_role.internal_tools = []
+    mock_router.roles = {"role_a": mock_role, "role_b": mock_role}
+
+    orch = QueryOrchestrator(mock_router, MagicMock())
+
+    async def mock_run_sub(sq, *args, **kwargs):
+        return {
+            "role": sq["role"],
+            "query": sq["query"],
+            "answer": f"Result for {sq['role']}",
+            "steps": [],
+        }
+
+    orch._run_sub_agent = mock_run_sub
+    orch._synthesize = AsyncMock(return_value="Combined answer")
+
+    sub_queries = [
+        {"role": "role_a", "query": "query a"},
+        {"role": "role_b", "query": "query b"},
+    ]
+
+    steps = []
+    with patch.object(settings, "agent_orchestrator_parallel", True), \
+         patch.object(settings, "orchestrator_deterministic_merge", False):
+        async for step in orch._run_parallel(sub_queries, "original", MagicMock(), MagicMock()):
+            steps.append(step)
+
+    final_answers = [s for s in steps if s.step_type == "final_answer"]
     assert len(final_answers) == 1
     assert final_answers[0].content == "Combined answer"
+    # Both sub-agent results were handed to the synthesizer.
+    assert len(orch._synthesize.call_args.args[1]) == 2
 
 
 @pytest.mark.unit
@@ -312,7 +365,10 @@ async def test_orchestrator_synthesis_none_falls_back_to_first_answer():
     orch._synthesize = AsyncMock(return_value=None)  # synthesizer fails
 
     steps = []
-    with patch.object(settings, "agent_orchestrator_parallel", True):
+    # The synthesizer only runs with the deterministic merge switched off, so
+    # this hole lives on the kill-switch path — pin it explicitly.
+    with patch.object(settings, "agent_orchestrator_parallel", True), \
+         patch.object(settings, "orchestrator_deterministic_merge", False):
         async for step in orch._run_parallel(
             [{"role": "a", "query": "q"}, {"role": "b", "query": "q"}],
             "msg", MagicMock(), MagicMock(),

--- a/tests/backend/test_agent_tools.py
+++ b/tests/backend/test_agent_tools.py
@@ -12,10 +12,11 @@ from services.agent_tools import AgentToolRegistry, ToolDefinition
 
 # The registry always registers the platform-owned internal tools in
 # __init__ via _register_internal_tools() — the union of KNOWLEDGE_TOOL,
-# MEMORY_LIST_TOOL, CHAT_UPLOAD_TOOLS and WIDGET_TOOLS. Tests that count
-# tools or assert an "empty" registry must account for these baseline
-# entries. Keep this set in sync when a platform internal.* tool is added
-# (ha_glue-registered tools come via the register_tools hook and are NOT
+# MEMORY_LIST_TOOL, CHAT_UPLOAD_TOOLS, WIDGET_TOOLS, KB_MAINTENANCE_TOOLS,
+# SYSTEM_HEALTH_TOOL, PAPERLESS_REEXTRACT_TOOL and PAPERLESS_DEDUPE_TOOL.
+# Tests that count tools or assert an "empty" registry must account for these
+# baseline entries. Keep this set in sync when a platform internal.* tool is
+# added (ha_glue-registered tools come via the register_tools hook and are NOT
 # in this baseline).
 INTERNAL_TOOL_NAMES = {
     "internal.knowledge_search",          # KNOWLEDGE_TOOL
@@ -25,6 +26,12 @@ INTERNAL_TOOL_NAMES = {
     "internal.render_table",              # WIDGET_TOOLS
     "internal.render_list",               # WIDGET_TOOLS
     "internal.weather_widget",            # WIDGET_TOOLS
+    "internal.ingest_status",             # KB_MAINTENANCE_TOOLS
+    "internal.reindex_documents",         # KB_MAINTENANCE_TOOLS
+    "internal.list_chunkless_documents",  # KB_MAINTENANCE_TOOLS
+    "internal.system_health",             # SYSTEM_HEALTH_TOOL
+    "internal.reextract_paperless_metadata",  # PAPERLESS_REEXTRACT_TOOL
+    "internal.paperless_dedupe",          # PAPERLESS_DEDUPE_TOOL
 }
 NUM_INTERNAL_TOOLS = len(INTERNAL_TOOL_NAMES)
 
@@ -208,7 +215,7 @@ class TestAgentToolRegistryMCPTools:
 
         registry = AgentToolRegistry(mcp_manager=mock_mcp, _init_only=True)
         names = registry.get_tool_names()
-        # 3 MCP tools + the 3 baseline internal tools.
+        # 3 MCP tools + the baseline internal tools.
         assert len(names) == 3 + NUM_INTERNAL_TOOLS
         assert "mcp.homeassistant.turn_on" in names
         assert "mcp.weather.get_forecast" in names

--- a/tests/backend/test_federation_agent_integration.py
+++ b/tests/backend/test_federation_agent_integration.py
@@ -90,7 +90,10 @@ class TestFederationRouting:
             "services.database.AsyncSessionLocal", lambda: session_mock,
         )
 
-        async def fake_query_peer(self, peer, text):
+        seen_user_ids: list[int | None] = []
+
+        async def fake_query_peer(self, peer, text, user_id=None):
+            seen_user_ids.append(user_id)
             yield ProgressChunk(label="retrieving", sequence=1)
             yield {"success": True, "message": f"answered {peer.remote_display_name}", "data": None}
 
@@ -101,7 +104,7 @@ class TestFederationRouting:
 
         items = []
         async for item in manager.execute_tool_streaming(
-            "mcp.peer_7.query_brain", {"query": "what's for dinner?"},
+            "mcp.peer_7.query_brain", {"query": "what's for dinner?"}, user_id=42,
         ):
             items.append(item)
 
@@ -110,6 +113,9 @@ class TestFederationRouting:
         assert len(progress) == 1
         assert finals[0]["success"] is True
         assert "Mom" in finals[0]["message"]
+        # F-ID-1: the authenticated asker must reach query_peer so it can
+        # resolve the person-scoped querier_ref.
+        assert seen_user_ids == [42]
 
         reset_federation_identity_for_tests()
 
@@ -145,7 +151,7 @@ class TestFederationRouting:
 
         asker_called = False
 
-        async def should_not_be_called(self, peer, text):
+        async def should_not_be_called(self, peer, text, user_id=None):
             nonlocal asker_called
             asker_called = True
             yield {"success": True, "message": "", "data": None}
@@ -222,7 +228,10 @@ class TestFederationRouting:
             "services.database.AsyncSessionLocal", lambda: session_mock,
         )
 
-        async def fake_query_peer(self, peer, text):
+        seen_user_ids: list[int | None] = []
+
+        async def fake_query_peer(self, peer, text, user_id=None):
+            seen_user_ids.append(user_id)
             yield ProgressChunk(label="retrieving", sequence=1)
             yield {"success": True, "message": f"answered by {peer.remote_display_name}", "data": None}
         monkeypatch.setattr(
@@ -232,11 +241,14 @@ class TestFederationRouting:
 
         # NON-STREAMING path — agent loop's entry point
         result = await manager.execute_tool(
-            "mcp.peer_5.query_brain", {"query": "?"},
+            "mcp.peer_5.query_brain", {"query": "?"}, user_id=5,
         )
 
         assert result["success"] is True
         assert "Dad" in result["message"]
+        # F-ID-1: execute_tool must thread the asker through too, not just
+        # execute_tool_streaming.
+        assert seen_user_ids == [5]
         # ProgressChunks are discarded on the non-streaming path, only
         # the final dict is returned.
         assert "data" in result
@@ -550,7 +562,7 @@ class TestFederationProgressSink:
         # progress labels during polling, then FinalResult on terminal
         # status (asker doesn't emit `complete`/`failed` as chunks — those
         # are responder-side status strings that break the poll loop).
-        async def fake_query_peer(self, peer, text):
+        async def fake_query_peer(self, peer, text, user_id=None):
             yield ProgressChunk(label="waking_up", detail={"peer": peer.remote_display_name}, sequence=1)
             yield ProgressChunk(label="retrieving", detail={"peer": peer.remote_display_name}, sequence=2)
             yield ProgressChunk(label="synthesizing", detail={"peer": peer.remote_display_name}, sequence=3)
@@ -627,7 +639,7 @@ class TestFederationProgressSink:
             "services.database.AsyncSessionLocal", lambda: session_mock,
         )
 
-        async def fake_query_peer(self, peer, text):
+        async def fake_query_peer(self, peer, text, user_id=None):
             yield ProgressChunk(label="retrieving", sequence=1)
             yield ProgressChunk(label="synthesizing", sequence=2)
             yield {"success": True, "message": "done", "data": None}
@@ -691,7 +703,7 @@ class TestFederationProgressSink:
             "services.database.AsyncSessionLocal", lambda: session_mock,
         )
 
-        async def fake_query_peer(self, peer, text):
+        async def fake_query_peer(self, peer, text, user_id=None):
             yield ProgressChunk(label="retrieving", sequence=1)
             yield {"success": True, "message": "ok", "data": None}
 

--- a/tests/backend/test_federation_audit.py
+++ b/tests/backend/test_federation_audit.py
@@ -356,7 +356,7 @@ class TestAuditIntegration:
             "services.database.AsyncSessionLocal", lambda: session_mock,
         )
 
-        async def fake_query_peer(self, peer, text):
+        async def fake_query_peer(self, peer, text, user_id=None):
             yield ProgressChunk(label="retrieving", sequence=1)
             yield {"success": True, "message": "the answer", "data": None}
 
@@ -586,7 +586,7 @@ class TestCancellationAuditRow:
             "services.database.AsyncSessionLocal", lambda: session_mock,
         )
 
-        async def fake_query_peer(self, peer, text):
+        async def fake_query_peer(self, peer, text, user_id=None):
             yield ProgressChunk(label="retrieving", sequence=1)
             # Simulated mid-query crash — no terminal dict reached.
             raise RuntimeError("simulated mid-query abort")

--- a/tests/backend/test_federation_cert_pin.py
+++ b/tests/backend/test_federation_cert_pin.py
@@ -248,10 +248,12 @@ class TestAskerCertPinIntegration:
         initiate_called = False
         original_initiate = FederationQueryAsker._initiate
 
-        async def spy_initiate(self, client, endpoint, query_text):
+        async def spy_initiate(self, client, endpoint, query_text, querier_ref=None):
             nonlocal initiate_called
             initiate_called = True
-            return await original_initiate(self, client, endpoint, query_text)
+            return await original_initiate(
+                self, client, endpoint, query_text, querier_ref,
+            )
 
         monkeypatch.setattr(
             FederationQueryAsker, "_initiate", spy_initiate,
@@ -310,7 +312,7 @@ class TestAskerCertPinIntegration:
         )
 
         # Stub the wire calls so we don't actually hit the network.
-        async def fake_initiate(self, client, endpoint, query_text):
+        async def fake_initiate(self, client, endpoint, query_text, querier_ref=None):
             return None  # signals "peer rejected initiate"
         monkeypatch.setattr(
             FederationQueryAsker, "_initiate", fake_initiate,

--- a/tests/backend/test_ha_glue_boundary.py
+++ b/tests/backend/test_ha_glue_boundary.py
@@ -85,6 +85,15 @@ ALLOWED_IMPORTERS = frozenset({
     # degrades to an empty section when ha_glue is absent). Never reached on a
     # platform-only deploy. Same lazy-pattern rule as the shims above.
     "api/websocket/kiosk_handler.py",
+    # (2) Lazy, guarded — the kiosk's internal-subsystem health probes
+    # (_presence_health / _media_health) read `ha_glue_settings` and the satellite
+    # roster through function-body imports. compute_internal_subsystem_health()
+    # runs each probe under its own try/except, so on a platform-only deploy the
+    # presence/media nodes simply drop out of the readout instead of crashing.
+    # This module was split out of the allowlisted kiosk_handler.py when the admin
+    # Command Center was decommissioned; it carries the same reads and the same
+    # lazy-pattern justification.
+    "api/websocket/kiosk_data.py",
     # (2) Lazy, try/except-guarded — emit_continued_handoff_frame() does a
     # function-body `from ha_glue.services.device_manager import get_device_manager`
     # inside a try block to broadcast the room-handoff chip; deferred + guarded, so

--- a/tests/backend/test_message_search.py
+++ b/tests/backend/test_message_search.py
@@ -156,11 +156,28 @@ async def messages_fts_installed(pg_db_session: AsyncSession) -> None:
 
 
 async def _add_conv(db: AsyncSession, session_id: str, user_id: int, msgs: list[tuple[str, str]]):
+    """Seed a linear (un-forked) conversation the way ``save_message`` does.
+
+    Chat branching (Phase 1) made the message tree load-bearing for reads:
+    search walks ``parent_message_id`` UPWARD from
+    ``conversations.active_leaf_message_id``, so a conversation whose rows carry
+    neither a parent chain nor an active leaf contributes NO rows. Hand-inserted
+    messages must therefore chain onto the tip and advance the leaf, exactly as
+    ``ConversationService.save_message`` does on every append.
+    """
     conv = Conversation(session_id=session_id, user_id=user_id)
     db.add(conv)
     await db.flush()
     for role, content in msgs:
-        db.add(Message(conversation_id=conv.id, role=role, content=content))
+        message = Message(
+            conversation_id=conv.id,
+            role=role,
+            content=content,
+            parent_message_id=conv.active_leaf_message_id,
+        )
+        db.add(message)
+        await db.flush()
+        conv.active_leaf_message_id = message.id
     await db.flush()
     return conv
 

--- a/tests/backend/test_orchestrator.py
+++ b/tests/backend/test_orchestrator.py
@@ -2098,6 +2098,7 @@ class TestSynthesisHooks:
             s.agent_router_model = "test-model"
             s.ollama_intent_model = "test-model"
             s.ollama_model = "test-model"
+            s.agent_ollama_url = None  # no dedicated agent URL → use the passed ollama.client
             s.orchestrator_synthesis_timeout = 10.0
 
             sub_results = [
@@ -2138,6 +2139,7 @@ class TestSynthesisHooks:
              patch("services.orchestrator.get_classification_chat_kwargs", return_value={}):
             pm.get.return_value = "X"
             s.agent_router_model = s.ollama_intent_model = s.ollama_model = "test-model"
+            s.agent_ollama_url = None  # no dedicated agent URL → use the passed ollama.client
             s.orchestrator_synthesis_timeout = 10.0
 
             await orchestrator._synthesize(
@@ -2171,6 +2173,7 @@ class TestSynthesisHooks:
              patch("services.orchestrator.get_classification_chat_kwargs", return_value={}):
             pm.get.return_value = "DEFAULT_PROMPT_NEVER_USED"
             s.agent_router_model = s.ollama_intent_model = s.ollama_model = "test-model"
+            s.agent_ollama_url = None  # no dedicated agent URL → use the passed ollama.client
             s.orchestrator_synthesis_timeout = 10.0
 
             await orchestrator._synthesize(
@@ -2204,6 +2207,7 @@ class TestSynthesisHooks:
              patch("services.orchestrator.get_classification_chat_kwargs", return_value={}):
             pm.get.return_value = "DEFAULT_PROMPT"
             s.agent_router_model = s.ollama_intent_model = s.ollama_model = "test-model"
+            s.agent_ollama_url = None  # no dedicated agent URL → use the passed ollama.client
             s.orchestrator_synthesis_timeout = 10.0
 
             await orchestrator._synthesize(
@@ -2272,6 +2276,7 @@ class TestSynthesisHooks:
              patch("services.orchestrator.get_classification_chat_kwargs", return_value={}):
             pm.get.return_value = "PROMPT"
             s.agent_router_model = s.ollama_intent_model = s.ollama_model = "test-model"
+            s.agent_ollama_url = None  # no dedicated agent URL → use the passed ollama.client
             s.orchestrator_synthesis_timeout = 10.0
 
             answer = await orchestrator._synthesize(
@@ -2309,6 +2314,7 @@ class TestSynthesisHooks:
              patch("services.orchestrator.logger") as mock_logger:
             pm.get.return_value = "PROMPT"
             s.agent_router_model = s.ollama_intent_model = s.ollama_model = "test-model"
+            s.agent_ollama_url = None  # no dedicated agent URL → use the passed ollama.client
             s.orchestrator_synthesis_timeout = 30.0
 
             answer = await orchestrator._synthesize("msg", sub_results, ollama, "de")
@@ -2342,6 +2348,7 @@ class TestSynthesisHooks:
              patch("services.orchestrator.logger") as mock_logger:
             pm.get.return_value = "PROMPT"
             s.agent_router_model = s.ollama_intent_model = s.ollama_model = "test-model"
+            s.agent_ollama_url = None  # no dedicated agent URL → use the passed ollama.client
             s.orchestrator_synthesis_timeout = 30.0
 
             answer = await orchestrator._synthesize("msg", sub_results, ollama, "de")
@@ -2401,7 +2408,10 @@ class TestEmitCombinedAnswerNoDataFilter:
         assert "No releases found" in finals[0].content
 
     @pytest.mark.asyncio
-    async def test_two_data_sources_both_synthesized(self):
+    async def test_two_data_sources_both_rendered(self):
+        """Default path: both data-bearing sources reach the combined answer via
+        the deterministic merge — each under its own role-keyed header, with no
+        LLM synthesis involved."""
         orch = QueryOrchestrator(_make_router([]), MagicMock())
         sub_results = [
             {"role": "konfigure", "answer": "Freezes ...", "has_data": True,
@@ -2409,7 +2419,31 @@ class TestEmitCombinedAnswerNoDataFilter:
             {"role": "jira", "answer": "Ticket RM27-4 ...", "has_data": True,
              "steps": [], "plugin_data": {}},
         ]
-        with patch.object(orch, "_synthesize",
+        with patch("services.orchestrator.settings.orchestrator_deterministic_merge", True), \
+             patch.object(orch, "_synthesize",
+                          new=AsyncMock(return_value="COMBINED")) as syn:
+            steps = [s async for s in
+                     orch._emit_combined_answer("msg", sub_results, _make_ollama(""), "en")]
+        syn.assert_not_called()
+        finals = [s for s in steps if s.step_type == "final_answer"]
+        assert len(finals) == 1
+        assert finals[0].content == (
+            "## konfigure\n\nFreezes ...\n\n## Jira\n\nTicket RM27-4 ..."
+        )
+
+    @pytest.mark.asyncio
+    async def test_two_data_sources_both_synthesized_when_merge_disabled(self):
+        """Kill-switch path: with the deterministic merge off, both data-bearing
+        sources are handed to the LLM synthesizer."""
+        orch = QueryOrchestrator(_make_router([]), MagicMock())
+        sub_results = [
+            {"role": "konfigure", "answer": "Freezes ...", "has_data": True,
+             "steps": [], "plugin_data": {}},
+            {"role": "jira", "answer": "Ticket RM27-4 ...", "has_data": True,
+             "steps": [], "plugin_data": {}},
+        ]
+        with patch("services.orchestrator.settings.orchestrator_deterministic_merge", False), \
+             patch.object(orch, "_synthesize",
                           new=AsyncMock(return_value="COMBINED")) as syn:
             steps = [s async for s in
                      orch._emit_combined_answer("msg", sub_results, _make_ollama(""), "en")]

--- a/tests/backend/test_satellite_updates_integration.py
+++ b/tests/backend/test_satellite_updates_integration.py
@@ -236,6 +236,11 @@ class TestSatelliteUpdateAPIFlow:
                 mock_settings.satellite_latest_version = "2.0.0"
                 mock_settings.advertise_host = "localhost"
                 mock_settings.advertise_port = 8000
+                # Production default. Left unset, the MagicMock attribute is
+                # truthy and trips the H6 signed-OTA gate, which refuses an
+                # unsigned release — that gate has its own coverage in
+                # test_satellite_ota_signing.py.
+                mock_settings.satellite_ota_require_signature = False
 
                 # Mock get_package_info since /app/satellite doesn't exist in CI
                 fake_package_info = {


### PR DESCRIPTION
## Summary

`/verify-tests`-Lauf: die 28 seit Monaten rotten Backend-Tests (CI ist aus; Refactors liefen nie gegen die Suite) sind gefixt — **ausschließlich Test-Änderungen, kein Produkt-Bug**. Klassifizierung vorab: alle 28 fielen identisch in völliger Isolation (echtes Rot, keine Kontamination); gefixt über 4 parallele Fixer-Scopes mit je eigener Test-DB.

**Vorher → Nachher: 28 failed / 5.941 passed → 0 failed / 5.969 passed** (43 dokumentierte Skips). Autoritativ re-verifiziert über den kombinierten Stand; Frontend-Gates grün (835 Tests, tsc).

### Root-Cause-Gruppen
1. **Orchestrator/Agent (9):** Deterministischer Multi-Domain-Merge (3b6e5136/b790edfa/e942b82e) ersetzte die LLM-Synthese als Default — ohne jede Testabdeckung gemergt. Tests decken jetzt Default- UND Kill-Switch-Pfad (+2 neue); `TestSynthesisHooks` stubbt `agent_ollama_url=None` (Synthesizer läuft seit d3771914 auf dem Agent-Client); `INTERNAL_TOOL_NAMES`-Baseline um 6 Tools ergänzt.
2. **Federation (8):** EIN Commit (3ac46d9d, F-ID-1) änderte `query_peer(+user_id)` und `_initiate(+querier_ref)` ohne die Asker-Tests. Stubs angepasst — und das `user_id`-Threading wird jetzt aktiv mit-asserted (schließt die eigentliche F-ID-1-Abdeckungslücke); auch der latent-rotte `spy_initiate` gefixt.
3. **Message-Search (6):** Chat-Branching (915f1882) machte `search_messages` aktiv-Branch-gescoped (CTE ab `active_leaf`); der Test-Seeder baute keine Parent-Kette. `_add_conv` seedet jetzt wie `save_message` (flush-only, Rollback-Isolation erhalten) — die Cross-User-Isolation wird erstmals nicht-vakuos geprüft.
4. **Misc (5):** Wakeword-401er = Intra-File-Kontamination durch prozessweit gecachte async-Redis-Clients über Event-Loop-Grenzen → zentrale autouse-Fixture `_reset_shared_redis_clients` in `conftest.py` (Vorbild `_reset_rate_limiter`, schützt alle authed-HTTP-Tests); Satellite-OTA-Mock setzt `satellite_ota_require_signature=False` (H6-Gate sonst auto-truthy MagicMock); ha_glue-Boundary-Allowlist um `kiosk_data.py` ergänzt (lazy-guarded Imports aus dem Command-Center-Split — kein echter Verstoß).

### Follow-ups (bewusst nicht in diesem PR)
- Regressionstest: verlassener Fork-Branch darf nicht in der Message-Suche erscheinen (genau die Eigenschaft, die hier still rottete)
- `TokenBlacklist` baut einen privaten aioredis-Client, der nie geschlossen wird (Cleanup — der `login_lockout`-Kommentar warnt exakt davor)

## Test plan
- [x] Alle 10 vormals roten Dateien einzeln grün
- [x] Volle Backend-Suite: 5.969 passed, 0 failed (isolierte DB, kein Parallel-Lauf)
- [x] Frontend: vitest 835 passed + tsc
- [x] `/code-review low` ohne Befund

🤖 Generated with [Claude Code](https://claude.com/claude-code)