### PR TITLE
fix(gitignore): private room audio and business screenshots were committable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,18 @@ coverage/
 data/wakeword-models/*.tflite
 data/wakeword-models/*.onnx
 
+# Private household room audio — wakeword commissioning captures.
+# CLAUDE.md and docs/SATELLITE_ACOUSTIC_COMMISSIONING.md both state these are
+# gitignored; they were NOT, so a `git add -A` would have committed raw
+# recordings of the house to a public repo. Captures are training material and
+# are meant to be deleted after use.
+data/wakeword-ambient/
+
+# Private business-instance screenshots — NEVER public git, same rule as the
+# Simba docs. These land in the repo root from browser verification runs.
+*xidra*.png
+*simba*.png
+
 # Test screenshots (ephemeral browser test artifacts)
 test-screenshots/
 


### PR DESCRIPTION
Found while verifying an unrelated PR's working tree (#1216). Not a code change
— it closes a gap between what the docs promise and what git actually enforces.

## The gap

`data/wakeword-ambient/` was **not** ignored, even though **CLAUDE.md and
`docs/SATELLITE_ACOUSTIC_COMMISSIONING.md` both state that it is**. The
neighbouring rule only covered `data/wakeword-models/*.onnx`, so the omission
was easy to miss — and the docs asserting the protection made it *less* likely
anyone would check.

Consequence: **247 MB of raw household room audio** sat untracked in the working
tree, one `git add -A` away from a public repository. Room captures are, by
design, recordings of the house.

Three business-instance screenshots (xidra / Simba) were untracked in the repo
root for the same reason — browser verification runs drop them there. Same rule
as the Simba documentation: these never belong in the public repo.

## Change

Adds to `.gitignore`:

- `data/wakeword-ambient/` — private household room audio
- `*xidra*.png`, `*simba*.png` — business-instance screenshots

The ignore rules land **before** the cleanup deliberately, so a re-created
capture or a screenshot from the next verification run is protected from the
moment it appears, not just today's files.

The six files themselves were deleted separately, at the owner's explicit
request. They were untracked, so git held no copy and the deletion is not
recoverable from this repo.

## Worth noting

A doc claiming something is gitignored is not evidence. `git check-ignore` is.

## Test plan

- [x] `git check-ignore` confirms all four sample paths are ignored after the change
- [x] No tracked file is affected — `.gitignore` is the only change
- [x] Remaining untracked files (`llm-bench.sh`, `satellite-faceplate/`,
      `renfield_de_v4.onnx.bak`, two household screenshots) deliberately
      untouched — not private, not flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iG4mG4bmRugn3xkJeJN8K
