### PR TITLE
fix: 5 backlog issues — DLNA force, review DISTINCT ON, atom reaper, SearXNG probe, folder-ingest rename

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -1010,6 +1010,12 @@ FOLDER_INGEST_TARGET_USER=            # Owner der auto-abgelegten Dokumente (Use
 FOLDER_INGEST_DEFAULT_TIER=0          # Circle-Tier beim Anlegen (0=self … 4=public)
 FOLDER_INGEST_TO_PAPERLESS=true       # zusätzlich in Paperless ablegen
 FOLDER_INGEST_NOTIFY_ON_FILED=true    # Bestätigungs-Notification nach Ablage
+# #881, dark: nach dem Ingest die bereits nach processed/ verschobene Quelldatei
+# auf den generierten Dokumenttitel umbenennen (menschenlesbarer Share). Best-effort
+# (ein Rename-Fehler bricht den Ingest NIE), idempotent + kollisionssicher; braucht
+# den filesystem-MCP-Tool `rename_processed` (renfield-mcp-filesystem). Siehe
+# docs/FOLDER_INGEST.md.
+FOLDER_INGEST_RENAME_PROCESSED_ENABLED=false
 # Autoritativer Push-Token (optional). Wenn gesetzt, seedet der Boot-Credential-
 # Reconciler (services/credential_reconciler.py) den DB-Token (SystemSetting
 # folder_ingest.token) aus diesem Wert — so heilt sich der Token nach einem DB-Wipe
@@ -2192,6 +2198,13 @@ N8N_BASE_URL=http://192.168.1.78:5678
 
 # SearXNG URL
 SEARXNG_API_URL=http://cuda.local:3002
+# #1162, dark: funktionale Health-Probe für den `search`-MCP. Ohne sie zeigt eine
+# erreichbare SearXNG-Instanz, deren Scraper-Engines alle CAPTCHA-blockiert sind
+# (0 echte Ergebnisse), grün. Die Probe fragt SearXNG direkt per JSON ab und meldet
+# `degraded` (nie down), wenn zu wenige distinct *general*-Engines beitragen bzw. das
+# Backbone in `unresponsive_engines` steht. Surface: internal.system_health.
+SEARCH_FUNCTIONAL_PROBE_ENABLED=false
+SEARCH_FUNCTIONAL_MIN_ENGINES=2       # degraded, wenn < N distinct general-Engines beitragen
 
 # Paperless-NGX URL
 PAPERLESS_API_URL=http://paperless.local:8000

--- a/docs/FOLDER_INGEST.md
+++ b/docs/FOLDER_INGEST.md
@@ -218,6 +218,29 @@ the role descriptions in `config/agent_roles.yaml`.
   locates the Paperless doc by the stored id else a filename match over recently-added
   docs, and skips any doc that already has a correspondent.
 
+## Processed-file rename (#881, `FOLDER_INGEST_RENAME_PROCESSED_ENABLED`, dark)
+
+The MCP moves the source file to `processed/` under its **original** filename at
+push time — but the human-readable `documents.generated_title` (issuer + type +
+date) does not exist yet; it's synthesized later in the worker, after the
+Schicht-A facts commit. So a **decoupled post-ingest step** renames the already-moved
+file once the title is known.
+
+- After the worker sets `generated_title` (`schicht_a_extractor.post_document_ingest`),
+  `services/folder_ingest_rename.py::rename_processed_to_title` — gated on
+  `FOLDER_INGEST_RENAME_PROCESSED_ENABLED` **+** `source == 'folder_ingest'` **+** a
+  non-empty title — calls the filesystem MCP `mcp.files.rename_processed(original_name,
+  new_base)`. The worker uses a lazy single-server (`files`) client
+  (`services/files_worker_client.py`), mirroring the Paperless worker client.
+- The MCP tool renames `processed/<original_name>` → `processed/<sanitized title><ext>`:
+  **idempotent** (missing source → success no-op), **collision-safe** (` (2)`, ` (3)`
+  suffix), **traversal-safe** (`original_name` must be a bare filename; separators are
+  scrubbed from `new_base`), keeping the original extension.
+- **Best-effort:** a rename failure (MCP down, tool absent, file gone) is swallowed +
+  logged — the ingest never breaks. It does NOT touch the 4-state move contract or the
+  `paperless_state` dedup (a purely post-move step). **Rollout:** deploy the MCP tool
+  first, then the backend, then flip the flag (dark until both are live).
+
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
@@ -234,6 +257,7 @@ the role descriptions in `config/agent_roles.yaml`.
 
 - Bridge: `services/folder_ingest.py` (dedup, 4-state, owner/tier, token helpers, resolvers)
 - Paperless leg: `services/folder_ingest_paperless.py`
+- Processed-file rename (#881): `services/folder_ingest_rename.py` + `services/files_worker_client.py` + the `rename_processed` tool in `renfield-mcp-filesystem`
 - Routes: `api/routes/folder_ingest.py` (`POST /document`, `GET /health`, `POST /token`)
 - Interactive tool: `services/folder_ingest_tool.py` (+ dispatch in `services/action_executor.py`)
 - Worker terminal-failure handling: `workers/document_processor_worker.py`

--- a/src/backend/api/routes/circles.py
+++ b/src/backend/api/routes/circles.py
@@ -463,17 +463,24 @@ async def _resolve_review_labels(
                 select(Document).where(Document.id.in_(source_ids))
             )).scalars().all()
             docs = {d.id: d for d in rows}
-            # Pull a preview chunk per document (lowest chunk_index) for the
+            # Pull ONE preview chunk per document (lowest chunk_index) for the
             # review-UI snippet. Chunks no longer carry atoms, so we fetch
-            # through document_chunks directly.
-            chunk_rows = (await db.execute(
+            # through document_chunks directly. Use Postgres DISTINCT ON so we
+            # transfer one row per document instead of EVERY chunk of every
+            # reviewed document just to keep the first (#450). sqlite has no
+            # DISTINCT ON, so there the client-side first-wins dedup below still
+            # applies (correctness identical, only the row count differs).
+            chunk_q = (
                 select(DocumentChunk)
                 .where(DocumentChunk.document_id.in_(source_ids))
                 .order_by(
                     DocumentChunk.document_id.asc(),
                     DocumentChunk.chunk_index.asc(),
                 )
-            )).scalars().all()
+            )
+            if db.bind is not None and db.bind.dialect.name == "postgresql":
+                chunk_q = chunk_q.distinct(DocumentChunk.document_id)
+            chunk_rows = (await db.execute(chunk_q)).scalars().all()
             for c in chunk_rows:
                 first_chunks.setdefault(c.document_id, c)
         for a in doc_atoms:

--- a/src/backend/ha_glue/services/internal_tools.py
+++ b/src/backend/ha_glue/services/internal_tools.py
@@ -1203,14 +1203,27 @@ class InternalToolService:
             # If device is busy and force is set, use the entity from the
             # busy-device data to proceed anyway.
             if force and resolve_result.get("data", {}).get("status") == "busy":
