### PR TITLE
fix(mcp): Hang-Guards für Reconnect/Self-Heal — Health-Monitor friert nie wieder ein (#1107)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,12 @@ docs/private/
 k8s/xidra/
 config/xidra/
 
+# Digital-twin adapter — PRIVATE package staged into the working tree for backend
+# image builds (canonical source: the private twin repo, see the twin-adapter
+# staging memory/DEPLOY.md). NEVER public git; without this entry a stray
+# `git add -A` would publish it permanently.
+src/backend/twin_adapter/
+
 # Secrets (should use .env)
 *.pem
 *.key

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -632,6 +632,13 @@ MCP_HEALTH_REALERT_SECONDS=21600              # laufendes Problem erst nach 6h e
 # Single-Shot-Reconnect) und alarmiert NUR, wenn die Selbstheilung scheitert.
 MCP_HEALTH_SELF_HEAL_ENABLED=true
 MCP_HEALTH_SELF_HEAL_MAX_PER_TICK=8           # Cap der Probe/Reconnect-Versuche je Tick
+# Harter Hang-Guard je Heilungs-Probe (Sekunden). Der Reconnect hinter der Probe
+# (Transport-Connect + init + tools/list) konnte auf einem pathologischen Upstream
+# unbegrenzt hängen und damit die GESAMTE Monitor-Schleife einfrieren (beobachtet
+# 2026-08-22, #1107). Muss über einem ehrlichen Worst-Case-Reconnect liegen
+# (~3x MCP_CONNECT_TIMEOUT). Heartbeat: renfield_mcp_health_ticks_total (Counter,
+# steht der still, hängt der Monitor) + renfield_mcp_health_problem_servers (Gauge).
+MCP_HEALTH_SELF_HEAL_PROBE_TIMEOUT=45
 # Funktionale Gesundheit: rollierendes Fenster der letzten N GESUNDHEITS-
 # KORRELIERTEN Ergebnisse je Server — True bei sauberem Ergebnis, False bei TIMEOUT
 # (Server antwortet nicht). NICHT gezählt: App-Fehler (Gerät aus / nicht gefunden /

--- a/docs/design/mcp-self-detection.md
+++ b/docs/design/mcp-self-detection.md
@@ -93,6 +93,22 @@ All three items shipped; the self-heal is gated `mcp_health_self_heal_enabled`
    Erfolg"). A `down` server the reconnect fixes is silently healed (no alert, ledger
    cleared); a `plugin_failed`/upstream-dead server a reconnect can't fix stays
    degraded and alerts. Capped `mcp_health_self_heal_max_per_tick` per tick.
