### PR TITLE
fix(connections): SSO-Verbindungen bieten kein Einfügefeld mehr an

### DIFF
--- a/src/frontend/src/api/resources/connections.ts
+++ b/src/frontend/src/api/resources/connections.ts
@@ -9,15 +9,29 @@ import apiClient from '../../utils/axios';
 import { useApiQuery, useApiMutation } from '../hooks';
 import { keys, STALE } from '../keys';
 
+/** Credential types the catalog can declare. `sso` has nothing to paste — its
+ *  credential is minted from the user's own login, so connect/disconnect are
+ *  refused server-side and the UI must not offer them. */
+export const SSO_CREDENTIAL_TYPE = 'sso';
+
 export interface ConnectionProvider {
   provider_key: string;
   display_name?: string;
   descriptor?: string;
+  /** 'paste_token' | 'oauth3lo' | 'sso' — see config/connections.yaml */
   credential_type?: string;
   read_only?: boolean;
   mint_url?: string;
   help?: string;
+  /** For `sso` providers: the vault key the login capture writes, which is
+   *  where `connected` is derived from. A provider name, never a secret. */
+  sso_source?: string;
   connected: boolean;
+}
+
+/** True when this connection is established by logging in, not by pasting. */
+export function isSsoProvider(p: ConnectionProvider): boolean {
+  return p.credential_type === SSO_CREDENTIAL_TYPE;
 }
 
 async function fetchConnections(): Promise<ConnectionProvider[]> {

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -53,6 +53,12 @@
     "disconnect": "Trennen",
     "disconnecting": "Wird getrennt…",
     "rotate": "Token ersetzen",
+    "details": "Details",
+    "viaSso": "Über deine SSO-Anmeldung",
+    "ssoTitle": "{{name}} über SSO",
+    "ssoDefaultHelp": "Diese Verbindung entsteht automatisch aus deiner Anmeldung. Es gibt kein Token zum Einfügen und keines zum Widerrufen.",
+    "ssoConnected": "Aktiv. Reva greift mit deinen eigenen Rechten zu, solange deine Anmeldung gültig ist. Zum Beenden melde dich ab.",
+    "ssoNotConnected": "Deine Anmeldung enthält derzeit kein gültiges Token für dieses Werkzeug. Melde dich über die Weboberfläche neu an — danach steht die Verbindung wieder. Ein Token einzufügen ist hier nicht möglich.",
     "status": {
       "connected": "Verbunden",
       "notConnected": "Nicht verbunden"

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -53,6 +53,12 @@
     "disconnect": "Disconnect",
     "disconnecting": "Disconnecting…",
     "rotate": "Replace token",
+    "details": "Details",
+    "viaSso": "Through your SSO login",
+    "ssoTitle": "{{name}} via SSO",
+    "ssoDefaultHelp": "This connection comes from your login automatically. There is no token to paste and none to revoke.",
+    "ssoConnected": "Active. Reva uses your own permissions for as long as your login is valid. Sign out to end it.",
+    "ssoNotConnected": "Your login currently carries no valid token for this tool. Sign in again through the web interface and the connection comes back. Pasting a token is not possible here.",
     "status": {
       "connected": "Connected",
       "notConnected": "Not connected"

--- a/src/frontend/src/pages/ConnectionsPage.tsx
+++ b/src/frontend/src/pages/ConnectionsPage.tsx
@@ -7,7 +7,7 @@
  */
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Plug, ExternalLink, Loader2, CheckCircle2, Circle } from 'lucide-react';
+import { Plug, ExternalLink, Loader2, CheckCircle2, Circle, KeyRound } from 'lucide-react';
 import PageHeader from '../components/PageHeader';
 import Modal from '../components/Modal';
 import Badge from '../components/Badge';
@@ -16,6 +16,7 @@ import {
   useConnections,
   useConnect,
   useDisconnect,
+  isSsoProvider,
   type ConnectionProvider,
 } from '../api/resources/connections';
 
@@ -25,14 +26,17 @@ export default function ConnectionsPage() {
   const connect = useConnect();
   const disconnect = useDisconnect();
 
-  // modal state: the provider being connected/managed, and the paste field
+  // modal state: the provider being connected/managed, and the paste field.
+  // `sso` is its own mode — those connections have no token to paste and no
+  // token to revoke, so both the paste form and the disconnect action would
+  // only lead to a server-side refusal.
   const [active, setActive] = useState<ConnectionProvider | null>(null);
-  const [mode, setMode] = useState<'connect' | 'manage'>('connect');
+  const [mode, setMode] = useState<'connect' | 'manage' | 'sso'>('connect');
   const [secret, setSecret] = useState('');
 
   const open = (p: ConnectionProvider) => {
     setActive(p);
-    setMode(p.connected ? 'manage' : 'connect');
+    setMode(isSsoProvider(p) ? 'sso' : p.connected ? 'manage' : 'connect');
     setSecret('');
     connect.reset?.();
   };
@@ -69,32 +73,47 @@ export default function ConnectionsPage() {
         </div>
       ) : (
         <div className="card divide-y divide-gray-100 dark:divide-gray-700 p-0 overflow-hidden">
-          {(providers ?? []).map((p) => (
-            <div key={p.provider_key} className="flex items-center gap-4 px-5 py-4">
-              <div className="flex-1 min-w-0">
-                <div className="font-semibold text-gray-900 dark:text-gray-100">
-                  {p.display_name ?? p.provider_key}
-                </div>
-                {p.descriptor && (
-                  <div className="text-sm text-gray-500 dark:text-gray-400 truncate">
-                    {p.descriptor}
+          {(providers ?? []).map((p) => {
+            const sso = isSsoProvider(p);
+            return (
+              <div key={p.provider_key} className="flex items-center gap-4 px-5 py-4">
+                <div className="flex-1 min-w-0">
+                  <div className="font-semibold text-gray-900 dark:text-gray-100">
+                    {p.display_name ?? p.provider_key}
                   </div>
+                  {p.descriptor && (
+                    <div className="text-sm text-gray-500 dark:text-gray-400 truncate">
+                      {p.descriptor}
+                    </div>
+                  )}
+                  {sso && (
+                    // Say up front that this one works differently, so an
+                    // unconnected state doesn't read as "go find a token".
+                    <div className="text-xs text-gray-400 dark:text-gray-500 mt-0.5 inline-flex items-center gap-1">
+                      <KeyRound className="w-3 h-3" aria-hidden="true" />
+                      {t('connections.viaSso')}
+                    </div>
+                  )}
+                </div>
+                {p.connected ? (
+                  <Badge color="green" icon={CheckCircle2}>{t('connections.status.connected')}</Badge>
+                ) : (
+                  <Badge color="gray" icon={Circle}>{t('connections.status.notConnected')}</Badge>
                 )}
+                <button
+                  type="button"
+                  onClick={() => open(p)}
+                  className={sso || p.connected ? 'btn-secondary' : 'btn-primary'}
+                >
+                  {sso
+                    ? t('connections.details')
+                    : p.connected
+                      ? t('connections.manage')
+                      : t('connections.connect')}
+                </button>
               </div>
-              {p.connected ? (
-                <Badge color="green" icon={CheckCircle2}>{t('connections.status.connected')}</Badge>
-              ) : (
-                <Badge color="gray" icon={Circle}>{t('connections.status.notConnected')}</Badge>
-              )}
-              <button
-                type="button"
-                onClick={() => open(p)}
-                className={p.connected ? 'btn-secondary' : 'btn-primary'}
-              >
-                {p.connected ? t('connections.manage') : t('connections.connect')}
-              </button>
-            </div>
-          ))}
+            );
+          })}
           {(providers ?? []).length === 0 && (
             <div className="px-5 py-10 text-center text-gray-500 dark:text-gray-400">
               {t('connections.empty')}
@@ -109,15 +128,39 @@ export default function ConnectionsPage() {
         onClose={close}
         title={
           active
-            ? t(mode === 'manage' ? 'connections.manageTitle' : 'connections.connectTitle', {
-                name: active.display_name ?? active.provider_key,
-              })
+            ? t(
+                mode === 'manage'
+                  ? 'connections.manageTitle'
+                  : mode === 'sso'
+                    ? 'connections.ssoTitle'
+                    : 'connections.connectTitle',
+                { name: active.display_name ?? active.provider_key },
+              )
             : ''
         }
       >
         {active && (
           <div className="space-y-4">
-            {mode === 'connect' ? (
+            {mode === 'sso' ? (
+              <>
+                <p className="text-sm text-gray-600 dark:text-gray-300">
+                  {active.help ?? t('connections.ssoDefaultHelp')}
+                </p>
+                {active.connected ? (
+                  <Alert variant="success">{t('connections.ssoConnected')}</Alert>
+                ) : (
+                  // The remedy is a fresh login, not a token hunt. Without
+                  // saying so, "Not connected" on a provider with no Connect
+                  // button is a dead end.
+                  <Alert variant="warning">{t('connections.ssoNotConnected')}</Alert>
+                )}
+                <div className="flex justify-end pt-1">
+                  <button type="button" className="btn-secondary" onClick={close}>
+                    {t('common.close')}
+                  </button>
+                </div>
+              </>
+            ) : mode === 'connect' ? (
               <>
                 <p className="text-sm text-gray-600 dark:text-gray-300">
                   {active.help ?? t('connections.defaultHelp')}

--- a/tests/frontend/react/pages/ConnectionsPage.test.tsx
+++ b/tests/frontend/react/pages/ConnectionsPage.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * ConnectionsPage — the paste-token vs SSO distinction.
+ *
+ * The catalog marks a provider `credential_type: "sso"` when its credential is
+ * minted from the user's own login. The server refuses connect/disconnect for
+ * those. Before this, the page ignored the field, so an SSO provider offered a
+ * "Connect" button, a paste box, and a "Disconnect" — three actions whose only
+ * possible outcome was a 400. These tests pin the distinction down.
+ *
+ * Assertions are in German: test-utils pins i18n to `de`, matching the
+ * production default.
+ */
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+
+import { renderWithProviders } from '../test-utils';
+import { server } from '../mocks/server';
+import ConnectionsPage from '../../../../src/frontend/src/pages/ConnectionsPage';
+import { TEST_CONFIG } from '../config';
+
+const BASE = TEST_CONFIG.API_BASE_URL;
+
+const PASTE_PROVIDER = {
+  provider_key: 'jira',
+  display_name: 'Jira',
+  descriptor: 'Issues, boards & releases',
+  credential_type: 'paste_token',
+  read_only: true,
+  mint_url: 'https://id.atlassian.com/manage-profile/security/api-tokens',
+  help: 'Create an Atlassian API token.',
+  connected: false,
+};
+
+const SSO_PROVIDER = {
+  provider_key: 'release',
+  display_name: 'Digital.ai Release',
+  descriptor: 'Releases, phases & deployment status',
+  credential_type: 'sso',
+  sso_source: 'keycloak',
+  read_only: false,
+  help: 'Connected automatically through your SSO login — no token needed.',
+  connected: false,
+};
+
+function serve(providers: unknown[]) {
+  server.use(http.get(`${BASE}/api/connections`, () => HttpResponse.json(providers)));
+}
+
+describe('ConnectionsPage — SSO providers', () => {
+  it('offers Details instead of Connect for an SSO provider', async () => {
+    serve([SSO_PROVIDER]);
+    renderWithProviders(<ConnectionsPage />);
+
+    await screen.findByText('Digital.ai Release');
+    expect(screen.getByRole('button', { name: /details/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^verbinden$/i })).not.toBeInTheDocument();
+  });
+
+  it('shows no paste box — there is no token to paste', async () => {
+    serve([SSO_PROVIDER]);
+    renderWithProviders(<ConnectionsPage />);
+
+    await screen.findByText('Digital.ai Release');
+    fireEvent.click(screen.getByRole('button', { name: /details/i }));
+
+    await screen.findByText(/über SSO/i);
+    expect(screen.queryByLabelText(/zugriffstoken/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /verbindung speichern/i })).not.toBeInTheDocument();
+  });
+
+  it('offers no Disconnect for a connected SSO provider', async () => {
+    serve([{ ...SSO_PROVIDER, connected: true }]);
+    renderWithProviders(<ConnectionsPage />);
+
+    await screen.findByText('Digital.ai Release');
+    fireEvent.click(screen.getByRole('button', { name: /details/i }));
+
+    await screen.findByText(/über SSO/i);
+    expect(screen.queryByRole('button', { name: /^trennen$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /token ersetzen/i })).not.toBeInTheDocument();
+  });
+
+  it('names the remedy when an SSO connection is not established', async () => {
+    // "Not connected" with no Connect button is a dead end unless the page
+    // says what to do instead — sign in again.
+    serve([SSO_PROVIDER]);
+    renderWithProviders(<ConnectionsPage />);
+
+    await screen.findByText('Digital.ai Release');
+    fireEvent.click(screen.getByRole('button', { name: /details/i }));
+
+    expect(await screen.findByText(/neu an/i)).toBeInTheDocument();
+  });
+
+  it('marks the row so the mechanism is visible before opening it', async () => {
+    serve([SSO_PROVIDER]);
+    renderWithProviders(<ConnectionsPage />);
+
+    expect(await screen.findByText(/über deine SSO-Anmeldung/i)).toBeInTheDocument();
+  });
+});
+
+describe('ConnectionsPage — paste-token providers are unchanged', () => {
+  it('still offers Connect and a paste box', async () => {
+    serve([PASTE_PROVIDER]);
+    renderWithProviders(<ConnectionsPage />);
+
+    await screen.findByText('Jira');
+    fireEvent.click(screen.getByRole('button', { name: /^verbinden$/i }));
+
+    expect(await screen.findByLabelText(/zugriffstoken/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /verbindung speichern/i })).toBeInTheDocument();
+  });
+
+  it('still offers Disconnect once connected', async () => {
+    serve([{ ...PASTE_PROVIDER, connected: true }]);
+    renderWithProviders(<ConnectionsPage />);
+
+    await screen.findByText('Jira');
+    fireEvent.click(screen.getByRole('button', { name: /verwalten/i }));
+
+    expect(await screen.findByRole('button', { name: /^trennen$/i })).toBeInTheDocument();
+  });
+
+  it('submits the pasted secret to the provider endpoint', async () => {
+    let sent: { key?: string; body?: unknown } = {};
+    serve([PASTE_PROVIDER]);
+    server.use(
+      http.put(`${BASE}/api/connections/:key`, async ({ params, request }) => {
+        sent = { key: params.key as string, body: await request.json() };
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+    renderWithProviders(<ConnectionsPage />);
+
+    await screen.findByText('Jira');
+    fireEvent.click(screen.getByRole('button', { name: /^verbinden$/i }));
+    fireEvent.change(await screen.findByLabelText(/zugriffstoken/i), {
+      target: { value: 'me@example.com:tok' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /verbindung speichern/i }));
+
+    await waitFor(() => expect(sent.key).toBe('jira'));
+    expect(sent.body).toEqual({ secret: 'me@example.com:tok' });
+  });
+});
+
+describe('ConnectionsPage — mixed catalog', () => {
+  it('renders each provider according to its own credential type', async () => {
+    serve([PASTE_PROVIDER, SSO_PROVIDER]);
+    renderWithProviders(<ConnectionsPage />);
+
+    await screen.findByText('Jira');
+    await screen.findByText('Digital.ai Release');
+    expect(screen.getByRole('button', { name: /^verbinden$/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /details/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Problem

Der Connections-Katalog kennt `credential_type: "sso"` — eine Verbindung, deren
Credential aus der eigenen Anmeldung entsteht statt aus einem eingefügten Token.
Reva weist `connect`/`disconnect` für solche Anbieter serverseitig ab:

```
400 — release is connected through your SSO login — there is no token to paste
```

`ConnectionsPage.tsx` wertete das Feld aber nirgends aus. Für **Digital.ai
Release** bedeutete das: Knopf „Verbinden" → Einfügefeld → Speichern → 400. Drei
Interaktionen, deren einziges mögliches Ergebnis eine Fehlermeldung war. Im
verbundenen Zustand entsprechend „Trennen" → 400.

## Lösung

- Die Kachel trägt **„Details"** statt „Verbinden"/„Verwalten", plus einen
  leisen Hinweis „Über deine SSO-Anmeldung" — sichtbar **bevor** man klickt,
  damit ein „Nicht verbunden" nicht als Aufforderung zur Tokensuche gelesen wird.
- Der Dialog zeigt Hilfetext und Zustand, **ohne** Eingabefeld und **ohne**
  Trennen-Knopf.
- Ist die Verbindung nicht aktiv, nennt er das Mittel: **neu anmelden**. Ein
  „Nicht verbunden" ohne Verbinden-Knopf wäre sonst eine Sackgasse.

`paste_token`-Anbieter bleiben unverändert.

`isSsoProvider()` + `SSO_CREDENTIAL_TYPE` liegen beim API-Client, damit die
Bedingung eine Stelle hat statt eines verstreuten Stringvergleichs. `sso_source`
ist in der TS-Schnittstelle ergänzt (liefert das Backend bereits; ein
Anbietername, nie ein Geheimnis).

## Tests

9 neue (RTL + MSW), die beide Pfade **getrennt** absichern — SSO ohne
Einfügefeld/Trennen, paste_token weiterhin mit beidem, plus ein gemischter
Katalog. Volle Frontend-Suite: **733 passed**, keine Regression. i18n in
`de.json` UND `en.json`; Testsprache ist `de`, das steht im Dateikopf.