-                entity_id = resolve_result["data"].get("entity_id")
-                if not entity_id:
+                busy_data = resolve_result["data"]
+                # A forced play needs SOME routable target on the busy device.
+                # HA devices carry entity_id; DLNA renderers carry
+                # dlna_renderer_name (no entity_id); output providers carry
+                # output_target_id. The old entity_id-only guard made force=true a
+                # silent no-op on a busy DLNA (or output-provider) device — the
+                # user was told "busy" even when asking to interrupt (#668).
+                if not (
+                    busy_data.get("entity_id")
+                    or busy_data.get("dlna_renderer_name")
+                    or busy_data.get("output_target_id")
+                ):
                     return resolve_result
                 resolve_result = {
                     "success": True,
-                    "data": resolve_result["data"],
+                    "data": busy_data,
                 }
-                logger.info(f"Force-playing on busy device {entity_id} in {room_name}")
+                logger.info(
+                    f"Force-playing on busy device in {room_name} "
+                    f"(target_type={busy_data.get('target_type') or 'homeassistant'})"
+                )
             else:
                 return resolve_result
 

--- a/src/backend/services/atom_service.py
+++ b/src/backend/services/atom_service.py
@@ -41,11 +41,11 @@ from __future__ import annotations
 
 import json
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from loguru import logger
-from sqlalchemy import select, text, update
+from sqlalchemy import delete, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.database import (
@@ -526,3 +526,33 @@ def _source_id_for(atom: Atom) -> str:
         f"payload missing document_id/chunk_id/entity_id/relation_id/"
         f"memory_id/skill_id/note_id"
     )
+
+
+async def reap_orphan_placeholder_atoms(
+    db: AsyncSession, older_than_seconds: int = 3600
+) -> int:
+    """Delete orphaned placeholder atoms (#446).
+
+    ``AtomService.create_with_source`` runs a 3-phase write: (1) INSERT the atoms
+    row with a ``__pending__<uuid>`` placeholder ``source_id``, (2) INSERT the
+    source row carrying the minted ``atom_id``, (3) ``finalize_source_id`` →
+    UPDATE the placeholder to the real PK. If the caller crashes (or forgets to
+    finalize) between steps 1 and 3, the placeholder atoms row survives the outer
+    commit with ``source_id = '__pending__…'`` and pollutes retrieval/review.
+
+    This reaps such rows, but ONLY those OLDER than ``older_than_seconds`` — a
+    legitimately in-flight create holds its placeholder for milliseconds, so the
+    age floor guarantees an active write is never reaped. Returns the count
+    deleted.
+    """
+    cutoff = datetime.now(UTC).replace(tzinfo=None) - timedelta(
+        seconds=older_than_seconds
+    )
+    result = await db.execute(
+        delete(AtomModel).where(
+            AtomModel.source_id.like("__pending__%"),
+            AtomModel.created_at < cutoff,
+        )
+    )
+    await db.commit()
+    return int(result.rowcount or 0)

--- a/src/backend/services/atom_service.py
+++ b/src/backend/services/atom_service.py
@@ -550,7 +550,9 @@ async def reap_orphan_placeholder_atoms(
     )
     result = await db.execute(
         delete(AtomModel).where(
-            AtomModel.source_id.like("__pending__%"),
+            # Escape the literal underscores — in LIKE, a bare `_` is a
+            # single-char wildcard, so the intent is only exact with ESCAPE.
+            AtomModel.source_id.like(r"\_\_pending\_\_%", escape="\\"),
             AtomModel.created_at < cutoff,
         )
     )

