### PR TITLE
chore(k8s): INTERNAL_AUTH_VERIFY_SECRET einheitlich via renfield-secrets verdrahten (#1116)

### DIFF
--- a/k8s/backend.yaml
+++ b/k8s/backend.yaml
@@ -161,6 +161,18 @@ spec:
                   name: twin-secrets
                   key: TWIN_INGEST_TOKEN
                   optional: true
+            # Shared secret gating POST /api/internal/auth/verify (login audit
+            # #1116). optional: unset → endpoint stays legacy-unauthenticated
+            # (byte-identical), so the pod boots dark on any instance without the
+            # key. TWO-SIDED: on an instance whose voice-server registry client
+            # calls verify (e.g. xidra), the SAME value must be set as that
+            # client's verify_secret in voice-registry-auth, else voice 401s.
+            - name: INTERNAL_AUTH_VERIFY_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: renfield-secrets
+                  key: internal-auth-verify-secret
+                  optional: true
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/k8s/renfield-env-private.secret.example.yaml
+++ b/k8s/renfield-env-private.secret.example.yaml
@@ -43,9 +43,9 @@ stringData:
   # Plugin wiring that references the private twin adapter.
   PLUGIN_MCP_BINDINGS: "CHANGEME"
   PLUGIN_MODULES: "CHANGEME"
-  # Shared secret gating POST /api/internal/auth/verify (login audit): when set,
-  # the ingress-reachable endpoint requires a matching X-Verify-Secret header,
-  # closing the unauthenticated validity-oracle/claims-leak. The shared voice-
-  # server (callback/registry mode) must send the SAME value; on instances
-  # without a voice-server, setting it simply 401s every (nonexistent) caller.
-  INTERNAL_AUTH_VERIFY_SECRET: "CHANGEME"
+  # NOTE: INTERNAL_AUTH_VERIFY_SECRET is NOT set here. It is wired uniformly for
+  # both instances via an individual env in backend.yaml
+  # (secretKeyRef renfield-secrets/internal-auth-verify-secret, optional). Setting
+  # it here too would double-source it (individual env vs envFrom precedence).
+  # Put the value in the `renfield-secrets` Secret's `internal-auth-verify-secret`
+  # key. See docs/SECURITY.md → "internal/auth/verify shared-secret gate".

--- a/k8s/secrets.yaml.example
+++ b/k8s/secrets.yaml.example
@@ -21,6 +21,11 @@ stringData:
   postgres-password: "CHANGEME"
   secret-key: "CHANGEME"            # openssl rand -hex 32
   default-admin-password: "CHANGEME"
+  # Optional (login audit #1116): gates POST /api/internal/auth/verify. Unset →
+  # endpoint stays legacy-unauthenticated. On an instance whose voice-server
+  # registry client calls verify (e.g. xidra), the SAME value must be the xidra
+  # client's verify_secret in the voice-registry-auth Secret. openssl rand -hex 32
+  internal-auth-verify-secret: ""
   home-assistant-token: "CHANGEME"
   openweather-api-key: ""
   newsapi-key: ""


### PR DESCRIPTION
## Summary

Follow-up zu #1117. Das Login-Audit-Feature braucht `INTERNAL_AUTH_VERIFY_SECRET` im laufenden Backend. #1117 hatte nur die Doku (`renfield-env-private.example`) angefasst — das reicht für xidra nicht: **xidras Backend mountet `renfield-env-private` nicht** (Kustomize-Overlay), es liest alle Secrets per einzelnem `valueFrom` aus **`renfield-secrets`**.

- **`k8s/backend.yaml`**: neuer individueller `env` `INTERNAL_AUTH_VERIFY_SECRET` via `secretKeyRef renfield-secrets/internal-auth-verify-secret`, **`optional: true`** (Muster wie `TWIN_INGEST_TOKEN`) → uniform für beide Instanzen; Pod bootet dark wenn Key fehlt = Endpoint bleibt legacy-unauthenticated (byte-identisch).
- **`k8s/secrets.yaml.example`**: `internal-auth-verify-secret` als optionaler Key dokumentiert + Hinweis auf die zweiseitige `voice-registry-auth`-Kopplung.
- **`k8s/renfield-env-private.secret.example.yaml`**: den in #1117 dort gesetzten Key entfernt → Verweis auf `renfield-secrets` (sonst Doppel-Quelle: individueller env übersteuert envFrom).

**Kein Live-Effekt bis der Key gesetzt wird.** Für xidra muss derselbe Wert als `verify_secret` des `xidra`-Clients in `voice-registry-auth` (ns `voice`) stehen, sonst 401t Voice (der geteilte registry-Mode-voice-server ruft xidras Verify).

## Verifikation
- [x] `kubectl apply --dry-run=client` grün für alle 3 Manifeste
- [x] `optional: true` → dark-boot ohne Key (byte-identisch legacy)
- [ ] Deploy via /deploy-production + Secret-Setzen laut Runbook

🤖 Generated with [Claude Code](https://claude.com/claude-code)