### PR TITLE
feat(platform): Twin-Guard-Härtung, #1104-Follow-ups komplett, Metriken aktiviert

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -174,6 +174,9 @@ PIPER_DEFAULT_VOICE=de_DE-thorsten-high  # Fallback when requested language has 
 #                                       # (raise TOGETHER with AGENT_RESPONSE_TRUNCATION —
 #                                       # that one caps text results at step creation)
 # KNOWLEDGE_CONTEXT_CHUNK_CHARS=500    # Per-chunk cap in internal.knowledge_search context
+# AGENT_PROMPT_TARGET_TOKENS=          # Optional soft target (#1104): above it only the
+#                                      # adaptive tool-result pass runs (prefill-latency
+#                                      # control on large-context servers). Empty = off.
 # CONVERSATION_SUMMARY_THRESHOLD=10
 # AGENT_ROLES_PATH=config/agent_roles.yaml
 # AGENT_ROUTER_TIMEOUT=30.0

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -182,8 +182,16 @@ METRICS_ENABLED=false
 
 **Default:** `false`
 
+**Exposure:** `/metrics` ist NUR in-cluster erreichbar — der Ingress routet den
+Pfad nicht (nur `/api`, `/ws`, `/health` gehen ans Backend), der Service ist
+ClusterIP; extern landet `/metrics` auf der SPA. Der Endpoint selbst hat keine
+Auth — vor einem externen Expose (Ingress-Pfad) MUSS eine Auth-Schicht davor.
+Der `endpoint`-Label der HTTP-Metriken normalisiert numerische/UUID/hex-
+Segmente zu `{id}` (Kardinalitätsschutz).
+
 **Wenn aktiviert:**
 - `/metrics` Endpoint im Prometheus-Format verfügbar
+- MCP-Health-Heartbeat: `renfield_mcp_health_ticks_total` + `renfield_mcp_health_problem_servers` (#1107)
 - HTTP Request Counter + Latency Histogram
 - WebSocket Connection Gauge
 - LLM Call Duration Histogram
@@ -254,6 +262,12 @@ AGENT_HISTORY_MESSAGE_MAX_CHARS=500
 AGENT_TOOL_RESULT_TEXT_MAX_CHARS=8000
 AGENT_RESPONSE_TRUNCATION=2000
 
+# Soft-Prompt-Target (#1104, optional): oberhalb dieses Werts (aber unter dem
+# harten 85%-Budget) läuft NUR die adaptive Tool-Result-Reduktion, dimensioniert
+# auf das Target — hält die Prefill-Latenz auf großen Kontextfenstern
+# interaktiv, ohne Historie/Memory/Dokumente zu opfern. Leer = aus.
+# AGENT_PROMPT_TARGET_TOKENS=65536
+
 # Ausgabe-Budget einer Agent-Antwort in Tokens. Steuert BEIDES: die
 # Reservierung, die _enforce_token_budget für die Antwort freihält, UND das
 # `max_tokens`, das an den Server geht. Bis 2026-08 waren die zwei entkoppelt
@@ -279,6 +293,7 @@ AGENT_ROUTER_TIMEOUT=30.0
 - `AGENT_HISTORY_MESSAGE_MAX_CHARS`: `500`
 - `AGENT_TOOL_RESULT_TEXT_MAX_CHARS`: `8000`
 - `AGENT_RESPONSE_TRUNCATION`: `2000`
+- `AGENT_PROMPT_TARGET_TOKENS`: None (aus)
 - `AGENT_DEFAULT_NUM_PREDICT`: `2048`
 - `AGENT_ROUTER_TIMEOUT`: `30.0`
 
@@ -2202,6 +2217,35 @@ PLUGIN_MCP_BINDINGS=some_adapter=some_server
 **Hook Events:** `startup`, `shutdown`, `register_routes`, `register_tools`, `post_message`, `retrieve_context`
 
 **Hinweis:** Das Hook-System ist der empfohlene Weg für tiefe Integrationen (Kontext-Injektion, Post-Processing, Custom Routes). Für einfache Tool-Integrationen sind MCP-Server weiterhin der bevorzugte Weg.
+
+### Digital-Twin-Adapter (privates Plugin `twin_adapter`)
+
+Der Twin-Adapter ist ein PRIVATES Paket (nicht in diesem Repo; wird für den
+Image-Build in den Arbeitsbaum gestaged, gitignored). Er liest reine Env-Vars —
+zur Vollständigkeit hier dokumentiert (keine Werte committen; der Ingest-Token
+kommt deklarativ aus dem k8s-Secret `twin-secrets`, siehe `k8s/backend.yaml`):
+
+```bash
+TWIN_ENABLED=false                # Capture an/aus (der MCP-Self-Access-Guard läuft IMMER)
+TWIN_INGEST_URL=                  # POST-Endpoint des Twin-Service (/ingest)
+TWIN_INGEST_TOKEN=                # Bearer für Ingest/Recall/Consent (Secret!)
+TWIN_RECALL_URL=                  # /recall — leer = keine Kontext-Injektion
+TWIN_SOURCE_APP=renfield          # Subject-Präfix (<source_app>:<user_id>)
+TWIN_INGEST_TIMEOUT=5.0           # Capture/Consent-Timeout (fire-and-forget)
+TWIN_RECALL_TIMEOUT=1.0           # Recall-Timeout — liegt auf dem KRITISCHEN Chat-Pfad
+TWIN_RECALL_COOLDOWN=60           # Nach Connect-Fehler Recall so lange überspringen
+TWIN_MCP_BINDING=twin             # Stanza-Name des Twin-MCP-Servers (Guard-Prefix mcp.<binding>.)
+TWIN_ANON_POLICY=auto             # auto|pool|drop — Umgang mit user_id=None-Turns:
+                                  # auto folgt AUTH_ENABLED (auth-off→pool, auth-on→drop)
+TWIN_CLIENT_CONSENT_GATE=false    # BetrVG: Consent-Check VOR jedem Ingest (fail-closed)
+TWIN_CONSENT_STATUS_URL=          # Override; sonst aus TWIN_INGEST_URL abgeleitet
+TWIN_CONSENT_CACHE_TTL=60         # Consent-Verdict-Cache (Sekunden)
+```
+
+Multi-User-Empfehlung: Auf Instanzen mit mehreren echten Nutzern die
+agent-callable Twin-MCP-Tools serverseitig aus lassen
+(`TWIN_MCP_TOOLS_ENABLED=false` am Twin-Service) und Recall nur über den
+REST-Pfad fahren — der `pre_mcp_call`-Guard ist Verteidigung, kein Ersatz.
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -880,13 +880,17 @@ Siehe [SECRETS_MANAGEMENT.md](SECRETS_MANAGEMENT.md) für Details.
 
 ### Prometheus Metrics
 
-Opt-in Endpoint für Prometheus-kompatible Metriken:
+Opt-in Endpoint für Prometheus-kompatible Metriken (in Prod seit 2026-08 auf
+beiden Instanzen aktiv):
 
 ```env
 METRICS_ENABLED=false               # Aktivieren: true
 ```
 
-Endpoint: `GET /metrics` (Prometheus Exposition Format)
+Endpoint: `GET /metrics` (Prometheus Exposition Format). Nur in-cluster
+erreichbar (Ingress routet den Pfad nicht); der `endpoint`-Label nutzt das
+exakte Route-Template (Kardinalitätsschutz, `{id}`-Fallback für 404-Pfade).
+Enthält u. a. den MCP-Health-Heartbeat `renfield_mcp_health_ticks_total`.
 
 ### Health Checks
 - `GET /health` — Backend Health Check

--- a/k8s/backend.yaml
+++ b/k8s/backend.yaml
@@ -150,6 +150,17 @@ spec:
             # the writable default when the secret isn't provisioned yet.
             - name: FEDERATION_IDENTITY_PERSISTED_KEY_PATH
               value: "/app/federation-identity/federation_identity_key"
+            # Digital-twin ingest token (private twin deployment). Declarative
+            # here — it used to be injected imperatively via `kubectl set env`,
+            # so EVERY re-apply of this manifest dropped it and silently
+            # disabled twin capture (the 2026-08-22 review's config-drift
+            # fail-open). optional: a cluster without the twin still boots.
+            - name: TWIN_INGEST_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: twin-secrets
+                  key: TWIN_INGEST_TOKEN
+                  optional: true
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -120,6 +120,10 @@ data:
   # outage the Ollama fallback still runs at OLLAMA_NUM_CTX — oversized
   # prompts degrade there (logged WARNING), which is acceptable best-effort.
   LLM_OPENAI_NUM_CTX: "262144"
+  # Soft-Prompt-Target (#1104): triggert NUR die adaptive Tool-Result-Reduktion
+  # (Pass 0) oberhalb dieses Werts, lange bevor das harte 85%-Budget greift —
+  # hält Prefill-Latenz interaktiv, ohne Historie/Memory zu opfern.
+  AGENT_PROMPT_TARGET_TOKENS: "65536"
   AGENT_CONV_CONTEXT_MESSAGES: "30"
   AGENT_HISTORY_MESSAGE_MAX_CHARS: "2000"
   # Both tool-result knobs must move together: AGENT_RESPONSE_TRUNCATION caps
@@ -129,6 +133,11 @@ data:
   AGENT_RESPONSE_TRUNCATION: "32000"
   AGENT_TOOL_RESULT_TEXT_MAX_CHARS: "32000"
   KNOWLEDGE_CONTEXT_CHUNK_CHARS: "1500"
+
+  # Prometheus /metrics (in-cluster only: der Ingress routet /metrics nicht,
+  # der Service ist ClusterIP — extern landet der Pfad auf der SPA). Enthält
+  # u. a. die MCP-Health-Heartbeats (renfield_mcp_health_ticks_total).
+  METRICS_ENABLED: "true"
 
   # Voice-server (B.4): when set, backend's /api/voice/voice-chat
   # orchestrator delegates STT + TTS to the voice-server pod

--- a/src/backend/api/websocket/chat_handler.py
+++ b/src/backend/api/websocket/chat_handler.py
@@ -2761,6 +2761,10 @@ WICHTIG: Nutze die ECHTEN Daten aus dem Ergebnis! Gib NUR die Antwort, KEIN JSON
                     assistant_msg=full_response,
                     user_id=user_id,
                     session_id=msg_session_id,
+                    # Real turn language for capture consumers (twin adapter
+                    # stamps its events with it) — the subsume-coordinated
+                    # path already passed it, this default path did not.
+                    lang=turn_lang,
                 ))
                 _background_tasks.add(_pm_task)
                 _pm_task.add_done_callback(_background_tasks.discard)

