### PR TITLE
feat(paperless): link paperless_document_id via checksum (#1166)

### DIFF
--- a/bin/backfill_paperless_document_ids.py
+++ b/bin/backfill_paperless_document_ids.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+Backfill documents.paperless_document_id from Paperless, matched by checksum.
+
+The Paperless consume task frequently settles ``success`` with NO
+``related_document``, even though Paperless created/holds the document — so the
+filing leg recorded ``paperless_state='done'`` but left ``paperless_document_id``
+NULL (observed across the whole xidra corpus: 398 done docs, 0 linked). Without
+the id there is no KB↔Paperless deep-link and no way to verify a doc is really in
+Paperless. renfield's ``documents.file_hash`` equals Paperless's ``checksum``, so
+we can resolve the real id with one read-only ``?checksum__iexact=`` query per doc.
+
+This is the batch companion to the live fix in
+``services.folder_ingest_paperless`` (#1166) — it links the docs that were filed
+BEFORE the fix. Idempotent: rows that already have a ``paperless_document_id`` are
+skipped, and a doc with no checksum match in Paperless is left NULL (genuinely not
+filed → surfaces honestly). Per-document commit, so a crash keeps earlier links.
+
+ALWAYS --dry-run first (prints what WOULD link, no writes).
+
+Usage:
+    python bin/backfill_paperless_document_ids.py --dry-run             # preview
+    python bin/backfill_paperless_document_ids.py --commit              # link
+    python bin/backfill_paperless_document_ids.py --commit --limit 100  # cap
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+_BACKEND = Path(__file__).resolve().parent.parent / "src" / "backend"
+sys.path.insert(0, str(_BACKEND))
+
+from sqlalchemy import select  # noqa: E402
+
+from models.database import Document  # noqa: E402
+from services.database import AsyncSessionLocal  # noqa: E402
+from services.folder_ingest_paperless import _resolve_paperless_id_by_checksum  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s")
+logger = logging.getLogger("backfill_paperless_document_ids")
+
+
+async def run(commit: bool, limit: int | None) -> None:
+    async with AsyncSessionLocal() as db:
+        stmt = (
+            select(Document)
+            .where(
+                Document.paperless_document_id.is_(None),
+                Document.file_hash.isnot(None),
+                Document.paperless_state == "done",
+            )
+            .order_by(Document.id)
+        )
+        if limit:
+            stmt = stmt.limit(limit)
+        docs = (await db.execute(stmt)).scalars().all()
+        logger.info(f"{len(docs)} done-but-unlinked documents to check")
+
+        linked = missing = 0
+        for doc in docs:
+            pid = await _resolve_paperless_id_by_checksum(doc.file_hash)
+            if pid is None:
+                missing += 1
+                logger.info(f"  doc {doc.id}: NO checksum match in Paperless (genuinely not filed?)")
+                continue
+            linked += 1
+            logger.info(f"  doc {doc.id} -> paperless_id={pid}{'' if commit else ' (dry-run)'}")
+            if commit:
+                doc.paperless_document_id = pid
+                await db.commit()
+
+        logger.info(
+            f"done: {linked} linked{'' if commit else ' (dry-run, no writes)'}, "
+            f"{missing} with no Paperless match"
+        )
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--dry-run", action="store_true", help="preview only (no writes)")
+    g.add_argument("--commit", action="store_true", help="persist the resolved ids")
+    ap.add_argument("--limit", type=int, default=None, help="cap documents processed")
+    args = ap.parse_args()
+    asyncio.run(run(commit=args.commit, limit=args.limit))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/FOLDER_INGEST.md
+++ b/docs/FOLDER_INGEST.md
@@ -166,6 +166,17 @@ the role descriptions in `config/agent_roles.yaml`.
   batch). The filed Paperless id is persisted on `documents.paperless_document_id`
   (migration `pc20260613`). The push itself never performs the external round-trip on a
   pooled DB connection — that inline leg was the 2026-07-01 pool-exhaustion outage.
+- **Paperless-id link via checksum (#1166).** The consume task frequently settles
+  `success`/`duplicate` with **no `related_document`** even though Paperless created/holds
+  the document, so the id came back NULL corpus-wide. `_resolve_paperless_id_by_checksum`
+  falls back to a read-only Paperless `?checksum__iexact=<file_hash>` lookup — renfield's
+  `documents.file_hash` equals Paperless's `checksum` (SHA256) — so the KB row still links
+  to the real Paperless doc. The deferred created_date/OCR PATCH stays guarded to the
+  TASK-reported id (never a checksum-resolved one, which may be a pre-existing doc).
+  `internal.ingest_status` reports `paperless_done_linked`/`paperless_done_unlinked` (the
+  *verified* filing count, not just `state='done'`); `bin/backfill_paperless_document_ids.py`
+  (`--dry-run`/`--commit`) links pre-fix docs by checksum. Needs `PAPERLESS_API_URL` +
+  `PAPERLESS_API_TOKEN` in the backend env (already provisioned for the MCP).
 - **Idempotent refile (no re-upload loop).** The leg persists the Paperless consume
   `task_id` on `documents.paperless_task_id` (migration `pc20260825`) BEFORE awaiting the
   verdict; on a retry it RE-POLLS that task (`await_consume_result`) instead of

--- a/src/backend/services/folder_ingest_paperless.py
+++ b/src/backend/services/folder_ingest_paperless.py
@@ -71,6 +71,40 @@ def _parse_paperless_result(mcp_result: dict | None) -> dict:
     return {"error": "unparseable_paperless_response"}
 
 
+async def _resolve_paperless_id_by_checksum(checksum: str | None) -> int | None:
+    """Look up a filed document's Paperless id by content checksum — renfield's
+    ``documents.file_hash`` equals Paperless's ``checksum``. Read-only, best-effort
+    (returns None on any error or if ``paperless_api_url``/``_token`` is unset).
+
+    Used when the consume task settles ``success`` but returns no
+    ``related_document`` (a common Paperless quirk observed across the whole xidra
+    corpus — the document IS created/held, the task just doesn't link it), so the
+    KB row can still record the real Paperless id (#1166). Both a fresh doc and a
+    duplicate resolve here, since Paperless holds exactly one doc per checksum."""
+    from utils.config import settings as _s
+
+    base = (_s.paperless_api_url or "").rstrip("/")
+    token = _s.paperless_api_token or ""
+    if not checksum or not base or not token:
+        return None
+    try:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base}/api/documents/",
+                params={"checksum__iexact": checksum, "page_size": 1, "fields": "id"},
+                headers={"Authorization": f"Token {token}"},
+            )
+            resp.raise_for_status()
+            results = (resp.json() or {}).get("results") or []
+            if results:
+                return int(results[0]["id"])
+    except Exception as e:  # noqa: BLE001 — link resolution is best-effort
+        logger.debug(f"paperless-leg: checksum id-lookup failed: {type(e).__name__}: {e}")
+    return None
+
+
 async def _settle_from_outcome(
     db: AsyncSession, doc: Document, outcome: dict
 ) -> bool:
@@ -91,7 +125,9 @@ async def _settle_from_outcome(
     status = outcome.get("status")
     if status in ("success", "duplicate"):
         doc.paperless_state = PAPERLESS_STATE_DONE
-        pid = outcome.get("document_id")
+        pid = outcome.get("document_id") or await _resolve_paperless_id_by_checksum(
+            getattr(doc, "file_hash", None)
+        )
         if pid:
             doc.paperless_document_id = pid
         doc.paperless_task_id = None
@@ -543,15 +579,21 @@ def make_paperless_leg(
         if status in ("success", "duplicate"):
             doc.paperless_state = PAPERLESS_STATE_DONE
             # Persist the filed Paperless id so a later re-tag / backfill can
-            # address it directly (a "duplicate" may carry no id — keep NULL).
-            pid = outcome.get("document_id")
+            # address it directly. The consume task frequently settles `success`
+            # with NO related_document even though Paperless created/holds the doc
+            # (observed across the whole xidra corpus) — fall back to a checksum
+            # lookup so the KB row still links to the real Paperless id (#1166).
+            task_pid = outcome.get("document_id")
+            pid = task_pid or await _resolve_paperless_id_by_checksum(
+                getattr(doc, "file_hash", None)
+            )
             if pid:
                 doc.paperless_document_id = pid
             doc.paperless_task_id = None  # settled — no outstanding upload
             await db.commit()
             logger.info(
                 f"paperless-leg: doc {doc.id} {status} "
-                f"(paperless_id={outcome.get('document_id')})"
+                f"(paperless_id={pid}{' via checksum' if pid and not task_pid else ''})"
             )
             # Post-consume PATCH — one update_document carrying two things:
             #  1. The DEFERRED metadata. With wait_for_consume=False the upload
@@ -562,10 +604,12 @@ def make_paperless_leg(
             #     Paperless keeps the consume-time date (the Jet-receipt drift).
             #  2. Renfield's high-quality OCR into Paperless's searchable
             #     content, overwriting Paperless's weaker consume-time OCR.
-            # Only on a freshly-filed 'success' with an id — a 'duplicate'
-            # already exists (leave its metadata/content untouched). Best-effort:
-            # a failure here does not un-settle the doc (it IS filed).
-            if status == "success" and pid:
+            # Only on a freshly-filed 'success' the TASK reported an id for — a
+            # 'duplicate' already exists (leave its metadata/content untouched),
+            # and a checksum-RESOLVED id may point at a pre-existing doc we must
+            # not overwrite. Best-effort: a failure here does not un-settle the
+            # doc (it IS filed).
+            if status == "success" and task_pid:
                 deferred = upload.get("deferred_patch") or {}
                 patch: dict = {"document_id": pid}
                 if deferred.get("created_date"):

--- a/src/backend/services/kb_maintenance_tool.py
+++ b/src/backend/services/kb_maintenance_tool.py
@@ -282,6 +282,25 @@ async def ingest_status(params: dict, user_id: int | None = None) -> dict:
                 ).all()
             }
 
+            # #1166: of the docs marked filed ('done'), how many actually LINK to a
+            # Paperless document id (verified present) vs. are unlinked (the id was
+            # never recorded → 'done' is unverified). Backfill links the rest.
+            pl_done_linked = int(
+                (
+                    await db.execute(
+                        select(func.count())
+                        .select_from(Document)
+                        .where(
+                            Document.paperless_state == "done",
+                            Document.paperless_document_id.isnot(None),
+                        )
+                    )
+                ).scalar()
+                or 0
+            )
+
+        pl_done_unlinked = max(0, int(pl_counts.get("done", 0)) - pl_done_linked)
+
         # worker liveness + live backlog (best-effort; never fail the readout)
         worker_alive = None
         queue_depth = None
@@ -343,6 +362,12 @@ async def ingest_status(params: dict, user_id: int | None = None) -> dict:
             f"{v} {_PL_LABELS.get(k, k)}" for k, v in sorted(pl_counts.items())
         )
         parts.append(f"Paperless: {pl_bits}.")
