### PR TITLE
feat(kg): route get_relevant_context through graph_expansion (#874)

### DIFF
--- a/src/backend/services/kg_retrieval.py
+++ b/src/backend/services/kg_retrieval.py
@@ -60,7 +60,7 @@ from loguru import logger
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from models.database import KGEntity, KGRelation
+from models.database import KGEntity
 from utils.config import settings
 from utils.llm_client import get_default_client, get_embed_client
 from utils.prompt_safety import neutralize_delimiters
@@ -276,6 +276,11 @@ class KGRetrieval:
         # Search for each text, collecting matching entity IDs
         relevant_ids: list[int] = []
         seen_ids: set[int] = set()
+        # Captured for the graph-expansion seam below: the per-entity match score
+        # (becomes the pivot score expand_fused decays from) and name (for the
+        # seed atom payload). Both are inert when graph expansion is flag-off.
+        seed_scores: dict[int, float] = {}
+        seed_names: dict[int, str] = {}
 
         for search_text in search_texts:
             try:
@@ -309,6 +314,8 @@ class KGRetrieval:
                 if sim >= threshold and row.id not in seen_ids:
                     relevant_ids.append(row.id)
                     seen_ids.add(row.id)
+                    seed_scores[row.id] = sim
+                    seed_names[row.id] = row.name
 
         if not relevant_ids:
             return None
@@ -357,14 +364,72 @@ class KGRetrieval:
             entity_ids, user_id, enforce_circles=enforce_circles
         )
 
-        # Format triples
+        # Format triples (the direct, flat-1-hop seed relations)
         triples = []
+        seed_relation_ids: set[int] = set()
         for r in relation_rows:
+            seed_relation_ids.add(r.id)
             # #686: KG entity names + predicates are document/conversation-derived
             # (untrusted); neutralize before they join the shared prompt context.
             subj = neutralize_delimiters(entity_map.get(r.subject_id, "?"))
             obj = neutralize_delimiters(entity_map.get(r.object_id, "?"))
             triples.append(f"- {subj} {neutralize_delimiters(r.predicate)} {obj}")
+
+        # Phase 4: graph expansion (#874). Route this STRING context path through
+        # the SAME expand_fused seam PolymorphicAtomStore uses, so the agent loop
+        # (`internal.knowledge_search`, ReAct) benefits from 1-2-hop multi-hop
+        # traversal — not just the fused-store path. Reuses expand_fused verbatim:
+        # per-hop kg_entities_circles_filter, leak-safe edges (both endpoints
+        # accessible), canonical_id tombstone-skip, decay + max_expanded cap.
+        # Flag-off (GRAPH_EXPANSION_ENABLED false) => the whole block is skipped
+        # and expand_fused would return [] anyway, so the output stays
+        # byte-identical to the flat-1-hop path.
+        if settings.graph_expansion_enabled and relevant_ids:
+            from datetime import datetime as _dt
+
+            from services.atom_types import Atom, AtomMatch
+            from services.graph_expansion import expand_fused
+
+            _now = _dt.now()
+            seeds = [
+                AtomMatch(
+                    atom=Atom(
+                        atom_id=f"kg_node:{eid}", atom_type="kg_node",
+                        owner_user_id=0, policy={"tier": 0},
+                        created_at=_now, updated_at=_now,
+                        payload={"entity_id": eid, "name": seed_names.get(eid, "")},
+                    ),
+                    score=seed_scores.get(eid, 0.0),
+                    snippet=seed_names.get(eid, ""), rank=0,
+                )
+                for eid in relevant_ids
+            ]
+            extra = await expand_fused(
+                seeds, user_id, self.db,
+                max_pivots=settings.graph_expansion_max_pivots,
+                max_hops=settings.graph_expansion_max_hops,
+                max_expanded=settings.graph_expansion_max_expanded,
+                enforce_circles=enforce_circles,
+            )
+            # The expanded kg_edge atoms are ALREADY circle-filtered + leak-safe
+            # (both endpoints accessible, relation-tier gated), so their names are
+            # safe to render. Dedup against the seed relations by relation id: the
+            # hop-1 edges touching a seed entity are already in `triples` above.
+            for m in extra:
+                if m.atom.atom_type != "kg_edge":
+                    continue
+                rid = m.atom.payload.get("relation_id")
+                if rid is None or rid in seed_relation_ids:
+                    continue
+                seed_relation_ids.add(rid)
+                subj = neutralize_delimiters(m.atom.payload.get("subject_name", "?"))
+                obj = neutralize_delimiters(m.atom.payload.get("object_name", "?"))
+                pred = neutralize_delimiters(m.atom.payload.get("predicate", ""))
+                triples.append(f"- {subj} {pred} {obj}")
+
+            # Cap the combined (seed + expanded) list. No-op when flag-off (the
+            # seed fetch is already SQL-LIMIT'd to max_triples), so byte-identical.
+            triples = triples[:max_triples]
 
         if not triples:
             return None