--- a/src/backend/services/files_worker_client.py
+++ b/src/backend/services/files_worker_client.py
@@ -1,0 +1,66 @@
+"""Minimal single-server filesystem MCP client for the document-worker.
+
+The worker deliberately does NOT run the full MCP lifecycle (10 servers +
+Whisper + Speechbrain) — see ``workers/document_processor_worker.py``. But the
+post-ingest **rename** hook (#881) needs the filesystem MCP to rename the
+already-moved archive copy in the share's ``processed/`` dir to the freshly
+synthesized ``documents.generated_title``. This spins up **only** the ``files``
+streamable-http server connection, lazily and once, so the worker keeps its
+memory budget while still reaching the mover.
+
+Requires ``FILES_MCP_ENABLED=true`` + ``FILES_MCP_URL`` in the worker's
+environment (the same vars the backend passes via mcp_servers.yaml). Returns
+None when the filesystem MCP is disabled/unconfigured or can't connect — callers
+then skip the rename (best-effort; the archive keeps its original filename)
+rather than crash the ingest.
+
+Mirrors ``services/paperless_worker_client.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from loguru import logger
+
+from utils.config import settings
+
+_manager: Any = None
+_lock = asyncio.Lock()
+
+
+async def get_files_mcp_manager() -> Any:
+    """Lazily create + connect a single-server (files-only) MCP manager.
+
+    Cached on success; a failed connect is NOT cached, so a later call retries
+    (e.g. the filesystem MCP came back up)."""
+    global _manager
+    if _manager is not None:
+        return _manager
+    async with _lock:
+        if _manager is not None:
+            return _manager
+        from services.mcp_client import MCPManager
+
+        mgr = MCPManager()
+        mgr.load_config(settings.mcp_config_path, only={"files"})
+        # Reach into the loaded set: with only={"files"} it holds 0 or 1
+        # servers. 0 → filesystem MCP disabled/unconfigured (enabled gate off).
+        state = mgr._servers.get("files")
+        if state is None:
+            logger.warning(
+                "files-worker-client: filesystem MCP not configured/enabled "
+                "(FILES_MCP_ENABLED/FILES_MCP_URL) — worker processed-rename disabled"
+            )
+            return None
+        await mgr.connect_all()
+        if not state.connected:
+            logger.warning(
+                "files-worker-client: filesystem MCP failed to connect in the "
+                "worker — skipping processed-rename"
+            )
+            return None
+        _manager = mgr
+        logger.info("files-worker-client: connected (single-server filesystem MCP)")
+    return _manager

--- a/src/backend/services/folder_ingest_rename.py
+++ b/src/backend/services/folder_ingest_rename.py
@@ -1,0 +1,116 @@
+"""Post-ingest rename of the archived folder-ingest copy (#881).
+
+Folder-ingest moves the source file into the share's ``processed/`` dir under its
+ORIGINAL filename (e.g. ``2026_03_29_14_33_13.pdf``) at push time — but the
+human-readable ``documents.generated_title`` (issuer + type + date) does not
+exist yet: it is synthesized later, in the worker, AFTER Schicht-A facts commit
+(``schicht_a_extractor.generate_document_title``).
+
+So this module is the callback that fires once the title is known: it asks the
+filesystem MCP to rename the already-moved file in ``processed/`` to the
+generated title, making the share human-browsable.
+
+Design (issue #881, Option 1 — backend-driven rename):
+
+* **Dark by default** — gated on ``folder_ingest_rename_processed_enabled`` so
+  the hook is inert until BOTH repos are deployed and the flag is flipped.
+* **Best-effort** — a rename failure (MCP down, file gone, tool absent) NEVER
+  breaks ingest. Every path here is wrapped so this function cannot raise.
+* **Sanitized** — the new base name is scrubbed to a safe SMB filename in the
+  backend before sending (and again in the MCP as defense-in-depth).
+* **Idempotent / collision-safe** — those properties live in the MCP tool (a
+  missing source file is a success no-op; a taken target name gets a `` (2)``
+  suffix). This side only has to send the sanitized title.
+"""
+
+from __future__ import annotations
+
+import re
+
+from loguru import logger
+
+from models.database import FOLDER_INGEST_SOURCE
+from utils.config import settings
+
+# Characters illegal in SMB/Windows filenames, plus the path separators. Replaced
+# with a single space (later collapsed). Control chars are stripped separately.
+_ILLEGAL_SMB_CHARS = r'/\\:*?"<>|'
+_ILLEGAL_RE = re.compile(f"[{re.escape(_ILLEGAL_SMB_CHARS)}]")
+_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
+_WS_RE = re.compile(r"\s+")
+
+# Cap the base name so ``<base><ext>`` stays comfortably within filesystem limits.
+_MAX_BASE_LEN = 150
+
+
+def sanitize_smb_filename(base: str, *, max_len: int = _MAX_BASE_LEN) -> str:
+    """Scrub ``base`` into a safe SMB/Windows filename component (NO extension).
+
+    Strips/replaces the illegal chars ``/ \\ : * ? " < > |`` and control chars,
+    collapses whitespace, trims leading/trailing whitespace and dots (Windows
+    forbids trailing dots/spaces), and caps the length. Returns ``""`` if nothing
+    usable remains — the caller then skips the rename.
+    """
+    if not base:
+        return ""
+    s = _CONTROL_RE.sub("", str(base))
+    s = _ILLEGAL_RE.sub(" ", s)
+    s = _WS_RE.sub(" ", s).strip()
+    # Windows disallows trailing dots/spaces on a filename component.
+    s = s.strip(" .")
+    if len(s) > max_len:
+        s = s[:max_len].strip(" .")
+    return s
+
+
+async def rename_processed_to_title(
+    *,
+    source: str | None,
+    filename: str | None,
+    generated_title: str | None,
+    mcp_manager=None,
+) -> bool:
+    """Best-effort: rename the archived ``processed/<filename>`` copy to the
+    sanitized ``generated_title`` via ``mcp.files.rename_processed``.
+
+    Returns True if the rename call was issued, False if skipped (flag off, not a
+    folder-ingest doc, no title, nothing to send, or the MCP is unavailable).
+    NEVER raises — a failure is logged at WARNING and swallowed so ingest cannot
+    break on the archive rename.
+    """
+    try:
+        if not settings.folder_ingest_rename_processed_enabled:
+            return False
+        if source != FOLDER_INGEST_SOURCE:
+            return False
+        if not filename or not str(filename).strip():
+            return False
+        if not generated_title or not str(generated_title).strip():
+            return False
+
+        new_base = sanitize_smb_filename(generated_title)
+        if not new_base:
+            return False
+
+        mgr = mcp_manager
+        if mgr is None:
+            from services.files_worker_client import get_files_mcp_manager
+
+            mgr = await get_files_mcp_manager()
+        if mgr is None:
+            return False
+
+        await mgr.execute_tool(
+            "mcp.files.rename_processed",
+            {"original_name": filename, "new_base": new_base},
+        )
+        logger.info(
+            f"folder-ingest: requested processed rename {filename!r} → {new_base!r}"
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001 — archive rename is non-essential
+        logger.warning(
+            f"folder-ingest: processed rename failed for {filename!r} "
+            f"(best-effort, ingest unaffected): {exc}"
+        )
+        return False

--- a/src/backend/services/scheduled_tasks/builtins.py
+++ b/src/backend/services/scheduled_tasks/builtins.py
@@ -441,6 +441,22 @@ async def _paperless_abandoned_confirm_sweep_handler(app: "FastAPI", params: dic
     return None
 
 
+async def _placeholder_atom_reaper_handler(app: "FastAPI", params: dict) -> str | None:
+    # No gate; DB-only. Reaps orphaned __pending__ placeholder atoms left by a
+    # crash between the placeholder INSERT and finalize_source_id (#446). Only
+    # rows older than older_than_seconds are reaped so an in-flight create is safe.
+    from services.atom_service import reap_orphan_placeholder_atoms
+    from services.database import AsyncSessionLocal
+
+    older = int(params.get("older_than_seconds", 3600))
+    async with AsyncSessionLocal() as db_session:
+        n = await reap_orphan_placeholder_atoms(db_session, older_than_seconds=older)
+    if n:
+        logger.info(f"Placeholder-atom reaper: deleted {n} orphaned __pending__ atom(s)")
+        return f"reaped={n}"
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Registration + seeds
 # ---------------------------------------------------------------------------
@@ -473,6 +489,7 @@ def register_builtin_handlers() -> None:
     register_handler("skill_shadow_log_cleanup", _skill_shadow_log_cleanup_handler)
     register_handler("paperless_ui_edit_sweep", _paperless_ui_edit_sweep_handler)
     register_handler("paperless_abandoned_confirm_sweep", _paperless_abandoned_confirm_sweep_handler)
+    register_handler("placeholder_atom_reaper", _placeholder_atom_reaper_handler)
 
 
 def builtin_task_seeds() -> list[TaskSeed]:
@@ -545,4 +562,8 @@ def builtin_task_seeds() -> list[TaskSeed]:
         TaskSeed(name="Skill-Schattenlog aufräumen", handler_key="skill_shadow_log_cleanup", interval_seconds=settings.skill_shadow_log_cleanup_interval, run_at_boot=True, enabled=True),
         TaskSeed(name="Paperless UI-Änderungen auswerten", handler_key="paperless_ui_edit_sweep", interval_seconds=3600, run_at_boot=True, enabled=True),
         TaskSeed(name="Paperless verwaiste Bestätigungen aufräumen", handler_key="paperless_abandoned_confirm_sweep", interval_seconds=3600, run_at_boot=True, enabled=True),
+        # #446: reap orphaned __pending__ placeholder atoms left by a crash mid
+        # create_with_source. DB-only, no runtime gate; the reaper's age floor
+        # protects in-flight creates.
+        TaskSeed(name="Verwaiste Platzhalter-Atoms aufräumen", handler_key="placeholder_atom_reaper", interval_seconds=settings.placeholder_atom_reaper_interval, run_at_boot=True, enabled=True),
     ]

--- a/src/backend/services/schicht_a_extractor.py
+++ b/src/backend/services/schicht_a_extractor.py
@@ -952,6 +952,24 @@ async def schicht_a_post_document_ingest_hook(
             except Exception as e:  # noqa: BLE001 — title is non-essential
                 logger.warning(f"Schicht A: title synthesis failed for doc {document_id}: {e}")
 
+            # #881: rename the archived folder-ingest copy in the share's
+            # processed/ dir to the freshly-synthesized human title so the SMB
+            # share is browsable. Dark by default + best-effort — this NEVER
+            # breaks ingest (the helper swallows its own errors; the wrap is
+            # belt-and-braces). Gated on source=='folder_ingest' + a title inside.
+            try:
+                from services.folder_ingest_rename import rename_processed_to_title
+
+                await rename_processed_to_title(
+                    source=doc.source,
+                    filename=doc.filename,
+                    generated_title=doc.generated_title,
+                )
+            except Exception as e:  # noqa: BLE001 — archive rename is non-essential
+                logger.warning(
+                    f"Schicht A: processed rename failed for doc {document_id}: {e}"
+                )
+
             # Derive the document's OWN date (invoice/letter date) for sorting on
             # /wissen/dokumente — same fact-ranking as the Simba period, as a full
             # date. Best-effort; a miss leaves document_date NULL (sorted last).

--- a/src/backend/services/search_health.py
+++ b/src/backend/services/search_health.py
@@ -1,0 +1,146 @@
+"""Functional health probe for the SearXNG-backed `search` MCP (#1162).
+
+MCP health folds connectivity + tool-presence (``MCPManager.get_status()``): a
+SearXNG instance that is UP and exposes ``web_search`` shows GREEN even when every
+upstream scraper engine is CAPTCHA-blocked from the datacenter IP and it returns 0
+real results. This is the "green-reachable-but-functionally-dead" class already
+called out for MCP nodes, applied to search.
+
+A raw result-count check is a false-green trap: Wikipedia (and a few other engines)
+answer almost any query, so ``N results > 0`` hides a total scraper outage. The
+correct signal is the number of **distinct _general_ engines that contributed** to a
+fixed neutral probe, PLUS SearXNG's top-level ``unresponsive_engines`` list. We mark
+``degraded`` (never a hard ``down`` — the Bing/Google-CSE backbone still works) when
+too few distinct general engines contribute OR when the backbone is unresponsive.
+
+We probe SearXNG DIRECTLY over its JSON API (``settings.searxng_api_url``), NOT
+through the third-party MCP, which may strip the per-result engine metadata the
+signal depends on. Any error/timeout → ``unknown`` (best-effort, never crashes the
+caller). Gated by ``settings.search_functional_probe_enabled`` (dark by default).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+from loguru import logger
+
+from utils.config import settings
+
+# Fixed, neutral, high-recall probe query — a common word every healthy general
+# engine answers, so a low contributing-engine count means a real scraper outage,
+# not a query that happens to be obscure. Module-level constant, NOT user config.
+PROBE_QUERY = "wikipedia"
+
+# The search backbone: if SearXNG reports these as unresponsive, general web search
+# is effectively dark regardless of how many niche engines still answer.
+BACKBONE_ENGINES = frozenset({"bing", "google", "google-cse", "duckduckgo"})
+
+_PROBE_TIMEOUT_S = 8.0
+
+
+def _distinct_general_engines(results: list[dict[str, Any]]) -> set[str]:
+    """Collect distinct engine names that contributed results.
+
+    SearXNG carries per-result attribution either as ``engines`` (a list, when the
+    same result was returned by several engines) or ``engine`` (a scalar). We union
+    both shapes. We deliberately do NOT count results with no engine attribution.
+    """
+    engines: set[str] = set()
+    for r in results:
+        if not isinstance(r, dict):
+            continue
+        multi = r.get("engines")
+        if isinstance(multi, list):
+            engines.update(str(e).lower() for e in multi if e)
+        single = r.get("engine")
+        if single:
+            engines.add(str(single).lower())
+    return engines
+
+
+def _classify(payload: dict[str, Any]) -> dict[str, Any]:
+    """Pure verdict logic over a parsed SearXNG JSON payload."""
+    results = payload.get("results")
+    if not isinstance(results, list):
+        results = []
+    unresponsive_raw = payload.get("unresponsive_engines") or []
+    # unresponsive_engines entries are typically [engine_name, reason]; be liberal.
+    unresponsive: list[str] = []
+    for entry in unresponsive_raw:
+        if isinstance(entry, (list, tuple)) and entry:
+            unresponsive.append(str(entry[0]))
+        elif entry:
+            unresponsive.append(str(entry))
+
+    contributing = _distinct_general_engines(results)
+    min_engines = settings.search_functional_min_engines
+
+    backbone_down = BACKBONE_ENGINES.intersection(e.lower() for e in unresponsive)
+
+    if len(contributing) < min_engines:
+        verdict = "degraded"
+        reason = (
+            f"nur {len(contributing)} von mind. {min_engines} allgemeinen Engines "
+            "haben zur Testsuche beigetragen (Scraper vermutlich CAPTCHA-blockiert)"
+        )
+    elif backbone_down:
+        verdict = "degraded"
+        reason = (
+            "Suchmaschinen-Backbone nicht erreichbar: "
+            + ", ".join(sorted(backbone_down))
+        )
+    else:
+        verdict = "healthy"
+        reason = f"{len(contributing)} allgemeine Engines aktiv"
+
+    return {
+        "verdict": verdict,
+        "contributing_engines": len(contributing),
+        "unresponsive": unresponsive,
+        "reason": reason,
+    }
+
+
+async def probe_search_functional() -> dict[str, Any]:
+    """Probe SearXNG's JSON API and return a functional verdict.
+
+    Returns ``{verdict, contributing_engines, unresponsive, reason}`` where verdict is
+    ``"healthy"``/``"degraded"``/``"unknown"``. Never raises: any error (probe disabled,
+    no configured URL, HTTP/timeout/parse failure) → ``"unknown"``.
+    """
+    if not settings.search_functional_probe_enabled:
+        return {
+            "verdict": "unknown",
+            "contributing_engines": 0,
+            "unresponsive": [],
+            "reason": "Funktionaler Suchtest deaktiviert",
+        }
+
+    base = settings.searxng_api_url
+    if not base:
+        return {
+            "verdict": "unknown",
+            "contributing_engines": 0,
+            "unresponsive": [],
+            "reason": "Keine SearXNG-URL konfiguriert",
+        }
+
+    url = base.rstrip("/") + "/search"
+    params = {"q": PROBE_QUERY, "format": "json", "categories": "general"}
+    try:
+        async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT_S) as client:
+            resp = await client.get(url, params=params)
+            resp.raise_for_status()
+            payload = resp.json()
+        if not isinstance(payload, dict):
+            raise ValueError("SearXNG-Antwort ist kein JSON-Objekt")
+        return _classify(payload)
+    except Exception as e:  # noqa: BLE001 — best-effort, never crash the caller
+        logger.warning(f"search_health: functional probe failed: {e}")
+        return {
+            "verdict": "unknown",
+            "contributing_engines": 0,
+            "unresponsive": [],
+            "reason": f"Testsuche fehlgeschlagen: {e!s}",
+        }

--- a/src/backend/services/system_health_tool.py
+++ b/src/backend/services/system_health_tool.py
@@ -206,6 +206,20 @@ async def system_health(
     except Exception as e:  # noqa: BLE001
         logger.warning(f"system_health: subsystem probe failed: {e}")
 
+    # Functional search-backbone probe (#1162): connectivity-only MCP health can't see
+    # a reachable SearXNG whose scraper engines are all CAPTCHA-blocked. Flag-gated —
+    # probe_search_functional() is inert (no HTTP) when the flag is off.
+    if settings.search_functional_probe_enabled:
+        try:
+            from services.search_health import probe_search_functional
+
+            sh = await probe_search_functional()
+            data["search_functional"] = sh
+            if sh.get("verdict") == "degraded":
+                problems.append(f"Websuche (SearXNG): DEGRADED ({sh.get('reason')})")
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"system_health: search functional probe failed: {e}")
+
     try:
         from services.kb_maintenance_tool import ingest_worker_and_backlog
 

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -954,6 +954,14 @@ class Settings(BaseSettings):
     # REVIEW queue (owner confirms category/type before the irreversible upload),
     # never automatically. Off elsewhere. See services/simba_ingest_review.py.
     folder_ingest_simba_enabled: bool = False
+    # After the worker synthesizes documents.generated_title (issuer+type+date),
+    # rename the already-moved archive copy in the share's processed/ dir to that
+    # human-readable title via the filesystem MCP (mcp.files.rename_processed) so
+    # the share is browsable (#881). DARK by default: the post-ingest rename hook
+    # is inert until BOTH the backend and the filesystem MCP (rename_processed
+    # tool) are deployed and this flag is flipped. Best-effort — a rename failure
+    # never breaks ingest.
+    folder_ingest_rename_processed_enabled: bool = False
     # Auto-populate the Paperless taxonomy: when on (default), the filing leg
     # resolve-OR-CREATEs document types / tags (like it already does for
     # correspondents) instead of only matching against the pre-curated taxonomy —

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -1246,6 +1246,13 @@ class Settings(BaseSettings):
     # SearXNG
     searxng_api_url: str | None = None
     searxng_instances: str | None = None
+    # SearXNG functional health probe (#1162): a reachable instance whose upstream
+    # scraper engines are all CAPTCHA-blocked returns 0 real results yet shows green
+    # under connectivity-only MCP health. Dark by default; when on, system_health
+    # issues a fixed neutral query and marks `search` degraded (never down) when too
+    # few distinct general engines contribute, or the backbone is unresponsive.
+    search_functional_probe_enabled: bool = False
+    search_functional_min_engines: int = Field(default=2, ge=1)
 
     # n8n MCP
     n8n_base_url: str | None = None

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -570,6 +570,9 @@ class Settings(BaseSettings):
     low_coverage_reindex_enabled: bool = False
     low_coverage_reindex_interval: int = Field(default=3600, ge=60)   # hourly sweep (>= engine tick)
     low_coverage_reindex_cap: int = Field(default=50, ge=1, le=500)  # docs re-enqueued per tick
+    # #446: interval for the placeholder-atom reaper scheduled task (deletes
+    # orphaned __pending__ atoms left by a crash mid create_with_source).
+    placeholder_atom_reaper_interval: int = Field(default=3600, ge=60)  # hourly
     # Adds a fast LM gibberish check (is_ocr_gibberish, intent model) to the VLM
     # trigger + acceptance — catches the 'pronounceable pseudo-word' garble
     # ('ZOGEOLONIGGY') that character statistics can't tell from real words. Without

--- a/tests/backend/test_atoms_for_review_labels.py
+++ b/tests/backend/test_atoms_for_review_labels.py
@@ -96,6 +96,35 @@ class TestResolveReviewLabels:
 
     @pytest.mark.asyncio
     @pytest.mark.unit
+    @pytest.mark.parametrize("dialect", [None, "postgresql", "sqlite"])
+    async def test_documents_branch_uses_first_chunk_preview(self, dialect):
+        """#450: the post-pc20260423 'documents' branch resolves the title +
+        a preview from the FIRST chunk (lowest chunk_index) per document. On
+        Postgres the query uses DISTINCT ON (one row/doc); elsewhere the
+        client-side first-wins dedup applies — identical result either way."""
+        atom = _atom("d1", "kb_document", "documents", "10")
+        doc = SimpleNamespace(id=10, title="Nebenkostenabrechnung 2025",
+                              filename="NK_2025.pdf")
+        # Two chunks in index order; the resolver keeps chunk_index=0 as preview.
+        chunk0 = SimpleNamespace(document_id=10, chunk_index=0,
+                                 content="Zusammenfassung der Nebenkosten 2025")
+        chunk1 = SimpleNamespace(document_id=10, chunk_index=1, content="Kapitel 2")
+
+        db = MagicMock()
+        db.bind = None if dialect is None else SimpleNamespace(
+            dialect=SimpleNamespace(name=dialect))
+        # The 'documents' branch issues two queries: Document, then DocumentChunk.
+        db.execute = AsyncMock(side_effect=[
+            _scalars_returning([doc]),
+            _scalars_returning([chunk0, chunk1]),
+        ])
+
+        out = await _resolve_review_labels(db, [atom])
+        assert out["d1"][0] == "Nebenkostenabrechnung 2025"
+        assert out["d1"][1].startswith("Zusammenfassung der Nebenkosten")
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
     async def test_conversation_memory_uses_timestamp_prefix(self):
         atom = _atom("m1", "conversation_memory", "conversation_memories", "99")
         mem = SimpleNamespace(

--- a/tests/backend/test_folder_ingest_rename.py
+++ b/tests/backend/test_folder_ingest_rename.py
@@ -1,0 +1,156 @@
+"""Tests for the post-ingest processed-file rename (#881).
+
+After the worker synthesizes ``documents.generated_title`` for a folder-ingest
+doc, a best-effort hook renames the already-moved archive copy in the share's
+``processed/`` dir to that human title via ``mcp.files.rename_processed``.
+
+Everything here is unit-mocked: the flag, the MCP manager, and the source/title
+inputs. The MCP is never actually reached.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+import services.folder_ingest_rename as rename_mod
+from models.database import FOLDER_INGEST_SOURCE
+from services.folder_ingest_rename import rename_processed_to_title, sanitize_smb_filename
+
+pytestmark = [pytest.mark.unit]
+
+
+# ---------------------------------------------------------------- sanitization
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("Rechnung der PVS Rhein-Ruhr GmbH vom 18.05.2026", "Rechnung der PVS Rhein-Ruhr GmbH vom 18.05.2026"),
+        ('a/b\\c:d*e?f"g<h>i|j', "a b c d e f g h i j"),
+        ("  lots   of\t whitespace  ", "lots of whitespace"),
+        ("trailing dots...", "trailing dots"),
+        (".leading dots.", "leading dots"),
+        ("///", ""),      # nothing usable → empty
+        ("", ""),
+    ],
+)
+def test_sanitize_smb_filename(raw, expected):
+    assert sanitize_smb_filename(raw) == expected
+
+
+def test_sanitize_caps_length():
+    out = sanitize_smb_filename("x" * 500)
+    assert len(out) == 150
+
+
+# ------------------------------------------------------------------- the hook
+
+def _mgr():
+    mgr = AsyncMock()
+    mgr.execute_tool = AsyncMock(return_value={"success": True})
+    return mgr
+
+
+@pytest.mark.asyncio
+async def test_calls_mcp_when_enabled_folder_ingest_with_title(monkeypatch):
+    monkeypatch.setattr(rename_mod.settings, "folder_ingest_rename_processed_enabled", True)
+    mgr = _mgr()
+    ok = await rename_processed_to_title(
+        source=FOLDER_INGEST_SOURCE,
+        filename="2026_03_29_14_33_13.pdf",
+        generated_title='Rechnung: PVS/Rhein vom 18.05.2026',
+        mcp_manager=mgr,
+    )
+    assert ok is True
+    mgr.execute_tool.assert_awaited_once()
+    name, args = mgr.execute_tool.await_args.args
+    assert name == "mcp.files.rename_processed"
+    # original filename passed through; title sanitized (: and / scrubbed).
+    assert args == {
+        "original_name": "2026_03_29_14_33_13.pdf",
+        "new_base": "Rechnung PVS Rhein vom 18.05.2026",
+    }
+
+
+@pytest.mark.asyncio
+async def test_no_call_when_flag_off(monkeypatch):
+    monkeypatch.setattr(rename_mod.settings, "folder_ingest_rename_processed_enabled", False)
+    mgr = _mgr()
+    ok = await rename_processed_to_title(
+        source=FOLDER_INGEST_SOURCE, filename="x.pdf", generated_title="Title", mcp_manager=mgr
+    )
+    assert ok is False
+    mgr.execute_tool.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_call_when_not_folder_ingest(monkeypatch):
+    monkeypatch.setattr(rename_mod.settings, "folder_ingest_rename_processed_enabled", True)
+    mgr = _mgr()
+    ok = await rename_processed_to_title(
+        source="upload", filename="x.pdf", generated_title="Title", mcp_manager=mgr
+    )
+    assert ok is False
+    mgr.execute_tool.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("title", [None, "", "   "])
+async def test_no_call_when_no_title(monkeypatch, title):
+    monkeypatch.setattr(rename_mod.settings, "folder_ingest_rename_processed_enabled", True)
+    mgr = _mgr()
+    ok = await rename_processed_to_title(
+        source=FOLDER_INGEST_SOURCE, filename="x.pdf", generated_title=title, mcp_manager=mgr
+    )
+    assert ok is False
+    mgr.execute_tool.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_call_when_title_sanitizes_to_empty(monkeypatch):
+    monkeypatch.setattr(rename_mod.settings, "folder_ingest_rename_processed_enabled", True)
+    mgr = _mgr()
+    ok = await rename_processed_to_title(
+        source=FOLDER_INGEST_SOURCE, filename="x.pdf", generated_title="///", mcp_manager=mgr
+    )
+    assert ok is False
+    mgr.execute_tool.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_call_when_no_filename(monkeypatch):
+    monkeypatch.setattr(rename_mod.settings, "folder_ingest_rename_processed_enabled", True)
+    mgr = _mgr()
+    ok = await rename_processed_to_title(
+        source=FOLDER_INGEST_SOURCE, filename="", generated_title="Title", mcp_manager=mgr
+    )
+    assert ok is False
+    mgr.execute_tool.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_mcp_exception_does_not_propagate(monkeypatch):
+    """A rename failure must NEVER break ingest — the helper swallows + logs."""
+    monkeypatch.setattr(rename_mod.settings, "folder_ingest_rename_processed_enabled", True)
+    mgr = _mgr()
+    mgr.execute_tool = AsyncMock(side_effect=RuntimeError("MCP down"))
+    ok = await rename_processed_to_title(
+        source=FOLDER_INGEST_SOURCE, filename="x.pdf", generated_title="Title", mcp_manager=mgr
+    )
+    assert ok is False  # swallowed, no raise
+    mgr.execute_tool.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_no_manager_available_is_noop(monkeypatch):
+    """Flag on + valid inputs but the worker MCP client returns None → no crash."""
+    monkeypatch.setattr(rename_mod.settings, "folder_ingest_rename_processed_enabled", True)
+    # The helper imports get_files_mcp_manager lazily from this module; patch it
+    # to return None (filesystem MCP unavailable in the worker).
+    import services.files_worker_client as fwc
+
+    monkeypatch.setattr(fwc, "get_files_mcp_manager", AsyncMock(return_value=None))
+    ok = await rename_processed_to_title(
+        source=FOLDER_INGEST_SOURCE, filename="x.pdf", generated_title="Title"
+    )
+    assert ok is False

--- a/tests/backend/test_internal_tools.py
+++ b/tests/backend/test_internal_tools.py
@@ -289,6 +289,67 @@ class TestResolveRoomPlayer:
         assert result["data"]["entity_id"] == "media_player.arbeitszimmer"
 
     @pytest.mark.unit
+    async def test_force_play_on_busy_dlna_proceeds(self, internal_tools):
+        """#668: force=true on a busy DLNA renderer (no entity_id, only
+        dlna_renderer_name) must reach the DLNA play path — not silently return
+        'busy'. The old entity_id-only force guard made it a no-op."""
+        busy_dlna = {
+            "success": False,
+            "message": "busy",
+            "action_taken": False,
+            "data": {
+                "target_type": "dlna",
+                "dlna_renderer_name": "HiFiBerry Garten",
+                "room_name": "Garten",
+                "device_name": "HiFiBerry Garten",
+                "status": "busy",
+            },
+        }
+        with patch.object(internal_tools, "_resolve_room_player",
+                          new_callable=AsyncMock, return_value=busy_dlna), \
+             patch.object(internal_tools, "_get_output_provider",
+                          return_value=None), \
+             patch.object(internal_tools, "_play_url_on_dlna",
+                          new_callable=AsyncMock,
+                          return_value={"success": True, "action_taken": True}) as mock_dlna:
+            result = await internal_tools._play_in_room({
+                "media_url": "http://jellyfin:8096/Audio/abc/universal",
+                "room_name": "Garten",
+                "force": "true",
+            })
+
+        mock_dlna.assert_awaited_once()
+        assert mock_dlna.await_args.kwargs.get("renderer_name") == "HiFiBerry Garten"
+        assert result["success"] is True
+
+    @pytest.mark.unit
+    async def test_force_play_on_busy_without_target_stays_busy(self, internal_tools):
+        """The force guard still holds: a busy device with NO routable target id
+        (no entity_id / dlna_renderer_name / output_target_id) returns busy even
+        with force=true — force can't play onto nothing."""
+        busy_no_target = {
+            "success": False,
+            "message": "busy",
+            "action_taken": False,
+            "data": {
+                "target_type": "homeassistant",
+                "entity_id": None,
+                "room_name": "Flur",
+                "status": "busy",
+            },
+        }
+        with patch.object(internal_tools, "_resolve_room_player",
+                          new_callable=AsyncMock, return_value=busy_no_target):
+            result = await internal_tools._play_in_room({
+                "media_url": "http://jellyfin:8096/Audio/abc/universal",
+                "room_name": "Flur",
+                "force": "true",
+            })
+
+        assert result["success"] is False
+        assert result["data"]["status"] == "busy"
+
+    @pytest.mark.unit
     async def test_resolve_room_player_dlna_device(self, internal_tools):
         """Room with DLNA renderer returns target_type='dlna' + renderer name."""
         mock_room = MagicMock()

--- a/tests/backend/test_placeholder_atom_reaper.py
+++ b/tests/backend/test_placeholder_atom_reaper.py
@@ -1,0 +1,74 @@
+"""#446 — reaper for orphaned ``__pending__`` placeholder atoms.
+
+``AtomService.create_with_source`` seeds an atoms row with a ``__pending__<uuid>``
+placeholder ``source_id`` and finalizes it to the real PK in a later step. A crash
+in between leaves the placeholder orphaned. ``reap_orphan_placeholder_atoms``
+deletes such rows — but only those older than a floor, so an in-flight create is
+never reaped.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+
+from models.database import Atom as AtomModel
+from services.atom_service import reap_orphan_placeholder_atoms
+
+
+def _atom(atom_id: str, source_id: str, created_at: datetime) -> AtomModel:
+    return AtomModel(
+        atom_id=atom_id,
+        atom_type="kb_document",
+        source_table="documents",
+        source_id=source_id,
+        owner_user_id=1,
+        policy={"tier": 0},
+        created_at=created_at,
+    )
+
+
+@pytest.mark.database
+@pytest.mark.asyncio
+class TestReapOrphanPlaceholderAtoms:
+    async def test_reaps_only_old_placeholders(self, db_session):
+        now = datetime.now(UTC).replace(tzinfo=None)
+        old = now - timedelta(hours=2)
+        db_session.add_all([
+            _atom("orphan-old", "__pending__orphan-old", old),        # reaped
+            _atom("inflight-fresh", "__pending__inflight-fresh", now),  # kept: age floor
+            _atom("real-old", "123", old),                             # kept: not a placeholder
+        ])
+        await db_session.commit()
+
+        n = await reap_orphan_placeholder_atoms(db_session, older_than_seconds=3600)
+
+        assert n == 1
+        remaining = {
+            a.atom_id
+            for a in (await db_session.execute(select(AtomModel))).scalars().all()
+        }
+        assert remaining == {"inflight-fresh", "real-old"}
+
+    async def test_no_placeholders_returns_zero(self, db_session):
+        db_session.add(_atom("real-1", "42", datetime.now(UTC).replace(tzinfo=None)))
+        await db_session.commit()
+
+        assert await reap_orphan_placeholder_atoms(db_session, older_than_seconds=3600) == 0
+
+    async def test_fresh_placeholder_not_reaped(self, db_session):
+        """A placeholder younger than the floor (a legitimately in-flight create)
+        is left untouched even though its source_id matches the pattern."""
+        now = datetime.now(UTC).replace(tzinfo=None)
+        db_session.add(_atom("inflight", "__pending__inflight", now))
+        await db_session.commit()
+
+        n = await reap_orphan_placeholder_atoms(db_session, older_than_seconds=3600)
+
+        assert n == 0
+        remaining = {
+            a.atom_id
+            for a in (await db_session.execute(select(AtomModel))).scalars().all()
+        }
+        assert remaining == {"inflight"}

--- a/tests/backend/test_scheduled_tasks_engine.py
+++ b/tests/backend/test_scheduled_tasks_engine.py
@@ -707,9 +707,9 @@ class TestBatchBCHandlers:
         builtins.register_builtin_handlers()
         seeds = builtins.builtin_task_seeds()
 
-        assert len(seeds) == 23  # +1: Low-Coverage-Reindex (autonomous OCR-recovery sweep)
+        assert len(seeds) == 24  # +1: Placeholder-Atom-Reaper (#446)
         names = [s.name for s in seeds]
-        assert len(set(names)) == 23  # unique names
+        assert len(set(names)) == 24  # unique names
         for seed in seeds:
             assert registry.get_handler(seed.handler_key) is not None, seed.handler_key
             if seed.interval_seconds is not None:

--- a/tests/backend/test_search_health.py
+++ b/tests/backend/test_search_health.py
@@ -1,0 +1,260 @@
+"""Tests for the SearXNG functional health probe (#1162).
+
+Covers the pure verdict logic and the httpx-mocked probe entry point:
+(a) healthy (>= threshold distinct general engines),
+(b) degraded (below threshold),
+(c) degraded when unresponsive_engines covers the backbone,
+(d) unknown on timeout/error,
+(e) flag-off / no searxng_api_url -> skipped (unknown, no HTTP).
+
+httpx is mocked throughout — no real SearXNG is contacted.
+"""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from services import search_health
+from services.search_health import (
+    PROBE_QUERY,
+    _classify,
+    probe_search_functional,
+)
+from utils.config import settings
+
+pytestmark = [pytest.mark.backend, pytest.mark.unit]
+
+
+def _payload(*, results=None, unresponsive=None) -> dict:
+    return {
+        "results": results if results is not None else [],
+        "unresponsive_engines": unresponsive if unresponsive is not None else [],
+    }
+
+
+def _install_fake_httpx(monkeypatch, *, json_payload=None, exc=None, status_code=200):
+    """Replace httpx.AsyncClient used by search_health with a fake.
+
+    ``exc`` (if given) is raised from ``get`` to simulate timeout/connect errors.
+    """
+    resp = MagicMock()
+    resp.json.return_value = json_payload if json_payload is not None else {}
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "err", request=MagicMock(), response=MagicMock()
+        )
+
+    client = MagicMock()
+    if exc is not None:
+        client.get = AsyncMock(side_effect=exc)
+    else:
+        client.get = AsyncMock(return_value=resp)
+
+    @asynccontextmanager
+    async def _fake_client(*args, **kwargs):
+        yield client
+
+    monkeypatch.setattr(search_health.httpx, "AsyncClient", _fake_client)
+    return client
+
+
+# --- pure verdict logic (_classify) ------------------------------------------
+
+
+class TestClassify:
+    def test_healthy_above_threshold(self, monkeypatch):
+        monkeypatch.setattr(settings, "search_functional_min_engines", 2)
+        payload = _payload(
+            results=[
+                {"engine": "bing", "title": "a"},
+                {"engines": ["google", "duckduckgo"], "title": "b"},
+            ]
+        )
+        v = _classify(payload)
+        assert v["verdict"] == "healthy"
+        assert v["contributing_engines"] == 3
+        assert v["unresponsive"] == []
+
+    def test_degraded_below_threshold(self, monkeypatch):
+        monkeypatch.setattr(settings, "search_functional_min_engines", 2)
+        # Only Wikipedia answered — the classic false-green outage.
+        payload = _payload(results=[{"engine": "wikipedia", "title": "x"}])
+        v = _classify(payload)
+        assert v["verdict"] == "degraded"
+        assert v["contributing_engines"] == 1
+
+    def test_degraded_zero_engines(self, monkeypatch):
+        monkeypatch.setattr(settings, "search_functional_min_engines", 1)
+        v = _classify(_payload(results=[]))
+        assert v["verdict"] == "degraded"
+        assert v["contributing_engines"] == 0
+
+    def test_degraded_when_backbone_unresponsive(self, monkeypatch):
+        monkeypatch.setattr(settings, "search_functional_min_engines", 2)
+        # Enough distinct engines to clear the count threshold, but the backbone is down.
+        payload = _payload(
+            results=[
+                {"engine": "wikipedia"},
+                {"engine": "wikidata"},
+                {"engine": "qwant"},
+            ],
+            unresponsive=[["bing", "timeout"], ["google", "CAPTCHA"]],
+        )
+        v = _classify(payload)
+        assert v["verdict"] == "degraded"
+        assert "bing" in v["reason"] or "google" in v["reason"]
+        assert set(v["unresponsive"]) == {"bing", "google"}
+
+    def test_scalar_unresponsive_entries(self, monkeypatch):
+        monkeypatch.setattr(settings, "search_functional_min_engines", 1)
+        payload = _payload(
+            results=[{"engine": "bing"}, {"engine": "google"}],
+            unresponsive=["startpage"],
+        )
+        v = _classify(payload)
+        # backbone bing/google contributed, startpage unresponsive is not backbone
+        assert v["verdict"] == "healthy"
+        assert v["unresponsive"] == ["startpage"]
+
+    def test_dedup_engines_across_shapes(self, monkeypatch):
+        monkeypatch.setattr(settings, "search_functional_min_engines", 2)
+        payload = _payload(
+            results=[
+                {"engine": "Bing"},
+                {"engines": ["bing", "GOOGLE"]},
+            ]
+        )
+        v = _classify(payload)
+        # case-folded + deduped -> {bing, google}
+        assert v["contributing_engines"] == 2
+        assert v["verdict"] == "healthy"
+
+    def test_missing_results_key_is_degraded(self, monkeypatch):
+        monkeypatch.setattr(settings, "search_functional_min_engines", 2)
+        v = _classify({})  # no results, no unresponsive
+        assert v["verdict"] == "degraded"
+        assert v["contributing_engines"] == 0
+
+
+# --- probe entry point (httpx-mocked) ----------------------------------------
+
+
+class TestProbe:
+    @pytest.mark.asyncio
+    async def test_flag_off_skips_probe_no_http(self, monkeypatch):
+        monkeypatch.setattr(settings, "search_functional_probe_enabled", False)
+        monkeypatch.setattr(settings, "searxng_api_url", "http://searxng.local")
+
+        # Any HTTP attempt would blow up — prove none is made.
+        def _boom(*a, **k):
+            raise AssertionError("httpx must not be called when flag is off")
+
+        monkeypatch.setattr(search_health.httpx, "AsyncClient", _boom)
+
+        v = await probe_search_functional()
+        assert v["verdict"] == "unknown"
+        assert "deaktiviert" in v["reason"]
+
+    @pytest.mark.asyncio
+    async def test_no_url_skips_probe(self, monkeypatch):
+        monkeypatch.setattr(settings, "search_functional_probe_enabled", True)
+        monkeypatch.setattr(settings, "searxng_api_url", None)
+
+        def _boom(*a, **k):
+            raise AssertionError("httpx must not be called without a URL")
+
+        monkeypatch.setattr(search_health.httpx, "AsyncClient", _boom)
+
+        v = await probe_search_functional()
+        assert v["verdict"] == "unknown"
+        assert "URL" in v["reason"]
+
+    @pytest.mark.asyncio
+    async def test_healthy(self, monkeypatch):
+        monkeypatch.setattr(settings, "search_functional_probe_enabled", True)
+        monkeypatch.setattr(settings, "searxng_api_url", "http://searxng.local")
+        monkeypatch.setattr(settings, "search_functional_min_engines", 2)
+        _install_fake_httpx(
+            monkeypatch,
+            json_payload=_payload(
+                results=[{"engine": "bing"}, {"engine": "google"}]
+            ),
+        )
+        v = await probe_search_functional()
+        assert v["verdict"] == "healthy"
+        assert v["contributing_engines"] == 2
+
+    @pytest.mark.asyncio
+    async def test_degraded(self, monkeypatch):
+        monkeypatch.setattr(settings, "search_functional_probe_enabled", True)
+        monkeypatch.setattr(settings, "searxng_api_url", "http://searxng.local")
+        monkeypatch.setattr(settings, "search_functional_min_engines", 2)
+        _install_fake_httpx(
+            monkeypatch,
+            json_payload=_payload(results=[{"engine": "wikipedia"}]),
+        )
+        v = await probe_search_functional()
+        assert v["verdict"] == "degraded"
+
+    @pytest.mark.asyncio
+    async def test_degraded_backbone_unresponsive(self, monkeypatch):
+        monkeypatch.setattr(settings, "search_functional_probe_enabled", True)
+        monkeypatch.setattr(settings, "searxng_api_url", "http://searxng.local")
+        monkeypatch.setattr(settings, "search_functional_min_engines", 2)
+        _install_fake_httpx(
+            monkeypatch,
+            json_payload=_payload(
+                results=[{"engine": "wikipedia"}, {"engine": "wikidata"}],
+                unresponsive=[["bing", "CAPTCHA"], ["google", "CAPTCHA"]],
+            ),
+        )
+        v = await probe_search_functional()
+        assert v["verdict"] == "degraded"
+        assert set(v["unresponsive"]) == {"bing", "google"}
+
+    @pytest.mark.asyncio
+    async def test_unknown_on_timeout(self, monkeypatch):
+        monkeypatch.setattr(settings, "search_functional_probe_enabled", True)
+        monkeypatch.setattr(settings, "searxng_api_url", "http://searxng.local")
+        _install_fake_httpx(
+            monkeypatch, exc=httpx.TimeoutException("timed out")
+        )
+        v = await probe_search_functional()
+        assert v["verdict"] == "unknown"
+        assert "fehlgeschlagen" in v["reason"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_on_http_error(self, monkeypatch):
+        monkeypatch.setattr(settings, "search_functional_probe_enabled", True)
+        monkeypatch.setattr(settings, "searxng_api_url", "http://searxng.local")
+        _install_fake_httpx(monkeypatch, json_payload={}, status_code=502)
+        v = await probe_search_functional()
+        assert v["verdict"] == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_unknown_on_non_dict_json(self, monkeypatch):
+        monkeypatch.setattr(settings, "search_functional_probe_enabled", True)
+        monkeypatch.setattr(settings, "searxng_api_url", "http://searxng.local")
+        _install_fake_httpx(monkeypatch, json_payload=["not", "a", "dict"])
+        v = await probe_search_functional()
+        assert v["verdict"] == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_probe_uses_neutral_query_and_json(self, monkeypatch):
+        monkeypatch.setattr(settings, "search_functional_probe_enabled", True)
+        monkeypatch.setattr(settings, "searxng_api_url", "http://searxng.local/")
+        client = _install_fake_httpx(
+            monkeypatch,
+            json_payload=_payload(results=[{"engine": "bing"}, {"engine": "google"}]),
+        )
+        await probe_search_functional()
+        # URL has no double slash, params request the JSON API + general category.
+        args, kwargs = client.get.call_args
+        assert args[0] == "http://searxng.local/search"
+        assert kwargs["params"]["q"] == PROBE_QUERY
+        assert kwargs["params"]["format"] == "json"
+        assert kwargs["params"]["categories"] == "general"


### PR DESCRIPTION
## Summary
Batch of 5 triaged backlog issues, each implemented + reviewed + tested (green on .159) + deployed to both instances.

- **#668** — `_play_in_room` busy/force guard now accepts `dlna_renderer_name`/`output_target_id` (force-play on a busy DLNA/output-provider renderer was a silent no-op). Active.
- **#450** — `_resolve_review_labels` uses Postgres `DISTINCT ON` for the chunk preview (was fetching every chunk of every reviewed doc). Active.
- **#446** — `reap_orphan_placeholder_atoms` + a `placeholder_atom_reaper` scheduled-task built-in; deletes orphaned `__pending__` atoms older than a floor (in-flight-safe; escaped LIKE). Active (task enabled, runs ok in prod).
- **#1162** — SearXNG functional probe (`services/search_health.py`): distinct contributing *general* engines + `unresponsive_engines`, marks `degraded` (never down). Flag `SEARCH_FUNCTIONAL_PROBE_ENABLED` (dark).
- **#881** — folder-ingest renames the `processed/` file to the generated title via a new `rename_processed` filesystem-MCP tool (paired change in `renfield-mcp-filesystem` v0.1.8). Best-effort, idempotent, collision-/traversal-safe. Flag `FOLDER_INGEST_RENAME_PROCESSED_ENABLED` (dark).

Also fixed en route: the filesystem-MCP `pyproject` pinned `mcp` without an upper bound → a rebuild pulled `mcp 2.x` (FastMCP renamed) and broke the server; pinned `mcp<2`.

## Test plan
- [x] Review (dedicated agent): no defects across all 5 + the MCP repo change
- [x] .159: test_internal_tools (191), test_atoms_for_review_labels (11), test_placeholder_atom_reaper (3), test_scheduled_tasks_engine (52), test_search_health (16), test_folder_ingest_rename (18) — all green
- [x] MCP: 123 passed against the built image
- [x] Deployed both instances; new flags verified dark (byte-identical); reaper task verified enabled + ok
- [x] Docs: ENVIRONMENT_VARIABLES.md + FOLDER_INGEST.md

Closes #668
Closes #450
Closes #446
Closes #1162
Closes #881

🤖 Generated with [Claude Code](https://claude.com/claude-code)