### PR TITLE
feat(auth): voice-WS short-lived scope:voice faucet token — full XSS elimination (#1116)

### DIFF
--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -479,14 +479,25 @@ async def liveness_check():
 async def create_ws_token(
     device_id: str = None,
     device_type: str = None,
+    purpose: str = "ws",
     current_user: User | None = Depends(get_current_user),
 ):
     """
     Generate a WebSocket authentication token.
 
+    ``purpose`` selects the faucet scope: ``ws`` (default) for renfield's own
+    /ws/* sockets (chat/kiosk/kg), or ``voice`` for the browser voice WS to the
+    external voice-server (whose verify path accepts a non-"ws" scope; this
+    replaces the full 24h access JWT the voice path used to ship in ?token=).
+
     Only relevant when WS_AUTH_ENABLED=true.
     In production, this endpoint should be protected by authentication.
     """
+    from services.auth_service import WS_FAUCET_SCOPES
+
+    if purpose not in WS_FAUCET_SCOPES:
+        raise HTTPException(status_code=422, detail="Invalid token purpose")
+
     if not settings.ws_auth_enabled:
         return {
             "token": None,
@@ -510,7 +521,9 @@ async def create_ws_token(
     # access token after the usual user existence/active/rotation checks.
     from services.auth_service import create_ws_token_jwt
 
-    token = create_ws_token_jwt(current_user.id, token_epoch=current_user.token_epoch)
+    token = create_ws_token_jwt(
+        current_user.id, token_epoch=current_user.token_epoch, scope=purpose
+    )
 
     return {
         "token": token,

--- a/src/backend/services/auth_service.py
+++ b/src/backend/services/auth_service.py
@@ -171,23 +171,41 @@ def create_refresh_token(user_id: int, token_epoch: int | None = None) -> str:
     return encoded_jwt
 
 
-def create_ws_token_jwt(user_id: int, token_epoch: int | None = None) -> str:
-    """
-    Mint a SHORT-LIVED, WS-scoped access JWT for the browser WebSocket handshake
-    (security audit M2).
+# WS-faucet token scopes. Each is a short-lived (~90s) type="access" token minted
+# by /api/ws/token for a specific handshake and REJECTED by the REST API
+# (get_current_user) so a token harvested from a WS URL / proxy log can't be
+# replayed against /api/*.
+#   "ws"    → renfield's own /ws/* (chat, kiosk, kg) — authenticate_websocket accepts it.
+#   "voice" → the browser voice WS to the external voice-server, whose verify path
+#             (internal_auth.verify) accepts any non-"ws" scope. This replaces the
+#             full 24h access JWT the voice path used to ship in ?token= — the last
+#             JS-readable long-lived-token exposure (JWT-cookie migration follow-up).
+WS_FAUCET_SCOPES = frozenset({"ws", "voice"})
 
-    The web client passes the WS token as ``?token=`` on the WebSocket URL, which
-    lands in reverse-proxy access logs / history / Referer. Handing over the
-    full 24h API access token there is the vulnerability; this token instead:
+
+def create_ws_token_jwt(
+    user_id: int, token_epoch: int | None = None, scope: str = "ws"
+) -> str:
+    """
+    Mint a SHORT-LIVED, faucet-scoped access JWT for a browser WebSocket handshake
+    (security audit M2 + voice-WS migration).
+
+    The web client passes the token as ``?token=`` on the WebSocket URL, which
+    lands in reverse-proxy access logs / history / Referer. Handing over the full
+    24h API access token there is the vulnerability; this token instead:
       - lives only ``ws_jwt_expire_seconds`` (~90s) — long enough to open the
         socket, far too short to be useful if harvested from a log later, and
-      - carries ``scope="ws"``, which :func:`get_current_user` REJECTS, so even
-        within its lifetime it is useless against the REST API.
-    It is a normal ``type="access"`` token so ``authenticate_websocket``
-    (Strategy 1) accepts it after the usual user existence/active/rotation checks.
-    Stateless (survives the single-replica Recreate restart), unlike the
-    in-memory device token store.
+      - carries a faucet ``scope`` (``ws``/``voice``, see ``WS_FAUCET_SCOPES``),
+        which :func:`get_current_user` REJECTS, so even within its lifetime it is
+        useless against the REST API.
+    It is a normal ``type="access"`` token. ``scope="ws"`` is accepted by
+    ``authenticate_websocket`` (renfield's own /ws/*); ``scope="voice"`` is
+    accepted by the voice-server's verify path but rejected by both the REST guard
+    and ``authenticate_websocket`` (it's only for the voice handshake). Stateless
+    (survives the single-replica Recreate restart), unlike the device token store.
     """
+    if scope not in WS_FAUCET_SCOPES:
+        raise ValueError(f"invalid WS faucet scope: {scope!r}")
     expire = datetime.now(UTC).replace(tzinfo=None) + timedelta(
         seconds=settings.ws_jwt_expire_seconds
     )
@@ -195,7 +213,7 @@ def create_ws_token_jwt(user_id: int, token_epoch: int | None = None) -> str:
         "sub": str(user_id),
         "exp": expire,
         "type": "access",
-        "scope": "ws",
+        "scope": scope,
         "jti": str(uuid4()),
     }
     if token_epoch is not None:
@@ -368,10 +386,11 @@ async def get_current_user(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    # A WS-scoped token (security audit M2) is ONLY valid on the WebSocket
-    # handshake, never against the REST API — reject it here so a short-lived WS
-    # token harvested from a proxy log can't be replayed as an API bearer.
-    if payload.get("scope") == "ws":
+    # A faucet-scoped token (security audit M2 + voice-WS migration) is ONLY valid
+    # on its WebSocket handshake, never against the REST API — reject any WS-faucet
+    # scope here so a short-lived ws/voice token harvested from a proxy log can't be
+    # replayed as an API bearer.
+    if payload.get("scope") in WS_FAUCET_SCOPES:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid token scope",

--- a/src/backend/services/websocket_auth.py
+++ b/src/backend/services/websocket_auth.py
@@ -213,6 +213,14 @@ async def authenticate_websocket(
     except Exception as e:  # noqa: BLE001 — decode_token shouldn't raise, but defend
         logger.debug(f"WebSocket JWT decode raised unexpectedly: {e}")
 
+    # A "voice"-scoped faucet token is ONLY for the external voice-server's
+    # /ws/voice handshake — reject it on renfield's own /ws/* so a harvested voice
+    # token can't open a chat/kiosk socket (scope hygiene; the "ws" scope stays
+    # valid here, and a legacy no-scope access token is still accepted).
+    if payload and payload.get("scope") == "voice":
+        logger.debug("WebSocket JWT rejected: voice-scoped token not valid on this socket")
+        return None
+
     if payload and payload.get("type") == "access":
         sub = payload.get("sub")
         try:

--- a/src/frontend/src/context/AuthContext.tsx
+++ b/src/frontend/src/context/AuthContext.tsx
@@ -59,14 +59,19 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   // Store tokens
   const setTokens = useCallback((accessToken?: string, refreshToken?: string) => {
+    // Cookie mode: NEITHER token is persisted to localStorage — the session
+    // lives entirely in the HttpOnly cookies, so an XSS has nothing to steal.
+    // (The voice WS now fetches its own short-lived scope:"voice" faucet token,
+    // so it no longer needs the access token here; the SPA's own requests use the
+    // cookie; the Reva fragment path writes its own token independently.)
+    // Flag off (legacy / rollback) → persist both as before.
+    if (cookieAuthRef.current) {
+      return;
+    }
     if (accessToken) {
       localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
     }
-    // Cookie mode: the 30-day refresh token — the real XSS target — lives ONLY
-    // in the HttpOnly cookie; never persist it to localStorage. The 24h access
-    // token is still stored (the voice WS reads it — its migration is deferred —
-    // and the Bearer dual-read needs it); full elimination awaits that follow-up.
-    if (refreshToken && !cookieAuthRef.current) {
+    if (refreshToken) {
       localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
     }
   }, []);
@@ -214,13 +219,14 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   // Change password
   const changePassword = useCallback(async (currentPassword: string, newPassword: string): Promise<{ message: string }> => {
+    // Attach the localStorage Bearer only if present (legacy); in cookie mode
+    // there is no JS-readable token and the HttpOnly cookie carries auth — don't
+    // send a literal "Bearer null" header (mirrors logout).
     const token = getAccessToken();
     const response = await apiClient.post('/api/auth/change-password', {
       current_password: currentPassword,
       new_password: newPassword
-    }, {
-      headers: { Authorization: `Bearer ${token}` }
-    });
+    }, token ? { headers: { Authorization: `Bearer ${token}` } } : undefined);
     // Security audit H3: the backend bumps the user's token_epoch on a password
     // change (revoking every OTHER outstanding session) and returns a fresh token
     // pair carrying the new epoch. Store them so THIS device stays logged in;

--- a/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
+++ b/src/frontend/src/pages/ChatPage/context/ChatContext.tsx
@@ -21,7 +21,6 @@ import {
 // voice-server) instead of the request-response REST pair. Off by default
 // during the soak period so flag-off is the safety path.
 const VOICE_STREAM_ENABLED = import.meta.env.VITE_FEATURE_VOICE_STREAM === 'true';
-const ACCESS_TOKEN_KEY = 'renfield_access_token';
 // Stable no-op for the legacy (flag-off) path's cancelAllPlayback so the
 // context value's identity doesn't churn every render.
 const NOOP = (): void => {};
@@ -1408,19 +1407,10 @@ export function ChatProvider({ children }: ChatProviderProps) {
     handleRecordingError(`${code}: ${message}`);
   }, [handleRecordingError]);
 
-  // Token: read once, refresh via storage event so a token rotation
-  // mid-session updates the ref without re-rendering this provider for
-  // every state change.
-  const [streamToken, setStreamToken] = useState<string | null>(() =>
-    localStorage.getItem(ACCESS_TOKEN_KEY),
-  );
-  useEffect(() => {
-    const handler = (e: StorageEvent) => {
-      if (e.key === ACCESS_TOKEN_KEY) setStreamToken(e.newValue);
-    };
-    window.addEventListener('storage', handler);
-    return () => window.removeEventListener('storage', handler);
-  }, []);
+  // Voice-WS auth: useVoiceStream now fetches its own short-lived scope:"voice"
+  // faucet token at connect time (see wsToken.fetchVoiceToken), so we no longer
+  // read the long-lived access JWT from localStorage here — that was the last
+  // JS-readable long-lived-token exposure (JWT-cookie migration follow-up).
 
   // Sentence-streaming TTS bookkeeping — onTtsSettled fires per
   // dispatched sentence on EVERY terminal outcome (done / cancelled /
@@ -1452,7 +1442,6 @@ export function ChatProvider({ children }: ChatProviderProps) {
   }, [resumeWakeWord]);
 
   const voiceStream = useVoiceStream({
-    token: streamToken,
     onFinal: handleStreamFinal,
     onError: handleStreamError,
     onTtsSettled: handleStreamTtsSettled,

--- a/src/frontend/src/pages/ChatPage/hooks/useVoiceStream.ts
+++ b/src/frontend/src/pages/ChatPage/hooks/useVoiceStream.ts
@@ -32,6 +32,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { getWebSocketUrl } from '../../../utils/env';
 import { debug } from '../../../utils/debug';
 import { computeRms, detectBargeIn, VOICE_MIC_CONSTRAINTS } from './voiceAudioUtils';
+import { fetchVoiceToken } from '../../../utils/wsToken';
 
 const RFWA_MAGIC = new Uint8Array([0x52, 0x46, 0x57, 0x41]); // "RFWA"
 const HEADER_LEN = 24; // 4 magic + 16 uuid + 4 sequence
@@ -110,7 +111,9 @@ interface FinalTranscript {
 }
 
 interface UseVoiceStreamOptions {
-  token: string | null;
+  // No token here anymore: the hook fetches a fresh short-lived scope:"voice"
+  // faucet token itself at connect time (see ensureSocket) instead of receiving
+  // the long-lived localStorage access JWT.
   onPartial?: (text: string, confidence: number) => void;
   onFinal?: (result: FinalTranscript) => void;
   onError?: (code: string, message: string, requestId?: string) => void;
@@ -179,7 +182,6 @@ function generateRequestId(): string {
 }
 
 export function useVoiceStream({
-  token,
   onPartial,
   onFinal,
   onError,
@@ -455,10 +457,13 @@ export function useVoiceStream({
     // never create a second WebSocket while one is CONNECTING.
     if (pendingSocketRef.current) return pendingSocketRef.current;
 
-    // token=null is allowed (no-auth deployments). buildVoiceWsUrl
-    // omits the query param; voice-server's auth.authenticate treats
-    // empty token as anonymous when auth_required=False.
-    const url = buildVoiceWsUrl(token);
+    // Fetch a fresh short-lived scope:"voice" faucet token per connect — this
+    // replaces shipping the long-lived localStorage access JWT (the last
+    // JS-readable long-lived-token exposure). fetchVoiceToken() returns null on
+    // auth-off deployments → buildVoiceWsUrl omits the query param and the
+    // voice-server treats the empty token as anonymous (auth_required=False).
+    const connect = fetchVoiceToken().then((wsToken) => {
+    const url = buildVoiceWsUrl(wsToken);
     const ws = new WebSocket(url);
     ws.binaryType = 'arraybuffer';
     wsRef.current = ws;
@@ -539,12 +544,15 @@ export function useVoiceStream({
       ws.addEventListener('error', onErrorEarly, { once: true });
     });
 
-    pendingSocketRef.current = handshake;
-    handshake.finally(() => {
-      if (pendingSocketRef.current === handshake) pendingSocketRef.current = null;
-    });
     return handshake;
-  }, [token, handleTextMessage, enqueuePlayback, clearAllPendingTts]);
+    });
+
+    pendingSocketRef.current = connect;
+    connect.finally(() => {
+      if (pendingSocketRef.current === connect) pendingSocketRef.current = null;
+    });
+    return connect;
+  }, [handleTextMessage, enqueuePlayback, clearAllPendingTts]);
 
   // Build the MediaRecorder + VAD loop on an already-open mic stream
   // and start streaming. Shared by startRecording (which gets a fresh

--- a/src/frontend/src/utils/wsToken.ts
+++ b/src/frontend/src/utils/wsToken.ts
@@ -16,12 +16,25 @@ import apiClient from './axios';
  * rejects and the caller retries on its normal reconnect path). We deliberately
  * do NOT fall back to the long-lived localStorage access token — that would
  * re-introduce the full-JWT-in-URL exposure this change closes.
+ *
+ * `purpose` selects the faucet scope: `"ws"` (default) for renfield's own /ws/*
+ * sockets, or `"voice"` for the external voice-server handshake (its verify path
+ * accepts a non-"ws" scope). Both are short-lived and REST-rejected.
  */
-export async function fetchWsToken(): Promise<string | null> {
+export async function fetchWsToken(purpose: 'ws' | 'voice' = 'ws'): Promise<string | null> {
   try {
-    const res = await apiClient.post('/api/ws/token');
+    const res = await apiClient.post('/api/ws/token', null, { params: { purpose } });
     return res.data?.token ?? null;
   } catch {
     return null;
   }
+}
+
+/**
+ * Short-lived `scope:"voice"` token for the browser voice WebSocket to the
+ * external voice-server — replaces shipping the long-lived localStorage access
+ * JWT in the voice `?token=` (the last JS-readable long-lived-token exposure).
+ */
+export function fetchVoiceToken(): Promise<string | null> {
+  return fetchWsToken('voice');
 }

--- a/tests/backend/test_auth_cookies.py
+++ b/tests/backend/test_auth_cookies.py
@@ -264,6 +264,109 @@ async def test_ws_scoped_token_rejected_on_rest(monkeypatch):
 
 
 # =============================================================================
+# Voice-WS faucet token (voice-WS migration): short-lived scope:"voice"
+# =============================================================================
+class TestVoiceFaucetToken:
+    @pytest.mark.unit
+    def test_minter_voice_scope(self):
+        from jose import jwt
+        from services.auth_service import ALGORITHM, WS_FAUCET_SCOPES, create_ws_token_jwt
+        from utils.config import settings
+        assert "voice" in WS_FAUCET_SCOPES
+        tok = create_ws_token_jwt(1, 0, scope="voice")
+        p = jwt.decode(tok, settings.secret_key.get_secret_value(), algorithms=[ALGORITHM])
+        assert p["scope"] == "voice" and p["type"] == "access"
+
+    @pytest.mark.unit
+    def test_minter_default_is_ws(self):
+        from jose import jwt
+        from services.auth_service import ALGORITHM, create_ws_token_jwt
+        from utils.config import settings
+        p = jwt.decode(
+            create_ws_token_jwt(1, 0),
+            settings.secret_key.get_secret_value(), algorithms=[ALGORITHM],
+        )
+        assert p["scope"] == "ws"
+
+    @pytest.mark.unit
+    def test_minter_invalid_scope_raises(self):
+        from services.auth_service import create_ws_token_jwt
+        with pytest.raises(ValueError, match="scope"):
+            create_ws_token_jwt(1, 0, scope="bogus")
+
+    @pytest.mark.asyncio
+    async def test_voice_token_rejected_on_rest(self, monkeypatch):
+        """A harvested scope:voice token must NOT work against the REST API."""
+        from fastapi import HTTPException
+        from services import auth_service as a
+        monkeypatch.setattr(a.settings, "auth_enabled", True)
+        tok = a.create_ws_token_jwt(1, 0, scope="voice")
+        with pytest.raises(HTTPException) as exc:
+            await a.get_current_user(token=tok, db=None, request=None)
+        assert exc.value.status_code == 401
+
+    @pytest.mark.database
+    @pytest.mark.asyncio
+    async def test_voice_token_rejected_on_chat_ws(self, ws_session_factory, monkeypatch):
+        """A scope:voice token must NOT open renfield's own /ws/* (chat) — only the
+        external voice-server's /ws/voice accepts it (via internal_auth.verify)."""
+        from services import websocket_auth as wa
+        from services.auth_service import create_ws_token_jwt
+        monkeypatch.setattr(wa.settings, "ws_auth_enabled", True)
+        uid = await _mk_user(ws_session_factory, epoch=0)
+        tok = create_ws_token_jwt(uid, 0, scope="voice")
+        # via query token (chat WS reads ?token=) → rejected
+        assert await wa.authenticate_websocket(_fake_ws({}), token=tok) is None
+
+    @pytest.mark.asyncio
+    async def test_faucet_route_purpose_threading(self, monkeypatch):
+        """/api/ws/token: bad purpose → 422; purpose=voice → a voice-scoped token;
+        WS auth off → {token:None}."""
+        from fastapi import HTTPException
+        from jose import jwt
+        from main import create_ws_token
+        from services import auth_service as a
+        from utils.config import settings
+        user = MagicMock(id=7, token_epoch=0)
+
+        monkeypatch.setattr(a.settings, "ws_auth_enabled", True, raising=False)
+        # bad purpose → 422 (before any minting)
+        with pytest.raises(HTTPException) as exc:
+            await create_ws_token(purpose="bogus", current_user=user)
+        assert exc.value.status_code == 422
+
+        # purpose=voice → voice-scoped token bound to the caller
+        res = await create_ws_token(purpose="voice", current_user=user)
+        p = jwt.decode(res["token"], settings.secret_key.get_secret_value(),
+                       algorithms=[a.ALGORITHM])
+        assert p["scope"] == "voice" and p["sub"] == "7"
+
+        # WS auth disabled (household) → no token regardless of purpose
+        monkeypatch.setattr(a.settings, "ws_auth_enabled", False, raising=False)
+        res_off = await create_ws_token(purpose="voice", current_user=user)
+        assert res_off["token"] is None
+
+    @pytest.mark.database
+    @pytest.mark.asyncio
+    async def test_voice_token_accepted_by_internal_verify(self, ws_session_factory, monkeypatch):
+        """internal_auth.verify accepts a scope:voice token (the voice-server path)
+        — it only rejects scope:ws."""
+        from unittest.mock import patch
+        from api.routes.internal_auth import VerifyRequest, verify_token
+        from services import auth_service as a
+        monkeypatch.setattr(a.settings, "auth_enabled", True)
+        monkeypatch.setattr(a.settings, "internal_auth_verify_secret", None, raising=False)
+        uid = await _mk_user(ws_session_factory, epoch=0)
+        tok = a.create_ws_token_jwt(uid, 0, scope="voice")
+        # verify_token has no db param — it opens AsyncSessionLocal internally,
+        # which the ws_session_factory fixture patches to the test engine.
+        with patch("services.token_blacklist.token_blacklist.is_blacklisted",
+                   new=AsyncMock(return_value=False)):
+            result = await verify_token(VerifyRequest(token=tok), x_verify_secret=None)
+        assert int(result.get("user_id")) == uid and result.get("scope") == "voice"
+
+
+# =============================================================================
 # Refresh cookie dual-read (High finding: {} body 422'd before the cookie read)
 # =============================================================================
 def _cookie_limiter_request(cookie_header: str, path="/api/auth/refresh"):

--- a/tests/frontend/react/context/AuthContext.test.tsx
+++ b/tests/frontend/react/context/AuthContext.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, renderHook, act } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { server } from '../mocks/server';
 import { BASE_URL } from '../mocks/handlers';
@@ -67,6 +67,65 @@ describe('AuthContext', () => {
 
   afterEach(() => {
     localStorage.clear();
+  });
+
+  describe('Cookie mode (XSS hardening)', () => {
+    it('login persists NEITHER token to localStorage when auth_cookie_enabled', async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/auth/status`, () =>
+          HttpResponse.json({
+            auth_enabled: true,
+            allow_registration: false,
+            auth_cookie_enabled: true,
+          })
+        ),
+        http.get(`${BASE_URL}/api/auth/me`, () =>
+          HttpResponse.json({ id: 1, username: 'u', role: 'Admin', permissions: ['admin'] })
+        ),
+        http.post(`${BASE_URL}/api/auth/login`, () =>
+          HttpResponse.json({
+            access_token: 'a', refresh_token: 'r', token_type: 'bearer', expires_in: 3600,
+          })
+        )
+      );
+
+      const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      await act(async () => {
+        await result.current.login('u', 'pw');
+      });
+
+      // The whole point of the migration: in cookie mode the session lives only
+      // in the HttpOnly cookies — an XSS has nothing to read from localStorage.
+      expect(localStorage.getItem('renfield_access_token')).toBeNull();
+      expect(localStorage.getItem('renfield_refresh_token')).toBeNull();
+      expect(result.current.isAuthenticated).toBe(true);
+    });
+
+    it('login DOES persist tokens to localStorage when cookie mode is off (legacy)', async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/auth/status`, () =>
+          HttpResponse.json({ auth_enabled: true, allow_registration: false })
+        ),
+        http.get(`${BASE_URL}/api/auth/me`, () =>
+          HttpResponse.json({ id: 1, username: 'u', role: 'Admin', permissions: ['admin'] })
+        ),
+        http.post(`${BASE_URL}/api/auth/login`, () =>
+          HttpResponse.json({
+            access_token: 'a', refresh_token: 'r', token_type: 'bearer', expires_in: 3600,
+          })
+        )
+      );
+
+      const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      await act(async () => {
+        await result.current.login('u', 'pw');
+      });
+
+      expect(localStorage.getItem('renfield_access_token')).toBe('a');
+      expect(localStorage.getItem('renfield_refresh_token')).toBe('r');
+    });
   });
 
   describe('Initialization', () => {

--- a/tests/frontend/react/hooks/useVoiceStream.bargein.test.ts
+++ b/tests/frontend/react/hooks/useVoiceStream.bargein.test.ts
@@ -15,6 +15,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useVoiceStream } from '../../../../src/frontend/src/pages/ChatPage/hooks/useVoiceStream';
 
+// The hook now fetches its own short-lived voice faucet token; mock it to null
+// (anonymous handshake) so these WS-plumbing tests stay HTTP-free + deterministic.
+vi.mock('../../../../src/frontend/src/utils/wsToken', () => ({
+  fetchVoiceToken: () => Promise.resolve(null),
+  fetchWsToken: () => Promise.resolve(null),
+}));
+
 type WsListener = (event: unknown) => void;
 
 // Mock WebSocket with addEventListener support — useVoiceStream's
@@ -265,6 +272,9 @@ async function speakAndConnect(
   act(() => {
     ridP = result.current.speakText(text);
   });
+  // The hook now fetches a short-lived voice token async before creating the
+  // socket — flush that microtask so the WebSocket exists before we grab it.
+  await act(async () => { await Promise.resolve(); });
   const ws = lastWs();
   await act(async () => {
     ws.fireOpen();
@@ -328,7 +338,7 @@ afterEach(() => {
 
 describe('useVoiceStream — barge-in plumbing', () => {
   it('speakText dispatches a tts_request and resolves to its request id', async () => {
-    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    const { result } = renderHook(() => useVoiceStream({}));
     const { ws, rid } = await speakAndConnect(result);
 
     expect(typeof rid).toBe('string');
@@ -341,11 +351,13 @@ describe('useVoiceStream — barge-in plumbing', () => {
   it('speakText is gated (returns null) when cancelAllPlayback fires during the handshake', async () => {
     // Headline 1A: TTS the agent produced before the user interrupted
     // must not reach the speaker.
-    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    const { result } = renderHook(() => useVoiceStream({}));
     let ridP!: Promise<string | null>;
     act(() => {
       ridP = result.current.speakText('soll nicht gesprochen werden');
     });
+    // Flush the async voice-token fetch so the socket is created (still pre-ready).
+    await act(async () => { await Promise.resolve(); });
     const ws = lastWs();
     // Barge-in lands while the socket handshake is still in flight.
     act(() => {
@@ -362,7 +374,7 @@ describe('useVoiceStream — barge-in plumbing', () => {
   });
 
   it('tts_done drains the request and ends playback after the grace window', async () => {
-    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    const { result } = renderHook(() => useVoiceStream({}));
     const { ws, rid } = await speakAndConnect(result);
     expect(result.current.playbackActive).toBe(true);
 
@@ -381,7 +393,7 @@ describe('useVoiceStream — barge-in plumbing', () => {
     const onError = vi.fn();
     const onTtsSettled = vi.fn();
     const { result } = renderHook(() =>
-      useVoiceStream({ token: null, onError, onTtsSettled }),
+      useVoiceStream({ onError, onTtsSettled }),
     );
     const { ws, rid } = await speakAndConnect(result);
 
@@ -401,7 +413,7 @@ describe('useVoiceStream — barge-in plumbing', () => {
     const onError = vi.fn();
     const onTtsSettled = vi.fn();
     const { result } = renderHook(() =>
-      useVoiceStream({ token: null, onError, onTtsSettled }),
+      useVoiceStream({ onError, onTtsSettled }),
     );
     const { ws, rid } = await speakAndConnect(result);
 
@@ -418,7 +430,7 @@ describe('useVoiceStream — barge-in plumbing', () => {
   });
 
   it('WS close clears pending TTS and ends playback immediately', async () => {
-    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    const { result } = renderHook(() => useVoiceStream({}));
     const { ws } = await speakAndConnect(result);
     expect(result.current.playbackActive).toBe(true);
 
@@ -430,7 +442,7 @@ describe('useVoiceStream — barge-in plumbing', () => {
   });
 
   it('the 60s watchdog force-drops a request whose terminal frame never arrives', async () => {
-    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    const { result } = renderHook(() => useVoiceStream({}));
     await speakAndConnect(result);
     expect(result.current.playbackActive).toBe(true);
 
@@ -445,7 +457,7 @@ describe('useVoiceStream — barge-in plumbing', () => {
   });
 
   it('cancelAllPlayback sends one cancel frame per in-flight request', async () => {
-    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    const { result } = renderHook(() => useVoiceStream({}));
     const { ws, rid } = await speakAndConnect(result, 'satz eins');
     const rid2 = await speakAgain(result, 'satz zwei');
     const rid3 = await speakAgain(result, 'satz drei');
@@ -464,7 +476,7 @@ describe('useVoiceStream — barge-in plumbing', () => {
   });
 
   it('cancelAllPlayback after the socket closed does not throw', async () => {
-    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    const { result } = renderHook(() => useVoiceStream({}));
     const { ws } = await speakAndConnect(result);
     act(() => {
       ws.fireClose();
@@ -477,7 +489,7 @@ describe('useVoiceStream — barge-in plumbing', () => {
   });
 
   it('a binary frame for an unknown request id is dropped (rid gate)', async () => {
-    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    const { result } = renderHook(() => useVoiceStream({}));
     const { ws, rid } = await speakAndConnect(result);
 
     // Settle the real request so playback is idle.
@@ -506,7 +518,7 @@ describe('useVoiceStream — barge-in plumbing', () => {
     // gate condition (drop the pending ones) would silently discard ALL
     // TTS audio and the suite would still pass.
     MockAudioContext.autoDecode = true;
-    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    const { result } = renderHook(() => useVoiceStream({}));
     const { ws, rid } = await speakAndConnect(result);
 
     await act(async () => {
@@ -524,7 +536,7 @@ describe('useVoiceStream — barge-in plumbing', () => {
     // The generation re-check after decodeAudioData must drop the buffer
     // instead of starting a source.
     MockAudioContext.autoDecode = false;
-    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    const { result } = renderHook(() => useVoiceStream({}));
     const { ws, rid } = await speakAndConnect(result);
 
     await act(async () => {
@@ -550,7 +562,7 @@ describe('useVoiceStream — barge-in plumbing', () => {
 
   it('the barge-in listener does not fire while the mic is silent', async () => {
     MockAudioContext.frequencyFrame = []; // silence
-    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    const { result } = renderHook(() => useVoiceStream({}));
     const { ws } = await speakAndConnect(result);
     await act(async () => { await flushMicrotasks(); }); // listener open() settles
     await act(async () => {
@@ -563,7 +575,7 @@ describe('useVoiceStream — barge-in plumbing', () => {
 
   it('voiced energy within the warmup window does not fire a barge-in', async () => {
     MockAudioContext.frequencyFrame = new Array(16).fill(200); // loud
-    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    const { result } = renderHook(() => useVoiceStream({}));
     const { ws } = await speakAndConnect(result);
     await act(async () => { await flushMicrotasks(); });
     // Only 200ms elapse — short of the 250ms warmup, so detection is
@@ -578,7 +590,7 @@ describe('useVoiceStream — barge-in plumbing', () => {
 
   it('sustained voiced energy fires a barge-in: cancels TTS and promotes to recording', async () => {
     MockAudioContext.frequencyFrame = new Array(16).fill(200); // user speaking
-    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    const { result } = renderHook(() => useVoiceStream({}));
     const { ws } = await speakAndConnect(result);
     await act(async () => { await flushMicrotasks(); });
 
@@ -600,7 +612,7 @@ describe('useVoiceStream — barge-in plumbing', () => {
     getUserMediaShouldReject = true;
     MockAudioContext.frequencyFrame = new Array(16).fill(200);
     const onError = vi.fn();
-    const { result } = renderHook(() => useVoiceStream({ token: null, onError }));
+    const { result } = renderHook(() => useVoiceStream({ onError }));
     const { ws } = await speakAndConnect(result);
     await act(async () => {
       vi.advanceTimersByTime(600);
@@ -616,7 +628,7 @@ describe('useVoiceStream — barge-in plumbing', () => {
     // open()-vs-cleanup race: getUserMedia is still in flight when the
     // reply finishes. The cancelled-flag guard must stop the late stream.
     getUserMediaDeferred = true;
-    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    const { result } = renderHook(() => useVoiceStream({}));
     const { ws, rid } = await speakAndConnect(result);
     await act(async () => { await flushMicrotasks(); }); // listener parked on getUserMedia
     expect(getUserMediaResolvers).toHaveLength(1);
@@ -641,9 +653,11 @@ describe('useVoiceStream — checkSilence regression (plan §8.3)', () => {
   // IRON RULE: the computeRms extraction (T4a) refactored checkSilence.
   // This proves end-of-utterance auto-stop still fires.
   it('still auto-stops the recorder after trailing silence', async () => {
-    const { result } = renderHook(() => useVoiceStream({ token: null }));
+    const { result } = renderHook(() => useVoiceStream({}));
     let startP!: Promise<void>;
     act(() => { startP = result.current.startRecording(); });
+    // Flush the async voice-token fetch so the socket exists before we grab it.
+    await act(async () => { await Promise.resolve(); });
     const ws = lastWs();
     await act(async () => {
       ws.fireOpen();

--- a/tests/frontend/react/utils/wsToken.test.ts
+++ b/tests/frontend/react/utils/wsToken.test.ts
@@ -11,7 +11,7 @@ vi.mock('../../../../src/frontend/src/utils/axios', () => ({
 }));
 
 import apiClient from '../../../../src/frontend/src/utils/axios';
-import { fetchWsToken } from '../../../../src/frontend/src/utils/wsToken';
+import { fetchVoiceToken, fetchWsToken } from '../../../../src/frontend/src/utils/wsToken';
 
 const post = apiClient.post as unknown as ReturnType<typeof vi.fn>;
 
@@ -23,7 +23,13 @@ describe('fetchWsToken', () => {
   it('returns the scoped token from the response', async () => {
     post.mockResolvedValueOnce({ data: { token: 'ws-scoped-token' } });
     await expect(fetchWsToken()).resolves.toBe('ws-scoped-token');
-    expect(post).toHaveBeenCalledWith('/api/ws/token');
+    expect(post).toHaveBeenCalledWith('/api/ws/token', null, { params: { purpose: 'ws' } });
+  });
+
+  it('fetchVoiceToken requests the voice purpose', async () => {
+    post.mockResolvedValueOnce({ data: { token: 'voice-scoped-token' } });
+    await expect(fetchVoiceToken()).resolves.toBe('voice-scoped-token');
+    expect(post).toHaveBeenCalledWith('/api/ws/token', null, { params: { purpose: 'voice' } });
   });
 
   it('returns null when the backend reports WS auth disabled (token: null)', async () => {


### PR DESCRIPTION
## Summary

Completes the JWT-cookie XSS-hardening: gets the **last** JS-readable long-lived token (the 24h access JWT) out of `localStorage`. It was kept there only because the browser voice WS shipped it as `?token=` to the external voice-server. Now voice fetches a **short-lived `scope:"voice"` faucet token** (like chat's `scope:"ws"`), and the SPA stops persisting **both** tokens to localStorage in cookie mode → nothing for an XSS to steal.

**Renfield-only** (no voice-server / reva change): `internal_auth.verify` already accepts any non-`"ws"` scope, and the voice-server keeps reading `?token=`. The cookie-on-handshake alternative was rejected (shared voice-server is cross-origin for reva; renfield's registry row is anonymous-only).

## Backend
- `auth_service`: `create_ws_token_jwt(scope=)` + `WS_FAUCET_SCOPES {ws, voice}`; `get_current_user` rejects **both** ws and voice scopes on REST.
- `websocket_auth`: `authenticate_websocket` rejects `scope:voice` (chat/kiosk/kg WS must not accept a voice token).
- `main`: `/api/ws/token` gains a `purpose` param (`ws`|`voice`, 422 on bad) → mints the scope.
- `internal_auth.verify`: unchanged (accepts `scope:voice` already).

## Frontend
- `wsToken`: `fetchWsToken(purpose)` + `fetchVoiceToken()`.
- `useVoiceStream`: fetches a fresh `scope:voice` faucet token at connect (async, like chat); the `token` prop is gone.
- `ChatContext`: drops the `streamToken` localStorage seeding + storage listener.
- `AuthContext.setTokens`: in cookie mode persists **NEITHER** token. Flag off unchanged (legacy/rollback). Reva fragment path writes its own token independently.

## Scope matrix (reviewed sound)
| scope | REST | chat/kiosk WS | voice-server verify |
|---|---|---|---|
| `ws` | ✗ | ✓ | ✗ |
| `voice` | ✗ | ✗ | ✓ |
| legacy (none) | ✓ | ✓ | ✓ |

## Review
Adversarial security review: **no high-confidence findings**. Applied the one low-severity cleanup (`changePassword` no longer sends `Bearer null` in cookie mode) + closed 2 named test gaps (the `/api/ws/token` `purpose` route test; the frontend XSS-property test asserting cookie-mode login persists neither token).

## Note
Browser voice is off on all auth-on instances today (xidra `FEATURE_VOICE=false`, household auth-off) → nothing breaks now; this is preventative + unlocks the localStorage removal. Full live-voice E2E deferred until voice is enabled on an auth-on instance.

## Test plan
- [x] Backend voice-scope cases (minter, REST-reject, chat-WS-reject, verify-accepts, `/api/ws/token` purpose) — 178 auth/cookie/ws green
- [x] Frontend bargein (fetchVoiceToken mocked + async-connect flush) + wsToken purpose + AuthContext cookie-mode XSS-property + full react suite (847) green
- [x] tsc + ruff/eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)