### PR TITLE
refactor(atoms): shared owner-resolver mixin + ATOM_TYPE_* constants (#448, #449)

### DIFF
--- a/src/backend/services/atom_owner.py
+++ b/src/backend/services/atom_owner.py
@@ -1,0 +1,47 @@
+"""Shared atoms-owner resolver (#448).
+
+`_resolve_owner_user_id` was copy-pasted identically into three atom-owning
+services (rag / conversation_memory / knowledge_graph). This mixin is the single
+canonical implementation of the `atoms.owner_user_id` back-fill policy, so a
+fourth atom-owning service can't drift a fourth copy.
+
+The host class must expose `self.db` (an `AsyncSession`). The per-instance
+fallback cache lives on `_fallback_owner_id` (class-level `None` default → each
+instance reads `None` until it resolves + caches its own).
+"""
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class AtomOwnerResolverMixin:
+    """Resolve a non-null `atoms.owner_user_id`, matching the migration back-fill.
+
+    Policy (identical to `pc20260420_circles_v1_schema.py`): prefer the explicit
+    `user_id`; else the first user by id (the bootstrap admin); else `None` only
+    in empty-users fresh-DB dev setups, so callers skip atom registration
+    (source row written with `atom_id=None`). Production always has the admin
+    from bootstrap, so this is never `None` in real deploys.
+    """
+
+    # Host classes hold an AsyncSession here; declared for type-checkers only.
+    db: AsyncSession
+
+    _fallback_owner_id: int | None = None
+
+    async def _resolve_owner_user_id(self, user_id: int | None) -> int | None:
+        if user_id is not None:
+            return user_id
+        if self._fallback_owner_id is not None:
+            return self._fallback_owner_id
+        from models.database import User
+
+        result = await self.db.execute(
+            select(User.id).order_by(User.id.asc()).limit(1)
+        )
+        fallback = result.scalar()
+        if fallback is None:
+            return None
+        self._fallback_owner_id = int(fallback)
+        return self._fallback_owner_id

--- a/src/backend/services/atom_service.py
+++ b/src/backend/services/atom_service.py
@@ -199,7 +199,7 @@ class AtomService:
         Returns the minted atom_id. Intended call pattern:
 
             atom_id = await atom_svc.create_with_source(
-                atom_type="conversation_memory",
+                atom_type=ATOM_TYPE_CONVERSATION_MEMORY,
                 owner_user_id=42, tier=0,
             )
             memory = ConversationMemory(..., atom_id=atom_id, circle_tier=0)

--- a/src/backend/services/conversation_memory_service.py
+++ b/src/backend/services/conversation_memory_service.py
@@ -19,6 +19,7 @@ from sqlalchemy import func, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.database import (
+    ATOM_TYPE_CONVERSATION_MEMORY,
     MEMORY_ACTION_CREATED,
     MEMORY_ACTION_DELETED,
     MEMORY_ACTION_UPDATED,
@@ -33,6 +34,7 @@ from models.database import (
     ConversationMemory,
     MemoryHistory,
 )
+from services.atom_owner import AtomOwnerResolverMixin
 from utils.config import settings
 from utils.llm_client import get_default_client, get_embed_client
 
@@ -67,7 +69,7 @@ _TRANSACTIONAL_PATTERNS = [
 ]
 
 
-class ConversationMemoryService:
+class ConversationMemoryService(AtomOwnerResolverMixin):
     """
     Manages long-term conversation memories with semantic deduplication
     and retrieval via pgvector cosine similarity.
@@ -77,31 +79,6 @@ class ConversationMemoryService:
         self.db = db
         self._embed_client = None
         self._chat_client = None
-        # Cached fallback admin id for atoms registration when save() is
-        # called without an authenticated user_id (single-user mode). See
-        # _resolve_owner_user_id.
-        self._fallback_owner_id: int | None = None
-
-    async def _resolve_owner_user_id(self, user_id: int | None) -> int | None:
-        """Resolve a non-null atoms owner, or None if no users exist.
-
-        Matches pc20260420_circles_v1_schema.py back-fill: explicit user_id,
-        else first user (admin), else None (empty-users-table dev setups
-        where atom registration is skipped).
-        """
-        if user_id is not None:
-            return user_id
-        if self._fallback_owner_id is not None:
-            return self._fallback_owner_id
-        from models.database import User
-        result = await self.db.execute(
-            select(User.id).order_by(User.id.asc()).limit(1)
-        )
-        fallback = result.scalar()
-        if fallback is None:
-            return None
-        self._fallback_owner_id = int(fallback)
-        return self._fallback_owner_id
 
     def _atom_service(self):
         """Lazy AtomService bound to the same DB session."""
@@ -204,7 +181,7 @@ class ConversationMemoryService:
         atom_svc = self._atom_service()
         if owner_id is not None:
             atom_id = await atom_svc.create_with_source(
-                atom_type="conversation_memory",
+                atom_type=ATOM_TYPE_CONVERSATION_MEMORY,
                 owner_user_id=owner_id,
                 tier=default_tier,
             )
@@ -1089,7 +1066,7 @@ class ConversationMemoryService:
         atom_svc = self._atom_service()
         if owner_id is not None:
             atom_id = await atom_svc.create_with_source(
-                atom_type="conversation_memory",
+                atom_type=ATOM_TYPE_CONVERSATION_MEMORY,
                 owner_user_id=owner_id,
                 tier=default_tier,
             )

--- a/src/backend/services/graph_expansion.py
+++ b/src/backend/services/graph_expansion.py
@@ -33,7 +33,7 @@ from typing import Any
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from models.database import TIER_PUBLIC
+from models.database import ATOM_TYPE_KG_EDGE, ATOM_TYPE_KG_NODE, TIER_PUBLIC
 from services.atom_types import Atom, AtomMatch
 from utils.config import settings
 
@@ -123,7 +123,7 @@ def _node_atom(e: dict[str, Any], score: float, hop: int) -> AtomMatch:
     now = datetime.now()
     return AtomMatch(
         atom=Atom(
-            atom_id=f"kg_node:{e['id']}", atom_type="kg_node", owner_user_id=0,
+            atom_id=f"kg_node:{e['id']}", atom_type=ATOM_TYPE_KG_NODE, owner_user_id=0,
             policy={"tier": e["circle_tier"]}, created_at=now, updated_at=now,
             payload={"entity_id": e["id"], "name": e.get("name", ""),
                      "entity_type": e.get("entity_type"), "expanded": True, "hop": hop},
@@ -138,7 +138,7 @@ def _edge_atom(r: dict[str, Any], names: dict[int, str], score: float, hop: int)
     subj, obj = names.get(r["subject_id"], "?"), names.get(r["object_id"], "?")
     return AtomMatch(
         atom=Atom(
-            atom_id=f"kg_edge:{r['id']}", atom_type="kg_edge", owner_user_id=0,
+            atom_id=f"kg_edge:{r['id']}", atom_type=ATOM_TYPE_KG_EDGE, owner_user_id=0,
             policy={"tier": r["circle_tier"]}, created_at=now, updated_at=now,
             payload={"relation_id": r["id"], "subject_id": r["subject_id"], "subject_name": subj,
                      "predicate": r["predicate"], "object_id": r["object_id"], "object_name": obj,

--- a/src/backend/services/knowledge_graph_service.py
+++ b/src/backend/services/knowledge_graph_service.py
@@ -18,12 +18,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.database import (
     ATOM_TYPE_KG_EDGE,
+    ATOM_TYPE_KG_NODE,
     EMBEDDING_DIMENSION,
     KG_ENTITY_TYPES,
     TIER_PUBLIC,
     KGEntity,
     KGRelation,
 )
+from services.atom_owner import AtomOwnerResolverMixin
 from services.kg_validator import load_heuristics as load_kg_heuristics
 from services.kg_validator import validate_relation as validate_kg_relation
 from services.merge_guard import is_already_merged
@@ -153,43 +155,13 @@ _GENERIC_ROLES = frozenset({
 })
 
 
-class KnowledgeGraphService:
+class KnowledgeGraphService(AtomOwnerResolverMixin):
     """Manages knowledge graph entities and relations with pgvector."""
 
     def __init__(self, db: AsyncSession):
         self.db = db
         self._embed_client = None
         self._chat_client = None
-        # Cached fallback owner id — resolved lazily via _resolve_owner_user_id
-        # when a writer doesn't carry an authenticated user (auth disabled, or
-        # background jobs extracted from anonymous context). Matches the
-        # migration's back-fill pattern: "first user by id" (see
-        # pc20260420_circles_v1_schema.py:344).
-        self._fallback_owner_id: int | None = None
-
-    async def _resolve_owner_user_id(self, user_id: int | None) -> int | None:
-        """Resolve a non-null owner for atom rows, or None if unavailable.
-
-        Falls back to the first user's id when ``user_id`` is None — matches
-        the migration's back-fill pattern (pc20260420_circles_v1_schema.py:344).
-        Returns None only in dev setups (empty users table) where atom
-        registration is skipped and the source row is written with
-        ``atom_id=None``. Production always has the admin user from
-        bootstrap, so this is never None in real deploys.
-        """
-        if user_id is not None:
-            return user_id
-        if self._fallback_owner_id is not None:
-            return self._fallback_owner_id
-        from models.database import User
-        result = await self.db.execute(
-            select(User.id).order_by(User.id.asc()).limit(1)
-        )
-        fallback = result.scalar()
-        if fallback is None:
-            return None
-        self._fallback_owner_id = int(fallback)
-        return self._fallback_owner_id
 
     # Speaker name is user-controlled (first_name/last_name/username are
     # free-text profile fields). It is interpolated into the instruction region
@@ -685,7 +657,7 @@ class KnowledgeGraphService:
         if owner_id is not None:
             async with self.db.begin_nested():
                 atom_id = await self._atom_service().create_with_source(
-                    atom_type="kg_node",
+                    atom_type=ATOM_TYPE_KG_NODE,
                     owner_user_id=owner_id,
                     tier=default_tier,
                 )
@@ -850,7 +822,7 @@ class KnowledgeGraphService:
         atom_id: str | None = None
         if owner_id is not None:
             atom_id = await self._atom_service().create_with_source(
-                atom_type="kg_edge",
+                atom_type=ATOM_TYPE_KG_EDGE,
                 owner_user_id=owner_id,
                 tier=relation_tier,
             )

--- a/src/backend/services/polymorphic_atom_store.py
+++ b/src/backend/services/polymorphic_atom_store.py
@@ -44,6 +44,12 @@ from typing import Any, Sequence
 from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from models.database import (
+    ATOM_TYPE_CONVERSATION_MEMORY,
+    ATOM_TYPE_KB_DOCUMENT,
+    ATOM_TYPE_KG_EDGE,
+    ATOM_TYPE_KG_NODE,
+)
 from services.atom_service import AtomService
 from services.atom_types import Atom, AtomMatch
 from services.circle_resolver import CircleResolver
@@ -284,7 +290,7 @@ def _wrap_rag_results(rag_results: Any) -> list[AtomMatch]:
         seen_atoms[atom_id] = AtomMatch(
             atom=Atom(
                 atom_id=atom_id,
-                atom_type="kb_document",
+                atom_type=ATOM_TYPE_KB_DOCUMENT,
                 owner_user_id=0,
                 # Chunks carry the denormalized tier from their document;
                 # either side gives the same value, chunk-side is cheap.
@@ -336,7 +342,7 @@ def _wrap_kg_atoms(kg_atoms: Any) -> list[AtomMatch]:
             AtomMatch(
                 atom=Atom(
                     atom_id=f"kg_node:{eid}",
-                    atom_type="kg_node",
+                    atom_type=ATOM_TYPE_KG_NODE,
                     owner_user_id=0,
                     policy={"tier": int(e.get("circle_tier", 0) or 0)},
                     created_at=now,
@@ -362,7 +368,7 @@ def _wrap_kg_atoms(kg_atoms: Any) -> list[AtomMatch]:
             AtomMatch(
                 atom=Atom(
                     atom_id=f"kg_edge:{rid}",
-                    atom_type="kg_edge",
+                    atom_type=ATOM_TYPE_KG_EDGE,
                     owner_user_id=0,
                     policy={"tier": int(r.get("circle_tier", 0) or 0)},
                     created_at=now,
@@ -522,7 +528,7 @@ def _wrap_memory_results(memory_results: Any) -> list[AtomMatch]:
             AtomMatch(
                 atom=Atom(
                     atom_id=str(atom_id),
-                    atom_type="conversation_memory",
+                    atom_type=ATOM_TYPE_CONVERSATION_MEMORY,
                     owner_user_id=0,
                     policy={"tier": m.get("circle_tier", 0)},
                     created_at=now,

--- a/src/backend/services/rag_service.py
+++ b/src/backend/services/rag_service.py
@@ -53,6 +53,7 @@ def detect_document_language(field_text: str, default: str) -> str:
 from sqlalchemy.orm import selectinload
 
 from models.database import (
+    ATOM_TYPE_KB_DOCUMENT,
     DOC_STATUS_COMPLETED,
     DOC_STATUS_FAILED,
     DOC_STATUS_PENDING,
@@ -63,6 +64,7 @@ from models.database import (
     DocumentFact,
     KnowledgeBase,
 )
+from services.atom_owner import AtomOwnerResolverMixin
 from services.document_processing_history import (
     DocumentProcessingHistoryService,
     ProcessingTrigger,
@@ -95,7 +97,7 @@ class DuplicateDocumentError(Exception):
         super().__init__("duplicate document")
 
 
-class RAGService:
+class RAGService(AtomOwnerResolverMixin):
     """
     RAG Service für Dokument-basierte Anfragen.
 
@@ -117,31 +119,6 @@ class RAGService:
         self.processor = DocumentProcessor()
         self.history = DocumentProcessingHistoryService(db)
         self._ollama_client = None
-        # Cached admin fallback id for atoms registration when the parent KB
-        # has no explicit owner (legacy rows / pre-auth KBs). Resolved lazily.
-        self._fallback_owner_id: int | None = None
-
-    async def _resolve_owner_user_id(self, user_id: int | None) -> int | None:
-        """Resolve a non-null atoms owner, or None when no users exist.
-
-        Matches pc20260420_circles_v1_schema.py back-fill logic: prefer the
-        explicit owner, else fall back to the first user (admin). Returns
-        None only in empty-users fresh-DB dev setups so callers can skip
-        atom registration (e.g. pre-bootstrap unit tests).
-        """
-        if user_id is not None:
-            return user_id
-        if self._fallback_owner_id is not None:
-            return self._fallback_owner_id
-        from models.database import User
-        result = await self.db.execute(
-            select(User.id).order_by(User.id.asc()).limit(1)
-        )
-        fallback = result.scalar()
-        if fallback is None:
-            return None
-        self._fallback_owner_id = int(fallback)
-        return self._fallback_owner_id
 
     def _atom_service(self):
         """Lazy AtomService bound to the same DB session."""
@@ -322,7 +299,7 @@ class RAGService:
         atom_svc = self._atom_service()
         if atom_owner is not None:
             atom_id = await atom_svc.create_with_source(
-                atom_type="kb_document",
+                atom_type=ATOM_TYPE_KB_DOCUMENT,
                 owner_user_id=atom_owner,
                 tier=kb_default_tier,
             )

--- a/tests/backend/test_atom_owner.py
+++ b/tests/backend/test_atom_owner.py
@@ -1,0 +1,62 @@
+"""Unit tests for the shared AtomOwnerResolverMixin (#448).
+
+Extracted from three identical `_resolve_owner_user_id` copies; these lock in
+the back-fill policy (explicit user → first user → None) + the per-instance cache.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from services.atom_owner import AtomOwnerResolverMixin
+
+
+class _Host(AtomOwnerResolverMixin):
+    def __init__(self, db):
+        self.db = db
+
+
+def _db_returning(first_user_id):
+    """A mock AsyncSession whose execute().scalar() yields first_user_id."""
+    db = MagicMock()
+    result = MagicMock()
+    result.scalar = MagicMock(return_value=first_user_id)
+    db.execute = AsyncMock(return_value=result)
+    return db
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestAtomOwnerResolver:
+    async def test_explicit_user_id_wins_without_query(self):
+        db = _db_returning(999)
+        host = _Host(db)
+        assert await host._resolve_owner_user_id(42) == 42
+        db.execute.assert_not_awaited()  # explicit id → no DB hit
+
+    async def test_falls_back_to_first_user_and_caches(self):
+        db = _db_returning(7)
+        host = _Host(db)
+        assert await host._resolve_owner_user_id(None) == 7
+        assert host._fallback_owner_id == 7
+        # second call hits the cache — no further query
+        assert await host._resolve_owner_user_id(None) == 7
+        assert db.execute.await_count == 1
+
+    async def test_none_when_no_users_and_not_cached(self):
+        db = _db_returning(None)
+        host = _Host(db)
+        assert await host._resolve_owner_user_id(None) is None
+        assert host._fallback_owner_id is None
+        # not cached → a later call re-queries (a user may have been created)
+        assert await host._resolve_owner_user_id(None) is None
+        assert db.execute.await_count == 2
+
+    async def test_cache_is_per_instance(self):
+        host_a = _Host(_db_returning(1))
+        host_b = _Host(_db_returning(2))
+        assert await host_a._resolve_owner_user_id(None) == 1
+        assert await host_b._resolve_owner_user_id(None) == 2
+        assert host_a._fallback_owner_id == 1
+        assert host_b._fallback_owner_id == 2


### PR DESCRIPTION
## Summary
Two maintainability refactors from the PR #444 review, no behavior change.

- **#448** — extract the triplicated `_resolve_owner_user_id` (rag / conversation_memory / knowledge_graph) into `AtomOwnerResolverMixin` (`services/atom_owner.py`); the three services inherit it. One canonical implementation of the atoms owner back-fill policy + the per-instance fallback cache.
- **#449** — replace `atom_type="..."` string literals with the `ATOM_TYPE_*` constants at the writer/emit call sites (rag, conversation_memory, knowledge_graph, atom_service, polymorphic_atom_store, graph_expansion).

## Test plan
- [x] `.159`: test_atom_owner (4, new) + test_atom_service (10) + test_atoms_for_review_labels (11) + test_polymorphic_kg_atoms (7) → **32 passed, 0 failed**
- [x] Pure refactor; new mixin unit test (explicit-id / first-user fallback / no-users / per-instance cache)

Closes #448
Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)