+        if pl_done_unlinked:
+            parts.append(
+                f"Hinweis: {pl_done_unlinked} als abgelegt markierte Dokument(e) sind noch "
+                f"nicht mit ihrer Paperless-ID verknüpft (Status unbestätigt; "
+                f"`bin/backfill_paperless_document_ids.py` verknüpft sie per Prüfsumme)."
+            )
         if worker_alive is not None:
             parts.append(
                 f"Worker: {'aktiv' if worker_alive else 'NICHT erreichbar'}"
@@ -361,6 +386,8 @@ async def ingest_status(params: dict, user_id: int | None = None) -> dict:
                 "paperless_state": pl_counts,
                 "paperless_pending": pl_pending,
                 "paperless_failed": pl_failed,
+                "paperless_done_linked": pl_done_linked,
+                "paperless_done_unlinked": pl_done_unlinked,
                 "worker_alive": worker_alive,
                 "queue_depth": queue_depth,
             },

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -408,6 +408,12 @@ class Settings(BaseSettings):
     # task that already finished returns terminal immediately; one still consuming
     # returns fast — we do not wait out a fresh consume here.
     paperless_refile_poll_timeout_s: float = 30.0
+    # Paperless REST base URL + token (same values the paperless MCP gets via
+    # mcp_servers.yaml). Used ONLY for the read-only checksum lookup that links a
+    # filed KB doc to its real Paperless document id when the consume task returns
+    # SUCCESS with no related_document (#1166). Env: PAPERLESS_API_URL / _TOKEN.
+    paperless_api_url: str | None = None
+    paperless_api_token: str | None = None
     mcp_max_response_size: int = Field(default=131072, ge=1024, le=524288)  # 128KB max response — accommodates list_correspondents on real corpora (~70KB at ~900 entries) without truncating mid-payload
     # MCP exponential-backoff for reconnect / transient failures
     mcp_backoff_initial_delay: float = Field(default=1.0, ge=0.1, le=60.0)

