### PR TITLE
fix(satellite): AIC3104 ADC high-pass — capture DC offset drove wakeword false positives

### DIFF
--- a/src/satellite/provisioning/provision.yml
+++ b/src/satellite/provisioning/provision.yml
@@ -516,9 +516,56 @@
     # Persist the WM8960 mixer state ONCE, after whichever of the two tuning
     # tasks above ran — so a host with BOTH ALC + input-path enabled doesn't
     # store twice. Restored on boot by alsa-restore.service.
-    - name: Persist WM8960 ALSA mixer state
+    # --- TLV320AIC3104 (hat_type "2mic-v2") ADC high-pass filter ---
+    # The AIC3104 ships with 'ADC HPF Cut-off' = Disabled, which leaves a large
+    # DC offset on the capture path. Measured on sat-kinderbad 2026-09-04:
+    #
+    #   DC component  2320.9  (-23.0 dBFS)
+    #   real ambient    56.4  (-55.3 dBFS)
+    #
+    # i.e. the offset sat 32 dB ABOVE the room. A spectrum of the capture put
+    # 100 % of the energy below 100 Hz, dominated by 0 Hz.
+    #
+    # Two consequences, and the second is the expensive one:
+    #   1. `audio_rms` in the heartbeat is computed without removing the mean,
+    #      so the satellite reported ~1812 where the true ambient was ~5. Any
+    #      comparison of mic levels across satellites was meaningless.
+    #   2. The wakeword model sees a constant offset it was never trained on and
+    #      fires at high confidence on it — sat-kinderbad produced false wakes at
+    #      0.84-0.98 (4 of 5 sessions ended in an empty transcription), while the
+    #      threshold sits at 0.5. Raising the threshold cannot fix that, and the
+    #      threshold is fleet-wide anyway.
+    #
+    # 0.0045xFs is the gentlest of the three cut-offs (~72 Hz at 16 kHz) — it
+    # removes the offset and leaves the speech band untouched. After enabling:
+    # DC 0.0, ambient -76 dBFS.
+    #
+    # Off by default; enable per host. Same `audio` tag → applies restart-free:
+    #   ansible-playbook … --tags audio --limit <host>
+    - name: Configure AIC3104 ADC high-pass filter (removes capture DC offset)
       tags: [driver, config, audio]
-      when: (wm8960_alc_enabled | default(false)) or (wm8960_input_path_enabled | default(false))
+      when: aic3104_adc_hpf_enabled | default(false)
+      ansible.builtin.command:
+        argv:
+          - amixer
+          - -c
+          - "{{ aic3104_alsa_card | default('0') }}"
+          - sset
+          - "ADC HPF Cut-off"
+          # Both channels: a single value only sets Item0 and leaves the right
+          # channel Disabled (verified on sat-kinderbad).
+          - "{{ aic3104_adc_hpf }},{{ aic3104_adc_hpf }}"
+      changed_when: true
+
+    # Persist the mixer state ONCE, after whichever tuning task above ran — so a
+    # host with several enabled doesn't store repeatedly. Restored on boot by
+    # alsa-restore.service.
+    - name: Persist ALSA mixer state
+      tags: [driver, config, audio]
+      when: >-
+        (wm8960_alc_enabled | default(false))
+        or (wm8960_input_path_enabled | default(false))
+        or (aic3104_adc_hpf_enabled | default(false))
       ansible.builtin.command:
         argv: [alsactl, store]
       changed_when: true


### PR DESCRIPTION
## Summary
Adds an opt-in Ansible task that enables the AIC3104 ADC high-pass filter. Enabled for `sat-kinderbad`, where a DC offset on the capture path was driving wakeword false positives and making every cross-satellite mic-level comparison meaningless.

## Symptom
`sat-kinderbad` produced a stream of false wakes — 4 of 5 sessions ended in an empty transcription, 15 in 6 h while the other two satellites produced zero. Confidences **0.84–0.98** against a threshold of **0.5**.

The threshold was the wrong lever twice over: it is fleet-wide, and a model firing at 0.9+ on noise cannot be thresholded away. The `renfield_de` FP-hardening work recorded exactly that lesson in 2026-06 — *"Threshold can't fix a model firing at 0.90-0.99 on noise"* — along with the follow-up: check the microphone path before retraining.

## Measurement
`ADC HPF Cut-off` ships as `Disabled` on the TLV320AIC3104:

| | Level |
|---|---|
| DC component | 2320.9 → **−23.0 dBFS** |
| Real room ambient | 56.4 → **−55.3 dBFS** |

The offset sat **32 dB above the room**, and a spectrum put **100 % of the captured energy below 100 Hz**, dominated by 0 Hz. After enabling the gentlest cut-off (`0.0045xFs`, ~72 Hz at 16 kHz — speech band untouched): **DC 0.0, ambient −76 dBFS.**

## I had this backwards first
`audio_rms` in the heartbeat is computed without removing the mean, so the satellite reported **1812** where the true ambient was **~5** — next to a healthy satellite reporting 86. I read that as "gain far too high" and was about to turn the microphone **down**, which would have made an already-quiet mic quieter and broken wake-word recall.

The comparison was measuring an artefact. The mic is not too loud; the signal has an offset. That the earlier `renfield_de` case *was* a genuine gain problem made the wrong reading tempting.

## Change
- New task, off by default, enabled per host via `aic3104_adc_hpf_enabled` — mirrors the existing WM8960 tasks and carries the `audio` tag, so it applies restart-free.
- Sets **both** channels: a single value only sets `Item0` and leaves the right channel `Disabled` (verified on the device).
- The persist task is widened so `alsactl store` still runs exactly once for a host with several tuning tasks enabled.
- The per-host values live in the gitignored `host_vars`. The stale header there claiming a WM8960 codec is corrected — `aplay -l` reports `bcm2835-i2s-tlv320aic3x-hifi`, and the inventory correctly says `hat_type: 2mic-v2`.

## Test plan
- [x] Applied live, measured before/after: DC 2320.9 → 0.0, total RMS 2321.6 → 5.2.
- [x] Satellite heartbeat now reports `audio_rms 2.8 / -81.4 dBFS` (was 1812) — non-zero, i.e. the ADC still produces signal, unlike the genuinely dead capture path in #1211.
- [x] `alsactl store` — survives reboot.
- [x] **Provisioning round-trip:** set the control back to `Disabled`, ran `--tags audio --limit satellite-kinderbad`, both channels returned to `0.0045xFs` and DC to −0.0. The setting survives a re-provision rather than living only in device state.

## What is NOT proven
- **That the false positives stop.** The cause of the measurement artefact is established; the FP claim is a reasoned expectation that needs hours of observation.
- **Recall.** Whether the device still hears a real "Renfield" cannot be checked remotely — that needs someone in the room. If recall regressed, `aic3104_adc_hpf_enabled: false` reverts it restart-free.

## Related
- #1211 — `sat-wohnzimmer` has no capture device at all, found during the same level comparison. Opposite failure, unrelated cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XD5cZpiHcMhmbDJxQdcH6x