### PR TITLE
feat(infra): CNPG HA Postgres for the renfield app DB (Phase 1-3)

### DIFF
--- a/docs/KUBERNETES_DEPLOYMENT.md
+++ b/docs/KUBERNETES_DEPLOYMENT.md
@@ -69,7 +69,7 @@ Cluster-wide Traefik changes (entrypoints, TLS, CRDs) are tracked in `../private
 |---------|-------|-------|
 | Backend | `your-registry.example/renfield/backend:latest` | CPU image (~3.5 GB). Includes wake-word models and renfield-mcp-dlna entrypoint |
 | Frontend | `your-registry.example/renfield/frontend:latest` | Nginx serving React SPA (vite-plugin-pwa PWA). `nginx.conf` serves `sw.js`/`registerSW.js`/`index.html`/manifest `no-cache` and content-hashed bundles `immutable` — required for new deploys to reach the browser; see deploy-production skill → "Frontend PWA cache propagation" |
-| PostgreSQL | `pgvector/pgvector:pg16` | pgvector for embedding search |
+| PostgreSQL | `pgvector/pgvector:pg16` | pgvector for embedding search. Single-node StatefulSet; an HA CloudNativePG track for the app DB is in progress — see "Postgres HA (CloudNativePG)" below |
 | Redis | `redis:7-alpine` | Message queue + cache (AOF enabled) |
 | Ollama | `ollama/ollama:latest` | LLM inference, requires GPU |
 | SearXNG | `searxng/searxng:latest` | In-cluster metasearch |
@@ -91,7 +91,10 @@ k8s/
 ├── namespace.yaml                  Namespace renfield
 ├── secrets.yaml.example            12 app secrets + harbor-pull-secret (TEMPLATE)
 ├── configmap.yaml                  Env vars (endpoints, models, feature flags)
-├── postgres.yaml                   StatefulSet + Service + PVC
+├── postgres.yaml                   StatefulSet + Service + PVC (single-node; still
+│                                    serves Paperless + digital-twin DBs)
+├── cnpg/                            HA CloudNativePG track for the app DB (applied
+│                                    by hand, NOT in kustomization) — see below
 ├── redis.yaml                      Deployment + Service + PVC
 ├── ollama.yaml                     Deployment (2 replicas, GPU-only workers,
 │                                    anti-affinity) + Service + model pre-pull Job
@@ -127,6 +130,35 @@ For K8s this means:
   ```
 
 A follow-up that consolidates all 41 migrations into a single clean baseline is tracked separately.
+
+## Postgres HA (CloudNativePG)
+
+The app database is being moved off the single-node `postgres` StatefulSet onto a
+3-instance **CloudNativePG (CNPG)** cluster (`renfield-pg`) with streaming
+replication + automatic failover + external S3 PITR backups. Manifests + the full
+phased runbook live in **`k8s/cnpg/`** (`README.md` there is the source of truth).
+
+Scope + status:
+
+- **Scope is the renfield app DB only.** Paperless (`paperlessdb`) and the
+  digital-twin DB stay on the legacy `postgres` StatefulSet, which keeps running
+  for them. The cutover is a pure host swap in `DATABASE_URL`:
+  `@postgres` → `@renfield-pg-rw` (services: `renfield-pg-rw`/`-ro`/`-r`).
+- **Rollout is household (`ns renfield`) first, then xidra** (Phase 6). Applied by
+  hand, phase by phase — the `k8s/cnpg/` files are deliberately **not** in
+  `kustomization.yaml`.
+- **Live so far:** operator stack (cert-manager, CNPG operator 1.27.0, Barman
+  Cloud plugin v0.14.0), the `longhorn-pg` StorageClass, the Garage-S3
+  `ObjectStore`, and the CNPG NetworkPolicy are applied; the pgvector operand
+  image is built (`cnpg-pg16-pgvector:16.9-pgvector0.8.6`); a scratch dry-run
+  proved import + failover with no data loss. **The household cutover (Phase 4)
+  has not run yet** — the app still uses the single-node `postgres`.
+- **pgvector image:** the stock CNPG operand has no pgvector, so a thin custom
+  image (`k8s/cnpg/Dockerfile.pgvector`) adds `postgresql-16-pgvector`.
+- **Backups:** base backups + WAL archiving go to the Garage S3 server on the NAS
+  (`renfield-pg-backups`) for PITR, plus a nightly `pg_dump` → NFS fallback.
+- **Known ceiling:** the single control-plane node bounds real availability until
+  the control plane is also HA (separate track).
 
 > **Auth-on instances (`AUTH_ENABLED=true` / `RENFIELD_ENV=production`):** the v2.20.0 boot
 > guard (`fail_closed_on_insecure_jwt_key`) validates `SECRET_KEY` at `Settings()` init, which
