### PR TITLE
docs: self-service FAQ + route Paperless-status questions to the documents role

### DIFF
--- a/config/agent_roles.yaml
+++ b/config/agent_roles.yaml
@@ -53,8 +53,8 @@ roles:
 
   documents:
     description:
-      de: "Dokumente und E-Mail: Suche in Wissensdatenbank und Paperless, Download, Versand; SOWIE Verwaltung & Status der Dokument-VERARBEITUNG selbst: Verarbeitungsstatus/Rückstau der Indexierung, wie viele Dokumente KEINE Chunks haben / leer oder unvollständig indexiert sind, Dokumente ohne Chunks NEU INDEXIEREN / neu einlesen / reparieren; SOWIE Paperless-Pflege: DUBLETTEN / doppelte Dokumente finden und aufräumen/löschen"
-      en: "Documents and email: search knowledge base and Paperless, download, send; AND administration & status of the document PROCESSING itself: indexing status/backlog, how many documents have NO chunks / are empty or incompletely indexed, RE-INDEX documents without chunks; AND Paperless upkeep: find and clean up/delete DUPLICATE documents"
+      de: "Dokumente und E-Mail: Suche in Wissensdatenbank und Paperless, Download, Versand; SOWIE Verwaltung & Status der Dokument-VERARBEITUNG selbst: Verarbeitungsstatus/Rückstau der Indexierung, wie viele Dokumente KEINE Chunks haben / leer oder unvollständig indexiert sind, Dokumente ohne Chunks NEU INDEXIEREN / neu einlesen / reparieren; SOWIE Paperless-Ablage-STATUS & -Pflege: ob ALLE Dokumente in Paperless (vollständig) abgelegt sind, ob Dokumente in Paperless FEHLEN, wie viele (noch nicht) in Paperless sind, DUBLETTEN / doppelte Dokumente finden und aufräumen/löschen"
+      en: "Documents and email: search knowledge base and Paperless, download, send; AND administration & status of the document PROCESSING itself: indexing status/backlog, how many documents have NO chunks / are empty or incompletely indexed, RE-INDEX documents without chunks; AND Paperless filing STATUS & upkeep: whether ALL documents are (fully) filed in Paperless, whether documents are MISSING from Paperless, how many are (not yet) in Paperless, find and clean up/delete DUPLICATE documents"
     mcp_servers: [paperless, email]
     internal_tools: [internal.knowledge_search, internal.forward_attachment_to_paperless, internal.render_table, internal.render_list, internal.ingest_status, internal.reindex_documents, internal.list_chunkless_documents, internal.system_health, internal.reextract_paperless_metadata, internal.paperless_dedupe]
     max_steps: 8
@@ -98,8 +98,8 @@ roles:
 
   knowledge:
     description:
