### PR TITLE
fix(k8s): Twin-Pod in die Postgres-NetworkPolicy aufnehmen (18d-Twin-Outage)

### DIFF
--- a/k8s/redis-postgres-netpol.yaml
+++ b/k8s/redis-postgres-netpol.yaml
@@ -51,5 +51,11 @@ spec:
         - podSelector: {matchLabels: {app.kubernetes.io/name: meeting-worker}}
         - podSelector: {matchLabels: {app.kubernetes.io/name: pdf-split-worker}}
         - podSelector: {matchLabels: {app.kubernetes.io/part-of: renfield, app.kubernetes.io/component: backend-job}}
+        # Digital twin (private deployment, label app=twin): stores its events in
+        # its OWN Postgres DB on this instance. Was cut off when this policy
+        # shipped (2026-08-18) — conntrack kept the pool alive until 2026-08-20,
+        # then /ready hung forever on blackholed reconnects (pod NotReady 18d,
+        # twin capture silently dead). Twin needs Postgres only, NOT Redis.
+        - podSelector: {matchLabels: {app: twin}}
       ports:
         - {protocol: TCP, port: 5432}


### PR DESCRIPTION
## Summary
- Die PDF-Split-Netpol-Härtung `postgres-allow-app-only` (#1100, 18.08.) ließ nur Backend-Image-Workloads zu Postgres — der private Twin-Pod (`app=twin`, eigene Twin-DB) fehlte. Conntrack hielt die Pool-Verbindungen bis 20.08. 18:46Z am Leben, danach SYN-Blackhole → `/ready` hing endlos → Twin 18 Tage NotReady, Backend-Twin-MCP ohne Session, Capture still tot.
- Fix: expliziter `podSelector {app: twin}` im Postgres-Ingress (nur Postgres, kein Redis).
- Bereits live appliziert + Twin-Rollout: `/ready` 200 (0,0s), MCP-Session 2/2 Tools healthy, Capture-Traffic wieder da.
- Folge-Bug am Self-Healing-Monitor (blieb trotz down-Server stumm): #1107.

## Test plan
- [x] Live verifiziert (Pod Ready, MCP healthy, Twin-Log zeigt Backend-Traffic)
- [x] Kein Code betroffen — reine k8s-Manifest-Änderung

🤖 Generated with [Claude Code](https://claude.com/claude-code)