### PR TITLE
fix(simba-ingest): resolve proposal owner via atom, not doc.user_id

### DIFF
--- a/src/backend/services/simba_ingest_review.py
+++ b/src/backend/services/simba_ingest_review.py
@@ -32,6 +32,7 @@ from models.database import (
     SIMBA_PROPOSAL_REJECTED,
     SIMBA_PROPOSAL_UPLOADED,
     SIMBA_PROPOSAL_UPLOADING,
+    Atom,
     Document,
     SimbaIngestProposal,
 )
@@ -84,6 +85,18 @@ async def simba_ingest_post_hook(
         if exists is not None:
             return
 
+        # Owner = the document's own atom owner (authoritative), else the ingesting
+        # user. Document has NO user_id column — the owner lives on the atom
+        # (mirrors schicht_a_post_document_ingest_hook). A null owner is fine here
+        # (the proposal is admin-visible), so we never skip on it.
+        owner_id: int | None = user_id
+        if doc.atom_id:
+            doc_atom = (
+                await db.execute(select(Atom).where(Atom.atom_id == doc.atom_id))
+            ).scalar_one_or_none()
+            if doc_atom is not None:
+                owner_id = doc_atom.owner_user_id
+
         category = type_ = None
         try:
             from services.simba_classify import classify_simba
@@ -98,7 +111,7 @@ async def simba_ingest_post_hook(
             db.add(
                 SimbaIngestProposal(
                     document_id=document_id,
-                    user_id=doc.user_id if doc.user_id is not None else user_id,
+                    user_id=owner_id,
                     filename=doc.filename,
                     suggested_category=category,
                     suggested_type=type_,

--- a/tests/backend/test_simba_ingest_review.py
+++ b/tests/backend/test_simba_ingest_review.py
@@ -24,21 +24,33 @@ from services import simba_ingest_review as review
 # Hook gating (mocked DB)
 # --------------------------------------------------------------------------
 
-def _doc(source=FOLDER_INGEST_SOURCE, filename="scan_2026.pdf", uid=7):
-    d = MagicMock()
+def _doc(source=FOLDER_INGEST_SOURCE, filename="scan_2026.pdf", atom_id=None):
+    from models.database import Document
+
+    # spec=Document: a real Document has NO ``user_id`` column, so a regression to
+    # ``doc.user_id`` (the bug this feature shipped with) raises AttributeError
+    # instead of silently returning a phantom mock attribute.
+    d = MagicMock(spec=Document)
     d.id = 1
     d.source = source
     d.filename = filename
-    d.user_id = uid
+    d.atom_id = atom_id
     return d
 
 
-async def _run_hook(doc, existing=None):
-    db = MagicMock()
-    db.execute = AsyncMock(side_effect=[
+async def _run_hook(doc, existing=None, atom_owner=None, user_id=None):
+    responses = [
         MagicMock(scalar_one_or_none=MagicMock(return_value=doc)),
         MagicMock(scalar_one_or_none=MagicMock(return_value=existing)),
-    ])
+    ]
+    # An atom-backed doc (not short-circuited by an existing proposal) triggers the
+    # owner-resolution Atom query.
+    if getattr(doc, "atom_id", None) and existing is None:
+        atom = MagicMock(owner_user_id=atom_owner) if atom_owner is not None else None
+        responses.append(MagicMock(scalar_one_or_none=MagicMock(return_value=atom)))
+
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=responses)
     db.add = MagicMock()
     db.commit = AsyncMock()
     db.rollback = AsyncMock()
@@ -53,19 +65,32 @@ async def _run_hook(doc, existing=None):
         "services.simba_classify.classify_simba", AsyncMock(return_value=("Belege", "Ausgangsrechnung"))
     ):
         ms.folder_ingest_simba_enabled = True
-        await review.simba_ingest_post_hook(document_id=1, field_text="Rechnung", lang="de")
+        await review.simba_ingest_post_hook(
+            document_id=1, field_text="Rechnung", lang="de", user_id=user_id
+        )
     return db
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_hook_creates_proposal_for_folder_pdf():
-    db = await _run_hook(_doc())
+async def test_hook_creates_proposal_owner_from_atom():
+    """Owner = the document's atom owner (authoritative) — NOT doc.user_id
+    (which doesn't exist on Document; the shipped-then-fixed bug)."""
+    db = await _run_hook(_doc(atom_id="atom-1"), atom_owner=7)
     db.add.assert_called_once()
     prop = db.add.call_args.args[0]
     assert isinstance(prop, SimbaIngestProposal)
     assert prop.suggested_category == "Belege" and prop.suggested_type == "Ausgangsrechnung"
     assert prop.user_id == 7
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_hook_owner_falls_back_to_ingesting_user():
+    """No atom → owner falls back to the ingesting user_id the hook was given."""
+    db = await _run_hook(_doc(atom_id=None), user_id=9)
+    db.add.assert_called_once()
+    assert db.add.call_args.args[0].user_id == 9
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
Hotfix on top of #1151. The watch-folder→Simba post-ingest hook read `doc.user_id`, but `Document` has **no `user_id` column** — ownership lives on the `atoms` row. On a real ingest that access raised `AttributeError`, which the proposal-insert `try/except` swallowed, so **no Simba review proposal was ever created in production**. The unit tests missed it because they used a bare `MagicMock` doc that auto-provides a phantom `.user_id`.

**Found via a live browser E2E on xidra:** the `/wissen/review` Simba section renders correctly, but the queue could never populate.

## Fix
- Owner now resolves via `doc.atom_id → Atom.owner_user_id` (authoritative), falling back to the ingesting `user_id` the hook is given; a null owner is fine (admin-visible). Mirrors `schicht_a_post_document_ingest_hook`.
- Tests use `MagicMock(spec=Document)` so a `doc.user_id` regression **raises** instead of silently passing, plus explicit atom-owner and ingesting-user fallback cases.

## Test plan
- [x] 17 backend tests green on .159
- [ ] Redeploy backend + document-worker to xidra; confirm a real folder-ingest PDF now files a proposal on `/brain/review`

🤖 Generated with [Claude Code](https://claude.com/claude-code)