### PR TITLE
fix(ocr): VLM re-OCR coverage trigger for usable-but-garbled text layers

### DIFF
--- a/src/backend/services/document_processor.py
+++ b/src/backend/services/document_processor.py
@@ -573,6 +573,22 @@ class DocumentProcessor:
             return []
         return out
 
+    @staticmethod
+    def _token_overlap(survivor_text: str, candidate_text: str) -> float:
+        """Fraction of the survivor's distinct alnum tokens (len≥3, lowercased)
+        that also appear in ``candidate_text``. 1.0 when the survivor has no such
+        tokens (nothing to verify → don't block). Anti-hallucination signal for
+        the VLM coverage-acceptance path."""
+        import re
+
+        def toks(s: str) -> set[str]:
+            return {t for t in re.findall(r"[A-Za-z0-9]{3,}", (s or "").lower())}
+
+        survivors = toks(survivor_text)
+        if not survivors:
+            return 1.0
+        return len(survivors & toks(candidate_text)) / len(survivors)
+
     async def _vlm_ocr_fallback(
         self, file_path: str, ocr_text: str, drop_rate: float | None = None
     ) -> str | None:
@@ -658,8 +674,20 @@ class DocumentProcessor:
                 if readable and settings.ocr_vlm_gibberish_gate_enabled:
                     readable = await svc.is_ocr_gibberish(vlm_text) is False
                 much_more = len(vlm_text) > 1.5 * max(1, len(ocr_text or ""))
-                coverage_accept = readable and much_more
+                # Anti-hallucination: a faithful transcription reproduces the
+                # known-correct survivor tokens; a fabrication (invented amounts /
+                # boilerplate) does not. Reject a longer-but-wrong VLM output.
+                overlap = self._token_overlap(ocr_text or "", vlm_text)
+                overlap_ok = overlap >= settings.ocr_vlm_coverage_min_overlap
+                coverage_accept = readable and much_more and overlap_ok
                 accept = coverage_accept
