### PR TITLE
feat(simba): prefill attachment-menu category/type from file content

### DIFF
--- a/src/backend/api/routes/chat_upload.py
+++ b/src/backend/api/routes/chat_upload.py
@@ -40,6 +40,7 @@ from .chat_upload_schemas import (
     IndexResponse,
     PaperlessResponse,
     SimbaCategoriesResponse,
+    SimbaSuggestResponse,
     SimbaUploadRequest,
     SimbaUploadResponse,
 )
@@ -465,21 +466,17 @@ async def forward_to_paperless(
 # ============================================================================
 
 
-@router.get("/upload/simba/categories", response_model=SimbaCategoriesResponse)
-async def simba_categories(request: Request, user=Depends(get_optional_user)):
-    """Categories → document types for the Simba transfer. Also the availability
-    gate: 503 when the simba MCP isn't configured (so the UI hides the menu)."""
-    manager = getattr(request.app.state, "mcp_manager", None)
+async def _simba_taxonomy(manager) -> dict[str, list[str]]:
+    """Fetch the Simba category→type map via the MCP. Returns {} when unavailable."""
     if not manager:
-        raise HTTPException(status_code=503, detail="MCP not available")
+        return {}
     try:
         result = await manager.execute_tool("mcp.simba.list_categories", {"live": False})
     except Exception as e:
         logger.warning(f"Simba categories unavailable: {e}")
-        raise HTTPException(status_code=503, detail="Simba not available")
+        return {}
     if not result or not result.get("success"):
-        raise HTTPException(status_code=503, detail="Simba not available")
-
+        return {}
     categories: dict = {}
     raw = result.get("message")
     if isinstance(raw, str):
@@ -488,11 +485,51 @@ async def simba_categories(request: Request, user=Depends(get_optional_user)):
             categories = inner.get("kategorien") or inner.get("categories") or {}
         except (json.JSONDecodeError, TypeError):
             categories = {}
-    if not isinstance(categories, dict) or not categories:
+    if not isinstance(categories, dict):
+        return {}
+    return {str(k): [str(t) for t in (v or [])] for k, v in categories.items()}
+
+
+@router.get("/upload/simba/categories", response_model=SimbaCategoriesResponse)
+async def simba_categories(request: Request, user=Depends(get_optional_user)):
+    """Categories → document types for the Simba transfer. Also the availability
+    gate: 503 when the simba MCP isn't configured (so the UI hides the menu)."""
+    manager = getattr(request.app.state, "mcp_manager", None)
+    if not manager:
+        raise HTTPException(status_code=503, detail="MCP not available")
+    categories = await _simba_taxonomy(manager)
+    if not categories:
         raise HTTPException(status_code=503, detail="Simba not available")
-    # Normalize to {str: [str, ...]}
-    norm = {str(k): [str(t) for t in (v or [])] for k, v in categories.items()}
-    return SimbaCategoriesResponse(categories=norm)
+    return SimbaCategoriesResponse(categories=categories)
+
+
+@router.get("/upload/{upload_id}/simba/suggest", response_model=SimbaSuggestResponse)
+async def simba_suggest(
+    upload_id: int,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user=Depends(get_optional_user),
+):
+    """Suggest a Simba category/type from the document content, to prefill the
+    chat menu picker. Best-effort — nulls when the text/model/taxonomy is missing
+    or the classification is invalid. Never a hard error (the user picks manually)."""
+    upload = await _get_owned_upload(db, upload_id, user)
+    if not upload:
+        raise HTTPException(status_code=404, detail="Upload not found")
+
+    text = (upload.extracted_text or "").strip()
+    if not text:
+        return SimbaSuggestResponse()
+
+    manager = getattr(request.app.state, "mcp_manager", None)
+    categories = await _simba_taxonomy(manager)
+    if not categories:
+        return SimbaSuggestResponse()
+
+    from services.simba_classify import classify_simba
+
+    category, type_ = await classify_simba(text, categories)
+    return SimbaSuggestResponse(category=category, type=type_)
 
 
 @router.post("/upload/{upload_id}/simba", response_model=SimbaUploadResponse)

--- a/src/backend/api/routes/chat_upload_schemas.py
+++ b/src/backend/api/routes/chat_upload_schemas.py
@@ -68,3 +68,9 @@ class SimbaUploadRequest(BaseModel):
 class SimbaUploadResponse(BaseModel):
     success: bool
     message: str
+
+
+class SimbaSuggestResponse(BaseModel):
+    """Category/type suggested from the document content (null when unknown)."""
+    category: str | None = None
+    type: str | None = None

--- a/src/backend/services/simba_classify.py
+++ b/src/backend/services/simba_classify.py
@@ -1,0 +1,115 @@
+"""
+Simba category/type classifier.
+
+Suggests where a document belongs in the Simba tax-portal taxonomy (category +
+document type) from its extracted OCR text, so the chat attachment menu can
+PREFILL the picker. Best-effort: returns (None, None) on empty text / no model /
+invalid output. Never raises — a missing suggestion just means the user picks
+manually. Mirrors the lightweight single-call pattern of
+schicht_a_extractor.generate_document_title.
+"""
+from __future__ import annotations
+
+import json
+
+from loguru import logger
+
+from utils.config import settings
+from utils.llm_client import (
+    extract_response_content,
+    get_classification_chat_kwargs,
+    get_default_client,
+)
+
+# Enough context to classify a document; keeps the call cheap + fast.
+_MAX_TEXT_CHARS = 4000
+
+
+def _taxonomy_block(categories: dict[str, list[str]]) -> str:
+    return "\n".join(f"- {cat}: {', '.join(types)}" for cat, types in categories.items())
+
+
+def _match(value: object, options: list[str]) -> str | None:
+    """Case-insensitive exact match of an LLM-returned value against the allowlist."""
+    if not isinstance(value, str):
+        return None
+    v = value.strip().lower()
+    for opt in options:
+        if opt.lower() == v:
+            return opt
+    return None
+
+
+def _parse_json(raw: str) -> dict | None:
+    raw = (raw or "").strip()
+    if raw.startswith("```"):
+        raw = raw.strip("`")
+    try:
+        parsed = json.loads(raw)
+        return parsed if isinstance(parsed, dict) else None
+    except (ValueError, TypeError):
+        start, end = raw.find("{"), raw.rfind("}")
+        if 0 <= start < end:
+            try:
+                parsed = json.loads(raw[start : end + 1])
+                return parsed if isinstance(parsed, dict) else None
+            except (ValueError, TypeError):
+                return None
+    return None
+
+
+async def classify_simba(
+    text: str,
+    categories: dict[str, list[str]],
+    *,
+    lang: str = "de",
+    llm_client=None,
+) -> tuple[str | None, str | None]:
+    """Classify `text` into (category, type) from the `categories` taxonomy.
+
+    Returns (category, type) where each is a validated taxonomy value or None.
+    The category is only returned if it matches an allowlist entry; the type is
+    only returned if it's a valid type FOR that category (so a plausible category
+    with an unknown type still prefills the category and lets the user pick the
+    type).
+    """
+    text = (text or "").strip()
+    if not text or not categories:
+        return None, None
+    model = settings.ollama_chat_model or settings.ollama_model
+    if not model:
+        return None, None
+
+    system = (
+        "Du ordnest ein Dokument in GENAU EINE Kategorie und EINEN Dokumenttyp des "
+        "Simba-Steuerportals ein. Wähle AUSSCHLIESSLICH aus der vorgegebenen Liste "
+        '(exakte Schreibweise). Antworte nur mit JSON: {"category": "...", "type": "..."}. '
+        "Bei Unsicherheit die plausibelste Kombination wählen."
+    )
+    user = (
+        f"Verfügbare Kategorien und Typen:\n{_taxonomy_block(categories)}\n\n"
+        f"Dokumentinhalt (Auszug):\n{text[:_MAX_TEXT_CHARS]}\n\nJSON:"
+    )
+    try:
+        client = llm_client or get_default_client()
+        kwargs = get_classification_chat_kwargs(model)
+        response = await client.chat(
+            model=model,
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            options={"temperature": 0.1},
+            **kwargs,
+        )
+        payload = _parse_json(extract_response_content(response) or "")
+        if not isinstance(payload, dict):
+            return None, None
+        cat = _match(payload.get("category"), list(categories.keys()))
+        if not cat:
+            return None, None
+        typ = _match(payload.get("type"), categories.get(cat, []))
+        return cat, typ
+    except Exception as e:  # noqa: BLE001 — a failed suggestion must never break the menu
+        logger.warning(f"Simba classification failed: {e}")
+        return None, None

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -334,6 +334,7 @@
     "sendToPaperlessAndKb": "An Paperless + Wissensdatenbank",
     "sendToPaperlessAndKbSuccess": "An Paperless und Wissensdatenbank gesendet",
     "sendToPaperlessAndKbFailed": "Senden teilweise fehlgeschlagen: {{detail}}",
+    "simbaSuggestion": "Vorschlag",
     "sendToSimba": "An Simba (Steuerkanzlei) senden",
     "sendToPaperlessAndSimba": "An Paperless + Simba",
     "confirmSimba": "Datei ENDGÜLTIG an die Steuerkanzlei (Simba) übertragen?\n{{category}} / {{type}}\nDies kann nicht widerrufen werden.",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -334,6 +334,7 @@
     "sendToPaperlessAndKb": "Send to Paperless + Knowledge Base",
     "sendToPaperlessAndKbSuccess": "Sent to Paperless and Knowledge Base",
     "sendToPaperlessAndKbFailed": "Send partially failed: {{detail}}",
+    "simbaSuggestion": "suggested",
     "sendToSimba": "Send to Simba (tax office)",
     "sendToPaperlessAndSimba": "Send to Paperless + Simba",
     "confirmSimba": "Transfer the file to the tax accountant (Simba) FOR GOOD?\n{{category}} / {{type}}\nThis cannot be undone.",

--- a/src/frontend/src/i18n/locales/it.json
+++ b/src/frontend/src/i18n/locales/it.json
@@ -280,6 +280,7 @@
     "sendToPaperlessAndKb": "Invia a Paperless + Base di conoscenza",
     "sendToPaperlessAndKbSuccess": "Inviato a Paperless e Base di conoscenza",
     "sendToPaperlessAndKbFailed": "Invio parzialmente fallito: {{detail}}",
+    "simbaSuggestion": "suggerito",
     "sendToSimba": "Invia a Simba (commercialista)",
     "sendToPaperlessAndSimba": "Invia a Paperless + Simba",
     "confirmSimba": "Trasferire il file al commercialista (Simba) DEFINITIVAMENTE?\n{{category}} / {{type}}\nQuesta operazione non può essere annullata.",

--- a/src/frontend/src/pages/ChatPage/AttachmentQuickActions.tsx
+++ b/src/frontend/src/pages/ChatPage/AttachmentQuickActions.tsx
@@ -55,6 +55,11 @@ export default function AttachmentQuickActions({
   const [simbaCategories, setSimbaCategories] = useState<Record<string, string[]>>({});
   const [simbaCategory, setSimbaCategory] = useState<string | null>(null);
   const [simbaLoading, setSimbaLoading] = useState(false);
+  // Content-derived suggestion (prefill): {category?, type?}. undefined = not
+  // fetched yet; an object (possibly empty) = fetched. Auto-drills to the
+  // suggested category and marks the suggested type.
+  const [simbaSuggestion, setSimbaSuggestion] = useState<{ category?: string; type?: string } | undefined>();
+  const [suggestionLoading, setSuggestionLoading] = useState(false);
   const menuRef = useRef<HTMLDivElement | null>(null);
 
   const isLoading = actionLoading?.[attachment.id];
@@ -99,6 +104,28 @@ export default function AttachmentQuickActions({
     }
   };
 
+  // Fetch the content-derived category/type suggestion once, then auto-drill
+  // into the suggested category (only while the user is still at the category
+  // level, so it never yanks the view out from under an active pick).
+  const ensureSuggestion = async () => {
+    if (simbaSuggestion !== undefined || suggestionLoading) return;
+    setSuggestionLoading(true);
+    try {
+      const response = await apiClient.get<{ category?: string; type?: string }>(
+        `/api/chat/upload/${attachment.id}/simba/suggest`,
+      );
+      const s = response.data || {};
+      setSimbaSuggestion(s);
+      if (s.category) {
+        setSimbaCategory((cur) => cur ?? s.category ?? null);
+      }
+    } catch {
+      setSimbaSuggestion({});
+    } finally {
+      setSuggestionLoading(false);
+    }
+  };
+
   const handleSimba = async (e: MouseEvent<HTMLButtonElement>, both: boolean) => {
     e.stopPropagation();
     const target: SubMenu = both ? 'simba_both' : 'simba';
@@ -109,6 +136,14 @@ export default function AttachmentQuickActions({
     setSimbaCategory(null);
     await ensureSimbaCategories();
     setSubmenu(target);
+    // Prefill: if we already classified this file, drill into the suggested
+    // category now; otherwise fetch it in the background (ensureSuggestion drills
+    // in when it resolves, unless the user has navigated by then).
+    if (simbaSuggestion?.category) {
+      setSimbaCategory(simbaSuggestion.category);
+    } else {
+      void ensureSuggestion();
+    }
   };
 
   const handleSelectSimbaType = (e: MouseEvent<HTMLButtonElement>, type: string) => {
@@ -309,19 +344,31 @@ export default function AttachmentQuickActions({
               ) : Object.keys(simbaCategories).length === 0 ? (
                 <div className="px-3 py-1.5 text-xs text-gray-400">{t('common.noResults')}</div>
               ) : simbaCategory === null ? (
-                Object.keys(simbaCategories).map((cat) => (
-                  <button
-                    key={cat}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setSimbaCategory(cat);
-                    }}
-                    className="w-full text-left px-5 py-1.5 text-xs hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors truncate flex items-center justify-between"
-                  >
-                    <span className="truncate">{cat}</span>
-                    <span className="text-gray-400">›</span>
-                  </button>
-                ))
+                Object.keys(simbaCategories).map((cat) => {
+                  const suggested = simbaSuggestion?.category === cat;
+                  return (
+                    <button
+                      key={cat}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setSimbaCategory(cat);
+                      }}
+                      className={`w-full text-left px-5 py-1.5 text-xs hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors truncate flex items-center justify-between ${
+                        suggested ? 'font-medium' : ''
+                      }`}
+                    >
+                      <span className="truncate">
+                        {cat}
+                        {suggested && (
+                          <span className="ml-1.5 text-[10px] text-blue-600 dark:text-blue-400">
+                            {t('chat.simbaSuggestion')}
+                          </span>
+                        )}
+                      </span>
+                      <span className="text-gray-400">›</span>
+                    </button>
+                  );
+                })
               ) : (
                 <>
                   <button
@@ -333,15 +380,26 @@ export default function AttachmentQuickActions({
                   >
                     ‹ {simbaCategory}
                   </button>
-                  {(simbaCategories[simbaCategory] || []).map((tp) => (
-                    <button
-                      key={tp}
-                      onClick={(e) => handleSelectSimbaType(e, tp)}
-                      className="w-full text-left px-6 py-1.5 text-xs hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors truncate"
-                    >
-                      {tp}
-                    </button>
-                  ))}
+                  {(simbaCategories[simbaCategory] || []).map((tp) => {
+                    const suggested =
+                      simbaSuggestion?.type === tp && simbaSuggestion?.category === simbaCategory;
+                    return (
+                      <button
+                        key={tp}
+                        onClick={(e) => handleSelectSimbaType(e, tp)}
+                        className={`w-full text-left px-6 py-1.5 text-xs hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors truncate ${
+                          suggested ? 'font-medium bg-blue-50 dark:bg-blue-900/20' : ''
+                        }`}
+                      >
+                        {tp}
+                        {suggested && (
+                          <span className="ml-1.5 text-[10px] text-blue-600 dark:text-blue-400">
+                            {t('chat.simbaSuggestion')}
+                          </span>
+                        )}
+                      </button>
+                    );
+                  })}
                 </>
               )}
             </div>

--- a/tests/backend/test_chat_upload.py
+++ b/tests/backend/test_chat_upload.py
@@ -1707,3 +1707,48 @@ class TestChatUploadSimba:
             "/api/chat/upload/99999/simba", json={"category": "Belege", "type": "x"},
         )
         assert resp.status_code == 404
+
+    @pytest.mark.backend
+    async def test_simba_suggest(self, async_client: AsyncClient, db_session: AsyncSession):
+        """Suggest returns a content-derived category/type."""
+        import json as _json
+        from unittest.mock import AsyncMock, patch
+
+        upload = ChatUpload(
+            session_id="simba-suggest", filename="brief.pdf", file_type="pdf",
+            file_size=500, status="completed", file_path="/tmp/none",
+            extracted_text="Sehr geehrte Damen und Herren, anbei das Schreiben vom Finanzamt.",
+        )
+        db_session.add(upload)
+        await db_session.commit()
+        await db_session.refresh(upload)
+
+        from main import app
+        mock = AsyncMock()
+        mock.execute_tool = AsyncMock(return_value={
+            "success": True,
+            "message": _json.dumps({"kategorien": {"Posteingang": ["Schriftverkehr"]}}),
+        })
+        app.state.mcp_manager = mock
+        try:
+            with patch("services.simba_classify.classify_simba",
+                       AsyncMock(return_value=("Posteingang", "Schriftverkehr"))):
+                resp = await async_client.get(f"/api/chat/upload/{upload.id}/simba/suggest")
+        finally:
+            app.state.mcp_manager = None
+        assert resp.status_code == 200
+        assert resp.json() == {"category": "Posteingang", "type": "Schriftverkehr"}
+
+    @pytest.mark.backend
+    async def test_simba_suggest_no_text(self, async_client: AsyncClient, db_session: AsyncSession):
+        """No extracted text → empty suggestion (no classification)."""
+        upload = ChatUpload(
+            session_id="simba-suggest-empty", filename="x.pdf", file_type="pdf",
+            file_size=1, status="completed", file_path="/tmp/none", extracted_text="",
+        )
+        db_session.add(upload)
+        await db_session.commit()
+        await db_session.refresh(upload)
+        resp = await async_client.get(f"/api/chat/upload/{upload.id}/simba/suggest")
+        assert resp.status_code == 200
+        assert resp.json() == {"category": None, "type": None}

--- a/tests/backend/test_simba_classify.py
+++ b/tests/backend/test_simba_classify.py
@@ -1,0 +1,65 @@
+"""Unit tests for the Simba category/type classifier (content → taxonomy)."""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services import simba_classify
+
+pytestmark = pytest.mark.unit
+
+CATS = {"Belege": ["Ausgangsrechnung", "Eingangsrechnung"], "Posteingang": ["Schriftverkehr"]}
+
+
+def _client():
+    c = MagicMock()
+    c.chat = AsyncMock(return_value="ignored")  # extract_response_content is patched
+    return c
+
+
+async def _classify(text, cats, llm_json):
+    with patch("services.simba_classify.extract_response_content", return_value=llm_json), patch(
+        "services.simba_classify.get_classification_chat_kwargs", return_value={}
+    ), patch("services.simba_classify.settings") as ms:
+        ms.ollama_chat_model = "m"
+        ms.ollama_model = "m"
+        return await simba_classify.classify_simba(text, cats, llm_client=_client())
+
+
+@pytest.mark.asyncio
+async def test_valid_pair():
+    assert await _classify("Schreiben vom Finanzamt", CATS,
+                           '{"category":"Posteingang","type":"Schriftverkehr"}') == ("Posteingang", "Schriftverkehr")
+
+
+@pytest.mark.asyncio
+async def test_case_insensitive_match():
+    assert await _classify("x", CATS, '{"category":"belege","type":"ausgangsrechnung"}') == ("Belege", "Ausgangsrechnung")
+
+
+@pytest.mark.asyncio
+async def test_invalid_category_returns_none():
+    assert await _classify("x", CATS, '{"category":"Unbekannt","type":"Foo"}') == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_valid_category_but_invalid_type_keeps_category():
+    # A plausible category with an unknown type still prefills the category.
+    assert await _classify("x", CATS, '{"category":"Belege","type":"Nichtvorhanden"}') == ("Belege", None)
+
+
+@pytest.mark.asyncio
+async def test_fenced_json_is_parsed():
+    assert await _classify("x", CATS, '```json\n{"category":"Belege","type":"Eingangsrechnung"}\n```') == (
+        "Belege", "Eingangsrechnung",
+    )
+
+
+@pytest.mark.asyncio
+async def test_garbage_output_returns_none():
+    assert await _classify("x", CATS, 'not json at all') == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_empty_text_returns_none_without_calling_llm():
+    assert await simba_classify.classify_simba("", CATS) == (None, None)
+    assert await simba_classify.classify_simba("text", {}) == (None, None)

--- a/tests/frontend/react/pages/ChatPage/AttachmentQuickActions.test.tsx
+++ b/tests/frontend/react/pages/ChatPage/AttachmentQuickActions.test.tsx
@@ -6,26 +6,36 @@ import type { MessageAttachment } from '../../../../../src/frontend/src/pages/Ch
 
 // Mock axios — the component uses it to fetch the KB list AND (for Simba) the
 // category→type map. Return the right shape per URL.
+// Mutable refs for per-test control of the feature flag and the content
+// suggestion (both read inside the hoisted mocks below).
+const { flagsRef, suggestRef } = vi.hoisted(() => ({
+  flagsRef: { current: {} as { simba_upload_enabled?: boolean } },
+  suggestRef: { current: {} as { category?: string; type?: string } },
+}));
+
 vi.mock('../../../../../src/frontend/src/utils/axios', () => ({
   default: {
-    get: vi.fn((url: string) =>
-      url.includes('simba/categories')
-        ? Promise.resolve({ data: { categories: { Belege: ['Ausgangsrechnung'] } } })
-        : Promise.resolve({
-            data: [
-              { id: 1, name: 'Hauptwissensbasis' },
-              { id: 2, name: 'Reise-KB' },
-            ],
-          }),
-    ),
+    get: vi.fn((url: string) => {
+      if (url.includes('simba/categories')) {
+        return Promise.resolve({
+          data: { categories: { Belege: ['Ausgangsrechnung'], Posteingang: ['Schriftverkehr'] } },
+        });
+      }
+      if (url.includes('simba/suggest')) {
+        return Promise.resolve({ data: suggestRef.current });
+      }
+      return Promise.resolve({
+        data: [
+          { id: 1, name: 'Hauptwissensbasis' },
+          { id: 2, name: 'Reise-KB' },
+        ],
+      });
+    }),
   },
 }));
 
 // Mock the feature-flags hook (react-query) — the component gates the Simba
-// items on simba_upload_enabled. A mutable ref lets each test set it.
-const { flagsRef } = vi.hoisted(() => ({
-  flagsRef: { current: {} as { simba_upload_enabled?: boolean } },
-}));
+// items on simba_upload_enabled.
 vi.mock('../../../../../src/frontend/src/api/resources/brain', () => ({
   useFeatureFlags: () => ({ data: flagsRef.current }),
 }));
@@ -90,6 +100,7 @@ describe('AttachmentQuickActions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     flagsRef.current = {}; // simba disabled by default
+    suggestRef.current = {}; // no content suggestion by default
   });
 
   it('opens the menu and shows the Paperless + KB combo at the top', async () => {
@@ -191,6 +202,24 @@ describe('AttachmentQuickActions', () => {
     expect(confirmSpy).toHaveBeenCalledTimes(1);
     expect(onSendToSimba).toHaveBeenCalledWith('upload-42', 'Belege', 'Ausgangsrechnung');
     confirmSpy.mockRestore();
+  });
+
+  it('prefills the Simba picker from content: auto-drills to the suggested category and marks the type', async () => {
+    flagsRef.current = { simba_upload_enabled: true };
+    suggestRef.current = { category: 'Posteingang', type: 'Schriftverkehr' };
+    const user = userEvent.setup();
+    renderActions();
+
+    await user.click(screen.getByRole('button', { name: 'chat.quickActions' }));
+    await user.click(screen.getByText('chat.sendToSimba'));
+
+    // Auto-drilled into the suggested category → its types are shown, and the
+    // suggested type carries the 'suggested' badge (chat.simbaSuggestion).
+    await waitFor(() => expect(screen.getByText('Schriftverkehr')).toBeInTheDocument());
+    const suggestedType = screen.getByText('Schriftverkehr').closest('button');
+    expect(suggestedType?.textContent).toContain('chat.simbaSuggestion');
+    // The non-suggested category's type is NOT shown (we drilled into Posteingang).
+    expect(screen.queryByText('Ausgangsrechnung')).not.toBeInTheDocument();
   });
 
   it('cancelling the Simba confirm does not upload', async () => {


### PR DESCRIPTION
## Summary
Opening **"An Simba senden"** in the chat attachment menu now classifies the document and **prefills** the category/type picker.

- **Backend**: `GET /api/chat/upload/{id}/simba/suggest` → `{category, type}` from the upload's extracted OCR text via `services/simba_classify.py` — one strict-JSON LLM call against the live Simba taxonomy; validates the pair (category-only when the type is unknown); best-effort, never errors. Shared `_simba_taxonomy` helper.
- **Frontend**: on submenu open, the suggestion is fetched in the background, the picker **auto-drills into the suggested category**, and the suggested type gets a **"Vorschlag"** badge. The user can still navigate freely and pick anything.

Builds on #1149 (the Simba menu). Deployed to xidra; household unaffected (menu hidden there).

## Test plan
- [x] 7 classifier unit tests (valid/case-insensitive/invalid-category/category-only/fenced-json/garbage/empty)
- [x] 2 `/simba/suggest` route tests + 1 frontend prefill test (auto-drill + badge)
- [x] frontend `tsc` clean; 8 AttachmentQuickActions tests green; pre-push gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)