@@ -327,6 +359,10 @@ Ollama model pulls: drop the model into the NFS share at `192.168.1.9:/mnt/data/
 - **Migration chain consolidation** — the 41-migration history is bypassed by `Base.metadata.create_all` for fresh installs; a clean baseline that replaces the empty stub is still pending
 - **HPA** — horizontal scaling for backend
 - **NetworkPolicy** — pod-to-pod traffic restrictions
-- **Backup** — Longhorn snapshot schedule for the postgres PVC
+- **Backup** — the legacy single-node `postgres` PVC still has no backup (Longhorn
+  snapshot schedule pending). The **CNPG app-DB track adds real backups** (Barman
+  base backups + WAL archiving to Garage S3 for PITR, plus a nightly `pg_dump` →
+  NFS) once the Phase-4 cutover lands — see "Postgres HA (CloudNativePG)". Paperless
+  + twin DBs on the legacy StatefulSet remain unbacked until migrated.
 - **Evolution API / WhatsApp** — optional profile
 - **Satellite management CRDs** — rollout orchestration for Pi Zero fleet

--- a/k8s/cnpg/00-storageclass-pg.yaml
+++ b/k8s/cnpg/00-storageclass-pg.yaml
@@ -2,9 +2,16 @@
 #
 # CNPG already replicates data 3x at the PostgreSQL level (streaming replication
 # across the 3 cluster instances). Longhorn replicating each PVC again would give
-# 9x storage for zero extra safety — so this SC pins Longhorn to a SINGLE replica
-# and keeps the volume node-local (strict-local) for latency. Durability comes
-# from PG replication + the Barman S3 base-backups/WAL, not from Longhorn here.
+# 9x storage for zero extra safety — so this SC pins Longhorn to a SINGLE replica.
+# Durability comes from PG replication + the Barman S3 base-backups/WAL, not from
+# Longhorn here.
+#
+# dataLocality: best-effort (NOT strict-local). This cluster has only 2 Longhorn
+# storage nodes (gpu-1/gpu-2), but CNPG's required pod anti-affinity spreads the 3
+# instances across 3 nodes — so a PG pod WILL land on a non-storage node and must
+# attach its volume over the network. strict-local makes that a hard, unsatisfiable
+# replica affinity ("hard affinity cannot be satisfied" -> volume stuck detached);
+# best-effort keeps locality where possible and falls back to remote attach.
 #
 # reclaimPolicy: Retain — a `kubectl delete pvc` (or an accidental Cluster delete)
 # leaves the underlying Longhorn volume intact for manual recovery. CNPG's own
@@ -21,6 +28,6 @@ reclaimPolicy: Retain
 volumeBindingMode: Immediate
 parameters:
   numberOfReplicas: "1"
-  dataLocality: "strict-local"
+  dataLocality: "best-effort"
   staleReplicaTimeout: "30"
   fsType: "ext4"

--- a/k8s/cnpg/00-storageclass-pg.yaml
+++ b/k8s/cnpg/00-storageclass-pg.yaml
@@ -1,0 +1,26 @@
+# Dedicated Longhorn StorageClass for CNPG PGDATA.
+#
+# CNPG already replicates data 3x at the PostgreSQL level (streaming replication
+# across the 3 cluster instances). Longhorn replicating each PVC again would give
+# 9x storage for zero extra safety — so this SC pins Longhorn to a SINGLE replica
+# and keeps the volume node-local (strict-local) for latency. Durability comes
+# from PG replication + the Barman S3 base-backups/WAL, not from Longhorn here.
+#
+# reclaimPolicy: Retain — a `kubectl delete pvc` (or an accidental Cluster delete)
+# leaves the underlying Longhorn volume intact for manual recovery. CNPG's own
+# PVCs are managed by the operator; Retain is the safe default for a database.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-pg
+  labels:
+    app.kubernetes.io/part-of: renfield
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+parameters:
+  numberOfReplicas: "1"
+  dataLocality: "strict-local"
+  staleReplicaTimeout: "30"
+  fsType: "ext4"

--- a/k8s/cnpg/10-objectstore.yaml
+++ b/k8s/cnpg/10-objectstore.yaml
@@ -1,0 +1,39 @@
+# Barman Cloud Plugin ObjectStore — the S3 backup target for the renfield-pg
+# cluster. Points at the Garage S3 server on the TrueNAS box (192.168.1.9:30188),
+# bucket `renfield-pg-backups`. This is where base backups + archived WAL land,
+# giving Point-In-Time-Recovery that is EXTERNAL to the k8s cluster (survives a
+# full cluster loss).
+#
+# Prereqs (already done during the Garage install):
+#   - Secret `renfield-pg-backup-s3` in ns renfield with keys
+#     ACCESS_KEY_ID + ACCESS_SECRET_KEY (the Garage `renfield-cnpg` key).
+#   - The Barman Cloud Plugin must be installed cluster-wide first (see README).
+#
+# NOTE: this is the NEW plugin-based backup CR (barmancloud.cnpg.io/v1), not the
+# deprecated in-Cluster `.spec.backup.barmanObjectStore` block.
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: renfield-pg-backup
+  namespace: renfield
+  labels:
+    app.kubernetes.io/part-of: renfield
+spec:
+  configuration:
+    destinationPath: s3://renfield-pg-backups/
+    endpointURL: http://192.168.1.9:30188
+    s3Credentials:
+      accessKeyId:
+        name: renfield-pg-backup-s3
+        key: ACCESS_KEY_ID
+      secretAccessKey:
+        name: renfield-pg-backup-s3
+        key: ACCESS_SECRET_KEY
+    wal:
+      compression: gzip
+      maxParallel: 2
+    data:
+      compression: gzip
+  # Keep the last 30 days of backups/WAL. Garage prunes nothing itself; CNPG's
+  # retention policy drives the delete. Tune to your NAS capacity.
+  retentionPolicy: "30d"

--- a/k8s/cnpg/20-cluster-renfield-pg.yaml
+++ b/k8s/cnpg/20-cluster-renfield-pg.yaml
@@ -1,0 +1,99 @@
+# The HA Postgres cluster for the renfield APP database (NOT Paperless, NOT the
+# digital-twin DB — those stay on the legacy single-node `postgres` StatefulSet
+# for now; see the DB-HA plan).
+#
+# 3 instances = 1 primary + 2 hot standbys with quorum-based synchronous
+# replication (the smallest correct sync-HA topology). Services created by CNPG:
+#   renfield-pg-rw  -> always the current primary  (app + alembic write here)
+#   renfield-pg-ro  -> round-robin over hot standbys
+#   renfield-pg-r   -> any instance
+# The app cutover is a pure host swap: `@postgres` -> `@renfield-pg-rw`.
+#
+# App user/DB are deliberately `renfield`/`renfield` (identical to the legacy DB)
+# so the DATABASE_URL only changes host. The app-user password comes from a
+# PRE-CREATED secret `renfield-pg-app` (see README) so it matches the value the
+# app already has in `renfield-secrets/postgres-password`.
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: renfield-pg
+  namespace: renfield
+  labels:
+    app.kubernetes.io/part-of: renfield
+spec:
+  instances: 3
+
+  # pgvector is NOT in the stock CNPG operand image — this is a thin custom image
+  # (see Dockerfile.pgvector) built + pushed to Harbor in Phase 2. Verify the
+  # bundled pgvector is >= 0.8.1 (halfvec + HNSW + 2560-dim) with `\dx vector`.
+  imageName: your-registry.example/renfield/cnpg-pg16-pgvector:16.9-pgvector0.8.6
+  imagePullPolicy: Always
+  imagePullSecrets:
+    - name: harbor-pull-secret
+
+  # --- HA: quorum-based synchronous replication (requires >= 3 instances) ------
+  postgresql:
+    synchronous:
+      method: any
+      number: 1            # at least 1 standby must confirm each commit
+      failoverQuorum: true # no data-losing failover without quorum
+
+  # --- One instance per node --------------------------------------------------
+  affinity:
+    enablePodAntiAffinity: true
+    topologyKey: kubernetes.io/hostname
+    podAntiAffinityType: required   # hard: never co-schedule two PG pods
+
+  # --- Storage (Longhorn, 1 replica — see 00-storageclass-pg.yaml) ------------
+  storage:
+    storageClassName: longhorn-pg
+    size: 10Gi
+
+  # --- Bootstrap: MIGRATE from the live single-node DB via pg_dump/restore -----
+  # `microservice` import copies exactly the `renfield` database and re-owns it
+  # to `renfield`. Runs in a superuser context inside the pod, so the dumped
+  # `CREATE EXTENSION vector` + halfvec/HNSW objects restore cleanly.
+  bootstrap:
+    initdb:
+      database: renfield
+      owner: renfield
+      import:
+        type: microservice
+        databases:
+          - renfield
+        source:
+          externalCluster: legacy-postgres
+      # Belt-and-suspenders: guarantee the extension exists post-import (runs as
+      # superuser). The app's boot-time `CREATE EXTENSION IF NOT EXISTS vector`
+      # then short-circuits as a harmless no-op for the non-superuser app user.
+      postImportApplicationSQL:
+        - "CREATE EXTENSION IF NOT EXISTS vector"
+
+  externalClusters:
+    - name: legacy-postgres
+      connectionParameters:
+        host: postgres          # the legacy StatefulSet headless service
+        user: renfield
+        dbname: renfield
+      password:
+        name: renfield-secrets
+        key: postgres-password
+
+  # --- Backups: WAL archiving + base backups via the Barman Cloud plugin -------
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: renfield-pg-backup   # -> 10-objectstore.yaml
+
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+
+  # CNPG manages its own PodDisruptionBudget (maxUnavailable derived from
+  # instances) — no manual PDB needed. A rolling node drain evicts at most one
+  # instance at a time and waits for re-sync.

--- a/k8s/cnpg/20-cluster-renfield-pg.yaml
+++ b/k8s/cnpg/20-cluster-renfield-pg.yaml
@@ -32,11 +32,15 @@ spec:
     - name: harbor-pull-secret
 
   # --- HA: quorum-based synchronous replication (requires >= 3 instances) ------
+  # `number: 1` = at least one standby must confirm every commit before it is
+  # acknowledged, so a primary loss never drops an acked write (no async data
+  # loss). CNPG promotes a caught-up standby automatically. (The explicit
+  # `failoverQuorum` knob is a newer field than the installed operator 1.27.0 and
+  # is intentionally omitted; the sync guarantee above already prevents data loss.)
   postgresql:
     synchronous:
       method: any
-      number: 1            # at least 1 standby must confirm each commit
-      failoverQuorum: true # no data-losing failover without quorum
+      number: 1
 
   # --- One instance per node --------------------------------------------------
   affinity:
@@ -46,7 +50,7 @@ spec:
 
   # --- Storage (Longhorn, 1 replica — see 00-storageclass-pg.yaml) ------------
   storage:
-    storageClassName: longhorn-pg
+    storageClass: longhorn-pg
     size: 10Gi
 
   # --- Bootstrap: MIGRATE from the live single-node DB via pg_dump/restore -----
@@ -63,11 +67,11 @@ spec:
           - renfield
         source:
           externalCluster: legacy-postgres
-      # Belt-and-suspenders: guarantee the extension exists post-import (runs as
-      # superuser). The app's boot-time `CREATE EXTENSION IF NOT EXISTS vector`
-      # then short-circuits as a harmless no-op for the non-superuser app user.
-      postImportApplicationSQL:
-        - "CREATE EXTENSION IF NOT EXISTS vector"
+        # Belt-and-suspenders: guarantee the extension exists post-import (runs as
+        # superuser). The app's boot-time `CREATE EXTENSION IF NOT EXISTS vector`
+        # then short-circuits as a harmless no-op for the non-superuser app user.
+        postImportApplicationSQL:
+          - "CREATE EXTENSION IF NOT EXISTS vector"
 
   externalClusters:
     - name: legacy-postgres

--- a/k8s/cnpg/20-cluster-renfield-pg.yaml
+++ b/k8s/cnpg/20-cluster-renfield-pg.yaml
@@ -37,10 +37,21 @@ spec:
   # loss). CNPG promotes a caught-up standby automatically. (The explicit
   # `failoverQuorum` knob is a newer field than the installed operator 1.27.0 and
   # is intentionally omitted; the sync guarantee above already prevents data loss.)
+  #
+  # dataDurability: required (explicit; also the default) — durability over write-
+  # availability. TRADEOFF: this cluster has only 3 schedulable nodes and required
+  # anti-affinity, so a downed instance cannot reschedule until its node returns.
+  # If a SECOND instance is then lost, the sync requirement (ANY 1 standby) can't
+  # be met and app WRITES BLOCK until a standby is back — the app hangs, not just
+  # degrades. Operational rule: drain exactly ONE node at a time and wait for full
+  # re-sync (3/3) before the next; never run with two instances down. Switch to
+  # `preferred` only if you want writes to continue (async, last-commit-loss risk)
+  # through a double fault instead of blocking.
   postgresql:
     synchronous:
       method: any
       number: 1
+      dataDurability: required
 
   # --- One instance per node --------------------------------------------------
   affinity:
@@ -52,6 +63,14 @@ spec:
   storage:
     storageClass: longhorn-pg
     size: 10Gi
+  # Separate WAL volume: if S3 WAL archiving stalls (Garage/NAS down) unarchived
+  # WAL accumulates — isolating it here means that pressure fills a dedicated 2Gi
+  # volume instead of PGDATA, and each is resizable independently
+  # (allowVolumeExpansion). Monitor free space on both; a full WAL volume still
+  # halts the primary (by design — never silently drop WAL).
+  walStorage:
+    storageClass: longhorn-pg
+    size: 2Gi
 
   # --- Bootstrap: MIGRATE from the live single-node DB via pg_dump/restore -----
   # `microservice` import copies exactly the `renfield` database and re-owns it

--- a/k8s/cnpg/30-scheduledbackup.yaml
+++ b/k8s/cnpg/30-scheduledbackup.yaml
@@ -1,0 +1,21 @@
+# Nightly base backup to Garage S3 (WAL is archived continuously by the plugin's
+# isWALArchiver on the cluster). Together they give PITR back to any point within
+# the ObjectStore retention window (30d).
+#
+# `method: plugin` is required for the Barman Cloud plugin (the old `barmanObjectStore`
+# method is deprecated). Time is in 6-field Go cron (sec min hour dom mon dow).
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: renfield-pg-nightly
+  namespace: renfield
+  labels:
+    app.kubernetes.io/part-of: renfield
+spec:
+  cluster:
+    name: renfield-pg
+  schedule: "0 30 2 * * *"        # 02:30 every night
+  backupOwnerReference: self
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/k8s/cnpg/40-netpol-cnpg.yaml
+++ b/k8s/cnpg/40-netpol-cnpg.yaml
@@ -1,0 +1,46 @@
+# NetworkPolicy for the renfield-pg CNPG pods — same defense-in-depth posture as
+# the legacy `postgres-allow-app-only` (pentest F6): only the renfield app
+# workloads may reach the DB port, everything else in the namespace is denied.
+#
+# CNPG pods do NOT carry `app.kubernetes.io/name: postgres`, so the existing
+# policy does not select them — WITHOUT this file they would be unrestricted
+# (deny-by-default only applies to pods some policy selects). This policy also
+# MUST allow the traffic CNPG itself needs, or HA breaks:
+#   - 5432 between the cluster's own instances (streaming replication)
+#   - 5432 + 8000 from the operator namespace (management + instance status)
+#
+# NB: requires a NetworkPolicy-enforcing CNI (Calico here).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: renfield-pg-allow
+  namespace: renfield
+  labels:
+    app.kubernetes.io/part-of: renfield
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: renfield-pg
+  policyTypes: [Ingress]
+  ingress:
+    # --- App workloads: Postgres wire protocol only -------------------------
+    - from:
+        - podSelector: {matchLabels: {app.kubernetes.io/name: backend}}
+        - podSelector: {matchLabels: {app.kubernetes.io/name: document-worker}}
+        - podSelector: {matchLabels: {app.kubernetes.io/name: meeting-worker}}
+        - podSelector: {matchLabels: {app.kubernetes.io/name: pdf-split-worker}}
+        # alembic-upgrade Job + any backend-image job carry this shared label.
+        - podSelector: {matchLabels: {app.kubernetes.io/part-of: renfield, app.kubernetes.io/component: backend-job}}
+      ports:
+        - {protocol: TCP, port: 5432}
+    # --- Intra-cluster replication between the renfield-pg instances ---------
+    - from:
+        - podSelector: {matchLabels: {cnpg.io/cluster: renfield-pg}}
+      ports:
+        - {protocol: TCP, port: 5432}
+    # --- The CNPG operator (management + instance-manager status on 8000) ----
+    - from:
+        - namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: cnpg-system}}
+      ports:
+        - {protocol: TCP, port: 5432}
+        - {protocol: TCP, port: 8000}

--- a/k8s/cnpg/50-pgdump-cronjob.yaml
+++ b/k8s/cnpg/50-pgdump-cronjob.yaml
@@ -1,0 +1,86 @@
+# Nightly LOGICAL backup (pg_dump -Fc) to NFS — the simple, image-independent
+# fallback ALONGSIDE the Barman S3 PITR. This is the Phase-0 safety floor: a
+# self-contained custom-format dump that restores with plain `pg_restore` onto
+# any pgvector-capable Postgres, no operator/plugin required. Barman is the
+# primary (PITR); this is the "can always get the data back" belt.
+#
+# The dump runs against `renfield-pg-rw` (primary). Custom format (-Fc) preserves
+# the pgvector/halfvec column types + HNSW index definitions. Restore + verify
+# procedure is in README.md (Phase 0).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: renfield-pg-dump-nfs
+  namespace: renfield
+  labels:
+    app.kubernetes.io/part-of: renfield
+spec:
+  accessModes: [ReadWriteMany]
+  # Reuses the existing NFS-CSI storage on 192.168.1.9. A DEDICATED backup export
+  # /SC would be cleaner (separates dumps from app uploads) — flagged in README.
+  storageClassName: nfs-csi-renfield-uploads
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: renfield-pg-dump
+  namespace: renfield
+  labels:
+    app.kubernetes.io/part-of: renfield
+spec:
+  schedule: "0 3 * * *"            # 03:00 nightly (after the 02:30 base backup)
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            # Inherit the app-job label so the DB NetworkPolicy admits this pod.
+            app.kubernetes.io/part-of: renfield
+            app.kubernetes.io/component: backend-job
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: pgdump
+              image: your-registry.example/renfield/cnpg-pg16-pgvector:16.9-pgvector0.8.6
+              imagePullPolicy: Always
+              env:
+                - name: PGHOST
+                  value: renfield-pg-rw
+                - name: PGUSER
+                  value: renfield
+                - name: PGDATABASE
+                  value: renfield
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: renfield-secrets
+                      key: postgres-password
+                - name: RETENTION_DAYS
+                  value: "14"
+              command: ["/bin/bash", "-c"]
+              args:
+                - |
+                  set -euo pipefail
+                  ts=$(date -u +%Y%m%dT%H%M%SZ)
+                  out=/backup/renfield-${ts}.dump
+                  echo "pg_dump -> ${out}"
+                  pg_dump -Fc -Z6 -f "${out}"
+                  echo "rotate: deleting dumps older than ${RETENTION_DAYS}d"
+                  find /backup -name 'renfield-*.dump' -type f -mtime +${RETENTION_DAYS} -delete
+                  echo "done; current dumps:"; ls -lh /backup/renfield-*.dump
+              volumeMounts:
+                - name: dump
+                  mountPath: /backup
+          imagePullSecrets:
+            - name: harbor-pull-secret
+          volumes:
+            - name: dump
+              persistentVolumeClaim:
+                claimName: renfield-pg-dump-nfs

--- a/k8s/cnpg/Dockerfile.pgvector
+++ b/k8s/cnpg/Dockerfile.pgvector
@@ -21,9 +21,12 @@
 FROM ghcr.io/cloudnative-pg/postgresql:16.9-standard-bookworm
 
 USER root
+# Pin the pgvector version so a rebuild can't silently drift from the :pgvectorX.Y.Z
+# tag. A PGDG bump makes this line fail loud (version not found) — the signal to
+# bump BOTH this pin and the image tag together, never a silent contents drift.
 RUN set -eux; \
     apt-get update; \
-    apt-get install -y --no-install-recommends postgresql-16-pgvector; \
+    apt-get install -y --no-install-recommends postgresql-16-pgvector=0.8.6-1.pgdg12+1; \
     rm -rf /var/lib/apt/lists/*
 # Drop back to the unprivileged CNPG runtime user.
 USER 26

--- a/k8s/cnpg/Dockerfile.pgvector
+++ b/k8s/cnpg/Dockerfile.pgvector
@@ -1,0 +1,29 @@
+# Thin CNPG operand image = stock CloudNativePG PostgreSQL 16 + pgvector.
+#
+# WHY a custom image: the stock CNPG operand images
+# (ghcr.io/cloudnative-pg/postgresql) do NOT bundle pgvector, which the renfield
+# app hard-requires (halfvec, HNSW, 2560-dim embeddings). We keep the CNPG base
+# (so the operator's instance-manager, entrypoints, and PG minor tracking stay
+# intact) and add ONLY the pgvector extension from the PGDG apt repo the base
+# image already trusts.
+#
+# Build + push (Phase 2, on the .159 build box):
+#   R=your-registry.example/renfield
+#   docker build -f Dockerfile.pgvector \
+#     -t $R/cnpg-pg16-pgvector:16.9-pgvector0.8.6 \
+#     -t $R/cnpg-pg16-pgvector:latest .
+#   docker push $R/cnpg-pg16-pgvector:16.9-pgvector0.8.6
+#   docker push $R/cnpg-pg16-pgvector:latest
+#
+# VERIFY after first boot (the whole reason this image exists):
+#   psql -c '\dx vector'      # extension present, version >= 0.8.1
+# Re-pin the base tag to the current 16.x minor at build time; never :latest base.
+FROM ghcr.io/cloudnative-pg/postgresql:16.9-standard-bookworm
+
+USER root
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends postgresql-16-pgvector; \
+    rm -rf /var/lib/apt/lists/*
+# Drop back to the unprivileged CNPG runtime user.
+USER 26

--- a/k8s/cnpg/README.md
+++ b/k8s/cnpg/README.md
@@ -42,8 +42,9 @@ kubectl apply --server-side -f \
   https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.27/releases/cnpg-1.27.0.yaml
 kubectl -n cnpg-system rollout status deploy/cnpg-controller-manager --timeout=180s
 
-# Barman Cloud plugin (needs cert-manager; check the latest plugin release tag)
-kubectl apply -f https://github.com/cloudnative-pg/plugin-barman-cloud/releases/latest/download/manifest.yaml
+# Barman Cloud plugin (needs cert-manager). Pin the version (v0.14.0 was verified
+# with operator 1.27.0); bump deliberately, don't float on latest/.
+kubectl apply -f https://github.com/cloudnative-pg/plugin-barman-cloud/releases/download/v0.14.0/manifest.yaml
 kubectl -n cnpg-system rollout status deploy/barman-cloud --timeout=180s
 
 # Renfield-side prereqs (safe — no cluster created yet)
@@ -62,7 +63,11 @@ Copy `20-cluster-renfield-pg.yaml` into a scratch ns, import from a **copy** of
 the DB, then:
 1. `kubectl cnpg status renfield-pg` → healthy, 1 primary + 2 standbys in sync.
 2. Kill the primary pod → `renfield-pg-rw` repoints within seconds.
-3. `kubectl drain` the primary's node → failover + the drained instance rejoins & re-syncs.
+3. `kubectl drain` the primary's node → failover + the drained instance rejoins &
+   re-syncs. Drain exactly ONE node at a time and wait for 3/3 before the next
+   (see the dataDurability tradeoff in `20-cluster-renfield-pg.yaml`); a full
+   drain also evicts co-located prod pods, so a cordon + pod-delete is the lighter
+   test when you only need to prove promotion + `-rw` repoint.
 4. `\dx vector` + a real similarity query return correct rows.
 
 ## Phase 4 — household cutover (`ns renfield`)
@@ -76,14 +81,24 @@ the DB, then:
      --from-literal=password="$PW"
    unset PW
    ```
