### PR TITLE
feat(vision): serve the vision tier from the multimodal main model (#1206)

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -115,16 +115,38 @@ OLLAMA_NUM_CTX=32768                  # Context Window für alle Ollama-Calls
 # Leer = Visual Queries deaktiviert (Bilder werden ignoriert)
 OLLAMA_VISION_MODEL=qwen3-vl:8b
 
-# Optional: Separate Ollama-URL für das Vision-Modell
-# Nützlich wenn Vision auf einer anderen GPU läuft als Chat
-OLLAMA_VISION_URL=http://host.docker.internal:11434
+# Separate URL für den Vision-Tier. Die URL bestimmt das PROTOKOLL:
+#   …/v1        → OpenAI-kompatibler Adapter (llama-server, multimodal)
+#   Host:Port   → nativer Ollama-Client
+OLLAMA_VISION_URL=http://cuda.local:8081/v1
 ```
 
 **Defaults:**
-- `OLLAMA_VISION_MODEL`: `""` (deaktiviert) — Code-Default. **Produktion setzt `qwen3-vl:8b`** (siehe `k8s/configmap.yaml`); der Vision-Tier ist seit 2026-05-22 aktiv und läuft auf dem cluster-internen `ollama`-Pod (k8s-gpu-1).
+- `OLLAMA_VISION_MODEL`: `""` (deaktiviert) — Code-Default. **Produktion setzt `qwen3.6`** (siehe `k8s/configmap.yaml`).
 - `OLLAMA_VISION_URL`: `None` (verwendet Standard-OLLAMA_URL)
 
-**Empfohlenes Modell:** `qwen3-vl:8b` (~12 GB VRAM, passt auf 16 GB Karten, gutes Deutsch).
+### Die URL bestimmt das Protokoll — beide Werte gehören zusammen
+
+`get_vision_client()` wählt anhand der URL: enthält sie `/v1`, kommt der OpenAI-kompatible Adapter zum Einsatz, sonst der native Ollama-Client. Das ist kein Flag, weil das Protokoll eine Eigenschaft des Endpunkts ist, nicht eine Präferenz.
+
+**Konsequenz:** `OLLAMA_VISION_URL` und `OLLAMA_VISION_MODEL` müssen **gemeinsam** umgestellt werden. Eine `/v1`-URL mit `qwen3-vl:8b` schickt einen Modellnamen an llama-server, den es ignoriert; ein Ollama-Host mit `qwen3.6` liefert ein 404, weil das Modell dort nicht liegt.
+
+### Vision läuft seit 2026-09-04 auf dem Hauptmodell (renfield#1206)
+
+`qwen3.6-35b-a3b` trägt `--mmproj` und ist auf der 5090 ohnehin geladen — Vision kostet damit **nirgends zusätzliches VRAM**.
+
+Vorher lief `qwen3-vl:8b` auf dem cluster-internen Ollama. Gemessen belegt dieses Modell **11,9 GB** (nicht die 6,14 GB Dateigröße aus dem Katalog) auf einer 16,3-GB-Karte, die sich Haushalt, xidra und reva teilen — das Laden **verdrängte alle drei anderen Modelle**, Kaltstart 25 s.
+
+Direktvergleich auf synthetischen Scans, drei Degradationsstufen, je 14 Ground-Truth-Felder:
+
+| | Felder | Latenz | VRAM | Kollateralschaden |
+|---|---|---|---|---|
+| **Hauptmodell** | **41/42** | **1,2–1,7 s** | 0 | keiner |
+| `qwen3-vl:8b` | 42/42 | 5,5–26,6 s warm, +25 s kalt | 11,9 GB | räumt die Karte leer |
+
+Der eine Fehltreffer ist eine Ziffer einer Steuernummer auf der am stärksten degradierten Vorlage. Solche Scans landen ohnehin in `/brain/review`.
+
+**Rückbau auf ein dediziertes VLM:** `OLLAMA_VISION_URL` zurück auf den Ollama-Host **und** `OLLAMA_VISION_MODEL` zurück auf `qwen3-vl:8b`. Vision ganz abschalten: `OLLAMA_VISION_MODEL=""`.
 
 Siehe [SATELLITE_CAMERA.md](SATELLITE_CAMERA.md) für Setup und Modellvergleich.
 

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -47,7 +47,12 @@ data:
   REDIS_URL: "redis://redis:6379"
   OLLAMA_URL: "http://ollama:11434"
   OLLAMA_EMBED_URL: "http://ollama:11434"
-  OLLAMA_VISION_URL: "http://ollama:11434"
+  # Vision tier moved to the multimodal MAIN model (renfield#1206, 2026-09-04).
+  # A /v1 URL selects the OpenAI-compat adapter (get_vision_client), which
+  # translates Ollama-style `images` into typed content parts. Rollback to a
+  # dedicated VLM = set this back to http://ollama:11434 AND
+  # OLLAMA_VISION_MODEL back to qwen3-vl:8b — the two must move together.
+  OLLAMA_VISION_URL: "http://cuda.local:8081/v1"
   OLLAMA_FALLBACK_URL: ""
   # DLNA MCP runs on hostNetwork (any worker); the `dlna-mcp` Service routes to it.
   DLNA_MCP_URL: "http://dlna-mcp:9091/mcp"
@@ -77,11 +82,26 @@ data:
   #     /v1/embeddings. Same qwen3-embedding:4b model, just GPU-served
   #     (10-20x faster than the previous CPU path on k8s-gpu-2).
   #     llama-server-embed deployment is scaled to 0 (replicas=0).
-  # Vision tier ENABLED — OLLAMA_VISION_MODEL=qwen3-vl:8b (see below),
-  # served by the existing in-cluster `ollama` pod on k8s-gpu-1 (idle
-  # 16 GB RTX 5060 Ti). OLLAMA_VISION_URL already routes there, so no
-  # separate llama-server-vision pod is needed. Rollback: set the model
-  # back to "".
+  # Vision tier ENABLED and served by the MAIN model since 2026-09-04
+  # (renfield#1206): qwen3.6-35b-a3b carries --mmproj and is already hot on the
+  # 5090, so vision costs no extra VRAM anywhere.
+  #
+  # It previously ran qwen3-vl:8b on the in-cluster Ollama. Measured, that model
+  # takes 11.9 GB resident (not the 6.14 GB catalogue file size) on a 16.3 GB
+  # card shared with reva — loading it EVICTED ALL THREE other models, and cost
+  # 25 s to load cold.
+  #
+  # Benchmarked head-to-head on synthetic scans across 3 degradation levels,
+  # 14 ground-truth fields each (invoice/customer/meter numbers, IBAN, tax id,
+  # amounts, dates):
+  #   main model      41/42 fields, 1.2-1.7 s, 0 GB extra, no eviction
+  #   qwen3-vl:8b     42/42 fields, 5.5-26.6 s warm (+25 s cold), evicts the card
+  # The single miss is one digit of a tax id on the most degraded page. Those
+  # scans land in /brain/review anyway.
+  #
+  # Rollback: OLLAMA_VISION_URL back to http://ollama:11434 AND
+  # OLLAMA_VISION_MODEL back to qwen3-vl:8b (both, or the schema mismatches).
+  # Disable entirely: OLLAMA_VISION_MODEL="".
   LLM_OPENAI_BASE_URL: "http://cuda.local:8081/v1"
   # LLM_OPENAI_API_KEY is sourced from the `renfield-secrets`/`llm-openai-api-key`
   # Secret in backend.yaml. llama-server accepts any non-empty value today;
@@ -212,7 +232,7 @@ data:
   OLLAMA_RAG_MODEL: "qwen3:14b"
   OLLAMA_INTENT_MODEL: "qwen3:8b"
   OLLAMA_EMBED_MODEL: "qwen3-embedding:4b"
-  OLLAMA_VISION_MODEL: "qwen3-vl:8b"
+  OLLAMA_VISION_MODEL: "qwen3.6"
   AGENT_MODEL: "qwen3.6"
   EMBEDDING_DIMENSION: "2560"
   # B.4.d: WHISPER_MODEL, PIPER_VOICES, PIPER_DEFAULT_VOICE removed.

--- a/src/backend/services/ollama_service.py
+++ b/src/backend/services/ollama_service.py
@@ -285,11 +285,13 @@ WICHTIGE REGELN FÜR ANTWORTEN:
                 "Answer with ONLY a single integer. /no_think"
             )
             messages = [{"role": "user", "content": prompt, "images": [image_b64]}]
-            if settings.ollama_vision_url:
-                from utils.llm_client import _make_client_with_fallback
-                vision_client = _make_client_with_fallback(settings.ollama_vision_url)
-            else:
-                vision_client = self.client
+            # Vision tier: get_vision_client picks the protocol from the URL, so a
+            # /v1 endpoint (the multimodal main model on cuda.local) gets the
+            # OpenAI-compat adapter and a plain host keeps the native Ollama
+            # client. Falls back to the chat client when vision has no own URL.
+            from utils.llm_client import get_vision_client
+            _vision = get_vision_client()
+            vision_client = _vision[0] if _vision else self.client
 
             resp = await vision_client.chat(
                 model=vision_model,
@@ -387,11 +389,13 @@ WICHTIGE REGELN FÜR ANTWORTEN:
                 "no markdown, no code fences. /no_think"
             )
             messages = [{"role": "user", "content": prompt, "images": [image_b64]}]
-            if settings.ollama_vision_url:
-                from utils.llm_client import _make_client_with_fallback
-                vision_client = _make_client_with_fallback(settings.ollama_vision_url)
-            else:
-                vision_client = self.client
+            # Vision tier: get_vision_client picks the protocol from the URL, so a
+            # /v1 endpoint (the multimodal main model on cuda.local) gets the
+            # OpenAI-compat adapter and a plain host keeps the native Ollama
+            # client. Falls back to the chat client when vision has no own URL.
+            from utils.llm_client import get_vision_client
+            _vision = get_vision_client()
+            vision_client = _vision[0] if _vision else self.client
 
             resp = await vision_client.chat(
                 model=vision_model,
@@ -455,11 +459,13 @@ WICHTIGE REGELN FÜR ANTWORTEN:
             })
 
             # Use dedicated vision URL if configured, otherwise default client
-            if settings.ollama_vision_url:
-                from utils.llm_client import _make_client_with_fallback
-                vision_client = _make_client_with_fallback(settings.ollama_vision_url)
-            else:
-                vision_client = self.client
+            # Vision tier: get_vision_client picks the protocol from the URL, so a
+            # /v1 endpoint (the multimodal main model on cuda.local) gets the
+            # OpenAI-compat adapter and a plain host keeps the native Ollama
+            # client. Falls back to the chat client when vision has no own URL.
+            from utils.llm_client import get_vision_client
+            _vision = get_vision_client()
+            vision_client = _vision[0] if _vision else self.client
 
             classification_kwargs = get_classification_chat_kwargs(vision_model)
             async for chunk in await vision_client.chat(

--- a/src/backend/utils/llm_client.py
+++ b/src/backend/utils/llm_client.py
@@ -656,19 +656,69 @@ class OpenAICompatibleClient:
         self._default_model = default_model
         self._base_url = base_url
 
-    @staticmethod
-    def _convert_messages(messages: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    # base64 magic prefixes -> mime type. Everything Renfield renders itself is
+    # PNG (document_processor re-encodes every page that way), but the satellite
+    # camera path forwards whatever the device sent, so sniff rather than assume.
+    _B64_IMAGE_MAGIC: tuple[tuple[str, str], ...] = (
+        ("iVBORw0KGgo", "image/png"),
+        ("/9j/", "image/jpeg"),
+        ("R0lGOD", "image/gif"),
+        ("UklGR", "image/webp"),
+    )
+
+    @classmethod
+    def _image_data_url(cls, raw: str) -> str:
+        """Turn a bare base64 image into a data: URL, passing through real URLs.
+
+        Ollama takes bare base64 in `images`; the OpenAI schema wants a URL, and
+        llama-server accepts a data: URL there.
+        """
+        s = (raw or "").strip()
+        if s.startswith("data:") or s.startswith("http://") or s.startswith("https://"):
+            return s
+        mime = "image/png"
+        for prefix, candidate in cls._B64_IMAGE_MAGIC:
+            if s.startswith(prefix):
+                mime = candidate
+                break
+        return f"data:{mime};base64,{s}"
+
+    @classmethod
+    def _convert_messages(cls, messages: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
         """Pass Renfield's chat-message list through with minor normalization.
 
-        Ollama and OpenAI use the same {role, content} shape; tool messages
-        and tool_calls also match. Only difference: Ollama allows `images`
-        on user messages — we strip those (vision goes to a separate tier).
+        Ollama and OpenAI use the same {role, content} shape; tool messages and
+        tool_calls also match. The one real difference is images: Ollama carries
+        them as a sibling `images: [b64]` key, OpenAI as typed parts inside
+        `content`.
+
+        This used to STRIP `images` ("vision goes to a separate tier"). That held
+        while vision only ever went to native Ollama, but it left a trap on the
+        OpenAI-compat path: the prompt still says "transcribe this document
+        image" while the image is silently dropped. Measured against
+        qwen3.6-35b-a3b the model then refuses ("no image has been provided")
+        rather than inventing text — a loud failure, but one whose cause is
+        invisible from the caller's side. Translating instead is what lets the
+        multimodal main model serve the vision tier (renfield#1206).
         """
         if not messages:
             return []
         out: list[dict[str, Any]] = []
         for m in messages:
+            images = m.get("images") or []
             mm = {k: v for k, v in m.items() if k != "images"}
+            if images:
+                content = mm.get("content")
+                parts: list[dict[str, Any]] = []
+                if isinstance(content, list):
+                    parts.extend(content)
+                elif content:
+                    parts.append({"type": "text", "text": content})
+                parts.extend(
+                    {"type": "image_url", "image_url": {"url": cls._image_data_url(img)}}
+                    for img in images
+                )
+                mm["content"] = parts
             out.append(mm)
         return out
 
@@ -857,6 +907,40 @@ def get_openai_compat_client() -> OpenAICompatibleClient | None:
             default_model=settings.llm_openai_model,
         )
     return _client_cache.get(cache_key)  # type: ignore[return-value]
+
+
+def get_vision_client() -> tuple[LLMClient, str] | None:
+    """Client + model for the vision tier, or None when vision is disabled.
+
+    ``OLLAMA_VISION_URL`` decides the protocol, because the two backends speak
+    different schemas and the caller must not have to care:
+
+    - a URL containing ``/v1`` -> the OpenAI-compatible adapter, which now
+      translates Ollama-style ``images`` into typed content parts
+      (``_convert_messages``). This is what lets the multimodal MAIN model serve
+      vision from cuda.local instead of loading a second VLM (renfield#1206).
+    - anything else -> the native Ollama client, unchanged behaviour.
+    - unset -> None, and the caller keeps using its chat client.
+
+    Sniffing the URL rather than adding another tier flag is deliberate: the
+    protocol is a property of the endpoint, not a preference. A flag could be
+    set to disagree with the URL, and the failure mode would be a 404 at request
+    time (llama-server has no ``/api/chat``) — or, before this change, a
+    silently image-less prompt the model could only refuse.
+    """
+    url = settings.ollama_vision_url
+    model = settings.ollama_vision_model
+    if not url or not model:
+        return None
+    if "/v1" in url:
+        cache_key = f"__openai_compat_vision__:{_normalize_url(url)}"
+        if cache_key not in _client_cache:
+            _client_cache[cache_key] = _make_openai_compat_client(  # type: ignore[assignment]
+                base_url=url,
+                default_model=model,
+            )
+        return _client_cache[cache_key], model  # type: ignore[return-value]
+    return _make_client_with_fallback(url), model
 
 
 def get_openai_compat_embed_client() -> OpenAICompatibleClient | None:

--- a/tests/backend/test_llm_client.py
+++ b/tests/backend/test_llm_client.py
@@ -47,6 +47,7 @@ from utils.llm_client import (
     get_embed_client,
     get_intent_client,
     get_openai_compat_client,
+    get_vision_client,
     get_openai_compat_embed_client,
     is_thinking_model,
     use_openai_for_tier,
@@ -766,22 +767,32 @@ class TestOpenAICompatibleClientChat:
 
     @pytest.mark.unit
     @pytest.mark.asyncio
-    async def test_strips_images_from_user_message(self, monkeypatch):
-        """Vision payloads (`images=[…]`) on user messages aren't supported
-        by the agent llama-server (single-model) and would otherwise be sent
-        as an unknown field. The adapter strips them silently."""
+    async def test_translates_images_on_user_message(self, monkeypatch):
+        """SUPERSEDES `test_strips_images_from_user_message` (renfield#1206).
+
+        The old expectation — strip `images` silently — was written when the
+        agent llama-server was text-only. It is now multimodal (`--mmproj`) and
+        serves the vision tier, so stripping would send "transcribe this image"
+        with no image attached; the model can only refuse, and nothing upstream
+        shows why. The adapter translates into typed OpenAI content parts
+        instead. The Ollama-only `images` key must still not reach the request.
+        """
         adapter = _make_openai_compat(monkeypatch)
         adapter._client.chat.completions.create.return_value = _stub_openai_response()
 
         await adapter.chat(
             messages=[
-                {"role": "user", "content": "describe", "images": ["base64-blob"]},
+                {"role": "user", "content": "describe", "images": ["iVBORw0KGgoAAAA"]},
             ],
         )
 
         sent = adapter._client.chat.completions.create.call_args.kwargs["messages"]
-        assert sent[0] == {"role": "user", "content": "describe"}
         assert "images" not in sent[0]
+        assert sent[0]["role"] == "user"
+        parts = sent[0]["content"]
+        assert parts[0] == {"type": "text", "text": "describe"}
+        assert parts[1]["type"] == "image_url"
+        assert parts[1]["image_url"]["url"].startswith("data:image/png;base64,")
 
 
 class TestOpenAICompatibleClientStreaming:
@@ -1760,6 +1771,95 @@ class TestGetIntentClient:
         monkeypatch.setattr("utils.llm_client.settings.ollama_url", "http://ollama:11434")
 
         assert not isinstance(get_intent_client(), OpenAICompatibleClient)
+# Vision tier — image translation + endpoint protocol (renfield#1206)
+# ============================================================================
+
+class TestVisionImageTranslation:
+    """`_convert_messages` used to DROP Ollama-style `images`. On the
+    OpenAI-compat path that silently produced an image-less prompt — the model
+    can only refuse, and nothing upstream shows why."""
+
+    @pytest.mark.unit
+    def test_images_become_typed_content_parts(self):
+        out = OpenAICompatibleClient._convert_messages(
+            [{"role": "user", "content": "transcribe this", "images": ["iVBORw0KGgoAAAA"]}]
+        )
+        assert len(out) == 1
+        parts = out[0]["content"]
+        assert isinstance(parts, list), "images must be translated, not dropped"
+        assert parts[0] == {"type": "text", "text": "transcribe this"}
+        assert parts[1]["type"] == "image_url"
+        assert parts[1]["image_url"]["url"].startswith("data:image/png;base64,iVBORw0KGgo")
+        assert "images" not in out[0], "the Ollama-only key must not leak into the request"
+
+    @pytest.mark.unit
+    def test_mime_is_sniffed_not_assumed(self):
+        """The satellite camera path forwards whatever the device sent."""
+        cases = [
+            ("iVBORw0KGgoAAAA", "image/png"),
+            ("/9j/4AAQSkZJRg", "image/jpeg"),
+            ("R0lGODlhAQAB", "image/gif"),
+            ("UklGRiQAAABX", "image/webp"),
+            ("Zm9vYmFy", "image/png"),  # unknown -> PNG, what Renfield renders
+        ]
+        for b64, expected in cases:
+            url = OpenAICompatibleClient._image_data_url(b64)
+            assert url.startswith(f"data:{expected};base64,"), f"{b64} -> {url}"
+
+    @pytest.mark.unit
+    def test_existing_data_url_and_http_pass_through(self):
+        for raw in ("data:image/png;base64,AAAA", "https://example.invalid/a.png"):
+            assert OpenAICompatibleClient._image_data_url(raw) == raw
+
+    @pytest.mark.unit
+    def test_messages_without_images_are_untouched(self):
+        """Every non-vision call must stay byte-identical."""
+        msgs = [
+            {"role": "system", "content": "s"},
+            {"role": "user", "content": "u"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "1"}]},
+        ]
+        assert OpenAICompatibleClient._convert_messages(msgs) == msgs
+
+    @pytest.mark.unit
+    def test_multiple_images_all_appended(self):
+        out = OpenAICompatibleClient._convert_messages(
+            [{"role": "user", "content": "t", "images": ["iVBORw0KGgo1", "iVBORw0KGgo2"]}]
+        )
+        parts = out[0]["content"]
+        assert [p["type"] for p in parts] == ["text", "image_url", "image_url"]
+
+
+class TestGetVisionClient:
+    """The vision endpoint's PROTOCOL is a property of its URL: llama-server has
+    no /api/chat, so sending it the Ollama schema is a 404."""
+
+    @pytest.mark.unit
+    def test_v1_url_selects_the_openai_adapter(self, monkeypatch):
+        monkeypatch.setattr("utils.llm_client.settings.ollama_vision_url", "http://cuda.local:8081/v1")
+        monkeypatch.setattr("utils.llm_client.settings.ollama_vision_model", "qwen3.6")
+        monkeypatch.setattr("utils.llm_client.settings.llm_openai_api_key", None)
+        client, model = get_vision_client()
+        assert isinstance(client, OpenAICompatibleClient)
+        assert client._base_url == "http://cuda.local:8081/v1"
+        assert model == "qwen3.6"
+
+    @pytest.mark.unit
+    def test_plain_host_keeps_the_ollama_client(self, monkeypatch):
+        monkeypatch.setattr("utils.llm_client.settings.ollama_vision_url", "http://ollama:11434")
+        monkeypatch.setattr("utils.llm_client.settings.ollama_vision_model", "qwen3-vl:8b")
+        client, model = get_vision_client()
+        assert not isinstance(client, OpenAICompatibleClient)
+        assert model == "qwen3-vl:8b"
+
+    @pytest.mark.unit
+    def test_none_when_vision_disabled(self, monkeypatch):
+        monkeypatch.setattr("utils.llm_client.settings.ollama_vision_url", "http://cuda.local:8081/v1")
+        monkeypatch.setattr("utils.llm_client.settings.ollama_vision_model", "")
+        assert get_vision_client() is None
+        monkeypatch.setattr("utils.llm_client.settings.ollama_vision_model", "qwen3.6")
+        monkeypatch.setattr("utils.llm_client.settings.ollama_vision_url", "")
+        assert get_vision_client() is None
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
Moves the vision tier off the dedicated `qwen3-vl:8b` onto the main model, which already carries `--mmproj` and is hot on the 5090. Closes the eviction problem in #1206 without waiting for the 4th GPU.

**This was not a config-only change** — see "Two things in the way" below.

## Measurement

`qwen3-vl:8b` takes **11.9 GB** resident — not the 6.14 GB catalogue file size — on a 16.3 GB card shared by the household, xidra and reva. Loading it **evicted all three** other models (embeddings, reva's router, reva's embeddings). Cold load: 25 s.

Head-to-head on synthetic scans across 3 degradation levels (0.6° skew → 3.4° skew + 55% contrast + heavy grain + JPEG q38 → 90° rotation), 14 ground-truth fields each — invoice/customer/meter numbers, IBAN, tax id, amounts, dates. Production prompt from `_vlm_ocr`, `temperature=0`.

| | Fields | Latency | Extra VRAM | Collateral |
|---|---|---|---|---|
| **main model** | **41/42** | **1.2–1.7 s** | **0** | none |
| `qwen3-vl:8b` | 42/42 | 5.5–26.6 s warm, +25 s cold | 11.9 GB | evicts the card |

The single miss is one digit of a tax id (`214/9678/9012` vs `214/5678/9012`) on the most degraded page, reproducible across runs. Those scans land in `/brain/review` anyway. Notably both models get the 22-digit IBAN and the meter number `1Z-4471-9930` — visually near-indistinguishable from `12-…` in the degraded image — right in all three cases.

Scans are synthetic on purpose: production paperwork must not go into a benchmark, and it makes the ground truth exact.

## Two things in the way

1. **`_convert_messages` stripped `images`.** Comment said "vision goes to a separate tier" — true while vision only went to native Ollama, but it left a trap: the prompt still says "transcribe this document image" while the image is silently dropped. Measured, the model then *refuses* ("no image has been provided") rather than inventing text — loud, but with no hint of the cause at the caller. Now translated into typed OpenAI content parts, with the mime type sniffed from base64 magic (the satellite camera path forwards whatever the device sent; everything Renfield renders itself is PNG).

2. **`create_llm_client` always returns an Ollama client**, regardless of URL. The comment in `agent_router.classify` claiming it picks the OpenAI adapter for `/v1` URLs is **wrong**. Simply repointing `OLLAMA_VISION_URL` would have produced a 404 on `/api/chat`. New `get_vision_client()` picks the protocol from the URL and returns `(client, model)`; the three vision call sites use it.

The URL decides the protocol rather than a new flag, because the protocol is a property of the endpoint, not a preference — a flag could be set to disagree with the URL. Documented consequence: `OLLAMA_VISION_URL` and `OLLAMA_VISION_MODEL` must move together.

## Test plan
- [x] **End-to-end through the real production path** (Ollama-schema messages → `get_vision_client` → llama-server), not a hand-built request: 14/14 on the clean page in 1.8 s; the degraded page reproduces the exact known 13/14 signature — which is what proves the image actually arrives rather than being answered from the prompt alone. A no-image control returns the refusal.
- [x] 9 new unit tests: translation shape, mime sniffing across png/jpeg/gif/webp/unknown, data-URL and http passthrough, multi-image, non-vision messages byte-identical, and the three `get_vision_client` protocol cases.
- [x] Supersedes `test_strips_images_from_user_message`, which encoded the old behaviour. The replacement asserts translation **and** that the Ollama-only `images` key still never reaches the request.
- [x] **364 passed, 3 skipped, 0 failed** on `.159` across `test_llm_client`, both `document_processor` suites, `test_followup_service`, `test_agent_router`, `test_metrics`, `test_pdf_splitter`.

## Scope
Does **not** replace option A from #1206. When the 4th GPU lands, a dedicated VLM there is still better — full accuracy without loading the 5090, whose prefix cache we are otherwise protecting. This is the version that is available today without hardware, and it is strictly better than the status quo: 13/14 in 1.5 s with no collateral beats 14/14 in 30 s that wipes a shared card.

xidra mirror: x-ren `feat/vision-on-main-model` (separate repo, gitignored here). **It requires this PR's image** — on an older backend the adapter still strips images and the model can only refuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XD5cZpiHcMhmbDJxQdcH6x