### PR TITLE
fix(auth): Login-Härtung Tier-2 Batch A — TOCTOU-Lock, Relation-Tier-Filter, Taxonomie-Gates (#1116)

### DIFF
--- a/src/backend/api/routes/auth.py
+++ b/src/backend/api/routes/auth.py
@@ -18,7 +18,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.database import Role, User
-from models.permissions import get_all_permissions
+from models.permissions import Permission, get_all_permissions
 from services.api_rate_limiter import limiter
 from services.auth_service import (
     create_access_token,
@@ -30,6 +30,7 @@ from services.auth_service import (
     get_user_by_id,
     oauth2_scheme,
     require_auth,
+    require_permission,
     validate_password,
 )
 from services.database import get_db
@@ -679,11 +680,17 @@ async def get_auth_status(
 
 
 @router.get("/permissions")
-async def list_all_permissions():
+async def list_all_permissions(user: User = Depends(require_permission(Permission.ROLES_VIEW))):
     """
     List all available permissions in the system.
 
-    Useful for admin UIs when creating/editing roles.
+    Gated on ROLES_VIEW (#1116): an anonymous caller could otherwise enumerate
+    the permission taxonomy. require_permission short-circuits to ALLOW when
+    AUTH_ENABLED=false (returns None WITHOUT a user lookup, so single-user mode
+    works even with no user rows), and rejects auth-on + missing/insufficient
+    credentials. Consistent with /api/roles/permissions/all.
+    NOTE: `require_auth` / `get_user_or_default` are wrong here — the former
+    raises 401 even auth-off, the latter needs a real user row to exist.
     """
     return get_all_permissions()
 

--- a/src/backend/api/routes/roles.py
+++ b/src/backend/api/routes/roles.py
@@ -23,7 +23,11 @@ from models.permissions import (
     has_permission,
     missing_grantable_permissions,
 )
-from services.auth_service import active_admin_ids, require_permission
+from services.auth_service import (
+    acquire_last_admin_guard_lock,
+    active_admin_ids,
+    require_permission,
+)
 from services.database import get_db
 
 router = APIRouter()
@@ -301,6 +305,7 @@ async def update_role(
             not has_permission(request.permissions, Permission.ADMIN)
         )
         if strips_admin:
+            await acquire_last_admin_guard_lock(db)
             admin_ids = await active_admin_ids(db)
             holders = {
                 r[0]
@@ -395,12 +400,17 @@ async def delete_role(
 
 
 @router.get("/permissions/all")
-async def list_permissions(request: Request):
+async def list_permissions(
+    request: Request,
+    user: User = Depends(require_permission(Permission.ROLES_VIEW)),
+):
     """
     List all available permissions including dynamic MCP permissions.
 
-    This endpoint is public (no auth required) as it's useful for
-    understanding the permission system.
+    Gated on ROLES_VIEW (#1116): an unauthenticated caller could otherwise
+    enumerate the full permission taxonomy AND the live MCP tool names. The
+    frontend role editor holds ROLES_VIEW; auth-off (AUTH_ENABLED=false) still
+    allows it (require_permission short-circuits when auth is disabled).
     """
     permissions = get_all_permissions()
 

--- a/src/backend/api/routes/users.py
+++ b/src/backend/api/routes/users.py
@@ -27,6 +27,7 @@ from models.permissions import (
 )
 from utils.hooks import run_hooks
 from services.auth_service import (
+    acquire_last_admin_guard_lock,
     active_admin_ids,
     get_password_hash,
     get_role_by_id,
@@ -419,6 +420,7 @@ async def update_user(
         )
         new_role_is_admin = has_permission(role.permissions or [], Permission.ADMIN)
         if target_is_admin and not new_role_is_admin:
+            await acquire_last_admin_guard_lock(db)
             admin_ids = await active_admin_ids(db)
             if not (admin_ids - {user.id}):
                 raise HTTPException(
@@ -446,6 +448,7 @@ async def update_user(
         # admin would lock the instance out of user/role management.
         if not request.is_active and user.is_active:
             if user.role and has_permission(user.role.permissions or [], Permission.ADMIN):
+                await acquire_last_admin_guard_lock(db)
                 admin_ids = await active_admin_ids(db)
                 if not (admin_ids - {user.id}):
                     raise HTTPException(
@@ -518,6 +521,7 @@ async def delete_user(
     # Last-admin guard (security audit M5): deleting the final active admin would
     # lock the instance out of user/role management. active_admin_ids already
     # counts only active admins, so an inactive-admin target is unaffected.
+    await acquire_last_admin_guard_lock(db)
     admin_ids = await active_admin_ids(db)
     if user.id in admin_ids and not (admin_ids - {user.id}):
         raise HTTPException(

--- a/src/backend/services/auth_service.py
+++ b/src/backend/services/auth_service.py
@@ -13,7 +13,7 @@ from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError, jwt
 from loguru import logger
 from passlib.context import CryptContext
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -232,6 +232,27 @@ async def authenticate_user(
         return None
 
     return user
+
+
+# M5 last-admin guard — TOCTOU fix (#1116). The four guarded mutations
+# (demote via role change, deactivate, delete, strip admin from a role) all
+# read active_admin_ids() then mutate+commit. Without serialization, two
+# concurrent txns targeting DIFFERENT admins on a 2-admin instance can both
+# pass "would this leave zero admins?" and race to zero. Each guarded path
+# takes this single transaction-scoped advisory lock BEFORE the check, so they
+# serialize; the lock auto-releases at commit/rollback. Postgres-only — a no-op
+# on sqlite (tests), where there is no cross-connection concurrency to guard.
+_LAST_ADMIN_GUARD_LOCK_KEY = 0x4D354C41  # "M5LA" (M5 Last-Admin)
+
+
+async def acquire_last_admin_guard_lock(db: AsyncSession) -> None:
+    """Serialize the last-admin guards (see note above). Call before
+    active_admin_ids() in every mutation that could remove an admin."""
+    if db.bind is not None and db.bind.dialect.name == "postgresql":
+        await db.execute(
+            text("SELECT pg_advisory_xact_lock(:k)"),
+            {"k": _LAST_ADMIN_GUARD_LOCK_KEY},
+        )
 
 
 async def active_admin_ids(db: AsyncSession) -> set[int]:

--- a/src/backend/services/graph_expansion.py
+++ b/src/backend/services/graph_expansion.py
@@ -82,20 +82,21 @@ def _relation_filter(
     A relation carries its OWN ``circle_tier`` (can be stricter than either
     endpoint), so accessible endpoints are NOT sufficient to disclose the
     predicate — a private relationship between two public entities would
-    otherwise leak to a peer.
+    otherwise leak.
 
-    Applied ONLY on the federation (``enforce_circles``) path so every
-    non-federation caller keeps the original endpoint-accessibility behavior
-    byte-identically. (Household/auth-on relation-tier filtering — where
-    entities are filtered but relations historically were not — is a separate,
-    pre-existing concern tracked as a follow-up, not part of this security fix.)
+    Mirrors ``_entity_filter``'s gating (#1116): auth-off with no federation
+    scope → no filter (byte-identical legacy); otherwise the relation's own tier
+    is enforced on BOTH the federation (peer-scoped) AND the auth-on household
+    path. Previously only the federation path was filtered, so a household member
+    who could see two entities also saw a stricter-tier relation between them —
+    entities were tier-filtered but relations were not.
     """
-    if not enforce_circles:
+    if not settings.auth_enabled and not enforce_circles:
         return ("", {})
     if asker_id is None:
         return ("AND r.circle_tier = :rel_pub_tier", {"rel_pub_tier": TIER_PUBLIC})
     from services.circle_sql import kg_relations_circles_filter
-    clause, params = kg_relations_circles_filter(asker_id, alias="r", peer_scoped=True)
+    clause, params = kg_relations_circles_filter(asker_id, alias="r", peer_scoped=enforce_circles)
     return (f"AND {clause}", params)
 
 

--- a/tests/backend/test_auth_audit_remediation.py
+++ b/tests/backend/test_auth_audit_remediation.py
@@ -716,3 +716,58 @@ class TestInternalVerifyGuards:
         with pytest.raises(HTTPException) as exc:
             await verify_token(VerifyRequest(token=ws))
         assert exc.value.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Tier-2 login-hardening batch (#1116): last-admin TOCTOU lock, kg_relations
+# tier filter on the auth-on path, taxonomy-endpoint auth gates.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.database
+class TestTier2AuthHardening:
+    async def test_last_admin_guard_lock_noop_on_sqlite(self, db_session):
+        """acquire_last_admin_guard_lock is Postgres-only; on sqlite (tests) it
+        must no-op WITHOUT error so the guarded mutation paths still run. The
+        existing last-admin guard tests exercise the guarded paths (which now
+        call this first) — this asserts the helper itself is a clean no-op."""
+        from services.auth_service import acquire_last_admin_guard_lock
+        await acquire_last_admin_guard_lock(db_session)  # must not raise
+
+    def test_relation_filter_gates_auth_on_and_off(self, monkeypatch):
+        """#1116: kg_relations tier filter now applies on the auth-on path
+        (was federation-only). Auth-off + no federation scope stays byte-
+        identical (no filter)."""
+        from services import graph_expansion as ge
+
+        monkeypatch.setattr(ge.settings, "auth_enabled", False)
+        assert ge._relation_filter(asker_id=5, enforce_circles=False) == ("", {})
+
+        monkeypatch.setattr(ge.settings, "auth_enabled", True)
+        clause, _ = ge._relation_filter(asker_id=5, enforce_circles=False)
+        # Must enforce the relation's OWN circle_tier — the leak was that
+        # relations (unlike entities) were unfiltered on the auth-on path, so a
+        # non-empty-but-tier-less clause would not close it.
+        assert clause and "circle_tier" in clause, (
+            "auth-on relation filter must reference r.circle_tier"
+        )
+
+        clause_anon, params_anon = ge._relation_filter(asker_id=None, enforce_circles=False)
+        assert "circle_tier" in clause_anon and params_anon
+
+    async def test_roles_taxonomy_gate(self, db_session, monkeypatch):
+        """#1116: /api/roles/permissions/all is gated on ROLES_VIEW — the gate
+        denies an unauthenticated caller when auth is ON, and allows when auth
+        is OFF (single-user household unaffected)."""
+        from services import auth_service
+        from services.auth_service import require_permission
+        from models.permissions import Permission
+
+        checker = require_permission(Permission.ROLES_VIEW)
+
+        monkeypatch.setattr(auth_service.settings, "auth_enabled", True)
+        with pytest.raises(HTTPException) as exc:
+            await checker(user=None, db=db_session)
+        assert exc.value.status_code in (401, 403)
+
+        monkeypatch.setattr(auth_service.settings, "auth_enabled", False)
+        assert await checker(user=None, db=db_session) is None  # auth-off allows


### PR DESCRIPTION
## Summary

Drei self-contained Backend-Härtungen aus dem Login-Audit (#1116), adversarial-reviewed (*„alle drei Changes korrekt, kein Critical/High, der prior require_auth-auth-off-Bug-Typ ist NICHT wiederholt"*):

- **#1 M5 last-admin TOCTOU:** neuer `acquire_last_admin_guard_lock()` nimmt einen txn-scoped `pg_advisory_xact_lock` VOR dem `active_admin_ids()`-Check in allen 4 Guard-Pfaden (users.py demote/deactivate/delete, roles.py strip-admin) → zwei parallele Txns gegen verschiedene Admins können nicht mehr beide passieren und auf 0 racen. Postgres-only, no-op auf sqlite.
- **#5 kg_relations Tier-Filter auf dem auth-on-Pfad:** `_relation_filter` filtert die eigene `circle_tier` einer Relation jetzt auch auf dem Household-Pfad (spiegelt `_entity_filter`) — schließt das Leak, dass ein Mitglied eine strenger-getierte Relation zwischen zwei sichtbaren Entities sah.
- **#3 Taxonomie-Gates:** `/api/roles/permissions/all` (enumerierte auch Live-MCP-Tool-Namen) + `/api/auth/permissions` auf `require_permission(ROLES_VIEW)` — short-circuitet auth-off OHNE User-Lookup (Household unberührt), gatet auth-on.

Item #4 (/api/atoms asker_id) war bereits gefixt (#695).

## Deploy-Kontext
Diese Gates beißen nur **auth-on (= xidra)**; Household ist auth-off → No-op. Braucht Backend-Deploy + auth-on-E2E auf xidra.

## Test plan
- [x] 81 Auth-Tests grün inkl. 3 neuer (TestTier2AuthHardening); last-admin-Guards + test_list_permissions auth-off ohne Regression
- [x] Backend-Lint sauber
- [x] Adversarialer /code-review (auth-off-Pfade getract, kein Frontend-Bruch — die API ist toter Code)
- [ ] Post-Merge: Backend-Deploy beide Instanzen + xidra auth-on-E2E (Rollen-Editor, unauth /permissions → 401)

Refs #1116

🤖 Generated with [Claude Code](https://claude.com/claude-code)