### PR TITLE
fix(ocr): log the silent VLM re-OCR reject branches for diagnosability

### DIFF
--- a/src/backend/services/document_processor.py
+++ b/src/backend/services/document_processor.py
@@ -640,13 +640,31 @@ class DocumentProcessor:
                     f"{old_score} was ok) — re-transcribing from the page image"
                 )
             if not ocr_bad and not coverage_bad:
+                logger.debug(
+                    f"VLM re-OCR not triggered for {Path(file_path).name}: "
+                    f"survivor score {old_score} ok and drop_rate "
+                    + (f"{drop_rate:.0%}" if drop_rate is not None else "n/a")
+                    + f" ≤ {settings.ocr_vlm_coverage_drop_threshold:.0%}"
+                )
                 return None
 
             loop = asyncio.get_event_loop()
             images = await loop.run_in_executor(
                 None, self._render_pages_b64, file_path, settings.ocr_vlm_fallback_max_pages
             )
+            # Observability: the two branches below used to return None SILENTLY, so a
+            # low-coverage doc that reached the VLM but recovered nothing was
+            # indistinguishable in the logs from one that never triggered. That masks the
+            # real failure mode (page render fails → the VLM never sees the image) exactly
+            # for the hard garbled scans one wants to diagnose. Log the trigger context
+            # (drop_rate + which trigger) and the reason — filename only, no doc content.
             if not images:
+                logger.info(
+                    f"VLM re-OCR SKIPPED for {Path(file_path).name}: no page images "
+                    f"rendered (ocr_bad={ocr_bad}, coverage_bad={coverage_bad}, drop_rate="
+                    + (f"{drop_rate:.0%}" if drop_rate is not None else "n/a")
+                    + ") — cannot re-transcribe, keeping OCR text"
+                )
                 return None
 
             parts: list[str] = []
@@ -656,6 +674,11 @@ class DocumentProcessor:
                     parts.append(t)
             vlm_text = "\n\n".join(parts).strip()
             if not vlm_text:
+                logger.info(
+                    f"VLM re-OCR produced EMPTY text for {Path(file_path).name} "
+                    f"({len(images)} page(s) rendered, ocr_bad={ocr_bad}, "
+                    f"coverage_bad={coverage_bad}) — keeping OCR text"
+                )
                 return None
 
             # Accept when the VLM is strictly better by the char score, OR (for the

--- a/tests/backend/test_document_processor_quality.py
+++ b/tests/backend/test_document_processor_quality.py
@@ -722,6 +722,50 @@ class TestVlmCoverageTrigger:
         out = await processor._vlm_ocr_fallback("x.pdf", "clean", drop_rate=0.99)
         assert out is None
 
+    # ---- observability of the previously-SILENT reject branches ---------------
+    # A low-coverage doc that triggered the VLM but recovered nothing used to
+    # return None with no log, indistinguishable from "never triggered". These
+    # assert the reason is now logged (filename only, never doc content).
+
+    async def test_no_images_rendered_logs_skip_reason(self, processor, monkeypatch):
+        """Coverage triggers, but page rendering yields no images → the VLM cannot
+        run; log the SKIP reason with the trigger context instead of a silent None.
+
+        The module logs via loguru, not stdlib logging, so caplog can't see it —
+        patch the module logger (the local convention, see test_warning_log_on_drop)."""
+        _vlm_settings(monkeypatch)
+        processor._ollama_service = _FakeOllama("unused")
+        processor._render_pages_b64 = lambda *a, **k: []  # render produced nothing
+
+        with patch("services.document_processor.logger") as mock_logger:
+            out = await processor._vlm_ocr_fallback("garbled.pdf", "clean survivor", drop_rate=0.98)
+
+        assert out is None
+        assert processor._ollama_service.extract_calls == 0  # VLM never queried
+        assert mock_logger.info.called
+        msg = " ".join(str(c.args[0]) for c in mock_logger.info.call_args_list)
+        assert "no page images rendered" in msg
+        assert "garbled.pdf" in msg
+        assert "coverage_bad=True" in msg
+
+    async def test_empty_vlm_text_logs_reason(self, processor, monkeypatch):
+        """Images render and the VLM runs, but returns empty text → log the reason
+        (VLM produced nothing) instead of a silent None."""
+        _vlm_settings(monkeypatch)
+        processor._ollama_service = _FakeOllama("")  # VLM returns empty
+        processor._render_pages_b64 = lambda *a, **k: ["img1", "img2"]
+
+        with patch("services.document_processor.logger") as mock_logger:
+            out = await processor._vlm_ocr_fallback("garbled.pdf", "clean survivor", drop_rate=0.98)
+
+        assert out is None
+        assert processor._ollama_service.extract_calls == 2  # VLM DID run on both pages
+        assert mock_logger.info.called
+        msg = " ".join(str(c.args[0]) for c in mock_logger.info.call_args_list)
+        assert "EMPTY text" in msg
+        assert "garbled.pdf" in msg
+        assert "2 page(s)" in msg
+
 
 class TestTokenOverlap:
     """Direct unit tests for the anti-hallucination survivor-overlap helper."""


### PR DESCRIPTION
## Summary
- `_vlm_ocr_fallback` returned `None` with **no log** on three branches (not triggered / no page images rendered / empty VLM text). A low-coverage doc that reached the VLM but recovered nothing was indistinguishable in the logs from one that never triggered — masking the real failure mode (page render fails → the VLM never sees the image) for exactly the hard garbled scans one wants to diagnose.
- Adds filename-only logs (**no document content**): `info` on the two "VLM warranted but recovered nothing" branches (`no page images rendered`, `produced EMPTY text`), `debug` on the healthy not-triggered branch. Each carries `drop_rate` + `ocr_bad`/`coverage_bad` flags.
- **Behavior unchanged** — every branch still returns `None` exactly as before.

## Why
Follow-up to the VLM coverage trigger (#1184) + the low-coverage reindex reconciler (#1185). Post-deploy the reconciler drained the reindexable backlog but VLM-recovered=0 on the hard scans, and the silent returns made it impossible to tell from logs *why* (never reached VLM vs empty output vs rejected). This closes that observability gap.

## Test plan
- [x] `tests/backend/test_document_processor_quality.py` on .159: **32 passed, 0 failed**
- [x] 2 new tests (`test_no_images_rendered_logs_skip_reason`, `test_empty_vlm_text_logs_reason`) — assert the new log messages via `patch(...logger)` (loguru convention, matching `test_warning_log_on_drop`; caplog can't see loguru)
- [x] Reviewed (dedicated agent): caught the caplog→loguru capture bug, fixed + re-validated
- [x] Deployed backend `2026-09-01-vlm-reject-logs` → both instances (backend + document-worker), rollout green, new log code verified present in the running workers

🤖 Generated with [Claude Code](https://claude.com/claude-code)