+   **Hang-guards (2026-08-22, #1107):** the reconnect a probe drives could wedge
+   indefinitely on a pathological upstream (observed: the run_at_boot tick hung in
+   the twin reconnect while its service had no endpoints, silencing the WHOLE
+   monitor loop for the outage's duration — no probe, no alert). Now bounded at
+   three layers, all same-task `asyncio.timeout` (anyio-cancel-scope-safe, never
+   `wait_for`): each self-heal probe (`mcp_health_self_heal_probe_timeout`, 45s),
+   the transport `__aenter__` in `_connect_server` (`mcp_connect_timeout` — init/
+   tools-list were always bounded, the transport connect was not), and every
+   exit-stack teardown (`_TEARDOWN_TIMEOUT_S`, runs under `reconnect_lock`). A
+   cancelled connect hands its partially-entered stack to a detached bounded
+   closer (a rare leak beats a frozen loop); the failed-connect path now closes
+   the LOCAL exit stack (previously leaked — only the always-None
+   `state.exit_stack` was closed). Observability: every COMPLETED tick increments
+   `renfield_mcp_health_ticks_total` + sets `renfield_mcp_health_problem_servers`
+   (a flatlining counter under a running backend = the monitor is stuck — exactly
+   the ambiguity that cost the diagnosis) plus a DEBUG tick-complete line.
 3. **Email-ingest backend-recovery re-reconcile** (`renfield-mcp-email-ingest`) —
    closes the asymmetry: `RenfieldPusher.health()` + a daemon `_health_poll_loop`
    (`EMAIL_HEALTH_POLL_SECONDS`, default 30s) re-reconcile every mailbox on a

--- a/src/backend/services/mcp_client.py
+++ b/src/backend/services/mcp_client.py
@@ -224,15 +224,41 @@ class TokenBucketRateLimiter:
 _TEARDOWN_TIMEOUT_S = 5.0
 
 
-async def _close_stack_quietly(stack: AsyncExitStack) -> None:
-    """Detached best-effort close of a partially-entered transport stack after a
-    cancelled connect. Bounded (a wedged teardown must not live forever) and
-    fully silent — cross-task anyio cancel-scope errors are expected here."""
+# Strong references to detached cleanup tasks: the event loop only holds weak
+# refs, so a fire-and-forget close task could be garbage-collected before it
+# runs ("Task was destroyed but it is pending!"). Done tasks self-remove.
+_detached_cleanup_tasks: set["asyncio.Task"] = set()
+
+
+async def _close_stack_bounded(stack: AsyncExitStack) -> None:
+    """Bounded best-effort close of a transport stack (shared idiom for every
+    teardown site — a wedged anyio teardown must never hold a caller). Swallows
+    teardown failures/timeouts; an OUTER cancellation still propagates."""
     try:
         async with asyncio.timeout(_TEARDOWN_TIMEOUT_S):
             await stack.__aexit__(None, None, None)
-    except BaseException:  # detached cleanup — nothing to surface
+    except asyncio.CancelledError:
+        raise
+    except BaseException:  # teardown of a half-broken stack — nothing to surface
         pass
+
+
+def _close_stack_detached(stack: AsyncExitStack) -> None:
+    """Schedule a detached best-effort close (used from a CANCELLED connect,
+    where awaiting anything would insta-cancel). Keeps a strong task reference
+    so the closer can't be GC'd before it runs; fully silent — cross-task anyio
+    cancel-scope errors are expected here."""
+
+    async def _run() -> None:
+        try:
+            async with asyncio.timeout(_TEARDOWN_TIMEOUT_S):
+                await stack.__aexit__(None, None, None)
+        except BaseException:  # detached cleanup — nothing to surface
+            pass
+
+    task = asyncio.get_running_loop().create_task(_run())
+    _detached_cleanup_tasks.add(task)
+    task.add_done_callback(_detached_cleanup_tasks.discard)
 
 
 def _coerce_arguments(arguments: dict, input_schema: dict) -> dict:
@@ -1254,6 +1280,11 @@ class MCPManager:
                 )
                 all_tools.append(info)
 
+            # A STALE stack from a prior session can still be set here (direct
+            # refresh_tools reconnects skip the teardown in _reconnect_server) —
+            # close it bounded before overwriting, else its transport leaks.
+            if state.exit_stack is not None and state.exit_stack is not exit_stack:
+                await _close_stack_bounded(state.exit_stack)
             state.session = session
             state.exit_stack = exit_stack
             self._set_connected(state, True)
@@ -1284,14 +1315,21 @@ class MCPManager:
 
         except asyncio.CancelledError:
             # Cancelled mid-connect (self-heal hang-guard or shutdown): mark the
-            # state honestly and hand the partially-entered transport to a
-            # detached best-effort closer — a wedged anyio teardown must not
-            # block the cancelling caller; a rare leak beats a frozen loop.
+            # state honestly and hand the partially-entered transport — plus a
+            # possibly still-live STALE stack from a prior session (direct
+            # refresh_tools reconnects don't tear down first) — to a detached
+            # best-effort closer; awaiting here would insta-cancel, and a rare
+            # leak beats a frozen loop. The same slow-upstream condition must
+            # advance backoff like an inner-timeout failure does.
             self._set_connected(state, False)
             state.last_error = "connect cancelled (timeout/shutdown)"
+            if state.backoff:
+                state.backoff.record_failure()
+            if state.exit_stack is not None and state.exit_stack is not exit_stack:
+                _close_stack_detached(state.exit_stack)
             state.exit_stack = None
             if exit_stack is not None:
-                asyncio.get_running_loop().create_task(_close_stack_quietly(exit_stack))
+                _close_stack_detached(exit_stack)
             raise
         except Exception as e:
             self._set_connected(state, False)
@@ -1308,18 +1346,19 @@ class MCPManager:
             else:
                 logger.warning(f"MCP server '{config.name}' connection failed: {e}")
 
-            # Clean up the LOCAL exit stack on failure. (The old code closed
-            # state.exit_stack here, which at this point is always None — the
-            # local one is only promoted to state on success — so every failed
-            # connect leaked its partially-entered transport contexts.) Bounded:
-            # a teardown of a half-broken anyio transport can itself wedge.
+            # Clean up BOTH stacks on failure, bounded: the LOCAL partially-
+            # entered one (previously leaked — only state.exit_stack was closed,
+            # which the reconnect path has already torn down), AND a possibly
+            # still-live STALE state.exit_stack from a prior session — direct
+            # refresh_tools reconnects (a list_tools failure flips connected
+            # without teardown) reach here with the old stack still set, and
+            # dropping it unclosed would orphan its transport/subprocess.
             if exit_stack is not None:
-                try:
-                    async with asyncio.timeout(_TEARDOWN_TIMEOUT_S):
-                        await exit_stack.__aexit__(None, None, None)
-                except Exception:
-                    pass
+                await _close_stack_bounded(exit_stack)
+            if state.exit_stack is not None and state.exit_stack is not exit_stack:
+                await _close_stack_bounded(state.exit_stack)
             state.exit_stack = None
+            state.session = None
 
     async def _reconnect_server(self, state: MCPServerState) -> bool:
         """Tear down a stale session and re-establish.
@@ -1341,11 +1380,7 @@ class MCPManager:
             # stream drain, and this runs under reconnect_lock — an unbounded
             # hang here would freeze every reconnect path for the server.
             if state.exit_stack is not None:
-                try:
-                    async with asyncio.timeout(_TEARDOWN_TIMEOUT_S):
-                        await state.exit_stack.__aexit__(None, None, None)
-                except Exception:
-                    pass
+                await _close_stack_bounded(state.exit_stack)
                 state.exit_stack = None
                 state.session = None
             logger.info(f"MCP reconnecting to '{state.config.name}'...")
@@ -2618,10 +2653,11 @@ class MCPManager:
 
         for state in self._servers.values():
             if state.exit_stack:
-                try:
-                    await state.exit_stack.__aexit__(None, None, None)
-                except Exception as e:
-                    logger.warning(f"MCP shutdown error for '{state.config.name}': {e}")
+                # Bounded like every other teardown site: a session wedged on
+                # stream drain (the #1107 failure mode) must not block graceful
+                # shutdown past the k8s grace period — later shutdown steps
+                # (plugin hooks, cleanup) still have to run.
+                await _close_stack_bounded(state.exit_stack)
             self._set_connected(state, False)
             state.session = None
             state.exit_stack = None

--- a/src/backend/services/mcp_client.py
+++ b/src/backend/services/mcp_client.py
@@ -217,6 +217,24 @@ class TokenBucketRateLimiter:
         self.last_update = time.monotonic()
 
 
+# Bound for tearing down a (half-)broken transport stack. anyio teardown of a
+# wedged streamable_http session can hang on stream drain; every teardown site
+# below is bounded by this so no caller (esp. one holding reconnect_lock) can
+# freeze on cleanup (#1107).
+_TEARDOWN_TIMEOUT_S = 5.0
+
+
+async def _close_stack_quietly(stack: AsyncExitStack) -> None:
+    """Detached best-effort close of a partially-entered transport stack after a
+    cancelled connect. Bounded (a wedged teardown must not live forever) and
+    fully silent — cross-task anyio cancel-scope errors are expected here."""
+    try:
+        async with asyncio.timeout(_TEARDOWN_TIMEOUT_S):
+            await stack.__aexit__(None, None, None)
+    except BaseException:  # detached cleanup — nothing to surface
+        pass
+
+
 def _coerce_arguments(arguments: dict, input_schema: dict) -> dict:
     """
     Coerce LLM-produced flat arguments to match nested JSON schemas.
@@ -1118,6 +1136,7 @@ class MCPManager:
     async def _connect_server(self, state: MCPServerState) -> None:
         """Connect to a single MCP server and discover its tools."""
         config = state.config
+        exit_stack: AsyncExitStack | None = None
         try:
             from mcp import ClientSession
             from mcp.client.sse import sse_client
@@ -1134,19 +1153,28 @@ class MCPManager:
                 if token:
                     headers["Authorization"] = f"Bearer {token}"
 
-            # Connect based on transport type
+            # Connect based on transport type. The WHOLE transport establishment
+            # is bounded by a same-task asyncio.timeout: init/list_tools below were
+            # always wait_for-bounded, but the transport __aenter__ itself was not —
+            # a pathological upstream could wedge here indefinitely while holding
+            # the reconnect_lock, silencing every reconnect path incl. the health
+            # monitor's self-heal tick (#1107). asyncio.timeout (not wait_for)
+            # keeps the cancellation in THIS task, so anyio cancel scopes entered
+            # by the transport contexts stay task-consistent for later teardown.
             if config.transport == MCPTransportType.STREAMABLE_HTTP:
                 if not config.url:
                     raise ValueError("URL required for streamable_http transport")
-                transport = await exit_stack.enter_async_context(
-                    streamablehttp_client(url=config.url, headers=headers)
-                )
+                async with asyncio.timeout(settings.mcp_connect_timeout):
+                    transport = await exit_stack.enter_async_context(
+                        streamablehttp_client(url=config.url, headers=headers)
+                    )
             elif config.transport == MCPTransportType.SSE:
                 if not config.url:
                     raise ValueError("URL required for SSE transport")
-                transport = await exit_stack.enter_async_context(
-                    sse_client(url=config.url, headers=headers)
-                )
+                async with asyncio.timeout(settings.mcp_connect_timeout):
+                    transport = await exit_stack.enter_async_context(
+                        sse_client(url=config.url, headers=headers)
+                    )
             elif config.transport == MCPTransportType.STDIO:
                 if not config.command:
                     raise ValueError("Command required for stdio transport")
@@ -1179,9 +1207,10 @@ class MCPManager:
                     args=config.args,
                     env=subprocess_env,
                 )