-      de: "Wissensdatenbank: INHALTLICHE Suche in eigenen hochgeladenen Dokumenten (was steht in einem Dokument, Fakten/Inhalte AUS Dokumenten). NICHT für Verwaltungs-/Statusfragen zur Verarbeitung selbst (Chunks, Indexierungsstatus, neu indexieren) — das ist 'documents'"
-      en: "Knowledge base: CONTENT search in own uploaded documents (what a document says, facts/content FROM documents). NOT for administration/status questions about the processing itself (chunks, indexing status, re-index) — that is 'documents'"
+      de: "Wissensdatenbank: INHALTLICHE Suche in eigenen hochgeladenen Dokumenten (was steht in einem Dokument, Fakten/Inhalte AUS Dokumenten). NICHT für Verwaltungs-/Statusfragen zur Verarbeitung selbst (Chunks, Indexierungsstatus, neu indexieren) und NICHT für die Frage, ob Dokumente in Paperless / vollständig abgelegt sind — das ist 'documents'"
+      en: "Knowledge base: CONTENT search in own uploaded documents (what a document says, facts/content FROM documents). NOT for administration/status questions about the processing itself (chunks, indexing status, re-index) and NOT for whether documents are filed in Paperless / fully archived — that is 'documents'"
     # No agent loop - uses RAG path directly
 
   general:

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,111 @@
+# FAQ — Dokumente, Verarbeitung & Paperless
+
+Häufige Fragen rund um Dokumente, die Wissensbasis, die Verarbeitung und
+Paperless — und was du **selbst per Chat oder Oberfläche** erledigen kannst,
+ohne dass jemand in die Technik schauen muss.
+
+---
+
+## „Ich finde ein Dokument nicht / wo ist meine Datei?"
+
+Renfield legt jedes Dokument unter einem automatisch erzeugten, **sprechenden
+Titel** ab (z. B. „McPaper AG – Kassenbon vom 14.04.2026"), **nicht** unter dem
+ursprünglichen Dateinamen. Suche deshalb nach dem **Inhalt oder Aussteller**,
+nicht nach dem Dateinamen.
+
+- **Oberfläche:** Suchfeld auf `/wissen/dokumente` (bzw. `/knowledge`) — die
+  Suche findet ein Dokument über **Name, Inhalt UND extrahierte Fakten**, auch
+  ältere, die nicht mehr in der Liste der zuletzt gezeigten Dokumente stehen.
+- **Chat:** *„Suche McPaper"* / *„finde die Rechnung von …"*
+
+**Warum eine neu abgelegte Datei „verschwindet":** Legst du eine Datei erneut in
+den Überwachungsordner, die inhaltlich **schon** in der Wissensbasis ist,
+erkennt Renfield sie als **Dublette** (byte-genauer Abgleich) und legt sie
+**nicht doppelt** an — sie ist bereits vorhanden (unter ihrem ursprünglichen
+Titel). Das ist gewollt und verhindert Doubletten. Über die Suche findest du das
+vorhandene Dokument.
+
+---
+
+## „Ist alles verarbeitet? Was hängt gerade?"
+
+- **Chat:** *„Wie ist der Verarbeitungsstatus?"*
+
+Renfield zeigt dann: wie viele Dokumente **fertig / in Warteschlange / in Arbeit
+/ fehlgeschlagen** sind, ob der Verarbeitungs-Worker **läuft**, wie tief die
+Queue ist, und die **Paperless-Ablage** (abgelegt / ausstehend / fehlgeschlagen).
+
+Das ist auch die zuverlässige Antwort auf **„Sind alle Dokumente in Paperless?"** —
+die Statusausgabe enthält genau diese Zahlen (z. B. „391 abgelegt, 7 ausstehend,
+3 fehlgeschlagen").
+
+---
+
+## „Welche Dokumente sind nicht durchsuchbar / leer?"
+
+Ein Dokument ist nur auffindbar, wenn es **Chunks** (durchsuchbare Textabschnitte)
+hat. Fehlen sie, ist das Dokument zwar da, aber die Suche findet es nicht über
+den Inhalt.
+
+- **Auflisten:** *„Welche Dokumente haben keine Chunks?"* — mit Kennzeichnung
+  **REPARIERBAR** vs. **UNINDEXIERBAR**.
+- **Reparieren:** *„Indexiere die Dokumente ohne Chunks neu."* — reparierbare
+  Dokumente werden neu eingelesen.
+
+---
+
+## „Doppelte Dokumente in Paperless aufräumen"
+
+- **Chat:** *„Finde und lösche die Duplikate in Paperless."*
+
+Renfield findet Dubletten (gleiche Datei, gleiche Metadaten oder gleicher
+OCR-Text), **behält das älteste Original** und verschiebt die Kopien in den
+**Papierkorb** (wiederherstellbar). Bei sehr vielen Dubletten läuft das
+in Schüben — Renfield meldet, wie viele noch übrig sind; einfach erneut fragen.
+
+---
+
+## „Ein Dokument an Simba (Steuerkanzlei) senden" *(nur xidra)*
+
+Auf einer Dokumentzeile in `/wissen/dokumente` (oder `/knowledge`) gibt es die
+Aktion **„An Simba senden"**. Ein Klick öffnet ein **Overlay**: du prüfst
+**Bezeichnung, Kategorie, Typ und Zeitraum** (vorbefüllt), bestätigst in **zwei
+Schritten** und überträgst das Dokument **direkt dort** an die Steuerkanzlei.
+
+> ⚠️ **Die Übertragung ist unwiderruflich.** Das Portal erlaubt keinen Rückzug.
+> Deshalb der bewusste Zwei-Schritt-Bestätigen-Dialog. Brichst du ab, bleibt der
+> Vorschlag in der Prüf-Queue unter `/brain/review` liegen (dort kannst du ihn
+> später übertragen oder verwerfen).
+
+Watch-Folder-PDFs landen automatisch als Vorschlag in derselben Queue — sie
+werden **nie** automatisch übertragen.
+
+---
+
+## Wie funktioniert die Dokument-Pipeline?
+
+1. Datei in den **Überwachungsordner** legen (SMB-Share).
+2. Renfield liest sie ein: **OCR / Docling → durchsuchbare Chunks** in der
+   Wissensbasis.
+3. Renfield legt sie in **Paperless** ab.
+4. **Dubletten** (byte-genau identische Dateien) werden übersprungen — kein
+   Doppel.
+
+E-Mail-Anhänge aus dem überwachten Postfach laufen durch dieselbe Pipeline.
+
+---
+
+## Kurzreferenz — was ich selbst per Chat erledigen kann
+
+| Ich möchte … | Chat-Frage |
+|---|---|
+| Ein Dokument finden | *„Suche &lt;Begriff&gt;"* |
+| Verarbeitungsstatus / was hängt | *„Wie ist der Verarbeitungsstatus?"* |
+| Paperless-Ablagestatus | *„Wie ist der Verarbeitungsstatus?"* (enthält Paperless-Zahlen) |
+| Dokumente ohne Chunks auflisten | *„Welche Dokumente haben keine Chunks?"* |
+| Dokumente ohne Chunks reparieren | *„Indexiere die Dokumente ohne Chunks neu."* |
+| Paperless-Duplikate aufräumen | *„Finde und lösche die Duplikate in Paperless."* |
+| Dokument an Simba senden *(xidra)* | Aktion **„An Simba senden"** auf der Dokumentzeile |
+
+> Funktioniert eine Chat-Frage einmal nicht wie erwartet, findest du dieselben
+> Informationen auch in der Oberfläche unter `/wissen` (Suche, Status, Prüfen).


### PR DESCRIPTION
## Summary
Adds `docs/FAQ.md` — a user-facing FAQ so a household/business user can find documents, check processing status, reindex, clean Paperless duplicates, and send to Simba **themselves**, via chat or the `/wissen` UI, without anyone inspecting the backend.

Prompted by a real support round: a file that seemed "missing from Paperless" was actually already in the KB (deduped), findable via the new document search; and "is everything processed?" is answerable via `internal.ingest_status`.

## Notes
- Uses the reliably-routing phrasing "Wie ist der Verarbeitungsstatus?" for the Paperless-completeness question (see the separate routing note — the natural "Sind alle Dokumente in Paperless?" currently misroutes to the RAG-only `knowledge` role).

🤖 Generated with [Claude Code](https://claude.com/claude-code)