### PR TITLE
pgvector-Image auf 16.14 — und der Befund, daß es nicht mehr gebraucht wird

### DIFF
--- a/k8s/cnpg/Dockerfile.pgvector
+++ b/k8s/cnpg/Dockerfile.pgvector
@@ -1,3 +1,24 @@
+# ================================================================================================
+# STAND 01.09.2026: DIESES IMAGE WIRD DERZEIT VON NIEMANDEM MEHR BENUTZT.
+#
+# Es entstand im August, weil das Standard-CNPG-Image damals pgvector 0.8.0 mitbrachte und die
+# Anwendung 0.8.6 braucht. Das hat sich erledigt — nachgesehen in
+# /usr/share/postgresql/16/extension/vector.control:
+#
+#     ghcr.io/cloudnative-pg/postgresql:16.9-standard-bookworm   ->  pgvector 0.8.0
+#     ghcr.io/cloudnative-pg/postgresql:16.14                    ->  pgvector 0.8.6
+#
+# Beim Neubau gegen die 16.14-Basis sagte apt woertlich „postgresql-16-pgvector is already the
+# newest version (0.8.6-1.pgdg12+1)". Das Image fuegte also nichts mehr hinzu, kostete aber eine
+# echte Abhaengigkeit: vier Cluster (reva, twin-reva, konfigure, konfigure-cloud) zogen dieselbe
+# Marke, der Bauplan lag NUR hier, ohne CI, und die im Kopf genannte Baumaschine war von aussen
+# nicht per Schluessel erreichbar. Alle vier stehen seit dem 01.09.2026 auf dem Standard-Image.
+#
+# Die Datei bleibt trotzdem — gepflegt und lauffaehig —, weil der Grund wiederkommen kann: eine
+# neue PG-Nebenversion kann pgvector wieder hinter dem zurueecklassen, was die Anwendung braucht.
+# Dann ist der Weg hier fertig beschrieben, statt ein zweites Mal rekonstruiert zu werden.
+# ================================================================================================
+#
 # Thin CNPG operand image = stock CloudNativePG PostgreSQL 16 + pgvector.
 #
 # WHY a custom image: the stock CNPG operand images
@@ -7,18 +28,33 @@
 # intact) and add ONLY the pgvector extension from the PGDG apt repo the base
 # image already trusts.
 #
-# Build + push (Phase 2, on the .159 build box):
-#   R=your-registry.example/renfield
+# Build + push. Dieses Image ist GETEILTE Infrastruktur — reva, twin-reva, konfigure und
+# konfigure-cloud ziehen dieselbe Marke —, aber sein Bauplan liegt nur hier, es gibt keine
+# CI-Aufgabe und aus den vier Verbrauchern zeigt nichts hierher. Wer wegen einer PG-Luecke neu
+# bauen muss, muss also WISSEN, dass es diese Datei gibt. Deshalb steht der Bau seit dem
+# 01.09.2026 als anwendbare Aufgabe daneben: k8s/cnpg/build-pgvector-job.yaml. Sie baut mit
+# kaniko IM CLUSTER (nativ amd64, Harbor-Zugang liegt dort schon) statt auf einer Maschine,
+# deren Zustand niemand kennt — die frueher hier genannte „.159-Baumaschine" war von diesem
+# Rechner aus nicht einmal per Schluessel erreichbar.
+#
+#   kubectl apply -f k8s/cnpg/build-pgvector-job.yaml   # Marke dort eintragen
+#
+# Von Hand geht es weiter wie bisher, auf einer amd64-Maschine mit docker:
+#   R=registry.treehouse.x-idra.de/renfield
 #   docker build -f Dockerfile.pgvector \
-#     -t $R/cnpg-pg16-pgvector:16.9-pgvector0.8.6 \
+#     -t $R/cnpg-pg16-pgvector:16.14-pgvector0.8.6 \
 #     -t $R/cnpg-pg16-pgvector:latest .
-#   docker push $R/cnpg-pg16-pgvector:16.9-pgvector0.8.6
-#   docker push $R/cnpg-pg16-pgvector:latest
+#   docker push $R/cnpg-pg16-pgvector:16.14-pgvector0.8.6
 #
 # VERIFY after first boot (the whole reason this image exists):
 #   psql -c '\dx vector'      # extension present, version >= 0.8.1
 # Re-pin the base tag to the current 16.x minor at build time; never :latest base.