-2. Brief write-freeze on the app, then create the cluster (imports from live `postgres`):
+2. **Write-freeze — held CONTINUOUSLY until step 5 completes.** The import is a
+   `pg_dump` snapshot taken at cluster-creation; ANY write to the legacy DB
+   between that snapshot and the app being repointed is lost at cutover. So freeze
+   *before* creating the cluster and keep it frozen through the repoint+rollout:
    ```bash
-   kubectl apply -f 20-cluster-renfield-pg.yaml
+   kubectl -n renfield scale deploy/backend deploy/document-worker \
+     deploy/meeting-worker deploy/pdf-split-worker --replicas=0
+   ```
+3. Create the cluster (imports from live `postgres`). These files carry the
+   `your-registry.example` placeholder — substitute the real registry at apply
+   time (same pattern as the alembic job in the deploy skill):
+   ```bash
+   sed "s#your-registry.example/renfield#$RENFIELD_REGISTRY#" 20-cluster-renfield-pg.yaml | kubectl apply -f -
    kubectl cnpg status renfield-pg -n renfield   # wait: import complete, 3/3 healthy
    ```
-3. Verify on the new cluster: `\dx vector`, HNSW indexes present, a real RAG
-   similarity query returns correct rows.
-4. **Repoint the renfield app DB** `@postgres` → `@renfield-pg-rw` (host swap only):
+4. Verify on the new cluster: `\dx vector` (≥0.8.6), HNSW indexes present, a real
+   RAG similarity query returns correct rows (count-only is enough).
+5. **Repoint the renfield app DB** `@postgres` → `@renfield-pg-rw` (host swap only):
    - `k8s/backend.yaml:185`
    - `k8s/document-worker.yaml:119`
    - `k8s/meeting-worker.yaml:90`
