### PR TITLE
feat(metrics): count router fallbacks and embedding errors (#1201)

### DIFF
--- a/src/backend/services/agent_router.py
+++ b/src/backend/services/agent_router.py
@@ -38,6 +38,7 @@ _ANTI_DASHBOARD = re.compile(
 
 from services.prompt_manager import prompt_manager
 from utils.config import settings
+from utils.metrics import record_router_fallback
 from utils.llm_client import (
     extract_response_content,
     get_agent_client,
@@ -604,13 +605,16 @@ class AgentRouter:
                 f"Router: invalid role '{role_name}' from LLM, "
                 f"falling back to 'general'"
             )
+            record_router_fallback("invalid_role")
             return self.get_role("general")
 
         except TimeoutError:
             logger.warning("Router: LLM timeout, falling back to 'general'")
+            record_router_fallback("timeout")
             return self.get_role("general")
         except Exception as e:
             logger.error(f"Router classification failed: {e}")
+            record_router_fallback("error")
             return self.get_role("general")
 
     @staticmethod

--- a/src/backend/utils/llm_client.py
+++ b/src/backend/utils/llm_client.py
@@ -484,8 +484,23 @@ class _CountingEmbedClient:
         except Exception:
             from utils.metrics import record_embedding_error
 
-            record_embedding_error(str(kwargs.get("model") or ""))
+            record_embedding_error(self._model_label(args, kwargs))
             raise
+
+    @staticmethod
+    def _model_label(args: tuple[Any, ...], kwargs: dict[str, Any]) -> str:
+        """Resolve the ``model`` label from either calling convention.
+
+        Every call site today passes ``model=`` as a keyword, but ``model`` is
+        the FIRST positional parameter of the ``LLMClient.embeddings``
+        protocol. Reading only ``kwargs`` would silently label a future
+        positional caller ``""`` — a metric that exists but cannot be grouped
+        by model is worse than one that is obviously missing.
+        """
+        model = kwargs.get("model")
+        if model is None and args:
+            model = args[0]
+        return str(model or "")
 
     async def chat(self, *args: Any, **kwargs: Any) -> Any:  # noqa: D102
         return await self.inner.chat(*args, **kwargs)

--- a/src/backend/utils/llm_client.py
+++ b/src/backend/utils/llm_client.py
@@ -462,6 +462,41 @@ def get_default_client() -> LLMClient:
     return _make_client_with_fallback(settings.ollama_url)
 
 
+class _CountingEmbedClient:
+    """Wrap the embed client so a raising ``embeddings()`` is counted.
+
+    Every consumer of embeddings (semantic router, memory retrieval, KG,
+    episodic memory, intent feedback) catches the exception, logs a WARNING
+    and degrades to "no context". That is the right per-turn behaviour, but
+    it means a dead embedding endpoint leaves no metric anywhere: in 2026-09
+    the embed model failed to load for two days and the only trace was one
+    WARNING per call in the pod log. Counting here, at the single chokepoint
+    every consumer goes through, makes it alertable. The exception is
+    re-raised unchanged; ``inner`` exposes the wrapped client.
+    """
+
+    def __init__(self, inner: LLMClient) -> None:
+        self.inner = inner
+
+    async def embeddings(self, *args: Any, **kwargs: Any) -> Any:  # noqa: D102
+        try:
+            return await self.inner.embeddings(*args, **kwargs)
+        except Exception:
+            from utils.metrics import record_embedding_error
+
+            record_embedding_error(str(kwargs.get("model") or ""))
+            raise
+
+    async def chat(self, *args: Any, **kwargs: Any) -> Any:  # noqa: D102
+        return await self.inner.chat(*args, **kwargs)
+
+    async def list(self, *args: Any, **kwargs: Any) -> Any:  # noqa: D102
+        return await self.inner.list(*args, **kwargs)
+
+    async def generate(self, *args: Any, **kwargs: Any) -> Any:  # noqa: D102
+        return await self.inner.generate(*args, **kwargs)
+
+
 def get_embed_client() -> LLMClient:
     """Return the client for embedding calls.
 
@@ -474,10 +509,10 @@ def get_embed_client() -> LLMClient:
     """
     embed_oa = get_openai_compat_embed_client()
     if embed_oa is not None:
-        return embed_oa  # type: ignore[return-value]
+        return _CountingEmbedClient(embed_oa)  # type: ignore[return-value]
     if settings.ollama_embed_url:
-        return _make_client_with_fallback(settings.ollama_embed_url)
-    return _make_client_with_fallback(settings.ollama_url)
+        return _CountingEmbedClient(_make_client_with_fallback(settings.ollama_embed_url))  # type: ignore[return-value]
+    return _CountingEmbedClient(_make_client_with_fallback(settings.ollama_url))  # type: ignore[return-value]
 
 
 def get_agent_client(

--- a/src/backend/utils/metrics.py
+++ b/src/backend/utils/metrics.py
@@ -40,6 +40,8 @@ _injection_attempts_total = None
 _budget_reductions_total = None
 _output_guard_violations_total = None
 _llm_response_truncated_total = None
+_router_fallback_total = None
+_embedding_errors_total = None
 _auth_provider_unreachable_total = None
 _login_failure_total = None
 _authz_denied_total = None
@@ -65,6 +67,7 @@ def _init_metrics():
     global _agent_outcome_total, _injection_attempts_total
     global _budget_reductions_total, _output_guard_violations_total
     global _llm_response_truncated_total
+    global _router_fallback_total, _embedding_errors_total
     global _auth_provider_unreachable_total
     global _login_failure_total, _authz_denied_total
     global _kg_conflation_candidates
@@ -198,6 +201,28 @@ def _init_metrics():
             "renfield_llm_response_truncated_total",
             "LLM completions that hit the output-token cap (finish_reason=length)",
             ["model", "call_type"],
+        )
+
+        # Routing silently collapsed to the generic role. The LLM router
+        # (AGENT_ROUTER_URL) failing does not error the turn: classify()
+        # returns 'general' and the user gets a generic answer with no
+        # role prompt, no sub-intent and no deterministic tool filter.
+        # Two days of that in 2026-09 left no trace beyond a WARNING per
+        # turn, while /api/health stayed green (it only lists models).
+        _router_fallback_total = Counter(
+            "renfield_router_fallback_total",
+            "Router LLM classification fell back to the general role",
+            ["reason"],
+        )
+
+        # Embedding calls that raised. Every consumer (semantic router,
+        # memory retrieval, KG, episodic memory) catches the exception,
+        # logs a WARNING and degrades to 'no context' — so a dead
+        # embedding endpoint is invisible everywhere except the log.
+        _embedding_errors_total = Counter(
+            "renfield_embedding_errors_total",
+            "Embedding requests that raised (endpoint down, model failed to load)",
+            ["model"],
         )
 
         # Pluggable-auth fail-open observability. Name intentionally matches
@@ -483,6 +508,23 @@ def record_llm_response_truncated(model: str, call_type: str):
     if not _metrics_initialized:
         return
     _llm_response_truncated_total.labels(model=model, call_type=call_type).inc()
+
+
+def record_router_fallback(reason: str):
+    """Record an LLM router classification that fell back to 'general'.
+
+    ``reason`` is one of ``timeout``, ``error`` or ``invalid_role``.
+    """
+    if not _metrics_initialized:
+        return
+    _router_fallback_total.labels(reason=reason).inc()
+
+
+def record_embedding_error(model: str):
+    """Record an embedding request that raised."""
+    if not _metrics_initialized:
+        return
+    _embedding_errors_total.labels(model=model or "").inc()
 
 
 # === Middleware & Endpoint Setup ===

--- a/tests/backend/test_agent_router.py
+++ b/tests/backend/test_agent_router.py
@@ -1722,3 +1722,80 @@ class TestInferSubIntent:
         assert AgentRouter._infer_sub_intent(
             "Hello world", defs, "de",
         ) is None
+
+
+# ============================================================================
+# Fallback-to-general is counted (renfield_router_fallback_total)
+# ============================================================================
+
+class TestRouterFallbackCounter:
+    """A router LLM failure must leave a metric, not just a WARNING."""
+
+    def _settings(self, mock_settings):
+        mock_settings.ollama_intent_model = "test-model"
+        mock_settings.ollama_model = "test-model"
+        mock_settings.agent_ollama_url = None
+        mock_settings.agent_router_model = None
+        mock_settings.agent_router_url = None
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_exception_falls_back_and_records_error(self):
+        ollama = make_mock_ollama("unused")
+        ollama.client.chat = AsyncMock(side_effect=RuntimeError("500: model requires more system memory"))
+        router = AgentRouter(SAMPLE_CONFIG)
+
+        with patch("services.agent_router.settings") as mock_settings, patch(
+            "services.agent_router.record_router_fallback"
+        ) as rec:
+            self._settings(mock_settings)
+            role = await router.classify("Welche Freeze Fenster haben wir 2027?", ollama)
+
+        assert role.name == "general"
+        rec.assert_called_once_with("error")
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_timeout_falls_back_and_records_timeout(self):
+        ollama = make_mock_ollama("unused")
+        ollama.client.chat = AsyncMock(side_effect=TimeoutError())
+        router = AgentRouter(SAMPLE_CONFIG)
+
+        with patch("services.agent_router.settings") as mock_settings, patch(
+            "services.agent_router.record_router_fallback"
+        ) as rec:
+            self._settings(mock_settings)
+            role = await router.classify("hallo", ollama)
+
+        assert role.name == "general"
+        rec.assert_called_once_with("timeout")
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_invalid_role_records_invalid_role(self):
+        ollama = make_mock_ollama('{"role": "does_not_exist"}')
+        router = AgentRouter(SAMPLE_CONFIG)
+
+        with patch("services.agent_router.settings") as mock_settings, patch(
+            "services.agent_router.record_router_fallback"
+        ) as rec:
+            self._settings(mock_settings)
+            role = await router.classify("hallo", ollama)
+
+        assert role.name == "general"
+        rec.assert_called_once_with("invalid_role")
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_successful_classification_records_nothing(self):
+        ollama = make_mock_ollama('{"role": "smart_home", "reason": "x"}')
+        router = AgentRouter(SAMPLE_CONFIG)
+
+        with patch("services.agent_router.settings") as mock_settings, patch(
+            "services.agent_router.record_router_fallback"
+        ) as rec:
+            self._settings(mock_settings)
+            role = await router.classify("Schalte das Licht ein", ollama)
+
+        assert role.name == "smart_home"
+        rec.assert_not_called()

--- a/tests/backend/test_llm_client.py
+++ b/tests/backend/test_llm_client.py
@@ -36,6 +36,7 @@ if "openai" not in sys.modules:
 from utils.llm_client import (
     LLMClient,
     OpenAICompatibleClient,
+    _CountingEmbedClient,
     clear_client_cache,
     create_llm_client,
     effective_agent_num_ctx,
@@ -1120,10 +1121,19 @@ class TestGetDefaultClientRoutesToOpenAI:
         monkeypatch.setattr("utils.llm_client.settings.llm_openai_embed_model", "qwen3-embedding")
         monkeypatch.setattr("utils.llm_client.settings.llm_openai_api_key", None)
 
+        # The factory now returns a _CountingEmbedClient wrapper (#1201 —
+        # embedding failures are counted at this single chokepoint). Unwrap it:
+        # the invariant under test is WHICH ENDPOINT the client points at, not
+        # the wrapper type. Asserting through `.inner` keeps the #527 guard
+        # exact instead of loosening it to "some object".
         embed = get_embed_client()
-        assert isinstance(embed, OpenAICompatibleClient)
-        assert embed._base_url == "http://embed:8080/v1"
-        assert embed._default_model == "qwen3-embedding"
+        assert isinstance(embed, _CountingEmbedClient), (
+            "embed factory must route through the failure-counting wrapper"
+        )
+        inner = embed.inner
+        assert isinstance(inner, OpenAICompatibleClient)
+        assert inner._base_url == "http://embed:8080/v1"
+        assert inner._default_model == "qwen3-embedding"
 
 
 # ============================================================================

--- a/tests/backend/test_llm_client.py
+++ b/tests/backend/test_llm_client.py
@@ -261,7 +261,7 @@ class TestGetEmbedClient:
 
         args, kwargs = mock_cls.call_args
         assert kwargs.get("host") == "http://embed-host:11434"
-        assert result is sentinel
+        assert result.inner is sentinel
 
     @pytest.mark.unit
     @patch("ollama.AsyncClient")
@@ -282,7 +282,7 @@ class TestGetEmbedClient:
 
         args, kwargs = mock_cls.call_args
         assert kwargs.get("host") == "http://default:11434"
-        assert result is sentinel
+        assert result.inner is sentinel
 
     @pytest.mark.unit
     @patch("ollama.AsyncClient")
@@ -301,7 +301,7 @@ class TestGetEmbedClient:
 
         result = get_embed_client()
 
-        assert isinstance(result, _FallbackLLMClient)
+        assert isinstance(result.inner, _FallbackLLMClient)
 
     @pytest.mark.unit
     @patch("ollama.AsyncClient")
@@ -1686,3 +1686,54 @@ class TestFinishReasonSurvivesTheAdapter:
         )]
 
         assert seen[-1].done_reason == "length"
+
+
+# ============================================================================
+# _CountingEmbedClient Tests
+# ============================================================================
+
+class TestCountingEmbedClient:
+    """The embed chokepoint counts raising embeddings() calls and re-raises."""
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_embedding_error_is_counted_and_reraised(self):
+        from utils.llm_client import _CountingEmbedClient
+
+        inner = MagicMock()
+        inner.embeddings = AsyncMock(side_effect=RuntimeError("model requires more system memory"))
+        client = _CountingEmbedClient(inner)
+
+        with patch("utils.metrics.record_embedding_error") as rec:
+            with pytest.raises(RuntimeError):
+                await client.embeddings(model="qwen3-embedding:4b", prompt="x")
+        rec.assert_called_once_with("qwen3-embedding:4b")
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_successful_embedding_is_not_counted(self):
+        from utils.llm_client import _CountingEmbedClient
+
+        inner = MagicMock()
+        inner.embeddings = AsyncMock(return_value={"embedding": [0.1]})
+        client = _CountingEmbedClient(inner)
+
+        with patch("utils.metrics.record_embedding_error") as rec:
+            result = await client.embeddings(model="m", prompt="x")
+        assert result == {"embedding": [0.1]}
+        rec.assert_not_called()
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_other_methods_delegate(self):
+        from utils.llm_client import _CountingEmbedClient
+
+        inner = MagicMock()
+        inner.chat = AsyncMock(return_value="c")
+        inner.list = AsyncMock(return_value="l")
+        inner.generate = AsyncMock(return_value="g")
+        client = _CountingEmbedClient(inner)
+        assert await client.chat(model="m") == "c"
+        assert await client.list() == "l"
+        assert await client.generate(model="m") == "g"
+        assert client.inner is inner

--- a/tests/backend/test_llm_client.py
+++ b/tests/backend/test_llm_client.py
@@ -1725,6 +1725,41 @@ class TestCountingEmbedClient:
 
     @pytest.mark.unit
     @pytest.mark.asyncio
+    async def test_positional_model_is_labelled(self):
+        """``model`` is the first POSITIONAL parameter of the protocol.
+
+        Every call site today passes it as a keyword, but a positional caller
+        must not silently produce an empty label — a counter that cannot be
+        grouped by model defeats the purpose of the metric.
+        """
+        from utils.llm_client import _CountingEmbedClient
+
+        inner = MagicMock()
+        inner.embeddings = AsyncMock(side_effect=RuntimeError("down"))
+        client = _CountingEmbedClient(inner)
+
+        with patch("utils.metrics.record_embedding_error") as rec:
+            with pytest.raises(RuntimeError):
+                await client.embeddings("qwen3-embedding:4b", "some text")
+        rec.assert_called_once_with("qwen3-embedding:4b")
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_missing_model_labels_empty_string(self):
+        """No model anywhere → empty label, never a TypeError or ``None``."""
+        from utils.llm_client import _CountingEmbedClient
+
+        inner = MagicMock()
+        inner.embeddings = AsyncMock(side_effect=RuntimeError("down"))
+        client = _CountingEmbedClient(inner)
+
+        with patch("utils.metrics.record_embedding_error") as rec:
+            with pytest.raises(RuntimeError):
+                await client.embeddings(prompt="x")
+        rec.assert_called_once_with("")
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
     async def test_other_methods_delegate(self):
         from utils.llm_client import _CountingEmbedClient
 

--- a/tests/backend/test_metrics.py
+++ b/tests/backend/test_metrics.py
@@ -313,3 +313,61 @@ class TestNormalizeEndpoint:
         assert normalize_endpoint("/health") == "/health"
         # Short hex-looking words stay literal (only >=16 hex chars collapse)
         assert normalize_endpoint("/api/atoms/facade") == "/api/atoms/facade"
+
+
+class TestRoutingAndEmbeddingCounters:
+    """renfield_router_fallback_total / renfield_embedding_errors_total."""
+
+    def test_noop_when_not_initialized(self):
+        from utils.metrics import record_embedding_error, record_router_fallback
+
+        record_router_fallback("error")
+        record_embedding_error("qwen3-embedding:4b")
+
+    def test_router_fallback_labels_reason(self):
+        import utils.metrics as metrics_module
+
+        counter = MagicMock()
+        metrics_module._metrics_initialized = True
+        metrics_module._router_fallback_total = counter
+        try:
+            metrics_module.record_router_fallback("timeout")
+            counter.labels.assert_called_once_with(reason="timeout")
+            counter.labels().inc.assert_called_once()
+        finally:
+            metrics_module._metrics_initialized = False
+            metrics_module._router_fallback_total = None
+
+    def test_embedding_error_labels_model(self):
+        import utils.metrics as metrics_module
+
+        counter = MagicMock()
+        metrics_module._metrics_initialized = True
+        metrics_module._embedding_errors_total = counter
+        try:
+            metrics_module.record_embedding_error("qwen3-embedding:4b")
+            counter.labels.assert_called_once_with(model="qwen3-embedding:4b")
+            counter.labels().inc.assert_called_once()
+        finally:
+            metrics_module._metrics_initialized = False
+            metrics_module._embedding_errors_total = None
+
+    def test_init_metrics_registers_the_counters(self):
+        """The #1109 lesson: a counter whose global was never declared stays
+        None after init and every record call dies in the except."""
+        import utils.metrics as metrics_module
+
+        metrics_module._metrics_initialized = False
+        with patch("prometheus_client.Counter") as counter_cls, patch(
+            "prometheus_client.Gauge"
+        ), patch("prometheus_client.Histogram"):
+            counter_cls.side_effect = lambda *a, **k: MagicMock(name=a[0])
+            metrics_module._init_metrics()
+            try:
+                names = {c.args[0] for c in counter_cls.call_args_list}
+                assert "renfield_router_fallback_total" in names
+                assert "renfield_embedding_errors_total" in names
+                assert metrics_module._router_fallback_total is not None
+                assert metrics_module._embedding_errors_total is not None
+            finally:
+                metrics_module._metrics_initialized = False


### PR DESCRIPTION
## Summary
- `renfield_router_fallback_total{reason=timeout|error|invalid_role}` — recorded in the three fallback branches of `AgentRouter.classify()`.
- `renfield_embedding_errors_total{model}` — recorded at the one chokepoint every embedding consumer shares: `get_embed_client()` returns a thin `_CountingEmbedClient` that counts and re-raises (`.inner` exposes the wrapped client).
- Tests for both, including the #1109 regression (global declared in `_init_metrics`, so the counter is not `None` after init).

## Why
A failing router LLM or embedding endpoint never errors a turn: `classify()` returns `general`, every embedding consumer degrades to "no context", each with one WARNING. 2026-09-01..03 in the Reva deployment: Ollama returned 500 on every embed/router call (GPU fell off the bus) and **every** message ran in the generic role for two days while the health endpoint stayed green (it only lists models). Closes #1201.

## Test plan
- [x] `tests/backend/test_metrics.py`, `test_llm_client.py`, `test_agent_router.py` run inside the Reva prod image against these sources: all new/adjusted tests pass; the remaining failures in those modules are pre-existing (older image code vs newer tests) and fail identically without this change.
- [ ] Consumer alert rules (Reva #254) go live with the next submodule bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9nTxX9Vpx9K3pj6jvwvkv