-FROM ghcr.io/cloudnative-pg/postgresql:16.9-standard-bookworm
+#
+# 16.14 seit 01.09.2026, vorher 16.9. Die 16.9 stammte vom Aufbau Ende August und war
+# liegengeblieben: beim Umzug von speisekarte fiel auf, dass DEREN Quelle schon auf 16.13 lief —
+# „wie die anderen" waere also vier Patch-Staende ZURUECK gewesen. Konsistenz mit einem
+# veralteten Stand ist keine Konsistenz.
+FROM ghcr.io/cloudnative-pg/postgresql:16.14-standard-bookworm
 
 USER root
 # Pin the pgvector version so a rebuild can't silently drift from the :pgvectorX.Y.Z

--- a/k8s/cnpg/build-pgvector-job.yaml
+++ b/k8s/cnpg/build-pgvector-job.yaml
@@ -1,0 +1,77 @@
+# Baut das pgvector-Operandenimage IM CLUSTER und schiebt es nach Harbor.
+#
+# WARUM als Aufgabe im Repo und nicht als Befehlszeile in einem Kommentar: das Image ist
+# GETEILTE Infrastruktur — reva, twin-reva, konfigure und konfigure-cloud ziehen dieselbe Marke —,
+# hat aber keine CI-Aufgabe, und aus keinem der vier Verbraucher zeigt etwas hierher. Bis zum
+# 01.09.2026 stand der Bau nur im Kopf von Dockerfile.pgvector, mit Verweis auf eine
+# „.159-Baumaschine", die von aussen nicht per Schluessel erreichbar war. Ein Neubau wegen einer
+# PG-Luecke haengt dann daran, dass jemand die richtige Datei kennt.
+#
+# WARUM im Cluster: die Knoten sind amd64 (Entwicklungsrechner sind arm64, cross-build braucht
+# Emulation), und die Harbor-Zugangsdaten liegen dort ohnehin. kaniko braucht keinen
+# Docker-Daemon und keine privilegierten Rechte.
+#
+# ANWENDEN — die Marke in `args` vorher auf den Zielstand setzen:
+#
+#   NS=imagebuild
+#   kubectl create namespace $NS
+#   # Harbor-Zugang aus einem Namensraum kopieren, der ihn schon hat:
+#   kubectl -n reva get secret harbor-pull-secret -o yaml \
+#     | sed "s/namespace: reva/namespace: $NS/" | kubectl apply -f -
+#   # Der Bauplan als ConfigMap (Quelle bleibt die Datei, nicht eine Kopie hier):
+#   kubectl -n $NS create configmap pgvector-dockerfile \
+#     --from-file=Dockerfile=k8s/cnpg/Dockerfile.pgvector
+#   kubectl apply -f k8s/cnpg/build-pgvector-job.yaml
+#   kubectl -n $NS logs -f job/build-pgvector
+#
+# NACH dem Bau pruefen (der Grund, warum es dieses Image gibt) — im fertigen Cluster:
+#   psql -c '\dx vector'      # Erweiterung da, Version >= 0.8.1
+#
+# Aufraeumen: kubectl delete namespace $NS
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: build-pgvector
+  namespace: imagebuild
+spec:
+  backoffLimit: 0          # ein Fehlschlag soll sichtbar stehenbleiben, nicht dreimal wiederholt
+  ttlSecondsAfterFinished: 3600
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: kaniko
+          image: gcr.io/kaniko-project/executor:v1.23.2
+          args:
+            - --dockerfile=/workspace/Dockerfile
+            - --context=dir:///workspace
+            # Die Marke bildet BEIDE Versionen ab, Postgres und pgvector. Der apt-Pin im
+            # Dockerfile ist damit gekoppelt: zieht PGDG die pgvector-Version weiter, schlaegt
+            # der Bau LAUT fehl, statt still etwas anderes zu liefern.
+            - --destination=registry.treehouse.x-idra.de/renfield/cnpg-pg16-pgvector:16.14-pgvector0.8.6
+            # `latest` bewusst MIT gepflegt: vier Manifeste zeigen auf die feste Marke, aber eine
+            # veraltete `latest` daneben ist eine Falle fuer den naechsten, der schnell etwas
+            # ausprobiert.
+            - --destination=registry.treehouse.x-idra.de/renfield/cnpg-pg16-pgvector:latest
+            - --cache=false
+          volumeMounts:
+            - name: dockerfile
+              mountPath: /workspace
+            - name: harbor
+              mountPath: /kaniko/.docker
+          resources:
+            requests: {cpu: 500m, memory: 1Gi}
+            limits: {memory: 2Gi}
+      volumes:
+        - name: dockerfile
+          configMap:
+            name: pgvector-dockerfile
+        - name: harbor
+          secret:
+            secretName: harbor-pull-secret
+            items:
+              # kaniko liest /kaniko/.docker/config.json; das Pull-Secret heisst den Schluessel
+              # anders. Ohne dieses Umbenennen scheitert erst der PUSH, ganz am Ende des Baus.
+              - key: .dockerconfigjson
+                path: config.json