+                if not coverage_accept and much_more and readable and not overlap_ok:
+                    logger.info(
+                        f"VLM re-OCR coverage REJECTED for {Path(file_path).name}: "
+                        f"survivor-token overlap {overlap:.0%} < "
+                        f"{settings.ocr_vlm_coverage_min_overlap:.0%} — likely "
+                        f"hallucination, keeping OCR text"
+                    )
             if accept:
                 logger.info(
                     f"VLM re-OCR: using vision transcription for "

--- a/src/backend/services/document_processor.py
+++ b/src/backend/services/document_processor.py
@@ -483,7 +483,16 @@ class DocumentProcessor:
             # result scores strictly better. Benefits ingest AND reindex, so an audit
             # re-OCR improvement actually reaches the KB (not re-garbled by Tesseract).
             _ocr_text = docling_text or "\n".join(c.get("text", "") for c in chunks)
-            _vlm_text = await self._vlm_ocr_fallback(file_path, _ocr_text)
+            # Effective drop-rate of the FINAL chunk set (text-layer or force-OCR
+            # path). A high value means most content was dropped even though the
+            # SURVIVING text scores clean — the letter-spacing "usable text layer"
+            # case that skips force-OCR. Pass it so the VLM coverage trigger can
+            # fire regardless of the survivor score.
+            _final_total = len(chunks) + dropped
+            _final_drop_rate = (dropped / _final_total) if _final_total else 0.0
+            _vlm_text = await self._vlm_ocr_fallback(
+                file_path, _ocr_text, drop_rate=_final_drop_rate
+            )
             if _vlm_text:
                 from utils.content_quality import is_low_quality_text
 
@@ -564,7 +573,9 @@ class DocumentProcessor:
             return []
         return out
 
-    async def _vlm_ocr_fallback(self, file_path: str, ocr_text: str) -> str | None:
+    async def _vlm_ocr_fallback(
+        self, file_path: str, ocr_text: str, drop_rate: float | None = None
+    ) -> str | None:
         """Vision-model re-OCR when the OCR text is bad (rotated / poor scan).
 
         Both Tesseract and EasyOCR fail on the same bad pixels; a vision model reads
@@ -597,7 +608,22 @@ class DocumentProcessor:
             ocr_bad = old_score <= settings.ocr_vlm_fallback_score_threshold
             if not ocr_bad and settings.ocr_vlm_gibberish_gate_enabled:
                 ocr_bad = await svc.is_ocr_gibberish(ocr_text) is True
-            if not ocr_bad:
+            # Coverage trigger (style-3): the survivors score clean, but most of the
+            # document was dropped as low-quality — a "usable-but-garbled" text layer
+            # that skipped force-OCR. The survivor score can't see the lost content;
+            # the high drop-rate can. Re-OCR from the page image regardless of score.
+            coverage_bad = (
+                drop_rate is not None
+                and settings.ocr_vlm_coverage_drop_threshold > 0
+                and drop_rate > settings.ocr_vlm_coverage_drop_threshold
+            )
+            if coverage_bad and not ocr_bad:
+                logger.info(
+                    f"VLM re-OCR coverage trigger: drop_rate={drop_rate:.0%} > "
+                    f"{settings.ocr_vlm_coverage_drop_threshold:.0%} (survivor score "
+                    f"{old_score} was ok) — re-transcribing from the page image"
+                )
+            if not ocr_bad and not coverage_bad:
                 return None
 
             loop = asyncio.get_event_loop()
@@ -622,11 +648,26 @@ class DocumentProcessor:
             accept = new_score > old_score
             if not accept and settings.ocr_vlm_gibberish_gate_enabled:
                 accept = await svc.is_ocr_gibberish(vlm_text) is False
+            # Coverage acceptance: on a coverage-triggered doc the survivors are a
+            # small CLEAN fragment, so the char score can tie/beat the fuller VLM
+            # text — accept when the VLM is itself readable (not garbled) AND
+            # recovers materially MORE content than the survivors.
+            coverage_accept = False
+            if not accept and coverage_bad:
+                readable = new_score > settings.ocr_vlm_fallback_score_threshold
+                if readable and settings.ocr_vlm_gibberish_gate_enabled:
+                    readable = await svc.is_ocr_gibberish(vlm_text) is False
+                much_more = len(vlm_text) > 1.5 * max(1, len(ocr_text or ""))
+                coverage_accept = readable and much_more
+                accept = coverage_accept
             if accept:
                 logger.info(
                     f"VLM re-OCR: using vision transcription for "
                     f"{Path(file_path).name} ({len(images)} page(s), "
-                    f"score {old_score}→{new_score})"
+                    f"score {old_score}→{new_score}"
+                    + (f", coverage-recovered {len(ocr_text or '')}→{len(vlm_text)} chars"
+                       if coverage_accept else "")
+                    + ")"
                 )
                 return vlm_text
             logger.info(

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -553,6 +553,14 @@ class Settings(BaseSettings):
     # raw text layer). 0 disables the coverage trigger (score gate only).
     # Measured 2026-09-01: ~15 xidra + ~56 household docs sit above 0.7.
     ocr_vlm_coverage_drop_threshold: float = Field(default=0.7, ge=0.0, le=1.0)
+    # Anti-hallucination guard for the COVERAGE-acceptance path: the surviving
+    # chunks are known-correct fragments, so a faithful VLM transcription
+    # reproduces most of their tokens while a fabrication does not. Require at
+    # least this fraction of the survivors' distinct tokens to appear in the VLM
+    # text before replacing chunks with it (on financial docs a longer-but-wrong
+    # transcription must NOT win on length alone). Only applies when there are
+    # survivor tokens to check.
+    ocr_vlm_coverage_min_overlap: float = Field(default=0.5, ge=0.0, le=1.0)
     # Adds a fast LM gibberish check (is_ocr_gibberish, intent model) to the VLM
     # trigger + acceptance — catches the 'pronounceable pseudo-word' garble
     # ('ZOGEOLONIGGY') that character statistics can't tell from real words. Without

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -544,6 +544,15 @@ class Settings(BaseSettings):
     ocr_vlm_fallback_enabled: bool = False
     ocr_vlm_fallback_score_threshold: int = 2   # OCR score <= this → try the VLM
     ocr_vlm_fallback_max_pages: int = Field(default=5, ge=1, le=20)
+    # Coverage trigger: even when the SURVIVING (post-drop) text scores fine, a
+    # doc whose chunker dropped more than this fraction is mostly-lost content —
+    # classically a "usable-but-garbled" embedded text layer (DATEV letter-
+    # spacing) that takes the text-layer short-circuit and skips force-OCR. The
+    # VLM reads the page IMAGE (unaffected by the broken text layer) and recovers
+    # it; Schicht-A positioned tokens are preserved (field_text still unions the
+    # raw text layer). 0 disables the coverage trigger (score gate only).
+    # Measured 2026-09-01: ~15 xidra + ~56 household docs sit above 0.7.
+    ocr_vlm_coverage_drop_threshold: float = Field(default=0.7, ge=0.0, le=1.0)
     # Adds a fast LM gibberish check (is_ocr_gibberish, intent model) to the VLM
     # trigger + acceptance — catches the 'pronounceable pseudo-word' garble
     # ('ZOGEOLONIGGY') that character statistics can't tell from real words. Without

--- a/tests/backend/test_document_processor_quality.py
+++ b/tests/backend/test_document_processor_quality.py
@@ -543,3 +543,112 @@ def test_images_scale_config_default_within_bounds():
 
     assert 0.5 <= settings.rag_ocr_images_scale <= 4.0
     assert settings.rag_ocr_images_scale == 1.5
+
+
+# ---- VLM re-OCR coverage trigger (fix/vlm-ocr-coverage-trigger) ------------
+#
+# The VLM fallback historically triggered ONLY on the SURVIVING text's char
+# score. A "usable-but-garbled" text layer (DATEV letter-spacing) drops most
+# chunks, the few survivors score clean, and the VLM was skipped — the doc lost
+# ~98% of its content with no recovery. The coverage trigger fires the VLM from
+# the page image when the drop-rate is high regardless of the survivor score,
+# and a coverage-aware acceptance keeps the fuller VLM transcription.
+
+
+class _FakeOllama:
+    def __init__(self, vlm_text, gibberish=False):
+        self._vlm = vlm_text
+        self._gib = gibberish
+        self.extract_calls = 0
+
+    async def extract_text_from_image(self, _img):
+        self.extract_calls += 1
+        return self._vlm
+
+    async def is_ocr_gibberish(self, _text):
+        return self._gib
+
+
+def _fake_score(text):
+    # Marker-based: "GARBAGE" → bad (1), else clean (5). Returns (score, meta).
+    return (1, {}) if "GARBAGE" in (text or "") else (5, {})
+
+
+def _vlm_settings(monkeypatch, *, coverage=0.7, score_thr=2, gibberish=False, enabled=True):
+    for k, v in {
+        "ocr_vlm_fallback_enabled": enabled,
+        "ocr_vlm_fallback_score_threshold": score_thr,
+        "ocr_vlm_coverage_drop_threshold": coverage,
+        "ocr_vlm_gibberish_gate_enabled": gibberish,
+        "ocr_vlm_fallback_max_pages": 3,
+    }.items():
+        monkeypatch.setattr(f"services.document_processor.settings.{k}", v)
+    monkeypatch.setattr("utils.ocr_quality.score_ocr_quality", _fake_score)
+
+
+class TestVlmCoverageTrigger:
+    async def test_coverage_trigger_fires_and_accepts(self, processor, monkeypatch):
+        """Survivors score clean, but drop_rate>threshold → VLM runs from the image
+        and its fuller readable transcription is accepted (coverage acceptance)."""
+        _vlm_settings(monkeypatch)
+        # No trailing space — the source strips the joined VLM text (…join().strip()).
+        long_clean = ("Pflegeversicherung freiwillige Mitglieder Beitrag " * 8).strip()
+        processor._ollama_service = _FakeOllama(long_clean)
+        processor._render_pages_b64 = lambda *a, **k: ["img1"]
+
+        out = await processor._vlm_ocr_fallback("x.pdf", "clean survivor", drop_rate=0.98)
+
+        assert out == long_clean
+        assert processor._ollama_service.extract_calls == 1
+
+    async def test_no_trigger_when_drop_rate_low(self, processor, monkeypatch):
+        """Low drop-rate + clean survivor score → VLM never runs."""
+        _vlm_settings(monkeypatch)
+        processor._ollama_service = _FakeOllama("should not be used")
+        processor._render_pages_b64 = lambda *a, **k: ["img1"]
+
+        out = await processor._vlm_ocr_fallback("x.pdf", "clean survivor", drop_rate=0.10)
+
+        assert out is None
+        assert processor._ollama_service.extract_calls == 0
+
+    async def test_coverage_rejects_when_vlm_not_longer(self, processor, monkeypatch):
+        """Coverage triggers, but the VLM text isn't materially longer than the
+        survivors → not a coverage gain → rejected."""
+        _vlm_settings(monkeypatch)
+        long_survivor = "clean survivor text " * 30  # ~600 chars
+        processor._ollama_service = _FakeOllama("tiny clean")  # much shorter
+        processor._render_pages_b64 = lambda *a, **k: ["img1"]
+
+        out = await processor._vlm_ocr_fallback("x.pdf", long_survivor, drop_rate=0.95)
+
+        assert out is None  # VLM ran but its output wasn't a coverage improvement
+
+    async def test_coverage_threshold_zero_disables(self, processor, monkeypatch):
+        """coverage_drop_threshold=0 → coverage trigger off; clean survivor → no VLM."""
+        _vlm_settings(monkeypatch, coverage=0.0)
+        processor._ollama_service = _FakeOllama("should not be used")
+        processor._render_pages_b64 = lambda *a, **k: ["img1"]
+
+        out = await processor._vlm_ocr_fallback("x.pdf", "clean survivor", drop_rate=0.99)
+
+        assert out is None
+        assert processor._ollama_service.extract_calls == 0
+
+    async def test_score_trigger_still_works(self, processor, monkeypatch):
+        """Legacy path: a garbled survivor (bad score) still triggers + accepts on a
+        strictly-better VLM score, independent of drop_rate."""
+        _vlm_settings(monkeypatch)
+        processor._ollama_service = _FakeOllama("clean recovered text")
+        processor._render_pages_b64 = lambda *a, **k: ["img1"]
+
+        out = await processor._vlm_ocr_fallback("x.pdf", "GARBAGE r . : n ; :", drop_rate=None)
+
+        assert out == "clean recovered text"
+
+    async def test_disabled_returns_none(self, processor, monkeypatch):
+        _vlm_settings(monkeypatch, enabled=False)
+        processor._ollama_service = _FakeOllama("x")
+        processor._render_pages_b64 = lambda *a, **k: ["img1"]
+        out = await processor._vlm_ocr_fallback("x.pdf", "clean", drop_rate=0.99)
+        assert out is None

--- a/tests/backend/test_document_processor_quality.py
+++ b/tests/backend/test_document_processor_quality.py
@@ -380,6 +380,38 @@ class TestProcessDocumentTextLayerChunkPath:
         assert "23.07.2026" in joined             # the dropped deadline date too
         assert "114/5876/5293" in result["field_text"]
 
+    async def test_call_site_passes_high_drop_rate_on_text_layer_path(
+        self, processor, tmp_path, monkeypatch
+    ):
+        """Second half of the coverage fix: when the text-layer short-circuit is
+        taken but the text layer ITSELF is garbled (usable-but-garbled), the
+        call-site `_final_drop_rate` fed into the VLM fallback is high (>0.7).
+        Bypass the VLM to capture exactly what process_document passes."""
+        f = tmp_path / "garbled_layer.pdf"
+        f.write_bytes(b"%PDF-1.4")
+        garbled_layer = "\n\n".join([GARBAGE_CHUNK] * 10)  # usable-but-garbled
+        self._wire(
+            processor,
+            first_chunks=[GARBAGE_CHUNK, GARBAGE_CHUNK, GARBAGE_CHUNK, CLEAN_CHUNK],
+            text_layer=garbled_layer,
+            tl_usable=True,
+        )
+        monkeypatch.setattr(
+            "services.document_processor.settings.rag_ocr_auto_detect", False
+        )
+        captured = {}
+
+        async def _fake_vlm(file_path, ocr_text, drop_rate=None):
+            captured["drop_rate"] = drop_rate
+            return None  # don't alter the result
+
+        processor._vlm_ocr_fallback = _fake_vlm
+
+        await processor.process_document(str(f), force_ocr=False)
+
+        assert captured.get("drop_rate") is not None
+        assert captured["drop_rate"] > 0.7  # text-layer path fed a high rate to the VLM
+
     async def test_unusable_text_layer_still_force_ocrs(
         self, processor, tmp_path, monkeypatch
     ):
@@ -588,18 +620,54 @@ def _vlm_settings(monkeypatch, *, coverage=0.7, score_thr=2, gibberish=False, en
 
 class TestVlmCoverageTrigger:
     async def test_coverage_trigger_fires_and_accepts(self, processor, monkeypatch):
-        """Survivors score clean, but drop_rate>threshold → VLM runs from the image
-        and its fuller readable transcription is accepted (coverage acceptance)."""
+        """Survivors score clean, but drop_rate>threshold → VLM runs from the image;
+        a FAITHFUL transcription (contains the survivor tokens) + materially longer
+        is accepted."""
         _vlm_settings(monkeypatch)
-        # No trailing space — the source strips the joined VLM text (…join().strip()).
-        long_clean = ("Pflegeversicherung freiwillige Mitglieder Beitrag " * 8).strip()
-        processor._ollama_service = _FakeOllama(long_clean)
+        survivor = "Pflegeversicherung freiwillige Mitglieder Beitrag"
+        # Faithful: repeats the survivor content (high token overlap) + recovers more.
+        vlm_text = (survivor + " " + "wiederhergestellte Zeile Betrag Euro " * 8).strip()
+        processor._ollama_service = _FakeOllama(vlm_text)
         processor._render_pages_b64 = lambda *a, **k: ["img1"]
 
-        out = await processor._vlm_ocr_fallback("x.pdf", "clean survivor", drop_rate=0.98)
+        out = await processor._vlm_ocr_fallback("x.pdf", survivor, drop_rate=0.98)
 
-        assert out == long_clean
+        assert out == vlm_text
         assert processor._ollama_service.extract_calls == 1
+
+    async def test_coverage_rejects_hallucination_low_overlap(self, processor, monkeypatch):
+        """The HIGH finding: a longer + readable but FABRICATED VLM transcription
+        (no survivor-token overlap) must be rejected, not silently replace the
+        correct sparse chunks."""
+        _vlm_settings(monkeypatch)
+        survivor = "Pflegeversicherung Beitrag Steuernummer Mitglied"
+        # Fluent, longer, readable — but entirely different content (a hallucination).
+        hallucination = "Vollkommen andere erfundene Rechnung Betrag Kaufvertrag " * 8
+        processor._ollama_service = _FakeOllama(hallucination)
+        processor._render_pages_b64 = lambda *a, **k: ["img1"]
+
+        out = await processor._vlm_ocr_fallback("x.pdf", survivor, drop_rate=0.98)
+
+        assert out is None  # rejected on low survivor overlap
+        assert processor._ollama_service.extract_calls == 1  # VLM DID run, then rejected
+
+    async def test_coverage_much_more_boundary(self, processor, monkeypatch):
+        """`much_more` is strict > 1.5×: a VLM text at exactly 1.5× (with full
+        overlap) is rejected; just over 1.5× is accepted."""
+        _vlm_settings(monkeypatch)
+        survivor = "alpha bravo charlie delta"  # 25 chars
+        processor._render_pages_b64 = lambda *a, **k: ["img1"]
+
+        # Exactly 1.5× (len 25 → boundary at 37.5; build 37 ≤ 37.5 → reject even
+        # though every survivor token is present).
+        at_boundary = (survivor + " echo foxtrot")[:37]
+        processor._ollama_service = _FakeOllama(at_boundary)
+        assert await processor._vlm_ocr_fallback("x.pdf", survivor, drop_rate=0.98) is None
+
+        # Comfortably over 1.5× with full overlap → accepted.
+        over = survivor + " echo foxtrot golf hotel india juliet kilo"
+        processor._ollama_service = _FakeOllama(over)
+        assert await processor._vlm_ocr_fallback("x.pdf", survivor, drop_rate=0.98) == over
 
     async def test_no_trigger_when_drop_rate_low(self, processor, monkeypatch):
         """Low drop-rate + clean survivor score → VLM never runs."""
@@ -623,6 +691,7 @@ class TestVlmCoverageTrigger:
         out = await processor._vlm_ocr_fallback("x.pdf", long_survivor, drop_rate=0.95)
 
         assert out is None  # VLM ran but its output wasn't a coverage improvement
+        assert processor._ollama_service.extract_calls == 1  # proves the trigger fired
 
     async def test_coverage_threshold_zero_disables(self, processor, monkeypatch):
         """coverage_drop_threshold=0 → coverage trigger off; clean survivor → no VLM."""
@@ -652,3 +721,22 @@ class TestVlmCoverageTrigger:
         processor._render_pages_b64 = lambda *a, **k: ["img1"]
         out = await processor._vlm_ocr_fallback("x.pdf", "clean", drop_rate=0.99)
         assert out is None
+
+
+class TestTokenOverlap:
+    """Direct unit tests for the anti-hallucination survivor-overlap helper."""
+
+    def test_full_overlap(self):
+        assert DocumentProcessor._token_overlap("alpha bravo charlie", "alpha bravo charlie delta") == 1.0
+
+    def test_no_overlap(self):
+        assert DocumentProcessor._token_overlap("alpha bravo", "xxxx yyyy zzzz") == 0.0
+
+    def test_partial_overlap(self):
+        # survivors {alpha,bravo,charlie,delta}; candidate has alpha,bravo → 0.5
+        assert DocumentProcessor._token_overlap("alpha bravo charlie delta", "alpha bravo") == 0.5
+
+    def test_empty_survivor_returns_one(self):
+        # No survivor tokens to verify → don't block (1.0). Covers the early-return.
+        assert DocumentProcessor._token_overlap("", "anything here") == 1.0
+        assert DocumentProcessor._token_overlap("a b", "nothing") == 1.0  # <3-char tokens ignored


### PR DESCRIPTION
## Summary

Fixes a gap where documents with a **"usable-but-garbled" embedded text layer** (DATEV letter-spacing) lost most of their content with no recovery. Such a doc takes the text-layer short-circuit (skips force-OCR to preserve positioned tokens), the quality gate drops the garbled chunks, and — because the few survivors score clean — the existing VLM re-OCR fallback was **skipped**. Measured 2026-09-01 (aggregate counts only): **~15 xidra + ~56 household** docs affected; every high-drop doc took the short-circuit and none ever escalated.

## Fix

A **coverage trigger**: `_vlm_ocr_fallback` now takes the final `drop_rate`; when it exceeds `ocr_vlm_coverage_drop_threshold` (new, default 0.7) the VLM re-transcribes from the page **image** (unaffected by the broken text layer) regardless of the survivor score.

Plus, from code review, an **anti-hallucination survivor-overlap guard** on acceptance: the surviving chunks are known-correct fragments, so a faithful transcription reproduces most of their tokens while a fabrication does not. Coverage acceptance requires `overlap >= ocr_vlm_coverage_min_overlap` (new, default 0.5) **and** readable **and** materially longer — a longer-but-wrong VLM output is rejected (logged).

**Schicht-A safe:** `field_text` still unions the raw text layer, so positioned tokens (Steuernummer/Fristen) are unaffected; the fix only touches free-text RAG chunks. Benefits ingest **and** reindex (existing affected docs recover on reindex).

## Test plan
- [x] 30 tests in `test_document_processor_quality.py`; new coverage-trigger + overlap-guard accept/reject branches fully covered (`.159`).
- [x] Dedicated code review; HIGH finding (hallucination) fixed with the overlap guard; call-site `_final_drop_rate` + boundary + `_token_overlap` tests added.
- [x] Deployed live on both instances (`2026-09-01-ocr-vlm-coverage`, backend + all workers); settings verified live (`coverage_drop_threshold=0.7, min_overlap=0.5, vlm_enabled=True` on both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)