### PR TITLE
fix(health): config-driven SearXNG probe backbone set (#1162 follow-up)

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -2205,6 +2205,11 @@ SEARXNG_API_URL=http://cuda.local:3002
 # Backbone in `unresponsive_engines` steht. Surface: internal.system_health.
 SEARCH_FUNCTIONAL_PROBE_ENABLED=false
 SEARCH_FUNCTIONAL_MIN_ENGINES=2       # degraded, wenn < N distinct general-Engines beitragen
+# Verlässliche Backbone-Engines (CSV) — ConfigMap-tunebar, KEIN Code-Release nötig,
+# um die Liste zu ändern. Default = API-Backbone (bing, google-cse); schließt bewusst
+# die CAPTCHA-anfälligen Scraper (duckduckgo, google-Scraper) aus, deren Blockade
+# erwartet ist und eine gesunde Instanz NICHT allein degraded flaggen darf.
+SEARCH_FUNCTIONAL_BACKBONE_ENGINES=bing,google-cse
 
 # Paperless-NGX URL
 PAPERLESS_API_URL=http://paperless.local:8000

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -338,6 +338,9 @@ data:
   # #1162: functional health probe for the search MCP (degraded when too few
   # distinct general engines contribute / backbone in unresponsive_engines).
   SEARCH_FUNCTIONAL_PROBE_ENABLED: "true"
+  # Reliable backbone (CSV) — tune here, no code release. Excludes CAPTCHA-prone
+  # scrapers (duckduckgo, google-scrape) whose blockage is expected.
+  SEARCH_FUNCTIONAL_BACKBONE_ENGINES: "bing,google-cse"
   SKILLS_ENABLED: "true"
   SKILL_CURATOR_ENABLED: "true"
   SPEAKER_CONTROLLED_ENROLLMENT_ENABLED: "true"

--- a/src/backend/services/search_health.py
+++ b/src/backend/services/search_health.py
@@ -32,11 +32,21 @@ from utils.config import settings
 # not a query that happens to be obscure. Module-level constant, NOT user config.
 PROBE_QUERY = "wikipedia"
 
-# The search backbone: if SearXNG reports these as unresponsive, general web search
-# is effectively dark regardless of how many niche engines still answer.
-BACKBONE_ENGINES = frozenset({"bing", "google", "google-cse", "duckduckgo"})
-
 _PROBE_TIMEOUT_S = 8.0
+
+
+def _backbone_engines() -> set[str]:
+    """The reliable search backbone, read from config (``SEARCH_FUNCTIONAL_BACKBONE_ENGINES``,
+    CSV) so it can be tuned via the ConfigMap WITHOUT a code release.
+
+    If SearXNG reports any of these as unresponsive, general web search is materially
+    degraded. The default (`bing,google-cse`) is the API-based backbone; it deliberately
+    EXCLUDES the CAPTCHA-prone scrapers (e.g. duckduckgo, the google scraper) whose
+    datacenter-IP blockage is EXPECTED and must not by itself flag a healthy instance
+    degraded.
+    """
+    raw = settings.search_functional_backbone_engines or ""
+    return {e.strip().lower() for e in raw.split(",") if e.strip()}
 
 
 def _distinct_general_engines(results: list[dict[str, Any]]) -> set[str]:
@@ -76,7 +86,7 @@ def _classify(payload: dict[str, Any]) -> dict[str, Any]:
     contributing = _distinct_general_engines(results)
     min_engines = settings.search_functional_min_engines
 
-    backbone_down = BACKBONE_ENGINES.intersection(e.lower() for e in unresponsive)
+    backbone_down = _backbone_engines().intersection(e.lower() for e in unresponsive)
 
     if len(contributing) < min_engines:
         verdict = "degraded"

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -1261,6 +1261,11 @@ class Settings(BaseSettings):
     # few distinct general engines contribute, or the backbone is unresponsive.
     search_functional_probe_enabled: bool = False
     search_functional_min_engines: int = Field(default=2, ge=1)
+    # Reliable search backbone (CSV) for the #1162 probe — ConfigMap-tunable, no
+    # code release needed to change it. Default = the API backbone (bing, google-cse);
+    # excludes CAPTCHA-prone scrapers (duckduckgo, google-scrape) whose blockage is
+    # expected and must not by itself flag a healthy instance degraded.
+    search_functional_backbone_engines: str = "bing,google-cse"
 
     # n8n MCP
     n8n_base_url: str | None = None

--- a/tests/backend/test_search_health.py
+++ b/tests/backend/test_search_health.py
@@ -95,6 +95,7 @@ class TestClassify:
 
     def test_degraded_when_backbone_unresponsive(self, monkeypatch):
         monkeypatch.setattr(settings, "search_functional_min_engines", 2)
+        monkeypatch.setattr(settings, "search_functional_backbone_engines", "bing,google-cse")
         # Enough distinct engines to clear the count threshold, but the backbone is down.
         payload = _payload(
             results=[
@@ -102,12 +103,41 @@ class TestClassify:
                 {"engine": "wikidata"},
                 {"engine": "qwant"},
             ],
-            unresponsive=[["bing", "timeout"], ["google", "CAPTCHA"]],
+            unresponsive=[["bing", "timeout"], ["google-cse", "CAPTCHA"]],
         )
         v = _classify(payload)
         assert v["verdict"] == "degraded"
-        assert "bing" in v["reason"] or "google" in v["reason"]
-        assert set(v["unresponsive"]) == {"bing", "google"}
+        assert "bing" in v["reason"] or "google-cse" in v["reason"]
+        assert set(v["unresponsive"]) == {"bing", "google-cse"}
+
+    def test_scraper_unresponsive_with_backbone_up_is_healthy(self, monkeypatch):
+        """#1162 over-sensitivity fix: a CAPTCHA-prone scraper (duckduckgo) being
+        unresponsive must NOT flag degraded while the real backbone still answers —
+        ddg is not in the default backbone set."""
+        monkeypatch.setattr(settings, "search_functional_min_engines", 2)
+        monkeypatch.setattr(settings, "search_functional_backbone_engines", "bing,google-cse")
+        payload = _payload(
+            results=[{"engine": "bing"}, {"engine": "google-cse"}],
+            unresponsive=[["duckduckgo", "CAPTCHA"]],
+        )
+        v = _classify(payload)
+        assert v["verdict"] == "healthy"
+        assert v["unresponsive"] == ["duckduckgo"]
+
+    def test_backbone_engines_config_driven(self, monkeypatch):
+        """The backbone set is read from config (ConfigMap-tunable, no release) —
+        adding an engine makes its outage count; removing one makes it not."""
+        monkeypatch.setattr(settings, "search_functional_min_engines", 2)
+        payload = _payload(
+            results=[{"engine": "bing"}, {"engine": "google-cse"}],
+            unresponsive=[["duckduckgo", "CAPTCHA"]],
+        )
+        # ddg IN the configured backbone → its outage now flags degraded
+        monkeypatch.setattr(settings, "search_functional_backbone_engines", "bing,duckduckgo")
+        assert _classify(payload)["verdict"] == "degraded"
+        # ddg NOT in the configured backbone → healthy
+        monkeypatch.setattr(settings, "search_functional_backbone_engines", "bing,google-cse")
+        assert _classify(payload)["verdict"] == "healthy"
 
     def test_scalar_unresponsive_entries(self, monkeypatch):
         monkeypatch.setattr(settings, "search_functional_min_engines", 1)


### PR DESCRIPTION
## Summary
Follow-up to the #1162 SearXNG functional probe. The backbone engine set was hardcoded in source and included the CAPTCHA-prone scraper **duckduckgo**, so a functionally-healthy instance (bing + google-cse answering) was flagged `degraded` merely because ddg was blocked — which is *expected* on a datacenter IP.

- Move the backbone set to config: **`SEARCH_FUNCTIONAL_BACKBONE_ENGINES`** (CSV) — ConfigMap-tunable, **no code release** needed to change the engine list.
- Corrected default: `bing,google-cse` (the reliable API backbone; excludes the CAPTCHA-prone scrapers). Shipped in both ConfigMaps.

## Test plan
- [x] `tests/backend/test_search_health.py` on .159: **18 passed** (incl. new `test_scraper_unresponsive_with_backbone_up_is_healthy` + `test_backbone_engines_config_driven`)
- [x] Deployed both instances; live probe now returns **healthy** (was `degraded` on the blocked-ddg signal); `backbone_engines = [bing, google-cse]` verified
- [x] Docs: ENVIRONMENT_VARIABLES.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)