--- a/src/backend/services/action_executor.py
+++ b/src/backend/services/action_executor.py
@@ -258,20 +258,30 @@ class ActionExecutor:
                         "verify_aborted": True,
                     }
 
-            # Plugin pre-call rewrite. Plugins may repair malformed LLM
-            # tool calls here (e.g. substitute a release id when the LLM
-            # passed a title). First well-shaped non-None dict replaces
-            # parameters; everything else is ignored.
-            pre_call_results = await run_hooks(
-                "pre_mcp_call",
-                intent=intent,
-                parameters=parameters,
-                user_id=user_id,
-            )
-            for rewritten in pre_call_results:
+            # Plugin pre-call rewrite — CHAINED (2026-08 twin-guard hardening):
+            # each handler receives the CURRENT parameters (including earlier
+            # handlers' rewrites) and a well-shaped dict result becomes the new
+            # current parameters. The old first-dict-wins run_hooks pass let an
+            # earlier plugin's repair silently discard a later SECURITY rewrite
+            # (the twin self-access guard's user_subject override). A handler
+            # that raises is skipped and logged — same fail-open semantics as
+            # run_hooks, so security-critical handlers must be exception-free
+            # by construction (the twin guard is: dict copy + f-string).
+            from utils.hooks import get_hook_handlers
+            for pre_call_handler in get_hook_handlers("pre_mcp_call"):
+                try:
+                    rewritten = await pre_call_handler(
+                        intent=intent, parameters=parameters, user_id=user_id
+                    )
+                except Exception as e:  # mirror run_hooks fail-open semantics
+                    logger.warning(
+                        f"pre_mcp_call handler "
+                        f"{getattr(pre_call_handler, '__name__', '?')} failed "
+                        f"(skipped): {e}"
+                    )
+                    continue
                 if isinstance(rewritten, dict):
                     parameters = rewritten
-                    break
             # `user_id` is passed as a kwarg to `execute_tool()` (used for
             # permission checks + audit), NOT merged into `parameters`. MCP
             # tools have strict Pydantic schemas; every unknown key triggers

--- a/src/backend/services/action_executor.py
+++ b/src/backend/services/action_executor.py
@@ -273,11 +273,13 @@ class ActionExecutor:
                     rewritten = await pre_call_handler(
                         intent=intent, parameters=parameters, user_id=user_id
                     )
