### PR TITLE
fix(metrics): Abschneide-Zähler war nie registriert — er zählte nichts

### DIFF
--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -543,8 +543,11 @@ def _warn_if_truncated(raw_response: Any, model: str, call_type: str, step_num: 
         from utils.metrics import record_llm_response_truncated
 
         record_llm_response_truncated(model, call_type)
-    except Exception:  # noqa: BLE001 — metrics must never break the agent loop
-        logger.debug("could not record llm truncation metric")
+    except Exception as e:  # noqa: BLE001 — metrics must never break the agent loop
+        # WARNING, not debug: this except is the reason the counter's own
+        # registration bug went unnoticed while the line above logged happily.
+        # A dead metric is invisible precisely because nothing depends on it.
+        logger.warning(f"could not record llm truncation metric: {e!r}")
     return True
 
 

--- a/src/backend/utils/metrics.py
+++ b/src/backend/utils/metrics.py
@@ -39,6 +39,7 @@ _agent_outcome_total = None
 _injection_attempts_total = None
 _budget_reductions_total = None
 _output_guard_violations_total = None
+_llm_response_truncated_total = None
 _auth_provider_unreachable_total = None
 _login_failure_total = None
 _authz_denied_total = None
@@ -61,6 +62,7 @@ def _init_metrics():
     global _mcp_tool_duration_seconds, _mcp_tool_errors_total
     global _agent_outcome_total, _injection_attempts_total
     global _budget_reductions_total, _output_guard_violations_total
+    global _llm_response_truncated_total
     global _auth_provider_unreachable_total
     global _login_failure_total, _authz_denied_total
     global _kg_conflation_candidates

--- a/tests/backend/test_metrics.py
+++ b/tests/backend/test_metrics.py
@@ -202,3 +202,90 @@ class TestCircuitBreakerMetricsIntegration:
             await breaker.allow_request()   # -> HALF_OPEN (recovery_timeout=0)
             await breaker.record_success()  # -> CLOSED
             mock_state.assert_called_with("test", "closed")
+
+
+class TestEveryCollectorIsReachable:
+    """A collector assigned in _init_metrics must reach module scope.
+
+    `_init_metrics` assigns its collectors to module-level names, which only
+    works if each name is also listed in one of the function's `global`
+    declarations. Miss that and the assignment silently creates a LOCAL — the
+    module attribute stays None (or never exists), and the recorder that reads
+    it raises. Callers wrap recorders in try/except so metrics can never break
+    a request path, so the counter is simply dead and nothing says so.
+
+    That happened to `renfield_llm_response_truncated_total`: the WARNING it
+    accompanies was logged for days while the metric an alert reads recorded
+    nothing. Enumerating the collectors from the source rather than by hand is
+    what keeps the next one from repeating it.
+    """
+
+    @staticmethod
+    def _collectors_assigned_in_init():
+        import ast
+        import inspect
+
+        import utils.metrics as metrics_module
+
+        tree = ast.parse(inspect.getsource(metrics_module))
+        init = next(
+            n for n in ast.walk(tree)
+            if isinstance(n, ast.FunctionDef) and n.name == "_init_metrics"
+        )
+        names = set()
+        for node in ast.walk(init):
+            if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Call):
+                continue
+            func = node.value.func
+            factory = getattr(func, "id", None) or getattr(func, "attr", None)
+            if factory not in ("Counter", "Gauge", "Histogram", "Summary"):
+                continue
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id.startswith("_"):
+                    names.add(target.id)
+        return names
+
+    def test_no_collector_is_stranded_in_local_scope(self):
+        import utils.metrics as metrics_module
+
+        assigned = self._collectors_assigned_in_init()
+        assert assigned, "found no collectors — the AST scan is broken, not the module"
+
+        metrics_module._metrics_initialized = False
+        try:
+            with patch.dict("sys.modules", {"prometheus_client": MagicMock()}):
+                metrics_module._init_metrics()
+
+            stranded = [
+                name for name in sorted(assigned)
+                if getattr(metrics_module, name, None) is None
+            ]
+            assert not stranded, (
+                f"assigned in _init_metrics but still None at module scope: "
+                f"{stranded} — add each to a `global` declaration in _init_metrics "
+                f"and give it a module-level `= None`"
+            )
+        finally:
+            metrics_module._metrics_initialized = False
+            for name in assigned:
+                setattr(metrics_module, name, None)
+
+    def test_every_collector_has_a_module_level_declaration(self):
+        """Without `<name> = None` at module scope the recorder raises NameError
+        rather than the AttributeError a None would give — same dead counter,
+        noisier failure."""
+        import ast
+        import inspect
+
+        import utils.metrics as metrics_module
+
+        tree = ast.parse(inspect.getsource(metrics_module))
+        declared = {
+            t.id
+            for node in tree.body
+            if isinstance(node, ast.Assign)
+            for t in node.targets
+            if isinstance(t, ast.Name)
+        }
+        missing = sorted(self._collectors_assigned_in_init() - declared)
+        assert not missing, f"no module-level declaration for: {missing}"


### PR DESCRIPTION
Nachtrag zu #1106, gefunden beim Nachprüfen in Produktion.

## Der Fehler

`_llm_response_truncated_total` wird in `_init_metrics` zugewiesen, war aber in
keiner `global`-Deklaration genannt und existierte nicht auf Modulebene. Die
Zuweisung erzeugte damit eine **lokale** Variable; `record_llm_response_truncated`
lief in einen `NameError`.

Die Wirkung ist die unangenehme Sorte: die WARNING neben dem Zähler wurde brav
geloggt —

```
✂️ LLM output hit the token cap at step 2 (agent_step, model=qwen3.6)
```

— während die Metrik, die `RevaAnswerTruncated` liest, nichts aufzeichnete. Die
Serie hat in Prometheus nie existiert.

## Warum kein Test das gesehen hat

Zwei Gründe, beide lehrreich:

1. `_warn_if_truncated` fängt Metrikfehler ab, damit sie nie eine Anfrage
   brechen — was einen toten Zähler perfekt versteckt.
2. `test_init_metrics_creates_collectors` prüft eine **handgepflegte** Liste von
   Kollektoren. Ein neuer gerät da nicht automatisch hinein.

## Änderungen

- Modul-Deklaration + `global`-Eintrag ergänzt.
- **Struktureller Test:** liest per AST *alle* in `_init_metrics` zugewiesenen
  `Counter`/`Gauge`/`Histogram` aus dem Quelltext und prüft, dass jeder danach
  am Modul erreichbar ist und eine Modul-Deklaration hat. Die Liste wird nicht
  gepflegt, sie wird abgeleitet — derselbe Fehler kann bei künftigen Zählern
  nicht mehr unbemerkt bleiben. Gegengeprüft: ohne den Fix schlagen beide Fälle
  mit genau dieser Diagnose fehl.
- Das verschluckende `except` loggt WARNING statt debug. Genau diese Zeile hat
  den Fehler verborgen.

Tests: 146 passed (test_metrics, test_metrics_extended, test_agent_service).