### PR TITLE
feat(auth): HttpOnly-cookie session + CSRF, flag-gated dual-read (#1116)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -326,6 +326,16 @@ LOG_LEVEL=INFO
 # AUTH_ENABLED=false                  # Enable auth (default off for dev)
 # ACCESS_TOKEN_EXPIRE_MINUTES=1440    # 24h
 # REFRESH_TOKEN_EXPIRE_DAYS=30
+# JWT HttpOnly-cookie session (XSS token-theft hardening). Off = byte-identical
+# localStorage-Bearer model. On requires pinned CORS_ORIGINS + AUTH_ENABLED +
+# COOKIE_SECURE (validated at boot). See docs/ENVIRONMENT_VARIABLES.md.
+# AUTH_COOKIE_ENABLED=false
+# AUTH_COOKIE_NAME=renfield_access
+# REFRESH_COOKIE_NAME=renfield_refresh
+# CSRF_COOKIE_NAME=renfield_csrf
+# COOKIE_SECURE=true
+# COOKIE_SAMESITE=lax
+# COOKIE_DOMAIN=                       # empty = host-only (recommended)
 # PASSWORD_MIN_LENGTH=8
 # ALLOW_REGISTRATION=true
 # REQUIRE_EMAIL_VERIFICATION=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,6 +185,54 @@ redirects with only `?code=&state=`; the SPA (`pages/AuthCallback.tsx`,
 is migrated onto `?code=`, then it is removed (cutover in the design doc). Design
 + threat model + cross-repo emitter contract: `docs/design/sso-token-handoff-hardening.md`.
 
+### JWT HttpOnly-cookie session + CSRF (`AUTH_COOKIE_ENABLED`, dark)
+
+Moves the session off `localStorage` (where any XSS steals the 30-day refresh
+token) into an **HttpOnly+Secure+SameSite=Lax cookie** JS can never read, plus a
+stateless **double-submit CSRF** token. **Flag off (default) → byte-identical**
+to the localStorage-Bearer model. Household is auth-off (inert); the real target
+is xidra (auth-on). Backward-compat seam is a **cookie-first-then-Bearer
+dual-read** so the Reva fragment→localStorage→Bearer path, the voice-server
+(`internal_auth.verify`, body+header, cookie-inert), and any legacy client keep
+working while cookies are on. Fully reversible per flag.
+
+- **Reader:** `services/auth_service.py` — `oauth2_scheme` rebound to
+  `_cookie_or_bearer_token` (cookie wins when present, else the `Authorization`
+  header), so all five auth deps become cookie-aware with zero call-site edits.
+- **Issuers set cookies too** (in addition to the unchanged JSON body):
+  `api/routes/auth.py` `_set_auth_cookies` on login/refresh/change-password/
+  sso-exchange; `_clear_auth_cookies` on logout. Refresh **dual-reads** the
+  refresh token (cookie `Path=/api/auth/refresh` → body). Rotation/reuse-
+  detection/blacklist/`token_epoch` all unchanged (they key on the decoded JWT,
+  not its transport).
+- **CSRF:** `main.py` `CSRFMiddleware` (inner of CORS) — enforces `X-CSRF-Token`
+  == the JS-readable `renfield_csrf` cookie (constant-time) ONLY on cookie-authed
+  mutating requests. A Bearer request (no auth cookie) is structurally CSRF-immune
+  → exempt, which also covers first-login, the refresh bootstrap, and
+  `/api/internal/*` (server-to-server, exempt by prefix).
+- **WebSocket:** `services/websocket_auth.py` Strategy-0 reads
+  `websocket.cookies` (a browser auto-sends the cookie on the same-origin WS
+  handshake → no long-lived JWT in the URL); safe because the `_ws_origin_allowed`
+  CSWSH allowlist runs first. The `/api/ws/token` faucet stays. **Voice WS is NOT
+  migrated** (deferred): it authenticates to the external voice-server via
+  `internal_auth.verify`, which needs a full access JWT and rejects `scope:ws` and
+  can't read the cookie — so voice keeps the localStorage JWT during the transition.
+- **Frontend:** `utils/axios.ts` `withCredentials:true` + a CSRF header
+  interceptor (Bearer interceptor kept for the Reva path); `context/AuthContext.tsx`
+  learns cookie-mode from `/api/auth/status` (`auth_cookie_enabled`) and, when on,
+  discovers "logged in?" via `/me` (cookie isn't JS-readable) and refreshes via the
+  HttpOnly cookie instead of gating on a localStorage token.
+- **Validator hard-fails** (`config.py`): `AUTH_COOKIE_ENABLED=true` with
+  `CORS_ORIGINS='*'` (credentialed CORS impossible + WS CSWSH bypass), with
+  `AUTH_ENABLED=false`, or with `COOKIE_SECURE=false` on a prod/staging env.
+- **Deferred** (own follow-ups): removing the SSO fragment handler / `?code=`
+  emitter wiring (= SSO cutover, needs Reva); retiring `/api/ws/token` + the
+  Bearer interceptor; migrating the voice WS. **Not touched:** `SECRET_KEY`
+  (tri-purpose: JWT + Fernet-at-rest + BLE IRK — no split/rotation).
+  Env: `AUTH_COOKIE_ENABLED`/`AUTH_COOKIE_NAME`/`REFRESH_COOKIE_NAME`/
+  `CSRF_COOKIE_NAME`/`COOKIE_SECURE`/`COOKIE_SAMESITE`/`COOKIE_DOMAIN`
+  (`docs/ENVIRONMENT_VARIABLES.md`).
+
 ### Circles v1 (access tiers)
 
 Detailed user-facing and architectural documentation: [`docs/CIRCLES.md`](docs/CIRCLES.md). Narrative of the broader knowledge system (the four subsystems circles protect): [`docs/SECOND_BRAIN.md`](docs/SECOND_BRAIN.md). Code-level summary below.

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -1712,7 +1712,8 @@ Jetzt ein **getracktes Settings-Feld** (#697, vorher nur via `os.getenv` gelesen
 
 **Konsistenz-Assertion (#697, `assert_auth_config_consistency`):**
 - **HARTER Boot-Fehler:** `AUTH_ENABLED=true` mit `WS_AUTH_ENABLED=false` — der WebSocket-Chat wäre unauthentifiziert und der WS-Session-Ownership-Check (#657) still deaktiviert. Beide Flags müssen gemeinsam an.
-- **WARN (nicht fatal):** `AUTH_ENABLED=true` mit `CORS_ORIGINS='*'`; `RENFIELD_ENV=production` mit `ALLOW_REGISTRATION=true`.
+- **HARTER Boot-Fehler (Cookie-Session):** `AUTH_COOKIE_ENABLED=true` mit (a) `CORS_ORIGINS='*'` (credentialed CORS unmöglich → Cookies würden nicht gesendet, und die WS-CSWSH-Origin-Allowlist wäre umgangen), (b) `AUTH_ENABLED=false` (Cookie-Session ohne Auth sinnlos), oder (c) `COOKIE_SECURE=false` auf `RENFIELD_ENV=production/prod/staging` (Session-Cookie über Klartext-HTTP).
+- **WARN (nicht fatal):** `AUTH_ENABLED=true` mit `CORS_ORIGINS='*'` (nur wenn Cookie-Mode AUS — mit Cookies ist es ein harter Fehler); `RENFIELD_ENV=production` mit `ALLOW_REGISTRATION=true`.
 - Bei der aktuellen Auth-off-Posture (alles false) greift nichts — byte-identisch.
 
 ### Authentication (RPBAC)
@@ -1724,6 +1725,23 @@ AUTH_ENABLED=false
 # JWT Token Gültigkeitsdauer
 ACCESS_TOKEN_EXPIRE_MINUTES=1440       # 24 Stunden
 REFRESH_TOKEN_EXPIRE_DAYS=30
+
+# === JWT HttpOnly-Cookie-Session (XSS-Token-Diebstahl-Härtung) ===
+# Master-Switch. AUS (Default) → byte-identisch zum localStorage-Bearer-Modell
+# (keine Cookies, Token-Reader fällt auf den Authorization-Header zurück, CSRF-
+# Middleware no-op). AN → die Token-Issuer setzen ZUSÄTZLICH HttpOnly-Cookies
+# (denselben JWT wie der Body), der Reader bevorzugt das Cookie, und CSRF wird
+# auf cookie-authentifizierten mutierenden Requests erzwungen. Der Bearer-/Reva-
+# Fragment-/voice-server-Pfad läuft weiter (Dual-Read). VORAUSSETZUNG (Validator
+# harter Boot-Fehler): gepinnte CORS_ORIGINS (kein '*') + AUTH_ENABLED=true +
+# COOKIE_SECURE=true (in prod/staging). Voll reversibel per Flag.
+AUTH_COOKIE_ENABLED=false
+AUTH_COOKIE_NAME=renfield_access        # HttpOnly Access-Cookie, Path=/
+REFRESH_COOKIE_NAME=renfield_refresh    # HttpOnly Refresh-Cookie, Path=/api/auth/refresh
+CSRF_COOKIE_NAME=renfield_csrf          # JS-lesbares Double-Submit-Token
+COOKIE_SECURE=true                      # Secure-Flag (nur HTTPS)
+COOKIE_SAMESITE=lax                     # lax = OIDC-Redirect + <a>-Downloads funktionieren weiter
+# COOKIE_DOMAIN=                        # leer = host-only (empfohlen)
 
 # Passwort-Policy
 PASSWORD_MIN_LENGTH=8

--- a/src/backend/api/routes/auth.py
+++ b/src/backend/api/routes/auth.py
@@ -8,9 +8,10 @@ Provides endpoints for user authentication:
 - Me (get current user info)
 """
 import hmac
+import secrets
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile, status
+from fastapi import APIRouter, Depends, File, HTTPException, Request, Response, UploadFile, status
 from fastapi.security import OAuth2PasswordRequestForm
 from loguru import logger
 from pydantic import BaseModel, EmailStr, Field
@@ -40,6 +41,78 @@ router = APIRouter()
 
 
 # =============================================================================
+# HttpOnly-cookie session helpers (JWT cookie migration)
+# =============================================================================
+# The token issuers below ALSO set these cookies (in addition to the JSON body,
+# which stays for backward-compat) when auth_cookie_enabled. The cookie carries
+# the SAME JWT the body returns — it is purely an additional, XSS-safe transport.
+
+def _set_auth_cookies(
+    response: Response | None,
+    *,
+    access_token: str,
+    refresh_token: str | None = None,
+) -> None:
+    """Set the HttpOnly access (+ optional refresh) cookie and a JS-readable
+    double-submit CSRF cookie. No-op unless ``auth_cookie_enabled``. ``response``
+    is None only on direct unit calls (FastAPI always injects it on a request)."""
+    if not settings.auth_cookie_enabled or response is None:
+        return
+    common = dict(
+        secure=settings.cookie_secure,
+        samesite=settings.cookie_samesite,
+        domain=settings.cookie_domain,
+    )
+    # Access: sent on every request (Path=/), HttpOnly so JS/XSS can't read it.
+    response.set_cookie(
+        settings.auth_cookie_name,
+        access_token,
+        httponly=True,
+        path="/",
+        max_age=settings.access_token_expire_minutes * 60,
+        **common,
+    )
+    # Refresh: scoped to the refresh endpoint so it's never sent elsewhere.
+    if refresh_token is not None:
+        response.set_cookie(
+            settings.refresh_cookie_name,
+            refresh_token,
+            httponly=True,
+            path="/api/auth/refresh",
+            max_age=settings.refresh_token_expire_days * 86400,
+            **common,
+        )
+    # CSRF: NOT HttpOnly — the SPA reads it and echoes it as X-CSRF-Token; the
+    # middleware compares header == cookie (stateless double-submit).
+    response.set_cookie(
+        settings.csrf_cookie_name,
+        secrets.token_urlsafe(32),
+        httponly=False,
+        path="/",
+        max_age=settings.access_token_expire_minutes * 60,
+        **common,
+    )
+
+
+def _clear_auth_cookies(response: Response | None) -> None:
+    """Expire all three session cookies (logout). No-op unless enabled."""
+    if not settings.auth_cookie_enabled or response is None:
+        return
+    for name, path in (
+        (settings.auth_cookie_name, "/"),
+        (settings.refresh_cookie_name, "/api/auth/refresh"),
+        (settings.csrf_cookie_name, "/"),
+    ):
+        response.delete_cookie(
+            name,
+            path=path,
+            domain=settings.cookie_domain,
+            secure=settings.cookie_secure,
+            samesite=settings.cookie_samesite,
+        )
+
+
+# =============================================================================
 # Request/Response Models
 # =============================================================================
 
@@ -56,8 +129,12 @@ class TokenResponse(BaseModel):
 
 
 class RefreshRequest(BaseModel):
-    """Request model for token refresh."""
-    refresh_token: str
+    """Request model for token refresh. The token is OPTIONAL so a cookie-mode
+    client can POST an empty/absent body and let the handler read the HttpOnly
+    refresh cookie: a *present* body `{}` with a required field would 422 at the
+    validation layer BEFORE the handler's cookie dual-read runs (only an omitted
+    body maps to None). Presence is validated in-handler."""
+    refresh_token: str | None = None
 
 
 class LogoutRequest(BaseModel):
@@ -123,6 +200,10 @@ class AuthStatusResponse(BaseModel):
     authenticated: bool
     user: UserResponse | None = None
     features: dict[str, bool] = {}
+    # HttpOnly-cookie session mode (JWT cookie migration). The SPA reads this to
+    # decide whether "logged in?" is discovered via /me (cookie, not JS-readable)
+    # vs the legacy localStorage-token gate. Off → byte-identical legacy behavior.
+    auth_cookie_enabled: bool = False
 
 
 # =============================================================================
@@ -134,7 +215,8 @@ class AuthStatusResponse(BaseModel):
 async def login(
     request: Request,
     form_data: OAuth2PasswordRequestForm = Depends(),
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    response: Response = None,
 ):
     """
     Authenticate user and return JWT tokens.
@@ -236,6 +318,8 @@ async def login(
         f"(provider={outcome.provider_id})"
     )
 
+    _set_auth_cookies(response, access_token=access_token, refresh_token=refresh_token)
+
     return TokenResponse(
         access_token=access_token,
         refresh_token=refresh_token,
@@ -249,15 +333,30 @@ async def login(
 @limiter.limit(settings.api_rate_limit_auth)
 async def refresh_token(
     request: Request,
-    refresh_request: RefreshRequest,
-    db: AsyncSession = Depends(get_db)
+    refresh_request: RefreshRequest | None = None,
+    db: AsyncSession = Depends(get_db),
+    response: Response = None,
 ):
     """
     Get a new access token using a refresh token.
 
     Refresh tokens are long-lived and can only be used to get new access tokens.
+    Dual-read: the HttpOnly refresh cookie is preferred when auth_cookie_enabled,
+    else the request body (Bearer/legacy clients) — so both models keep working.
     """
-    payload = decode_token(refresh_request.refresh_token)
+    refresh_jwt: str | None = None
+    if settings.auth_cookie_enabled:
+        refresh_jwt = request.cookies.get(settings.refresh_cookie_name)
+    if not refresh_jwt and refresh_request is not None:
+        refresh_jwt = refresh_request.refresh_token
+    if not refresh_jwt:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid refresh token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    payload = decode_token(refresh_jwt)
 
     if not payload:
         raise HTTPException(
@@ -332,6 +431,8 @@ async def refresh_token(
     )
     new_refresh_token = create_refresh_token(user.id, token_epoch=user.token_epoch)
 
+    _set_auth_cookies(response, access_token=access_token, refresh_token=new_refresh_token)
+
     return TokenResponse(
         access_token=access_token,
         refresh_token=new_refresh_token,
@@ -350,6 +451,7 @@ async def sso_exchange(
     request: Request,
     exchange: SsoExchangeRequest,
     db: AsyncSession = Depends(get_db),
+    response: Response = None,
 ):
     """Exchange a one-time SSO hand-off code for the session tokens.
 
@@ -394,6 +496,9 @@ async def sso_exchange(
     refresh_token = create_refresh_token(user.id, token_epoch=user.token_epoch)
 
     logger.info(f"SSO hand-off exchanged: user={user.username} provider={session.provider!r}")
+    # Set cookies too, so when Reva's emitter flips to ?code= the exchange lands
+    # cookie-native for free (the fragment→localStorage path stays for now).
+    _set_auth_cookies(response, access_token=access_token, refresh_token=refresh_token)
     return TokenResponse(
         access_token=access_token,
         refresh_token=refresh_token,
@@ -505,7 +610,8 @@ async def get_current_user_info(
 async def change_password(
     request: ChangePasswordRequest,
     user: User = Depends(require_auth),
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    response: Response = None,
 ):
     """
     Change the current user's password.
@@ -571,6 +677,10 @@ async def change_password(
 
     logger.info(f"Password changed for user: {user.username} (all other sessions revoked)")
 
+    # Re-set cookies with the fresh pair so THIS device stays logged in; other
+    # devices' cookies are now epoch-stale and rejected at get_current_user.
+    _set_auth_cookies(response, access_token=access_token, refresh_token=refresh_token)
+
     return {
         "message": "Password changed successfully",
         "access_token": access_token,
@@ -585,6 +695,8 @@ async def logout(
     user: User = Depends(require_auth),
     token: str = Depends(oauth2_scheme),
     logout_request: LogoutRequest | None = None,
+    request: Request = None,
+    response: Response = None,
 ):
     """
     Logout the current user by revoking their access token AND, when supplied,
@@ -617,12 +729,17 @@ async def logout(
         if ttl > 0 and not await token_blacklist.add(jti, ttl):
             write_failed = True
 
+    # The refresh token to revoke: body (Bearer clients) or the HttpOnly cookie.
+    refresh_to_revoke = logout_request.refresh_token if logout_request else None
+    if not refresh_to_revoke and settings.auth_cookie_enabled and request is not None:
+        refresh_to_revoke = request.cookies.get(settings.refresh_cookie_name)
+
     # Revoke the REFRESH token first (audit review): it is the long-lived
     # replay risk (30d), so if the blacklist write fails partway we must not have
     # already burned the access-token write (which would 401 the retry at
     # require_auth while leaving the refresh token live). Refresh first → a 503
     # retry can still reach here to revoke it.
-    await _revoke(logout_request.refresh_token if logout_request else None, "refresh")
+    await _revoke(refresh_to_revoke, "refresh")
     # ...then the access token authenticating this request.
     await _revoke(token, "access")
 
@@ -631,6 +748,9 @@ async def logout(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Logout could not be completed — revocation store unavailable, please retry",
         )
+
+    # Expire the session cookies on this device (no-op unless cookie mode is on).
+    _clear_auth_cookies(response)
 
     logger.info(f"User logged out: {user.username}")
     return {"message": "Successfully logged out"}
@@ -675,7 +795,8 @@ async def get_auth_status(
         allow_registration=settings.allow_registration,
         authenticated=user is not None,
         user=user_response,
-        features=settings.features
+        features=settings.features,
+        auth_cookie_enabled=settings.auth_cookie_enabled,
     )
 
 

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -2,6 +2,7 @@
 Renfield - Persönlicher KI-Assistent
 Hauptanwendung mit FastAPI
 """
+import hmac
 import os
 import sys
 from datetime import UTC, datetime
@@ -156,7 +157,49 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         return response
 
 
+class CSRFMiddleware(BaseHTTPMiddleware):
+    """Double-submit CSRF guard for the HttpOnly-cookie session (JWT cookie
+    migration). No-op unless ``auth_cookie_enabled``.
+
+    Enforced ONLY when the request is authenticated via the auth **cookie** AND
+    the method is mutating: the SPA echoes the JS-readable ``renfield_csrf``
+    cookie as ``X-CSRF-Token`` and this compares header == cookie (constant
+    time). A Bearer request carries no ambient credential (an attacker's page
+    can't read our localStorage) → structurally CSRF-immune → exempt, which also
+    covers first-login (no cookie yet), the refresh bootstrap after cookie
+    expiry, and every legacy client. ``/api/internal/*`` (server-to-server, no
+    browser) is exempt defensively. Safe methods and CORS preflight pass through.
+    """
+
+    _SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE"})
+    _EXEMPT_PREFIXES = ("/api/internal/",)
+
+    async def dispatch(self, request: Request, call_next):
+        if (
+            settings.auth_cookie_enabled
+            and request.method not in self._SAFE_METHODS
+            and not request.url.path.startswith(self._EXEMPT_PREFIXES)
+            and request.cookies.get(settings.auth_cookie_name)  # cookie-authed only
+        ):
+            header = request.headers.get("X-CSRF-Token")
+            cookie = request.cookies.get(settings.csrf_cookie_name)
+            # Encode both to bytes: hmac.compare_digest raises TypeError on a
+            # non-ASCII str (a crafted header), which would surface as a 500.
+            if (
+                not header
+                or not cookie
+                or not hmac.compare_digest(header.encode("utf-8"), cookie.encode("utf-8"))
+            ):
+                return JSONResponse(
+                    status_code=403,
+                    content={"detail": "CSRF token missing or invalid"},
+                )
+        return await call_next(request)
+
+
 app.add_middleware(SecurityHeadersMiddleware)
+# CSRF guard (inner of CORS so preflight OPTIONS is handled by CORS first).
+app.add_middleware(CSRFMiddleware)
 
 # CORS Middleware - configured via settings
 _cors_origins = (
@@ -168,7 +211,7 @@ app.add_middleware(
     allow_origins=_cors_origins,
     allow_credentials=settings.cors_origins != "*",
     allow_methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
-    allow_headers=["Authorization", "Content-Type", "X-Request-ID"],
+    allow_headers=["Authorization", "Content-Type", "X-Request-ID", "X-CSRF-Token"],
 )
 
 # Prometheus Metrics (opt-in via METRICS_ENABLED=true)

--- a/src/backend/services/auth_service.py
+++ b/src/backend/services/auth_service.py
@@ -34,9 +34,39 @@ pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 # import (a single bcrypt round) to stay valid against the live bcrypt backend.
 _DUMMY_PASSWORD_HASH = pwd_context.hash("renfield-login-timing-equalizer")
 
-# OAuth2 scheme for token extraction
-# tokenUrl is the endpoint where users can get a token
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/login", auto_error=False)
+# OAuth2 scheme for token extraction (the Authorization: Bearer header). Kept as
+# the private base extractor; the public `oauth2_scheme` dependency below reads a
+# cookie first (JWT HttpOnly-cookie migration). tokenUrl is where a token is minted.
+_bearer_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/login", auto_error=False)
+
+
+async def _cookie_or_bearer_token(request: Request) -> str | None:
+    """Resolve the access token cookie-first, then Bearer header.
+
+    When ``auth_cookie_enabled`` and the HttpOnly access cookie is present it
+    wins; otherwise fall back to ``Authorization: Bearer`` — so the Reva
+    fragment→localStorage→Bearer path, the voice-server, and any legacy client
+    keep working (the migration's backward-compat seam). Stamps
+    ``request.state.auth_via`` (``cookie``/``bearer``/``none``) so the CSRF
+    middleware can exempt Bearer (structurally CSRF-immune) requests. Never
+    raises (mirrors ``auto_error=False``): returns ``None`` when no token.
+    Flag off → behaves exactly like the bare bearer scheme.
+    """
+    if settings.auth_cookie_enabled:
+        cookie_token = request.cookies.get(settings.auth_cookie_name)
+        if cookie_token:
+            request.state.auth_via = "cookie"
+            return cookie_token
+    bearer = await _bearer_scheme(request)
+    request.state.auth_via = "bearer" if bearer else "none"
+    return bearer
+
+
+# The dependency every auth dependency injects. Rebinding it here (instead of the
+# raw OAuth2PasswordBearer) makes all of get_current_user/get_optional_user/
+# require_auth/require_permission/get_user_or_default cookie-aware with zero
+# call-site edits.
+oauth2_scheme = _cookie_or_bearer_token
 
 # JWT configuration
 ALGORITHM = "HS256"

--- a/src/backend/services/auth_service.py
+++ b/src/backend/services/auth_service.py
@@ -46,20 +46,16 @@ async def _cookie_or_bearer_token(request: Request) -> str | None:
     When ``auth_cookie_enabled`` and the HttpOnly access cookie is present it
     wins; otherwise fall back to ``Authorization: Bearer`` — so the Reva
     fragment→localStorage→Bearer path, the voice-server, and any legacy client
-    keep working (the migration's backward-compat seam). Stamps
-    ``request.state.auth_via`` (``cookie``/``bearer``/``none``) so the CSRF
-    middleware can exempt Bearer (structurally CSRF-immune) requests. Never
-    raises (mirrors ``auto_error=False``): returns ``None`` when no token.
-    Flag off → behaves exactly like the bare bearer scheme.
+    keep working (the migration's backward-compat seam). Never raises (mirrors
+    ``auto_error=False``): returns ``None`` when no token. Flag off → behaves
+    exactly like the bare bearer scheme. (The CSRF middleware independently
+    re-derives cookie-vs-bearer from access-cookie presence on the raw request.)
     """
     if settings.auth_cookie_enabled:
         cookie_token = request.cookies.get(settings.auth_cookie_name)
         if cookie_token:
-            request.state.auth_via = "cookie"
             return cookie_token
-    bearer = await _bearer_scheme(request)
-    request.state.auth_via = "bearer" if bearer else "none"
-    return bearer
+    return await _bearer_scheme(request)
 
 
 # The dependency every auth dependency injects. Rebinding it here (instead of the

--- a/src/backend/services/websocket_auth.py
+++ b/src/backend/services/websocket_auth.py
@@ -166,6 +166,15 @@ async def authenticate_websocket(
     if not settings.ws_auth_enabled:
         return {"authenticated": True, "auth_skipped": True}
 
+    # Strategy 0: the HttpOnly access cookie (JWT cookie migration). A browser
+    # auto-attaches it on the same-origin WS handshake, so browsers need no
+    # ?token= in the URL (no long-lived JWT in proxy logs). Safe because the
+    # CSWSH Origin allowlist above already ran and only a pinned-origin deploy
+    # enables cookies. Only when auth_cookie_enabled and no explicit query /
+    # first-message token was supplied.
+    if not token and settings.auth_cookie_enabled:
+        token = websocket.cookies.get(settings.auth_cookie_name)
+
     # Fallback: read token from Authorization header if not provided via query
     if not token:
         auth_header = websocket.headers.get("authorization", "")

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -1163,6 +1163,21 @@ class Settings(BaseSettings):
     access_token_expire_minutes: int = 60 * 24  # 24 hours
     refresh_token_expire_days: int = 30
 
+    # === JWT HttpOnly-cookie session (XSS token-theft hardening) ===
+    # Master switch. OFF (default) → byte-identical to the localStorage-Bearer
+    # model: no cookies are set, the token reader falls back to the Authorization
+    # header, the CSRF middleware no-ops. ON → token issuers ALSO set HttpOnly
+    # cookies, the reader prefers the cookie, and CSRF is enforced on
+    # cookie-authenticated mutating requests. Requires a pinned cors_origins and
+    # auth_enabled (validated). Reva/voice/Bearer paths keep working (dual-read).
+    auth_cookie_enabled: bool = False
+    auth_cookie_name: str = "renfield_access"        # HttpOnly access, Path=/
+    refresh_cookie_name: str = "renfield_refresh"    # HttpOnly refresh, Path=/api/auth/refresh
+    csrf_cookie_name: str = "renfield_csrf"          # JS-readable double-submit token
+    cookie_secure: bool = True                       # Secure flag (HTTPS-only)
+    cookie_samesite: str = "lax"                     # lax = OIDC redirect + <a> downloads keep working
+    cookie_domain: str | None = None                 # None = host-only (recommended)
+
     # SSO token hand-off hardening — replaces the URL-fragment token hand-off
     # (implicit flow) with a one-time, single-use, PKCE-bound code exchanged over
     # POST (a token never rides in a URL). Gates POST /api/auth/sso/exchange
@@ -1679,13 +1694,41 @@ class Settings(BaseSettings):
                 "(refusing to start with a phantom security control)."
             )
 
-        if self.auth_enabled and self.cors_origins.strip() == "*":
+        env = self.renfield_env.lower()
+
+        # HARD FAIL — cookie session with a broken/unsafe posture. Cookies need
+        # credentialed CORS (impossible with a wildcard origin) AND the WS Origin
+        # allowlist as the CSWSH guard (also defeated by a wildcard); they are
+        # meaningless with auth off; and a non-Secure cookie leaks the session on
+        # plain HTTP. Refuse to boot rather than run a broken/insecure cookie mode.
+        if self.auth_cookie_enabled:
+            if self.cors_origins.strip() == "*":
+                raise ValueError(
+                    "Inconsistent auth config: AUTH_COOKIE_ENABLED=true with "
+                    "CORS_ORIGINS='*' — credentialed CORS is impossible with a "
+                    "wildcard origin (cookies won't be sent) and the WS CSWSH "
+                    "Origin allowlist is skipped. Pin CORS_ORIGINS to the "
+                    "frontend origin(s) before enabling cookie auth."
+                )
+            if not self.auth_enabled:
+                raise ValueError(
+                    "Inconsistent auth config: AUTH_COOKIE_ENABLED=true with "
+                    "AUTH_ENABLED=false — a cookie session is meaningless without "
+                    "authentication. Enable AUTH_ENABLED or disable cookie auth."
+                )
+            if not self.cookie_secure and env in {"production", "prod", "staging"}:
+                raise ValueError(
+                    "Inconsistent auth config: AUTH_COOKIE_ENABLED=true with "
+                    f"COOKIE_SECURE=false on RENFIELD_ENV={self.renfield_env!r} — "
+                    "the session cookie would be sent over plain HTTP. Set "
+                    "COOKIE_SECURE=true (only relax it in a dev env)."
+                )
+        elif self.auth_enabled and self.cors_origins.strip() == "*":
             logger.warning(
                 "⚠ AUTH_ENABLED=true with CORS_ORIGINS='*' (wildcard). A real "
                 "deployment should pin CORS_ORIGINS to the frontend origin(s)."
             )
 
-        env = self.renfield_env.lower()
         if env in {"production", "prod", "staging"} and self.allow_registration:
             logger.warning(
                 f"⚠ RENFIELD_ENV={self.renfield_env!r} with ALLOW_REGISTRATION=true "

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -1723,6 +1723,12 @@ class Settings(BaseSettings):
                     "the session cookie would be sent over plain HTTP. Set "
                     "COOKIE_SECURE=true (only relax it in a dev env)."
                 )
+            if self.cookie_samesite.lower() not in {"lax", "strict", "none"}:
+                raise ValueError(
+                    "Invalid COOKIE_SAMESITE="
+                    f"{self.cookie_samesite!r} — must be one of lax/strict/none "
+                    "(a typo would 500 at Set-Cookie time, not boot)."
+                )
         elif self.auth_enabled and self.cors_origins.strip() == "*":
             logger.warning(
                 "⚠ AUTH_ENABLED=true with CORS_ORIGINS='*' (wildcard). A real "

--- a/src/frontend/src/context/AuthContext.tsx
+++ b/src/frontend/src/context/AuthContext.tsx
@@ -4,7 +4,7 @@
  * Provides global authentication state and methods for login/logout.
  * Handles JWT token storage and automatic refresh.
  */
-import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react';
+import { createContext, useContext, useState, useEffect, useCallback, useRef, ReactNode } from 'react';
 import apiClient from '../utils/axios';
 import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from '../utils/authTokens';
 import type { User, LoginResponse } from '../types/api';
@@ -46,6 +46,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const [authEnabled, setAuthEnabled] = useState(false);
   const [allowRegistration, setAllowRegistration] = useState(false);
   const [features, setFeatures] = useState<Record<string, boolean>>({});
+  // HttpOnly-cookie session mode (JWT cookie migration), learned from
+  // /api/auth/status. A ref (not state) so fetchUser/refresh — defined below and
+  // memoized — read the current value without re-creating on every render. When
+  // on, "logged in?" is discovered via /me (the cookie isn't JS-readable) and
+  // refresh relies on the HttpOnly refresh cookie; off → legacy localStorage gates.
+  const cookieAuthRef = useRef(false);
 
   // Get stored tokens
   const getAccessToken = useCallback(() => localStorage.getItem(ACCESS_TOKEN_KEY), []);
@@ -95,12 +101,18 @@ export function AuthProvider({ children }: AuthProviderProps) {
   // Refresh access token
   const refreshAccessToken = useCallback(async (): Promise<boolean> => {
     const refreshToken = getRefreshToken();
-    if (!refreshToken) return false;
+    // Cookie mode: no localStorage refresh token, but the HttpOnly refresh cookie
+    // rides the request (backend dual-reads). Legacy mode: bail early without a
+    // token (byte-identical to before).
+    if (!refreshToken && !cookieAuthRef.current) return false;
 
     try {
-      const response = await apiClient.post('/api/auth/refresh', {
-        refresh_token: refreshToken
-      });
+      // No body in cookie mode (send undefined, NOT {}): a present `{}` would
+      // 422 at FastAPI validation before the handler reads the refresh cookie.
+      const response = await apiClient.post(
+        '/api/auth/refresh',
+        refreshToken ? { refresh_token: refreshToken } : undefined
+      );
       setTokens(response.data.access_token, response.data.refresh_token);
       return true;
     } catch {
@@ -112,16 +124,19 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   // Fetch current user info
   const fetchUser = useCallback(async (): Promise<AuthUser | null> => {
+    // Cookie mode: the session lives in an HttpOnly cookie JS can't read, so we
+    // must ASK /me rather than gate on a localStorage token. Legacy mode: keep
+    // the token-present short-circuit (no wasted /me on the logged-out login page).
     const token = getAccessToken();
-    if (!token) {
+    if (!token && !cookieAuthRef.current) {
       setUser(null);
       return null;
     }
 
     try {
-      const response = await apiClient.get('/api/auth/me', {
-        headers: { Authorization: `Bearer ${token}` }
-      });
+      // No explicit Authorization header: the axios interceptor attaches the
+      // localStorage Bearer if present, else the cookie carries auth.
+      const response = await apiClient.get('/api/auth/me');
       setUser(response.data);
       return response.data;
     } catch (error: unknown) {
@@ -220,6 +235,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         setAuthEnabled(response.data.auth_enabled);
         setAllowRegistration(response.data.allow_registration);
         setFeatures(response.data.features || {});
+        cookieAuthRef.current = !!response.data.auth_cookie_enabled;
 
         if (response.data.auth_enabled) {
           await fetchUser();
@@ -264,7 +280,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
           originalRequest._retry = true;
           const refreshed = await refreshAccessToken();
           if (refreshed) {
-            originalRequest.headers.Authorization = `Bearer ${getAccessToken()}`;
+            // Legacy: re-attach the fresh Bearer. Cookie mode: the Set-Cookie
+            // from /refresh already re-armed the session; don't set "Bearer null".
+            const fresh = getAccessToken();
+            if (fresh) {
+              originalRequest.headers.Authorization = `Bearer ${fresh}`;
+            }
             return apiClient(originalRequest);
           }
         }

--- a/src/frontend/src/context/AuthContext.tsx
+++ b/src/frontend/src/context/AuthContext.tsx
@@ -62,7 +62,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
     if (accessToken) {
       localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
     }
-    if (refreshToken) {
+    // Cookie mode: the 30-day refresh token — the real XSS target — lives ONLY
+    // in the HttpOnly cookie; never persist it to localStorage. The 24h access
+    // token is still stored (the voice WS reads it — its migration is deferred —
+    // and the Bearer dual-read needs it); full elimination awaits that follow-up.
+    if (refreshToken && !cookieAuthRef.current) {
       localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
     }
   }, []);
@@ -276,7 +280,13 @@ export function AuthProvider({ children }: AuthProviderProps) {
       async (error) => {
         const originalRequest = error.config;
 
-        if (error.response?.status === 401 && !originalRequest._retry && authEnabled) {
+        // Never attempt refresh-on-401 for the refresh endpoint itself: a 401
+        // from /api/auth/refresh (logged out / expired refresh cookie) would
+        // otherwise recurse into another refresh POST on every 401 until the
+        // auth rate-limiter 429s — which then blocks the user's legitimate login.
+        const isRefreshCall = (originalRequest?.url || '').includes('/api/auth/refresh');
+
+        if (error.response?.status === 401 && !originalRequest._retry && authEnabled && !isRefreshCall) {
           originalRequest._retry = true;
           const refreshed = await refreshAccessToken();
           if (refreshed) {

--- a/src/frontend/src/utils/axios.ts
+++ b/src/frontend/src/utils/axios.ts
@@ -3,10 +3,23 @@ import axios, { AxiosInstance, InternalAxiosRequestConfig, AxiosResponse, AxiosE
 import { getApiBaseUrl } from './env';
 import { ACCESS_TOKEN_KEY } from './authTokens';
 
+// JS-readable double-submit CSRF cookie name (must match backend csrf_cookie_name).
+const CSRF_COOKIE_NAME = 'renfield_csrf';
+const MUTATING_METHODS = new Set(['post', 'put', 'patch', 'delete']);
+
+function readCookie(name: string): string | null {
+  const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
 // Axios Instance mit Base URL
 const apiClient: AxiosInstance = axios.create({
   baseURL: getApiBaseUrl(),
   timeout: 30000,
+  // Send the HttpOnly session cookie on every request (JWT cookie migration).
+  // Harmless in the localStorage-Bearer era: no cookie is set until the backend
+  // auth_cookie_enabled flag is on, so nothing is sent.
+  withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
   }
@@ -25,9 +38,21 @@ const apiClient: AxiosInstance = axios.create({
 // that ordering dependency entirely.
 apiClient.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
+    // Bearer from localStorage — KEPT during the cookie transition so the Reva
+    // fragment→localStorage path and any pre-cutover client still authenticate.
+    // When cookie mode is on the backend reads the cookie first; the header is
+    // a harmless no-op (no token stored).
     const token = localStorage.getItem(ACCESS_TOKEN_KEY);
     if (token && !config.headers.Authorization) {
       config.headers.Authorization = `Bearer ${token}`;
+    }
+    // Double-submit CSRF: echo the JS-readable csrf cookie on mutating requests.
+    // No-op when the cookie is absent (Bearer/household → CSRF middleware exempt).
+    if (MUTATING_METHODS.has((config.method || 'get').toLowerCase())) {
+      const csrf = readCookie(CSRF_COOKIE_NAME);
+      if (csrf && !config.headers['X-CSRF-Token']) {
+        config.headers['X-CSRF-Token'] = csrf;
+      }
     }
     return config;
   },

--- a/tests/backend/test_auth_cookies.py
+++ b/tests/backend/test_auth_cookies.py
@@ -83,7 +83,6 @@ class TestTokenReader:
         req = _fake_request(cookies={"renfield_access": "COOKIEJWT"},
                             auth_header="Bearer HEADERJWT")
         assert await a._cookie_or_bearer_token(req) == "COOKIEJWT"
-        assert req.state.auth_via == "cookie"
 
     async def test_falls_back_to_bearer(self, monkeypatch):
         from services import auth_service as a
@@ -91,14 +90,12 @@ class TestTokenReader:
         monkeypatch.setattr(a.settings, "auth_cookie_name", "renfield_access")
         req = _fake_request(cookies={}, auth_header="Bearer HEADERJWT")
         assert await a._cookie_or_bearer_token(req) == "HEADERJWT"
-        assert req.state.auth_via == "bearer"
 
     async def test_flag_off_ignores_cookie(self, monkeypatch):
         from services import auth_service as a
         monkeypatch.setattr(a.settings, "auth_cookie_enabled", False)
         req = _fake_request(cookies={"renfield_access": "COOKIEJWT"}, auth_header=None)
         assert await a._cookie_or_bearer_token(req) is None
-        assert req.state.auth_via == "none"
 
 
 # =============================================================================
@@ -211,6 +208,59 @@ class TestCsrfMiddleware:
         c = _csrf_client(monkeypatch, enabled=False)
         c.cookies.set("renfield_access", "A")
         assert c.post("/api/x").status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_non_ascii_csrf_header_403_not_500(self, monkeypatch):
+        # The fix-2 regression: compare_digest on a non-ASCII str would TypeError
+        # → 500. With bytes-encoding it's a clean mismatch → 403. Call dispatch
+        # directly with a latin-1 header value (as Starlette hands it to the
+        # middleware on a real server) — httpx's TestClient rejects non-ASCII
+        # header values client-side, so it can't exercise this path.
+        import main as m
+        from main import CSRFMiddleware
+        monkeypatch.setattr(m.settings, "auth_cookie_enabled", True)
+        mw = CSRFMiddleware(app=None)
+        req = SimpleNamespace(
+            method="POST",
+            url=SimpleNamespace(path="/api/x"),
+            cookies={"renfield_access": "A", "renfield_csrf": "TOK"},
+            headers={"X-CSRF-Token": "café"},
+        )
+
+        async def _call_next(_r):
+            raise AssertionError("handler must not be reached on a CSRF failure")
+
+        resp = await mw.dispatch(req, _call_next)
+        assert resp.status_code == 403
+
+
+@pytest.mark.unit
+def test_set_cookies_emits_real_setcookie(monkeypatch):
+    """End-to-end helper wiring: a real fastapi Response actually gets the three
+    Set-Cookie headers with the right attributes (the MagicMock test only checks
+    the call, this checks the emitted headers)."""
+    from api.routes import auth as ar
+    monkeypatch.setattr(ar.settings, "auth_cookie_enabled", True)
+    r = Response()
+    ar._set_auth_cookies(r, access_token="AAA", refresh_token="RRR")
+    emitted = " | ".join(v.decode() for k, v in r.raw_headers if k == b"set-cookie")
+    assert "renfield_access=AAA" in emitted and "httponly" in emitted.lower()
+    assert "renfield_refresh=RRR" in emitted and "/api/auth/refresh" in emitted
+    assert "renfield_csrf=" in emitted
+
+
+@pytest.mark.asyncio
+async def test_ws_scoped_token_rejected_on_rest(monkeypatch):
+    """A scope='ws' token delivered via the access cookie must NOT authenticate
+    the REST API (only the WS handshake) — get_current_user rejects it before any
+    DB use, so db=None is safe here."""
+    from fastapi import HTTPException
+    from services import auth_service as a
+    monkeypatch.setattr(a.settings, "auth_enabled", True)
+    ws_token = a.create_ws_token_jwt(user_id=1, token_epoch=0)
+    with pytest.raises(HTTPException) as exc:
+        await a.get_current_user(token=ws_token, db=None, request=None)
+    assert exc.value.status_code == 401
 
 
 # =============================================================================

--- a/tests/backend/test_auth_cookies.py
+++ b/tests/backend/test_auth_cookies.py
@@ -1,0 +1,339 @@
+"""JWT HttpOnly-cookie session + CSRF (auth cookie migration).
+
+Covers the flag-gated cookie mode end to end: the config validator hard-fails,
+the cookie-first-then-Bearer token reader, the cookie set/clear helpers, the
+double-submit CSRF middleware, and the WebSocket Strategy-0 cookie read. Flag
+OFF is asserted byte-identical (no cookies, reader = bearer, CSRF no-op).
+"""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI, Response
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from utils.config import Settings
+
+_STRONG = "x" * 48  # passes the insecure-JWT-key boot guard that runs first
+
+
+# =============================================================================
+# Config validator hard-fails
+# =============================================================================
+class TestCookieValidator:
+    @pytest.mark.unit
+    def test_cookie_with_wildcard_cors_raises(self):
+        with pytest.raises(ValueError, match="CORS_ORIGINS"):
+            Settings(
+                auth_cookie_enabled=True, auth_enabled=True, ws_auth_enabled=True,
+                cors_origins="*", secret_key=SecretStr(_STRONG),
+            )
+
+    @pytest.mark.unit
+    def test_cookie_without_auth_raises(self):
+        with pytest.raises(ValueError, match="AUTH_ENABLED"):
+            Settings(
+                auth_cookie_enabled=True, auth_enabled=False,
+                cors_origins="https://x.local", secret_key=SecretStr(_STRONG),
+            )
+
+    @pytest.mark.unit
+    def test_cookie_insecure_on_prod_raises(self):
+        with pytest.raises(ValueError, match="COOKIE_SECURE"):
+            Settings(
+                auth_cookie_enabled=True, auth_enabled=True, ws_auth_enabled=True,
+                cors_origins="https://x.local", cookie_secure=False,
+                renfield_env="production", secret_key=SecretStr(_STRONG),
+            )
+
+    @pytest.mark.unit
+    def test_cookie_happy_path_constructs(self):
+        s = Settings(
+            auth_cookie_enabled=True, auth_enabled=True, ws_auth_enabled=True,
+            cors_origins="https://x.local", cookie_secure=True,
+            secret_key=SecretStr(_STRONG),
+        )
+        assert s.auth_cookie_enabled is True
+
+    @pytest.mark.unit
+    def test_flag_off_is_noop(self):
+        # Default posture: everything off → never raises (byte-identical).
+        s = Settings(auth_cookie_enabled=False, auth_enabled=False)
+        assert s.auth_cookie_enabled is False
+
+
+# =============================================================================
+# Cookie-first-then-Bearer token reader
+# =============================================================================
+def _fake_request(*, cookies=None, auth_header=None):
+    headers = {}
+    if auth_header:
+        headers["Authorization"] = auth_header
+    return SimpleNamespace(cookies=cookies or {}, headers=headers, state=SimpleNamespace())
+
+
+@pytest.mark.asyncio
+class TestTokenReader:
+    async def test_cookie_wins_when_enabled(self, monkeypatch):
+        from services import auth_service as a
+        monkeypatch.setattr(a.settings, "auth_cookie_enabled", True)
+        monkeypatch.setattr(a.settings, "auth_cookie_name", "renfield_access")
+        req = _fake_request(cookies={"renfield_access": "COOKIEJWT"},
+                            auth_header="Bearer HEADERJWT")
+        assert await a._cookie_or_bearer_token(req) == "COOKIEJWT"
+        assert req.state.auth_via == "cookie"
+
+    async def test_falls_back_to_bearer(self, monkeypatch):
+        from services import auth_service as a
+        monkeypatch.setattr(a.settings, "auth_cookie_enabled", True)
+        monkeypatch.setattr(a.settings, "auth_cookie_name", "renfield_access")
+        req = _fake_request(cookies={}, auth_header="Bearer HEADERJWT")
+        assert await a._cookie_or_bearer_token(req) == "HEADERJWT"
+        assert req.state.auth_via == "bearer"
+
+    async def test_flag_off_ignores_cookie(self, monkeypatch):
+        from services import auth_service as a
+        monkeypatch.setattr(a.settings, "auth_cookie_enabled", False)
+        req = _fake_request(cookies={"renfield_access": "COOKIEJWT"}, auth_header=None)
+        assert await a._cookie_or_bearer_token(req) is None
+        assert req.state.auth_via == "none"
+
+
+# =============================================================================
+# Cookie set / clear helpers
+# =============================================================================
+class TestCookieHelpers:
+    @pytest.mark.unit
+    def test_set_cookies_flag_on(self, monkeypatch):
+        from api.routes import auth as ar
+        monkeypatch.setattr(ar.settings, "auth_cookie_enabled", True)
+        resp = MagicMock(spec=Response)
+        ar._set_auth_cookies(resp, access_token="A", refresh_token="R")
+        names = {c.args[0] if c.args else c.kwargs.get("key") for c in resp.set_cookie.call_args_list}
+        assert names == {"renfield_access", "renfield_refresh", "renfield_csrf"}
+        # access + refresh are HttpOnly; csrf is not.
+        by_name = {}
+        for c in resp.set_cookie.call_args_list:
+            n = c.args[0] if c.args else c.kwargs["key"]
+            by_name[n] = c.kwargs
+        assert by_name["renfield_access"]["httponly"] is True
+        assert by_name["renfield_refresh"]["httponly"] is True
+        assert by_name["renfield_refresh"]["path"] == "/api/auth/refresh"
+        assert by_name["renfield_csrf"]["httponly"] is False
+
+    @pytest.mark.unit
+    def test_set_cookies_flag_off_noop(self, monkeypatch):
+        from api.routes import auth as ar
+        monkeypatch.setattr(ar.settings, "auth_cookie_enabled", False)
+        resp = MagicMock(spec=Response)
+        ar._set_auth_cookies(resp, access_token="A", refresh_token="R")
+        resp.set_cookie.assert_not_called()
+
+    @pytest.mark.unit
+    def test_helpers_tolerate_none_response(self, monkeypatch):
+        from api.routes import auth as ar
+        monkeypatch.setattr(ar.settings, "auth_cookie_enabled", True)
+        # Direct unit-call path (FastAPI would inject a real Response on a request).
+        ar._set_auth_cookies(None, access_token="A", refresh_token="R")
+        ar._clear_auth_cookies(None)
+
+
+# =============================================================================
+# CSRF middleware (double-submit)
+# =============================================================================
+def _csrf_client(monkeypatch, *, enabled=True):
+    from main import CSRFMiddleware
+    import main as m
+    monkeypatch.setattr(m.settings, "auth_cookie_enabled", enabled)
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+
+    @app.get("/api/x")
+    def _gx():
+        return {"ok": True}
+
+    @app.post("/api/x")
+    def _px():
+        return {"ok": True}
+
+    @app.post("/api/internal/x")
+    def _pix():
+        return {"ok": True}
+
+    return TestClient(app)
+
+
+class TestCsrfMiddleware:
+    @pytest.mark.unit
+    def test_get_is_exempt(self, monkeypatch):
+        c = _csrf_client(monkeypatch)
+        c.cookies.set("renfield_access", "A")
+        assert c.get("/api/x").status_code == 200
+
+    @pytest.mark.unit
+    def test_post_cookie_valid_token_passes(self, monkeypatch):
+        c = _csrf_client(monkeypatch)
+        c.cookies.set("renfield_access", "A")
+        c.cookies.set("renfield_csrf", "TOK")
+        r = c.post("/api/x", headers={"X-CSRF-Token": "TOK"})
+        assert r.status_code == 200
+
+    @pytest.mark.unit
+    def test_post_cookie_missing_header_403(self, monkeypatch):
+        c = _csrf_client(monkeypatch)
+        c.cookies.set("renfield_access", "A")
+        c.cookies.set("renfield_csrf", "TOK")
+        assert c.post("/api/x").status_code == 403
+
+    @pytest.mark.unit
+    def test_post_cookie_mismatched_header_403(self, monkeypatch):
+        c = _csrf_client(monkeypatch)
+        c.cookies.set("renfield_access", "A")
+        c.cookies.set("renfield_csrf", "TOK")
+        assert c.post("/api/x", headers={"X-CSRF-Token": "WRONG"}).status_code == 403
+
+    @pytest.mark.unit
+    def test_post_bearer_no_cookie_is_exempt(self, monkeypatch):
+        # No auth cookie present → Bearer/legacy request → structurally CSRF-immune.
+        c = _csrf_client(monkeypatch)
+        assert c.post("/api/x").status_code == 200
+
+    @pytest.mark.unit
+    def test_internal_path_exempt(self, monkeypatch):
+        c = _csrf_client(monkeypatch)
+        c.cookies.set("renfield_access", "A")
+        assert c.post("/api/internal/x").status_code == 200
+
+    @pytest.mark.unit
+    def test_flag_off_no_enforcement(self, monkeypatch):
+        c = _csrf_client(monkeypatch, enabled=False)
+        c.cookies.set("renfield_access", "A")
+        assert c.post("/api/x").status_code == 200
+
+
+# =============================================================================
+# Refresh cookie dual-read (High finding: {} body 422'd before the cookie read)
+# =============================================================================
+def _cookie_limiter_request(cookie_header: str, path="/api/auth/refresh"):
+    """A real starlette Request (so @limiter.limit is happy) carrying a Cookie
+    header, mirroring test_auth_audit_remediation._limiter_request."""
+    from starlette.requests import Request
+
+    from services.api_rate_limiter import limiter as app_limiter
+    state = type("S", (), {})()
+    state.limiter = app_limiter
+    app = type("A", (), {})()
+    app.state = state
+    return Request({
+        "type": "http", "method": "POST", "path": path,
+        "headers": [(b"cookie", cookie_header.encode())],
+        "client": ("127.0.0.1", 12345), "app": app,
+    })
+
+
+@pytest.mark.database
+@pytest.mark.asyncio
+class TestRefreshCookieDualRead:
+    def test_refresh_request_now_optional(self):
+        # The fix: a present `{}` body no longer 422s — RefreshRequest constructs
+        # with no token (handler then reads the HttpOnly refresh cookie).
+        from api.routes.auth import RefreshRequest
+        assert RefreshRequest().refresh_token is None
+
+    async def test_refresh_reads_cookie_when_body_absent(self, db_session, monkeypatch):
+        from unittest.mock import patch
+        from api.routes.auth import refresh_token
+        from services import auth_service
+        from services.auth_service import create_refresh_token
+        monkeypatch.setattr(auth_service.settings, "auth_enabled", True, raising=False)
+        monkeypatch.setattr(auth_service.settings, "auth_cookie_enabled", True, raising=False)
+        monkeypatch.setattr(auth_service.settings, "refresh_cookie_name", "renfield_refresh", raising=False)
+
+        from models.database import Role, User
+        role = Role(name="RCK", description="", permissions=["chat.own"])
+        db_session.add(role)
+        await db_session.flush()
+        user = User(username="rck", password_hash="x", role_id=role.id,
+                    is_active=True, token_epoch=0)
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+
+        token = create_refresh_token(user.id, token_epoch=0)
+        req = _cookie_limiter_request(f"renfield_refresh={token}")
+        with patch("services.token_blacklist.token_blacklist.is_blacklisted",
+                   new=AsyncMock(return_value=False)), \
+             patch("services.token_blacklist.token_blacklist.add",
+                   new=AsyncMock(return_value=True)):
+            # refresh_request=None (no body) → handler must fall through to the cookie.
+            resp = await refresh_token(request=req, refresh_request=None, db=db_session)
+        assert resp.access_token and resp.refresh_token
+
+
+# =============================================================================
+# WebSocket Strategy-0 cookie read
+# =============================================================================
+@pytest.fixture
+def ws_session_factory(monkeypatch, db_session):
+    import services.database as db_mod
+    smk = async_sessionmaker(db_session.bind, class_=AsyncSession, expire_on_commit=False)
+    monkeypatch.setattr(db_mod, "AsyncSessionLocal", smk)
+    return smk
+
+
+async def _mk_user(smk, *, epoch=0):
+    from models.database import Role, User
+    async with smk() as db:
+        role = Role(name="WSC", description="", permissions=["chat.own"])
+        db.add(role)
+        await db.flush()
+        user = User(username="wsc", password_hash="x", role_id=role.id,
+                    is_active=True, token_epoch=epoch)
+        db.add(user)
+        await db.commit()
+        await db.refresh(user)
+        return user.id
+
+
+def _fake_ws(cookies):
+    m = MagicMock()
+    m.headers = {}          # no Origin → non-browser, allowlist-exempt
+    m.cookies = cookies
+    return m
+
+
+@pytest.mark.database
+@pytest.mark.asyncio
+class TestWebSocketCookieAuth:
+    async def test_cookie_authenticates_ws(self, ws_session_factory, monkeypatch):
+        from services import websocket_auth as wa
+        from services.auth_service import create_access_token
+        monkeypatch.setattr(wa.settings, "ws_auth_enabled", True)
+        monkeypatch.setattr(wa.settings, "auth_cookie_enabled", True)
+        monkeypatch.setattr(wa.settings, "auth_cookie_name", "renfield_access")
+        uid = await _mk_user(ws_session_factory, epoch=0)
+        cookie = create_access_token(data={"sub": str(uid)}, token_epoch=0)
+        result = await wa.authenticate_websocket(_fake_ws({"renfield_access": cookie}))
+        assert result and result.get("user_id") == uid
+
+    async def test_epoch_stale_cookie_rejected(self, ws_session_factory, monkeypatch):
+        from services import websocket_auth as wa
+        from services.auth_service import create_access_token
+        monkeypatch.setattr(wa.settings, "ws_auth_enabled", True)
+        monkeypatch.setattr(wa.settings, "auth_cookie_enabled", True)
+        monkeypatch.setattr(wa.settings, "auth_cookie_name", "renfield_access")
+        uid = await _mk_user(ws_session_factory, epoch=3)
+        stale = create_access_token(data={"sub": str(uid)}, token_epoch=2)  # < 3
+        assert await wa.authenticate_websocket(_fake_ws({"renfield_access": stale})) is None
+
+    async def test_flag_off_ignores_cookie(self, ws_session_factory, monkeypatch):
+        from services import websocket_auth as wa
+        from services.auth_service import create_access_token
+        monkeypatch.setattr(wa.settings, "ws_auth_enabled", True)
+        monkeypatch.setattr(wa.settings, "auth_cookie_enabled", False)
+        uid = await _mk_user(ws_session_factory, epoch=0)
+        cookie = create_access_token(data={"sub": str(uid)}, token_epoch=0)
+        # Flag off → cookie not read; no query token → unauthenticated → None.
+        assert await wa.authenticate_websocket(_fake_ws({"renfield_access": cookie})) is None


### PR DESCRIPTION
## Summary

Moves the session off `localStorage` — where any XSS steals the 30-day refresh token — into **HttpOnly + Secure + SameSite=Lax cookies** plus a stateless **double-submit CSRF** token. The biggest remaining token-theft surface from the login/user-management audit (#1116 umbrella / SSO review #1004 §9).

**Flag off (`AUTH_COOKIE_ENABLED=false`, default) → byte-identical** to the localStorage-Bearer model. Backward-compat seam is a **cookie-first-then-Bearer dual-read**, so the Reva fragment→localStorage→Bearer path, the voice-server (`/api/internal/auth/verify`, body+header), and any legacy client keep working while cookies are on. Fully reversible per flag.

Household is auth-off (migration inert there); the real target is **xidra** (auth-on, same-origin behind Traefik).

## Backend
- **`auth_service`**: `oauth2_scheme` rebound to `_cookie_or_bearer_token` (cookie wins, else `Authorization` header) → all five auth deps cookie-aware, zero call-site edits.
- **`routes/auth`**: `_set_auth_cookies` on login/refresh/change-password/sso-exchange, `_clear_auth_cookies` on logout; refresh + logout **dual-read** the refresh token (cookie `Path=/api/auth/refresh` → body); `/auth/status` exposes `auth_cookie_enabled`. Rotation / reuse-detection / blacklist / `token_epoch` unchanged (they key on the decoded JWT, not its transport).
- **`main`**: `CSRFMiddleware` (inner of CORS) — `X-CSRF-Token` == `renfield_csrf` cookie (constant-time, bytes-encoded), enforced only on cookie-authed mutating requests; Bearer + `/api/internal/*` exempt. CORS `allow_headers += X-CSRF-Token`.
- **`websocket_auth`**: Strategy-0 reads `websocket.cookies` (browser auto-sends on the same-origin handshake → no long-lived JWT in the URL); safe because `_ws_origin_allowed` (CSWSH) runs first. `/api/ws/token` faucet kept.
- **`config`**: 7 cookie settings + validator hard-fails (cookie + wildcard CORS / auth-off / insecure-on-prod). `SECRET_KEY` untouched (tri-purpose: JWT + Fernet-at-rest + BLE IRK).

## Frontend
- **`axios`**: `withCredentials` + CSRF header interceptor (Bearer interceptor kept for the Reva path).
- **`AuthContext`**: learns cookie-mode from `/auth/status`; when on, discovers login via `/me` (cookie isn't JS-readable) and refreshes via the HttpOnly cookie instead of a localStorage-token gate.

## Deferred (own follow-ups, documented)
- SSO fragment-handler removal / `?code=` emitter wiring = **SSO cutover** (needs Reva + §10.1).
- Retiring `/api/ws/token` + the Bearer interceptor.
- **Voice WS** — authenticates to the external voice-server via `internal_auth.verify` (needs a full access JWT, rejects `scope:ws`, can't read the cookie), so it keeps the localStorage JWT during the transition.

## Review
Adversarial security review run; both findings fixed in-branch:
- **High** — cookie-mode refresh was broken: the frontend posted `{}`, which FastAPI 422'd against the required `RefreshRequest.refresh_token` before the handler read the cookie. Fixed (model field optional + frontend sends no body) + 2 tests.
- **Low** — CSRF `compare_digest` now bytes-encodes both sides.
Everything else cleared as sound (CSRF not bypassable, dual-read not an auth bypass, cookie attributes correct, validator correctly scoped, no frontend refresh loop, Reva/voice compat intact).

## Test plan
- [x] `tests/backend/test_auth_cookies.py` (23) — validator hard-fails, cookie-first reader, cookie set/clear helpers, CSRF middleware (GET/valid/missing/mismatch/Bearer-exempt/internal-exempt/flag-off), WS Strategy-0 (accept/epoch-stale/flag-off), refresh cookie dual-read
- [x] 196 existing auth/WS tests green — **flag-off byte-identical**
- [x] Frontend `tsc --noEmit` + eslint + `AuthContext.test.tsx` (14) green
- [x] ruff clean on changed files (pre-existing main.py E402 untouched)

## Rollout note
Flag-off is byte-identical → safe to merge/deploy with no behavior change. The **flag-flip on xidra is a separate later step** (Phase 5) with a mandatory browser E2E (login → chat → refresh-after-expiry → change-password → logout, cookie flags, no JWT in Traefik logs). No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)