-                transport = await exit_stack.enter_async_context(
-                    stdio_client(server=params)
-                )
+                async with asyncio.timeout(settings.mcp_connect_timeout):
+                    transport = await exit_stack.enter_async_context(
+                        stdio_client(server=params)
+                    )
             else:
                 raise ValueError(f"Unknown transport: {config.transport}")
 
@@ -1253,9 +1282,21 @@ class MCPManager:
             else:
                 logger.info(f"MCP server '{config.name}' connected: {len(state.tools)} tools")
 
+        except asyncio.CancelledError:
+            # Cancelled mid-connect (self-heal hang-guard or shutdown): mark the
+            # state honestly and hand the partially-entered transport to a
+            # detached best-effort closer — a wedged anyio teardown must not
+            # block the cancelling caller; a rare leak beats a frozen loop.
+            self._set_connected(state, False)
+            state.last_error = "connect cancelled (timeout/shutdown)"
+            state.exit_stack = None
+            if exit_stack is not None:
+                asyncio.get_running_loop().create_task(_close_stack_quietly(exit_stack))
+            raise
         except Exception as e:
             self._set_connected(state, False)
-            state.last_error = str(e)
+            # str(TimeoutError()) is "" — always keep a meaningful error text.
+            state.last_error = str(e) or type(e).__name__
 
             # Record failure for exponential backoff
             if state.backoff:
@@ -1267,13 +1308,18 @@ class MCPManager:
             else:
                 logger.warning(f"MCP server '{config.name}' connection failed: {e}")
 
-            # Clean up exit stack on failure
-            if state.exit_stack:
+            # Clean up the LOCAL exit stack on failure. (The old code closed
+            # state.exit_stack here, which at this point is always None — the
+            # local one is only promoted to state on success — so every failed
+            # connect leaked its partially-entered transport contexts.) Bounded:
+            # a teardown of a half-broken anyio transport can itself wedge.
+            if exit_stack is not None:
                 try:
-                    await state.exit_stack.__aexit__(None, None, None)
+                    async with asyncio.timeout(_TEARDOWN_TIMEOUT_S):
+                        await exit_stack.__aexit__(None, None, None)
                 except Exception:
                     pass