-                except Exception as e:  # mirror run_hooks fail-open semantics
-                    logger.warning(
+                except Exception:  # mirror run_hooks fail-open semantics
+                    # Full traceback (like run_hooks): a silently-skipped
+                    # SECURITY handler must be diagnosable from the log alone.
+                    logger.opt(exception=True).warning(
                         f"pre_mcp_call handler "
                         f"{getattr(pre_call_handler, '__name__', '?')} failed "
-                        f"(skipped): {e}"
+                        f"(skipped)"
                     )
                     continue
                 if isinstance(rewritten, dict):

--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -465,11 +465,9 @@ _SAME_TOOL_ABORT_THRESHOLD = 5
 # (server --ctx-size governs), while on the in-cluster Ollama fallback it
 # protects the fallback model from an oversized KV-cache allocation. The
 # backend token budget scales via effective_agent_num_ctx() instead.
-# KNOWN GAP (pre-existing): on an Ollama-PRIMARY agent path with a raised
-# OLLAMA_NUM_CTX (> 32768), the budget follows ollama_num_ctx while the
-# request still carries this 32768 — Ollama then truncates the prompt head.
-# Tracked as a follow-up; align these if you raise OLLAMA_NUM_CTX without
-# an OpenAI-compat endpoint.
+# Ollama-PRIMARY gap CLOSED (#1104): _llm_options_or_default raises num_ctx
+# to settings.ollama_num_ctx for the budgeted option sets when the agent tier
+# runs on Ollama, so budget and request window stay in step.
 _DEFAULT_LLM_OPTIONS = {
     "temperature": 0.1, "top_p": 0.2, "num_predict": 2048, "num_ctx": 32768,
 }
@@ -577,6 +575,18 @@ def _llm_options_or_default(prompt_key: str, fallback: dict) -> dict:
         opts["num_predict"] = max(
             int(opts.get("num_predict") or 0), settings.agent_default_num_predict
         )
+        # #1104 follow-up: on an OLLAMA-PRIMARY agent path the request's
+        # options.num_ctx governs the actual window, while the token budget
+        # follows settings.ollama_num_ctx — a raised OLLAMA_NUM_CTX with the
+        # stale 32768 literal meant Ollama silently truncated the prompt HEAD.
+        # Keep them in step (max(): a deliberately larger YAML value wins).
+        # OpenAI-compat path: untouched — the server drops num_ctx anyway and
+        # the 32768 literal deliberately protects the in-cluster FALLBACK
+        # model from an oversized KV-cache allocation.
+        if not use_openai_for_tier("agent"):
+            opts["num_ctx"] = max(
+                int(opts.get("num_ctx") or 0), settings.ollama_num_ctx
+            )
     return opts
 
 
@@ -1009,6 +1019,56 @@ class AgentService:
             logger.warning(f"Tool pre-selection failed (using all tools): {e}")
             return None
 
+    async def _apply_adaptive_tool_budget(
+        self,
+        message: str,
+        context: AgentContext,
+        conversation_history: list[dict] | None,
+        memory_context: str,
+        document_context: str,
+        lang: str,
+        build_kwargs: dict,
+        *,
+        budget_tokens: int,
+        reserved: int,
+    ) -> tuple[str, int, int, int] | None:
+        """Shared adaptive tool-result pass (Pass 0 of the budget ladder, also
+        the soft-target pass): measure the prompt skeleton, distribute the
+        remaining headroom over the tool results via
+        ``context.tool_result_budget_chars``, rebuild.
+
+        Returns ``(prompt, prompt_tokens, per_result_chars, n_results)``, or
+        ``None`` when there are no tool results to shrink. Leaves
+        ``tool_result_budget_chars`` at the applied value (the returned prompt
+        was built with it).
+        """
+        from utils.token_counter import token_counter
+
+        tool_result_steps = [
+            s for s in context.steps
+            if s.step_type == "tool_result" and (s.data is not None or s.content)
+        ]
+        if not tool_result_steps:
+            return None
+        context.tool_result_budget_chars = 1  # minimal — just get the skeleton
+        prompt = await self._build_agent_prompt(
+            message, context, conversation_history,
+            memory_context=memory_context, document_context=document_context,
+            lang=lang, **build_kwargs,
+        )
+        skeleton_tokens = token_counter.count(prompt)
+        token_headroom = max(0, budget_tokens - reserved - skeleton_tokens)
+        total_chars_budget = int(token_headroom * 3.5)
+        n_results = len(tool_result_steps)
+        per_result_chars = max(200, total_chars_budget // max(1, n_results))
+        context.tool_result_budget_chars = per_result_chars
+        prompt = await self._build_agent_prompt(
+            message, context, conversation_history,
+            memory_context=memory_context, document_context=document_context,
+            lang=lang, **build_kwargs,
+        )
+        return prompt, token_counter.count(prompt), per_result_chars, n_results
+
     async def _enforce_token_budget(
         self,
         prompt: str,
@@ -1050,6 +1110,31 @@ class AgentService:
 
         try:
             if utilization <= threshold:
+                # Soft prompt target (#1104): the hard budget only protects the
+                # context WINDOW; on a 256k server a legally huge prompt still
+                # costs painful prefill latency. Above the (optional) target,
+                # run ONLY the adaptive tool-result pass against the target —
+                # history/memory/documents stay untouched.
+                target = settings.agent_prompt_target_tokens
+                if target and prompt_tokens + reserved > target:
+                    from utils.metrics import record_budget_reduction
+
+                    soft_budget = min(target, int(max_tokens * threshold))
+                    soft = await self._apply_adaptive_tool_budget(
+                        message, context, conversation_history,
+                        memory_context, document_context, lang, build_kwargs,
+                        budget_tokens=soft_budget, reserved=reserved,
+                    )
+                    if soft is not None:
+                        prompt, prompt_tokens, per_result_chars, n_results = soft
+                        utilization = (prompt_tokens + reserved) / max_tokens
+                        record_budget_reduction("soft_target_tool_budget")
+                        passes_run.append("soft_target_tool_budget")
+                        logger.info(
+                            f"Budget soft-target pass: {prompt_tokens + reserved}"
+                            f"/{target} target ({per_result_chars} chars/result "
+                            f"x {n_results} results)"
+                        )
                 return prompt, memory_context, document_context, conversation_history
 
             logger.warning(
@@ -1059,28 +1144,13 @@ class AgentService:
             from utils.metrics import record_budget_reduction
 
             # Pass 0: Adaptive tool result budgeting via _serialize_for_prompt
-            tool_result_steps = [
-                s for s in context.steps if s.step_type == "tool_result" and (s.data is not None or s.content)
-            ]
-            if tool_result_steps:
-                context.tool_result_budget_chars = 1  # minimal — just get the skeleton
-                prompt = await self._build_agent_prompt(
-                    message, context, conversation_history,
-                    memory_context=memory_context, document_context=document_context,
-                    lang=lang, **build_kwargs,
-                )
-                skeleton_tokens = token_counter.count(prompt)
-                token_headroom = max(0, int(max_tokens * threshold) - reserved - skeleton_tokens)
-                total_chars_budget = int(token_headroom * 3.5)
-                n_results = len(tool_result_steps)
-                per_result_chars = max(200, total_chars_budget // max(1, n_results))
-                context.tool_result_budget_chars = per_result_chars
-                prompt = await self._build_agent_prompt(
-                    message, context, conversation_history,
-                    memory_context=memory_context, document_context=document_context,
-                    lang=lang, **build_kwargs,
-                )
-                prompt_tokens = token_counter.count(prompt)
+            pass0 = await self._apply_adaptive_tool_budget(
+                message, context, conversation_history,
+                memory_context, document_context, lang, build_kwargs,
+                budget_tokens=int(max_tokens * threshold), reserved=reserved,
+            )
+            if pass0 is not None:
+                prompt, prompt_tokens, per_result_chars, n_results = pass0
                 utilization = (prompt_tokens + reserved) / max_tokens
                 record_budget_reduction("adaptive_tool_budget")
                 passes_run.append("adaptive_tool_budget")

--- a/src/backend/services/agent_service.py
+++ b/src/backend/services/agent_service.py
@@ -518,6 +518,11 @@ def _with_required_companions(selected_names: list[str]) -> list[str]:
 # therefore must not carry an output cap below that reservation.
 _BUDGETED_OPTION_KEYS = frozenset({"llm_options", "llm_options_retry"})
 
+# Minimum per-result char budget for the ADVISORY soft-target pass to be worth
+# applying — below this the agent can't meaningfully read its own tool results
+# and the pass is skipped (the hard budget's 200-char emergency floor stays).
+_SOFT_TARGET_MIN_RESULT_CHARS = 1000
+
 
 def _warn_if_truncated(raw_response: Any, model: str, call_type: str, step_num: int | None = None) -> bool:
     """Log + count a completion the model had to cut at the output-token cap.
@@ -1125,7 +1130,13 @@ class AgentService:
                         memory_context, document_context, lang, build_kwargs,
                         budget_tokens=soft_budget, reserved=reserved,
                     )
-                    if soft is not None:
+                    # The soft target is ADVISORY (latency control), never an
+                    # emergency: if the target is so tight relative to the
+                    # prompt skeleton that tool results would be crushed to
+                    # near the 200-char floor (agent can't read its own
+                    # results any more), revert and let the prompt pass — the
+                    # hard budget still protects the window.
+                    if soft is not None and soft[2] >= _SOFT_TARGET_MIN_RESULT_CHARS:
                         prompt, prompt_tokens, per_result_chars, n_results = soft
                         utilization = (prompt_tokens + reserved) / max_tokens
                         record_budget_reduction("soft_target_tool_budget")
@@ -1135,6 +1146,14 @@ class AgentService:
                             f"/{target} target ({per_result_chars} chars/result "
                             f"x {n_results} results)"
                         )
+                    elif soft is not None:
+                        context.tool_result_budget_chars = 0
+                        logger.warning(
+                            f"Soft prompt target {target} leaves <"
+                            f"{_SOFT_TARGET_MIN_RESULT_CHARS} chars/result "
+                            f"(skeleton too large) — soft pass skipped; raise "
+                            f"AGENT_PROMPT_TARGET_TOKENS"
+                        )
                 return prompt, memory_context, document_context, conversation_history
 
             logger.warning(
@@ -1143,11 +1162,19 @@ class AgentService:
             )
             from utils.metrics import record_budget_reduction
 
-            # Pass 0: Adaptive tool result budgeting via _serialize_for_prompt
+            # Pass 0: Adaptive tool result budgeting via _serialize_for_prompt.
+            # With a soft target set, Pass 0 sizes toward min(target, hard) —
+            # otherwise a prompt just OVER the hard threshold would come out
+            # ~3x LARGER than one just under it (the soft pass squeezed the
+            # latter to the target, while Pass 0 refilled the former to 85%
+            # of the window — a non-monotonic latency inversion).
+            pass0_budget = int(max_tokens * threshold)
+            if settings.agent_prompt_target_tokens:
+                pass0_budget = min(settings.agent_prompt_target_tokens, pass0_budget)
             pass0 = await self._apply_adaptive_tool_budget(
                 message, context, conversation_history,
                 memory_context, document_context, lang, build_kwargs,
-                budget_tokens=int(max_tokens * threshold), reserved=reserved,
+                budget_tokens=pass0_budget, reserved=reserved,
             )
             if pass0 is not None:
                 prompt, prompt_tokens, per_result_chars, n_results = pass0

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -417,6 +417,11 @@ class Settings(BaseSettings):
     agent_history_limit: int = Field(default=20, ge=1, le=100)       # Max history steps in agent loop
     agent_response_truncation: int = Field(default=2000, ge=100, le=50000)  # Max chars for tool response truncation
     agent_budget_threshold: float = Field(default=0.85, ge=0.5, le=0.99)   # Token budget utilization threshold (triggers reduction above this)
+    # Soft prompt target (#1104): OPTIONAL second, lower bound. Above it (but
+    # under the hard threshold) ONLY the adaptive tool-result pass runs, sized
+    # to this target — prefill-latency control on large-context servers without
+    # sacrificing history/memory/documents. None = off (hard budget only).
+    agent_prompt_target_tokens: int | None = Field(default=None, ge=1024, le=2_000_000)
     # Per-message char cap when compressing conversation history into the agent
     # prompt (_compress_history_message). Raise together with llm_openai_num_ctx
     # to actually exploit a large server-side context window.

--- a/src/backend/utils/hooks.py
+++ b/src/backend/utils/hooks.py
@@ -305,11 +305,19 @@ HOOK_EVENTS: frozenset[str] = frozenset({
     # ``MCPManager.execute_tool`` for any ``mcp.*`` intent. Handlers
     # receive ``intent: str, parameters: dict, user_id: int | None`` and
     # may return a ``dict`` to **replace** the parameters before the MCP
-    # call, or ``None`` to leave them unchanged. First well-shaped
-    # non-None result wins — registration order determines precedence.
-    # Used by plugins to repair LLM tool calls (e.g. resolve a release
-    # title to its API id when the LLM passed the wrong parameter
-    # shape). Platform default (no handler) is a no-op.
+    # call, or ``None`` to leave them unchanged. **CHAINED** (since the
+    # 2026-08 twin-guard hardening): handlers run in registration order and
+    # each receives the CURRENT parameters — i.e. including earlier
+    # handlers' rewrites — and a well-shaped dict result becomes the new
+    # current parameters for the next handler and, ultimately, the call.
+    # (The old first-dict-wins contract let any earlier plugin's repair
+    # silently discard a later security rewrite.) Handlers must therefore
+    # be idempotent and preserve keys they don't own. NOTE: a handler that
+    # RAISES is skipped (logged) — a security-critical handler must be
+    # exception-free by construction rather than rely on ordering.
+    # Used by plugins to repair LLM tool calls and by the twin adapter's
+    # self-access guard (host-resolved ``user_subject`` override).
+    # Platform default (no handler) is a no-op.
     "pre_mcp_call",
     # Pre-MCP tool call gate — fired by ActionExecutor BEFORE
     # ``pre_mcp_call`` for any ``mcp.*`` intent. Handlers receive
@@ -442,6 +450,17 @@ def is_hook_registered(event: str, fn: HookFn) -> bool:
     representation private to this module.
     """
     return fn in _hooks.get(event, [])
+
+
+def get_hook_handlers(event: str) -> list[HookFn]:
+    """Snapshot of the registered handlers for *event*, in registration order.
+
+    For callers that must CHAIN handler results (feed each handler the
+    previous handler's output — e.g. the ``pre_mcp_call`` parameter rewrite),
+    which ``run_hooks``' same-kwargs-for-all model cannot express. Returns a
+    copy; the internal registry stays private to this module.
+    """
+    return list(_hooks.get(event, []))
 
 
 def clear_hooks() -> None:

--- a/src/backend/utils/hooks.py
+++ b/src/backend/utils/hooks.py
@@ -370,11 +370,29 @@ HookFn = Callable[..., Coroutine[Any, Any, Any]]
 _hooks: dict[str, list[HookFn]] = defaultdict(list)
 
 
-def register_hook(event: str, fn: HookFn) -> None:
-    """Register an async callback for *event*. Raises ValueError for unknown events."""
+# (event, fn) -> priority for handlers registered with a non-default priority.
+# Kept OUTSIDE _hooks so the list representation (and every test doing
+# `_hooks[event].remove(fn)`) stays untouched; a stale entry after a direct
+# list removal is harmless (keyed by fn identity, re-registration overwrites).
+_hook_priorities: dict[tuple[str, int], int] = {}
+
+
+def register_hook(event: str, fn: HookFn, *, priority: int = 0) -> None:
+    """Register an async callback for *event*. Raises ValueError for unknown events.
+
+    ``priority`` orders handlers for callers that consume them via
+    ``get_hook_handlers`` (higher runs LATER; ties keep registration order).
+    Security handlers that must have the last word in a CHAINED consumer
+    (e.g. the twin self-access guard on ``pre_mcp_call``) register with a
+    high priority so no later-loaded plugin can sit behind them by accident.
+    ``run_hooks`` deliberately ignores priority (its results are unordered
+    contributions, not a chain).
+    """
     if event not in HOOK_EVENTS:
         raise ValueError(f"Unknown hook event {event!r}. Valid: {sorted(HOOK_EVENTS)}")
     _hooks[event].append(fn)
+    if priority:
+        _hook_priorities[(event, id(fn))] = priority
     logger.debug(f"Hook registered: {event} → {getattr(fn, '__qualname__', repr(fn))}")
 
 
@@ -453,16 +471,21 @@ def is_hook_registered(event: str, fn: HookFn) -> bool:
 
 
 def get_hook_handlers(event: str) -> list[HookFn]:
-    """Snapshot of the registered handlers for *event*, in registration order.
+    """Snapshot of the registered handlers for *event*, sorted by priority
+    (ascending — higher priority runs LATER), ties in registration order.
 
     For callers that must CHAIN handler results (feed each handler the
     previous handler's output — e.g. the ``pre_mcp_call`` parameter rewrite),
     which ``run_hooks``' same-kwargs-for-all model cannot express. Returns a
     copy; the internal registry stays private to this module.
     """
-    return list(_hooks.get(event, []))
+    handlers = _hooks.get(event, [])
+    return sorted(
+        handlers, key=lambda fn: _hook_priorities.get((event, id(fn)), 0)
+    )
 
 
 def clear_hooks() -> None:
     """Remove all registered hooks. Used for test isolation."""
     _hooks.clear()
+    _hook_priorities.clear()

--- a/src/backend/utils/llm_client.py
+++ b/src/backend/utils/llm_client.py
@@ -291,31 +291,67 @@ class _OpenAICompatFallbackClient:
         return kwargs
 
     @staticmethod
-    def _warn_if_prompt_exceeds_fallback_ctx(
+    def _shrink_messages_for_fallback(
         messages: list[dict[str, Any]] | None, kwargs: dict[str, Any]
-    ) -> None:
-        """The fallback runs at the ``options.num_ctx`` forwarded verbatim in
-        the call kwargs (else Ollama's own default) — NOT at whatever wide
-        window the primary served (``llm_openai_num_ctx``). An oversized prompt
-        is silently truncated by Ollama, dropping the system/tools framing at
-        the head. We can't shrink the prompt here (outage mode is best-effort),
-        but the degradation must be visible in the logs. Token estimation goes
-        through the content-aware ``token_counter`` (rare path — one extra scan
-        per fail-over call is fine) so the warning neither misses real oversize
-        nor cries wolf on prompts that fit.
+    ) -> list[dict[str, Any]] | None:
+        """Fit the prompt into the fallback's context window (#1104).
+
+        The fallback runs at the ``options.num_ctx`` forwarded verbatim in the
+        call kwargs (else Ollama's own default) — NOT at whatever wide window
+        the primary served (``llm_openai_num_ctx``). On overflow Ollama silently
+        drops the prompt HEAD (system/tools framing) and the ReAct contract
+        collapses. Instead: keep the system message whole and MIDDLE-CUT the
+        oversized user message (the agent prompt is one monolithic string —
+        framing at the head, question at the tail, compressible mass in the
+        middle), so an outage answer stays coherent instead of turning to
+        garbage. Token estimation via the content-aware ``token_counter``
+        (rare path — one scan per fail-over call is fine).
         """
         from utils.token_counter import token_counter
 
+        if not messages:
+            return messages
         options = kwargs.get("options") or {}
         effective_ctx = options.get("num_ctx") or settings.ollama_num_ctx
-        text = "".join(str(m.get("content") or "") for m in messages or [])
-        estimated_tokens = token_counter.count(text)
-        if estimated_tokens > effective_ctx:
+        reserved = int(options.get("num_predict") or 0)
+        total = sum(
+            token_counter.count(str(m.get("content") or "")) for m in messages
+        )
+        if total + reserved <= effective_ctx:
+            return messages
+
+        # Budget for the LARGEST message = window minus everything else.
+        # In practice that is the monolithic agent user-prompt; the small
+        # system message stays whole.
+        largest_i = max(
+            range(len(messages)),
+            key=lambda i: len(str(messages[i].get("content") or "")),
+        )
+        others = sum(
+            token_counter.count(str(m.get("content") or ""))
+            for i, m in enumerate(messages) if i != largest_i
+        )
+        # Safety margin: the chars/token estimate can undercount; leave 10%.
+        budget = int((effective_ctx - reserved - others) * 0.9)
+        shrunk_text, shrunk = token_counter.truncate_middle_to_budget(
+            str(messages[largest_i].get("content") or ""), budget
+        )
+        if not shrunk:
             logger.warning(
-                f"Fallback prompt (~{estimated_tokens} tokens) exceeds the "
-                f"in-cluster fallback context (num_ctx={effective_ctx}) — the "
-                f"response may be truncated/degraded until the primary recovers"
+                f"Fallback prompt (~{total} tokens) exceeds the in-cluster "
+                f"fallback context (num_ctx={effective_ctx}) and could not be "
+                f"shrunk — the response may be truncated/degraded"
             )
+            return messages
+        out = [dict(m) for m in messages]
+        out[largest_i]["content"] = shrunk_text
+        logger.warning(
+            f"Fallback prompt (~{total} tokens) exceeded the in-cluster "
+            f"fallback context (num_ctx={effective_ctx}) — middle-cut the "
+            f"prompt to ~{token_counter.count(shrunk_text)} tokens so the "
+            f"framing and the question survive the outage"
+        )
+        return out
 
     def _prepare_fallback(
         self,
@@ -324,10 +360,10 @@ class _OpenAICompatFallbackClient:
         kwargs: dict[str, Any],
         *,
         stream: bool,
-    ) -> tuple[str, dict[str, Any]]:
+    ) -> tuple[str, dict[str, Any], list[dict[str, Any]] | None]:
         """Shared fail-over preamble for the streaming and non-streaming paths:
         resolve the in-cluster model, adjust kwargs, log the fail-over, and
-        surface a possible prompt-oversize degradation."""
+        shrink an oversized prompt into the fallback window."""
         fb_model = self._fallback_model()
         fb_kwargs = self._fallback_kwargs(kwargs, fb_model)
         where = " on stream open" if stream else ""
@@ -335,8 +371,8 @@ class _OpenAICompatFallbackClient:
             f"OpenAI-compat LLM primary failed{where} ({exc!r}); "
             f"falling back to in-cluster Ollama (model={fb_model})"
         )
-        self._warn_if_prompt_exceeds_fallback_ctx(messages, kwargs)
-        return fb_model, fb_kwargs
+        fb_messages = self._shrink_messages_for_fallback(messages, kwargs)
+        return fb_model, fb_kwargs, fb_messages
 
     async def chat(
         self,
@@ -353,8 +389,8 @@ class _OpenAICompatFallbackClient:
         except Exception as exc:  # noqa: BLE001 — _should_fallback re-raises what it can't handle
             if not _should_fallback(exc):
                 raise
-            fb_model, fb_kwargs = self._prepare_fallback(exc, messages, kwargs, stream=False)
-            return await self._fallback.chat(model=fb_model, messages=messages, stream=False, **fb_kwargs)
+            fb_model, fb_kwargs, fb_messages = self._prepare_fallback(exc, messages, kwargs, stream=False)
+            return await self._fallback.chat(model=fb_model, messages=fb_messages, stream=False, **fb_kwargs)
 
     async def _chat_stream(
         self, model: str, messages: list[dict[str, Any]] | None, kwargs: dict[str, Any]
@@ -367,8 +403,8 @@ class _OpenAICompatFallbackClient:
         except Exception as exc:  # noqa: BLE001
             if not _should_fallback(exc):
                 raise
-            fb_model, fb_kwargs = self._prepare_fallback(exc, messages, kwargs, stream=True)
-            fb_gen = await self._fallback.chat(model=fb_model, messages=messages, stream=True, **fb_kwargs)
+            fb_model, fb_kwargs, fb_messages = self._prepare_fallback(exc, messages, kwargs, stream=True)
+            fb_gen = await self._fallback.chat(model=fb_model, messages=fb_messages, stream=True, **fb_kwargs)
             async for chunk in fb_gen:
                 yield chunk
             return

--- a/src/backend/utils/metrics.py
+++ b/src/backend/utils/metrics.py
@@ -488,23 +488,26 @@ def record_llm_response_truncated(model: str, call_type: str):
 # === Middleware & Endpoint Setup ===
 
 
-# Path segments that are per-resource identifiers → one label value each would
-# explode the `endpoint` label cardinality (a Counter time series per document
-# id, session uuid, …). Numeric ids, UUIDs, and long hex tokens collapse to
-# `{id}`; everything else stays literal.
-_ID_SEGMENT_RE = None
+import re as _re
+
+# Fallback heuristic for paths WITHOUT a matched route (404s, scanner probes):
+# numeric ids, UUIDs, and long hex tokens collapse to `{id}` so even unmatched
+# traffic can't mint unbounded label values.
+_ID_SEGMENT_RE = _re.compile(
+    r"^(\d+|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}"
+    r"-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{16,})$"
+)
 
 
 def normalize_endpoint(path: str) -> str:
-    """Collapse per-resource path segments to `{id}` for the metrics label
-    (e.g. /api/knowledge/documents/123 → /api/knowledge/documents/{id})."""
-    global _ID_SEGMENT_RE
-    if _ID_SEGMENT_RE is None:
-        import re
-        _ID_SEGMENT_RE = re.compile(
-            r"^(\d+|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}"
-            r"-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{16,})$"
-        )
+    """Heuristic id-collapse for the metrics `endpoint` label
+    (e.g. /api/knowledge/documents/123 → /api/knowledge/documents/{id}).
+
+    Only the FALLBACK for requests without a matched route — matched requests
+    use the exact route template (``scope["route"].path_format``), which also
+    covers non-hex string path params ({session_id}, {intent_name}, …) this
+    regex cannot recognise.
+    """
     parts = path.split("/")
     return "/".join("{id}" if _ID_SEGMENT_RE.match(p) else p for p in parts)
 
@@ -538,9 +541,13 @@ def setup_metrics(app: "FastAPI"):
             response = await call_next(request)
             duration = time.monotonic() - start
 
-            # Normalize endpoint path (remove IDs to reduce cardinality) —
-            # the comment used to be aspirational; now it's implemented.
-            endpoint = normalize_endpoint(request.url.path)
+            # Cardinality-safe endpoint label: the EXACT route template when
+            # the request matched a route (covers every path param, including
+            # non-hex strings like {session_id}); heuristic id-collapse only
+            # for unmatched paths (404s / scanner probes).
+            route = request.scope.get("route")
+            path_format = getattr(route, "path_format", None)
+            endpoint = path_format or normalize_endpoint(request.url.path)
             record_http_request(
                 method=request.method,
                 endpoint=endpoint,

--- a/src/backend/utils/metrics.py
+++ b/src/backend/utils/metrics.py
@@ -488,6 +488,27 @@ def record_llm_response_truncated(model: str, call_type: str):
 # === Middleware & Endpoint Setup ===
 
 
+# Path segments that are per-resource identifiers → one label value each would
+# explode the `endpoint` label cardinality (a Counter time series per document
+# id, session uuid, …). Numeric ids, UUIDs, and long hex tokens collapse to
+# `{id}`; everything else stays literal.
+_ID_SEGMENT_RE = None
+
+
+def normalize_endpoint(path: str) -> str:
+    """Collapse per-resource path segments to `{id}` for the metrics label
+    (e.g. /api/knowledge/documents/123 → /api/knowledge/documents/{id})."""
+    global _ID_SEGMENT_RE
+    if _ID_SEGMENT_RE is None:
+        import re
+        _ID_SEGMENT_RE = re.compile(
+            r"^(\d+|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}"
+            r"-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{16,})$"
+        )
+    parts = path.split("/")
+    return "/".join("{id}" if _ID_SEGMENT_RE.match(p) else p for p in parts)
+
+
 def setup_metrics(app: "FastAPI"):
     """
     Add Prometheus metrics middleware and /metrics endpoint to the app.
@@ -517,8 +538,9 @@ def setup_metrics(app: "FastAPI"):
             response = await call_next(request)
             duration = time.monotonic() - start
 
-            # Normalize endpoint path (remove IDs to reduce cardinality)
-            endpoint = request.url.path
+            # Normalize endpoint path (remove IDs to reduce cardinality) —
+            # the comment used to be aspirational; now it's implemented.
+            endpoint = normalize_endpoint(request.url.path)
             record_http_request(
                 method=request.method,
                 endpoint=endpoint,

--- a/src/backend/utils/token_counter.py
+++ b/src/backend/utils/token_counter.py
@@ -181,6 +181,56 @@ class TokenCounter:
 
         return truncated + suffix, True
 
+    def truncate_middle_to_budget(
+        self,
+        text: str,
+        max_tokens: int,
+        reserved: int = 0,
+        marker: str = "\n…[Mitte wegen Fallback-Kontextfenster gekürzt]…\n",
+    ) -> tuple[str, bool]:
+        """Shrink text to the token budget by cutting the MIDDLE, preserving
+        head and tail.
+
+        Built for the LLM-fallback path (#1104): the agent prompt is ONE
+        monolithic user message — instructions/tools framing at the head,
+        question + step directive at the tail, the compressible mass (history,
+        tool results) in the middle. A head-preserving tail-cut destroys the
+        question; Ollama's own overflow handling silently drops the HEAD.
+        Cutting the middle keeps both load-bearing ends.
+
+        Head gets ~55% of the budget (the tools/format contract is larger and
+        less redundant than the scratchpad tail), tail the rest. Cuts snap to
+        line boundaries where one is reasonably close, so the marker lands
+        between lines instead of mid-JSON-token.
+
+        Returns (text, was_shrunk).
+        """
+        available = max_tokens - reserved - self.count(marker)
+        if available <= 0:
+            return text, False
+        if self.count(text) <= available:
+            return text, False
+
+        chars_per_token = self._detect_content_type(text)
+        target_chars = int(available * chars_per_token)
+        if target_chars >= len(text) or target_chars < 200:
+            return text, False
+
+        head_chars = int(target_chars * 0.55)
+        tail_chars = target_chars - head_chars
+
+        head = text[:head_chars]
+        cut = head.rfind("\n")
+        if cut > head_chars * 0.8:
+            head = head[:cut]
+
+        tail = text[-tail_chars:]
+        cut = tail.find("\n")
+        if 0 <= cut < tail_chars * 0.2:
+            tail = tail[cut + 1:]
+
+        return head + marker + tail, True
+
     def truncate_messages_to_budget(
         self,
         messages: list[dict],

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2,20 +2,21 @@
 
 Plan: ~/.claude/plans/buzzing-crafting-meerkat.md (genehmigt; anon-Policy=Auto via AUTH_ENABLED, B3=jetzt)
 
-- [ ] C. Metriken: METRICS_ENABLED beide ConfigMaps + Endpoint-Label-Normalisierung (Kardinalität) + Test
-- [ ] B1. Ollama-Primary num_ctx-Forwarding in `_llm_options_or_default` + Test
-- [ ] B2. Soft-Prompt-Target `AGENT_PROMPT_TARGET_TOKENS` (Pass-0-only-Zweig) + ConfigMaps 65536 + Tests
-- [ ] A1. Guard bedingungslos registrieren + Prefix-Match `TWIN_MCP_BINDING` (Adapter, Privat-Repo)
-- [ ] A1b. `k8s/backend.yaml`: TWIN_INGEST_TOKEN aus Secret twin-secrets `optional: true` + twin/DEPLOY.md
-- [ ] A2. Host: pre_mcp_call Chaining statt First-Dict-wins (action_executor + hooks-Doku + Test-Umbau)
-- [ ] A3. anon-Policy Auto via AUTH_ENABLED + TWIN_ANON_POLICY-Override (Adapter)
-- [ ] A4. Shared httpx-Client + TWIN_RECALL_TIMEOUT (1s) + Cooldown-Latch (Adapter)
-- [ ] A5. lang durchreichen (chat_handler Pfad A + Adapter build_event)
-- [ ] A6. Adapter-Tests (Privat-Repo) + TWIN_*-Doku in ENVIRONMENT_VARIABLES.md + Docstring-Fixes
-- [ ] B3. Middle-Cut-Utility + Fallback-seitige Prompt-Kürzung in _prepare_fallback + Tests
-- [ ] Re-Stage Adapter kanonisch → src/backend/twin_adapter/
-- [ ] Suite .159 (voll + PG) + Adapter-Tests + Lint-Diff
+- [x] C. Metriken: METRICS_ENABLED beide ConfigMaps + Endpoint-Label-Normalisierung (Kardinalität) + Test
+- [x] B1. Ollama-Primary num_ctx-Forwarding in `_llm_options_or_default` + Test
+- [x] B2. Soft-Prompt-Target `AGENT_PROMPT_TARGET_TOKENS` (Pass-0-only-Zweig) + ConfigMaps 65536 + Tests
+- [x] A1. Guard bedingungslos registrieren + Prefix-Match `TWIN_MCP_BINDING` (Adapter, Privat-Repo)
+- [x] A1b. `k8s/backend.yaml`: TWIN_INGEST_TOKEN aus Secret twin-secrets `optional: true` + twin/DEPLOY.md
+- [x] A2. Host: pre_mcp_call Chaining statt First-Dict-wins (action_executor + hooks-Doku + Test-Umbau)
+- [x] A3. anon-Policy Auto via AUTH_ENABLED + TWIN_ANON_POLICY-Override (Adapter)
+- [x] A4. Shared httpx-Client + TWIN_RECALL_TIMEOUT (1s) + Cooldown-Latch (Adapter)
+- [x] A5. lang durchreichen (chat_handler Pfad A + Adapter build_event)
+- [x] A6. Adapter-Tests (Privat-Repo) + TWIN_*-Doku in ENVIRONMENT_VARIABLES.md + Docstring-Fixes
+- [x] B3. Middle-Cut-Utility + Fallback-seitige Prompt-Kürzung in _prepare_fallback + Tests
+- [x] Re-Stage Adapter kanonisch → src/backend/twin_adapter/
+- [x] Suite .159 (5686 + 355 PG passed, 0 failed; Adapter 35 passed; Lint-Diff 0 neu) (voll + PG) + Adapter-Tests + Lint-Diff
 - [ ] /review high → Fixes → Push/PR/Merge NUR nach Freigabe → Deploy + Smoke inkl. Metrics-Nachweis
 
 ## Review
-(wird ergänzt)
+- Renfield-Commit b6edd7cc (Branch feat/twin-hardening-ctx-followups) · Twin-Repo-Commit 85362d0 (lokal)
+- /review high läuft

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,23 +1,21 @@
-# Großen LLM-Kontext (256k llama-server) ausnutzen — feat/exploit-large-llm-context
+# Twin-Härtung + #1104-Follow-ups + Metriken — feat/twin-hardening-ctx-followups
 
-Plan: ~/.claude/plans/buzzing-crafting-meerkat.md (genehmigt, Zuschnitt: Moderat) · Issue #1103 · Follow-ups #1104
+Plan: ~/.claude/plans/buzzing-crafting-meerkat.md (genehmigt; anon-Policy=Auto via AUTH_ENABLED, B3=jetzt)
 
-- [x] 1-8. Implementierung + Tests + Doku (Commit `bac65900`)
-- [x] 9. Suite auf .159 grün (5998 → nach Review-Fixes 6001 passed, 0 failed); Lint-Diff gegen main: 0 neue Verstöße
-- [x] 10. Commit `bac65900` (Feature) 
-- [x] 11. /review high abgearbeitet (2. Commit mit Review-Fixes):
-  - F2 CONFIRMED: `AGENT_RESPONSE_TRUNCATION=32000` in beide ConfigMaps (Text-Ergebnisse wurden sonst schon bei Step-Erzeugung auf 2000 gekappt → Lese-Cap inert)
-  - F4 CONFIRMED: Pass-0-Budget (`tool_result_budget_chars`) greift jetzt auch auf TEXT-Ergebnisse (min mit `agent_tool_result_text_max_chars`); Pass-4-500er-Floor als bewusster Notfall-Crush dokumentiert
-  - F5 CONFIRMED: Fallback-Oversize-Warnung keyt auf das tatsächlich geforwardete `options.num_ctx` + content-aware `token_counter` statt `ollama_num_ctx*3` (beide Fehlrichtungen behoben)
-  - F7 CONFIRMED: `llm_openai_num_ctx` mit Field-Bounds (ge=1024) — negativer Wert kann Budget nicht mehr still deaktivieren
-  - F9/F10 cleanup: gemeinsames `_prepare_fallback`, toter `max_chars`-Param entfernt, loop-invariante Settings-Reads gehoistet
-  - F3 PLAUSIBLE: token_counter sampelt Head+Tail (Code-Tail → konservative 3.0 statt German 4.5 → kein 33%-Undercount am Budget-Rand)
-  - F1/F6/F8 PLAUSIBLE (bewusst vertagt, dokumentiert): Follow-up-Issue #1104 (Fallback-seitige Re-Reduktion, Ollama-Primary num_ctx-Forwarding, Soft-Prompt-Target); F6 zusätzlich als KNOWN GAP im Code kommentiert
-  - Refuted: V3 (multimodal), V12 (tool_calls), Timing-Flake
-- [ ] 12. Push/PR/Merge — NUR nach expliziter Freigabe
-- [ ] 13. Deploy nach Freigabe (`bin/deploy-production.sh`, Backend-Image beide Instanzen + ConfigMap-Apply, keine Migration) + Browser-E2E + Log-Nachweis `Token budget: N/262144`
+- [ ] C. Metriken: METRICS_ENABLED beide ConfigMaps + Endpoint-Label-Normalisierung (Kardinalität) + Test
+- [ ] B1. Ollama-Primary num_ctx-Forwarding in `_llm_options_or_default` + Test
+- [ ] B2. Soft-Prompt-Target `AGENT_PROMPT_TARGET_TOKENS` (Pass-0-only-Zweig) + ConfigMaps 65536 + Tests
+- [ ] A1. Guard bedingungslos registrieren + Prefix-Match `TWIN_MCP_BINDING` (Adapter, Privat-Repo)
+- [ ] A1b. `k8s/backend.yaml`: TWIN_INGEST_TOKEN aus Secret twin-secrets `optional: true` + twin/DEPLOY.md
+- [ ] A2. Host: pre_mcp_call Chaining statt First-Dict-wins (action_executor + hooks-Doku + Test-Umbau)
+- [ ] A3. anon-Policy Auto via AUTH_ENABLED + TWIN_ANON_POLICY-Override (Adapter)
+- [ ] A4. Shared httpx-Client + TWIN_RECALL_TIMEOUT (1s) + Cooldown-Latch (Adapter)
+- [ ] A5. lang durchreichen (chat_handler Pfad A + Adapter build_event)
+- [ ] A6. Adapter-Tests (Privat-Repo) + TWIN_*-Doku in ENVIRONMENT_VARIABLES.md + Docstring-Fixes
+- [ ] B3. Middle-Cut-Utility + Fallback-seitige Prompt-Kürzung in _prepare_fallback + Tests
+- [ ] Re-Stage Adapter kanonisch → src/backend/twin_adapter/
+- [ ] Suite .159 (voll + PG) + Adapter-Tests + Lint-Diff
+- [ ] /review high → Fixes → Push/PR/Merge NUR nach Freigabe → Deploy + Smoke inkl. Metrics-Nachweis
 
 ## Review
-- Suite-Läufe isoliert auf .159: non-PG 5647 passed / 382 skipped, PG-markiert 354 passed / 12 skipped — 0 Failures (beide Commits).
-- Ruff-Diff main↔branch nach beiden Commits: 0 neue Verstöße.
-- Bewusste Tradeoffs: Fallback bleibt bei 32k (VRAM-Schutz, Outage = best-effort mit korrekter Warnung); Prefill-Latenz durch moderate Caps begrenzt, Soft-Target als Follow-up.
+(wird ergänzt)

--- a/tests/backend/test_action_executor.py
+++ b/tests/backend/test_action_executor.py
@@ -295,18 +295,24 @@ class TestActionExecutorPreMCPCall:
         assert call_args.args[1] == {"id": "Applications/Folder/Release1"}
 
     @pytest.mark.unit
-    async def test_pre_mcp_call_first_dict_wins(self, action_executor):
-        """When multiple handlers return dicts, the first one wins."""
-        from utils.hooks import register_hook, _hooks
+    async def test_pre_mcp_call_handlers_chain(self, action_executor):
+        """Handlers CHAIN: each receives the previous handler's rewrite, and a
+        later (security) handler's override survives an earlier repair — the
+        old first-dict-wins contract let it be silently discarded (2026-08-22
+        twin-guard review, Finding 2)."""
+        from utils.hooks import _hooks, register_hook
 
-        async def first(intent, parameters, user_id=None, **_):
-            return {"id": "first"}
+        seen_by_second = {}
 
-        async def second(intent, parameters, user_id=None, **_):
-            return {"id": "second"}
+        async def repair(intent, parameters, user_id=None, **_):
+            return {**parameters, "id": "repaired", "user_subject": "model-supplied"}
 
-        register_hook("pre_mcp_call", first)
-        register_hook("pre_mcp_call", second)
+        async def security_guard(intent, parameters, user_id=None, **_):
+            seen_by_second.update(parameters)
+            return {**parameters, "user_subject": "host-resolved"}
+
+        register_hook("pre_mcp_call", repair)
+        register_hook("pre_mcp_call", security_guard)
         try:
             await action_executor.execute({
                 "intent": "mcp.release.get_release",
@@ -314,11 +320,41 @@ class TestActionExecutorPreMCPCall:
                 "confidence": 0.9,
             })
         finally:
-            _hooks["pre_mcp_call"].remove(first)
-            _hooks["pre_mcp_call"].remove(second)
+            _hooks["pre_mcp_call"].remove(repair)
+            _hooks["pre_mcp_call"].remove(security_guard)
+
+        # The second handler saw the first handler's rewrite...
+        assert seen_by_second.get("id") == "repaired"
+        # ...and the FINAL parameters carry BOTH: the repair and the override.
+        call_args = action_executor.mcp_manager.execute_tool.call_args
+        assert call_args.args[1]["id"] == "repaired"
+        assert call_args.args[1]["user_subject"] == "host-resolved"
+
+    @pytest.mark.unit
+    async def test_pre_mcp_call_crashing_handler_is_skipped(self, action_executor):
+        """A raising handler is skipped (logged); later handlers still run."""
+        from utils.hooks import _hooks, register_hook
+
+        async def boom(intent, parameters, user_id=None, **_):
+            raise RuntimeError("handler bug")
+
+        async def rewrite(intent, parameters, user_id=None, **_):
+            return {**parameters, "id": "rewritten"}
+
+        register_hook("pre_mcp_call", boom)
+        register_hook("pre_mcp_call", rewrite)
+        try:
+            await action_executor.execute({
+                "intent": "mcp.release.get_release",
+                "parameters": {"title": "x"},
+                "confidence": 0.9,
+            })
+        finally:
+            _hooks["pre_mcp_call"].remove(boom)
+            _hooks["pre_mcp_call"].remove(rewrite)
 
         call_args = action_executor.mcp_manager.execute_tool.call_args
-        assert call_args.args[1] == {"id": "first"}
+        assert call_args.args[1]["id"] == "rewritten"
 
 
 # ============================================================================

--- a/tests/backend/test_action_executor.py
+++ b/tests/backend/test_action_executor.py
@@ -331,6 +331,35 @@ class TestActionExecutorPreMCPCall:
         assert call_args.args[1]["user_subject"] == "host-resolved"
 
     @pytest.mark.unit
+    async def test_pre_mcp_call_high_priority_guard_runs_last(self, action_executor):
+        """A priority-registered security guard has the LAST word even when a
+        later-loaded plugin returns a fresh dict that drops its key."""
+        from utils.hooks import _hooks, register_hook
+
+        async def guard(intent, parameters, user_id=None, **_):
+            return {**parameters, "user_subject": "host-resolved"}
+
+        async def careless_plugin(intent, parameters, user_id=None, **_):
+            return {"id": "rebuilt"}  # fresh dict, drops user_subject
+
+        # Guard registers FIRST (plugin load order) but with high priority;
+        # the careless plugin registers after it.
+        register_hook("pre_mcp_call", guard, priority=100)
+        register_hook("pre_mcp_call", careless_plugin)
+        try:
+            await action_executor.execute({
+                "intent": "mcp.release.get_release",
+                "parameters": {"title": "x"},
+                "confidence": 0.9,
+            })
+        finally:
+            _hooks["pre_mcp_call"].remove(guard)
+            _hooks["pre_mcp_call"].remove(careless_plugin)
+
+        call_args = action_executor.mcp_manager.execute_tool.call_args
+        assert call_args.args[1]["user_subject"] == "host-resolved"
+
+    @pytest.mark.unit
     async def test_pre_mcp_call_crashing_handler_is_skipped(self, action_executor):
         """A raising handler is skipped (logged); later handlers still run."""
         from utils.hooks import _hooks, register_hook

--- a/tests/backend/test_agent_service.py
+++ b/tests/backend/test_agent_service.py
@@ -2507,6 +2507,39 @@ class TestBudgetedLlmOptions:
         assert agent_service._llm_options_or_default("llm_options_retry", {})["num_predict"] == 4096
 
     @pytest.mark.unit
+    def test_ollama_primary_num_ctx_follows_setting(self, monkeypatch):
+        """#1104: on an Ollama-primary agent path the request num_ctx must
+        follow a raised OLLAMA_NUM_CTX, else Ollama truncates the prompt head
+        while the budget thinks the window is wide."""
+        from services import agent_service
+
+        monkeypatch.setattr(
+            agent_service.prompt_manager, "get_config",
+            lambda *a, **k: {"num_predict": 2048, "num_ctx": 32768},
+        )
+        monkeypatch.setattr(agent_service.settings, "agent_default_num_predict", 2048, raising=False)
+        monkeypatch.setattr(agent_service.settings, "ollama_num_ctx", 65536, raising=False)
+        monkeypatch.setattr(agent_service, "use_openai_for_tier", lambda tier: False)
+
+        assert agent_service._llm_options_or_default("llm_options", {})["num_ctx"] == 65536
+
+    @pytest.mark.unit
+    def test_openai_path_keeps_num_ctx_literal(self, monkeypatch):
+        """OpenAI-compat path: the 32768 literal stays — the server drops
+        num_ctx anyway and it protects the in-cluster fallback's KV cache."""
+        from services import agent_service
+
+        monkeypatch.setattr(
+            agent_service.prompt_manager, "get_config",
+            lambda *a, **k: {"num_predict": 2048, "num_ctx": 32768},
+        )
+        monkeypatch.setattr(agent_service.settings, "agent_default_num_predict", 2048, raising=False)
+        monkeypatch.setattr(agent_service.settings, "ollama_num_ctx", 65536, raising=False)
+        monkeypatch.setattr(agent_service, "use_openai_for_tier", lambda tier: True)
+
+        assert agent_service._llm_options_or_default("llm_options", {})["num_ctx"] == 32768
+
+    @pytest.mark.unit
     def test_short_by_design_option_sets_are_left_alone(self, monkeypatch):
         """Summary and pre-selection are meant to be brief — their small caps
         are the point, so the reservation must not inflate them."""

--- a/tests/backend/test_hooks.py
+++ b/tests/backend/test_hooks.py
@@ -267,3 +267,44 @@ def test_plugin_spec_no_callable():
     """Plugin spec without ':' means module-only import."""
     spec = "renfield_twin.hooks"
     assert ":" not in spec
+
+
+class TestHookPriority:
+    """get_hook_handlers orders by priority (higher runs later); run_hooks
+    deliberately ignores priority."""
+
+    @pytest.mark.unit
+    def test_priority_orders_handlers_for_chained_consumers(self):
+        from utils.hooks import get_hook_handlers, register_hook
+
+        async def early(**_):
+            return None
+
+        async def guard(**_):
+            return None
+
+        async def late_registered(**_):
+            return None
+
+        register_hook("pre_mcp_call", guard, priority=100)
+        register_hook("pre_mcp_call", early)
+        register_hook("pre_mcp_call", late_registered)
+
+        handlers = get_hook_handlers("pre_mcp_call")
+        # Default-priority handlers keep registration order; the high-priority
+        # guard runs LAST even though it registered first.
+        assert handlers == [early, late_registered, guard]
+
+    @pytest.mark.unit
+    def test_default_priority_keeps_registration_order(self):
+        from utils.hooks import get_hook_handlers, register_hook
+
+        async def a(**_):
+            return None
+
+        async def b(**_):
+            return None
+
+        register_hook("pre_mcp_call", a)
+        register_hook("pre_mcp_call", b)
+        assert get_hook_handlers("pre_mcp_call") == [a, b]

--- a/tests/backend/test_llm_client.py
+++ b/tests/backend/test_llm_client.py
@@ -1269,10 +1269,10 @@ class TestOpenAICompatFallbackClient:
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_oversized_prompt_warns_on_fallback(self, monkeypatch):
-        """A prompt wider than the fallback's num_ctx (budgeted for the large
-        llama-server window) must log a WARNING — Ollama would silently
-        truncate it, and that degradation has to be visible."""
+    async def test_oversized_prompt_is_middle_cut_for_fallback(self, monkeypatch):
+        """#1104: a prompt wider than the fallback's num_ctx is MIDDLE-CUT
+        before the fallback call — head (framing) and tail (question) survive,
+        and the degradation is visible in the log."""
         import httpx
         primary = AsyncMock()
         fallback = AsyncMock()
@@ -1280,19 +1280,27 @@ class TestOpenAICompatFallbackClient:
         fallback.chat.return_value = "ok"
         w = self._wrapper(monkeypatch, primary, fallback)
         monkeypatch.setattr("utils.llm_client.settings.ollama_num_ctx", 1000)
-        big_messages = [{"role": "user", "content": "x" * 5000}]  # > 1000*3 chars
+        content = "HEAD-" + ("x" * 8000) + "-TAIL"
+        big_messages = [{"role": "user", "content": content}]
 
         with patch("utils.llm_client.logger") as log:
             assert await w.chat(model="qwen3.6", messages=big_messages) == "ok"
         warnings = [str(c.args[0]) for c in log.warning.call_args_list]
-        assert any("exceeds the in-cluster fallback context" in m for m in warnings)
+        assert any("middle-cut" in m for m in warnings)
+        sent = fallback.chat.call_args.kwargs["messages"][0]["content"]
+        assert len(sent) < len(content)
+        assert "[Mitte wegen Fallback-Kontextfenster gekürzt]" in sent
+        assert sent.startswith("HEAD-")
+        assert sent.endswith("-TAIL")
+        # The original message dict must not be mutated (caller may retry primary)
+        assert big_messages[0]["content"] == content
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_oversize_warning_keys_on_forwarded_num_ctx(self, monkeypatch):
+    async def test_shrink_keys_on_forwarded_num_ctx(self, monkeypatch):
         """The fallback actually runs at the options.num_ctx forwarded in the
         call kwargs, not at settings.ollama_num_ctx — a raised OLLAMA_NUM_CTX
-        must not mask real truncation at the smaller forwarded window."""
+        must not mask real overflow at the smaller forwarded window."""
         import httpx
         primary = AsyncMock()
         fallback = AsyncMock()
@@ -1309,10 +1317,12 @@ class TestOpenAICompatFallbackClient:
             ) == "ok"
         warnings = [str(c.args[0]) for c in log.warning.call_args_list]
         assert any("num_ctx=1000" in m for m in warnings)
+        sent = fallback.chat.call_args.kwargs["messages"][0]["content"]
+        assert len(sent) < 20000
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_small_prompt_no_oversize_warning(self, monkeypatch):
+    async def test_small_prompt_passes_unshrunk(self, monkeypatch):
         import httpx
         primary = AsyncMock()
         fallback = AsyncMock()
@@ -1325,7 +1335,32 @@ class TestOpenAICompatFallbackClient:
         with patch("utils.llm_client.logger") as log:
             assert await w.chat(model="qwen3.6", messages=small_messages) == "ok"
         warnings = [str(c.args[0]) for c in log.warning.call_args_list]
-        assert not any("exceeds the in-cluster fallback context" in m for m in warnings)
+        assert not any("fallback context" in m for m in warnings)
+        assert fallback.chat.call_args.kwargs["messages"] is small_messages
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_shrink_preserves_system_message(self, monkeypatch):
+        """Only the LARGEST message (the monolithic agent prompt) is cut —
+        the system message carries the JSON contract and stays whole."""
+        import httpx
+        primary = AsyncMock()
+        fallback = AsyncMock()
+        primary.chat.side_effect = httpx.ConnectError("refused")
+        fallback.chat.return_value = "ok"
+        w = self._wrapper(monkeypatch, primary, fallback)
+        monkeypatch.setattr("utils.llm_client.settings.ollama_num_ctx", 1000)
+        system = "Antworte NUR mit JSON."
+        msgs = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": "y" * 9000},
+        ]
+
+        with patch("utils.llm_client.logger"):
+            assert await w.chat(model="qwen3.6", messages=msgs) == "ok"
+        sent = fallback.chat.call_args.kwargs["messages"]
+        assert sent[0]["content"] == system
+        assert len(sent[1]["content"]) < 9000
 
     @pytest.mark.unit
     @pytest.mark.asyncio

--- a/tests/backend/test_metrics.py
+++ b/tests/backend/test_metrics.py
@@ -289,3 +289,27 @@ class TestEveryCollectorIsReachable:
         }
         missing = sorted(self._collectors_assigned_in_init() - declared)
         assert not missing, f"no module-level declaration for: {missing}"
+
+
+class TestNormalizeEndpoint:
+    """Cardinality guard: per-resource path segments collapse to {id} so the
+    endpoint label can't explode into one time series per document/session."""
+
+    def test_numeric_and_uuid_segments_collapse(self):
+        from utils.metrics import normalize_endpoint
+
+        assert normalize_endpoint("/api/knowledge/documents/123") == \
+            "/api/knowledge/documents/{id}"
+        assert normalize_endpoint(
+            "/api/meetings/0f8b2c1a-1234-4abc-9def-001122334455/segments"
+        ) == "/api/meetings/{id}/segments"
+        assert normalize_endpoint("/api/chat/deadbeefdeadbeefdeadbeef/branch/42") == \
+            "/api/chat/{id}/branch/{id}"
+
+    def test_literal_segments_survive(self):
+        from utils.metrics import normalize_endpoint
+
+        assert normalize_endpoint("/api/mcp/status") == "/api/mcp/status"
+        assert normalize_endpoint("/health") == "/health"
+        # Short hex-looking words stay literal (only >=16 hex chars collapse)
+        assert normalize_endpoint("/api/atoms/facade") == "/api/atoms/facade"

--- a/tests/backend/test_routine_agent.py
+++ b/tests/backend/test_routine_agent.py
@@ -247,6 +247,7 @@ class TestRoutineAgentExecution:
                 mock_settings.ollama_num_ctx = 32768
                 mock_settings.agent_default_num_predict = 1024
                 mock_settings.agent_budget_threshold = 0.9
+                mock_settings.agent_prompt_target_tokens = None
                 mock_settings.agent_conv_context_messages = 6
                 mock_settings.agent_history_limit = 10
                 mock_settings.agent_parallel_tools = False

--- a/tests/backend/test_token_budget.py
+++ b/tests/backend/test_token_budget.py
@@ -79,6 +79,7 @@ class TestEnforceTokenBudget:
             s.ollama_num_ctx = 32768
             s.agent_default_num_predict = 2048
             s.agent_budget_threshold = 0.85
+            s.agent_prompt_target_tokens = None
 
             result = await agent._enforce_token_budget(
                 short_prompt, ctx, "test", None,
@@ -189,6 +190,7 @@ class TestTokenBudgetLogLine:
             s.ollama_num_ctx = 32768
             s.agent_default_num_predict = 2048
             s.agent_budget_threshold = 0.85
+            s.agent_prompt_target_tokens = None
             log.info.side_effect = lambda msg, *a, **kw: captured.append(msg)
 
             await agent._enforce_token_budget(
@@ -252,6 +254,87 @@ class TestConfigurableContentCaps:
         assert "z" * 301 not in prompt
 
 
+class TestSoftPromptTarget:
+    """#1104: AGENT_PROMPT_TARGET_TOKENS triggers ONLY the adaptive tool-result
+    pass above the target — long before the hard threshold — and touches
+    neither history nor memory/documents."""
+
+    def _ctx_with_tool_results(self):
+        ctx = AgentContext(original_message="test")
+        ctx.steps = [
+            AgentStep(step_number=1, step_type="tool_result",
+                      content="r" * 40000, tool="t"),
+        ]
+        return ctx
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_over_target_under_threshold_runs_soft_pass_only(self):
+        agent = _make_agent()
+        ctx = self._ctx_with_tool_results()
+        prompt = "x" * 80000  # ~20k tokens: over 10k target, far under 85% of 262144
+
+        async def mock_build(*args, **kwargs):
+            # Shrunken rebuild — well under the target
+            return "x" * 20000
+
+        agent._build_agent_prompt = mock_build
+        hist = [{"role": "user", "content": f"m{i}"} for i in range(10)]
+
+        with patch("services.agent_service.settings") as s, \
+             patch("services.agent_service.effective_agent_num_ctx", return_value=262144):
+            s.agent_default_num_predict = 2048
+            s.agent_budget_threshold = 0.85
+            s.agent_prompt_target_tokens = 10000
+
+            out_prompt, mem, doc, out_hist = await agent._enforce_token_budget(
+                prompt, ctx, "test", hist,
+                memory_context="mem", document_context="doc", lang="de",
+            )
+            assert len(out_prompt) < len(prompt)   # soft pass rebuilt the prompt
+            assert mem == "mem" and doc == "doc"   # never dropped
+            assert out_hist is hist                # history untouched
+            assert ctx.tool_result_budget_chars > 0
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_under_target_passthrough(self):
+        agent = _make_agent()
+        ctx = self._ctx_with_tool_results()
+        prompt = "x" * 8000  # ~2k tokens < 10k target
+
+        with patch("services.agent_service.settings") as s, \
+             patch("services.agent_service.effective_agent_num_ctx", return_value=262144):
+            s.agent_default_num_predict = 2048
+            s.agent_budget_threshold = 0.85
+            s.agent_prompt_target_tokens = 10000
+
+            out_prompt, _, _, _ = await agent._enforce_token_budget(
+                prompt, ctx, "test", None,
+                memory_context="", document_context="", lang="de",
+            )
+            assert out_prompt == prompt
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_no_target_means_hard_budget_only(self):
+        agent = _make_agent()
+        ctx = self._ctx_with_tool_results()
+        prompt = "x" * 80000
+
+        with patch("services.agent_service.settings") as s, \
+             patch("services.agent_service.effective_agent_num_ctx", return_value=262144):
+            s.agent_default_num_predict = 2048
+            s.agent_budget_threshold = 0.85
+            s.agent_prompt_target_tokens = None
+
+            out_prompt, _, _, _ = await agent._enforce_token_budget(
+                prompt, ctx, "test", None,
+                memory_context="", document_context="", lang="de",
+            )
+            assert out_prompt == prompt  # under hard threshold, target off
+
+
 class TestBackendAwareBudget:
     """The budget must follow the effective serving backend: when the agent
     tier routes to the OpenAI-compat llama-server and its --ctx-size is
@@ -270,6 +353,7 @@ class TestBackendAwareBudget:
              patch("services.agent_service.effective_agent_num_ctx", return_value=262144):
             s.agent_default_num_predict = 2048
             s.agent_budget_threshold = 0.85
+            s.agent_prompt_target_tokens = None
 
             prompt, mem, doc, _hist = await agent._enforce_token_budget(
                 large_prompt, ctx, "test", None,

--- a/tests/backend/test_token_budget.py
+++ b/tests/backend/test_token_budget.py
@@ -122,6 +122,7 @@ class TestEnforceTokenBudget:
             s.ollama_num_ctx = 32768
             s.agent_default_num_predict = 2048
             s.agent_budget_threshold = 0.85
+            s.agent_prompt_target_tokens = None
 
             result = await agent._enforce_token_budget(
                 large_prompt, ctx, "test", None,
@@ -158,6 +159,7 @@ class TestEnforceTokenBudget:
             s.ollama_num_ctx = 32768
             s.agent_default_num_predict = 2048
             s.agent_budget_threshold = 0.85
+            s.agent_prompt_target_tokens = None
 
             result = await agent._enforce_token_budget(
                 large_prompt, ctx, "test", full_history,
@@ -298,6 +300,71 @@ class TestSoftPromptTarget:
 
     @pytest.mark.unit
     @pytest.mark.asyncio
+    async def test_soft_pass_reverts_when_target_too_tight(self):
+        """Advisory floor: a target so tight that tool results would be
+        crushed near the 200-char floor is skipped (prompt passes unreduced,
+        tool_result_budget_chars reset) — the soft target is latency control,
+        never an emergency crush."""
+        agent = _make_agent()
+        ctx = self._ctx_with_tool_results()
+        prompt = "x" * 80000  # over the tiny target
+
+        async def mock_build(*args, **kwargs):
+            # Skeleton alone nearly fills the tiny target → headroom ~0.
+            return "s" * 8000
+
+        agent._build_agent_prompt = mock_build
+
+        with patch("services.agent_service.settings") as s, \
+             patch("services.agent_service.effective_agent_num_ctx", return_value=262144):
+            s.agent_default_num_predict = 2048
+            s.agent_budget_threshold = 0.85
+            s.agent_prompt_target_tokens = 2048  # <= reserved → headroom 0
+
+            out_prompt, _, _, _ = await agent._enforce_token_budget(
+                prompt, ctx, "test", None,
+                memory_context="", document_context="", lang="de",
+            )
+            assert out_prompt == prompt              # NOT the crushed rebuild
+            assert ctx.tool_result_budget_chars == 0  # reverted
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_hard_pass_respects_soft_target_ceiling(self):
+        """No latency inversion at the threshold: a prompt OVER the hard
+        threshold sizes Pass 0 toward min(target, hard), not the full 85%
+        window."""
+        agent = _make_agent()
+        ctx = self._ctx_with_tool_results()
+        prompt = "x" * 950000  # ~237k tokens > 85% of 262144
+
+        captured_budgets = []
+
+        async def spy(*args, **kwargs):
+            captured_budgets.append(kwargs.get("budget_tokens"))
+            return None  # no tool results shrunk — fall through to later passes
+
+        agent._apply_adaptive_tool_budget = spy
+
+        async def mock_build(*args, **kwargs):
+            return "x" * 10000
+
+        agent._build_agent_prompt = mock_build
+
+        with patch("services.agent_service.settings") as s, \
+             patch("services.agent_service.effective_agent_num_ctx", return_value=262144):
+            s.agent_default_num_predict = 2048
+            s.agent_budget_threshold = 0.85
+            s.agent_prompt_target_tokens = 65536
+
+            await agent._enforce_token_budget(
+                prompt, ctx, "test", None,
+                memory_context="", document_context="", lang="de",
+            )
+        assert captured_budgets == [65536]  # min(target, int(262144*0.85))
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
     async def test_under_target_passthrough(self):
         agent = _make_agent()
         ctx = self._ctx_with_tool_results()
@@ -381,6 +448,7 @@ class TestBackendAwareBudget:
              patch("services.agent_service.effective_agent_num_ctx", return_value=32768):
             s.agent_default_num_predict = 2048
             s.agent_budget_threshold = 0.85
+            s.agent_prompt_target_tokens = None
 
             prompt, _, _, _ = await agent._enforce_token_budget(
                 large_prompt, ctx, "test", None,

--- a/tests/backend/test_token_counter.py
+++ b/tests/backend/test_token_counter.py
@@ -446,6 +446,48 @@ class TestGlobalInstance:
         assert result > 0
 
 
+class TestTruncateMiddleToBudget:
+    """#1104 fallback shrink: middle-cut preserves head (framing) and tail
+    (question) while fitting the token budget."""
+
+    @pytest.mark.unit
+    def test_fits_unchanged(self):
+        counter = TokenCounter()
+        text = "short text"
+        out, shrunk = counter.truncate_middle_to_budget(text, max_tokens=1000)
+        assert out == text
+        assert shrunk is False
+
+    @pytest.mark.unit
+    def test_oversize_keeps_head_and_tail(self):
+        counter = TokenCounter()
+        text = "HEAD-START\n" + ("filler line\n" * 4000) + "TAIL-QUESTION"
+        out, shrunk = counter.truncate_middle_to_budget(text, max_tokens=1000)
+        assert shrunk is True
+        assert out.startswith("HEAD-START")
+        assert out.endswith("TAIL-QUESTION")
+        assert "[Mitte wegen Fallback-Kontextfenster gekürzt]" in out
+        assert counter.count(out) <= 1000
+
+    @pytest.mark.unit
+    def test_reserved_shrinks_available(self):
+        counter = TokenCounter()
+        text = "z" * 40000
+        out_no_res, _ = counter.truncate_middle_to_budget(text, max_tokens=2000)
+        out_res, _ = counter.truncate_middle_to_budget(text, max_tokens=2000, reserved=1000)
+        assert len(out_res) < len(out_no_res)
+
+    @pytest.mark.unit
+    def test_tiny_budget_returns_unchanged(self):
+        """A budget too small for a meaningful head+tail (target < 200 chars)
+        falls back to no-op rather than emitting marker-only garbage."""
+        counter = TokenCounter()
+        text = "y" * 10000
+        out, shrunk = counter.truncate_middle_to_budget(text, max_tokens=20)
+        assert out == text
+        assert shrunk is False
+
+
 class TestDetectContentTypeSampling:
     """_detect_content_type runs on a bounded head+tail sample so count()
     stays O(1) on the hot agent path even for very wide prompts."""


### PR DESCRIPTION
## Summary
- **Twin-Härtung (Host-Seite; Adapter-Gegenstück im privaten Twin-Repo):** `pre_mcp_call` läuft jetzt GECHAINED statt First-Dict-wins — ein früher Plugin-Repair kann den Security-Rewrite des Twin-Self-Access-Guards nicht mehr still verwerfen; neue `register_hook(priority=)`-Ordnung lässt den Guard deterministisch zuletzt laufen; `post_message` (Pfad A) übergibt die echte Turn-Sprache; `TWIN_INGEST_TOKEN` deklarativ aus Secret `twin-secrets` (`optional: true`) statt per flüchtigem `kubectl set env`; TWIN_*-Env-Doku.
- **#1104 komplett:** Ollama-Primary `num_ctx`-Forwarding (Budget und Request-Fenster in Schritt); Soft-Prompt-Target `AGENT_PROMPT_TARGET_TOKENS` (ConfigMaps 65536) mit Review-gehärteter Semantik (min(target, hart) auch im Over-Threshold-Pfad — keine Latenz-Inversion; Advisory-Floor 1000 Zeichen/Result statt Emergency-Crush); fallback-seitige **Middle-Cut-Kürzung** (`truncate_middle_to_budget` + `_prepare_fallback`) — bei cuda-Ausfall überleben Framing (Head) und Frage (Tail) das 32k-Fallback-Fenster.
- **Metriken aktiviert:** `METRICS_ENABLED=true` beide ConfigMaps (nur in-cluster erreichbar — Ingress routet `/metrics` nicht, Service ClusterIP); `endpoint`-Label nutzt das exakte Route-Template (`scope['route'].path_format`), Regex-`{id}`-Fallback nur für 404/Scanner-Pfade.

## Test plan
- [x] +31 Tests neu/umgebaut (Chaining + Priorität + Crash-Skip, Soft-Target inkl. Inversion/Floor, Middle-Cut, Fallback-Shrink, num_ctx beide Pfade, normalize_endpoint); Adapter-Tests im Privat-Repo 35/35
- [x] Suite auf .159 isoliert: **5691 passed, 0 failed** (+ 355 Postgres-markiert)
- [x] `/code-review high` auf den Branch-Diff: 6 Findings, alle adressiert; Lint-Diff gegen main 0 neu
- [ ] Post-Deploy: Smoke beide Instanzen + `/metrics`-Nachweis in-cluster (Heartbeat-Counter steigt) + extern weiterhin SPA

🤖 Generated with [Claude Code](https://claude.com/claude-code)