### PR TITLE
fix(agent): Antworten wurden still am Token-Limit abgeschnitten

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -254,6 +254,16 @@ AGENT_HISTORY_MESSAGE_MAX_CHARS=500
 AGENT_TOOL_RESULT_TEXT_MAX_CHARS=8000
 AGENT_RESPONSE_TRUNCATION=2000
 
+# Ausgabe-Budget einer Agent-Antwort in Tokens. Steuert BEIDES: die
+# Reservierung, die _enforce_token_budget für die Antwort freihält, UND das
+# `max_tokens`, das an den Server geht. Bis 2026-08 waren die zwei entkoppelt
+# (die Grenze stand als Literal in prompts/agent.yaml) — dieser Wert zu
+# erhöhen verschob nur die Reservierung, und längere Antworten wurden weiter
+# bei 2048 Tokens mitten im Satz gekappt. Anheben, wenn Antworten lange Listen
+# aufzählen sollen; ein Erreichen der Grenze loggt jetzt eine WARNING und
+# zählt renfield_llm_response_truncated_total.
+AGENT_DEFAULT_NUM_PREDICT=2048
+
 # Agent Router Timeout (Sekunden)
 AGENT_ROUTER_TIMEOUT=30.0
 ```
@@ -269,6 +279,7 @@ AGENT_ROUTER_TIMEOUT=30.0
 - `AGENT_HISTORY_MESSAGE_MAX_CHARS`: `500`
 - `AGENT_TOOL_RESULT_TEXT_MAX_CHARS`: `8000`
 - `AGENT_RESPONSE_TRUNCATION`: `2000`
+- `AGENT_DEFAULT_NUM_PREDICT`: `2048`
 - `AGENT_ROUTER_TIMEOUT`: `30.0`
 
 ### OpenAI-kompatibler LLM-Endpoint (llama-server / vLLM / OpenRouter)
@@ -293,7 +304,9 @@ AGENT_ROUTER_TIMEOUT=30.0
 # Budget gegen OLLAMA_NUM_CTX (Legacy). Um das Fenster real zu füllen,
 # zusätzlich AGENT_HISTORY_MESSAGE_MAX_CHARS / AGENT_TOOL_RESULT_TEXT_MAX_CHARS
 # + AGENT_RESPONSE_TRUNCATION (beide zusammen!) / KNOWLEDGE_CONTEXT_CHUNK_CHARS
-# / AGENT_CONV_CONTEXT_MESSAGES anheben.
+# / AGENT_CONV_CONTEXT_MESSAGES anheben. Das sind alles EINGABE-Caps: soll die
+# Antwort selbst länger werden, braucht es AGENT_DEFAULT_NUM_PREDICT (Default
+# 2048 Tokens, kappt sonst mitten im Satz).
 # ACHTUNG Fallback: bei LLM_OPENAI_FALLBACK_ENABLED laufen Prompts > OLLAMA_NUM_CTX
 # im Ausfall-Fall degradiert (Ollama schneidet still ab; WARNING im Log).
 # LLM_OPENAI_NUM_CTX=262144

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -913,7 +913,10 @@ OLLAMA_NUM_CTX=32768                # Context Window (Ollama-Calls)
                                     # auch AGENT_HISTORY_MESSAGE_MAX_CHARS /
                                     # AGENT_TOOL_RESULT_TEXT_MAX_CHARS /
                                     # KNOWLEDGE_CONTEXT_CHUNK_CHARS anheben
-                                    # (siehe docs/ENVIRONMENT_VARIABLES.md)
+                                    # (siehe docs/ENVIRONMENT_VARIABLES.md).
+                                    # Das sind EINGABE-Caps — für längere
+                                    # ANTWORTEN: AGENT_DEFAULT_NUM_PREDICT
+                                    # (Default 2048, kappt sonst im Satz)
 
 # Pro Aufgabe
 OLLAMA_CHAT_MODEL=qwen3:14b        # Chat-Antworten

--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -516,6 +516,38 @@ def _with_required_companions(selected_names: list[str]) -> list[str]:
     return out
 
 
+# Option sets whose completion the token budget reserves room for, and which
+# therefore must not carry an output cap below that reservation.
+_BUDGETED_OPTION_KEYS = frozenset({"llm_options", "llm_options_retry"})
+
+
+def _warn_if_truncated(raw_response: Any, model: str, call_type: str, step_num: int | None = None) -> bool:
+    """Log + count a completion the model had to cut at the output-token cap.
+
+    A capped completion reaches the user as an ordinary answer that just stops
+    mid-sentence — or, on the ReAct path, as unparseable JSON that looks like a
+    model failure. Neither left any trace before this, so the only way to notice
+    was for someone to read the answer. Returns whether it was truncated so a
+    caller can react beyond logging.
+    """
+    from utils.llm_client import response_was_truncated
+
+    if not response_was_truncated(raw_response):
+        return False
+    where = f" at step {step_num}" if step_num is not None else ""
+    logger.warning(
+        f"✂️ LLM output hit the token cap{where} ({call_type}, model={model}) — "
+        f"the response is cut off. Raise AGENT_DEFAULT_NUM_PREDICT if this recurs."
+    )
+    try:
+        from utils.metrics import record_llm_response_truncated
+
+        record_llm_response_truncated(model, call_type)
+    except Exception:  # noqa: BLE001 — metrics must never break the agent loop
+        logger.debug("could not record llm truncation metric")
+    return True
+
+
 def _llm_options_or_default(prompt_key: str, fallback: dict) -> dict:
     """Resolve LLM options from prompts/agent.yaml, falling back to a default.
 
@@ -525,7 +557,24 @@ def _llm_options_or_default(prompt_key: str, fallback: dict) -> dict:
     while a missing key falls through to the in-code fallback.
     """
     cfg = prompt_manager.get_config("agent", prompt_key)
-    return cfg if cfg is not None else fallback
+    opts = dict(cfg if cfg is not None else fallback)
+
+    # The token budget RESERVES `agent_default_num_predict` tokens for the
+    # answer (see _enforce_token_budget), but the cap actually sent to the
+    # model came from a separate literal in the YAML. Raising the setting
+    # therefore changed the reservation and NOT the cap, and an answer longer
+    # than the YAML value was silently cut mid-sentence. Keep the two in step
+    # for the answer-producing calls so one knob governs both.
+    #
+    # max(): a YAML value ABOVE the setting still wins — this raises a stale
+    # floor, it never lowers a deliberately generous cap. The summary and
+    # tool-preselect options are excluded on purpose: they are meant to be
+    # short, and their small caps are the point.
+    if prompt_key in _BUDGETED_OPTION_KEYS:
+        opts["num_predict"] = max(
+            int(opts.get("num_predict") or 0), settings.agent_default_num_predict
+        )
+    return opts
 
 
 async def _apply_agent_system_prompt_hook(
@@ -1661,6 +1710,7 @@ class AgentService:
                     _fc_parsed = None
                     response_text = extract_response_content(raw_response) or ""
                 await agent_circuit_breaker.record_success()
+                _warn_if_truncated(raw_response, agent_model, "agent_step", step_num)
 
                 # Track token usage
                 context.track_tokens(prompt, response_text)
@@ -1722,6 +1772,7 @@ class AgentService:
                         ),
                         timeout=self.step_timeout,
                     )
+                    _warn_if_truncated(retry_response, agent_model, "agent_retry", step_num)
                     if use_native_fc:
                         parsed, response_text = self._native_fc_parsed(retry_response)
                     else:
@@ -2259,6 +2310,7 @@ class AgentService:
                 ),
                 timeout=self.step_timeout,
             )
+            _warn_if_truncated(raw_response, agent_model, "agent_summary")
             summary = (extract_response_content(raw_response) or "").strip()
 
             # Track tokens for summary call

--- a/src/backend/utils/llm_client.py
+++ b/src/backend/utils/llm_client.py
@@ -497,14 +497,25 @@ class _OllamaShapedMessage:
 
 
 class _OllamaShapedResponse:
-    """Mimics ollama.ChatResponse with .message attribute."""
+    """Mimics ollama.ChatResponse with .message attribute.
 
-    __slots__ = ("message", "model", "done")
+    ``done_reason`` carries why generation stopped, using ollama's vocabulary
+    (``"stop"`` / ``"length"``). OpenAI calls the same thing ``finish_reason``
+    and the values coincide for the cases we care about, so the adapter maps it
+    straight through. Without it a completion cut off at ``max_tokens`` is
+    indistinguishable from one the model chose to end — see
+    ``response_was_truncated``.
+    """
 
-    def __init__(self, message: _OllamaShapedMessage, model: str) -> None:
+    __slots__ = ("message", "model", "done", "done_reason")
+
+    def __init__(
+        self, message: _OllamaShapedMessage, model: str, done_reason: str | None = None
+    ) -> None:
         self.message = message
         self.model = model
         self.done = True
+        self.done_reason = done_reason
 
 
 class OpenAICompatibleClient:
@@ -655,6 +666,7 @@ class OpenAICompatibleClient:
                     thinking=None,
                 ),
                 model,
+                done_reason=getattr(choice, "finish_reason", None),
             )
 
     @staticmethod
@@ -673,6 +685,7 @@ class OpenAICompatibleClient:
                 thinking=thinking,
             ),
             model,
+            done_reason=getattr(choice, "finish_reason", None) if choice else None,
         )
 
     async def embeddings(
@@ -837,6 +850,24 @@ def extract_response_content(response: Any) -> str:
             # Instead, return empty so caller falls back to default behavior
 
     return content
+
+
+def response_was_truncated(response: Any) -> bool:
+    """True when the model stopped because it hit the output-token cap.
+
+    Both back-ends report this, under different names — ollama on
+    ``response.done_reason``, OpenAI-compatible servers on the choice's
+    ``finish_reason`` (which the adapter maps onto ``done_reason``). Either way
+    the value is ``"length"``.
+
+    This distinction is not cosmetic: a capped completion is delivered to the
+    user as a normal answer that simply stops mid-sentence, with nothing in the
+    logs to say why. Callers are expected to at least record it.
+
+    Unknown/absent reason → False: never claim truncation we cannot see.
+    """
+    reason = getattr(response, "done_reason", None)
+    return isinstance(reason, str) and reason.strip().lower() == "length"
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/utils/metrics.py
+++ b/src/backend/utils/metrics.py
@@ -173,6 +173,16 @@ def _init_metrics():
             ["violation"],
         )
 
+        # Answers cut off at the output-token cap. This used to be entirely
+        # invisible: the user simply got a reply that stopped mid-sentence.
+        # Any sustained non-zero rate means num_predict is too low for what
+        # the model is being asked to produce.
+        _llm_response_truncated_total = Counter(
+            "renfield_llm_response_truncated_total",
+            "LLM completions that hit the output-token cap (finish_reason=length)",
+            ["model", "call_type"],
+        )
+
         # Pluggable-auth fail-open observability. Name intentionally matches
         # the cross-repo design contract (ebongard/renfield#591) verbatim —
         # no `renfield_` prefix — so dashboards/alerts written against the
@@ -437,6 +447,13 @@ def record_output_guard_violation(violation: str):
     if not _metrics_initialized:
         return
     _output_guard_violations_total.labels(violation=violation).inc()
+
+
+def record_llm_response_truncated(model: str, call_type: str):
+    """Record a completion that hit the output-token cap (finish_reason=length)."""
+    if not _metrics_initialized:
+        return
+    _llm_response_truncated_total.labels(model=model, call_type=call_type).inc()
 
 
 # === Middleware & Endpoint Setup ===

--- a/tests/backend/test_agent_service.py
+++ b/tests/backend/test_agent_service.py
@@ -2452,3 +2452,139 @@ def test_with_required_companions_is_dedup_safe_and_inert():
     # unrelated tools untouched
     assert _with_required_companions(["internal.media_control"]) == ["internal.media_control"]
     assert _with_required_companions([]) == []
+
+
+# ============================================================================
+# Output-cap handling.
+#
+# The token budget reserves `agent_default_num_predict` tokens for the answer,
+# but the cap actually sent to the model came from a separate literal in
+# prompts/agent.yaml. Raising the setting moved the reservation and not the
+# cap, so a long answer was cut mid-sentence — silently, since finish_reason
+# was never inspected.
+# ============================================================================
+
+
+class TestBudgetedLlmOptions:
+    """_llm_options_or_default keeps the answer cap >= the budget reservation."""
+
+    @pytest.mark.unit
+    def test_answer_cap_is_raised_to_the_setting(self, monkeypatch):
+        from services import agent_service
+
+        monkeypatch.setattr(
+            agent_service.prompt_manager, "get_config",
+            lambda *a, **k: {"temperature": 0.1, "num_predict": 2048},
+        )
+        monkeypatch.setattr(agent_service.settings, "agent_default_num_predict", 6000, raising=False)
+
+        opts = agent_service._llm_options_or_default("llm_options", {})
+
+        assert opts["num_predict"] == 6000
+        assert opts["temperature"] == 0.1  # everything else untouched
+
+    @pytest.mark.unit
+    def test_a_more_generous_yaml_cap_wins(self, monkeypatch):
+        """The reconciliation raises a stale floor; it never lowers a cap."""
+        from services import agent_service
+
+        monkeypatch.setattr(
+            agent_service.prompt_manager, "get_config", lambda *a, **k: {"num_predict": 8192}
+        )
+        monkeypatch.setattr(agent_service.settings, "agent_default_num_predict", 2048, raising=False)
+
+        assert agent_service._llm_options_or_default("llm_options", {})["num_predict"] == 8192
+
+    @pytest.mark.unit
+    def test_retry_options_are_reconciled_too(self, monkeypatch):
+        from services import agent_service
+
+        monkeypatch.setattr(
+            agent_service.prompt_manager, "get_config", lambda *a, **k: {"num_predict": 2048}
+        )
+        monkeypatch.setattr(agent_service.settings, "agent_default_num_predict", 4096, raising=False)
+
+        assert agent_service._llm_options_or_default("llm_options_retry", {})["num_predict"] == 4096
+
+    @pytest.mark.unit
+    def test_short_by_design_option_sets_are_left_alone(self, monkeypatch):
+        """Summary and pre-selection are meant to be brief — their small caps
+        are the point, so the reservation must not inflate them."""
+        from services import agent_service
+
+        monkeypatch.setattr(
+            agent_service.prompt_manager, "get_config", lambda *a, **k: {"num_predict": 512}
+        )
+        monkeypatch.setattr(agent_service.settings, "agent_default_num_predict", 6000, raising=False)
+
+        assert agent_service._llm_options_or_default(
+            "llm_options_tool_preselect", {}
+        )["num_predict"] == 512
+        assert agent_service._llm_options_or_default(
+            "llm_options_summary", {}
+        )["num_predict"] == 512
+
+    @pytest.mark.unit
+    def test_missing_yaml_still_falls_back(self, monkeypatch):
+        from services import agent_service
+
+        monkeypatch.setattr(agent_service.prompt_manager, "get_config", lambda *a, **k: None)
+        monkeypatch.setattr(agent_service.settings, "agent_default_num_predict", 2048, raising=False)
+
+        opts = agent_service._llm_options_or_default("llm_options", {"temperature": 0.7})
+
+        assert opts["temperature"] == 0.7
+        assert opts["num_predict"] == 2048
+
+
+class TestWarnIfTruncated:
+    """A capped completion must leave a trace."""
+
+    @pytest.mark.unit
+    def test_truncated_response_warns_and_counts(self, monkeypatch):
+        from types import SimpleNamespace
+
+        from services import agent_service
+
+        recorded = []
+        monkeypatch.setattr(
+            "utils.metrics.record_llm_response_truncated",
+            lambda model, call_type: recorded.append((model, call_type)),
+        )
+
+        assert agent_service._warn_if_truncated(
+            SimpleNamespace(done_reason="length"), "qwen3.6", "agent_step", 3
+        ) is True
+        assert recorded == [("qwen3.6", "agent_step")]
+
+    @pytest.mark.unit
+    def test_complete_response_is_silent(self, monkeypatch):
+        from types import SimpleNamespace
+
+        from services import agent_service
+
+        recorded = []
+        monkeypatch.setattr(
+            "utils.metrics.record_llm_response_truncated",
+            lambda model, call_type: recorded.append((model, call_type)),
+        )
+
+        assert agent_service._warn_if_truncated(
+            SimpleNamespace(done_reason="stop"), "qwen3.6", "agent_step", 1
+        ) is False
+        assert recorded == []
+
+    @pytest.mark.unit
+    def test_metrics_failure_never_breaks_the_agent_loop(self, monkeypatch):
+        from types import SimpleNamespace
+
+        from services import agent_service
+
+        def boom(*a, **k):
+            raise RuntimeError("registry exploded")
+
+        monkeypatch.setattr("utils.metrics.record_llm_response_truncated", boom)
+
+        assert agent_service._warn_if_truncated(
+            SimpleNamespace(done_reason="length"), "m", "agent_step", 1
+        ) is True

--- a/tests/backend/test_llm_client.py
+++ b/tests/backend/test_llm_client.py
@@ -642,7 +642,7 @@ class TestExtractResponseContent:
 # ============================================================================
 
 
-def _stub_openai_choice(content="", tool_calls=None, reasoning_content=None):
+def _stub_openai_choice(content="", tool_calls=None, reasoning_content=None, finish_reason="stop"):
     """Build a non-stream openai.ChatCompletion-shaped fake."""
     msg = SimpleNamespace(
         content=content,
@@ -650,12 +650,12 @@ def _stub_openai_choice(content="", tool_calls=None, reasoning_content=None):
         reasoning_content=reasoning_content,
         role="assistant",
     )
-    return SimpleNamespace(message=msg, finish_reason="stop", index=0)
+    return SimpleNamespace(message=msg, finish_reason=finish_reason, index=0)
 
 
-def _stub_openai_response(content="", tool_calls=None, reasoning_content=None):
+def _stub_openai_response(content="", tool_calls=None, reasoning_content=None, finish_reason="stop"):
     """Top-level non-stream openai response with a single choice."""
-    choice = _stub_openai_choice(content, tool_calls, reasoning_content)
+    choice = _stub_openai_choice(content, tool_calls, reasoning_content, finish_reason)
     return SimpleNamespace(choices=[choice], usage=None, model="qwen3.6")
 
 
@@ -1560,3 +1560,94 @@ class TestOpenAICompatFallbackClient:
         mock_cls.return_value = MagicMock()
         wrapped = llm_client._maybe_wrap_openai_fallback(MagicMock())
         assert isinstance(wrapped, llm_client._OpenAICompatFallbackClient)
+
+
+# ============================================================================
+# Output-cap visibility: a completion cut at max_tokens must be recognisable.
+# Before this, `finish_reason` was dropped by the adapter, so an answer that
+# stopped mid-sentence was indistinguishable from a complete one.
+# ============================================================================
+
+
+class TestResponseWasTruncated:
+    """response_was_truncated() over both back-ends' vocabulary."""
+
+    @pytest.mark.unit
+    def test_length_finish_reason_is_truncation(self):
+        from utils.llm_client import response_was_truncated
+
+        assert response_was_truncated(SimpleNamespace(done_reason="length")) is True
+
+    @pytest.mark.unit
+    def test_stop_is_not_truncation(self):
+        from utils.llm_client import response_was_truncated
+
+        assert response_was_truncated(SimpleNamespace(done_reason="stop")) is False
+
+    @pytest.mark.unit
+    def test_case_and_whitespace_tolerant(self):
+        from utils.llm_client import response_was_truncated
+
+        assert response_was_truncated(SimpleNamespace(done_reason=" Length ")) is True
+
+    @pytest.mark.unit
+    def test_missing_reason_is_not_truncation(self):
+        """Never claim truncation we cannot observe (ollama pre-done_reason)."""
+        from utils.llm_client import response_was_truncated
+
+        assert response_was_truncated(SimpleNamespace()) is False
+        assert response_was_truncated(SimpleNamespace(done_reason=None)) is False
+
+
+class TestFinishReasonSurvivesTheAdapter:
+    """The OpenAI-compat wrapper must carry finish_reason through as done_reason."""
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_truncated_completion_is_flagged(self, monkeypatch):
+        from utils.llm_client import response_was_truncated
+
+        adapter = _make_openai_compat(monkeypatch)
+        adapter._client.chat.completions.create.return_value = _stub_openai_response(
+            content="Die Freeze-Fenster für 2027 sind: Januar", finish_reason="length"
+        )
+
+        response = await adapter.chat(messages=[{"role": "user", "content": "freeze?"}])
+
+        assert response.done_reason == "length"
+        assert response_was_truncated(response) is True
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_complete_completion_is_not_flagged(self, monkeypatch):
+        from utils.llm_client import response_was_truncated
+
+        adapter = _make_openai_compat(monkeypatch)
+        adapter._client.chat.completions.create.return_value = _stub_openai_response(
+            content="Fertig.", finish_reason="stop"
+        )
+
+        response = await adapter.chat(messages=[{"role": "user", "content": "hi"}])
+
+        assert response.done_reason == "stop"
+        assert response_was_truncated(response) is False
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_streaming_chunks_carry_the_reason(self, monkeypatch):
+        adapter = _make_openai_compat(monkeypatch)
+        chunk = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    delta=SimpleNamespace(content="…", tool_calls=None),
+                    finish_reason="length",
+                )
+            ]
+        )
+        adapter._client.chat.completions.create.return_value = _async_iter([chunk])
+
+        seen = [c async for c in await adapter.chat(
+            messages=[{"role": "user", "content": "hi"}], stream=True
+        )]
+
+        assert seen[-1].done_reason == "length"


### PR DESCRIPTION
## Problem

Eine Frage nach den Freeze-Fenstern eines ganzen Jahres kam **mitten im Wort** zurück — die Monate August bis Dezember fehlten:

```
**Juli 2027**
*   **HR Portal MINOR Release:** 01.07.2027 – 15.07.2027 (Code Freeze, PARTIAL
```

`llama-server` protokollierte dazu exakt `eval time = 2048 tokens`. In Renfield gab es dazu **kein einziges Signal** — kein Log, keine Metrik, kein Alarm. Aufgefallen ist es nur, weil ein Testfall zufällig auf das Wort „abgeschnitten" geprüft hat.

Zwei zusammenhängende Ursachen.

### 1. Das Ausgabelimit war vom Budget entkoppelt

`_enforce_token_budget` reserviert `settings.agent_default_num_predict` Tokens für die Antwort. Das tatsächlich gesendete `max_tokens` kam aber aus einem **eigenen Literal** in `prompts/agent.yaml` (2048). `AGENT_DEFAULT_NUM_PREDICT` zu erhöhen verschob damit nur die Reservierung und nicht die Grenze — die Reservierung war also schlicht unwahr, und eine längere Antwort wurde gekappt.

`_llm_options_or_default` gleicht beide jetzt für die antwortproduzierenden Optionssätze an. Bewusst per `max()`: das hebt einen veralteten Boden an, senkt aber nie eine absichtlich großzügige Grenze. `llm_options_summary` und `llm_options_tool_preselect` bleiben ausgenommen — deren kleine Limits sind der Zweck.

### 2. Das Erreichen der Grenze hinterließ keine Spur

`_wrap_response` verwarf `finish_reason`, und niemand hat es je gelesen. Eine gekappte Antwort erreicht den Nutzer als normale Antwort, die einfach aufhört — auf dem ReAct-Pfad sogar als unparsebares JSON, das wie ein Modellfehler aussieht.

- `_OllamaShapedResponse` trägt jetzt `done_reason` (ollamas Vokabular; `finish_reason` wird darauf abgebildet, die Werte decken sich)
- `response_was_truncated()` wertet es aus — fehlender Grund heißt **nicht** abgeschnitten, es wird nie etwas behauptet, das nicht beobachtbar ist
- `_warn_if_truncated` loggt eine WARNING und zählt `renfield_llm_response_truncated_total{model,call_type}`, an allen drei Aufrufstellen (Schritt, Retry, Summary)

Metrikfehler brechen die Agent-Schleife nie ab.

## Tests

16 neue Fälle: Durchreichung durch den Adapter inklusive Streaming, Angleichung der Optionen in beide Richtungen, Warn- und Zählpfad, sowie dass ein Metrikfehler folgenlos bleibt.

```
228 passed  (test_llm_client.py + test_agent_service.py, gegen das Prod-Image)
```

## Auswirkung stromabwärts

Reva hat parallel eine Alarmgruppe `reva.quality` bekommen; deren Regel `RevaAnswerTruncated` liest genau diesen Zähler und bleibt bis zum Merge und Submodul-Bump wirkungslos.