### PR TITLE
test(chat-mock): add Simba quick-action stubs to fix the tsc gate

### DIFF
--- a/tests/frontend/react/test-chat-mock.ts
+++ b/tests/frontend/react/test-chat-mock.ts
@@ -88,6 +88,8 @@ export const defaultChatContextValue: ChatContextValue = {
   indexToKb: async () => {},
   sendToPaperless: async () => {},
   sendToBoth: async () => {},
+  sendToSimba: async () => {},
+  sendToPaperlessAndSimba: async () => {},
   handleSummarize: () => {},
   handleSendViaEmail: () => {},
 


### PR DESCRIPTION
## Summary

`ChatContextValue` gained `sendToSimba` + `sendToPaperlessAndSimba` (the Simba chat quick-actions), but the shared no-op test stub `tests/frontend/react/test-chat-mock.ts` was never updated — so `npx tsc --noEmit` in `tests/frontend/react` failed with **TS2739 (missing properties)**. The typecheck gate was red on `main` independent of any feature work (surfaced while verifying #1181).

**Fix:** add the two no-op async stubs alongside the existing `sendToPaperless`/`sendToBoth`, keeping the fully-typed default in sync with the current type (no `as any`, no partial).

## Test plan
- [x] `npx tsc --noEmit` clean in `tests/frontend/react` (TS2739 gone).
- [x] A consumer page test still green (`pages/KnowledgePage.test.tsx`, 5 passed).
- Test-only change — no runtime bundle impact, no deploy needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)