### PR TITLE
fix(search): pin SearXNG image + add best-effort redundant engines

### DIFF
--- a/k8s/searxng.yaml
+++ b/k8s/searxng.yaml
@@ -55,6 +55,19 @@ data:
     # merges this list into the defaults by engine `name`, so unlisted engines
     # keep their default state. No API key, fully self-hosted. If result quality
     # proves thin, add the native `braveapi` engine with a key (PR2 / Option B).
+    #
+    # Redundancy (2026-08-29 follow-up): DuckDuckGo, like Google/Startpage/Brave,
+    # is blocked BY IP from a datacenter/self-hosted egress (DDG changed to
+    # IP-reputation blocking in late 2025 — SearXNG issues #4824/#5541, won't-fix:
+    # it's not a scraper bug, no config or image upgrade recovers it). We keep DDG
+    # enabled as best-effort (it self-recovers after ~1h idle) but must NOT depend
+    # on it. So enable several independent CAPTCHA-tolerant general engines — Yahoo
+    # + Marginalia on top of Bing/Mojeek/Wikipedia — so any single engine's CAPTCHA
+    # is a non-event. (Yandex/Baidu are also CAPTCHA-tolerant but deliberately
+    # omitted: routing queries to a Russian/Chinese engine is the wrong privacy
+    # posture for this product. Crossref is academic-only, not general web search.)
+    # For Google-grade coverage the real lever is a key-based engine (braveapi /
+    # the already-working google-cse), NOT scraping from this IP.
     engines:
       - name: google
         disabled: true
@@ -69,6 +82,10 @@ data:
       - name: mojeek
         disabled: false
       - name: wikipedia
+        disabled: false
+      - name: yahoo
+        disabled: false
+      - name: marginalia
         disabled: false
     ui:
       default_theme: simple
@@ -113,7 +130,13 @@ spec:
             runAsUser: 0
       containers:
         - name: searxng
-          image: searxng/searxng:latest
+          # Pinned by digest (2026-08-29) for reproducibility — SearXNG ships
+          # rolling date tags and its scraper code shifts every build as upstreams
+          # change bot defenses, so :latest could silently alter engine behavior
+          # mid-outage. This digest == version 2026.8.29+d226b78bc (the build in
+          # use, verified returning results). Bump deliberately to adopt newer
+          # engine fixes. An immutable digest makes the pull policy moot.
+          image: searxng/searxng@sha256:b36af7984b87191b595bc5301418ed6432c047668a4547ab531a7439b816fac3
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/k8s/searxng.yaml
+++ b/k8s/searxng.yaml
@@ -68,13 +68,22 @@ data:
     # posture for this product. Crossref is academic-only, not general web search.)
     # For Google-grade coverage the real lever is a key-based engine (braveapi /
     # the already-working google-cse), NOT scraping from this IP.
+    # Brave/Startpage/Qwant are enabled as additional best-effort engines (by
+    # request). Honest note: from this datacenter IP Brave-scrape + Startpage are
+    # CAPTCHA-prone and Qwant tends to a ~24h suspension, so they often show as
+    # unresponsive and self-recover — harmless (each engine has its own network
+    # object, so a CAPTCHA on one does NOT suspend Bing/CSE; SearXNG drops
+    # unresponsive engines gracefully). google-scrape stays disabled: google-cse
+    # already covers it and the raw scraper is the most aggressively IP-blocked.
     engines:
       - name: google
         disabled: true
       - name: startpage
-        disabled: true
+        disabled: false
       - name: brave
-        disabled: true
+        disabled: false
+      - name: qwant
+        disabled: false
       - name: duckduckgo
         disabled: false
       - name: bing


### PR DESCRIPTION
## Summary
Follow-up to the engine retune (#1158), implementing the two hardening items from the CAPTCHA research.

**1. Pin the image by digest** — was `searxng/searxng:latest`, now pinned to the digest of the verified running build (`== 2026.8.29+d226b78bc`). SearXNG ships rolling date tags and its scraper code shifts every build as upstreams change bot defenses, so `:latest` could silently alter engine behavior mid-outage. Bump the pin deliberately to adopt newer engine fixes.

**2. Add redundant CAPTCHA-tolerant engines** — Yahoo + Marginalia on top of Bing/Mojeek/Wikipedia, so any one engine's CAPTCHA is a non-event.

## Honest measurement (applied live + verified)
Query `beste restaurants berlin` after deploy → **30 results**, but:
- Yahoo is **also IP-blocked** from the datacenter egress (`unresponsive`).
- Marginalia's indie index returned nothing for a commercial query.
- **Bing + Google-CSE remain the effective backbone** (both essentially non-scraper: CSE is key-based, Bing tolerates the IP).

So the added engines are **harmless best-effort fallback** (SearXNG drops unresponsive engines gracefully; they self-recover after ~1h idle) rather than a robust redundancy layer. Kept because they cost nothing and help on some queries / if Bing degrades.

## The CAPTCHA is fundamental (not fixable here)
DuckDuckGo/Google/Yahoo block **by datacenter-IP reputation** (SearXNG issues [#4824](https://github.com/searxng/searxng/issues/4824)/[#5541](https://github.com/searxng/searxng/issues/5541), won't-fix — not a scraper bug; no config or image upgrade recovers it). Tor/proxy egress doesn't reliably beat it either. Yandex/Baidu are CAPTCHA-tolerant but omitted on privacy grounds (Russian/Chinese egress is the wrong posture for this product).

**For Google-grade coverage from this IP the real lever is a key-based engine** — the native `braveapi` engine (~$5/mo) or the already-working `google-cse` — not scraping. That's the deferred Option B.

## Verification
- [x] Applied live + `rollout restart`; running image is the pinned digest.
- [x] Web search returns results (30) via Bing + Google-CSE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)