### PR TITLE
fix(security): Login-Härtung Tier-2 Batch B — WS-Size-Cap, WS-Origin, Paperless-Write-Gate (#1116)

### DIFF
--- a/config/mcp_servers.yaml
+++ b/config/mcp_servers.yaml
@@ -337,19 +337,28 @@ servers:
     permissions:
       - mcp.paperless.read
       - mcp.paperless.write
+    # COMPLETE map over every paperless MCP tool — an unmapped tool would fall
+    # back to the server-level `permissions` (which accepts read OR write), so a
+    # mutation left unmapped would stay drivable by a read-only role. Reads →
+    # read, every state-changing tool (incl. reprocess_document) → write.
     tool_permissions:
       search_documents: mcp.paperless.read
       get_document: mcp.paperless.read
+      download_document: mcp.paperless.read
+      await_consume_result: mcp.paperless.read
       list_correspondents: mcp.paperless.read
       list_document_types: mcp.paperless.read
       list_tags: mcp.paperless.read
+      list_custom_fields: mcp.paperless.read
+      list_storage_paths: mcp.paperless.read
       update_document: mcp.paperless.write
+      reprocess_document: mcp.paperless.write
+      upload_document: mcp.paperless.write
       create_correspondent: mcp.paperless.write
       create_document_type: mcp.paperless.write
       create_storage_path: mcp.paperless.write
       create_tag: mcp.paperless.write
       delete_document: mcp.paperless.write
-      upload_document: mcp.paperless.write
     # Note: ``upload_document`` is intentionally NOT exposed to the agent
     # prompt. The agent has no access to raw file bytes, so when it saw this
     # tool it hallucinated placeholder base64 ("base64_encoded_content_of...")

--- a/config/mcp_servers.yaml
+++ b/config/mcp_servers.yaml
@@ -324,6 +324,32 @@ servers:
     env:
       PAPERLESS_API_URL: "${PAPERLESS_API_URL:-}"
       PAPERLESS_API_TOKEN: "${PAPERLESS_API_TOKEN:-}"
+    # Read/write permission split (#1116) — mirrors the calendar stanza. Without
+    # a per-tool map, the single convention grant `mcp.paperless` authorized BOTH
+    # reads (search) AND writes (update_document) — no separation. Now reads map
+    # to mcp.paperless.read, mutations to mcp.paperless.write.
+    # BACKWARD-COMPATIBLE: a role holding the broad `mcp.paperless` server grant
+    # still satisfies both (wildcard covers all paperless tools), so existing
+    # search flows do NOT break on deploy. The write restriction only bites once
+    # a role is tightened to grant `mcp.paperless.read` (read-only) instead of
+    # the broad `mcp.paperless` — the operational activation step (auth-on
+    # instances only; auth-off passes user_permissions=None → allowed).
+    permissions:
+      - mcp.paperless.read
+      - mcp.paperless.write
+    tool_permissions:
+      search_documents: mcp.paperless.read
+      get_document: mcp.paperless.read
+      list_correspondents: mcp.paperless.read
+      list_document_types: mcp.paperless.read
+      list_tags: mcp.paperless.read
+      update_document: mcp.paperless.write
+      create_correspondent: mcp.paperless.write
+      create_document_type: mcp.paperless.write
+      create_storage_path: mcp.paperless.write
+      create_tag: mcp.paperless.write
+      delete_document: mcp.paperless.write
+      upload_document: mcp.paperless.write
     # Note: ``upload_document`` is intentionally NOT exposed to the agent
     # prompt. The agent has no access to raw file bytes, so when it saw this
     # tool it hallucinated placeholder base64 ("base64_encoded_content_of...")

--- a/k8s/backend.yaml
+++ b/k8s/backend.yaml
@@ -127,7 +127,10 @@ spec:
           ports:
             - containerPort: 8000
           command: ["uvicorn"]
-          args: ["main:app", "--host", "0.0.0.0", "--port", "8000"]
+          # --ws-max-size caps inbound WebSocket frames at the protocol layer
+          # (#1116) so an oversized frame is dropped before any /ws handler
+          # parses it. 1000000 = ws_max_message_size default; keep in sync.
+          args: ["main:app", "--host", "0.0.0.0", "--port", "8000", "--ws-max-size", "1000000"]
           envFrom:
             - configMapRef:
                 name: renfield-env

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -217,4 +217,5 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
 
 EXPOSE 8000
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+# --ws-max-size caps inbound WebSocket frames (#1116); matches ws_max_message_size.
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload", "--ws-max-size", "1000000"]

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -643,5 +643,12 @@ if __name__ == "__main__":
         host="0.0.0.0",
         port=8000,
         reload=True,
-        log_level="info"
+        log_level="info",
+        # Cap inbound WebSocket frames at the protocol layer (#1116): drops an
+        # oversized frame before any handler parses/buffers it, covering every
+        # /ws endpoint. All legit inbound frames are small (chat = text + attach
+        # IDs, attachments upload via REST; audio streams in ~KB chunks). The
+        # prod launch (k8s/backend.yaml uvicorn args) sets the same via
+        # --ws-max-size; keep the two in sync with settings.ws_max_message_size.
+        ws_max_size=settings.ws_max_message_size,
     )