### PR DESCRIPTION
Beim Nachziehen der CNPG-Cluster von Postgres 16.9 auf 16.14 stellte sich heraus: **dieses Image wird nicht mehr gebraucht.**

## Der Befund

Es entstand im August, weil das Standard-CNPG-Image damals pgvector 0.8.0 mitbrachte und die Anwendung 0.8.6 braucht. Nachgesehen in `/usr/share/postgresql/16/extension/vector.control`:

| Image | pgvector |
|---|---|
| `ghcr.io/cloudnative-pg/postgresql:16.9-standard-bookworm` | 0.8.0 |
| `ghcr.io/cloudnative-pg/postgresql:16.14` | **0.8.6** |

Beim Neubau gegen die 16.14-Basis sagte apt wörtlich:

```
postgresql-16-pgvector is already the newest version (0.8.6-1.pgdg12+1).
0 upgraded, 0 newly installed, 0 to remove
```

Das Image fügte also nichts mehr hinzu — kostete aber eine echte Abhängigkeit. Alle vier Verbraucher (`reva`, `twin-reva`, `konfigure`, `konfigure-cloud`) stehen seit dem 01.09.2026 auf dem Standard-Image; `reva` ist der einzige, der pgvector überhaupt benutzt, und dort sind Erweiterung (0.8.6), zwölf vector-Spalten und acht HNSW/ivfflat-Indizes nach dem Wechsel unverändert.

## Warum das eine Erleichterung ist

Das Image war **geteilte Infrastruktur** — vier Cluster in drei fremden Repos zogen dieselbe Marke —, hatte aber genau *einen* Bauplan: diese Datei. Ohne CI, ohne Verweis aus irgendeinem der Verbraucher, mit einer Bau-Anleitung, die auf eine „.159-Baumaschine" zeigt, die von außen nicht per Schlüssel erreichbar ist. Ein Neubau wegen einer PG-Lücke hätte daran gehangen, daß jemand weiß, daß es diese Datei gibt.

## Was hier drin ist

- **`Dockerfile.pgvector`** — Basis auf `16.14-standard-bookworm` gehoben, bleibt lauffähig. Im Kopf steht jetzt der Befund samt Meßwerten. **Die Datei bleibt bewußt**: eine künftige PG-Nebenversion kann pgvector wieder hinter dem zurücklassen, was die Anwendung braucht — dann ist der Weg fertig beschrieben, statt ein zweites Mal rekonstruiert zu werden.
- **`build-pgvector-job.yaml`** (neu) — der Bau als anwendbare Aufgabe, mit kaniko **im Cluster** (nativ amd64, Harbor-Zugang liegt dort ohnehin, kein Docker-Daemon nötig) statt als Befehlszeile in einem Kommentar. Damit tatsächlich gebaut: die Aufgabe hat `16.14-pgvector0.8.6` erzeugt und nach Harbor geschoben — bevor sich herausstellte, daß sie überflüssig war.

🤖 Generated with [Claude Code](https://claude.com/claude-code)