@@ -93,13 +108,29 @@ the DB, then:
 
    **Do NOT touch** Paperless `PAPERLESS_DBHOST=postgres` or the twin DB config —
    they stay on the legacy StatefulSet.
-5. `kubectl apply -f k8s/configmap.yaml` + `rollout restart` backend + workers.
-   Run the alembic job against `-rw` first.
-6. Browser E2E (chat + Wissenssuche), watch Traefik/backend logs. Soak a few days.
+6. `kubectl apply -f k8s/configmap.yaml`, run the alembic job against `-rw` FIRST,
+   then scale backend + workers back up (this ends the write-freeze):
+   ```bash
+   kubectl -n renfield scale deploy/backend deploy/document-worker \
+     deploy/meeting-worker deploy/pdf-split-worker --replicas=1   # or prior replica counts
+   ```
+7. **Turn on backups** (both the plugin base backup and the pg_dump fallback are
+   inert until applied — WAL archiving alone is NOT restorable):
+   ```bash
+   kubectl apply -f 30-scheduledbackup.yaml
+   sed "s#your-registry.example/renfield#$RENFIELD_REGISTRY#" 50-pgdump-cronjob.yaml | kubectl apply -f -
+   kubectl cnpg backup renfield-pg -n renfield   # take an immediate base backup — don't wait for 02:30
+   ```
+8. Browser E2E (chat + Wissenssuche), watch Traefik/backend logs. Soak a few days.
 
 ## Phase 5 — backups sharp + verified