--- a/tests/backend/test_folder_ingest_paperless.py
+++ b/tests/backend/test_folder_ingest_paperless.py
@@ -877,3 +877,50 @@ async def test_await_consume_uses_per_call_timeout(monkeypatch):
 
     consume = [ct for tool, ct in calls if tool == "mcp.paperless.await_consume_result"]
     assert consume and consume[0] is not None and consume[0] > 30  # per-call override applied
+
+
+# ---------------------------------------------------------------------------
+# #1166: link paperless_document_id via checksum when the task returns no id
+# ---------------------------------------------------------------------------
+
+async def test_resolve_paperless_id_unconfigured_returns_none(monkeypatch):
+    from utils.config import settings
+    monkeypatch.setattr(settings, "paperless_api_url", None, raising=False)
+    monkeypatch.setattr(settings, "paperless_api_token", None, raising=False)
+    assert await leg_mod._resolve_paperless_id_by_checksum("abc123") is None
+    # no checksum → also None even if configured
+    monkeypatch.setattr(settings, "paperless_api_url", "http://paperless:8000", raising=False)
+    monkeypatch.setattr(settings, "paperless_api_token", "tok", raising=False)
+    assert await leg_mod._resolve_paperless_id_by_checksum(None) is None
+
+
+async def test_success_without_task_id_links_via_checksum(monkeypatch):
+    """The consume task settled `success` but returned NO document_id → the leg
+    resolves the real Paperless id by the file checksum and persists it (#1166)."""
+    _patch_extractor(monkeypatch)
+    resolver = AsyncMock(return_value=32)
+    monkeypatch.setattr(leg_mod, "_resolve_paperless_id_by_checksum", resolver)
+    leg = make_paperless_leg(_mcp(await_inner={"status": "success"}))  # NO document_id
+    doc, db = _doc(), AsyncMock()
+    doc.file_hash = "5d7af995"
+    doc.paperless_document_id = None
+
+    assert await leg(db, doc, _PDF, _meta()) is True
+    assert doc.paperless_state == PAPERLESS_STATE_DONE
+    assert doc.paperless_document_id == 32
+    resolver.assert_awaited_once_with("5d7af995")
+
+
+async def test_success_with_task_id_skips_checksum(monkeypatch):
+    """When the task DOES report a document_id, use it directly and never do the
+    checksum lookup (nor risk patching a pre-existing doc)."""
+    _patch_extractor(monkeypatch)
+    resolver = AsyncMock(return_value=99)
+    monkeypatch.setattr(leg_mod, "_resolve_paperless_id_by_checksum", resolver)
+    leg = make_paperless_leg(_mcp(await_inner={"status": "success", "document_id": 7}))
+    doc, db = _doc(), AsyncMock()
+    doc.paperless_document_id = None
+
+    assert await leg(db, doc, _PDF, _meta()) is True
+    assert doc.paperless_document_id == 7
+    resolver.assert_not_awaited()

--- a/tests/backend/test_kb_maintenance_tool.py
+++ b/tests/backend/test_kb_maintenance_tool.py
@@ -296,6 +296,7 @@ async def test_ingest_status_reports_counts(monkeypatch):
         _scalar_result(3),                                                     # chunkless total
         _scalar_result(1),                                                     # chunkless unindexable
         _all_result([("done", 8), (None, 2), ("pending", 5)]),                 # paperless group