-                state.exit_stack = None
+            state.exit_stack = None
 
     async def _reconnect_server(self, state: MCPServerState) -> bool:
         """Tear down a stale session and re-establish.
@@ -1290,10 +1336,14 @@ class MCPManager:
             if state.connected and state.session is not None:
                 return True
             # Tear down old session/streams. Failures here are expected
-            # (the resource is half-broken — that's why we're here).
+            # (the resource is half-broken — that's why we're here). Bounded:
+            # anyio teardown of a broken streamable_http session can hang on
+            # stream drain, and this runs under reconnect_lock — an unbounded
+            # hang here would freeze every reconnect path for the server.
             if state.exit_stack is not None:
                 try:
-                    await state.exit_stack.__aexit__(None, None, None)
+                    async with asyncio.timeout(_TEARDOWN_TIMEOUT_S):
+                        await state.exit_stack.__aexit__(None, None, None)
                 except Exception:
                     pass
                 state.exit_stack = None

--- a/src/backend/services/mcp_health_monitor.py
+++ b/src/backend/services/mcp_health_monitor.py
@@ -21,6 +21,7 @@ alerts. Detect-and-notify ONLY — healing is Phase 2 (mirrors the ``system_heal
 """
 from __future__ import annotations
 
+import asyncio
 import time
 from typing import Any
 
@@ -158,10 +159,22 @@ async def _self_heal(mcp_manager, problem_names: list[str]) -> set[str]:
     healed = 0
     for name in problem_names[: settings.mcp_health_self_heal_max_per_tick]:
         try:
-            res = await probe(name)
+            # Hard hang-guard: the probe drives a reconnect, and a wedged
+            # transport used to hang here forever — freezing the WHOLE monitor
+            # loop (the scheduler awaits each tick), so a down server never
+            # alerted and never healed (#1107). asyncio.timeout keeps the
+            # cancellation in this task (anyio-scope-safe).
+            async with asyncio.timeout(settings.mcp_health_self_heal_probe_timeout):
+                res = await probe(name)
             attempted.add(name)
             if isinstance(res, dict) and res.get("ok"):
                 healed += 1
+        except TimeoutError:
+            attempted.add(name)  # we DID try — the alert may say "Selbstheilung versucht"
+            logger.warning(
+                f"mcp_health: self-heal probe for '{name}' exceeded "
+                f"{settings.mcp_health_self_heal_probe_timeout:.0f}s hang-guard — aborted"
+            )
         except Exception as e:  # noqa: BLE001 — a probe failure must not break the tick
             logger.warning(f"mcp_health: self-heal probe failed for '{name}': {e}")
     if attempted:
@@ -233,6 +246,17 @@ async def monitor_tick(app) -> None:
     for key in [k for k in _alerted if k.startswith("planea:")]:
         if key not in current_problems:
             _clear_alert(key)
+
+    # Tick heartbeat (#1107): a stuck monitor loop used to be indistinguishable
+    # from "all healthy". DEBUG log + a monotonically increasing counter make
+    # "the monitor stopped ticking" observable without log noise.
+    from utils.metrics import record_mcp_health_tick
+
+    record_mcp_health_tick(len(current_problems))
+    logger.debug(
+        f"mcp_health: tick complete — {len(status.get('servers', []))} servers, "
+        f"{len(current_problems)} problem(s), {len(healed_attempted)} heal attempt(s)"
+    )
 
 
 # A Plane-B report older than this with no newer one is treated as recovered — the

--- a/src/backend/services/mcp_health_monitor.py
+++ b/src/backend/services/mcp_health_monitor.py
@@ -145,6 +145,12 @@ async def ingest_report(payload: dict[str, Any]) -> None:
 
 # --- Plane-A: poll MCPManager.get_status() -----------------------------------
 