--- a/src/backend/services/websocket_auth.py
+++ b/src/backend/services/websocket_auth.py
@@ -114,6 +114,26 @@ def get_token_store() -> WSTokenStore:
     return _token_store
 
 
+def _ws_origin_allowed(websocket: WebSocket) -> bool:
+    """CSWSH origin allowlist for the WS handshake (#1116).
+
+    - ``cors_origins == "*"`` → allow all (dev / permissive).
+    - no ``Origin`` header → allow (non-browser client; browsers always send it).
+    - else the ``Origin`` must be one of the comma-separated ``cors_origins``.
+
+    Mirrors the CORS-middleware allowlist in main.py, so any origin the SPA is
+    already served from (and passes CORS with) also passes the WS check.
+    """
+    configured = settings.cors_origins.strip()
+    if configured == "*":
+        return True
+    origin = websocket.headers.get("origin")
+    if not origin:
+        return True
+    allowed = {o.strip() for o in configured.split(",") if o.strip()}
+    return origin in allowed
+
+
 async def authenticate_websocket(
     websocket: WebSocket,
     token: str | None = None
@@ -128,6 +148,20 @@ async def authenticate_websocket(
     Returns:
         Token data if authenticated, None otherwise
     """
+    # CSWSH protection (#1116): a browser ALWAYS sends an Origin header on the
+    # WS handshake, so reject a browser Origin that is not in the CORS allowlist
+    # (cross-site WebSocket hijacking). A MISSING Origin = a non-browser client
+    # (satellite/device/server-to-server) → allowed (an attacker's browser can't
+    # omit Origin). cors_origins="*" (dev/permissive, e.g. the auth-off
+    # household) skips the check. Applied before the ws_auth_enabled short-
+    # circuit so it protects even ws-auth-off browser sockets.
+    if not _ws_origin_allowed(websocket):
+        logger.warning(
+            "WS handshake rejected: disallowed Origin {!r}",
+            websocket.headers.get("origin"),
+        )
+        return None
+
     # Skip authentication if disabled
     if not settings.ws_auth_enabled:
         return {"authenticated": True, "auth_skipped": True}

--- a/tests/backend/test_paperless_permissions.py
+++ b/tests/backend/test_paperless_permissions.py
@@ -49,3 +49,11 @@ def test_paperless_stanza_maps_tools():
     assert tp.get("update_document") == "mcp.paperless.write"
     assert tp.get("search_documents") == "mcp.paperless.read"
     assert "mcp.paperless.write" in (paperless.get("permissions") or [])
+    # EVERY mutation must be mapped to write — an unmapped mutation falls back to
+    # the server-level [read, write] and stays drivable by a read-only role.
+    for mutation in (
+        "update_document", "reprocess_document", "upload_document",
+        "create_correspondent", "create_document_type", "create_storage_path",
+        "create_tag", "delete_document",
+    ):
+        assert tp.get(mutation) == "mcp.paperless.write", f"{mutation} not write-gated"

--- a/tests/backend/test_paperless_permissions.py
+++ b/tests/backend/test_paperless_permissions.py
@@ -1,0 +1,51 @@
+"""Paperless MCP read/write permission split (login audit #1116, Batch B, #2).
+
+The paperless stanza (config/mcp_servers.yaml) now maps read tools to
+mcp.paperless.read and mutations (update_document, create_*, delete_document,
+upload_document) to mcp.paperless.write, so a read-only role can no longer
+drive a Paperless write. BACKWARD-COMPATIBLE: the broad `mcp.paperless` server
+grant still covers both, so existing search flows don't break on deploy — the
+restriction bites once a role is tightened to `mcp.paperless.read`.
+"""
+from models.permissions import has_mcp_permission
+
+
+def test_paperless_read_write_separation():
+    # read-only grant: reads yes, writes NO
+    assert has_mcp_permission(["mcp.paperless.read"], "mcp.paperless.read") is True
+    assert has_mcp_permission(["mcp.paperless.read"], "mcp.paperless.write") is False
+
+    # write grant: writes yes, reads NO (separation is symmetric)
+    assert has_mcp_permission(["mcp.paperless.write"], "mcp.paperless.write") is True
+    assert has_mcp_permission(["mcp.paperless.write"], "mcp.paperless.read") is False
+
+    # broad server grant still covers BOTH → no breakage for existing roles
+    assert has_mcp_permission(["mcp.paperless"], "mcp.paperless.read") is True
+    assert has_mcp_permission(["mcp.paperless"], "mcp.paperless.write") is True
+
+    # mcp.* wildcard covers both
+    assert has_mcp_permission(["mcp.*"], "mcp.paperless.write") is True
+
+
+def test_paperless_stanza_maps_tools():
+    """The committed stanza actually carries the split (guards against someone
+    dropping tool_permissions)."""
+    import yaml
+    from pathlib import Path
+
+    import pytest
+    candidates = [
+        Path("config/mcp_servers.yaml"),
+        Path("/app/config/mcp_servers.yaml"),
+        Path(__file__).resolve().parents[2] / "config" / "mcp_servers.yaml",
+    ]
+    path = next((p for p in candidates if p.exists()), None)
+    if path is None:
+        pytest.skip("mcp_servers.yaml not reachable in this test env")
+    cfg = yaml.safe_load(path.read_text())
+    servers = cfg.get("servers") or cfg.get("mcpServers") or []
+    paperless = next(s for s in servers if s.get("name") == "paperless")
+    tp = paperless.get("tool_permissions", {})
+    assert tp.get("update_document") == "mcp.paperless.write"
+    assert tp.get("search_documents") == "mcp.paperless.read"
+    assert "mcp.paperless.write" in (paperless.get("permissions") or [])

--- a/tests/backend/test_ws_hardening.py
+++ b/tests/backend/test_ws_hardening.py
@@ -1,0 +1,19 @@
+"""WebSocket hardening (login audit #1116, Tier-2 Batch B).
+
+#6 — inbound WS frame size cap. The prod uvicorn launch
+(``k8s/backend.yaml`` args + the Dockerfile CMD) passes
+``--ws-max-size 1000000`` so an oversized frame is dropped at the protocol
+layer before any /ws handler parses it; ``main.py``'s direct uvicorn.run uses
+``settings.ws_max_message_size``. All legitimate inbound frames are small
+(chat = text + attachment IDs; attachments upload via REST; audio streams in
+~KB chunks), so 1 MB is generous.
+"""
+from utils.config import settings
+
+
+def test_ws_max_message_size_value():
+    """Guard the value the launch args hardcode: the k8s/Dockerfile
+    ``--ws-max-size`` is a literal 1000000 (CLI args can't read the config), so
+    if this config changes the launch args (k8s/backend.yaml + Dockerfile) must
+    be updated in lockstep. main.py's uvicorn.run reads the config directly."""
+    assert settings.ws_max_message_size == 1_000_000

--- a/tests/backend/test_ws_hardening.py
+++ b/tests/backend/test_ws_hardening.py
@@ -17,3 +17,33 @@ def test_ws_max_message_size_value():
     if this config changes the launch args (k8s/backend.yaml + Dockerfile) must
     be updated in lockstep. main.py's uvicorn.run reads the config directly."""
     assert settings.ws_max_message_size == 1_000_000
+
+
+# #7 — CSWSH Origin allowlist on the WS handshake.
+
+def _fake_ws(origin=None):
+    from unittest.mock import MagicMock
+    m = MagicMock()
+    m.headers = {"origin": origin} if origin else {}
+    return m
+
+
+def test_ws_origin_allowlist(monkeypatch):
+    """#1116: browser Origin must be in cors_origins; missing Origin (non-browser
+    satellite/device) is allowed; cors_origins='*' skips the check."""
+    from services import websocket_auth as wa
+
+    # dev/permissive: allow everything
+    monkeypatch.setattr(wa.settings, "cors_origins", "*")
+    assert wa._ws_origin_allowed(_fake_ws("https://evil.example")) is True
+
+    # pinned (xidra-style): SPA origin allowed, cross-origin rejected, no-Origin exempt
+    monkeypatch.setattr(wa.settings, "cors_origins", "https://x-ren.local")
+    assert wa._ws_origin_allowed(_fake_ws("https://x-ren.local")) is True
+    assert wa._ws_origin_allowed(_fake_ws("https://evil.example")) is False
+    assert wa._ws_origin_allowed(_fake_ws(None)) is True  # satellite/device: no Origin
+
+    # comma-separated allowlist
+    monkeypatch.setattr(wa.settings, "cors_origins", "https://a.local, https://b.local")
+    assert wa._ws_origin_allowed(_fake_ws("https://b.local")) is True
+    assert wa._ws_origin_allowed(_fake_ws("https://c.local")) is False


### PR DESCRIPTION
## Summary

Die drei prod-riskanten Login-Audit-Härtungen (#1116, Batch B) — jeweils mit den nötigen Sicherheits-Vorabprüfungen:

- **#6 WS-Frame-Size-Cap:** uvicorn `--ws-max-size 1000000` (k8s/backend.yaml + Dockerfile) + `main.py` `ws_max_size=settings.ws_max_message_size` — droppt oversized Inbound-WS-Frames am Protokoll-Layer VOR dem Parsen, deckt alle /ws-Endpoints. **Sicher:** alle legitimen Frames sind klein (Chat = Text+attachment_ids, Attachments via REST; Audio-Chunks ~KB; Satelliten-Frames app-seitig ≤1MB). uvicorn 0.46 unterstützt das Flag (verifiziert → kein Boot-Crash). Cappt nur Inbound.
- **#7 WS-Origin-Check (CSWSH):** `_ws_origin_allowed()` in `authenticate_websocket`. `cors_origins="*"` → skip (Household); **kein Origin = Nicht-Browser (Satellit/Device) → erlaubt**; sonst Origin gegen die CORS-Allowlist. **Live verifiziert:** Household `CORS_ORIGINS=*` → skippt (kein Lockout); xidra `CORS_ORIGINS=https://x-ren.local` = SPA-Origin → SPA passt, Cross-Origin abgelehnt.
- **#2 Paperless read/write-Split:** `tool_permissions` mappt Reads → `mcp.paperless.read`, Mutationen → `mcp.paperless.write` (spiegelt calendar). **Backward-compatible:** der breite `mcp.paperless`-Grant deckt per Wildcard weiter beide → Search bricht nicht; die Write-Restriktion aktiviert erst, wenn eine Rolle auf `mcp.paperless.read` verengt wird (operativer Schritt, auth-on only).

## Deploy-Kontext (prod-riskant, daher getrennt von Batch A)
- **#6:** k8s/backend.yaml-args brauchen `kubectl apply` (nicht nur set-image); main.py/Dockerfile greifen im Image.
- **#7:** greift nur auth-on/pinned-CORS (xidra) — Household `*` skippt. Braucht xidra Browser-WS + (falls vorhanden) Satelliten-E2E.
- **#2:** config/mcp_servers.yaml ist ConfigMap-served → ConfigMap neu + rollout-restart. Nur auth-on. Aktivierung = Rollen auf `mcp.paperless.read` verengen (separater xidra-Ops-Schritt).

## Test plan
- [x] #6: uvicorn-Flag verifiziert (kein Crash); Wert-Guard-Test
- [x] #7: `_ws_origin_allowed`-Unit-Test (`*`/no-origin/match/mismatch/CSV)
- [x] #2: has_mcp_permission-Resolution (read-only ⊬ write, breiter Grant ⊨ beide) + Stanza-Mapping-Guard
- [x] 0 neue Lint-Fehler
- [ ] Post-Merge: Backend-Deploy (inkl. `apply k8s/backend.yaml` für #6-args + ConfigMap für #2) + xidra-WS/Origin-E2E

Refs #1116

🤖 Generated with [Claude Code](https://claude.com/claude-code)