### PR TITLE
fix(paperless): raise per-call timeout for dedupe_documents (#1137)

### DIFF
--- a/src/backend/services/paperless_dedupe_tool.py
+++ b/src/backend/services/paperless_dedupe_tool.py
@@ -100,6 +100,9 @@ async def paperless_dedupe(
             "mcp.paperless.dedupe_documents",
             {"dry_run": dry_run, "max_delete": max_delete, "metadata_match": metadata_match},
             truncate=False,
+            # Single-call full-archive dedupe exceeds the default 30s on a large
+            # archive — raise the per-call timeout so it doesn't time out mid-sweep.
+            call_timeout=settings.paperless_dedupe_call_timeout_s,
         ))
     except Exception as e:  # noqa: BLE001
         logger.warning(f"paperless_dedupe failed: {e}")

--- a/src/backend/services/scheduled_tasks/builtins.py
+++ b/src/backend/services/scheduled_tasks/builtins.py
@@ -71,6 +71,9 @@ async def _paperless_dedupe_handler(app: "FastAPI", params: dict) -> str | None:
             "metadata_match": settings.paperless_dedupe_metadata_match_enabled,
         },
         truncate=False,
+        # The single-call full-archive dedupe exceeds the default 30s on a large
+        # archive — raise the per-call timeout (else the drain never progresses).
+        call_timeout=settings.paperless_dedupe_call_timeout_s,
     ))
     if res.get("error"):
         raise RuntimeError(f"dedupe_documents error: {res['error']}")

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -1028,6 +1028,13 @@ class Settings(BaseSettings):
     # pass stays inside the MCP rate limit + the tool's wall-clock budget; the job
     # re-runs each interval until remaining reaches 0.
     paperless_dedupe_reconciler_max_delete: int = Field(default=200, ge=1, le=1000)
+    # Per-call MCP timeout for mcp.paperless.dedupe_documents. It does the WHOLE
+    # dedupe in ONE call (full-archive enumeration + grouping + a batch delete
+    # bounded by the tool's ~75s wall-clock budget), which on a large archive far
+    # exceeds the default 30s mcp_call_timeout → the call would time out and the
+    # drain never progresses. Both the scheduled paperless-dedupe job AND the
+    # interactive internal.paperless_dedupe pass this as execute_tool(call_timeout=).
+    paperless_dedupe_call_timeout_s: float = Field(default=180.0, ge=30.0, le=600.0)
 
     # Document-worker stale-task recovery. reclaim_stale() re-adopts entries a
     # dead consumer left un-ACKed in the Redis PEL. It used to run ONLY at worker

--- a/tests/backend/test_paperless_dedupe_tool.py
+++ b/tests/backend/test_paperless_dedupe_tool.py
@@ -25,12 +25,17 @@ def _make_mcp(inner: dict | None = None, *, transport_error: bool = False):
     class _MCP:
         def __init__(self):
             self.last_params: dict | None = None
+            self.last_kw: dict | None = None
             self.calls: list[str] = []
 
         async def execute_tool(self, tool, params, **kw):
             self.calls.append(tool)
             self.last_params = params
+            self.last_kw = kw
             assert kw.get("truncate") is False  # large payloads must not be truncated
+            # The single-call full-archive dedupe needs a raised per-call timeout
+            # (the default 30s times out on a large archive).
+            assert kw.get("call_timeout") and kw["call_timeout"] > 30
             if transport_error:
                 return {"success": False, "message": "boom"}
             return _envelope(inner or {})

--- a/tests/backend/test_scheduled_tasks_engine.py
+++ b/tests/backend/test_scheduled_tasks_engine.py
@@ -415,6 +415,7 @@ class TestPaperlessDedupeHandler:
             async def execute_tool(self, tool, params, **kw):
                 assert tool == "mcp.paperless.dedupe_documents"
                 assert params["dry_run"] is False
+                assert kw.get("call_timeout") and kw["call_timeout"] > 30  # raised per-call timeout
                 # MCPManager envelope: the tool's dict is JSON in "message". Include
                 # the marker keys a real dedupe_documents response always carries, so
                 # the contract-marker guard treats it as a legitimate result.


### PR DESCRIPTION
## Summary
The D9 rewire consolidated dedupe into a single `mcp.paperless.dedupe_documents` call (full-archive enumeration + batch delete in one shot). On a large archive (xidra ~3000 duplicates) that exceeds the default **30s** `mcp_call_timeout` → `Tool-Aufruf Timeout` and the autonomous drain never progresses (caught via the scheduled task's `last_status=error`, `last_duration_ms≈30000`).

Both call sites (scheduled `paperless_dedupe` handler + interactive `internal.paperless_dedupe` thin caller) now pass `execute_tool(call_timeout=settings.paperless_dedupe_call_timeout_s)` — new config, default **180s**. `execute_tool` already supports per-call timeout overrides for slow paperless polls (`await_consume_result`).

## Test plan
- [x] 62/62 green on `.159` (14 dedupe-tool + 48 engine) — both dedupe mocks now assert `call_timeout > 30` is threaded through.
- [ ] Post-deploy: xidra paperless-dedupe task advances (`last_status=ok`, `remaining` decreasing) instead of timing out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)