### PR TITLE
feat(security): server-side scope enforcement for WS tokens in the URL (#1116 A)

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -2005,6 +2005,36 @@ curl -X POST "http://localhost:8000/api/ws/token?device_id=my-device&device_type
 const ws = new WebSocket(`ws://localhost:8000/ws?token=${token}`);
 ```
 
+### `WS_REQUIRE_SCOPED_QUERY_TOKEN` (Security-Audit #1116, Befund A)
+
+Erzwingt serverseitig, dass ein Token **im URL-Query-String** ein kurzlebiges
+`scope:ws`-Token ist. Ohne das Flag akzeptiert `authenticate_websocket` jedes
+`type:access`-JWT auf `?token=` — die Eigenschaft "nur kurzlebige Scope-Tokens
+stehen in URLs" ist dann reine Frontend-Disziplin, und genau so blieb der
+Voice-Pfad unbemerkt. Ein URL-Token landet in Proxy-Access-Logs, im
+Browser-Verlauf und in `Referer`-Headern.
+
+| Wert | Verhalten |
+|---|---|
+| `false` (Default) | Byte-identisch zu vorher. Ein ungescoptes Access-JWT aus der URL wird **akzeptiert**, aber mit einer WARNING protokolliert — so werden die verbliebenen Aufrufer sichtbar, bevor etwas bricht. |
+| `true` | Ein Query-String-Token **muss** `scope == "ws"` tragen. Vollwertige Access-JWTs funktionieren dann nur noch über `Authorization: Bearer` oder das Auth-Cookie. |
+
+Der Header- und der Cookie-Pfad sind unberührt: dieselbe Anmeldung funktioniert
+weiter, nur der Transportweg, der sie preisgibt, wird geschlossen.
+
+**Reihenfolge beim Ausrollen** (wie bei der Satelliten-Enrollment-Leiter):
+
+1. Deployen mit `false`, Logs auf die Soak-WARNING beobachten.
+2. Jeden gemeldeten Aufrufer auf Header, Cookie oder ein `POST /api/ws/token`
+   gemintetes `scope:ws`-Token umstellen.
+3. Erst wenn die WARNING über einen vollen Deploy-Zyklus stumm bleibt, auf
+   `true` flippen.
+
+**Cross-Repo-Abhängigkeit:** Der externe Voice-Server validiert Tokens mit
+eigenem Code (`voice_server/auth.py::_validate_local` prüft weder `type` noch
+`scope`). Dessen Umstellung ist ein eigener Schritt in einem anderen Repository
+und gatet Schritt 3.
+
 ---
 
 ## Integrationen

--- a/src/backend/services/websocket_auth.py
+++ b/src/backend/services/websocket_auth.py
@@ -162,6 +162,13 @@ async def authenticate_websocket(
         )
         return None
 
+    # Whether the token travelled in the URL query string. Every caller passes
+    # its `token: str = Query(None)` straight through, so a non-None argument
+    # here means "came from the URL" — the cookie and Authorization-header
+    # fallbacks below only ever run when this is None. Captured BEFORE those
+    # fallbacks, because afterwards the two sources are indistinguishable.
+    token_from_url = token is not None
+
     # Skip authentication if disabled
     if not settings.ws_auth_enabled:
         return {"authenticated": True, "auth_skipped": True}
@@ -220,6 +227,29 @@ async def authenticate_websocket(
     if payload and payload.get("scope") == "voice":
         logger.debug("WebSocket JWT rejected: voice-scoped token not valid on this socket")
         return None
+
+    # Security audit #1116 finding A: a token in the URL must be a scoped,
+    # short-lived one. A full access JWT on `?token=` is a durable credential
+    # sitting in proxy logs, browser history and Referer headers — the header
+    # and cookie paths carry the same JWT without that exposure, so the
+    # restriction costs nothing there. Soak first (WARNING only), enforce once
+    # `ws_require_scoped_query_token` is flipped; see the config comment for
+    # why the external voice-server gates that flip.
+    if payload and payload.get("type") == "access" and token_from_url:
+        if payload.get("scope") != "ws":
+            if settings.ws_require_scoped_query_token:
+                logger.warning(
+                    "WebSocket JWT rejected: unscoped access token in the URL "
+                    "query string (ws_require_scoped_query_token is on)"
+                )
+                return None
+            logger.warning(
+                "WebSocket auth: unscoped access token accepted from the URL "
+                "query string — will be REJECTED once "
+                "ws_require_scoped_query_token is enabled. Move it to the "
+                "Authorization header, the auth cookie, or mint a scope:ws "
+                "token via POST /api/ws/token."
+            )
 
     if payload and payload.get("type") == "access":
         sub = payload.get("sub")

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -1402,6 +1402,29 @@ class Settings(BaseSettings):
     # WebSocket Security
     ws_auth_enabled: bool = False  # Enable WebSocket authentication (set True in production)
     ws_token_expire_minutes: int = 60  # WebSocket token expiration (device token store)
+    # Security audit #1116 finding A — server-side scope enforcement for tokens
+    # that arrive in the URL query string.
+    #
+    # `authenticate_websocket` accepts any `type:access` JWT on `?token=`; it
+    # does NOT require `scope == "ws"`. The "only short-lived scoped tokens
+    # travel in URLs" property is therefore frontend discipline only, which is
+    # exactly how the voice path went unnoticed. A URL token lands in proxy
+    # access logs, browser history and Referer headers; a full access JWT there
+    # is a durable credential in places that are not treated as secret.
+    #
+    # Rollout mirrors the satellite-enrollment ladder (OFF → soak → enforce):
+    #   False (default) — byte-identical to before, except one WARNING per
+    #                     unscoped URL token so the remaining callers become
+    #                     visible in the logs before anything breaks.
+    #   True            — a query-string token MUST carry `scope == "ws"`;
+    #                     full access JWTs then only work via the
+    #                     `Authorization: Bearer` header or the auth cookie.
+    #
+    # Do NOT flip this before the soak WARNING is silent for a full deploy
+    # cycle: the external voice-server validates tokens with its own code
+    # (`voice_server/auth.py::_validate_local` checks neither type nor scope),
+    # so its cutover is a separate, cross-repo step.
+    ws_require_scoped_query_token: bool = False
     # Lifetime of the short-lived, WS-scoped access JWT the browser fetches from
     # /api/ws/token and passes as ?token= on the WebSocket URL (security audit M2).
     # Kept tiny: long enough to open the socket, far too short to be useful if

--- a/tests/backend/test_websocket.py
+++ b/tests/backend/test_websocket.py
@@ -616,6 +616,119 @@ class TestWebSocketAuthentication:
 
     @pytest.mark.unit
     @pytest.mark.asyncio
+    async def test_unscoped_url_token_rejected_when_enforcement_on(self):
+        """#1116 A: with enforcement on, a full access JWT in the URL is refused.
+
+        The header/cookie paths are untouched — see the companion test — so the
+        same credential still works, just not from a place that lands in proxy
+        logs and browser history.
+        """
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from services.auth_service import create_access_token
+        from services.websocket_auth import authenticate_websocket
+        from utils.config import settings
+
+        tok = create_access_token({"sub": "7"}, token_epoch=0)
+        fake_user = MagicMock(id=7, is_active=True, must_change_password=False, token_epoch=0)
+        ws = MagicMock(); ws.headers = {}; ws.cookies = {}
+        orig_auth, orig_scope = settings.ws_auth_enabled, settings.ws_require_scoped_query_token
+        settings.ws_auth_enabled = True
+        settings.ws_require_scoped_query_token = True
+        try:
+            with patch("services.auth_service.get_user_by_id", new=AsyncMock(return_value=fake_user)), \
+                 patch("services.database.AsyncSessionLocal", new=_fake_session_local()), \
+                 patch("services.token_blacklist.token_blacklist.is_blacklisted", new=AsyncMock(return_value=False)):
+                result = await authenticate_websocket(ws, token=tok)
+        finally:
+            settings.ws_auth_enabled = orig_auth
+            settings.ws_require_scoped_query_token = orig_scope
+        assert result is None
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_unscoped_url_token_accepted_when_enforcement_off(self):
+        """Flag off is byte-identical to before — soak logs, never rejects."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from services.auth_service import create_access_token
+        from services.websocket_auth import authenticate_websocket
+        from utils.config import settings
+
+        tok = create_access_token({"sub": "7"}, token_epoch=0)
+        fake_user = MagicMock(id=7, is_active=True, must_change_password=False, token_epoch=0)
+        ws = MagicMock(); ws.headers = {}; ws.cookies = {}
+        orig_auth, orig_scope = settings.ws_auth_enabled, settings.ws_require_scoped_query_token
+        settings.ws_auth_enabled = True
+        settings.ws_require_scoped_query_token = False
+        try:
+            with patch("services.auth_service.get_user_by_id", new=AsyncMock(return_value=fake_user)), \
+                 patch("services.database.AsyncSessionLocal", new=_fake_session_local()), \
+                 patch("services.token_blacklist.token_blacklist.is_blacklisted", new=AsyncMock(return_value=False)):
+                result = await authenticate_websocket(ws, token=tok)
+        finally:
+            settings.ws_auth_enabled = orig_auth
+            settings.ws_require_scoped_query_token = orig_scope
+        assert result is not None and result.get("user_id") == 7
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_scoped_url_token_still_accepted_under_enforcement(self):
+        """The scope:ws faucet token is exactly what enforcement wants in a URL."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from services.auth_service import create_ws_token_jwt
+        from services.websocket_auth import authenticate_websocket
+        from utils.config import settings
+
+        tok = create_ws_token_jwt(7, token_epoch=0)
+        fake_user = MagicMock(id=7, is_active=True, must_change_password=False, token_epoch=0)
+        ws = MagicMock(); ws.headers = {}; ws.cookies = {}
+        orig_auth, orig_scope = settings.ws_auth_enabled, settings.ws_require_scoped_query_token
+        settings.ws_auth_enabled = True
+        settings.ws_require_scoped_query_token = True
+        try:
+            with patch("services.auth_service.get_user_by_id", new=AsyncMock(return_value=fake_user)), \
+                 patch("services.database.AsyncSessionLocal", new=_fake_session_local()), \
+                 patch("services.token_blacklist.token_blacklist.is_blacklisted", new=AsyncMock(return_value=False)):
+                result = await authenticate_websocket(ws, token=tok)
+        finally:
+            settings.ws_auth_enabled = orig_auth
+            settings.ws_require_scoped_query_token = orig_scope
+        assert result is not None and result.get("user_id") == 7
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_header_bearer_token_bypasses_scope_enforcement(self):
+        """A full JWT stays valid via Authorization: Bearer under enforcement.
+
+        This is the property that makes the flag safe to flip: the credential
+        is not devalued, only the transport that leaks it is closed.
+        """
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from services.auth_service import create_access_token
+        from services.websocket_auth import authenticate_websocket
+        from utils.config import settings
+
+        tok = create_access_token({"sub": "7"}, token_epoch=0)
+        fake_user = MagicMock(id=7, is_active=True, must_change_password=False, token_epoch=0)
+        ws = MagicMock(); ws.headers = {"authorization": f"Bearer {tok}"}; ws.cookies = {}
+        orig_auth, orig_scope = settings.ws_auth_enabled, settings.ws_require_scoped_query_token
+        settings.ws_auth_enabled = True
+        settings.ws_require_scoped_query_token = True
+        try:
+            with patch("services.auth_service.get_user_by_id", new=AsyncMock(return_value=fake_user)), \
+                 patch("services.database.AsyncSessionLocal", new=_fake_session_local()), \
+                 patch("services.token_blacklist.token_blacklist.is_blacklisted", new=AsyncMock(return_value=False)):
+                result = await authenticate_websocket(ws, token=None)
+        finally:
+            settings.ws_auth_enabled = orig_auth
+            settings.ws_require_scoped_query_token = orig_scope
+        assert result is not None and result.get("user_id") == 7
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
     async def test_authenticate_websocket_rejects_stale_epoch(self):
         """H3/H4: a token minted before token_epoch was bumped can't (re)connect."""
         from unittest.mock import AsyncMock, MagicMock, patch


### PR DESCRIPTION
## Summary
Adds `WS_REQUIRE_SCOPED_QUERY_TOKEN` (default `false` = byte-identical) so the server, not the frontend, decides what may travel in a WebSocket URL.

- **off** — an unscoped access token from the query string is still accepted, but logs a WARNING naming the fix, so the remaining callers become visible before anything breaks.
- **on** — a query-string token must carry `scope == "ws"`.

Closes finding **A** of #1116.

## Why
`authenticate_websocket` accepted any `type:access` JWT on `?token=`; it never required `scope == "ws"`. The property "only short-lived scoped tokens travel in URLs" was therefore frontend discipline only — which is exactly how the voice path went unnoticed. A URL token lands in proxy access logs, browser history and `Referer` headers, so a full access JWT there is a durable credential sitting in places nobody treats as secret.

**The discriminator** is the `token` argument being non-`None` on entry: every caller passes its `Query(None)` parameter straight through, and the cookie/header fallbacks only run when it is `None`. Captured *before* those fallbacks, since afterwards the two sources are indistinguishable.

**Header and cookie paths are deliberately untouched** (a test pins this): the credential is not devalued, only the transport that leaks it is closed. That is what makes the flag safe to flip.

## Rollout
Mirrors the satellite-enrollment ladder (off → soak → enforce):
1. Deploy with `false`, watch for the soak WARNING.
2. Move each reported caller to the `Authorization` header, the auth cookie, or a `scope:ws` token from `POST /api/ws/token`.
3. Flip to `true` only once the WARNING has been silent for a full deploy cycle.

**Cross-repo gate on step 3:** the external voice-server validates tokens with its own code (`voice_server/auth.py::_validate_local` checks neither `type` nor `scope`). Its cutover is a separate step in another repository.

## Test plan
- [x] 4 new tests: enforcement rejects an unscoped URL token; flag-off still accepts it; a `scope:ws` token is accepted under enforcement; a full JWT via `Authorization: Bearer` bypasses enforcement.
- [x] `tests/backend/test_websocket.py` — **53 passed** on `.159`.
- [x] Auth-adjacent regression suites (`test_wakeword_ws_auth`, `test_kiosk_handler`, `test_user_events_endpoint`, `test_must_change_password`, `test_auth`) — **75 passed, 1 skipped**.
- [x] Docs: `docs/ENVIRONMENT_VARIABLES.md` documents the flag, the two states, the rollout order and the cross-repo gate.

## Not in scope (with reasons)
- **Finding B** (`/api/internal/auth/verify` as a validity oracle) is **already closed in production**: the code has `INTERNAL_AUTH_VERIFY_SECRET` and the secret is set in both running backend pods via `secretKeyRef`. The issue text predates that. An ingress path allowlist would be belt-and-suspenders only.
- **Finding C** (OAuth `state` + PKCE) is dead code today — all providers `enabled=false`, no callback route in renfield. It becomes a blocker when the Reva callback wiring lands; building it now means building against unknown callback semantics.
- **Finding D** (LDAP as authority) only matters once LDAP is enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XD5cZpiHcMhmbDJxQdcH6x