+        _scalar_result(6),                                                     # done docs LINKED to a paperless id (#1166)
     ])
     monkeypatch.setattr(kb, "AsyncSessionLocal", cm)
     # force the worker/queue probe down the except path (keep the test hermetic)
@@ -312,6 +313,10 @@ async def test_ingest_status_reports_counts(monkeypatch):
     assert d["paperless_state"]["done"] == 8
     assert d["paperless_state"]["unfiled"] == 2   # NULL → unfiled
     assert d["paperless_pending"] == 5
+    # #1166: 6 of the 8 'done' docs actually link to a Paperless id; 2 are unverified.
+    assert d["paperless_done_linked"] == 6
+    assert d["paperless_done_unlinked"] == 2
+    assert "noch nicht mit ihrer Paperless-ID verknüpft" in out["message"]
     assert "KB-Verarbeitung" in out["message"]
     assert "3 fertige Dokument(e) haben KEINE Chunks" in out["message"]
     assert "2 reparierbar" in out["message"] and "1 vermutlich unlesbar" in out["message"]
@@ -324,6 +329,7 @@ async def test_ingest_status_all_unindexable_message(monkeypatch):
         _scalar_result(2),   # chunkless total
         _scalar_result(2),   # all unindexable
         _all_result([("done", 4)]),
+        _scalar_result(4),   # all done docs linked (#1166) → no unlinked hint
     ])
     monkeypatch.setattr(kb, "AsyncSessionLocal", cm)
     monkeypatch.setattr(
@@ -409,6 +415,7 @@ async def test_ingest_status_reports_split_lifecycle(monkeypatch):
         _scalar_result(0),
         _scalar_result(0),
         _all_result([("done", 12)]),
+        _scalar_result(12),  # all done docs linked (#1166)
     ])
     monkeypatch.setattr(kb, "AsyncSessionLocal", cm)
     monkeypatch.setattr(
@@ -429,6 +436,7 @@ async def test_ingest_status_no_split_line_when_no_split_docs(monkeypatch):
         _scalar_result(0),
         _scalar_result(0),
         _all_result([("done", 10)]),
+        _scalar_result(10),  # all done docs linked (#1166)
     ])
     monkeypatch.setattr(kb, "AsyncSessionLocal", cm)
     monkeypatch.setattr(


### PR DESCRIPTION
Fixes #1166.

## Problem
The Paperless consume task frequently settles `success`/`duplicate` with **no `related_document`**, even though Paperless created/holds the document. So the filing leg recorded `paperless_state='done'` but left `paperless_document_id` **NULL** — measured corpus-wide on xidra: **398 'done' docs, 0 linked**. No KB↔Paperless deep-link, and "is it in Paperless?" was unverified (a genuinely-missing doc could look `done`).

## Fix
- **`_resolve_paperless_id_by_checksum()`** (`folder_ingest_paperless.py`): read-only Paperless `?checksum__iexact=<file_hash>` lookup — renfield's `documents.file_hash` **equals** Paperless's `checksum` (verified: doc #26 → Paperless id **32**). Both settle sites (`_settle_from_outcome` + the main `_leg`) fall back to it when the outcome has no `document_id`. The deferred post-consume PATCH (created_date + OCR) stays guarded to the **task-reported** id, so a checksum-resolved id never overwrites a pre-existing doc.
- **`ingest_status`** now reports `paperless_done_linked` / `paperless_done_unlinked` (+ a hint pointing at the backfill) → the "in Paperless?" answer reflects the **verified** link count.
- **`bin/backfill_paperless_document_ids.py`**: links the pre-fix done-but-unlinked docs by checksum (`--dry-run`/`--commit`/`--limit`); no match → left NULL (surfaces honestly as not-actually-filed).
- config: `paperless_api_url`/`paperless_api_token` (env-backed, read-only lookup only).

## Test plan
- [x] `test_folder_ingest_paperless.py` **55/55** (3 new: unconfigured→None, no-task-id→checksum link, task-id→skip checksum).
- [x] `test_kb_maintenance_tool.py` **23/23** (ingest_status linked/unlinked).
- [ ] Deploy to xidra; run the backfill `--dry-run` then `--commit`; confirm `ingest_status` linked count rises.

Frontend KB→Paperless deep-link deferred as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)