--- a/tests/backend/test_kg_retrieval_expansion_pg.py
+++ b/tests/backend/test_kg_retrieval_expansion_pg.py
@@ -1,0 +1,170 @@
+"""Postgres-only tests for the graph-expansion seam in the KG STRING path (#874).
+
+``KGRetrieval.get_relevant_context`` is the agent's string KG-context path
+(backs ``internal.knowledge_search`` + the ReAct loop). #874 routes it through
+the SAME ``graph_expansion.expand_fused`` seam that ``PolymorphicAtomStore``
+already uses, so the agent benefits from 1-2-hop multi-hop traversal — without
+changing the method's signature.
+
+Guarantees under test:
+  (a) GRAPH_EXPANSION_ENABLED off  -> flat-1-hop output unchanged (snapshot).
+  (b) GRAPH_EXPANSION_ENABLED on   -> a 2-hop fact surfaces that the flat path
+      (which only fetches relations touching a *seed* entity) never returns.
+  (c) tier-leak guard: a private hop-2 entity/relation must NOT appear in the
+      string for an asker who can't see it — relying on expand_fused's per-hop
+      ``kg_entities_circles_filter`` + leak-safe edges.
+
+Real PG via ``pg_db_session`` (the ``e.embedding <=> vector`` similarity search +
+the circle filter's json::int cast both require Postgres). ``_get_embedding`` and
+``_extract_query_entities`` are mocked so no Ollama/LLM call is made; entities get
+deterministic pgvector embeddings so a chosen entity is the only seed.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import (
+    EMBEDDING_DIMENSION,
+    TIER_PUBLIC,
+    KGEntity,
+    KGRelation,
+    Role,
+    User,
+)
+from services.kg_retrieval import KGRetrieval
+from utils.config import settings
+
+pytestmark = [pytest.mark.postgres, pytest.mark.asyncio]
+
+
+def _unit(i: int) -> list[float]:
+    """A unit vector with 1.0 at index ``i`` — orthogonal units have cosine 0."""
+    v = [0.0] * EMBEDDING_DIMENSION
+    v[i % EMBEDDING_DIMENSION] = 1.0
+    return v
+
+
+async def _make_user(db: AsyncSession, name: str) -> User:
+    role = Role(name=f"{name}_role")
+    db.add(role)
+    await db.flush()
+    u = User(username=name, email=f"{name}@ex.test", password_hash="x",
+             role_id=role.id, is_active=True)
+    db.add(u)
+    await db.flush()
+    return u
+
+
+async def _entity(db, owner, name, *, tier=0, etype="person", emb=None) -> KGEntity:
+    e = KGEntity(user_id=owner.id, name=name, entity_type=etype, circle_tier=tier,
+                 is_active=True, embedding=emb)
+    db.add(e)
+    await db.flush()
+    return e
+
+
+async def _rel(db, owner, s, o, pred="kennt", *, tier=None) -> KGRelation:
+    r = KGRelation(
+        user_id=owner.id, subject_id=s.id, predicate=pred, object_id=o.id,
+        circle_tier=min(s.circle_tier, o.circle_tier) if tier is None else tier,
+        is_active=True,
+    )
+    db.add(r)
+    await db.flush()
+    return r
+
+
+def _retrieval(db, monkeypatch, *, seed_vec: list[float]) -> KGRetrieval:
+    """A KGRetrieval whose LLM calls are stubbed: no entity-name extraction (so it
+    embeds the full query once) and a fixed query embedding = ``seed_vec``."""
+    kg = KGRetrieval(db)
+    monkeypatch.setattr(kg, "_extract_query_entities", AsyncMock(return_value=[]))
+    monkeypatch.setattr(kg, "_get_embedding", AsyncMock(return_value=seed_vec))
+    return kg
+
+
+def _triple_lines(out: str | None) -> list[str]:
+    return [ln for ln in (out or "").splitlines() if ln.startswith("- ")]
+
+
+class TestGetRelevantContextExpansion:
+    async def test_flag_off_flat_output_unchanged(self, pg_db_session, monkeypatch):
+        # SNAPSHOT: with expansion OFF, only relations touching a SEED entity are
+        # returned (flat 1-hop). The hop-2 entity/fact must be absent — proving
+        # the new block is inert and the output is byte-identical to today.
+        monkeypatch.setattr(settings, "auth_enabled", False)
+        monkeypatch.setattr(settings, "graph_expansion_enabled", False)
+        owner = await _make_user(pg_db_session, "gxs_off")
+        anna = await _entity(pg_db_session, owner, "Anna", emb=_unit(0))
+        bonn = await _entity(pg_db_session, owner, "Bonn", etype="place", emb=_unit(5))
+        chur = await _entity(pg_db_session, owner, "Chur", etype="place", emb=_unit(6))
+        await _rel(pg_db_session, owner, anna, bonn, pred="wohnt_in")
+        await _rel(pg_db_session, owner, bonn, chur, pred="liegt_bei")
+
+        kg = _retrieval(pg_db_session, monkeypatch, seed_vec=_unit(0))
+        out = await kg.get_relevant_context("Wo wohnt Anna?", user_id=owner.id)
+
+        lines = _triple_lines(out)
+        assert lines == ["- Anna wohnt_in Bonn"]     # exactly the flat seed triple
+        assert "Chur" not in (out or "")             # hop-2 fact NOT surfaced
+
+    async def test_flag_on_two_hop_fact_surfaces(self, pg_db_session, monkeypatch):
+        # With expansion ON, the same graph now surfaces the hop-2 fact
+        # (Bonn liegt_bei Chur) that the flat path never returns.
+        monkeypatch.setattr(settings, "auth_enabled", False)
+        monkeypatch.setattr(settings, "graph_expansion_enabled", True)
+        owner = await _make_user(pg_db_session, "gxs_on")
+        anna = await _entity(pg_db_session, owner, "Anna", emb=_unit(0))
+        bonn = await _entity(pg_db_session, owner, "Bonn", etype="place", emb=_unit(5))
+        chur = await _entity(pg_db_session, owner, "Chur", etype="place", emb=_unit(6))
+        await _rel(pg_db_session, owner, anna, bonn, pred="wohnt_in")
+        await _rel(pg_db_session, owner, bonn, chur, pred="liegt_bei")
+
+        kg = _retrieval(pg_db_session, monkeypatch, seed_vec=_unit(0))
+        out = await kg.get_relevant_context("Wo wohnt Anna?", user_id=owner.id)
+
+        assert "- Anna wohnt_in Bonn" in (out or "")   # seed relation kept
+        assert "- Bonn liegt_bei Chur" in (out or "")  # hop-2 fact ADDED
+        # no duplicate of the seed (hop-1) relation from the expansion edges
+        assert _triple_lines(out).count("- Anna wohnt_in Bonn") == 1
+
+    async def test_flag_on_tier_leak_guard_hop2_entity(self, pg_db_session, monkeypatch):
+        # CRITICAL: a private hop-2 entity/relation must NOT leak into the string
+        # for an asker who can't see it. Anna(a_user) -- Bonn(public) -- Secret
+        # (b_user, self-tier 0). Even with the B->Secret relation forced PUBLIC
+        # (so relation-traversal passes), the per-hop ENTITY circle filter drops
+        # Secret, and the leak-safe edge never names it.
+        monkeypatch.setattr(settings, "auth_enabled", True)
+        monkeypatch.setattr(settings, "graph_expansion_enabled", True)
+        a_user = await _make_user(pg_db_session, "gxs_a")
+        b_user = await _make_user(pg_db_session, "gxs_b")
+        anna = await _entity(pg_db_session, a_user, "Anna", tier=0, emb=_unit(0))
+        bonn = await _entity(pg_db_session, a_user, "Bonn", tier=TIER_PUBLIC,
+                             etype="place", emb=_unit(5))
+        secret = await _entity(pg_db_session, b_user, "SecretPlace", tier=0,
+                               etype="place", emb=_unit(6))
+        await _rel(pg_db_session, a_user, anna, bonn, pred="wohnt_in")
+        # relation forced public so ONLY the entity filter can stop the leak
+        await _rel(pg_db_session, a_user, bonn, secret, pred="liegt_bei",
+                   tier=TIER_PUBLIC)
+
+        kg = _retrieval(pg_db_session, monkeypatch, seed_vec=_unit(0))
+        out = await kg.get_relevant_context("Wo wohnt Anna?", user_id=a_user.id)
+
+        assert "- Anna wohnt_in Bonn" in (out or "")   # accessible hop-1 kept
+        assert "SecretPlace" not in (out or "")        # private hop-2 entity hidden
+        assert "liegt_bei" not in (out or "")          # and its predicate/edge too
+
+    async def test_flag_on_no_seed_returns_none(self, pg_db_session, monkeypatch):
+        # No entity clears the similarity threshold -> None, unchanged, no crash.
+        monkeypatch.setattr(settings, "auth_enabled", False)
+        monkeypatch.setattr(settings, "graph_expansion_enabled", True)
+        owner = await _make_user(pg_db_session, "gxs_none")
+        await _entity(pg_db_session, owner, "Anna", emb=_unit(5))  # orthogonal to seed
+
+        kg = _retrieval(pg_db_session, monkeypatch, seed_vec=_unit(0))
+        out = await kg.get_relevant_context("Wo wohnt Anna?", user_id=owner.id)
+        assert out is None


### PR DESCRIPTION
## Summary
The agent's STRING KG-context path (`KGRetrieval.get_relevant_context`, backing `internal.knowledge_search` + the ReAct loop) did NOT get graph_expansion, while the fused store path did. Route it through the SAME `expand_fused` seam so the agent benefits from 1–2-hop multi-hop traversal.

- Builds `kg_node` seed AtomMatches from the seed entity ids → `expand_fused` (reused verbatim) → merges the returned `kg_edge` relations into the context-string triples, deduped by relation id, capped by `kg_max_context_triples`.
- **No signature change** to `get_relevant_context` (agent-loop contract intact).
- **Flag-off (`GRAPH_EXPANSION_ENABLED` false) byte-identical** — the whole block is skipped.
- **Tier-safe at every hop** via `expand_fused`'s per-hop `kg_entities_circles_filter` + leak-safe edges; expanded names are `neutralize_delimiters`-sanitized (#686).

## Test plan
- [x] `.159` (real Postgres): 4 new tests (flag-off snapshot / flag-on 2-hop surfaces / **tier-leak guard** / dedup) + regression `test_graph_expansion_pg` / `test_kg_retrieval_name_leak_pg` / `test_kg_retrieval_extract` / `test_knowledge_graph_service` → **153 passed, 1 skipped**
- [x] Reviewed (tier-leak focus); reuses `expand_fused`, did not resurrect the deleted buggy MVP

Closes #874

🤖 Generated with [Claude Code](https://claude.com/claude-code)