+# Fixed share of the probe hang-guard floor beyond the 3x transport/init/list
+# window: probe (2s) + bounded teardown (5s) + re-probe (2s), padded. Module
+# constant (not config) so tests can shrink it.
+_PROBE_GUARD_OVERHEAD_S = 15.0
+
+
 async def _self_heal(mcp_manager, problem_names: list[str]) -> set[str]:
     """Phase 2 self-heal: actively probe each degraded/down server, which drives a
     single-shot reconnect (``probe_server``). Returns the set of names we attempted
@@ -157,6 +163,15 @@ async def _self_heal(mcp_manager, problem_names: list[str]) -> set[str]:
     if not (settings.mcp_health_self_heal_enabled and callable(probe)):
         return attempted
     healed = 0
+    # The guard must stay ABOVE a worst-case honest reconnect (probe + bounded
+    # teardown + transport/init/tools-list at mcp_connect_timeout each + re-probe),
+    # else raising MCP_CONNECT_TIMEOUT alone would make every slow-but-honest
+    # heal get cancelled mid-connect and self-heal permanently fail. The floor
+    # tracks the connect timeout so the two knobs can't be misconfigured apart.
+    probe_guard_s = max(
+        settings.mcp_health_self_heal_probe_timeout,
+        settings.mcp_connect_timeout * 3 + _PROBE_GUARD_OVERHEAD_S,
+    )
     for name in problem_names[: settings.mcp_health_self_heal_max_per_tick]:
         try:
             # Hard hang-guard: the probe drives a reconnect, and a wedged
@@ -164,7 +179,7 @@ async def _self_heal(mcp_manager, problem_names: list[str]) -> set[str]:
             # loop (the scheduler awaits each tick), so a down server never
             # alerted and never healed (#1107). asyncio.timeout keeps the
             # cancellation in this task (anyio-scope-safe).
-            async with asyncio.timeout(settings.mcp_health_self_heal_probe_timeout):
+            async with asyncio.timeout(probe_guard_s):
                 res = await probe(name)
             attempted.add(name)
             if isinstance(res, dict) and res.get("ok"):
@@ -173,7 +188,7 @@ async def _self_heal(mcp_manager, problem_names: list[str]) -> set[str]:
             attempted.add(name)  # we DID try — the alert may say "Selbstheilung versucht"
             logger.warning(
                 f"mcp_health: self-heal probe for '{name}' exceeded "
-                f"{settings.mcp_health_self_heal_probe_timeout:.0f}s hang-guard — aborted"
+                f"{probe_guard_s:.0f}s hang-guard — aborted"
             )
         except Exception as e:  # noqa: BLE001 — a probe failure must not break the tick
             logger.warning(f"mcp_health: self-heal probe failed for '{name}': {e}")
@@ -194,6 +209,24 @@ async def monitor_tick(app) -> None:
     mcp_manager = getattr(app.state, "mcp_manager", None)
     if mcp_manager is None:
         return
+    # Tick heartbeat (#1107): a stuck monitor loop used to be indistinguishable
+    # from "all healthy". The COUNTER ticks in the finally (so a live loop whose
+    # get_status keeps failing still reads as alive — WARNs tell the rest), the
+    # problem GAUGE is only set when a tick actually completed with a verdict.
+    try:
+        await _monitor_tick_body(mcp_manager)
+    finally:
+        from utils.metrics import record_mcp_health_tick
+
+        record_mcp_health_tick(_last_tick_problem_count)
+
+
+_last_tick_problem_count: int | None = None
+
+
+async def _monitor_tick_body(mcp_manager) -> None:
+    global _last_tick_problem_count
+    _last_tick_problem_count = None
     try:
         status = mcp_manager.get_status()
     except Exception as e:  # noqa: BLE001
@@ -247,12 +280,7 @@ async def monitor_tick(app) -> None:
         if key not in current_problems:
             _clear_alert(key)
 
-    # Tick heartbeat (#1107): a stuck monitor loop used to be indistinguishable
-    # from "all healthy". DEBUG log + a monotonically increasing counter make
-    # "the monitor stopped ticking" observable without log noise.
-    from utils.metrics import record_mcp_health_tick
-
-    record_mcp_health_tick(len(current_problems))
+    _last_tick_problem_count = len(current_problems)
     logger.debug(
         f"mcp_health: tick complete — {len(status.get('servers', []))} servers, "
         f"{len(current_problems)} problem(s), {len(healed_attempted)} heal attempt(s)"

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -1365,6 +1365,12 @@ class Settings(BaseSettings):
     # reconnect can't fix still alert (the post-probe health re-read decides).
     mcp_health_self_heal_enabled: bool = True
     mcp_health_self_heal_max_per_tick: int = 8         # cap probe/reconnect attempts per tick
+    # Hard hang-guard per self-heal probe. probe_server's own RPC probes are 2s-
+    # bounded, but the reconnect it drives (transport connect + init + tools/list)
+    # can wedge on a pathological upstream (observed 2026-08-22: the run_at_boot
+    # tick hung in the twin reconnect and silenced the WHOLE monitor loop — #1107).
+    # Must exceed a worst-case honest reconnect (~3x mcp_connect_timeout + probes).
+    mcp_health_self_heal_probe_timeout: float = Field(default=45.0, ge=5.0, le=600.0)
     # Functional health: track the last N HEALTH-CORRELATED tool-call outcomes per
     # server — True on a clean result, False on a TIMEOUT (server didn't respond).
     # App-level errors (device off / not found / success:false envelopes), caller

--- a/src/backend/utils/metrics.py
+++ b/src/backend/utils/metrics.py
@@ -48,6 +48,8 @@ _orchestrator_domains_requested_total = None
 _orchestrator_domains_rendered_total = None
 _orchestrator_contract_version_mismatch_total = None
 _orchestrator_contract_demotions_total = None
+_mcp_health_ticks_total = None
+_mcp_health_problem_servers = None
 
 
 def _init_metrics():
@@ -67,6 +69,7 @@ def _init_metrics():
     global _speaker_inprocess_embedding_blocked_total
     global _orchestrator_domains_requested_total, _orchestrator_domains_rendered_total
     global _orchestrator_contract_version_mismatch_total, _orchestrator_contract_demotions_total
+    global _mcp_health_ticks_total, _mcp_health_problem_servers
 
     if _metrics_initialized:
         return
@@ -171,6 +174,18 @@ def _init_metrics():
             "renfield_output_guard_violations_total",
             "Output guard violations detected",
             ["violation"],
+        )
+
+        # MCP self-detection tick heartbeat (#1107): a monitor whose tick wedged
+        # used to be indistinguishable from "all healthy" (both are silent).
+        # A flatlining counter under a running backend = the monitor is stuck.
+        _mcp_health_ticks_total = Counter(
+            "renfield_mcp_health_ticks_total",
+            "Completed MCP health monitor ticks",
+        )
+        _mcp_health_problem_servers = Gauge(
+            "renfield_mcp_health_problem_servers",
+            "Degraded/down MCP servers seen by the last completed monitor tick",
         )
 
         # Pluggable-auth fail-open observability. Name intentionally matches
@@ -367,6 +382,15 @@ def record_mcp_tool_call(server: str, tool: str, duration: float, success: bool)
     _mcp_tool_duration_seconds.labels(server=server, tool=tool).observe(duration)
     if not success:
         _mcp_tool_errors_total.labels(server=server, tool=tool).inc()
+
+
+def record_mcp_health_tick(problem_count: int):
+    """Record one COMPLETED MCP health monitor tick (heartbeat, #1107) and the
+    number of degraded/down servers it saw."""
+    if not _metrics_initialized:
+        return
+    _mcp_health_ticks_total.inc()
+    _mcp_health_problem_servers.set(problem_count)
 
 
 def record_agent_outcome(outcome: str):

--- a/src/backend/utils/metrics.py
+++ b/src/backend/utils/metrics.py
@@ -384,13 +384,16 @@ def record_mcp_tool_call(server: str, tool: str, duration: float, success: bool)
         _mcp_tool_errors_total.labels(server=server, tool=tool).inc()
 
 
-def record_mcp_health_tick(problem_count: int):
-    """Record one COMPLETED MCP health monitor tick (heartbeat, #1107) and the
-    number of degraded/down servers it saw."""
+def record_mcp_health_tick(problem_count: int | None):
+    """Record one MCP health monitor tick (heartbeat, #1107). The counter ticks
+    for every ATTEMPTED tick (liveness — a flatline means the loop is stuck);
+    the gauge is only set when the tick completed with a verdict
+    (``problem_count is not None``) so a failing get_status can't fake 0."""
     if not _metrics_initialized:
         return
     _mcp_health_ticks_total.inc()
-    _mcp_health_problem_servers.set(problem_count)
+    if problem_count is not None:
+        _mcp_health_problem_servers.set(problem_count)
 
 
 def record_agent_outcome(outcome: str):

--- a/tests/backend/test_mcp_client.py
+++ b/tests/backend/test_mcp_client.py
@@ -1897,3 +1897,98 @@ class TestFunctionalHealthCallTracking:
         manager._servers["srv"] = state
         await manager.execute_tool("mcp.srv.slow", {})
         assert list(state.recent_outcomes) == [False]
+
+
+# ============================================================================
+# #1107 — connect/teardown hang-guards (a wedged transport must never freeze
+# a reconnect path or the health monitor's self-heal tick)
+# ============================================================================
+
+
+class TestConnectHangGuards:
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_connect_server_bounds_hanging_transport_enter(self, monkeypatch):
+        """A streamable_http transport whose __aenter__ wedges must fail within
+        mcp_connect_timeout instead of hanging the caller (which may hold the
+        reconnect_lock)."""
+        import services.mcp_client as mc
+
+        class _WedgedTransport:
+            async def __aenter__(self):
+                await asyncio.sleep(3600)
+
+            async def __aexit__(self, *exc):
+                return False
+
+        import mcp.client.streamable_http as sh
+        monkeypatch.setattr(sh, "streamablehttp_client", lambda **kw: _WedgedTransport())
+        monkeypatch.setattr(mc.settings, "mcp_connect_timeout", 0.05)
+
+        manager = MCPManager()
+        state = MCPServerState(
+            config=MCPServerConfig(name="wedged", url="http://wedged:1/mcp"),
+        )
+        await asyncio.wait_for(manager._connect_server(state), timeout=5.0)
+        assert state.connected is False
+        assert state.last_error  # timeout surfaced as the connect failure
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_connect_failure_closes_local_exit_stack(self, monkeypatch):
+        """The partially-entered LOCAL exit stack must be closed on a failed
+        connect (it used to leak: only the always-None state.exit_stack was
+        closed)."""
+        import services.mcp_client as mc
+
+        closed: list[bool] = []
+
+        class _FailingTransport:
+            async def __aenter__(self):
+                raise RuntimeError("refused")
+
+            async def __aexit__(self, *exc):
+                closed.append(True)
+                return False
+
+        import mcp.client.streamable_http as sh
+        monkeypatch.setattr(sh, "streamablehttp_client", lambda **kw: _FailingTransport())
+        monkeypatch.setattr(mc.settings, "mcp_connect_timeout", 1.0)
+
+        manager = MCPManager()
+        state = MCPServerState(
+            config=MCPServerConfig(name="refused", url="http://refused:1/mcp"),
+        )
+        await manager._connect_server(state)
+        assert state.connected is False
+        # AsyncExitStack unwinds entered contexts on __aexit__; a transport whose
+        # __aenter__ raised was never entered, so nothing to close — but the
+        # stack itself must have been exited without hanging. The observable
+        # contract: the call returns and no exception escapes.
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_reconnect_bounds_hanging_teardown(self, monkeypatch):
+        """A stale session whose exit-stack teardown wedges must not block the
+        reconnect (it runs under reconnect_lock) — bounded by _TEARDOWN_TIMEOUT_S."""
+        import services.mcp_client as mc
+
+        monkeypatch.setattr(mc, "_TEARDOWN_TIMEOUT_S", 0.05)
+
+        class _WedgedStack:
+            async def __aexit__(self, *exc):
+                await asyncio.sleep(3600)
+
+        manager = MCPManager()
+        state = MCPServerState(
+            config=MCPServerConfig(name="stale", url="http://stale:1/mcp"),
+            connected=False,
+        )
+        state.exit_stack = _WedgedStack()
+        state.session = object()
+        manager._connect_server = AsyncMock()  # reconnect proceeds after teardown
+
+        await asyncio.wait_for(manager._reconnect_server(state), timeout=5.0)
+        assert state.exit_stack is None
+        manager._connect_server.assert_awaited_once()

--- a/tests/backend/test_mcp_client.py
+++ b/tests/backend/test_mcp_client.py
@@ -1934,22 +1934,71 @@ class TestConnectHangGuards:
         assert state.connected is False
         assert state.last_error  # timeout surfaced as the connect failure
 
+    @staticmethod
+    def _recording_transport(closed: list):
+        """Async CM that ENTERS successfully (2-tuple of fake streams) and
+        records its __aexit__ — the shape _connect_server unpacks."""
+
+        class _T:
+            async def __aenter__(self):
+                return (MagicMock(), MagicMock())
+
+            async def __aexit__(self, *exc):
+                closed.append("transport")
+                return False
+
+        return _T()
+
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_connect_failure_closes_local_exit_stack(self, monkeypatch):
-        """The partially-entered LOCAL exit stack must be closed on a failed
-        connect (it used to leak: only the always-None state.exit_stack was
-        closed)."""
+    async def test_connect_failure_closes_entered_transport(self, monkeypatch):
+        """A transport that was ENTERED before a later stage fails must be
+        closed via the local exit stack (it used to leak: only the stale
+        state.exit_stack was closed)."""
         import services.mcp_client as mc
 
-        closed: list[bool] = []
+        closed: list[str] = []
+        import mcp as mcp_mod
+        import mcp.client.streamable_http as sh
+        monkeypatch.setattr(
+            sh, "streamablehttp_client", lambda **kw: self._recording_transport(closed)
+        )
+
+        def _boom(*a, **kw):
+            raise RuntimeError("session construction failed")
+
+        monkeypatch.setattr(mcp_mod, "ClientSession", _boom)
+        monkeypatch.setattr(mc.settings, "mcp_connect_timeout", 1.0)
+
+        manager = MCPManager()
+        state = MCPServerState(
+            config=MCPServerConfig(name="failing", url="http://failing:1/mcp"),
+        )
+        await manager._connect_server(state)
+        assert state.connected is False
+        assert closed == ["transport"]
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_connect_failure_closes_stale_state_stack(self, monkeypatch):
+        """Direct refresh_tools reconnects reach _connect_server with a STALE
+        state.exit_stack from the prior session (no teardown happened) — a
+        failed connect must close it, not silently drop it (regression vs the
+        first hang-guard cut)."""
+        import services.mcp_client as mc
+
+        closed: list[str] = []
+
+        class _StaleStack:
+            async def __aexit__(self, *exc):
+                closed.append("stale")
+                return False
 
         class _FailingTransport:
             async def __aenter__(self):
                 raise RuntimeError("refused")
 
             async def __aexit__(self, *exc):
-                closed.append(True)
                 return False
 
         import mcp.client.streamable_http as sh
@@ -1958,14 +2007,44 @@ class TestConnectHangGuards:
 
         manager = MCPManager()
         state = MCPServerState(
-            config=MCPServerConfig(name="refused", url="http://refused:1/mcp"),
+            config=MCPServerConfig(name="stale2", url="http://stale2:1/mcp"),
         )
+        state.exit_stack = _StaleStack()
+        state.session = object()
         await manager._connect_server(state)
+        assert closed == ["stale"]
+        assert state.exit_stack is None
+        assert state.session is None
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_cancelled_connect_records_backoff_and_detached_close(self, monkeypatch):
+        """An outer-guard-cancelled connect must advance backoff like an inner
+        timeout does, and schedule a strongly-referenced detached closer."""
+        import services.mcp_client as mc
+
+        class _WedgedTransport:
+            async def __aenter__(self):
+                await asyncio.sleep(3600)
+
+            async def __aexit__(self, *exc):
+                return False
+
+        import mcp.client.streamable_http as sh
+        monkeypatch.setattr(sh, "streamablehttp_client", lambda **kw: _WedgedTransport())
+        monkeypatch.setattr(mc.settings, "mcp_connect_timeout", 30.0)  # inner must NOT fire
+
+        manager = MCPManager()
+        state = MCPServerState(
+            config=MCPServerConfig(name="cancelled", url="http://cancelled:1/mcp"),
+        )
+        state.backoff = MagicMock()
+        with pytest.raises(TimeoutError):
+            async with asyncio.timeout(0.05):
+                await manager._connect_server(state)
+        state.backoff.record_failure.assert_called_once()
         assert state.connected is False
-        # AsyncExitStack unwinds entered contexts on __aexit__; a transport whose
-        # __aenter__ raised was never entered, so nothing to close — but the
-        # stack itself must have been exited without hanging. The observable
-        # contract: the call returns and no exception escapes.
+        assert "cancelled" in (state.last_error or "")
 
     @pytest.mark.unit
     @pytest.mark.asyncio

--- a/tests/backend/test_mcp_health_monitor.py
+++ b/tests/backend/test_mcp_health_monitor.py
@@ -158,6 +158,69 @@ async def test_self_heal_disabled_alerts_without_probe(monkeypatch):
     assert notes[0]["data"]["self_heal_attempted"] is False
 
 
+async def test_self_heal_hang_guard_bounds_a_wedged_probe(monkeypatch):
+    """#1107: a probe whose reconnect wedges must NOT freeze the tick — the
+    hang-guard cancels it, the tick completes, the alert still fires and is
+    honest about the attempted heal."""
+    import asyncio
+
+    monkeypatch.setattr(m.settings, "mcp_health_self_heal_probe_timeout", 0.05)
+    notes = _capture_notes(monkeypatch)
+    mgr = MagicMock()
+
+    async def _wedged_probe(name):
+        await asyncio.sleep(3600)
+
+    mgr.probe_server = _wedged_probe
+    down = {"servers": [{"name": "twin", "health": "down", "last_error": "no session"}]}
+    mgr.get_status = MagicMock(return_value=down)
+
+    await asyncio.wait_for(m.monitor_tick(_app_with(mgr)), timeout=5.0)
+
+    assert len(notes) == 1
+    assert notes[0]["data"]["self_heal_attempted"] is True
+    assert "Selbstheilung versucht" in notes[0]["message"]
+
+
+async def test_self_heal_hang_guard_spares_other_servers(monkeypatch):
+    """One wedged server must not starve the heal attempts of the others."""
+    import asyncio
+
+    monkeypatch.setattr(m.settings, "mcp_health_self_heal_probe_timeout", 0.05)
+    _capture_notes(monkeypatch)
+    mgr = MagicMock()
+    probed: list[str] = []
+
+    async def _probe(name):
+        probed.append(name)
+        if name == "wedged":
+            await asyncio.sleep(3600)
+        return {"ok": False}
+
+    mgr.probe_server = _probe
+    mgr.get_status = MagicMock(return_value={"servers": [
+        {"name": "wedged", "health": "down"},
+        {"name": "other", "health": "down"},
+    ]})
+
+    await asyncio.wait_for(m.monitor_tick(_app_with(mgr)), timeout=5.0)
+    assert probed == ["wedged", "other"]
+
+
+async def test_monitor_tick_records_heartbeat(monkeypatch):
+    """#1107: every COMPLETED tick must emit the heartbeat metric so a stuck
+    monitor is distinguishable from an all-healthy one."""
+    ticks: list[int] = []
+    monkeypatch.setattr(
+        "utils.metrics.record_mcp_health_tick", lambda n: ticks.append(n)
+    )
+    _capture_notes(monkeypatch)
+    mgr = MagicMock()
+    mgr.get_status = MagicMock(return_value={"servers": [{"name": "ok", "health": "healthy"}]})
+    await m.monitor_tick(_app_with(mgr))
+    assert ticks == [0]
+
+
 async def test_plugin_failed_skips_probe_still_alerts(monkeypatch):
     # A reconnect provably can't reload a failed startup plugin → we DON'T probe it
     # (no wasted RPC, no false "Selbstheilung versucht"), but it STILL alerts.

--- a/tests/backend/test_mcp_health_monitor.py
+++ b/tests/backend/test_mcp_health_monitor.py
@@ -165,6 +165,8 @@ async def test_self_heal_hang_guard_bounds_a_wedged_probe(monkeypatch):
     import asyncio
 
     monkeypatch.setattr(m.settings, "mcp_health_self_heal_probe_timeout", 0.05)
+    monkeypatch.setattr(m.settings, "mcp_connect_timeout", 0.001)
+    monkeypatch.setattr(m, "_PROBE_GUARD_OVERHEAD_S", 0.001)
     notes = _capture_notes(monkeypatch)
     mgr = MagicMock()
 
@@ -187,6 +189,8 @@ async def test_self_heal_hang_guard_spares_other_servers(monkeypatch):
     import asyncio
 
     monkeypatch.setattr(m.settings, "mcp_health_self_heal_probe_timeout", 0.05)
+    monkeypatch.setattr(m.settings, "mcp_connect_timeout", 0.001)
+    monkeypatch.setattr(m, "_PROBE_GUARD_OVERHEAD_S", 0.001)
     _capture_notes(monkeypatch)
     mgr = MagicMock()
     probed: list[str] = []
@@ -219,6 +223,21 @@ async def test_monitor_tick_records_heartbeat(monkeypatch):
     mgr.get_status = MagicMock(return_value={"servers": [{"name": "ok", "health": "healthy"}]})
     await m.monitor_tick(_app_with(mgr))
     assert ticks == [0]
+
+
+async def test_heartbeat_ticks_even_when_get_status_fails(monkeypatch):
+    """The liveness counter must tick for a live-but-erroring loop (else a
+    persistently failing get_status flatlines the counter and mimics the very
+    hang the metric exists to expose); the gauge verdict stays None."""
+    ticks: list = []
+    monkeypatch.setattr(
+        "utils.metrics.record_mcp_health_tick", lambda n: ticks.append(n)
+    )
+    _capture_notes(monkeypatch)
+    mgr = MagicMock()
+    mgr.get_status = MagicMock(side_effect=RuntimeError("broken status shape"))
+    await m.monitor_tick(_app_with(mgr))
+    assert ticks == [None]
 
 
 async def test_plugin_failed_skips_probe_still_alerts(monkeypatch):


### PR DESCRIPTION
## Summary
- **Root Cause #1107:** Der run_at_boot-Tick des MCP-Health-Monitors hing im Twin-Reconnect (Service ohne Endpoints) und legte die gesamte Monitor-Schleife still — >1h down-Server ohne Probe/Alert/Heilung, erst manueller `POST /api/mcp/refresh` half.
- **Drei Timeout-Schichten**, alle same-task `asyncio.timeout` (anyio-cancel-scope-sicher): Transport-`__aenter__` in `_connect_server` (`mcp_connect_timeout` — die Lücke; init/tools-list waren immer gebounded), jeder Teardown (`_TEARDOWN_TIMEOUT_S`, inkl. `shutdown()`), und ein harter Hang-Guard je Self-Heal-Probe (`MCP_HEALTH_SELF_HEAL_PROBE_TIMEOUT`, Untergrenze an `mcp_connect_timeout` gekoppelt).
- **Leak-Fixes:** lokaler halb geöffneter Exit-Stack UND Stale-Stack der Vorsession (direkte refresh_tools-Reconnects ohne Teardown) werden auf Fehler-/Cancel-/Erfolgspfad bounded geschlossen; detached Closer GC-sicher referenziert; Backoff advanced auch bei Guard-Cancel; `last_error` nie leer.
- **Beobachtbarkeit:** `renfield_mcp_health_ticks_total` (Counter, tickt auch bei get_status-Fehlern — Flatline = Monitor hängt wirklich) + `renfield_mcp_health_problem_servers` (Gauge, nur bei komplettem Verdict) + DEBUG-Tick-Zeile.
- Nebenbei: `.gitignore`-Schutz für das private `src/backend/twin_adapter/` (Review-Fund; restliche Twin-Findings sind im privaten Repo dokumentiert).

Closes #1107

## Test plan
- [x] 9 neue Tests: wedged Probe → Tick läuft durch + ehrlicher Alert; wedged Server verhungert andere nicht; Heartbeat inkl. get_status-Fehlerpfad; wedged Transport-Connect gebounded; entered-Transport-Close; Stale-Stack-Close; Backoff-bei-Cancel; wedged Teardown gebounded
- [x] Suite auf .159 isoliert: **5656 passed, 0 failed** (+ zweiter /code-review-Durchgang mit 8 Findings, alle adressiert)
- [x] Ruff-Diff gegen main: 0 neue Verstöße

🤖 Generated with [Claude Code](https://claude.com/claude-code)