### PR TITLE
chore: Verify-Tests-Follow-ups — Blacklist-Client, Fork-Branch-Regressionstest, Deploy-Script-Fix

### DIFF
--- a/bin/deploy-production.sh
+++ b/bin/deploy-production.sh
@@ -122,7 +122,10 @@ fi
 if [[ $DO_MIGRATE == 1 ]]; then
   log "alembic migration (new image, before rollout)"
   run "${KUBECTL[*]} delete job alembic-upgrade --ignore-not-found"
-  run "${KUBECTL[*]} apply -f $REPO_ROOT/k8s/alembic-upgrade-job.yaml"
+  # The public manifest carries the registry placeholder — substitute the real
+  # registry + the freshly pushed tag at apply time (a raw apply fails the
+  # image pull; bit the 2026-08-18 pdfsplit deploy).
+  run "sed 's#your-registry.example/renfield/backend:latest#$REGISTRY/backend:${BACKEND_TAG:-latest}#' $REPO_ROOT/k8s/alembic-upgrade-job.yaml | ${KUBECTL[*]} apply -f -"
   if [[ $DRY_RUN == 0 ]]; then
     if ! "${KUBECTL[@]}" wait --for=condition=Complete job/alembic-upgrade --timeout=300s; then
       echo "ERROR: migration job did not complete — logs follow:" >&2

--- a/src/backend/services/token_blacklist.py
+++ b/src/backend/services/token_blacklist.py
@@ -7,23 +7,21 @@ Stores JTI (JWT ID) with TTL matching the token's remaining lifetime.
 import redis.asyncio as aioredis
 from loguru import logger
 
-from utils.config import settings
-
 BLACKLIST_PREFIX = "blacklist:"
 
 
 class TokenBlacklist:
     """Redis-backed JWT token blacklist."""
 
-    def __init__(self):
-        self._redis: aioredis.Redis | None = None
-
     def _get_redis(self) -> aioredis.Redis:
-        if self._redis is None:
-            self._redis = aioredis.from_url(
-                settings.redis_url, decode_responses=True
-            )
-        return self._redis
+        # Shared process-wide pooled client (services.redis_client), closed by
+        # lifecycle.close_redis() on shutdown — mirrors login_lockout, which
+        # documents why: a PRIVATE from_url client here was never closed and
+        # leaked its pool past shutdown (flagged in the 2026-08-20 test-rot
+        # sweep). Kept as an instance method: tests patch this seam.
+        from services.redis_client import get_redis
+
+        return get_redis()
 
     async def add(self, jti: str, ttl_seconds: int) -> bool:
         """

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -33,7 +33,7 @@ Plan: `~/.claude/plans/harmonic-toasting-toucan.md` (approved 2026-08-16). Dark 
 ## Deployed 2026-08-18 (household)
 - [x] Images `2026-08-18-pdfsplit`, migration applied, flag ON, worker live, netpols enforced, E2E green (synthetic 3-doc split perfect)
 - [x] xidra rollout DONE 2026-08-20 (migration, flag, worker, netpols mit eigener privater Quelle k8s/xidra/redis-postgres-netpol.yaml; ~3-min Paperless-Netpol-Incident, behoben) ·
-- [ ] Follow-ups: deploy-script fix (sed registry for alembic job) · /verify-tests for the 28 rotten main tests · test docs 421-424 cleanup (user decision)
+- [ ] Follow-ups: deploy-script fix (sed registry for alembic job) · [x] /verify-tests DONE 2026-08-20: 28→0, branch fix/test-rot-28 (awaiting push/merge) — Follow-ups: search-excludes-abandoned-branch Regressionstest, TokenBlacklist private-client cleanup · test docs 421-424 cleanup (user decision)
 
 ## Review / verification log
 (fill during implementation)

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -177,15 +177,8 @@ def _reset_shared_redis_clients():
             pass
         else:
             _rc._client = None
-        try:
-            from services.token_blacklist import token_blacklist as _tb
-        except ImportError:
-            pass
-        else:
-            try:
-                _tb._redis = None
-            except Exception:
-                pass
+        # (TokenBlacklist now delegates to the shared services.redis_client
+        # pool — resetting _rc._client above covers it.)
 
     _drop()
     yield

--- a/tests/backend/test_auth_audit_remediation.py
+++ b/tests/backend/test_auth_audit_remediation.py
@@ -478,7 +478,7 @@ class TestBlacklistWriteFailure:
         bl = TokenBlacklist()
         redis = MagicMock()
         redis.setex = AsyncMock(side_effect=RuntimeError("redis down"))
-        bl._redis = redis
+        bl._get_redis = lambda: redis
         assert await bl.add("some-jti", 60) is False
 
     async def test_add_returns_true_on_success(self):
@@ -487,7 +487,7 @@ class TestBlacklistWriteFailure:
         bl = TokenBlacklist()
         redis = MagicMock()
         redis.setex = AsyncMock(return_value=True)
-        bl._redis = redis
+        bl._get_redis = lambda: redis
         assert await bl.add("some-jti", 60) is True
 
     async def test_add_noop_for_expired_ttl_is_true(self):

--- a/tests/backend/test_message_search.py
+++ b/tests/backend/test_message_search.py
@@ -22,7 +22,7 @@ the migration ADDs the GENERATED one).
 from __future__ import annotations
 
 import pytest
-from sqlalchemy import text
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.database import Conversation, Message, Role, User
@@ -280,3 +280,39 @@ class TestSearchMessagesPostgres:
         svc = ConversationService(pg_db_session)
         out = await svc.search_messages("café", user_id=u1)
         assert {r["session_id"] for r in out["results"]} == {"pg-fr"}
+
+    async def test_abandoned_fork_branch_excluded(
+        self, pg_db_session: AsyncSession, messages_fts_installed, two_users
+    ):
+        """The property that silently rotted in the 2026-08 sweep, now pinned:
+        search is ACTIVE-branch-scoped. A message on an abandoned fork (parented
+        into the tree but not on the path walked up from active_leaf_message_id)
+        must NOT surface, while the active branch's content does."""
+        u1, _ = two_users
+        conv = await _add_conv(
+            pg_db_session, "pg-fork", u1,
+            [("user", "Aktivstrang Xylophonkonzert"), ("assistant", "Gern!")],
+        )
+        # Fork off the ROOT message: an alternative reply that was abandoned
+        # (the active leaf stays on the linear branch seeded above).
+        root_id = (
+            await pg_db_session.execute(
+                select(Message.id)
+                .where(Message.conversation_id == conv.id,
+                       Message.parent_message_id.is_(None))
+            )
+        ).scalar_one()
+        abandoned = Message(
+            conversation_id=conv.id,
+            role="assistant",
+            content="Verwaister Zweig Quastenflosserfund",
+            parent_message_id=root_id,
+        )
+        pg_db_session.add(abandoned)
+        await pg_db_session.flush()  # active_leaf deliberately NOT advanced
+
+        svc = ConversationService(pg_db_session)
+        active = await svc.search_messages("Xylophonkonzert", user_id=u1)
+        assert {r["session_id"] for r in active["results"]} == {"pg-fork"}
+        orphaned = await svc.search_messages("Quastenflosserfund", user_id=u1)
+        assert orphaned["results"] == []


### PR DESCRIPTION
## Summary

Die drei im `/verify-tests`-Sweep (#1101) notierten Follow-ups:

- **TokenBlacklist → geteilter Redis-Pool:** statt eines privaten `from_url`-Clients, der nie geschlossen wurde (exakt das Leck, vor dem der `login_lockout`-Kommentar warnt), delegiert `_get_redis` jetzt an `services.redis_client.get_redis` (von `lifecycle.close_redis()` geschlossen). Die Test-Naht bleibt; `test_auth_audit_remediation` injiziert über die Naht statt über das entfernte `_redis`-Attribut; die conftest-Reset-Fixture entsprechend vereinfacht.
- **Regressionstest `test_abandoned_fork_branch_excluded`:** pinnt die im Sweep still gerottete Eigenschaft — die Message-Suche ist aktiv-Branch-gescoped, verlassene Fork-Zweige bleiben unsichtbar, der aktive Strang wird gefunden.
- **`bin/deploy-production.sh`:** der Alembic-Job wird beim Apply mit echter Registry + frisch gepushtem Tag substituiert (der Raw-Apply mit Registry-Platzhalter ließ den 2026-08-18-Deploy am Image-Pull scheitern); per `--dry-run` verifiziert.

## Test plan
- [x] Volle Backend-Suite: 5.969+1 passed, 0 failed (isolierte DB)
- [x] Blacklist/Auth/Wakeword/WebSocket-Suiten gezielt: 164 + 40 passed
- [x] Deploy-Script `--dry-run`: korrekte sed-Apply-Zeile
- [x] `/code-review low` ohne Befund

🤖 Generated with [Claude Code](https://claude.com/claude-code)