### PR TITLE
feat(agent): 256k-Kontext des llama-servers ausnutzen — backend-bewusstes Token-Budget + konfigurierbare Content-Caps (#1103)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -171,6 +171,8 @@ PIPER_DEFAULT_VOICE=de_DE-thorsten-high  # Fallback when requested language has 
 # AGENT_CONV_CONTEXT_MESSAGES=12
 # AGENT_HISTORY_MESSAGE_MAX_CHARS=500  # Per-message cap in the compressed agent history
 # AGENT_TOOL_RESULT_TEXT_MAX_CHARS=8000  # Cap for text tool results in the agent scratchpad
+#                                       # (raise TOGETHER with AGENT_RESPONSE_TRUNCATION —
+#                                       # that one caps text results at step creation)
 # KNOWLEDGE_CONTEXT_CHUNK_CHARS=500    # Per-chunk cap in internal.knowledge_search context
 # CONVERSATION_SUMMARY_THRESHOLD=10
 # AGENT_ROLES_PATH=config/agent_roles.yaml

--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,16 @@ REDIS_URL=redis://redis:6379
 # LLM_OPENAI_BASE_URL=http://llama-server-agent:8080/v1
 # LLM_OPENAI_API_KEY=no-key
 # LLM_OPENAI_MODEL=qwen3.6
+# LLM_OPENAI_NUM_CTX=                   # Context window of the external server
+#                                       # (must match its --ctx-size, e.g. 262144).
+#                                       # Widens the agent token budget only; unset
+#                                       # = budget against OLLAMA_NUM_CTX. To fill it,
+#                                       # also raise AGENT_HISTORY_MESSAGE_MAX_CHARS /
+#                                       # AGENT_TOOL_RESULT_TEXT_MAX_CHARS /
+#                                       # KNOWLEDGE_CONTEXT_CHUNK_CHARS /
+#                                       # AGENT_CONV_CONTEXT_MESSAGES. With the
+#                                       # in-cluster fallback enabled, prompts wider
+#                                       # than OLLAMA_NUM_CTX degrade during outages.
 # LLM_OPENAI_FOR_AGENT=true             # Default when BASE_URL is set
 # LLM_OPENAI_FOR_CHAT=true
 # LLM_OPENAI_FOR_RAG=true
@@ -159,6 +169,9 @@ PIPER_DEFAULT_VOICE=de_DE-thorsten-high  # Fallback when requested language has 
 # AGENT_MODEL=                        # Optional separate model
 # AGENT_OLLAMA_URL=                   # Optional separate host
 # AGENT_CONV_CONTEXT_MESSAGES=12
+# AGENT_HISTORY_MESSAGE_MAX_CHARS=500  # Per-message cap in the compressed agent history
+# AGENT_TOOL_RESULT_TEXT_MAX_CHARS=8000  # Cap for text tool results in the agent scratchpad
+# KNOWLEDGE_CONTEXT_CHUNK_CHARS=500    # Per-chunk cap in internal.knowledge_search context
 # CONVERSATION_SUMMARY_THRESHOLD=10
 # AGENT_ROLES_PATH=config/agent_roles.yaml
 # AGENT_ROUTER_TIMEOUT=30.0

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -248,8 +248,11 @@ AGENT_HISTORY_MESSAGE_MAX_CHARS=500
 
 # Zeichen-Cap für Text-Tool-Ergebnisse im Agent-Scratchpad (strukturierte
 # Ergebnisse steuert das Token-Budget). Bei großem Kontextfenster anheben
-# (z. B. 32000).
+# (z. B. 32000). WICHTIG: zusammen mit AGENT_RESPONSE_TRUNCATION anheben —
+# das kappt Text-Ergebnisse bereits bei der Step-Erzeugung (Default 2000);
+# ohne beides bleibt der Lese-Cap wirkungslos.
 AGENT_TOOL_RESULT_TEXT_MAX_CHARS=8000
+AGENT_RESPONSE_TRUNCATION=2000
 
 # Agent Router Timeout (Sekunden)
 AGENT_ROUTER_TIMEOUT=30.0
@@ -265,6 +268,7 @@ AGENT_ROUTER_TIMEOUT=30.0
 - `AGENT_CONV_CONTEXT_MESSAGES`: `12`
 - `AGENT_HISTORY_MESSAGE_MAX_CHARS`: `500`
 - `AGENT_TOOL_RESULT_TEXT_MAX_CHARS`: `8000`
+- `AGENT_RESPONSE_TRUNCATION`: `2000`
 - `AGENT_ROUTER_TIMEOUT`: `30.0`
 
 ### OpenAI-kompatibler LLM-Endpoint (llama-server / vLLM / OpenRouter)
@@ -288,7 +292,8 @@ AGENT_ROUTER_TIMEOUT=30.0
 # ignoriert client-seitiges num_ctx, sein --ctx-size gilt. Ungesetzt =>
 # Budget gegen OLLAMA_NUM_CTX (Legacy). Um das Fenster real zu füllen,
 # zusätzlich AGENT_HISTORY_MESSAGE_MAX_CHARS / AGENT_TOOL_RESULT_TEXT_MAX_CHARS
-# / KNOWLEDGE_CONTEXT_CHUNK_CHARS / AGENT_CONV_CONTEXT_MESSAGES anheben.
+# + AGENT_RESPONSE_TRUNCATION (beide zusammen!) / KNOWLEDGE_CONTEXT_CHUNK_CHARS
+# / AGENT_CONV_CONTEXT_MESSAGES anheben.
 # ACHTUNG Fallback: bei LLM_OPENAI_FALLBACK_ENABLED laufen Prompts > OLLAMA_NUM_CTX
 # im Ausfall-Fall degradiert (Ollama schneidet still ab; WARNING im Log).
 # LLM_OPENAI_NUM_CTX=262144

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -238,8 +238,18 @@ AGENT_TOTAL_TIMEOUT=120.0
 # Optionale separate Ollama-Instanz für Agent
 # AGENT_OLLAMA_URL=http://cuda.local:11434
 
-# Konversations-Kontext im Agent Loop
-AGENT_CONV_CONTEXT_MESSAGES=6
+# Konversations-Kontext im Agent Loop (Anzahl Nachrichten)
+AGENT_CONV_CONTEXT_MESSAGES=12
+
+# Zeichen-Cap pro komprimierter Historien-Nachricht im Agent-Prompt.
+# Zusammen mit LLM_OPENAI_NUM_CTX anheben, um ein großes Kontextfenster
+# tatsächlich zu nutzen (z. B. 2000 bei 256k-Server).
+AGENT_HISTORY_MESSAGE_MAX_CHARS=500
+
+# Zeichen-Cap für Text-Tool-Ergebnisse im Agent-Scratchpad (strukturierte
+# Ergebnisse steuert das Token-Budget). Bei großem Kontextfenster anheben
+# (z. B. 32000).
+AGENT_TOOL_RESULT_TEXT_MAX_CHARS=8000
 
 # Agent Router Timeout (Sekunden)
 AGENT_ROUTER_TIMEOUT=30.0
@@ -252,7 +262,9 @@ AGENT_ROUTER_TIMEOUT=30.0
 - `AGENT_TOTAL_TIMEOUT`: `120.0`
 - `AGENT_MODEL`: None (nutzt `OLLAMA_MODEL`)
 - `AGENT_OLLAMA_URL`: None (nutzt `OLLAMA_URL`)
-- `AGENT_CONV_CONTEXT_MESSAGES`: `6`
+- `AGENT_CONV_CONTEXT_MESSAGES`: `12`
+- `AGENT_HISTORY_MESSAGE_MAX_CHARS`: `500`
+- `AGENT_TOOL_RESULT_TEXT_MAX_CHARS`: `8000`
 - `AGENT_ROUTER_TIMEOUT`: `30.0`
 
 ### OpenAI-kompatibler LLM-Endpoint (llama-server / vLLM / OpenRouter)
@@ -269,6 +281,17 @@ AGENT_ROUTER_TIMEOUT=30.0
 
 # Logischer Modellname des Endpoints (llama-server --alias)
 # LLM_OPENAI_MODEL=qwen3.6
+
+# Kontextfenster des externen Servers (MUSS dessen --ctx-size entsprechen,
+# z. B. 262144 auf cuda.local:8081). Weitet NUR das backendseitige
+# Token-Budget des Agent-Loops (_enforce_token_budget) — der Server selbst
+# ignoriert client-seitiges num_ctx, sein --ctx-size gilt. Ungesetzt =>
+# Budget gegen OLLAMA_NUM_CTX (Legacy). Um das Fenster real zu füllen,
+# zusätzlich AGENT_HISTORY_MESSAGE_MAX_CHARS / AGENT_TOOL_RESULT_TEXT_MAX_CHARS
+# / KNOWLEDGE_CONTEXT_CHUNK_CHARS / AGENT_CONV_CONTEXT_MESSAGES anheben.
+# ACHTUNG Fallback: bei LLM_OPENAI_FALLBACK_ENABLED laufen Prompts > OLLAMA_NUM_CTX
+# im Ausfall-Fall degradiert (Ollama schneidet still ab; WARNING im Log).
+# LLM_OPENAI_NUM_CTX=262144
 
 # Reasoning-Budget für Reasoning-Modelle hinter dem Endpoint
 # ("minimal"/"low"/"medium"/"high"/"none", providerabhängig). Wird NUR bei
@@ -315,6 +338,7 @@ AGENT_ROUTER_TIMEOUT=30.0
 - `LLM_OPENAI_BASE_URL`: None (Ollama wird verwendet)
 - `LLM_OPENAI_API_KEY`: None (sendet "no-key")
 - `LLM_OPENAI_MODEL`: `qwen3.6`
+- `LLM_OPENAI_NUM_CTX`: None (Budget gegen `OLLAMA_NUM_CTX`)
 - `LLM_OPENAI_REASONING_EFFORT`: None (kein reasoning_effort im Request)
 - `LLM_OPENAI_FALLBACK_ENABLED`: `false` (opt-in pro Instanz; braucht ein erreichbares In-Cluster-`OLLAMA_URL`)
 - `LLM_OPENAI_FALLBACK_MODEL`: `""` (=> `OLLAMA_MODEL`, z. B. `qwen3:14b`)
@@ -864,6 +888,10 @@ RAG_CHUNK_SIZE=512               # Token-Limit pro Chunk
 RAG_CHUNK_OVERLAP=50             # Überlappung zwischen Chunks
 RAG_TOP_K=5                      # Anzahl der relevantesten Chunks
 RAG_SIMILARITY_THRESHOLD=0.4     # Minimum Similarity für Dense-only (0-1)
+KNOWLEDGE_CONTEXT_CHUNK_CHARS=500  # Zeichen-Cap pro Chunk im Kontext-Block von
+                                 # internal.knowledge_search. Zusammen mit
+                                 # LLM_OPENAI_NUM_CTX anheben (z. B. 1500),
+                                 # damit Chunks den Agenten ungekürzt erreichen.
 
 # Hybrid Search (Dense + BM25 via Reciprocal Rank Fusion)
 RAG_HYBRID_ENABLED=true          # Hybrid Search aktivieren
@@ -899,6 +927,7 @@ OCR_VLM_GIBBERISH_GATE_ENABLED=false  # Schneller LM-Check (is_ocr_gibberish, In
 - `RAG_CHUNK_OVERLAP`: `50`
 - `RAG_TOP_K`: `5`
 - `RAG_SIMILARITY_THRESHOLD`: `0.4`
+- `KNOWLEDGE_CONTEXT_CHUNK_CHARS`: `500`
 - `RAG_HYBRID_ENABLED`: `true`
 - `RAG_HYBRID_BM25_WEIGHT`: `0.3`
 - `RAG_HYBRID_DENSE_WEIGHT`: `0.7`

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -906,7 +906,14 @@ Renfield unterstützt separate Modelle pro Aufgabe. Jedes kann auf einer anderen
 ```env
 # Basis
 OLLAMA_URL=http://ollama:11434
-OLLAMA_NUM_CTX=32768                # Context Window
+OLLAMA_NUM_CTX=32768                # Context Window (Ollama-Calls)
+# LLM_OPENAI_NUM_CTX=262144         # Context Window des externen OpenAI-compat
+                                    # llama-servers (= dessen --ctx-size). Weitet
+                                    # das Agent-Token-Budget; zum realen Ausnutzen
+                                    # auch AGENT_HISTORY_MESSAGE_MAX_CHARS /
+                                    # AGENT_TOOL_RESULT_TEXT_MAX_CHARS /
+                                    # KNOWLEDGE_CONTEXT_CHUNK_CHARS anheben
+                                    # (siehe docs/ENVIRONMENT_VARIABLES.md)
 
 # Pro Aufgabe
 OLLAMA_CHAT_MODEL=qwen3:14b        # Chat-Antworten

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -110,6 +110,21 @@ data:
   LLM_OPENAI_FALLBACK_MODEL: "qwen3:14b"
   WAIT_CUDA_MAX_SECONDS: "30"
 
+  # Exploit the llama-server's large context window. LLM_OPENAI_NUM_CTX must
+  # match the server's --ctx-size (cuda.local:8081 runs 262144); it only
+  # widens the backend token budget — the server ignores client num_ctx.
+  # The AGENT_*/KNOWLEDGE_* knobs raise the content caps that used to bind
+  # long before the budget (history 12×500 chars, tool-result text 8000,
+  # knowledge chunks 500). Moderate sizing: typical prompts stay well under
+  # ~64k tokens so prefill latency remains interactive. Caveat: during a cuda
+  # outage the Ollama fallback still runs at OLLAMA_NUM_CTX — oversized
+  # prompts degrade there (logged WARNING), which is acceptable best-effort.
+  LLM_OPENAI_NUM_CTX: "262144"
+  AGENT_CONV_CONTEXT_MESSAGES: "30"
+  AGENT_HISTORY_MESSAGE_MAX_CHARS: "2000"
+  AGENT_TOOL_RESULT_TEXT_MAX_CHARS: "32000"
+  KNOWLEDGE_CONTEXT_CHUNK_CHARS: "1500"
+
   # Voice-server (B.4): when set, backend's /api/voice/voice-chat
   # orchestrator delegates STT + TTS to the voice-server pod
   # (k8s-gpu-3) instead of running them in-process. Backend retains

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -122,6 +122,11 @@ data:
   LLM_OPENAI_NUM_CTX: "262144"
   AGENT_CONV_CONTEXT_MESSAGES: "30"
   AGENT_HISTORY_MESSAGE_MAX_CHARS: "2000"
+  # Both tool-result knobs must move together: AGENT_RESPONSE_TRUNCATION caps
+  # text results at STEP CREATION (before they ever reach the scratchpad),
+  # AGENT_TOOL_RESULT_TEXT_MAX_CHARS caps them at prompt-build time — raising
+  # only the latter leaves it inert behind the 2000-char creation default.
+  AGENT_RESPONSE_TRUNCATION: "32000"
   AGENT_TOOL_RESULT_TEXT_MAX_CHARS: "32000"
   KNOWLEDGE_CONTEXT_CHUNK_CHARS: "1500"
 

--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -69,14 +69,14 @@ token_budget_info: ContextVar[dict | None] = ContextVar("token_budget_info", def
 token_usage_info: ContextVar[dict | None] = ContextVar("token_usage_info", default=None)
 
 
-def _compress_history_message(content: str, max_chars: int | None = None) -> str:
+def _compress_history_message(content: str) -> str:
     """Compress a conversation history message for the agent prompt.
 
     Action result blocks can be very large (full document lists, base64 data).
-    This extracts the essential summary and truncates the natural-language response.
+    This extracts the essential summary and truncates the natural-language
+    response to ``agent_history_message_max_chars``.
     """
-    if max_chars is None:
-        max_chars = settings.agent_history_message_max_chars
+    max_chars = settings.agent_history_message_max_chars
     if not content:
         return ""
 
@@ -238,6 +238,14 @@ class AgentContext:
             no_result = "Kein Ergebnis"
 
         lines = [header]
+        # Hoisted: loop-invariant caps. The token-budget reduction (Pass 0)
+        # must bite TEXT results too, not only structured step.data — else a
+        # text-dominated overrun is irreducible and falls through to the
+        # harsher history/memory passes.
+        budget = self.tool_result_budget_chars
+        text_cap = settings.agent_tool_result_text_max_chars
+        if budget:
+            text_cap = min(text_cap, budget)
         for step in recent_steps:
             if step.step_type == "tool_call":
                 tool_text = tool_called.format(tool=step.tool)
@@ -253,10 +261,8 @@ class AgentContext:
                 )
             elif step.step_type == "tool_result":
                 if step.data is not None:
-                    budget = self.tool_result_budget_chars
                     content = _serialize_for_prompt(step.data, budget_chars=budget)
                 else:
-                    text_cap = settings.agent_tool_result_text_max_chars
                     content = step.content[:text_cap] if step.content else no_result
                 tool_name = step.tool or "unknown"
                 # #686: neutralize structural delimiters in untrusted tool output
@@ -459,6 +465,11 @@ _SAME_TOOL_ABORT_THRESHOLD = 5
 # (server --ctx-size governs), while on the in-cluster Ollama fallback it
 # protects the fallback model from an oversized KV-cache allocation. The
 # backend token budget scales via effective_agent_num_ctx() instead.
+# KNOWN GAP (pre-existing): on an Ollama-PRIMARY agent path with a raised
+# OLLAMA_NUM_CTX (> 32768), the budget follows ollama_num_ctx while the
+# request still carries this 32768 — Ollama then truncates the prompt head.
+# Tracked as a follow-up; align these if you raise OLLAMA_NUM_CTX without
+# an OpenAI-compat endpoint.
 _DEFAULT_LLM_OPTIONS = {
     "temperature": 0.1, "top_p": 0.2, "num_predict": 2048, "num_ctx": 32768,
 }
@@ -1078,7 +1089,12 @@ class AgentService:
                 if utilization <= threshold:
                     return prompt, "", "", conversation_history
 
-            # Pass 4: Truncate history results
+            # Pass 4: Truncate history results. The 500-char floor is the
+            # DELIBERATE last-resort emergency crush — it only fires when the
+            # prompt is still over budget after every gentler pass, where
+            # fitting the window beats honoring the operator's configured
+            # tool-result caps. Note it mutates step.content in place, so it
+            # sticks for the remaining steps of this turn.
             context.truncate_history_results(max_chars=500)
             prompt = await self._build_agent_prompt(
                 message, context, conversation_history,

--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -25,6 +25,7 @@ from utils.circuit_breaker import agent_circuit_breaker
 from utils.config import settings
 from utils.prompt_safety import neutralize_delimiters
 from utils.llm_client import (
+    effective_agent_num_ctx,
     extract_response_content,
     get_agent_client,
     get_classification_chat_kwargs,
@@ -68,12 +69,14 @@ token_budget_info: ContextVar[dict | None] = ContextVar("token_budget_info", def
 token_usage_info: ContextVar[dict | None] = ContextVar("token_usage_info", default=None)
 
 
-def _compress_history_message(content: str, max_chars: int = 500) -> str:
+def _compress_history_message(content: str, max_chars: int | None = None) -> str:
     """Compress a conversation history message for the agent prompt.
 
     Action result blocks can be very large (full document lists, base64 data).
     This extracts the essential summary and truncates the natural-language response.
     """
+    if max_chars is None:
+        max_chars = settings.agent_history_message_max_chars
     if not content:
         return ""
 
@@ -133,8 +136,9 @@ class AgentContext:
     steps: list[AgentStep] = field(default_factory=list)
     tool_results: list[dict] = field(default_factory=list)
 
-    # Maximum number of steps to include in the prompt (sliding window)
-    # With 32k context window, we can keep all steps from a typical agent run
+    # Maximum number of steps to include in the prompt (sliding window) —
+    # sized so a typical agent run keeps all its steps within the token budget
+    # (effective_agent_num_ctx)
     MAX_HISTORY_STEPS: int = settings.agent_history_limit
 
     # Blob store for large binary data (base64) passed between tool steps.
@@ -252,7 +256,8 @@ class AgentContext:
                     budget = self.tool_result_budget_chars
                     content = _serialize_for_prompt(step.data, budget_chars=budget)
                 else:
-                    content = step.content[:8000] if step.content else no_result
+                    text_cap = settings.agent_tool_result_text_max_chars
+                    content = step.content[:text_cap] if step.content else no_result
                 tool_name = step.tool or "unknown"
                 # #686: neutralize structural delimiters in untrusted tool output
                 # (and the tool name) so a crafted MCP/tool result can't forge or
@@ -449,6 +454,11 @@ _SAME_TOOL_ABORT_THRESHOLD = 5
 # YAML always wins when present (keys defined at the bottom of agent.yaml).
 # Centralizing the defaults here so they aren't duplicated as inline literals
 # at each call site, where they previously read like the source of truth.
+# The num_ctx=32768 here is DELIBERATE even when the agent routes to the
+# large-context llama-server: the OpenAI-compat path drops num_ctx anyway
+# (server --ctx-size governs), while on the in-cluster Ollama fallback it
+# protects the fallback model from an oversized KV-cache allocation. The
+# backend token budget scales via effective_agent_num_ctx() instead.
 _DEFAULT_LLM_OPTIONS = {
     "temperature": 0.1, "top_p": 0.2, "num_predict": 2048, "num_ctx": 32768,
 }
@@ -954,7 +964,11 @@ class AgentService:
         """
         from utils.token_counter import token_counter
 
-        max_tokens = settings.ollama_num_ctx
+        # Backend-aware: the OpenAI-compat llama-server ignores client num_ctx
+        # (its --ctx-size governs), so when the agent tier routes there the
+        # budget may fill the declared llm_openai_num_ctx instead of the
+        # Ollama window.
+        max_tokens = effective_agent_num_ctx()
         reserved = settings.agent_default_num_predict
         threshold = settings.agent_budget_threshold
 
@@ -1128,8 +1142,10 @@ class AgentService:
         if summary_text:
             conv_prefix += f"## Earlier in this conversation\n{neutralize_delimiters(summary_text)}\n\n"
 
-        # With 32k context, include conversation history for follow-up references
-        # like "Schick die gleiche Rechnung nochmal" or "Und wie ist es morgen?"
+        # Include conversation history for follow-up references like "Schick
+        # die gleiche Rechnung nochmal" or "Und wie ist es morgen?" — depth via
+        # agent_conv_context_messages, per-message size via
+        # agent_history_message_max_chars (both budget-guarded downstream)
         conv_context = ""
         if conversation_history:
             n = settings.agent_conv_context_messages

--- a/src/backend/services/knowledge_tool.py
+++ b/src/backend/services/knowledge_tool.py
@@ -223,7 +223,8 @@ async def knowledge_search(params: dict) -> dict:
             )
             source = doc.get("filename", "") or r.get("filename", "")
             if content:
-                context_parts.append(f"[{source}] {content[:500]}")
+                chunk_cap = settings.knowledge_context_chunk_chars
+                context_parts.append(f"[{source}] {content[:chunk_cap]}")
 
             doc_id = doc.get("id")
             if doc_id is not None and doc_id not in seen_doc_ids:

--- a/src/backend/services/knowledge_tool.py
+++ b/src/backend/services/knowledge_tool.py
@@ -214,6 +214,7 @@ async def knowledge_search(params: dict) -> dict:
         # Deduped by document_id (one chip per source document, not per chunk).
         sources: list[dict] = []
         seen_doc_ids: set = set()
+        chunk_cap = settings.knowledge_context_chunk_chars
         for r in results:
             doc = r.get("document") if isinstance(r.get("document"), dict) else {}
             content = (
@@ -223,7 +224,6 @@ async def knowledge_search(params: dict) -> dict:
             )
             source = doc.get("filename", "") or r.get("filename", "")
             if content:
-                chunk_cap = settings.knowledge_context_chunk_chars
                 context_parts.append(f"[{source}] {content[:chunk_cap]}")
 
             doc_id = doc.get("id")

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -316,6 +316,14 @@ class Settings(BaseSettings):
     # Qwen3-Embedding-4B). When set, embeddings route here instead of Ollama.
     llm_openai_embed_base_url: str | None = None
     llm_openai_embed_model: str = "qwen3-embedding"
+    # Context window of the external OpenAI-compat server (must match the
+    # llama-server's --ctx-size). Used ONLY for the backend-side token budget
+    # (_enforce_token_budget) when the agent tier routes to that server — the
+    # server itself ignores client num_ctx. None = budget against
+    # ollama_num_ctx (legacy behavior). Caveat: with llm_openai_fallback_enabled
+    # a prompt wider than ollama_num_ctx degrades on fail-over (the in-cluster
+    # fallback model still runs at ollama_num_ctx and truncates).
+    llm_openai_num_ctx: int | None = None
     agent_conv_context_messages: int = 12  # Number of conversation history messages in agent loop
     conversation_summary_threshold: int = 10  # Trigger LLM summary when message count exceeds this
     agent_roles_path: str = "config/agent_roles.yaml"  # Path to agent role definitions
@@ -406,6 +414,14 @@ class Settings(BaseSettings):
     agent_history_limit: int = Field(default=20, ge=1, le=100)       # Max history steps in agent loop
     agent_response_truncation: int = Field(default=2000, ge=100, le=50000)  # Max chars for tool response truncation
     agent_budget_threshold: float = Field(default=0.85, ge=0.5, le=0.99)   # Token budget utilization threshold (triggers reduction above this)
+    # Per-message char cap when compressing conversation history into the agent
+    # prompt (_compress_history_message). Raise together with llm_openai_num_ctx
+    # to actually exploit a large server-side context window.
+    agent_history_message_max_chars: int = Field(default=500, ge=100, le=50000)
+    # Char cap for text-form tool results in the agent scratchpad
+    # (AgentContext.build_history_prompt step.content path). Structured results
+    # are governed by tool_result_budget_chars / the token budget instead.
+    agent_tool_result_text_max_chars: int = Field(default=8000, ge=500, le=500000)
     agent_parallel_tools: bool = True                                       # Allow multi-action in single step
     agent_orchestrator_parallel: bool = True                                # Run orchestrator sub-agents in parallel
 
@@ -457,6 +473,10 @@ class Settings(BaseSettings):
     rag_rerank_enabled: bool = True            # Rerank results with dedicated model
     rag_rerank_model: str = "mxbai-rerank-base-v1"
     rag_rerank_top_k: int = Field(default=5, ge=1, le=50)  # Final results after reranking
+    # Per-chunk char cap when internal.knowledge_search assembles its context
+    # block (services/knowledge_tool.py). Raise together with llm_openai_num_ctx
+    # so retrieved chunks reach the agent uncut.
+    knowledge_context_chunk_chars: int = Field(default=500, ge=100, le=10000)
 
     # OCR Processing
     rag_force_ocr: bool = False               # Always force full-page OCR (ignores embedded text)

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -323,7 +323,10 @@ class Settings(BaseSettings):
     # ollama_num_ctx (legacy behavior). Caveat: with llm_openai_fallback_enabled
     # a prompt wider than ollama_num_ctx degrades on fail-over (the in-cluster
     # fallback model still runs at ollama_num_ctx and truncates).
-    llm_openai_num_ctx: int | None = None
+    # Bounded so a fat-fingered/negative value fails at startup instead of
+    # silently disabling budget enforcement (negative max → negative
+    # utilization → reduction never fires).
+    llm_openai_num_ctx: int | None = Field(default=None, ge=1024, le=2_000_000)
     agent_conv_context_messages: int = 12  # Number of conversation history messages in agent loop
     conversation_summary_threshold: int = 10  # Trigger LLM summary when message count exceeds this
     agent_roles_path: str = "config/agent_roles.yaml"  # Path to agent role definitions

--- a/src/backend/utils/llm_client.py
+++ b/src/backend/utils/llm_client.py
@@ -291,22 +291,52 @@ class _OpenAICompatFallbackClient:
         return kwargs
 
     @staticmethod
-    def _warn_if_prompt_exceeds_fallback_ctx(messages: list[dict[str, Any]] | None) -> None:
-        """The fallback runs at ``ollama_num_ctx`` regardless of how wide the
-        primary's window is (``llm_openai_num_ctx``); an oversized prompt is
-        silently truncated by Ollama, dropping the system/tools framing at the
-        head. We can't shrink the prompt here (outage mode is best-effort), but
-        the degradation must be visible in the logs. Chars/token ≈ 3 is a
-        deliberately conservative estimate — only clear oversize warns.
+    def _warn_if_prompt_exceeds_fallback_ctx(
+        messages: list[dict[str, Any]] | None, kwargs: dict[str, Any]
+    ) -> None:
+        """The fallback runs at the ``options.num_ctx`` forwarded verbatim in
+        the call kwargs (else Ollama's own default) — NOT at whatever wide
+        window the primary served (``llm_openai_num_ctx``). An oversized prompt
+        is silently truncated by Ollama, dropping the system/tools framing at
+        the head. We can't shrink the prompt here (outage mode is best-effort),
+        but the degradation must be visible in the logs. Token estimation goes
+        through the content-aware ``token_counter`` (rare path — one extra scan
+        per fail-over call is fine) so the warning neither misses real oversize
+        nor cries wolf on prompts that fit.
         """
-        total_chars = sum(len(str(m.get("content") or "")) for m in messages or [])
-        limit_chars = settings.ollama_num_ctx * 3
-        if total_chars > limit_chars:
+        from utils.token_counter import token_counter
+
+        options = kwargs.get("options") or {}
+        effective_ctx = options.get("num_ctx") or settings.ollama_num_ctx
+        text = "".join(str(m.get("content") or "") for m in messages or [])
+        estimated_tokens = token_counter.count(text)
+        if estimated_tokens > effective_ctx:
             logger.warning(
-                f"Fallback prompt (~{total_chars} chars) exceeds the in-cluster "
-                f"fallback context (num_ctx={settings.ollama_num_ctx}) — the "
+                f"Fallback prompt (~{estimated_tokens} tokens) exceeds the "
+                f"in-cluster fallback context (num_ctx={effective_ctx}) — the "
                 f"response may be truncated/degraded until the primary recovers"
             )
+
+    def _prepare_fallback(
+        self,
+        exc: Exception,
+        messages: list[dict[str, Any]] | None,
+        kwargs: dict[str, Any],
+        *,
+        stream: bool,
+    ) -> tuple[str, dict[str, Any]]:
+        """Shared fail-over preamble for the streaming and non-streaming paths:
+        resolve the in-cluster model, adjust kwargs, log the fail-over, and
+        surface a possible prompt-oversize degradation."""
+        fb_model = self._fallback_model()
+        fb_kwargs = self._fallback_kwargs(kwargs, fb_model)
+        where = " on stream open" if stream else ""
+        logger.warning(
+            f"OpenAI-compat LLM primary failed{where} ({exc!r}); "
+            f"falling back to in-cluster Ollama (model={fb_model})"
+        )
+        self._warn_if_prompt_exceeds_fallback_ctx(messages, kwargs)
+        return fb_model, fb_kwargs
 
     async def chat(
         self,
@@ -323,13 +353,7 @@ class _OpenAICompatFallbackClient:
         except Exception as exc:  # noqa: BLE001 — _should_fallback re-raises what it can't handle
             if not _should_fallback(exc):
                 raise
-            fb_model = self._fallback_model()
-            fb_kwargs = self._fallback_kwargs(kwargs, fb_model)
-            logger.warning(
-                f"OpenAI-compat LLM primary failed ({exc!r}); "
-                f"falling back to in-cluster Ollama (model={fb_model})"
-            )
-            self._warn_if_prompt_exceeds_fallback_ctx(messages)
+            fb_model, fb_kwargs = self._prepare_fallback(exc, messages, kwargs, stream=False)
             return await self._fallback.chat(model=fb_model, messages=messages, stream=False, **fb_kwargs)
 
     async def _chat_stream(
@@ -343,13 +367,7 @@ class _OpenAICompatFallbackClient:
         except Exception as exc:  # noqa: BLE001
             if not _should_fallback(exc):
                 raise
-            fb_model = self._fallback_model()
-            fb_kwargs = self._fallback_kwargs(kwargs, fb_model)
-            logger.warning(
-                f"OpenAI-compat LLM primary failed on stream open ({exc!r}); "
-                f"falling back to in-cluster Ollama (model={fb_model})"
-            )
-            self._warn_if_prompt_exceeds_fallback_ctx(messages)
+            fb_model, fb_kwargs = self._prepare_fallback(exc, messages, kwargs, stream=True)
             fb_gen = await self._fallback.chat(model=fb_model, messages=messages, stream=True, **fb_kwargs)
             async for chunk in fb_gen:
                 yield chunk

--- a/src/backend/utils/llm_client.py
+++ b/src/backend/utils/llm_client.py
@@ -290,6 +290,24 @@ class _OpenAICompatFallbackClient:
             return {**kwargs, "think": False}
         return kwargs
 
+    @staticmethod
+    def _warn_if_prompt_exceeds_fallback_ctx(messages: list[dict[str, Any]] | None) -> None:
+        """The fallback runs at ``ollama_num_ctx`` regardless of how wide the
+        primary's window is (``llm_openai_num_ctx``); an oversized prompt is
+        silently truncated by Ollama, dropping the system/tools framing at the
+        head. We can't shrink the prompt here (outage mode is best-effort), but
+        the degradation must be visible in the logs. Chars/token ≈ 3 is a
+        deliberately conservative estimate — only clear oversize warns.
+        """
+        total_chars = sum(len(str(m.get("content") or "")) for m in messages or [])
+        limit_chars = settings.ollama_num_ctx * 3
+        if total_chars > limit_chars:
+            logger.warning(
+                f"Fallback prompt (~{total_chars} chars) exceeds the in-cluster "
+                f"fallback context (num_ctx={settings.ollama_num_ctx}) — the "
+                f"response may be truncated/degraded until the primary recovers"
+            )
+
     async def chat(
         self,
         model: str = "",
@@ -311,6 +329,7 @@ class _OpenAICompatFallbackClient:
                 f"OpenAI-compat LLM primary failed ({exc!r}); "
                 f"falling back to in-cluster Ollama (model={fb_model})"
             )
+            self._warn_if_prompt_exceeds_fallback_ctx(messages)
             return await self._fallback.chat(model=fb_model, messages=messages, stream=False, **fb_kwargs)
 
     async def _chat_stream(
@@ -330,6 +349,7 @@ class _OpenAICompatFallbackClient:
                 f"OpenAI-compat LLM primary failed on stream open ({exc!r}); "
                 f"falling back to in-cluster Ollama (model={fb_model})"
             )
+            self._warn_if_prompt_exceeds_fallback_ctx(messages)
             fb_gen = await self._fallback.chat(model=fb_model, messages=messages, stream=True, **fb_kwargs)
             async for chunk in fb_gen:
                 yield chunk
@@ -730,6 +750,22 @@ def use_openai_for_tier(tier: str) -> bool:
     if agent is None:
         return True  # default: route everything through llama-server when configured
     return bool(agent)
+
+
+def effective_agent_num_ctx() -> int:
+    """Context window the agent tier can actually fill.
+
+    The OpenAI-compat server (llama-server) ignores client-side ``num_ctx`` —
+    its ``--ctx-size`` governs — so when the agent tier routes there AND the
+    operator declared that size via ``llm_openai_num_ctx``, the backend token
+    budget may fill it. Everywhere else (Ollama routing, or the setting unset)
+    the budget stays at ``ollama_num_ctx``. NOTE: this is a budget bound only;
+    with ``llm_openai_fallback_enabled`` a prompt wider than ``ollama_num_ctx``
+    degrades on fail-over (see ``_OpenAICompatFallbackClient``).
+    """
+    if settings.llm_openai_num_ctx and use_openai_for_tier("agent"):
+        return settings.llm_openai_num_ctx
+    return settings.ollama_num_ctx
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/utils/token_counter.py
+++ b/src/backend/utils/token_counter.py
@@ -267,26 +267,38 @@ class TokenCounter:
             reserved_tokens=reserved_for_response
         )
 
+    # Sample size for content-type detection. count() runs on the hot agent
+    # path up to ~7x per ReAct step; scanning a multi-hundred-KB prompt in
+    # full (plus the .lower() copy) blocks the event loop for tens of ms per
+    # call. A prefix sample classifies just as reliably — prompts are
+    # homogeneous enough that the first few KB decide the ratio.
+    DETECT_SAMPLE_CHARS = 4096
+
     def _detect_content_type(self, text: str) -> float:
         """
         Detect content type and return appropriate chars-per-token ratio.
+
+        Operates on a bounded prefix sample (DETECT_SAMPLE_CHARS) so the cost
+        stays O(1) regardless of prompt size.
         """
+        sample = text[:self.DETECT_SAMPLE_CHARS]
+
         # Check for JSON
-        if text.strip().startswith("{") or text.strip().startswith("["):
+        if sample.strip().startswith("{") or sample.strip().startswith("["):
             return self.CHARS_PER_TOKEN_JSON
 
         # Check for code (simple heuristics)
         code_indicators = ["def ", "class ", "function ", "import ", "const ", "let ", "var "]
-        if any(indicator in text for indicator in code_indicators):
+        if any(indicator in sample for indicator in code_indicators):
             return self.CHARS_PER_TOKEN_CODE
 
         # Check for German text (umlauts and common words)
         german_chars = "äöüÄÖÜß"
         german_words = ["der", "die", "das", "und", "ist", "ein", "eine", "nicht"]
-        text_lower = text.lower()
+        sample_lower = sample.lower()
 
-        has_umlauts = any(c in text for c in german_chars)
-        has_german_words = sum(1 for w in german_words if f" {w} " in f" {text_lower} ") >= 2
+        has_umlauts = any(c in sample for c in german_chars)
+        has_german_words = sum(1 for w in german_words if f" {w} " in f" {sample_lower} ") >= 2
 
         if has_umlauts or has_german_words:
             return self.CHARS_PER_TOKEN_GERMAN

--- a/src/backend/utils/token_counter.py
+++ b/src/backend/utils/token_counter.py
@@ -270,18 +270,23 @@ class TokenCounter:
     # Sample size for content-type detection. count() runs on the hot agent
     # path up to ~7x per ReAct step; scanning a multi-hundred-KB prompt in
     # full (plus the .lower() copy) blocks the event loop for tens of ms per
-    # call. A prefix sample classifies just as reliably — prompts are
-    # homogeneous enough that the first few KB decide the ratio.
+    # call. Sampling head AND tail keeps the cost O(1) while still seeing the
+    # scratchpad end of an agent prompt: a German system-template head with
+    # code/JSON-bearing tool results at the tail must classify as CODE (3.0,
+    # the conservative direction) rather than GERMAN (4.5) — a head-only
+    # sample would undercount such prompts right where the budget runs close
+    # to the real context limit.
     DETECT_SAMPLE_CHARS = 4096
 
     def _detect_content_type(self, text: str) -> float:
         """
         Detect content type and return appropriate chars-per-token ratio.
 
-        Operates on a bounded prefix sample (DETECT_SAMPLE_CHARS) so the cost
-        stays O(1) regardless of prompt size.
+        Operates on a bounded head+tail sample (DETECT_SAMPLE_CHARS each) so
+        the cost stays O(1) regardless of prompt size.
         """
-        sample = text[:self.DETECT_SAMPLE_CHARS]
+        n = self.DETECT_SAMPLE_CHARS
+        sample = text if len(text) <= 2 * n else text[:n] + "\n" + text[-n:]
 
         # Check for JSON
         if sample.strip().startswith("{") or sample.strip().startswith("["):

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,39 +1,17 @@
-# PDF-Split — automatic multi-document PDF detection + splitting at ingest
+# Großen LLM-Kontext (256k llama-server) ausnutzen — feat/exploit-large-llm-context
 
-Plan: `~/.claude/plans/harmonic-toasting-toucan.md` (approved 2026-08-16). Dark by default (`PDF_SPLIT_ENABLED=false`).
+Plan: ~/.claude/plans/buzzing-crafting-meerkat.md (genehmigt, Zuschnitt: Moderat)
 
-**Hard requirement: page count is NEVER a gate, cap, or signal.** Input is arbitrary mixes of single-page docs + multi-page contracts. Boundaries come from content evidence only; long inputs are handled by context-window batching (sliding windows), bad scans by unbounded per-page VLM transcription in the dedicated split worker.
+- [ ] 1. Neue Settings in `utils/config.py` (`llm_openai_num_ctx`, `agent_history_message_max_chars`, `agent_tool_result_text_max_chars`, `knowledge_context_chunk_chars`)
+- [ ] 2. `effective_agent_num_ctx()` in `utils/llm_client.py` + Budget-Umstellung in `agent_service._enforce_token_budget`
+- [ ] 3. Content-Caps auf Settings umstellen (`_compress_history_message`, `step.content[:8000]`, knowledge_tool `[:500]`) + stale Kommentare
+- [ ] 4. Fallback-Oversize-WARNING in `_OpenAICompatFallbackClient`
+- [ ] 5. token_counter `_detect_content_type` Sampling-Fix (4096-Zeichen-Sample)
+- [ ] 6. ConfigMaps beide Instanzen (`k8s/configmap.yaml`, `k8s/xidra/renfield-env.configmap.yaml`)
+- [ ] 7. Tests: test_token_budget (Mocks + neue Fälle), test_llm_client (Fallback-Warnung), Caps-Tests, test_token_counter (Sampling); test_routine_agent Mock ergänzen
+- [ ] 8. Doku: ENVIRONMENT_VARIABLES.md + .env.example
+- [ ] 9. /verify-tests auf .159 grün
+- [ ] 10. /review + Docs-Sweep + Commit (kein Push ohne Freigabe)
 
-## PR1 — core auto-split (text-layer path)
-- [x] Migration `pc20260816_pdf_split` (verified: up/down/up cycle on scratch PG + fresh-install no-op path)
-- [x] `models/database.py`: columns, `PdfSplitProposal`, status constants `split_pending`/`split_review`/`split_archived`
-- [x] `utils/config.py`: `pdf_split_enabled=False`, `pdf_split_window_chars`, `pdf_split_vlm_page_timeout_s`, `pdf_split_auto_threshold` (NO page-count settings)
-- [x] `services/pdf_split_detector.py`: page signals, windowed boundary LLM call(s) with open-piece carry, pure-Python validation/merge
-- [x] `prompts/pdf_split.yaml` (de/en, mixed-shapes guidance, strict JSON)
-- [x] `services/pdf_splitter.py`: `split_pdf_bytes`, `execute_split` (idempotent filename-keyed resume, children via `ingest_document`, parent archived LAST + chunk purge), `maybe_split_at_ingest`
-- [x] `workers/document_processor_worker.py` pre-stage (lazy import, flag/skip_split guard; slow-lane + low-confidence → logged single-doc until PR2/PR3)
-- [x] `services/folder_ingest.py`: `classify_existing` `split_archived` → DUPLICATE, split-in-flight → RETRY
-- [x] Tests: 100 passed on .159 (detector/splitter/prestage/folder-ingest); neighboring suites 159 passed
-- [x] `docs/design/pdf-split.md` + `docs/ENVIRONMENT_VARIABLES.md` section
-- [x] Full backend suite on .159: failure set byte-identical to main baseline (28 pre-existing rotten tests — NOT this feature; user should schedule /verify-tests)
-- [x] Commit `eb6ce554` → high-effort /code-review → 10 verified findings → ALL fixed in `a177f270` (persisted plan, parent-hash resume keys, SplitTransientError taxonomy, flag-independent archive guard, reindex 409, status contract, ORM partial unique, model tests, poppler-first signals, shared parse_llm_json+salvage)
-- [x] Docs sweep: CLAUDE.md, docs/FEATURES.md, docs/design/pdf-split.md, docs/ENVIRONMENT_VARIABLES.md, paperless-llm-metadata deferral resolved
-- [ ] Post-fix full suite (running) + medium /review of fix commit → then WAIT for push/merge approval (no push without permission)
-
-## PR2 — review flow — DONE, PR #1099 (pushed, awaiting merge approval)
-- [x] `services/pdf_split_proposals.py` (create idempotent + notify-once, durable conditional-UPDATE resolutions, idempotent same-action retry = strand recovery, has_rejected_proposal consulted by detection)
-- [x] `api/routes/pdf_split.py` + main.py mount (owner-scoped, NULL-owner admin-resolvable, JPEG thumbs from bounded executor, worker-alive 503; `document_worker_is_alive` promoted to task_queue)
-- [x] `api/routes/config.py` FeatureFlags `pdf_split_enabled`
-- [x] Frontend: PdfSplitReviewSection (contiguity-by-construction editing, opt-in thumbs, prop re-sync), StatusBadge split states (DESIGN warning tone), polling terminal states, i18n de/en/it
-- [x] Tests: 16 route/service + 6 RTL; 2 review cycles (10+1 findings fixed); full suite baseline-identical; rotten MeetingsPage test fixed (undici/jsdom File)
-
-## PR3 — VLM slow path — DONE, merged #1100 (98348c07)
-- [x] All of it + 2 review cycles (incl. release-blocking inert-queue-defaults bug) — see design doc
-
-## Deployed 2026-08-18 (household)
-- [x] Images `2026-08-18-pdfsplit`, migration applied, flag ON, worker live, netpols enforced, E2E green (synthetic 3-doc split perfect)
-- [x] xidra rollout DONE 2026-08-20 (migration, flag, worker, netpols mit eigener privater Quelle k8s/xidra/redis-postgres-netpol.yaml; ~3-min Paperless-Netpol-Incident, behoben) ·
-- [ ] Follow-ups: deploy-script fix (sed registry for alembic job) · /verify-tests for the 28 rotten main tests · test docs 421-424 cleanup (user decision)
-
-## Review / verification log
-(fill during implementation)
+## Review
+(wird nach Abschluss ergänzt)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,17 +1,23 @@
 # Großen LLM-Kontext (256k llama-server) ausnutzen — feat/exploit-large-llm-context
 
-Plan: ~/.claude/plans/buzzing-crafting-meerkat.md (genehmigt, Zuschnitt: Moderat)
+Plan: ~/.claude/plans/buzzing-crafting-meerkat.md (genehmigt, Zuschnitt: Moderat) · Issue #1103 · Follow-ups #1104
 
-- [ ] 1. Neue Settings in `utils/config.py` (`llm_openai_num_ctx`, `agent_history_message_max_chars`, `agent_tool_result_text_max_chars`, `knowledge_context_chunk_chars`)
-- [ ] 2. `effective_agent_num_ctx()` in `utils/llm_client.py` + Budget-Umstellung in `agent_service._enforce_token_budget`
-- [ ] 3. Content-Caps auf Settings umstellen (`_compress_history_message`, `step.content[:8000]`, knowledge_tool `[:500]`) + stale Kommentare
-- [ ] 4. Fallback-Oversize-WARNING in `_OpenAICompatFallbackClient`
-- [ ] 5. token_counter `_detect_content_type` Sampling-Fix (4096-Zeichen-Sample)
-- [ ] 6. ConfigMaps beide Instanzen (`k8s/configmap.yaml`, `k8s/xidra/renfield-env.configmap.yaml`)
-- [ ] 7. Tests: test_token_budget (Mocks + neue Fälle), test_llm_client (Fallback-Warnung), Caps-Tests, test_token_counter (Sampling); test_routine_agent Mock ergänzen
-- [ ] 8. Doku: ENVIRONMENT_VARIABLES.md + .env.example
-- [ ] 9. /verify-tests auf .159 grün
-- [ ] 10. /review + Docs-Sweep + Commit (kein Push ohne Freigabe)
+- [x] 1-8. Implementierung + Tests + Doku (Commit `bac65900`)
+- [x] 9. Suite auf .159 grün (5998 → nach Review-Fixes 6001 passed, 0 failed); Lint-Diff gegen main: 0 neue Verstöße
+- [x] 10. Commit `bac65900` (Feature) 
+- [x] 11. /review high abgearbeitet (2. Commit mit Review-Fixes):
+  - F2 CONFIRMED: `AGENT_RESPONSE_TRUNCATION=32000` in beide ConfigMaps (Text-Ergebnisse wurden sonst schon bei Step-Erzeugung auf 2000 gekappt → Lese-Cap inert)
+  - F4 CONFIRMED: Pass-0-Budget (`tool_result_budget_chars`) greift jetzt auch auf TEXT-Ergebnisse (min mit `agent_tool_result_text_max_chars`); Pass-4-500er-Floor als bewusster Notfall-Crush dokumentiert
+  - F5 CONFIRMED: Fallback-Oversize-Warnung keyt auf das tatsächlich geforwardete `options.num_ctx` + content-aware `token_counter` statt `ollama_num_ctx*3` (beide Fehlrichtungen behoben)
+  - F7 CONFIRMED: `llm_openai_num_ctx` mit Field-Bounds (ge=1024) — negativer Wert kann Budget nicht mehr still deaktivieren
+  - F9/F10 cleanup: gemeinsames `_prepare_fallback`, toter `max_chars`-Param entfernt, loop-invariante Settings-Reads gehoistet
+  - F3 PLAUSIBLE: token_counter sampelt Head+Tail (Code-Tail → konservative 3.0 statt German 4.5 → kein 33%-Undercount am Budget-Rand)
+  - F1/F6/F8 PLAUSIBLE (bewusst vertagt, dokumentiert): Follow-up-Issue #1104 (Fallback-seitige Re-Reduktion, Ollama-Primary num_ctx-Forwarding, Soft-Prompt-Target); F6 zusätzlich als KNOWN GAP im Code kommentiert
+  - Refuted: V3 (multimodal), V12 (tool_calls), Timing-Flake
+- [ ] 12. Push/PR/Merge — NUR nach expliziter Freigabe
+- [ ] 13. Deploy nach Freigabe (`bin/deploy-production.sh`, Backend-Image beide Instanzen + ConfigMap-Apply, keine Migration) + Browser-E2E + Log-Nachweis `Token budget: N/262144`
 
 ## Review
-(wird nach Abschluss ergänzt)
+- Suite-Läufe isoliert auf .159: non-PG 5647 passed / 382 skipped, PG-markiert 354 passed / 12 skipped — 0 Failures (beide Commits).
+- Ruff-Diff main↔branch nach beiden Commits: 0 neue Verstöße.
+- Bewusste Tradeoffs: Fallback bleibt bei 32k (VRAM-Schutz, Outage = best-effort mit korrekter Warnung); Prefill-Latenz durch moderate Caps begrenzt, Soft-Target als Follow-up.

--- a/tests/backend/test_knowledge_tool.py
+++ b/tests/backend/test_knowledge_tool.py
@@ -96,6 +96,42 @@ class TestKnowledgeSearch:
         )
 
     @pytest.mark.unit
+    async def test_chunk_cap_follows_setting(self, monkeypatch):
+        """The per-chunk char cap in the context block is configurable
+        (knowledge_context_chunk_chars) so a large-context deployment can pass
+        retrieved chunks to the agent uncut."""
+        long_content = "A" * 900
+        mock_rag = MagicMock()
+        mock_rag.search = AsyncMock(return_value=[
+            {
+                "chunk": {"content": long_content},
+                "document": {"filename": "doc.pdf"},
+                "similarity": 0.9,
+            },
+        ])
+
+        mock_db = AsyncMock()
+
+        @asynccontextmanager
+        async def mock_session():
+            yield mock_db
+
+        monkeypatch.setattr(
+            "services.knowledge_tool.settings.knowledge_context_chunk_chars", 100
+        )
+        stubs = _stub_db_and_rag_modules()
+        try:
+            with patch("services.database.AsyncSessionLocal", mock_session, create=True), \
+                 patch("services.rag_service.RAGService", return_value=mock_rag, create=True):
+                result = await knowledge_search({"query": "test"})
+        finally:
+            _teardown_stubs(stubs)
+
+        context = result["data"]["context"]
+        assert "A" * 100 in context
+        assert "A" * 101 not in context
+
+    @pytest.mark.unit
     async def test_returns_structured_sources(self):
         """Results carry a deduped, document-keyed `sources` list for the chat
         provenance-chips UI (filename, title, tier)."""

--- a/tests/backend/test_llm_client.py
+++ b/tests/backend/test_llm_client.py
@@ -38,6 +38,7 @@ from utils.llm_client import (
     OpenAICompatibleClient,
     clear_client_cache,
     create_llm_client,
+    effective_agent_num_ctx,
     extract_response_content,
     get_agent_client,
     get_classification_chat_kwargs,
@@ -1045,6 +1046,45 @@ class TestUseOpenAIForTier:
         assert use_openai_for_tier("chat") is False
 
 
+class TestEffectiveAgentNumCtx:
+    """The token budget's context window must follow the serving backend."""
+
+    @pytest.mark.unit
+    def test_openai_ctx_when_agent_routed_and_declared(self, monkeypatch):
+        monkeypatch.setattr("utils.llm_client.settings.llm_openai_base_url", "http://llama:8080/v1")
+        monkeypatch.setattr("utils.llm_client.settings.llm_openai_for_agent", None)
+        monkeypatch.setattr("utils.llm_client.settings.llm_openai_num_ctx", 262144, raising=False)
+        monkeypatch.setattr("utils.llm_client.settings.ollama_num_ctx", 32768)
+        assert effective_agent_num_ctx() == 262144
+
+    @pytest.mark.unit
+    def test_ollama_ctx_when_setting_unset(self, monkeypatch):
+        """llm_openai_num_ctx=None (default) → legacy budget, even when the
+        agent tier routes to the OpenAI-compat server."""
+        monkeypatch.setattr("utils.llm_client.settings.llm_openai_base_url", "http://llama:8080/v1")
+        monkeypatch.setattr("utils.llm_client.settings.llm_openai_for_agent", None)
+        monkeypatch.setattr("utils.llm_client.settings.llm_openai_num_ctx", None, raising=False)
+        monkeypatch.setattr("utils.llm_client.settings.ollama_num_ctx", 32768)
+        assert effective_agent_num_ctx() == 32768
+
+    @pytest.mark.unit
+    def test_ollama_ctx_when_agent_tier_on_ollama(self, monkeypatch):
+        """A declared llm_openai_num_ctx must NOT widen the budget when the
+        agent tier is routed to Ollama (per-tier override off)."""
+        monkeypatch.setattr("utils.llm_client.settings.llm_openai_base_url", "http://llama:8080/v1")
+        monkeypatch.setattr("utils.llm_client.settings.llm_openai_for_agent", False)
+        monkeypatch.setattr("utils.llm_client.settings.llm_openai_num_ctx", 262144, raising=False)
+        monkeypatch.setattr("utils.llm_client.settings.ollama_num_ctx", 32768)
+        assert effective_agent_num_ctx() == 32768
+
+    @pytest.mark.unit
+    def test_ollama_ctx_when_no_openai_endpoint(self, monkeypatch):
+        monkeypatch.setattr("utils.llm_client.settings.llm_openai_base_url", None)
+        monkeypatch.setattr("utils.llm_client.settings.llm_openai_num_ctx", 262144, raising=False)
+        monkeypatch.setattr("utils.llm_client.settings.ollama_num_ctx", 32768)
+        assert effective_agent_num_ctx() == 32768
+
+
 class TestGetDefaultClientRoutesToOpenAI:
     """get_default_client() / get_agent_client() prefer OpenAI when configured."""
 
@@ -1226,6 +1266,43 @@ class TestOpenAICompatFallbackClient:
         result = await w.chat(model="qwen3.6", messages=[])
         assert result == "fallback"
         assert fallback.chat.call_args.kwargs["model"] == "qwen3:14b"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_oversized_prompt_warns_on_fallback(self, monkeypatch):
+        """A prompt wider than the fallback's num_ctx (budgeted for the large
+        llama-server window) must log a WARNING — Ollama would silently
+        truncate it, and that degradation has to be visible."""
+        import httpx
+        primary = AsyncMock()
+        fallback = AsyncMock()
+        primary.chat.side_effect = httpx.ConnectError("refused")
+        fallback.chat.return_value = "ok"
+        w = self._wrapper(monkeypatch, primary, fallback)
+        monkeypatch.setattr("utils.llm_client.settings.ollama_num_ctx", 1000)
+        big_messages = [{"role": "user", "content": "x" * 5000}]  # > 1000*3 chars
+
+        with patch("utils.llm_client.logger") as log:
+            assert await w.chat(model="qwen3.6", messages=big_messages) == "ok"
+        warnings = [str(c.args[0]) for c in log.warning.call_args_list]
+        assert any("exceeds the in-cluster fallback context" in m for m in warnings)
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_small_prompt_no_oversize_warning(self, monkeypatch):
+        import httpx
+        primary = AsyncMock()
+        fallback = AsyncMock()
+        primary.chat.side_effect = httpx.ConnectError("refused")
+        fallback.chat.return_value = "ok"
+        w = self._wrapper(monkeypatch, primary, fallback)
+        monkeypatch.setattr("utils.llm_client.settings.ollama_num_ctx", 1000)
+        small_messages = [{"role": "user", "content": "hi"}]
+
+        with patch("utils.llm_client.logger") as log:
+            assert await w.chat(model="qwen3.6", messages=small_messages) == "ok"
+        warnings = [str(c.args[0]) for c in log.warning.call_args_list]
+        assert not any("exceeds the in-cluster fallback context" in m for m in warnings)
 
     @pytest.mark.unit
     @pytest.mark.asyncio

--- a/tests/backend/test_llm_client.py
+++ b/tests/backend/test_llm_client.py
@@ -1289,6 +1289,29 @@ class TestOpenAICompatFallbackClient:
 
     @pytest.mark.unit
     @pytest.mark.asyncio
+    async def test_oversize_warning_keys_on_forwarded_num_ctx(self, monkeypatch):
+        """The fallback actually runs at the options.num_ctx forwarded in the
+        call kwargs, not at settings.ollama_num_ctx — a raised OLLAMA_NUM_CTX
+        must not mask real truncation at the smaller forwarded window."""
+        import httpx
+        primary = AsyncMock()
+        fallback = AsyncMock()
+        primary.chat.side_effect = httpx.ConnectError("refused")
+        fallback.chat.return_value = "ok"
+        w = self._wrapper(monkeypatch, primary, fallback)
+        monkeypatch.setattr("utils.llm_client.settings.ollama_num_ctx", 65536)
+        big_messages = [{"role": "user", "content": "x" * 20000}]  # ~5k tokens
+
+        with patch("utils.llm_client.logger") as log:
+            assert await w.chat(
+                model="qwen3.6", messages=big_messages,
+                options={"num_ctx": 1000},
+            ) == "ok"
+        warnings = [str(c.args[0]) for c in log.warning.call_args_list]
+        assert any("num_ctx=1000" in m for m in warnings)
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
     async def test_small_prompt_no_oversize_warning(self, monkeypatch):
         import httpx
         primary = AsyncMock()

--- a/tests/backend/test_token_budget.py
+++ b/tests/backend/test_token_budget.py
@@ -74,7 +74,8 @@ class TestEnforceTokenBudget:
         ctx = AgentContext(original_message="test")
         short_prompt = "Hello " * 100  # ~600 chars ~ 150 tokens
 
-        with patch("services.agent_service.settings") as s:
+        with patch("services.agent_service.settings") as s, \
+             patch("services.agent_service.effective_agent_num_ctx", return_value=32768):
             s.ollama_num_ctx = 32768
             s.agent_default_num_predict = 2048
             s.agent_budget_threshold = 0.85
@@ -115,7 +116,8 @@ class TestEnforceTokenBudget:
 
         agent._build_agent_prompt = mock_build
 
-        with patch("services.agent_service.settings") as s:
+        with patch("services.agent_service.settings") as s, \
+             patch("services.agent_service.effective_agent_num_ctx", return_value=32768):
             s.ollama_num_ctx = 32768
             s.agent_default_num_predict = 2048
             s.agent_budget_threshold = 0.85
@@ -150,7 +152,8 @@ class TestEnforceTokenBudget:
 
         agent._build_agent_prompt = mock_build
 
-        with patch("services.agent_service.settings") as s:
+        with patch("services.agent_service.settings") as s, \
+             patch("services.agent_service.effective_agent_num_ctx", return_value=32768):
             s.ollama_num_ctx = 32768
             s.agent_default_num_predict = 2048
             s.agent_budget_threshold = 0.85
@@ -181,6 +184,7 @@ class TestTokenBudgetLogLine:
 
         captured: list[str] = []
         with patch("services.agent_service.settings") as s, \
+             patch("services.agent_service.effective_agent_num_ctx", return_value=32768), \
              patch("services.agent_service.logger") as log:
             s.ollama_num_ctx = 32768
             s.agent_default_num_predict = 2048
@@ -199,3 +203,87 @@ class TestTokenBudgetLogLine:
         # Sanity-check the format: should contain a slash, a percentage sign, parens.
         assert "/" in canonical[0]
         assert "%)" in canonical[0]
+
+
+class TestConfigurableContentCaps:
+    """The former hardcoded content caps must follow their settings so a
+    large-context deployment can raise them via ConfigMap."""
+
+    @pytest.mark.unit
+    def test_compress_history_message_follows_setting(self, monkeypatch):
+        from services.agent_service import _compress_history_message
+        monkeypatch.setattr(
+            "services.agent_service.settings.agent_history_message_max_chars", 2000
+        )
+        content = "y" * 3000
+        out = _compress_history_message(content)
+        assert len(out) == 2003  # 2000 chars + "..."
+        # Explicit max_chars argument still wins over the setting
+        assert len(_compress_history_message(content, max_chars=150)) == 153
+
+    @pytest.mark.unit
+    def test_tool_result_text_cap_follows_setting(self, monkeypatch):
+        monkeypatch.setattr(
+            "services.agent_service.settings.agent_tool_result_text_max_chars", 12000
+        )
+        ctx = AgentContext(original_message="test")
+        ctx.steps = [
+            AgentStep(step_number=1, step_type="tool_result",
+                      content="z" * 20000, tool="t"),
+        ]
+        prompt = ctx.build_history_prompt(lang="de")
+        assert "z" * 12000 in prompt
+        assert "z" * 12001 not in prompt
+
+
+class TestBackendAwareBudget:
+    """The budget must follow the effective serving backend: when the agent
+    tier routes to the OpenAI-compat llama-server and its --ctx-size is
+    declared (llm_openai_num_ctx), a prompt far over the Ollama window must
+    pass through un-reduced."""
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_large_ctx_prompt_passes_untouched(self):
+        agent = _make_agent()
+        ctx = AgentContext(original_message="test")
+        # ~30k tokens — over 85% of 32768, but far under 262144.
+        large_prompt = "x" * 120000
+
+        with patch("services.agent_service.settings") as s, \
+             patch("services.agent_service.effective_agent_num_ctx", return_value=262144):
+            s.agent_default_num_predict = 2048
+            s.agent_budget_threshold = 0.85
+
+            prompt, mem, doc, _hist = await agent._enforce_token_budget(
+                large_prompt, ctx, "test", None,
+                memory_context="mem", document_context="doc", lang="de",
+            )
+            assert prompt == large_prompt
+            assert mem == "mem"
+            assert doc == "doc"
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_same_prompt_reduced_on_ollama_ctx(self):
+        """Control: identical prompt IS reduced when the effective window is
+        the Ollama one — proves the backend switch is what widens the budget."""
+        agent = _make_agent()
+        ctx = AgentContext(original_message="test")
+        large_prompt = "x" * 120000
+
+        async def mock_build(*args, **kwargs):
+            return "x" * 50000
+
+        agent._build_agent_prompt = mock_build
+
+        with patch("services.agent_service.settings") as s, \
+             patch("services.agent_service.effective_agent_num_ctx", return_value=32768):
+            s.agent_default_num_predict = 2048
+            s.agent_budget_threshold = 0.85
+
+            prompt, _, _, _ = await agent._enforce_token_budget(
+                large_prompt, ctx, "test", None,
+                memory_context="mem", document_context="doc", lang="de",
+            )
+            assert len(prompt) < len(large_prompt)

--- a/tests/backend/test_token_budget.py
+++ b/tests/backend/test_token_budget.py
@@ -218,8 +218,6 @@ class TestConfigurableContentCaps:
         content = "y" * 3000
         out = _compress_history_message(content)
         assert len(out) == 2003  # 2000 chars + "..."
-        # Explicit max_chars argument still wins over the setting
-        assert len(_compress_history_message(content, max_chars=150)) == 153
 
     @pytest.mark.unit
     def test_tool_result_text_cap_follows_setting(self, monkeypatch):
@@ -234,6 +232,24 @@ class TestConfigurableContentCaps:
         prompt = ctx.build_history_prompt(lang="de")
         assert "z" * 12000 in prompt
         assert "z" * 12001 not in prompt
+
+    @pytest.mark.unit
+    def test_budget_reduction_bites_text_results_too(self, monkeypatch):
+        """Pass-0 budget reduction (tool_result_budget_chars) must also cap
+        TEXT results — else a text-dominated overrun is irreducible and falls
+        through to the harsher history/memory passes."""
+        monkeypatch.setattr(
+            "services.agent_service.settings.agent_tool_result_text_max_chars", 12000
+        )
+        ctx = AgentContext(original_message="test")
+        ctx.tool_result_budget_chars = 300
+        ctx.steps = [
+            AgentStep(step_number=1, step_type="tool_result",
+                      content="z" * 20000, tool="t"),
+        ]
+        prompt = ctx.build_history_prompt(lang="de")
+        assert "z" * 300 in prompt
+        assert "z" * 301 not in prompt
 
 
 class TestBackendAwareBudget:

--- a/tests/backend/test_token_counter.py
+++ b/tests/backend/test_token_counter.py
@@ -447,18 +447,30 @@ class TestGlobalInstance:
 
 
 class TestDetectContentTypeSampling:
-    """_detect_content_type runs on a bounded prefix sample so count() stays
-    O(1) on the hot agent path even for very wide prompts."""
+    """_detect_content_type runs on a bounded head+tail sample so count()
+    stays O(1) on the hot agent path even for very wide prompts."""
 
     @pytest.mark.unit
-    def test_prefix_decides_ratio(self):
-        """Content type is classified from the prefix — a huge suffix of a
-        different flavor doesn't flip the decision."""
+    def test_head_decides_ratio_for_plain_tail(self):
+        """A huge plain-text middle/tail doesn't flip a German head."""
         counter = TokenCounter()
-        german_prefix = "Der Hund und die Katze sind nicht im Haus. " * 200
-        english_suffix = "plain english filler text " * 50000
-        ratio = counter._detect_content_type(german_prefix + english_suffix)
+        german_head = "Der Hund und die Katze sind nicht im Haus. " * 200
+        english_tail = "plain english filler text " * 50000
+        ratio = counter._detect_content_type(german_head + english_tail)
         assert ratio == TokenCounter.CHARS_PER_TOKEN_GERMAN
+
+    @pytest.mark.unit
+    def test_code_tail_wins_over_german_head(self):
+        """Agent prompts end in the tool-result scratchpad: a code-bearing
+        tail must classify CODE (3.0, conservative — more estimated tokens)
+        even under a German system-template head, else wide mixed prompts
+        undercount by up to ~33% right at the budget edge."""
+        counter = TokenCounter()
+        german_head = "Der Hund und die Katze sind nicht im Haus. " * 200
+        filler = "plain filler text " * 50000
+        code_tail = "def handler():\n    return import_result\n" * 200
+        ratio = counter._detect_content_type(german_head + filler + code_tail)
+        assert ratio == TokenCounter.CHARS_PER_TOKEN_CODE
 
     @pytest.mark.unit
     def test_short_text_unchanged(self):

--- a/tests/backend/test_token_counter.py
+++ b/tests/backend/test_token_counter.py
@@ -444,3 +444,42 @@ class TestGlobalInstance:
         """Global instance should function correctly."""
         result = token_counter.count("Test string")
         assert result > 0
+
+
+class TestDetectContentTypeSampling:
+    """_detect_content_type runs on a bounded prefix sample so count() stays
+    O(1) on the hot agent path even for very wide prompts."""
+
+    @pytest.mark.unit
+    def test_prefix_decides_ratio(self):
+        """Content type is classified from the prefix — a huge suffix of a
+        different flavor doesn't flip the decision."""
+        counter = TokenCounter()
+        german_prefix = "Der Hund und die Katze sind nicht im Haus. " * 200
+        english_suffix = "plain english filler text " * 50000
+        ratio = counter._detect_content_type(german_prefix + english_suffix)
+        assert ratio == TokenCounter.CHARS_PER_TOKEN_GERMAN
+
+    @pytest.mark.unit
+    def test_short_text_unchanged(self):
+        """Texts under the sample size classify exactly as before."""
+        counter = TokenCounter()
+        assert counter._detect_content_type(
+            "def foo():\n    return 1"
+        ) == TokenCounter.CHARS_PER_TOKEN_CODE
+        assert counter._detect_content_type(
+            '{"key": "value"}'
+        ) == TokenCounter.CHARS_PER_TOKEN_JSON
+
+    @pytest.mark.unit
+    def test_large_text_count_is_fast(self):
+        """count() on a ~1 MB text must not do full-text scans — generous
+        wall-clock bound as a regression tripwire."""
+        import time
+        counter = TokenCounter()
+        big = "plain english filler text without code markers " * 22000  # ~1 MB
+        start = time.perf_counter()
+        for _ in range(20):
+            counter.count(big)
+        elapsed = time.perf_counter() - start
+        assert elapsed < 1.0, f"20 counts on 1MB took {elapsed:.2f}s"


### PR DESCRIPTION
## Summary
- **Backend-bewusstes Token-Budget:** Neues `LLM_OPENAI_NUM_CTX` (Default `None` = byte-identisches Legacy-Verhalten) deklariert das `--ctx-size` des externen llama-servers; `_enforce_token_budget` budgetiert via `effective_agent_num_ctx()` gegen 262144, wenn der Agent-Tier dorthin geroutet ist — statt stur gegen `OLLAMA_NUM_CTX=32768`.
- **Hartkodierte Content-Caps konfigurierbar** (Defaults unverändert): `AGENT_HISTORY_MESSAGE_MAX_CHARS` (Historie-Kompression, war 500 fix), `AGENT_TOOL_RESULT_TEXT_MAX_CHARS` (Scratchpad-Text, war `[:8000]` fix), `KNOWLEDGE_CONTEXT_CHUNK_CHARS` (knowledge_search-Chunks, war `[:500]` fix).
- **ConfigMaps beider Instanzen** (Household in git, xidra lokal/gitignored identisch): `LLM_OPENAI_NUM_CTX=262144`, Historie 30×2000, Tool-Results 32000 (**inkl. `AGENT_RESPONSE_TRUNCATION=32000`** — der Creation-Time-Cap, ohne den der Lese-Cap inert wäre), Chunks 1500. Moderater Zuschnitt: typische Prompts bleiben unter ~64k Tokens.
- **Review-Fixes (`/code-review high`, 2. Commit):** Pass-0-Budget-Reduktion greift auch auf Text-Ergebnisse; Fallback-Oversize-Warnung keyt auf das real geforwardete `options.num_ctx` + content-aware Token-Schätzung; `llm_openai_num_ctx` mit Field-Bounds; token_counter Head+Tail-Sampling (Perf-Fix + konservative Klassifikation); Dedup des Failover-Preambles.
- **Bewusster Tradeoff:** Bei cuda-Ausfall läuft der Ollama-Fallback (qwen3:14b) weiter bei 32k — breitere Prompts degradieren dann sichtbar (WARNING) statt still. Größere Follow-ups (fallback-seitige Re-Reduktion, Ollama-Primary num_ctx-Forwarding, Soft-Prompt-Target) → #1104.

Closes #1103

## Test plan
- [x] Neue Tests: backend-bewusstes Budget (öffnet/kontrolliert), Cap-Settings (Historie/Text/Chunks), Budget-biss auf Text-Ergebnisse, Fallback-Warnung (oversize/klein/forwarded num_ctx), Head+Tail-Sampling
- [x] Volle Suite auf .159 isoliert: **5647 passed** (non-PG) + **354 passed** (Postgres-markiert, `renfield_test`-DB) — 0 failed
- [x] Ruff-Diff gegen main (voller Baum): 0 neue Verstöße
- [ ] Post-Deploy Browser-E2E beide Instanzen + Log-Nachweis `Token budget: N/262144` (nach Merge-Freigabe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)