### PR TITLE
fix(simba): refresh documents list after upload so the in_simba icon updates

### DIFF
--- a/src/frontend/src/api/resources/simbaIngest.ts
+++ b/src/frontend/src/api/resources/simbaIngest.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
+import { keys } from '../keys';
 import apiClient from '../../utils/axios';
 
 export interface SimbaProposal {
@@ -70,7 +71,18 @@ export function useConfirmSimbaProposal() {
       }>(`/api/simba-ingest/${id}/confirm`, { category, type, description, month, year, force });
       return r.data;
     },
-    onSuccess: () => void queryClient.invalidateQueries({ queryKey: PROPOSALS_KEY }),
+    onSuccess: (data) => {
+      void queryClient.invalidateQueries({ queryKey: PROPOSALS_KEY });
+      // A landed upload flips the document's `in_simba` state → refresh the
+      // knowledge documents list so the row's Simba status icon updates without
+      // a manual reload. Both the doc-page send overlay and the /brain/review
+      // section confirm through here. Gated on an actual upload — an
+      // already-in-Simba (no force) or rejected confirm returns success:false
+      // and changes no document state, so it needs no documents refetch.
+      if (data?.success) {
+        void queryClient.invalidateQueries({ queryKey: keys.knowledge.all });
+      }
+    },
   });
 }
 

--- a/tests/frontend/react/api/invalidation.test.tsx
+++ b/tests/frontend/react/api/invalidation.test.tsx
@@ -16,6 +16,8 @@ import type {
   Memory,
   MemoryInput,
 } from '../../../../src/frontend/src/api/resources/memories';
+import { useKnowledgeDocumentsQuery } from '../../../../src/frontend/src/api/resources/knowledge';
+import { useConfirmSimbaProposal } from '../../../../src/frontend/src/api/resources/simbaIngest';
 
 const BASE = TEST_CONFIG.API_BASE_URL;
 
@@ -87,5 +89,105 @@ describe('Resource invalidation contract (memories as canonical example)', () =>
     // The list now shows the new item without anyone calling refetch()
     await waitFor(() => expect(queryResult.current.data?.memories).toHaveLength(2));
     expect(queryResult.current.data?.memories[1].content).toBe('second');
+  });
+});
+
+describe('Simba upload invalidates the knowledge documents list (in_simba status icon)', () => {
+  it('a successful confirm refetches useKnowledgeDocumentsQuery so in_simba flips to true', async () => {
+    // Regression: the confirm mutation only invalidated the Simba proposals list,
+    // not keys.knowledge.all, so the doc row's Simba status icon stayed stale
+    // after a successful upload until a manual reload.
+    let inSimba = false;
+
+    server.use(
+      http.get(`${BASE}/api/knowledge/documents`, () =>
+        HttpResponse.json([{ id: 5, filename: 'rechnung.pdf', in_simba: inSimba }]),
+      ),
+      http.post(`${BASE}/api/simba-ingest/42/confirm`, () => {
+        inSimba = true; // the upload landed → backend now reports in_simba: true
+        return HttpResponse.json({ success: true, message: 'An Simba übertragen' });
+      }),
+    );
+
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0, staleTime: 0 },
+        mutations: { retry: false },
+      },
+    });
+    const wrapper = makeWrapper(client);
+
+    const { result: docs } = renderHook(
+      () => useKnowledgeDocumentsQuery({ knowledgeBaseId: null, statusFilter: 'all' }),
+      { wrapper },
+    );
+    const { result: confirm } = renderHook(() => useConfirmSimbaProposal(), { wrapper });
+
+    await waitFor(() => expect(docs.current.data?.[0]?.in_simba).toBe(false));
+
+    await act(async () => {
+      await confirm.current.mutateAsync({
+        id: 42,
+        category: 'Belege',
+        type: 'Eingangsrechnung',
+        description: 'Rechnung',
+        month: 3,
+        year: 2026,
+      });
+    });
+
+    // The documents list refetched itself (no explicit refetch) and the icon flips.
+    await waitFor(() => expect(docs.current.data?.[0]?.in_simba).toBe(true));
+  });
+
+  it('an already-in-Simba confirm (success:false) does NOT refetch the documents list', async () => {
+    // Guard the gate: only a genuine upload should refetch knowledge; an
+    // already-in-Simba / rejected confirm returns success:false and changes no
+    // document state, so it must not thrash the documents query.
+    let docFetches = 0;
+
+    server.use(
+      http.get(`${BASE}/api/knowledge/documents`, () => {
+        docFetches += 1;
+        return HttpResponse.json([{ id: 5, filename: 'rechnung.pdf', in_simba: false }]);
+      }),
+      http.post(`${BASE}/api/simba-ingest/42/confirm`, () =>
+        HttpResponse.json({ success: false, message: 'already_in_simba', already_in_simba: true }),
+      ),
+    );
+
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0, staleTime: 0 },
+        mutations: { retry: false },
+      },
+    });
+    const wrapper = makeWrapper(client);
+
+    const { result: docs } = renderHook(
+      () => useKnowledgeDocumentsQuery({ knowledgeBaseId: null, statusFilter: 'all' }),
+      { wrapper },
+    );
+    const { result: confirm } = renderHook(() => useConfirmSimbaProposal(), { wrapper });
+
+    await waitFor(() => expect(docs.current.data).toHaveLength(1));
+    const fetchesAfterInitial = docFetches;
+
+    await act(async () => {
+      await confirm.current.mutateAsync({
+        id: 42,
+        category: 'Belege',
+        type: 'Eingangsrechnung',
+        description: 'Rechnung',
+        month: 3,
+        year: 2026,
+      });
+    });
+
+    // No extra documents fetch was triggered by the non-upload confirm.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+    expect(docFetches).toBe(fetchesAfterInitial);
   });
 });


### PR DESCRIPTION
## Summary

After a successful Simba upload, the doc-row **Simba status icon** (`Landmark`, `in_simba`) on `/wissen/dokumente` (+ `/knowledge`) did **not** update until a manual reload.

**Root cause:** `useConfirmSimbaProposal.onSuccess` invalidated only the Simba proposals list (`PROPOSALS_KEY`), **not** the knowledge documents query (`keys.knowledge.all`). `in_simba` is derived server-side from a proposal in the `UPLOADED` state (`_simba_uploaded_ids`) and returned on the documents list — so the backend was correct, but the frontend never refetched the list. Both the doc-page send overlay (`SimbaSendModal`) and the `/brain/review` section confirm through this one mutation, so the row stayed stale everywhere.

**Fix:** on a landed upload (`data.success`), also invalidate `keys.knowledge.all`. Gated on `success` so an already-in-Simba (no force) or rejected confirm — which returns `success:false` and changes no document state — doesn't thrash the documents query.

## Test plan
- [x] Two MSW invalidation-contract cases in `tests/frontend/react/api/invalidation.test.tsx`: a successful confirm flips `in_simba` false→true via automatic refetch; a non-upload confirm triggers **no** extra documents fetch.
- [x] `api/invalidation.test.tsx` green (3 tests).
- [x] Frontend `tsc --noEmit` clean for the touched files (a pre-existing, unrelated `test-chat-mock.ts` type error is untouched by this change).

## Scope
- xidra-only surface (Simba icon shows only when `simba_ingest_review_enabled`); needs a **frontend** deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)