### PR TITLE
feat(infra): DB-HA Phase 4 — household cutover to renfield-pg

### DIFF
--- a/k8s/alembic-upgrade-job.yaml
+++ b/k8s/alembic-upgrade-job.yaml
@@ -59,7 +59,7 @@ spec:
                   key: secret-key
                   optional: true
             - name: DATABASE_URL
-              value: postgresql+asyncpg://renfield:$(POSTGRES_PASSWORD)@postgres:5432/renfield
+              value: postgresql+asyncpg://renfield:$(POSTGRES_PASSWORD)@renfield-pg-rw:5432/renfield
           resources:
             requests:
               cpu: 100m

--- a/k8s/backend.yaml
+++ b/k8s/backend.yaml
@@ -182,7 +182,7 @@ spec:
                   name: renfield-secrets
                   key: postgres-password
             - name: DATABASE_URL
-              value: postgresql+asyncpg://renfield:$(POSTGRES_PASSWORD)@postgres:5432/renfield
+              value: postgresql+asyncpg://renfield:$(POSTGRES_PASSWORD)@renfield-pg-rw:5432/renfield
             - name: SECRET_KEY
               valueFrom:
                 secretKeyRef:

--- a/k8s/cnpg/10-objectstore.yaml
+++ b/k8s/cnpg/10-objectstore.yaml
@@ -29,6 +29,13 @@ spec:
       secretAccessKey:
         name: renfield-pg-backup-s3
         key: ACCESS_SECRET_KEY
+      # Garage signs SigV4 against its configured region ("garage"); without this
+      # barman/boto defaults the region and Garage rejects HeadBucket with
+      # 400 Bad Request → WAL archiving + backups fail. Must match the Garage
+      # app's s3_region.
+      region:
+        name: renfield-pg-backup-s3
+        key: REGION
     wal:
       compression: gzip
       maxParallel: 2

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -43,7 +43,7 @@ data:
   # ────────────────────────────────────────────────────────────────────────────
 
   # Infra endpoints (cluster-internal DNS)
-  DATABASE_URL: "postgresql+asyncpg://renfield:__PG_PASSWORD__@postgres:5432/renfield"
+  DATABASE_URL: "postgresql+asyncpg://renfield:__PG_PASSWORD__@renfield-pg-rw:5432/renfield"
   REDIS_URL: "redis://redis:6379"
   OLLAMA_URL: "http://ollama:11434"
   OLLAMA_EMBED_URL: "http://ollama:11434"

--- a/k8s/document-worker.yaml
+++ b/k8s/document-worker.yaml
@@ -116,7 +116,7 @@ spec:
               valueFrom:
                 secretKeyRef: {name: renfield-secrets, key: secret-key, optional: true}
             - name: DATABASE_URL
-              value: postgresql+asyncpg://renfield:$(POSTGRES_PASSWORD)@postgres:5432/renfield
+              value: postgresql+asyncpg://renfield:$(POSTGRES_PASSWORD)@renfield-pg-rw:5432/renfield
             # Integration secrets mirror the backend so Docling/RAG code paths
             # that eventually call out (e.g. contextual retrieval LLM) work.
             - name: HOME_ASSISTANT_TOKEN

--- a/k8s/meeting-worker.yaml
+++ b/k8s/meeting-worker.yaml
@@ -87,7 +87,7 @@ spec:
               valueFrom:
                 secretKeyRef: {name: renfield-secrets, key: secret-key, optional: true}
             - name: DATABASE_URL
-              value: postgresql+asyncpg://renfield:$(POSTGRES_PASSWORD)@postgres:5432/renfield
+              value: postgresql+asyncpg://renfield:$(POSTGRES_PASSWORD)@renfield-pg-rw:5432/renfield
           volumeMounts:
             # Read the audio the backend streamed here; ingest_document also
             # persists the rendered transcript under this PVC.

--- a/k8s/pdf-split-worker.yaml
+++ b/k8s/pdf-split-worker.yaml
@@ -78,7 +78,7 @@ spec:
               valueFrom:
                 secretKeyRef: {name: renfield-secrets, key: secret-key, optional: true}
             - name: DATABASE_URL
-              value: postgresql+asyncpg://renfield:$(POSTGRES_PASSWORD)@postgres:5432/renfield
+              value: postgresql+asyncpg://renfield:$(POSTGRES_PASSWORD)@renfield-pg-rw:5432/renfield
           volumeMounts:
             # Read the parent PDF; execute_split persists the child PDFs here
             # via ingest_document.


### PR DESCRIPTION
## Summary
Executes the **Phase 4 household cutover** of the DB-HA plan: the renfield app DB
(ns `renfield`) now runs on the 3-instance CloudNativePG cluster `renfield-pg`
instead of the single-node `postgres` StatefulSet. Done live + verified.

Follows #1130 (which shipped the manifests + Phases 1-3).

## What changed
- **Repoint** `DATABASE_URL` `@postgres` → `@renfield-pg-rw` in the 6 household
  app-DB consumers: `backend.yaml`, `document-worker.yaml`, `meeting-worker.yaml`,
  `pdf-split-worker.yaml`, `alembic-upgrade-job.yaml`, `configmap.yaml` (template).
- **ObjectStore region fix** (`10-objectstore.yaml`): add `s3Credentials.region`
  → `REGION=garage` key on the backup secret.

## Live execution (already done)
1. Pre-created `renfield-pg-app` secret (same password → pure host swap).
2. Write-freeze: scaled backend + 3 workers to 0.
3. Created `renfield-pg` (registry-substituted) → microservice import from the
   frozen legacy DB → 3/3 healthy. Verified: pgvector 0.8.6, 4 HNSW indexes,
   alembic at head (`pc20260824_pf_finalize`), 2846 chunks / 2162 embedded, real KNN OK.
4. Repointed via `kubectl set env` (NOT apply — live pods run pinned image tags
   the yamls don't carry; apply would revert the image), scaled back up.
5. Browser E2E on `https://renfield.local`: chat persists + `internal.ingest_status`
   read **378 docs** from the new DB, 0 console errors.
6. Backups: hit the `HeadBucket 400 Bad Request` region footgun (flagged in the
   #1130 review) → added `REGION=garage`. Result: **ContinuousArchiving=True**,
   base backup completed (`20260825T181842`), **14 objects / ~169 MB in Garage**.

## Deploy notes / caveats
- The repoint was applied with `kubectl set env`, so live ≠ a raw `kubectl apply`
  of these yamls (which would revert the pinned images). Treat these edits as the
  git record of the live env, not an apply-me manifest.
- `configmap.yaml`'s `DATABASE_URL` is a `__PG_PASSWORD__` template and is inert
  live (the app uses the deployments' inline env) — edited for consistency only.
- **Rollback:** the legacy `postgres` StatefulSet was left running (also serves
  Paperless + digital-twin DBs) → `kubectl set env … DATABASE_URL=…@postgres…` +
  scale, and the app is back on it.

## Test plan
- [x] Cluster import verified (pgvector, HNSW, counts, KNN)
- [x] Browser E2E (chat persist + DB read) green, 0 console errors
- [x] Backups land in Garage (base backup + WAL, region fix)
- [ ] Multi-day soak
- [ ] PITR restore drill from Garage (Phase 5)
- [ ] xidra (Phase 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)