### PR TITLE
fix(infra): CNPG netpol — allow intra-cluster :8000 failsafe cross-check

### DIFF
--- a/k8s/cnpg/40-netpol-cnpg.yaml
+++ b/k8s/cnpg/40-netpol-cnpg.yaml
@@ -33,11 +33,16 @@ spec:
         - podSelector: {matchLabels: {app.kubernetes.io/part-of: renfield, app.kubernetes.io/component: backend-job}}
       ports:
         - {protocol: TCP, port: 5432}
-    # --- Intra-cluster replication between the renfield-pg instances ---------
+    # --- Intra-cluster: streaming replication (5432) AND the instance-manager
+    # failsafe/liveness cross-check (8000). Instances probe each other's
+    # /failsafe on 8000; without it the split-brain self-fencing safety net is
+    # blocked (cluster still promotes via the operator, but the instance-to-
+    # instance failsafe degrades — silent HA weakening). ------------------------
     - from:
         - podSelector: {matchLabels: {cnpg.io/cluster: renfield-pg}}
       ports:
         - {protocol: TCP, port: 5432}
+        - {protocol: TCP, port: 8000}
     # --- The CNPG operator (management + instance-manager status on 8000) ----
     - from:
         - namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: cnpg-system}}


### PR DESCRIPTION
## Summary
The `renfield-pg` CNPG instances probe each other's instance-manager `/failsafe`
on **port 8000** (split-brain self-fencing + liveness cross-check). The
`renfield-pg-allow` NetworkPolicy's intra-cluster rule only opened **5432**
(streaming replication), so those probes were blackholed:

```
Instance connectivity error ... Get "https://<peer>:8000/failsafe": context deadline exceeded
```

The cluster still promoted on failover (the operator reaches instances on 8000
from `cnpg-system`, which was allowed), so it read as **healthy 3/3** — but the
**instance-to-instance failsafe safety net was silently degraded** on BOTH the
household and xidra clusters. Fix: add 8000 to the `cnpg.io/cluster` intra-cluster
ingress rule.

## Verification
- Reproduced on both `renfield` and `renfield-xidra` (repeated connectivity errors).
- After `kubectl apply`: connectivity errors → **0** in the following 20s on both.
- Found during the xidra Phase 6 cutover (xidra's netpol is generated from this
  file; the gitignored `k8s/xidra/cnpg/` copy was regenerated + applied too).

## Test plan
- [x] Connectivity errors cleared on both clusters
- [x] Both clusters remain healthy 3/3
- [ ] (already applied live to both — this PR is the git record)

🤖 Generated with [Claude Code](https://claude.com/claude-code)