### PR TITLE
fix(paperless): pass truncate=False on list_all_documents (Fix C prod bug)

### DIFF
--- a/src/backend/services/paperless_dedupe_tool.py
+++ b/src/backend/services/paperless_dedupe_tool.py
@@ -137,7 +137,14 @@ async def _gather_all_documents(
     still works, degraded. That fallback CANNOT reach a duplicate group whose >500
     copies share one creation date (the failure that hid the 2289-copy group);
     ``list_all_documents`` fixes it by walking an id cursor, not a date window."""
-    res = await _call_with_retry(mcp_manager, "mcp.paperless.list_all_documents", {})
+    # truncate=False is ESSENTIAL: the whole-archive payload (thousands of rows ×
+    # checksum) far exceeds the default 128KB mcp_max_response_size cap. A truncated
+    # response is unparseable → the guard below would silently fall back to the
+    # partial date-window sweep (the ~566-of-4056 symptom on xidra). Same reason the
+    # legacy sweep passes truncate=False.
+    res = await _call_with_retry(
+        mcp_manager, "mcp.paperless.list_all_documents", {}, truncate=False
+    )
     # Accept ONLY a genuine list_all_documents response — it is the only paperless
     # tool whose summary carries ``total_count``. Critical: on an OLD MCP that lacks
     # this tool, MCPManager does NOT error — it FUZZY-FALLS-BACK to another paperless

--- a/tests/backend/test_paperless_dedupe_tool.py
+++ b/tests/backend/test_paperless_dedupe_tool.py
@@ -50,11 +50,13 @@ def _make_mcp(docs, contents=None, pages=None, rate_limit_first=0, search_error_
         def __init__(self):
             self.deleted: list[int] = []
             self.get_document_calls: list[tuple[int, dict]] = []
+            self.list_all_kw: dict | None = None
             self._search_i = 0
             self._del_i = 0
 
         async def execute_tool(self, tool, params, **kw):
             if tool == "mcp.paperless.list_all_documents":
+                self.list_all_kw = kw
                 if all_docs is None:
                     # Reproduce MCPManager's REAL behavior on an OLD MCP that lacks
                     # this tool: it does NOT error — it fuzzy-falls-back to
@@ -548,3 +550,14 @@ async def test_gather_uses_list_all_when_total_count_present(monkeypatch):
     gathered, complete, err = await mod._gather_all_documents(mcp)
     assert called["sweep"] is False
     assert [d["id"] for d in gathered] == [1] and complete is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_list_all_documents_called_with_truncate_false():
+    # The whole-archive payload (thousands of rows × checksum) exceeds the 128KB
+    # response cap; without truncate=False it is silently truncated → unparseable →
+    # falls back to the partial sweep (the ~566-of-4056 xidra symptom).
+    mcp = _make_mcp([], all_docs=[_doc(1, checksum="X"), _doc(2, checksum="X")])
+    await paperless_dedupe({"dry_run": True}, mcp_manager=mcp)
+    assert mcp.list_all_kw.get("truncate") is False


### PR DESCRIPTION
## Summary
Fix C shipped but the xidra dry-run still scanned only ~566 of 4056 docs. Root cause: `_gather_all_documents` called `list_all_documents` **without `truncate=False`**, so the whole-archive payload (thousands of rows × checksum, ~500KB) exceeded the 128KB `mcp_max_response_size` cap → truncated → unparseable → the `total_count`-marker guard silently fell back to the partial date-window sweep (which carries no checksum, so the 2289-copy group stayed invisible).

Fix: pass `truncate=False` (as the legacy sweep already does). One-line + test asserting the flag.

## Test plan
- [x] `.159`: 29 passed (new `test_list_all_documents_called_with_truncate_false`).
- [ ] Deploy both instances; re-run the xidra dry-run → should now scan ~4056 and report ~3616.

🤖 Generated with [Claude Code](https://claude.com/claude-code)