### PR TITLE
chore(config): activate agent_orchestrator + memory_episodic (household)

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -202,6 +202,7 @@ data:
   # preference against this list). 'it' added with the Italian locale (#628).
   SUPPORTED_LANGUAGES: "de,en,it"
   AGENT_ENABLED: "true"
+  AGENT_ORCHESTRATOR_ENABLED: "true"
   MCP_ENABLED: "true"
   # MCP self-detection (Phase 1): surface MCP failures renfield already detects
   # (Plane-A get_status() degrade/down + Plane-B ingest-MCP OPERATOR-NOTIFY pushes)
@@ -209,6 +210,7 @@ data:
   # of dead-ending in logs. Needs PROACTIVE_ENABLED (on here) for the push.
   MCP_HEALTH_MONITOR_ENABLED: "true"
   MEMORY_ENABLED: "true"
+  MEMORY_EPISODIC_ENABLED: "true"
   MEMORY_EXTRACTION_ENABLED: "true"
   KNOWLEDGE_GRAPH_ENABLED: "true"
   PRESENCE_ENABLED: "true"


### PR DESCRIPTION
Activate two dark features on the household (renfield): the multi-agent orchestrator and episodic memory. ConfigMap-in-git per the drift rule; applied + rolled after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)