-- Confirm base backup + WAL archiving land in Garage (`kubectl cnpg status` +
-  list the bucket).
+- Confirm the on-demand base backup + continuous WAL archiving actually LAND in
+  Garage (`kubectl cnpg status renfield-pg` shows `First/Last Point of Recoverability`
+  + list the bucket). NB: the ObjectStore CR has no `region` field; barman/boto
+  default the S3 region — the ListBuckets connectivity check does not exercise
+  barman's signing, so explicitly confirm a base backup + a WAL segment upload
+  succeed before trusting the backup (Garage is generally region-lenient, but
+  verify, don't assume).
 - **Test a PITR restore into a scratch cluster** (`bootstrap.recovery` from the
   ObjectStore) — a backup you have not restored is not a backup.
 - Confirm the nightly `pg_dump` CronJob wrote a dump to NFS and restores cleanly.

--- a/k8s/cnpg/README.md
+++ b/k8s/cnpg/README.md
@@ -1,0 +1,136 @@
+# CNPG HA Postgres for the renfield app DB (`renfield-pg`)
+
+Manifests for moving the **renfield application database** off the single-node
+`postgres` StatefulSet onto a 3-instance CloudNativePG (CNPG) cluster with
+automatic failover + external S3 backups (PITR).
+
+**Scope:** the `renfield` app DB only, **household (`ns renfield`) first**.
+Paperless (`paperlessdb`) and the digital-twin DB stay on the legacy `postgres`
+StatefulSet — it keeps running for them. xidra is Phase 6, after a household soak.
+
+These files are **NOT in `kustomization.yaml`** — they are applied by hand,
+phase by phase, so nothing here touches prod until you run the step.
+
+## Files
+| File | What |
+|---|---|
+| `00-storageclass-pg.yaml` | `longhorn-pg` SC — 1 Longhorn replica, node-local (PG replicates 3×) |
+| `10-objectstore.yaml` | Barman ObjectStore → Garage S3 (`192.168.1.9:30188`, bucket `renfield-pg-backups`) |
+| `20-cluster-renfield-pg.yaml` | The 3-instance `Cluster` — quorum sync, anti-affinity, pgvector image, import-from-legacy |
+| `30-scheduledbackup.yaml` | Nightly base backup via the Barman plugin |
+| `40-netpol-cnpg.yaml` | NetworkPolicy for the CNPG pods (app + intra-cluster + operator) |
+| `50-pgdump-cronjob.yaml` | Nightly `pg_dump -Fc` → NFS (image-independent fallback) |
+| `Dockerfile.pgvector` | Thin CNPG-16 + pgvector image (Phase 2 build) |
+
+## Already done (Garage install)
+- Garage S3 RUNNING on `192.168.1.9:30188`, bucket `renfield-pg-backups`, key `renfield-cnpg` (rw).
+- Secret `renfield-pg-backup-s3` (ns `renfield`) with `ACCESS_KEY_ID` + `ACCESS_SECRET_KEY`.
+- Verified end-to-end: an in-cluster pod did `ListBuckets`/`ListObjects` against the bucket.
+
+---
+
+## Phase 1 — operator + prerequisites
+Pin to the current releases (verify latest before running):
+
+```bash
+# cert-manager (Barman plugin dependency)
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.16.2/cert-manager.yaml
+kubectl -n cert-manager rollout status deploy/cert-manager-webhook --timeout=180s
+
+# CNPG operator (installs into ns cnpg-system)
+kubectl apply --server-side -f \
+  https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.27/releases/cnpg-1.27.0.yaml
+kubectl -n cnpg-system rollout status deploy/cnpg-controller-manager --timeout=180s
+
+# Barman Cloud plugin (needs cert-manager; check the latest plugin release tag)
+kubectl apply -f https://github.com/cloudnative-pg/plugin-barman-cloud/releases/latest/download/manifest.yaml
+kubectl -n cnpg-system rollout status deploy/barman-cloud --timeout=180s
+
+# Renfield-side prereqs (safe — no cluster created yet)
+kubectl apply -f 00-storageclass-pg.yaml
+kubectl apply -f 10-objectstore.yaml
+kubectl apply -f 40-netpol-cnpg.yaml
+```
+
+## Phase 2 — build the pgvector operand image
+The stock CNPG image has no pgvector. Build the thin image on `.159` and push to
+Harbor (see header of `Dockerfile.pgvector`). Re-pin the base tag to the current
+16.x minor. After the cluster is up, verify `\dx vector` is **≥ 0.8.1**.
+
+## Phase 3 — dry-run + failover drill (scratch namespace, BEFORE prod)
+Copy `20-cluster-renfield-pg.yaml` into a scratch ns, import from a **copy** of
+the DB, then:
+1. `kubectl cnpg status renfield-pg` → healthy, 1 primary + 2 standbys in sync.
+2. Kill the primary pod → `renfield-pg-rw` repoints within seconds.
+3. `kubectl drain` the primary's node → failover + the drained instance rejoins & re-syncs.
+4. `\dx vector` + a real similarity query return correct rows.
+
+## Phase 4 — household cutover (`ns renfield`)
+1. **Pre-create the app-user secret** so the app password matches the legacy one
+   (value taken from the existing secret; never printed):
+   ```bash
+   PW=$(kubectl -n renfield get secret renfield-secrets -o jsonpath='{.data.postgres-password}' | base64 -d)
+   kubectl -n renfield create secret generic renfield-pg-app \
+     --type=kubernetes.io/basic-auth \
+     --from-literal=username=renfield \
+     --from-literal=password="$PW"
+   unset PW
+   ```
+2. Brief write-freeze on the app, then create the cluster (imports from live `postgres`):
+   ```bash
+   kubectl apply -f 20-cluster-renfield-pg.yaml
+   kubectl cnpg status renfield-pg -n renfield   # wait: import complete, 3/3 healthy
+   ```
+3. Verify on the new cluster: `\dx vector`, HNSW indexes present, a real RAG
+   similarity query returns correct rows.
+4. **Repoint the renfield app DB** `@postgres` → `@renfield-pg-rw` (host swap only):
+   - `k8s/backend.yaml:185`
+   - `k8s/document-worker.yaml:119`
+   - `k8s/meeting-worker.yaml:90`
+   - `k8s/pdf-split-worker.yaml:81`
+   - `k8s/alembic-upgrade-job.yaml:62`
+   - `k8s/configmap.yaml:46` (the `__PG_PASSWORD__` template — keep consistent)
+
+   **Do NOT touch** Paperless `PAPERLESS_DBHOST=postgres` or the twin DB config —
+   they stay on the legacy StatefulSet.
+5. `kubectl apply -f k8s/configmap.yaml` + `rollout restart` backend + workers.
+   Run the alembic job against `-rw` first.
+6. Browser E2E (chat + Wissenssuche), watch Traefik/backend logs. Soak a few days.
+
+## Phase 5 — backups sharp + verified
+- Confirm base backup + WAL archiving land in Garage (`kubectl cnpg status` +
+  list the bucket).
+- **Test a PITR restore into a scratch cluster** (`bootstrap.recovery` from the
+  ObjectStore) — a backup you have not restored is not a backup.
+- Confirm the nightly `pg_dump` CronJob wrote a dump to NFS and restores cleanly.
+
+## Phase 6 — xidra (`ns renfield-xidra`)
+Repeat 4–5 in `renfield-xidra` after the household soak. Repoint targets:
+`k8s/xidra/meeting-worker.yaml:70`, `k8s/xidra/renfield-env.configmap.yaml:22`
+(+ the base files xidra reuses). The xidra Barman ObjectStore/secret + app
+secret need their own copies in that ns; Garage can hold a second bucket
+(`xidra-pg-backups`) with its own key.
+
+---
+
+## Rollback (per cutover)
+The legacy `postgres` StatefulSet was never stopped → set `DATABASE_URL` back to
+`@postgres`, `rollout restart`. Divergence window = time since cutover (small
+write volume during soak; acceptable).
+
+## Open decisions / honest flags
+- **pgvector image (Phase 2):** required custom build — the plan's "pgvector rides
+  along in the stock image" assumption is **false**; the stock CNPG operand has no
+  pgvector. Handled by `Dockerfile.pgvector`.
+- **asyncpg + TLS:** CNPG's default pg_hba allows scram over the pod network
+  without client certs, so `@renfield-pg-rw` should work unchanged. If the app
+  can't connect, append `?ssl=require` to the DATABASE_URL. Verify in Phase 4.
+- **NFS dump export:** `50-pgdump-cronjob.yaml` reuses `nfs-csi-renfield-uploads`.
+  A dedicated backup export/SC would cleanly separate dumps from app uploads.
+- **Garage is on the NAS box itself:** external to the k8s *cluster* (survives a
+  cluster loss) but NOT to a NAS-box loss. A later off-box/offsite sync of the
+  bucket would complete 3-2-1. Deferred.
+- **Single control-plane node (`k8s-cp`):** the real availability ceiling. DB-HA
+  is real but capped until the control plane is also HA. Separate track.
+- **Deferred:** Paperless + twin DB migration into CNPG; control-plane HA;
+  ImageVolume-pgvector (needs k8s 1.33+/PG18).

--- a/k8s/redis-postgres-netpol.yaml
+++ b/k8s/redis-postgres-netpol.yaml
@@ -57,5 +57,10 @@ spec:
         # then /ready hung forever on blackholed reconnects (pod NotReady 18d,
         # twin capture silently dead). Twin needs Postgres only, NOT Redis.
         - podSelector: {matchLabels: {app: twin}}
+        # CNPG migration (DB-HA): the renfield-pg cluster pods run pg_dump against
+        # this legacy DB during bootstrap.initdb.import. They carry the cnpg.io
+        # cluster label, not the app labels, so without this they'd be blackholed
+        # and the import would hang. Same-namespace (ns renfield). See k8s/cnpg/.
+        - podSelector: {matchLabels: {cnpg.io/cluster: renfield-pg}}
       ports:
         - {protocol: TCP, port: 5432}


### PR DESCRIPTION
## Summary

Introduces **CloudNativePG (CNPG) HA Postgres** for the renfield **application
database** — 3-instance streaming replication with automatic failover + external
S3 PITR backups (Garage on the NAS). Manifests live in `k8s/cnpg/`, applied
**by hand, phase by phase** (NOT wired into `kustomization.yaml`), household
(`ns renfield`) first.

Scope is deliberately the renfield app DB only. **Paperless (`paperlessdb`) and
the digital-twin DB stay on the legacy `postgres` StatefulSet** — it keeps
running for them. xidra is Phase 6.

### What's in `k8s/cnpg/`
- `00-storageclass-pg.yaml` — `longhorn-pg` SC (1 Longhorn replica, best-effort locality; PG replicates 3× itself)
- `10-objectstore.yaml` — Barman ObjectStore → Garage S3 (`192.168.1.9:30188`, bucket `renfield-pg-backups`)
- `20-cluster-renfield-pg.yaml` — the 3-instance `Cluster`: quorum sync, hard anti-affinity, pgvector operand image, microservice import from the live DB, `postImportApplicationSQL` extension guard
- `30-scheduledbackup.yaml` — nightly plugin base backup
- `40-netpol-cnpg.yaml` — NetworkPolicy for the CNPG pods (app + intra-cluster + operator)
- `50-pgdump-cronjob.yaml` — nightly `pg_dump -Fc` → NFS (image-independent fallback) + PVC
- `Dockerfile.pgvector` — thin CNPG-16 + `postgresql-16-pgvector` image
- `README.md` — phased rollout, repoint targets, verify, rollback

Plus: `redis-postgres-netpol.yaml` gains a `cnpg.io/cluster: renfield-pg` allow so
the bootstrap import can reach the legacy `postgres`.

## Status of the rollout
- **Phase 1 (operator + prereqs): DONE, live in `ns renfield`** — cert-manager v1.16.2, CNPG operator 1.27.0, Barman Cloud plugin v0.14.0, `longhorn-pg` SC, ObjectStore, netpol.
- **Phase 2 (pgvector image): DONE** — `registry.treehouse.x-idra.de/renfield/cnpg-pg16-pgvector:16.9-pgvector0.8.6` built + pushed. Verified pgvector 0.8.6 (≥ live 0.8.2).
- **Phase 3 (dry-run + failover drill): DONE, torn down clean** — a scratch cluster imported the live DB (2846 chunks, 4 HNSW indexes preserved, real KNN OK), then a primary-kill failover promoted a standby, `-rw` repointed automatically with **zero data loss**, and the old instance rejoined → 3/3.
- **Phase 4 (household cutover): NOT started** — the first step that touches the real app DB (write-freeze + repoint + rollout, ~5-10 min chat downtime). Awaiting an explicit go + timing.

## Three bugs caught in the Phase-3 dry-run (fixed here)
1. CRD field names for operator 1.27.0: `storageClassName`→`storageClass`, dropped `synchronous.failoverQuorum` (newer than 1.27; `number:1` quorum sync already prevents async data loss), moved `postImportApplicationSQL` under `import`.
2. Netpol: CNPG pods carry `cnpg.io/cluster`, not the app labels → the import would have been blackholed by `postgres-allow-app-only`.
3. `strict-local`→`best-effort`: only 2 Longhorn storage nodes (gpu-3 has scheduling disabled), but anti-affinity spreads 3 instances across 3 nodes → strict-local was unsatisfiable.

## Test plan
- [x] `kubectl apply --dry-run=server` validates all manifests against the installed CRDs
- [x] Live dry-run cluster: import from legacy DB, pgvector 0.8.6, HNSW indexes + real KNN, failover with no data loss, clean teardown
- [ ] Phase 4 household cutover + browser E2E (chat + Wissenssuche) — separate go
- [ ] Phase 5 PITR restore test from Garage
- [ ] Phase 6 xidra

## Honest flags (in README)
- Garage sits on the NAS box → external to the k8s *cluster*, not to a NAS-box loss (offsite sync deferred).
- Single control-plane node is the real availability ceiling (separate track).
- Paperless + twin DB migration deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)