### PR TITLE
fix(db): roll back the txn the checkin unlock SELECT opens

### DIFF
--- a/src/backend/services/database.py
+++ b/src/backend/services/database.py
@@ -64,6 +64,23 @@ def _release_leaked_advisory_locks_on_checkin(dbapi_connection, connection_recor
                 cursor.close()
             except Exception:
                 pass
+        # Close the transaction the reset SELECT opened. SQLAlchemy's asyncpg
+        # DBAPI adapter is NOT autocommit — it lazily opens a real transaction
+        # for the SELECT above and relies on an explicit commit/rollback to
+        # close it. reset_on_return has already fired (closing the work
+        # session's txn) before this checkin hook runs, so nothing else closes
+        # this one. Without the rollback the connection returns to the pool
+        # `idle in transaction` (last query pg_advisory_unlock_all()) holding a
+        # virtualxid lock; a rarely-reused overflow connection can sit wedged
+        # for hours — long enough to block a CREATE INDEX CONCURRENTLY migration
+        # (observed on xidra 2026-08-29: two connections idle ~4.5 h stalled the
+        # FTS index build ~27 min). pg_advisory_unlock_all() is session-level
+        # and non-transactional, so this rollback does NOT re-acquire the locks.
+        # Must never raise — a throwing checkin hook breaks pool return.
+        try:
+            dbapi_connection.rollback()
+        except Exception as e:
+            logger.warning(f"checkin: post-unlock rollback failed (swallowed): {type(e).__name__}: {e}")
 
 
 # Session Factory

--- a/tests/backend/test_database_checkin_hook.py
+++ b/tests/backend/test_database_checkin_hook.py
@@ -1,0 +1,57 @@
+"""The connection-checkin hook must leave the connection with NO open
+transaction.
+
+Regression: the checkin hook runs ``SELECT pg_advisory_unlock_all()`` through
+SQLAlchemy's asyncpg DBAPI adapter, which is not autocommit — the SELECT opens a
+real transaction. Before the fix nothing closed it, so the connection returned to
+the pool ``idle in transaction`` holding a virtualxid lock; a rarely-reused
+overflow connection could sit wedged for hours and block a
+``CREATE INDEX CONCURRENTLY`` migration (observed on xidra 2026-08-29). The hook
+now issues an explicit rollback after the unlock (safe — the unlock is
+session-level / non-transactional).
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from services.database import _release_leaked_advisory_locks_on_checkin as checkin
+
+pytestmark = pytest.mark.unit
+
+
+def _conn():
+    c = MagicMock()
+    c.cursor.return_value = MagicMock()
+    return c
+
+
+def test_checkin_rolls_back_after_unlock():
+    """The reset SELECT ran, then the transaction it opened is rolled back."""
+    conn = _conn()
+    checkin(conn, MagicMock())
+    conn.cursor.return_value.execute.assert_called_once_with(
+        "SELECT pg_advisory_unlock_all();"
+    )
+    conn.rollback.assert_called_once()
+
+
+def test_checkin_rolls_back_even_if_select_fails():
+    """A failed unlock still leaves no dangling transaction behind."""
+    conn = _conn()
+    conn.cursor.return_value.execute.side_effect = RuntimeError("boom")
+    checkin(conn, MagicMock())  # must not raise
+    conn.rollback.assert_called_once()
+
+
+def test_checkin_never_raises_when_rollback_fails():
+    """A throwing rollback is swallowed — a checkin hook that raises breaks pool
+    return for every caller."""
+    conn = _conn()
+    conn.rollback.side_effect = RuntimeError("rollback boom")
+    checkin(conn, MagicMock())  # must not raise
+    conn.rollback.assert_called_once()
+
+
+def test_checkin_noop_on_none_connection():
+    """A dead/None connection (checked in after its loop closed) is a no-op."""
+    checkin(None, MagicMock())  # must not raise


### PR DESCRIPTION
## Summary
The connection-pool **checkin hook** in `services/database.py` runs `SELECT pg_advisory_unlock_all()` through SQLAlchemy's asyncpg DBAPI adapter, which **is not autocommit** — the SELECT lazily opens a real transaction. `reset_on_return` has already fired before the checkin hook runs, and `cursor.close()` does not end the transaction, so **nothing closed it**: every connection returned to the pool `idle in transaction` (last query `pg_advisory_unlock_all()`), holding a `virtualxid` lock.

Hot connections clear it on next reuse, but a **rarely-reused overflow connection sits wedged for hours** — long enough to block a `CREATE INDEX CONCURRENTLY` migration.

### Production impact (root of the 2026-08-29 incident)
On the xidra deploy of the documents-FTS migration (`pc20260829_documents_fts`), **two** pooled connections were `idle in transaction` for ~4.5 h, stalling the `CREATE INDEX CONCURRENTLY idx_documents_search_vector_gin` build for ~27 min. The migration only completed after the leaked backends were terminated by hand.

## Fix
One `dbapi_connection.rollback()` in the hook's `finally`, after the unlock. Safe because `pg_advisory_unlock_all()` is **session-level and non-transactional** — the rollback does NOT re-acquire the locks, so the advisory-lock leak backstop still works. The rollback is guarded so a checkin hook can still never raise.

The advisory-lock loopers (KG reconciler, obligation notifier/digest/calendar-sync, Schicht-A reindex, scheduled-tasks engine) were **not** the cause — they use dedicated connections that roll back on close. The leak was purely this hook's own reset SELECT.

## Test plan
- [x] `tests/backend/test_database_checkin_hook.py` — 4 unit tests (rollback runs after unlock; rollback still runs when the SELECT fails; a throwing rollback is swallowed; None connection no-op). All 4 pass on .159.
- [ ] Deploy to both instances (backend pool change) + confirm no `idle in transaction` stragglers accrue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)