### PR TITLE
feat(ingest): per-integration credentials + auth path, Phase 1 (#1218)

### DIFF
--- a/docs/design/ingest-credentials.md
+++ b/docs/design/ingest-credentials.md
@@ -67,17 +67,35 @@ ingest_credentials
 Storing a **bcrypt hash, never the plaintext**, is the material improvement over
 the current SystemSetting, which holds the token in the clear.
 
-### Auth path
+### Auth path — self-identifying tokens
 
 `verify_folder_ingest_token(db, token)` becomes
-`resolve_ingest_client(db, route, token) -> IngestClient | None`: it walks the
-enabled, unrevoked credentials for that route and returns the matching client.
-Push handlers gain the client's identity.
+`resolve_ingest_client(db, route, token) -> IngestClient | None`.
 
-Cost to note honestly: bcrypt-per-push over N credentials is slower than one
-constant-time compare. With a handful of clients this is irrelevant next to the
-document processing that follows, but it is a real change and belongs in the
-plan rather than discovered later.
+**The token carries its own client_id: `rfi.<client_id>.<secret>`.** Resolution
+is one indexed lookup plus **one** bcrypt round.
+
+This replaces the obvious design — walk the stored credentials and bcrypt each
+until one matches — which costs N bcrypt rounds for every *rejected* token. At
+~250ms per round that hands anyone who can reach the push endpoint a cheap
+denial of service, and it degrades with each integration added. Putting the
+client_id in the token is not a secret leak: it names the client, it does not
+authenticate it.
+
+Two details that follow from it:
+
+- **Timing equalisation on the miss path.** An unknown client_id would
+  otherwise return without hashing (~0ms) while a real one spends a full round,
+  which enumerates valid client_ids. One throwaway verify against a dummy hash
+  equalises the branches — the same defence, for the same reason, as
+  `auth_service._DUMMY_PASSWORD_HASH`.
+- **Route/revocation checks come AFTER the hash**, so a revoked, disabled or
+  wrong-route credential cannot be distinguished from a wrong secret by timing.
+
+The parser is deliberately strict (a token containing an uppercase client_id is
+not ours) while *minting* normalises case and whitespace. Every minted token is
+already canonical, so normalising at parse time would let two spellings resolve
+to one row.
 
 ### Knowing the client unlocks server-authoritative sphere routing
 
@@ -193,9 +211,9 @@ a time; the legacy credential is removed only once no client has used it, which
 
 ## Risks / accepted residuals
 
-- **bcrypt per push, over N credentials**, replaces one constant-time compare.
-  Negligible beside document processing at this scale; revisit if the credential
-  count ever grows large.
+- **One bcrypt round per push** replaces one constant-time compare. Negligible
+  beside the document processing that follows, and it does NOT grow with the
+  number of credentials, because the token identifies its own row.
 - **A rotation grace window means two valid tokens briefly.** Deliberate: the
   alternative is locking a client out on a mid-rotation crash. Bounded and
   configurable.

--- a/src/backend/alembic/versions/pc20260908_ingest_credentials.py
+++ b/src/backend/alembic/versions/pc20260908_ingest_credentials.py
@@ -1,0 +1,71 @@
+"""ingest_credentials — per-integration machine credentials for the push routes.
+
+Revision ID: pc20260908_ingest_credentials
+Revises: pc20260901_doc_content_emb
+Create Date: 2026-09-08 00:00:00.000000
+
+Replaces the single shared SystemSetting token (``folder_ingest.token`` /
+``email_ingest.token``) with one credential per pushing integration. The shared
+token was stored in the CLEAR, could not be revoked per client, and left the
+backend unable to tell WHICH client pushed — the last of which is exactly what
+server-authoritative sphere routing needs.
+
+Mirrors ``pc20260624_satellite_enrollment``: bcrypt ``token_hash`` only,
+``revoked_at`` + ``is_enabled`` for independent revocation, and
+``last_authenticated_at`` so retiring the legacy token is an observation rather
+than a guess.
+
+ADDITIVE ONLY. The legacy SystemSetting tokens keep working; nothing is dropped
+here. The legacy row is removed in a later migration, once
+``last_authenticated_at`` shows no client still using it.
+
+See docs/design/ingest-credentials.md.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "pc20260908_ingest_credentials"
+down_revision = "pc20260901_doc_content_emb"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ingest_credentials",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        # Rides INSIDE the token (rfi.<client_id>.<secret>) so verification is
+        # one lookup + one bcrypt, not a bcrypt round per credential.
+        sa.Column("client_id", sa.String(length=64), nullable=False),
+        sa.Column("label", sa.String(length=200), nullable=False),
+        sa.Column("route", sa.String(length=32), nullable=False),
+        sa.Column("token_hash", sa.String(length=255), nullable=False),
+        sa.Column(
+            "created_by_user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("rotated_at", sa.DateTime(), nullable=True),
+        sa.Column("last_authenticated_at", sa.DateTime(), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(), nullable=True),
+        sa.Column(
+            "is_enabled", sa.Boolean(), nullable=False, server_default=sa.text("true")
+        ),
+    )
+    # UNIQUE, not just indexed: client_id is parsed out of the presented token
+    # and must resolve to exactly one row, or verification is ambiguous.
+    op.create_index(
+        "ix_ingest_credentials_client_id",
+        "ingest_credentials",
+        ["client_id"],
+        unique=True,
+    )
+    op.create_index("ix_ingest_credentials_route", "ingest_credentials", ["route"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ingest_credentials_route", table_name="ingest_credentials")
+    op.drop_index("ix_ingest_credentials_client_id", table_name="ingest_credentials")
+    op.drop_table("ingest_credentials")

--- a/src/backend/api/routes/email_ingest.py
+++ b/src/backend/api/routes/email_ingest.py
@@ -39,7 +39,7 @@ from services.email_ingest import (
     generate_email_ingest_token,
     ingest_email_document,
     resolve_mailbox_target,
-    verify_email_ingest_token,
+    resolve_email_ingest_client,
 )
 from services.folder_ingest import IngestStatus
 from utils.config import settings
@@ -117,7 +117,7 @@ async def ingest_pushed_email(
     if not authorization or not authorization.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
     token = authorization.removeprefix("Bearer ").strip()
-    if not await verify_email_ingest_token(db, token):
+    if await resolve_email_ingest_client(db, token) is None:
         raise HTTPException(status_code=403, detail="Invalid email-ingest token")
 
     # 3. Worker-alive gate (enqueuing into a stream nobody consumes → orphan).
@@ -195,7 +195,7 @@ async def health(
     if not authorization or not authorization.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
     token = authorization.removeprefix("Bearer ").strip()
-    if not await verify_email_ingest_token(db, token):
+    if await resolve_email_ingest_client(db, token) is None:
         raise HTTPException(status_code=403, detail="Invalid email-ingest token")
 
     mailbox_ids = [

--- a/src/backend/api/routes/folder_ingest.py
+++ b/src/backend/api/routes/folder_ingest.py
@@ -44,7 +44,7 @@ from services.folder_ingest import (
     resolve_owner_user_id,
     resolve_target_kb,
     target_kb_exists,
-    verify_folder_ingest_token,
+    resolve_folder_ingest_client,
 )
 from utils.config import settings
 
@@ -132,7 +132,10 @@ async def ingest_pushed_document(
     if not authorization or not authorization.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
     token = authorization.removeprefix("Bearer ").strip()
-    if not await verify_folder_ingest_token(db, token):
+    # Resolves to the PUSHING CLIENT, not just a boolean — per-integration
+    # credentials, with the legacy shared token still accepted as `legacy`.
+    ingest_client = await resolve_folder_ingest_client(db, token)
+    if ingest_client is None:
         raise HTTPException(status_code=403, detail="Invalid folder-ingest token")
 
     # 3. Worker-alive gate (reuse knowledge.py:_worker_is_alive). Enqueuing into
@@ -216,7 +219,10 @@ async def health(
     if not authorization or not authorization.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
     token = authorization.removeprefix("Bearer ").strip()
-    if not await verify_folder_ingest_token(db, token):
+    # Resolves to the PUSHING CLIENT, not just a boolean — per-integration
+    # credentials, with the legacy shared token still accepted as `legacy`.
+    ingest_client = await resolve_folder_ingest_client(db, token)
+    if ingest_client is None:
         raise HTTPException(status_code=403, detail="Invalid folder-ingest token")
 
     return FolderIngestHealthResponse(

--- a/src/backend/api/routes/ingest_credentials.py
+++ b/src/backend/api/routes/ingest_credentials.py
@@ -1,0 +1,196 @@
+"""Admin CRUD for per-integration ingest credentials (#1218 Phase 2).
+
+Closes the gap that provisioning a machine credential required hand-crafting an
+API call. Surfaced on the page that already manages MCP integrations.
+
+Two things this endpoint must get right, both of which the single-token model
+could not express:
+
+* **A token value is returned exactly once**, at mint or rotate. The list route
+  never returns one, and only a bcrypt hash is stored.
+* **The legacy shared token is reported with its SOURCE.** When
+  ``FOLDER_INGEST_TOKEN`` is set in the backend env, the boot reconciler
+  re-seeds the DB from it, so rotating it in the UI would silently revert at the
+  next restart. The UI renders an env-managed credential read-only rather than
+  offering an action it cannot make stick.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from loguru import logger
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import (
+    SETTING_EMAIL_INGEST_TOKEN,
+    SETTING_FOLDER_INGEST_TOKEN,
+    SystemSetting,
+)
+from models.permissions import Permission
+from services.api_rate_limiter import limiter
+from services.auth_service import require_permission
+from services.database import get_db
+from services.ingest_credentials import (
+    ROUTE_EMAIL,
+    ROUTE_FOLDER,
+    InvalidClientId,
+    list_credentials,
+    mint_credential,
+    revoke_credential,
+    rotate_credential,
+)
+from utils.config import settings
+
+router = APIRouter()
+
+_ROUTES = (ROUTE_FOLDER, ROUTE_EMAIL)
+# Which env var (if any) is authoritative for each route's legacy shared token.
+_LEGACY_ENV = {
+    ROUTE_FOLDER: ("folder_ingest_token", SETTING_FOLDER_INGEST_TOKEN),
+    ROUTE_EMAIL: ("email_ingest_token", SETTING_EMAIL_INGEST_TOKEN),
+}
+
+
+class CredentialOut(BaseModel):
+    client_id: str
+    label: str
+    route: str
+    created_at: str | None = None
+    rotated_at: str | None = None
+    last_authenticated_at: str | None = None
+    revoked_at: str | None = None
+    is_enabled: bool = True
+
+
+class LegacyOut(BaseModel):
+    """The shared token, if one is still provisioned for this route."""
+
+    route: str
+    configured: bool
+    # "env" => the boot reconciler re-seeds it; a UI rotation would silently
+    # revert at the next restart, so the UI must render it read-only.
+    source: str
+
+
+class CredentialListOut(BaseModel):
+    credentials: list[CredentialOut]
+    legacy: list[LegacyOut]
+    enabled: bool
+
+
+class MintIn(BaseModel):
+    client_id: str = Field(min_length=1, max_length=64)
+    label: str = Field(min_length=1, max_length=200)
+    route: str
+
+
+class TokenOut(BaseModel):
+    """The plaintext, returned ONCE. Never persisted, never returned again."""
+
+    client_id: str
+    token: str
+
+
+def _iso(value) -> str | None:
+    return value.isoformat() if value else None
+
+
+async def _legacy_state(db: AsyncSession) -> list[LegacyOut]:
+    out: list[LegacyOut] = []
+    for route, (settings_attr, setting_key) in _LEGACY_ENV.items():
+        env_value = (getattr(settings, settings_attr, "") or "").strip()
+        row = await db.get(SystemSetting, setting_key)
+        configured = bool(env_value) or bool(row and (row.value or "").strip())
+        out.append(
+            LegacyOut(
+                route=route,
+                configured=configured,
+                source="env" if env_value else "db",
+            )
+        )
+    return out
+
+
+@router.get("", response_model=CredentialListOut)
+@limiter.limit(settings.api_rate_limit_admin)
+async def list_all(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user=Depends(require_permission(Permission.SETTINGS_MANAGE)),
+):
+    """List credentials. NEVER returns a token value — only a bcrypt hash is
+    stored, and the plaintext existed once, at mint time."""
+    rows = await list_credentials(db)
+    return CredentialListOut(
+        credentials=[
+            CredentialOut(
+                client_id=r.client_id, label=r.label, route=r.route,
+                created_at=_iso(r.created_at), rotated_at=_iso(r.rotated_at),
+                last_authenticated_at=_iso(r.last_authenticated_at),
+                revoked_at=_iso(r.revoked_at), is_enabled=bool(r.is_enabled),
+            )
+            for r in rows
+        ],
+        legacy=await _legacy_state(db),
+        enabled=bool(getattr(settings, "ingest_credentials_enabled", False)),
+    )
+
+
+@router.post("", response_model=TokenOut)
+@limiter.limit(settings.api_rate_limit_admin)
+async def mint(
+    request: Request,
+    body: MintIn,
+    db: AsyncSession = Depends(get_db),
+    user=Depends(require_permission(Permission.SETTINGS_MANAGE)),
+):
+    """Mint a credential. The token is shown ONCE and cannot be recovered."""
+    if body.route not in _ROUTES:
+        raise HTTPException(status_code=400, detail=f"unknown route: {body.route}")
+    try:
+        token = await mint_credential(
+            db, client_id=body.client_id, label=body.label, route=body.route,
+            created_by_user_id=getattr(user, "id", None),
+        )
+    except InvalidClientId as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from None
+    logger.info(f"ingest credential minted via UI: {body.client_id}")
+    return TokenOut(client_id=body.client_id.strip().lower(), token=token)
+
+
+@router.post("/{client_id}/rotate", response_model=TokenOut)
+@limiter.limit(settings.api_rate_limit_admin)
+async def rotate(
+    request: Request,
+    client_id: str,
+    db: AsyncSession = Depends(get_db),
+    user=Depends(require_permission(Permission.SETTINGS_MANAGE)),
+):
+    """Rotate. The client keeps failing until its copy is updated — the UI warns
+    which client that is before the operator confirms."""
+    try:
+        token = await rotate_credential(db, client_id)
+    except InvalidClientId as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from None
+    return TokenOut(client_id=client_id.strip().lower(), token=token)
+
+
+@router.delete("/{client_id}")
+@limiter.limit(settings.api_rate_limit_admin)
+async def revoke(
+    request: Request,
+    client_id: str,
+    db: AsyncSession = Depends(get_db),
+    user=Depends(require_permission(Permission.SETTINGS_MANAGE)),
+):
+    """Revoke. The row is kept (not deleted) so the audit trail survives."""
+    try:
+        ok = await revoke_credential(db, client_id)
+    except InvalidClientId as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+    if not ok:
+        raise HTTPException(status_code=404, detail=f"unknown client_id: {client_id}")
+    return {"revoked": True, "client_id": client_id.strip().lower()}

--- a/src/backend/api/routes/mcp_health.py
+++ b/src/backend/api/routes/mcp_health.py
@@ -14,8 +14,8 @@ from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from services.database import get_db
-from services.email_ingest import verify_email_ingest_token
-from services.folder_ingest import verify_folder_ingest_token
+from services.email_ingest import resolve_email_ingest_client
+from services.folder_ingest import resolve_folder_ingest_client
 from services.mcp_health_monitor import ingest_report
 
 router = APIRouter()
@@ -25,8 +25,9 @@ async def _verify_any_ingest_token(db: AsyncSession, token: str) -> bool:
     """A health report is not a data path — the token only proves the caller is a
     legit renfield ingest MCP. Accept EITHER provisioned ingest token so the
     filesystem MCP (folder token) AND the email-ingest MCP (email token) can report."""
-    return await verify_folder_ingest_token(db, token) or await verify_email_ingest_token(
-        db, token
+    return (
+        await resolve_folder_ingest_client(db, token) is not None
+        or await resolve_email_ingest_client(db, token) is not None
     )
 
 

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -33,6 +33,7 @@ from api.routes import (
     federation_user_links,
     feedback,
     folder_ingest,
+    ingest_credentials,
     intents,
     internal_auth,
     document_dedupe,
@@ -245,6 +246,11 @@ app.include_router(config_routes.router, prefix="/api/config", tags=["Config"])
 app.include_router(speakers.router, prefix="/api/speakers", tags=["Speakers"])
 app.include_router(knowledge.router, prefix="/api/knowledge", tags=["Knowledge"])
 app.include_router(folder_ingest.router, prefix="/api/folder-ingest", tags=["Folder Ingest"])
+app.include_router(
+    ingest_credentials.router,
+    prefix="/api/ingest-credentials",
+    tags=["Ingest Credentials"],
+)
 app.include_router(pdf_split.router, prefix="/api/pdf-split", tags=["PDF Split"])
 app.include_router(simba_ingest.router, prefix="/api", tags=["Simba Ingest"])
 app.include_router(document_dedupe.router, prefix="/api", tags=["Document Dedupe"])

--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -3207,6 +3207,49 @@ class FederationQueryLog(Base):
     peer = relationship("PeerUser", foreign_keys=[peer_user_id])
 
 
+class IngestCredential(Base):
+    """One machine credential per pushing integration (folder/email ingest).
+
+    Replaces the single shared ``SystemSetting`` token, which had three
+    problems: it was stored in the CLEAR, every client of a route presented the
+    SAME string (so none could be revoked alone and the backend could not tell
+    who pushed), and it existed in three hand-synchronised places.
+
+    Mirrors the ``satellites`` table (``pc20260624_satellite_enrollment``),
+    which already solves per-device machine credentials here: bcrypt hash only,
+    never the plaintext; ``revoked_at`` + ``is_enabled`` for independent
+    revocation; ``last_authenticated_at`` to make "is this still in use?"
+    observable rather than a guess.
+
+    **Tokens are self-identifying** — ``rfi.<client_id>.<secret>``. The client_id
+    rides in the token so verification is ONE row lookup plus ONE bcrypt, not a
+    bcrypt round against every credential. That is both faster and safer: the
+    naive walk costs N bcrypt rounds per rejected token, which is a cheap
+    denial-of-service for anyone who can reach the push endpoint.
+
+    See ``docs/design/ingest-credentials.md``.
+    """
+
+    __tablename__ = "ingest_credentials"
+
+    id = Column(Integer, primary_key=True)
+    # Opaque, operator-chosen, appears IN the token: [a-z0-9][a-z0-9-]{0,63}
+    client_id = Column(String(64), nullable=False, unique=True, index=True)
+    label = Column(String(200), nullable=False)
+    # Which push route this credential may use: folder_ingest | email_ingest
+    route = Column(String(32), nullable=False, index=True)
+    # bcrypt. NEVER the plaintext — that is returned once, at mint time only.
+    token_hash = Column(String(255), nullable=False)
+    created_by_user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    rotated_at = Column(DateTime, nullable=True)
+    # Stamped on every successful push. This is what makes retiring the legacy
+    # shared token an observation instead of a guess.
+    last_authenticated_at = Column(DateTime, nullable=True)
+    revoked_at = Column(DateTime, nullable=True)
+    is_enabled = Column(Boolean, nullable=False, default=True, server_default="true")
+
+
 class DocumentProcessingHistory(Base):
     """
     Audit row for every ingestion attempt against a Document.

--- a/src/backend/services/email_ingest.py
+++ b/src/backend/services/email_ingest.py
@@ -232,3 +232,13 @@ async def generate_email_ingest_token(db: AsyncSession) -> str:
 
 async def verify_email_ingest_token(db: AsyncSession, token: str) -> bool:
     return await verify_ingest_token(db, SETTING_EMAIL_INGEST_TOKEN, token)
+
+
+async def resolve_email_ingest_client(db: AsyncSession, token: str):
+    """Resolve a Bearer token to the pushing client (or None). See
+    :func:`services.folder_ingest.resolve_folder_ingest_client`."""
+    from services.ingest_credentials import ROUTE_EMAIL, resolve_ingest_client
+
+    return await resolve_ingest_client(
+        db, ROUTE_EMAIL, token, legacy_verify=verify_email_ingest_token
+    )

--- a/src/backend/services/folder_ingest.py
+++ b/src/backend/services/folder_ingest.py
@@ -421,6 +421,23 @@ async def verify_folder_ingest_token(db: AsyncSession, token: str) -> bool:
     return await verify_ingest_token(db, SETTING_FOLDER_INGEST_TOKEN, token)
 
 
+async def resolve_folder_ingest_client(db: AsyncSession, token: str):
+    """Resolve a Bearer token to the pushing client (or None).
+
+    Supersedes the boolean :func:`verify_folder_ingest_token`, which could only
+    say "valid", never "who". Knowing the client is what makes per-integration
+    revocation and server-authoritative sphere routing possible.
+
+    The legacy shared token still authenticates, reported as the synthetic
+    ``legacy`` client, for the whole transition.
+    """
+    from services.ingest_credentials import ROUTE_FOLDER, resolve_ingest_client
+
+    return await resolve_ingest_client(
+        db, ROUTE_FOLDER, token, legacy_verify=verify_folder_ingest_token
+    )
+
+
 # ---------------------------------------------------------------------------
 # Target KB + owner resolution (shared by the push route and the
 # internal.ingest_file agent tool). Both file into the single configured

--- a/src/backend/services/ingest_credentials.py
+++ b/src/backend/services/ingest_credentials.py
@@ -155,8 +155,18 @@ async def rotate_credential(db: AsyncSession, client_id: str) -> str:
     secret = secrets.token_urlsafe(48)
     row.token_hash = await asyncio.to_thread(pwd_context.hash, secret)
     row.rotated_at = datetime.utcnow()
+    # Rotation is also the RECOVERY path. Without this, revoking is a permanent
+    # dead end: the row keeps the client_id (it is unique), so mint refuses it
+    # forever and the name can never be used again. Re-enabling here is safe
+    # because rotation issues a NEW secret — the revoked one stays dead — and it
+    # takes a deliberate operator action.
+    was_revoked = row.revoked_at is not None or not row.is_enabled
+    row.revoked_at = None
+    row.is_enabled = True
     await db.commit()
-    logger.info(f"🔑 ingest credential rotated: {cid}")
+    logger.info(
+        f"🔑 ingest credential rotated: {cid}" + (" (re-enabled)" if was_revoked else "")
+    )
     return _format_token(cid, secret)
 
 

--- a/src/backend/services/ingest_credentials.py
+++ b/src/backend/services/ingest_credentials.py
@@ -14,6 +14,7 @@ Nothing here ever stores or returns a plaintext token except at mint/rotate
 time, where it is returned exactly once.
 """
 
+import asyncio
 import re
 import secrets
 from dataclasses import dataclass
@@ -22,6 +23,7 @@ from datetime import datetime
 from loguru import logger
 from passlib.context import CryptContext
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.database import IngestCredential
@@ -34,6 +36,23 @@ pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 # spends a full round (~250ms) — a timing oracle that enumerates valid client_ids.
 # One throwaway verify on the miss path equalises the two.
 _DUMMY_TOKEN_HASH = pwd_context.hash("renfield-ingest-timing-equalizer")
+
+# Stamping last_authenticated_at on EVERY push would put a write + commit in the
+# ingest hot path — the same pooled-connection pressure that exhausted the pool
+# in the 2026-07-01 watch-folder outage. The signal it feeds ("is this
+# credential still in use?") does not need second precision, so it is throttled.
+_LAST_SEEN_THROTTLE_SECONDS = 60
+
+# Reserved: `legacy` is the synthetic client reported for the shared token, so a
+# real credential of that name would be indistinguishable from it downstream.
+_RESERVED_CLIENT_IDS = frozenset({"legacy"})
+
+
+async def _verify(secret: str, hashed: str) -> bool:
+    """bcrypt is CPU-bound and takes ~150ms. Called inline it would block the
+    event loop — every other request in this worker — for that long ON EVERY
+    PUSH. Logins can afford it; a watch-folder backlog cannot."""
+    return await asyncio.to_thread(pwd_context.verify, secret, hashed)
 
 TOKEN_PREFIX = "rfi"
 ROUTE_FOLDER = "folder_ingest"
@@ -64,6 +83,8 @@ def _validate_client_id(client_id: str) -> str:
         raise InvalidClientId(
             f"client_id must match {_CLIENT_ID_RE.pattern!r} (got {client_id!r})"
         )
+    if cid in _RESERVED_CLIENT_IDS:
+        raise InvalidClientId(f"client_id {cid!r} is reserved")
     return cid
 
 
@@ -106,12 +127,19 @@ async def mint_credential(
             client_id=cid,
             label=label or cid,
             route=route,
-            token_hash=pwd_context.hash(secret),
+            token_hash=await asyncio.to_thread(pwd_context.hash, secret),
             created_by_user_id=created_by_user_id,
             created_at=datetime.utcnow(),
         )
     )
-    await db.commit()
+    try:
+        await db.commit()
+    except IntegrityError:
+        # The unique index on client_id makes a concurrent duplicate mint safe,
+        # but unhandled it surfaces as a 500. Report the same error the
+        # pre-check would have.
+        await db.rollback()
+        raise ValueError(f"client_id {cid!r} already exists — rotate it instead") from None
     logger.info(f"🔑 ingest credential minted: {cid} ({route})")
     return _format_token(cid, secret)
 
@@ -125,7 +153,7 @@ async def rotate_credential(db: AsyncSession, client_id: str) -> str:
     if row is None:
         raise ValueError(f"unknown client_id: {cid}")
     secret = secrets.token_urlsafe(48)
-    row.token_hash = pwd_context.hash(secret)
+    row.token_hash = await asyncio.to_thread(pwd_context.hash, secret)
     row.rotated_at = datetime.utcnow()
     await db.commit()
     logger.info(f"🔑 ingest credential rotated: {cid}")
@@ -181,9 +209,9 @@ async def resolve_ingest_client(
             if row is None:
                 # Equalise timing against the found-but-wrong-secret path so a
                 # response time cannot enumerate valid client_ids.
-                pwd_context.verify(secret, _DUMMY_TOKEN_HASH)
+                await _verify(secret, _DUMMY_TOKEN_HASH)
                 return None
-            if not pwd_context.verify(secret, row.token_hash):
+            if not await _verify(secret, row.token_hash):
                 return None
             # Checked AFTER the hash so a revoked/disabled/wrong-route client
             # cannot be distinguished from a wrong secret by timing either.
@@ -194,8 +222,11 @@ async def resolve_ingest_client(
                     f"route={row.route} wanted={route})"
                 )
                 return None
-            row.last_authenticated_at = datetime.utcnow()
-            await db.commit()
+            now = datetime.utcnow()
+            last = row.last_authenticated_at
+            if last is None or (now - last).total_seconds() >= _LAST_SEEN_THROTTLE_SECONDS:
+                row.last_authenticated_at = now
+                await db.commit()
             return IngestClient(client_id=row.client_id, label=row.label, route=row.route)
         # Not one of ours → fall through to the legacy shared token.
 

--- a/src/backend/services/ingest_credentials.py
+++ b/src/backend/services/ingest_credentials.py
@@ -1,0 +1,205 @@
+"""Per-integration machine credentials for the ingest push routes.
+
+Replaces the single shared SystemSetting token. See
+``docs/design/ingest-credentials.md``.
+
+Token format is ``rfi.<client_id>.<secret>`` — SELF-IDENTIFYING on purpose. The
+client_id rides in the token so verification is one indexed lookup plus ONE
+bcrypt round. The obvious alternative (bcrypt every stored credential until one
+matches) costs N rounds for every REJECTED token, which hands anyone who can
+reach the push endpoint a cheap denial of service, and gets worse with each
+integration added.
+
+Nothing here ever stores or returns a plaintext token except at mint/rotate
+time, where it is returned exactly once.
+"""
+
+import re
+import secrets
+from dataclasses import dataclass
+from datetime import datetime
+
+from loguru import logger
+from passlib.context import CryptContext
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.database import IngestCredential
+from utils.config import settings
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+# Same trick as auth_service._DUMMY_PASSWORD_HASH (security audit M3): an unknown
+# client_id would otherwise return without running bcrypt (~0ms) while a real one
+# spends a full round (~250ms) — a timing oracle that enumerates valid client_ids.
+# One throwaway verify on the miss path equalises the two.
+_DUMMY_TOKEN_HASH = pwd_context.hash("renfield-ingest-timing-equalizer")
+
+TOKEN_PREFIX = "rfi"
+ROUTE_FOLDER = "folder_ingest"
+ROUTE_EMAIL = "email_ingest"
+
+# client_id appears inside the token and in URLs; keep it boring.
+_CLIENT_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
+
+
+class InvalidClientId(ValueError):
+    """client_id fails the charset rule."""
+
+
+@dataclass(frozen=True)
+class IngestClient:
+    """Who pushed. ``legacy`` marks the shared SystemSetting token, which has no
+    identity — that is precisely the gap this module closes."""
+
+    client_id: str
+    label: str
+    route: str
+    legacy: bool = False
+
+
+def _validate_client_id(client_id: str) -> str:
+    cid = (client_id or "").strip().lower()
+    if not _CLIENT_ID_RE.match(cid):
+        raise InvalidClientId(
+            f"client_id must match {_CLIENT_ID_RE.pattern!r} (got {client_id!r})"
+        )
+    return cid
+
+
+def _split_token(token: str) -> tuple[str, str] | None:
+    """Parse ``rfi.<client_id>.<secret>``. None when it is not one of ours
+    (a legacy token), which is a normal path, not an error."""
+    parts = (token or "").split(".", 2)
+    if len(parts) != 3 or parts[0] != TOKEN_PREFIX:
+        return None
+    if not _CLIENT_ID_RE.match(parts[1]) or not parts[2]:
+        return None
+    return parts[1], parts[2]
+
+
+def _format_token(client_id: str, secret: str) -> str:
+    return f"{TOKEN_PREFIX}.{client_id}.{secret}"
+
+
+async def mint_credential(
+    db: AsyncSession,
+    *,
+    client_id: str,
+    label: str,
+    route: str,
+    created_by_user_id: int | None = None,
+) -> str:
+    """Create a credential. Returns the plaintext ONCE; only the hash is stored."""
+    cid = _validate_client_id(client_id)
+    if route not in (ROUTE_FOLDER, ROUTE_EMAIL):
+        raise ValueError(f"unknown ingest route: {route!r}")
+    existing = (
+        await db.execute(select(IngestCredential).where(IngestCredential.client_id == cid))
+    ).scalar_one_or_none()
+    if existing is not None:
+        raise ValueError(f"client_id {cid!r} already exists — rotate it instead")
+
+    secret = secrets.token_urlsafe(48)
+    db.add(
+        IngestCredential(
+            client_id=cid,
+            label=label or cid,
+            route=route,
+            token_hash=pwd_context.hash(secret),
+            created_by_user_id=created_by_user_id,
+            created_at=datetime.utcnow(),
+        )
+    )
+    await db.commit()
+    logger.info(f"🔑 ingest credential minted: {cid} ({route})")
+    return _format_token(cid, secret)
+
+
+async def rotate_credential(db: AsyncSession, client_id: str) -> str:
+    """Issue a new secret for an existing credential. Returns plaintext once."""
+    cid = _validate_client_id(client_id)
+    row = (
+        await db.execute(select(IngestCredential).where(IngestCredential.client_id == cid))
+    ).scalar_one_or_none()
+    if row is None:
+        raise ValueError(f"unknown client_id: {cid}")
+    secret = secrets.token_urlsafe(48)
+    row.token_hash = pwd_context.hash(secret)
+    row.rotated_at = datetime.utcnow()
+    await db.commit()
+    logger.info(f"🔑 ingest credential rotated: {cid}")
+    return _format_token(cid, secret)
+
+
+async def revoke_credential(db: AsyncSession, client_id: str) -> bool:
+    """Revoke. Kept as a row (not deleted) so the audit trail survives."""
+    cid = _validate_client_id(client_id)
+    row = (
+        await db.execute(select(IngestCredential).where(IngestCredential.client_id == cid))
+    ).scalar_one_or_none()
+    if row is None:
+        return False
+    row.revoked_at = datetime.utcnow()
+    row.is_enabled = False
+    await db.commit()
+    logger.info(f"🔒 ingest credential revoked: {cid}")
+    return True
+
+
+async def list_credentials(db: AsyncSession, route: str | None = None) -> list[IngestCredential]:
+    """List credentials. Rows carry the HASH; callers must never expose it."""
+    stmt = select(IngestCredential).order_by(IngestCredential.client_id)
+    if route:
+        stmt = stmt.where(IngestCredential.route == route)
+    return list((await db.execute(stmt)).scalars().all())
+
+
+async def resolve_ingest_client(
+    db: AsyncSession, route: str, token: str, legacy_verify=None
+) -> IngestClient | None:
+    """Resolve a presented Bearer token to the client that owns it.
+
+    ``legacy_verify`` is the route's existing shared-token check, kept as a
+    fallback for the whole transition so a client that has not been migrated
+    keeps working. It is awaited only when the token is NOT one of ours.
+
+    Flag off ⇒ the legacy path only, byte-identical to before.
+    """
+    if not token:
+        return None
+
+    if getattr(settings, "ingest_credentials_enabled", False):
+        parsed = _split_token(token)
+        if parsed is not None:
+            cid, secret = parsed
+            row = (
+                await db.execute(
+                    select(IngestCredential).where(IngestCredential.client_id == cid)
+                )
+            ).scalar_one_or_none()
+            if row is None:
+                # Equalise timing against the found-but-wrong-secret path so a
+                # response time cannot enumerate valid client_ids.
+                pwd_context.verify(secret, _DUMMY_TOKEN_HASH)
+                return None
+            if not pwd_context.verify(secret, row.token_hash):
+                return None
+            # Checked AFTER the hash so a revoked/disabled/wrong-route client
+            # cannot be distinguished from a wrong secret by timing either.
+            if not row.is_enabled or row.revoked_at is not None or row.route != route:
+                logger.warning(
+                    f"ingest credential {cid} rejected "
+                    f"(enabled={row.is_enabled} revoked={row.revoked_at is not None} "
+                    f"route={row.route} wanted={route})"
+                )
+                return None
+            row.last_authenticated_at = datetime.utcnow()
+            await db.commit()
+            return IngestClient(client_id=row.client_id, label=row.label, route=row.route)
+        # Not one of ours → fall through to the legacy shared token.
+
+    if legacy_verify is not None and await legacy_verify(db, token):
+        return IngestClient(client_id="legacy", label="Legacy shared token",
+                            route=route, legacy=True)
+    return None

--- a/src/backend/utils/config.py
+++ b/src/backend/utils/config.py
@@ -999,6 +999,18 @@ class Settings(BaseSettings):
     folder_ingest_token: str = ""
     folder_ingest_notify_on_filed: bool = True
 
+    # Per-integration ingest credentials (docs/design/ingest-credentials.md).
+    # Replaces the single shared SystemSetting token with one credential per
+    # pushing client, so each can be rotated/revoked alone and the backend knows
+    # WHICH client pushed (what server-authoritative sphere routing needs).
+    # OFF ⇒ the legacy shared-token path only, byte-identical to before.
+    ingest_credentials_enabled: bool = False
+    # Upper bound on the old-token overlap after a rotation. The primary cutover
+    # is acknowledgement-based (the old token stays valid until the client
+    # authenticates with the new one, proving it persisted the value) — a timer
+    # alone would cut off a client that had not yet managed to write its file.
+    ingest_credential_rotation_grace_seconds: int = 300
+
     # PDF-split: ingest-time detection + splitting of multi-document PDFs
     # (docs/design/pdf-split.md). Runs as a document-worker pre-stage on EVERY
     # ingested PDF when enabled. Deliberately NO page-count settings: input is

--- a/src/frontend/src/api/keys.ts
+++ b/src/frontend/src/api/keys.ts
@@ -59,6 +59,7 @@ export const keys = {
   integrations: {
     all: ['integrations'] as const,
     list: () => ['integrations', 'list'] as const,
+    ingestCredentials: () => ['integrations', 'ingest-credentials'] as const,
   },
   knowledge: {
     all: ['knowledge'] as const,

--- a/src/frontend/src/api/resources/ingestCredentials.ts
+++ b/src/frontend/src/api/resources/ingestCredentials.ts
@@ -1,0 +1,125 @@
+/**
+ * Per-integration ingest credentials admin API (#1218 Phase 2).
+ *
+ * Mints / rotates / revokes the Bearer token each pushing MCP uses. The
+ * plaintext is returned exactly once, by mint and rotate — the list route never
+ * returns one, and only a bcrypt hash is stored server-side.
+ */
+import { useQueryClient } from '@tanstack/react-query';
+
+import apiClient from '../../utils/axios';
+import { useApiQuery, useApiMutation } from '../hooks';
+import { keys, STALE } from '../keys';
+
+export type IngestRoute = 'folder_ingest' | 'email_ingest';
+
+export interface IngestCredential {
+  client_id: string;
+  label: string;
+  route: IngestRoute;
+  created_at: string | null;
+  rotated_at: string | null;
+  last_authenticated_at: string | null;
+  revoked_at: string | null;
+  is_enabled: boolean;
+}
+
+/**
+ * The legacy shared token. `source: 'env'` means the backend re-seeds it from
+ * its environment on every boot, so rotating it here would silently revert at
+ * the next restart — the UI renders those read-only.
+ */
+export interface LegacyToken {
+  route: IngestRoute;
+  configured: boolean;
+  source: 'env' | 'db';
+}
+
+export interface IngestCredentialList {
+  credentials: IngestCredential[];
+  legacy: LegacyToken[];
+  enabled: boolean;
+}
+
+export interface MintPayload {
+  client_id: string;
+  label: string;
+  route: IngestRoute;
+}
+
+/** Carries the plaintext. Shown once, never re-fetchable. */
+export interface MintResult {
+  client_id: string;
+  token: string;
+}
+
+async function fetchCredentials(): Promise<IngestCredentialList> {
+  const res = await apiClient.get<IngestCredentialList>('/api/ingest-credentials');
+  return res.data ?? { credentials: [], legacy: [], enabled: false };
+}
+
+async function mintRequest(input: MintPayload): Promise<MintResult> {
+  const res = await apiClient.post<MintResult>('/api/ingest-credentials', input);
+  return res.data;
+}
+
+async function rotateRequest(clientId: string): Promise<MintResult> {
+  const res = await apiClient.post<MintResult>(
+    `/api/ingest-credentials/${encodeURIComponent(clientId)}/rotate`,
+  );
+  return res.data;
+}
+
+async function revokeRequest(clientId: string): Promise<void> {
+  await apiClient.delete(`/api/ingest-credentials/${encodeURIComponent(clientId)}`);
+}
+
+export function useIngestCredentialsQuery() {
+  return useApiQuery(
+    {
+      queryKey: keys.integrations.ingestCredentials(),
+      queryFn: fetchCredentials,
+      staleTime: STALE.DEFAULT,
+    },
+    'common.error',
+  );
+}
+
+export function useMintIngestCredential() {
+  const queryClient = useQueryClient();
+  return useApiMutation(
+    {
+      mutationFn: mintRequest,
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: keys.integrations.all });
+      },
+    },
+    'common.error',
+  );
+}
+
+export function useRotateIngestCredential() {
+  const queryClient = useQueryClient();
+  return useApiMutation(
+    {
+      mutationFn: rotateRequest,
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: keys.integrations.all });
+      },
+    },
+    'common.error',
+  );
+}
+
+export function useRevokeIngestCredential() {
+  const queryClient = useQueryClient();
+  return useApiMutation(
+    {
+      mutationFn: revokeRequest,
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: keys.integrations.all });
+      },
+    },
+    'common.error',
+  );
+}

--- a/src/frontend/src/components/integrations/IngestCredentials.tsx
+++ b/src/frontend/src/components/integrations/IngestCredentials.tsx
@@ -1,0 +1,252 @@
+/**
+ * Per-integration ingest credentials (#1218 Phase 2).
+ *
+ * Closes the gap that provisioning a machine credential meant hand-crafting an
+ * API call. Mirrors SatelliteEnrollment's show-once UX, including its
+ * failed-clipboard handling: the token is displayed exactly once, so a silently
+ * failed copy would lose it.
+ *
+ * Two behaviours here are deliberate and load-bearing:
+ *
+ *  - Rotating shows WHICH client stops working until its copy is updated. The
+ *    credential is shared with nothing else, but the client itself keeps
+ *    presenting the old token until an operator updates it.
+ *  - A legacy token whose source is `env` is rendered READ-ONLY. The backend
+ *    re-seeds it from its environment on every boot, so a rotation here would
+ *    silently revert at the next restart — the UI must not offer an action it
+ *    cannot make stick.
+ */
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import {
+  useIngestCredentialsQuery,
+  useMintIngestCredential,
+  useRotateIngestCredential,
+  useRevokeIngestCredential,
+  type IngestCredential,
+  type IngestRoute,
+  type MintResult,
+} from '../../api/resources/ingestCredentials';
+import { formatDateTime } from '../../utils/datetime';
+import Alert from '../Alert';
+import Badge from '../Badge';
+
+const ROUTES: IngestRoute[] = ['folder_ingest', 'email_ingest'];
+
+export default function IngestCredentials() {
+  const { t } = useTranslation();
+  const { data, isLoading } = useIngestCredentialsQuery();
+  const mint = useMintIngestCredential();
+  const rotate = useRotateIngestCredential();
+  const revoke = useRevokeIngestCredential();
+
+  const [clientId, setClientId] = useState('');
+  const [label, setLabel] = useState('');
+  const [route, setRoute] = useState<IngestRoute>('folder_ingest');
+  const [minted, setMinted] = useState<(MintResult & { rotated: boolean }) | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [copyFailed, setCopyFailed] = useState(false);
+  const [confirming, setConfirming] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const credentials = data?.credentials ?? [];
+  const legacy = data?.legacy ?? [];
+  const flagOn = data?.enabled ?? false;
+
+  const reveal = (result: MintResult, rotated: boolean) => {
+    setMinted({ ...result, rotated });
+    setCopied(false);
+    setCopyFailed(false);
+    setError(null);
+  };
+
+  const doMint = async () => {
+    try {
+      reveal(await mint.mutateAsync({ client_id: clientId.trim(), label: label.trim() || clientId.trim(), route }), false);
+      setClientId('');
+      setLabel('');
+    } catch {
+      setError(t('integrations.credentials.mintFailed'));
+    }
+  };
+
+  const doRotate = async (id: string) => {
+    setConfirming(null);
+    try {
+      reveal(await rotate.mutateAsync(id), true);
+    } catch {
+      setError(t('integrations.credentials.rotateFailed'));
+    }
+  };
+
+  const copyToken = async () => {
+    if (!minted) return;
+    try {
+      await navigator.clipboard.writeText(minted.token);
+      setCopied(true);
+      setCopyFailed(false);
+    } catch {
+      // Shown ONCE — a silently failed copy loses it. Tell the user to select
+      // it manually rather than leaving the button apparently inert.
+      setCopied(false);
+      setCopyFailed(true);
+    }
+  };
+
+  const fmt = (iso: string | null) => (iso ? formatDateTime(iso) : t('integrations.credentials.never'));
+
+  const stateBadge = (c: IngestCredential) => {
+    if (c.revoked_at || !c.is_enabled) return <Badge color="red">{t('integrations.credentials.revoked')}</Badge>;
+    if (!c.last_authenticated_at) return <Badge color="yellow">{t('integrations.credentials.neverUsed')}</Badge>;
+    return <Badge color="green">{t('integrations.credentials.active')}</Badge>;
+  };
+
+  return (
+    <div className="card mt-6">
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+        {t('integrations.credentials.title')}
+      </h3>
+      <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        {t('integrations.credentials.description')}
+      </p>
+
+      {!flagOn && (
+        <Alert variant="info" className="mt-3">
+          {t('integrations.credentials.flagOff')}
+        </Alert>
+      )}
+      {error && <Alert variant="error" className="mt-3">{error}</Alert>}
+
+      {/* One-time token reveal */}
+      {minted && (
+        <div className="mt-4 rounded-lg border border-amber-300 bg-amber-50 p-3 dark:border-amber-700 dark:bg-amber-900/20">
+          <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
+            {minted.rotated
+              ? t('integrations.credentials.tokenRotated', { id: minted.client_id })
+              : t('integrations.credentials.tokenMinted', { id: minted.client_id })}
+          </p>
+          <p className="mt-1 text-xs text-amber-700 dark:text-amber-400">
+            {t('integrations.credentials.tokenOnceWarning')}
+          </p>
+          <div className="mt-2 flex items-center gap-2">
+            <code className="flex-1 break-all rounded-sm bg-white px-2 py-1 font-mono text-xs text-gray-800 dark:bg-gray-800 dark:text-gray-100">
+              {minted.token}
+            </code>
+            <button className="btn-secondary text-sm" onClick={copyToken}>
+              {copied ? t('integrations.credentials.copied') : t('integrations.credentials.copy')}
+            </button>
+          </div>
+          {copyFailed && (
+            <p className="mt-2 text-xs text-red-600 dark:text-red-400">
+              {t('integrations.credentials.copyFailed')}
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Mint */}
+      <div className="mt-4 flex flex-wrap items-end gap-2">
+        <label className="flex flex-col text-xs text-gray-500 dark:text-gray-400">
+          {t('integrations.credentials.clientId')}
+          <input className="input mt-1 w-40" value={clientId} placeholder="scanner"
+                 onChange={(e) => setClientId(e.target.value)} />
+        </label>
+        <label className="flex flex-col text-xs text-gray-500 dark:text-gray-400">
+          {t('integrations.credentials.label')}
+          <input className="input mt-1 w-48" value={label}
+                 onChange={(e) => setLabel(e.target.value)} />
+        </label>
+        <label className="flex flex-col text-xs text-gray-500 dark:text-gray-400">
+          {t('integrations.credentials.route')}
+          <select className="input mt-1 w-44" value={route}
+                  onChange={(e) => setRoute(e.target.value as IngestRoute)}>
+            {ROUTES.map((r) => (
+              <option key={r} value={r}>{t(`integrations.credentials.routes.${r}`)}</option>
+            ))}
+          </select>
+        </label>
+        <button className="btn-primary" disabled={!clientId.trim() || mint.isPending} onClick={doMint}>
+          {t('integrations.credentials.mint')}
+        </button>
+      </div>
+
+      {isLoading && (
+        <p className="mt-4 text-sm text-gray-500 dark:text-gray-400">{t('common.loading')}</p>
+      )}
+
+      {credentials.length > 0 && (
+        <ul className="mt-5 divide-y divide-gray-200 dark:divide-gray-700">
+          {credentials.map((c) => (
+            <li key={c.client_id} className="py-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="font-mono text-sm text-gray-900 dark:text-white">{c.client_id}</span>
+                <span className="text-sm text-gray-500 dark:text-gray-400">{c.label}</span>
+                <Badge color="gray">{t(`integrations.credentials.routes.${c.route}`)}</Badge>
+                {stateBadge(c)}
+                <span className="ml-auto flex gap-2">
+                  <button className="btn-secondary text-xs" disabled={rotate.isPending}
+                          onClick={() => setConfirming(c.client_id)}>
+                    {t('integrations.credentials.rotate')}
+                  </button>
+                  {!c.revoked_at && (
+                    <button className="btn-secondary text-xs" disabled={revoke.isPending}
+                            onClick={() => revoke.mutate(c.client_id)}>
+                      {t('integrations.credentials.revoke')}
+                    </button>
+                  )}
+                </span>
+              </div>
+              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                {t('integrations.credentials.lastSeen')}: {fmt(c.last_authenticated_at)}
+                {' · '}
+                {t('integrations.credentials.created')}: {fmt(c.created_at)}
+              </p>
+              {confirming === c.client_id && (
+                <div className="mt-2 rounded-lg border border-amber-300 bg-amber-50 p-3 dark:border-amber-700 dark:bg-amber-900/20">
+                  {/* Blast radius, named. A bare Rotate button is a footgun: the
+                      client keeps presenting the old token until updated. */}
+                  <p className="text-xs text-amber-800 dark:text-amber-300">
+                    {t('integrations.credentials.rotateWarning', { id: c.client_id })}
+                  </p>
+                  <div className="mt-2 flex gap-2">
+                    <button className="btn-primary text-xs" onClick={() => doRotate(c.client_id)}>
+                      {t('integrations.credentials.rotateConfirm')}
+                    </button>
+                    <button className="btn-secondary text-xs" onClick={() => setConfirming(null)}>
+                      {t('common.cancel')}
+                    </button>
+                  </div>
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* Legacy shared tokens */}
+      {legacy.some((l) => l.configured) && (
+        <div className="mt-5 border-t border-gray-200 pt-4 dark:border-gray-700">
+          <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">
+            {t('integrations.credentials.legacyTitle')}
+          </h4>
+          <ul className="mt-2 space-y-1">
+            {legacy.filter((l) => l.configured).map((l) => (
+              <li key={l.route} className="flex flex-wrap items-center gap-2 text-sm">
+                <Badge color="gray">{t(`integrations.credentials.routes.${l.route}`)}</Badge>
+                <span className="text-gray-500 dark:text-gray-400">
+                  {l.source === 'env'
+                    ? t('integrations.credentials.legacyEnvManaged')
+                    : t('integrations.credentials.legacyDbManaged')}
+                </span>
+              </li>
+            ))}
+          </ul>
+          <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+            {t('integrations.credentials.legacyNote')}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/components/integrations/IngestCredentials.tsx
+++ b/src/frontend/src/components/integrations/IngestCredentials.tsx
@@ -47,7 +47,7 @@ export default function IngestCredentials() {
   const [minted, setMinted] = useState<(MintResult & { rotated: boolean }) | null>(null);
   const [copied, setCopied] = useState(false);
   const [copyFailed, setCopyFailed] = useState(false);
-  const [confirming, setConfirming] = useState<string | null>(null);
+  const [confirming, setConfirming] = useState<{ id: string; action: 'rotate' | 'revoke' } | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const credentials = data?.credentials ?? [];
@@ -77,6 +77,16 @@ export default function IngestCredentials() {
       reveal(await rotate.mutateAsync(id), true);
     } catch {
       setError(t('integrations.credentials.rotateFailed'));
+    }
+  };
+
+  const doRevoke = async (id: string) => {
+    setConfirming(null);
+    try {
+      await revoke.mutateAsync(id);
+      setError(null);
+    } catch {
+      setError(t('integrations.credentials.revokeFailed'));
     }
   };
 
@@ -186,12 +196,12 @@ export default function IngestCredentials() {
                 {stateBadge(c)}
                 <span className="ml-auto flex gap-2">
                   <button className="btn-secondary text-xs" disabled={rotate.isPending}
-                          onClick={() => setConfirming(c.client_id)}>
+                          onClick={() => setConfirming({ id: c.client_id, action: 'rotate' })}>
                     {t('integrations.credentials.rotate')}
                   </button>
                   {!c.revoked_at && (
                     <button className="btn-secondary text-xs" disabled={revoke.isPending}
-                            onClick={() => revoke.mutate(c.client_id)}>
+                            onClick={() => setConfirming({ id: c.client_id, action: 'revoke' })}>
                       {t('integrations.credentials.revoke')}
                     </button>
                   )}
@@ -202,16 +212,27 @@ export default function IngestCredentials() {
                 {' · '}
                 {t('integrations.credentials.created')}: {fmt(c.created_at)}
               </p>
-              {confirming === c.client_id && (
+              {confirming?.id === c.client_id && (
                 <div className="mt-2 rounded-lg border border-amber-300 bg-amber-50 p-3 dark:border-amber-700 dark:bg-amber-900/20">
-                  {/* Blast radius, named. A bare Rotate button is a footgun: the
-                      client keeps presenting the old token until updated. */}
+                  {/* Blast radius, named. Both actions break the client until an
+                      operator acts, so neither is a bare one-click button. */}
                   <p className="text-xs text-amber-800 dark:text-amber-300">
-                    {t('integrations.credentials.rotateWarning', { id: c.client_id })}
+                    {confirming.action === 'rotate'
+                      ? t('integrations.credentials.rotateWarning', { id: c.client_id })
+                      : t('integrations.credentials.revokeWarning', { id: c.client_id })}
                   </p>
                   <div className="mt-2 flex gap-2">
-                    <button className="btn-primary text-xs" onClick={() => doRotate(c.client_id)}>
-                      {t('integrations.credentials.rotateConfirm')}
+                    <button
+                      className="btn-primary text-xs"
+                      onClick={() =>
+                        confirming.action === 'rotate'
+                          ? doRotate(c.client_id)
+                          : doRevoke(c.client_id)
+                      }
+                    >
+                      {confirming.action === 'rotate'
+                        ? t('integrations.credentials.rotateConfirm')
+                        : t('integrations.credentials.revokeConfirm')}
                     </button>
                     <button className="btn-secondary text-xs" onClick={() => setConfirming(null)}>
                       {t('common.cancel')}

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -1228,7 +1228,42 @@
     "toolInactive": "Inaktiv",
     "resetDefaults": "Auf Standard zurücksetzen",
     "toolToggleError": "Tool-Aktivierung konnte nicht aktualisiert werden",
-    "activeTools": "aktiv"
+    "activeTools": "aktiv",
+    "credentials": {
+      "title": "Ingest-Zugangsdaten",
+      "description": "Je ein Token pro anbindender Integration (MCP). Jedes lässt sich einzeln erneuern oder widerrufen; der Klartext erscheint genau einmal.",
+      "flagOff": "Die Zugangsdaten sind angelegt, aber noch nicht aktiv: INGEST_CREDENTIALS_ENABLED ist ausgeschaltet. Bis dahin gilt weiterhin das gemeinsame Alt-Token.",
+      "clientId": "Client-ID",
+      "label": "Bezeichnung",
+      "route": "Route",
+      "mint": "Token erzeugen",
+      "rotate": "Erneuern",
+      "rotateConfirm": "Erneuern bestätigen",
+      "revoke": "Widerrufen",
+      "copy": "Kopieren",
+      "copied": "Kopiert",
+      "copyFailed": "Kopieren fehlgeschlagen — bitte das Token manuell markieren und sichern. Es wird nur dieses eine Mal angezeigt.",
+      "tokenMinted": "Token für {{id}} erzeugt",
+      "tokenRotated": "Token für {{id}} erneuert",
+      "tokenOnceWarning": "Dieses Token wird nur jetzt angezeigt und lässt sich nicht erneut abrufen — es wird ausschließlich als Hash gespeichert.",
+      "rotateWarning": "„{{id}}“ meldet sich weiterhin mit dem alten Token an und schlägt fehl, bis dessen Kopie dort aktualisiert ist.",
+      "lastSeen": "Zuletzt verwendet",
+      "created": "Erstellt",
+      "never": "nie",
+      "active": "Aktiv",
+      "neverUsed": "Noch nicht verwendet",
+      "revoked": "Widerrufen",
+      "mintFailed": "Token konnte nicht erzeugt werden.",
+      "rotateFailed": "Token konnte nicht erneuert werden.",
+      "legacyTitle": "Gemeinsames Alt-Token",
+      "legacyEnvManaged": "über die Umgebung des Backends verwaltet — hier bewusst nicht änderbar, da eine Erneuerung beim nächsten Neustart überschrieben würde",
+      "legacyDbManaged": "in der Datenbank hinterlegt",
+      "legacyNote": "Das Alt-Token gilt weiter, bis jede Integration eine eigene Zugangskennung nutzt.",
+      "routes": {
+        "folder_ingest": "Ordner-Ingest",
+        "email_ingest": "E-Mail-Ingest"
+      }
+    }
   },
   "intents": {
     "title": "Intent-Übersicht",

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -1259,6 +1259,9 @@
       "legacyEnvManaged": "über die Umgebung des Backends verwaltet — hier bewusst nicht änderbar, da eine Erneuerung beim nächsten Neustart überschrieben würde",
       "legacyDbManaged": "in der Datenbank hinterlegt",
       "legacyNote": "Das Alt-Token gilt weiter, bis jede Integration eine eigene Zugangskennung nutzt.",
+      "revokeWarning": "„{{id}}“ kann sich danach nicht mehr anmelden. Die Kennung bleibt vergeben — reaktiviert wird sie über „Erneuern“, das ein neues Token ausgibt.",
+      "revokeConfirm": "Widerruf bestätigen",
+      "revokeFailed": "Widerruf fehlgeschlagen.",
       "routes": {
         "folder_ingest": "Ordner-Ingest",
         "email_ingest": "E-Mail-Ingest"

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -1228,7 +1228,42 @@
     "toolInactive": "Inactive",
     "resetDefaults": "Reset to defaults",
     "toolToggleError": "Failed to update tool activation",
-    "activeTools": "active"
+    "activeTools": "active",
+    "credentials": {
+      "title": "Ingest credentials",
+      "description": "One token per pushing integration (MCP). Each can be rotated or revoked on its own; the plaintext is shown exactly once.",
+      "flagOff": "Credentials are configured but not yet in effect: INGEST_CREDENTIALS_ENABLED is off. The shared legacy token remains in use until it is switched on.",
+      "clientId": "Client ID",
+      "label": "Label",
+      "route": "Route",
+      "mint": "Create token",
+      "rotate": "Rotate",
+      "rotateConfirm": "Confirm rotation",
+      "revoke": "Revoke",
+      "copy": "Copy",
+      "copied": "Copied",
+      "copyFailed": "Copy failed — select the token manually and store it. It is shown only this once.",
+      "tokenMinted": "Token created for {{id}}",
+      "tokenRotated": "Token rotated for {{id}}",
+      "tokenOnceWarning": "This token is shown only now and cannot be retrieved again — only a hash is stored.",
+      "rotateWarning": "“{{id}}” keeps presenting the old token and will fail until its copy is updated there.",
+      "lastSeen": "Last used",
+      "created": "Created",
+      "never": "never",
+      "active": "Active",
+      "neverUsed": "Not yet used",
+      "revoked": "Revoked",
+      "mintFailed": "Could not create the token.",
+      "rotateFailed": "Could not rotate the token.",
+      "legacyTitle": "Legacy shared token",
+      "legacyEnvManaged": "managed by the backend environment — deliberately not editable here, because a rotation would be overwritten at the next restart",
+      "legacyDbManaged": "stored in the database",
+      "legacyNote": "The legacy token stays valid until every integration uses its own credential.",
+      "routes": {
+        "folder_ingest": "Folder ingest",
+        "email_ingest": "Email ingest"
+      }
+    }
   },
   "intents": {
     "title": "Intent Overview",

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -1259,6 +1259,9 @@
       "legacyEnvManaged": "managed by the backend environment — deliberately not editable here, because a rotation would be overwritten at the next restart",
       "legacyDbManaged": "stored in the database",
       "legacyNote": "The legacy token stays valid until every integration uses its own credential.",
+      "revokeWarning": "“{{id}}” can no longer authenticate. The client id stays taken — reactivate it with Rotate, which issues a new token.",
+      "revokeConfirm": "Confirm revocation",
+      "revokeFailed": "Could not revoke the credential.",
       "routes": {
         "folder_ingest": "Folder ingest",
         "email_ingest": "Email ingest"

--- a/src/frontend/src/pages/IntegrationsPage.tsx
+++ b/src/frontend/src/pages/IntegrationsPage.tsx
@@ -10,6 +10,7 @@ import Modal from '../components/Modal';
 import PageHeader from '../components/PageHeader';
 import Alert from '../components/Alert';
 import Badge from '../components/Badge';
+import IngestCredentials from '../components/integrations/IngestCredentials';
 import type { BadgeColor } from '../components/Badge';
 import {
   Server,
@@ -416,6 +417,7 @@ export default function IntegrationsPage() {
         )}
       </Modal>
 
+      <IngestCredentials />
     </div>
   );
 }

--- a/tests/backend/test_ingest_credentials.py
+++ b/tests/backend/test_ingest_credentials.py
@@ -1,0 +1,206 @@
+"""Per-integration ingest credentials (docs/design/ingest-credentials.md).
+
+The properties that matter here are security properties, so they are asserted
+directly rather than inferred: the plaintext is never stored, a credential is
+bound to ONE route, revocation is immediate, the legacy shared token keeps
+working through the transition, and the whole thing is inert when the flag is
+off.
+"""
+
+import pytest
+from sqlalchemy import select
+
+from models.database import IngestCredential
+from services import ingest_credentials as ic
+
+pytestmark = [pytest.mark.backend, pytest.mark.database]
+
+
+async def _legacy_true(db, token):
+    return token == "legacy-shared-token"
+
+
+async def _legacy_false(db, token):
+    return False
+
+
+@pytest.fixture(autouse=True)
+def _enable(monkeypatch):
+    monkeypatch.setattr(ic.settings, "ingest_credentials_enabled", True, raising=False)
+
+
+# --- token format -----------------------------------------------------------
+
+def test_token_is_self_identifying():
+    # The client_id rides in the token so verification is ONE lookup + ONE
+    # bcrypt, instead of a bcrypt round against every stored credential.
+    assert ic._split_token("rfi.scanner.abc123") == ("scanner", "abc123")
+
+
+@pytest.mark.parametrize("bad", [
+    "", "nope", "rfi.scanner", "rfi..secret", "xyz.scanner.secret",
+    "rfi.Scanner.secret", "rfi.scan_ner.secret", "rfi.scanner.",
+])
+def test_non_conforming_tokens_are_not_ours(bad):
+    # These must fall through to the legacy path, not raise.
+    assert ic._split_token(bad) is None
+
+
+def test_secret_may_contain_dots():
+    # split(".", 2) — a secret containing a dot must survive intact.
+    assert ic._split_token("rfi.scanner.a.b.c") == ("scanner", "a.b.c")
+
+
+@pytest.mark.parametrize("bad", ["", "-x", "x" * 65, "a_b", "a.b", "ä", " ", "a b"])
+def test_client_id_charset_enforced(bad):
+    with pytest.raises(ic.InvalidClientId):
+        ic._validate_client_id(bad)
+
+
+@pytest.mark.parametrize("given,expected", [
+    ("Scanner", "scanner"), ("  files  ", "files"), ("EMAIL-INGEST", "email-ingest"),
+])
+def test_client_id_is_normalised_not_rejected(given, expected):
+    # Case and surrounding space are normalised on the way IN, so an operator
+    # typing "Scanner" gets a working credential. The token PARSER stays strict
+    # (rfi.Scanner.x is not ours) because every minted token is already
+    # canonical — normalising there would let two spellings hit one row.
+    assert ic._validate_client_id(given) == expected
+    assert ic._split_token(f"rfi.{given}.secret") is None or given == expected
+
+
+# --- mint / verify ----------------------------------------------------------
+
+async def test_mint_returns_plaintext_and_stores_only_a_hash(db_session):
+    token = await ic.mint_credential(
+        db_session, client_id="scanner", label="Scanner", route=ic.ROUTE_FOLDER)
+    assert token.startswith("rfi.scanner.")
+    row = (await db_session.execute(
+        select(IngestCredential).where(IngestCredential.client_id == "scanner")
+    )).scalar_one()
+    secret = token.split(".", 2)[2]
+    assert secret not in row.token_hash        # never the plaintext
+    assert row.token_hash.startswith("$2")     # bcrypt
+
+
+async def test_minted_token_resolves_to_its_client(db_session):
+    token = await ic.mint_credential(
+        db_session, client_id="scanner", label="Scanner", route=ic.ROUTE_FOLDER)
+    client = await ic.resolve_ingest_client(db_session, ic.ROUTE_FOLDER, token)
+    assert client is not None
+    assert client.client_id == "scanner" and not client.legacy
+
+
+async def test_wrong_secret_is_rejected(db_session):
+    await ic.mint_credential(
+        db_session, client_id="scanner", label="S", route=ic.ROUTE_FOLDER)
+    assert await ic.resolve_ingest_client(
+        db_session, ic.ROUTE_FOLDER, "rfi.scanner.wrong") is None
+
+
+async def test_unknown_client_id_is_rejected(db_session):
+    assert await ic.resolve_ingest_client(
+        db_session, ic.ROUTE_FOLDER, "rfi.ghost.secret") is None
+
+
+async def test_duplicate_client_id_refused(db_session):
+    await ic.mint_credential(
+        db_session, client_id="scanner", label="S", route=ic.ROUTE_FOLDER)
+    with pytest.raises(ValueError, match="already exists"):
+        await ic.mint_credential(
+            db_session, client_id="scanner", label="S2", route=ic.ROUTE_FOLDER)
+
+
+async def test_unknown_route_refused(db_session):
+    with pytest.raises(ValueError, match="unknown ingest route"):
+        await ic.mint_credential(
+            db_session, client_id="x", label="X", route="nope")
+
+
+# --- the isolation properties ----------------------------------------------
+
+async def test_credential_is_bound_to_one_route(db_session):
+    # A folder-ingest credential must not authenticate on the email route.
+    token = await ic.mint_credential(
+        db_session, client_id="files", label="Files", route=ic.ROUTE_FOLDER)
+    assert await ic.resolve_ingest_client(db_session, ic.ROUTE_FOLDER, token) is not None
+    assert await ic.resolve_ingest_client(db_session, ic.ROUTE_EMAIL, token) is None
+
+
+async def test_revocation_is_immediate_and_independent(db_session):
+    a = await ic.mint_credential(
+        db_session, client_id="files", label="Files", route=ic.ROUTE_FOLDER)
+    b = await ic.mint_credential(
+        db_session, client_id="scanner", label="Scanner", route=ic.ROUTE_FOLDER)
+    assert await ic.revoke_credential(db_session, "files") is True
+    # The whole point of per-integration credentials: one dies, the other lives.
+    assert await ic.resolve_ingest_client(db_session, ic.ROUTE_FOLDER, a) is None
+    assert await ic.resolve_ingest_client(db_session, ic.ROUTE_FOLDER, b) is not None
+
+
+async def test_revoking_unknown_client_is_false_not_an_error(db_session):
+    assert await ic.revoke_credential(db_session, "ghost") is False
+
+
+async def test_rotation_invalidates_the_old_secret(db_session):
+    old = await ic.mint_credential(
+        db_session, client_id="scanner", label="S", route=ic.ROUTE_FOLDER)
+    new = await ic.rotate_credential(db_session, "scanner")
+    assert new != old
+    assert await ic.resolve_ingest_client(db_session, ic.ROUTE_FOLDER, new) is not None
+    assert await ic.resolve_ingest_client(db_session, ic.ROUTE_FOLDER, old) is None
+
+
+async def test_rotate_unknown_client_raises(db_session):
+    with pytest.raises(ValueError, match="unknown client_id"):
+        await ic.rotate_credential(db_session, "ghost")
+
+
+async def test_last_authenticated_at_is_stamped(db_session):
+    # This is what makes "is the legacy token still in use?" observable rather
+    # than a guess, so it must actually be written.
+    token = await ic.mint_credential(
+        db_session, client_id="scanner", label="S", route=ic.ROUTE_FOLDER)
+    row = (await db_session.execute(
+        select(IngestCredential).where(IngestCredential.client_id == "scanner")
+    )).scalar_one()
+    assert row.last_authenticated_at is None
+    await ic.resolve_ingest_client(db_session, ic.ROUTE_FOLDER, token)
+    await db_session.refresh(row)
+    assert row.last_authenticated_at is not None
+
+
+# --- legacy fallback + the flag --------------------------------------------
+
+async def test_legacy_shared_token_still_works(db_session):
+    client = await ic.resolve_ingest_client(
+        db_session, ic.ROUTE_FOLDER, "legacy-shared-token", legacy_verify=_legacy_true)
+    assert client is not None and client.legacy and client.client_id == "legacy"
+
+
+async def test_new_and_legacy_tokens_coexist(db_session):
+    token = await ic.mint_credential(
+        db_session, client_id="scanner", label="S", route=ic.ROUTE_FOLDER)
+    assert await ic.resolve_ingest_client(
+        db_session, ic.ROUTE_FOLDER, token, legacy_verify=_legacy_true) is not None
+    assert await ic.resolve_ingest_client(
+        db_session, ic.ROUTE_FOLDER, "legacy-shared-token",
+        legacy_verify=_legacy_true) is not None
+
+
+async def test_flag_off_ignores_credentials_entirely(db_session, monkeypatch):
+    # Flag off must be byte-identical to the legacy path: a perfectly good
+    # credential is not consulted at all.
+    token = await ic.mint_credential(
+        db_session, client_id="scanner", label="S", route=ic.ROUTE_FOLDER)
+    monkeypatch.setattr(ic.settings, "ingest_credentials_enabled", False, raising=False)
+    assert await ic.resolve_ingest_client(
+        db_session, ic.ROUTE_FOLDER, token, legacy_verify=_legacy_false) is None
+    assert await ic.resolve_ingest_client(
+        db_session, ic.ROUTE_FOLDER, "legacy-shared-token",
+        legacy_verify=_legacy_true) is not None
+
+
+async def test_empty_token_is_rejected(db_session):
+    assert await ic.resolve_ingest_client(
+        db_session, ic.ROUTE_FOLDER, "", legacy_verify=_legacy_true) is None

--- a/tests/backend/test_ingest_credentials.py
+++ b/tests/backend/test_ingest_credentials.py
@@ -204,3 +204,73 @@ async def test_flag_off_ignores_credentials_entirely(db_session, monkeypatch):
 async def test_empty_token_is_rejected(db_session):
     assert await ic.resolve_ingest_client(
         db_session, ic.ROUTE_FOLDER, "", legacy_verify=_legacy_true) is None
+
+
+# --- review findings ---------------------------------------------------------
+
+def test_legacy_client_id_is_reserved():
+    # "legacy" is the synthetic client reported for the shared token; a real
+    # credential of that name would be indistinguishable from it downstream.
+    with pytest.raises(ic.InvalidClientId, match="reserved"):
+        ic._validate_client_id("legacy")
+    with pytest.raises(ic.InvalidClientId, match="reserved"):
+        ic._validate_client_id("  LEGACY  ")
+
+
+async def test_cannot_mint_a_reserved_client_id(db_session):
+    with pytest.raises(ic.InvalidClientId):
+        await ic.mint_credential(
+            db_session, client_id="legacy", label="x", route=ic.ROUTE_FOLDER)
+
+
+async def test_last_seen_write_is_throttled(db_session, monkeypatch):
+    # A write + commit on EVERY push is pooled-connection pressure in the ingest
+    # hot path. The freshness signal does not need second precision.
+    token = await ic.mint_credential(
+        db_session, client_id="scanner", label="S", route=ic.ROUTE_FOLDER)
+    await ic.resolve_ingest_client(db_session, ic.ROUTE_FOLDER, token)
+    row = (await db_session.execute(
+        select(IngestCredential).where(IngestCredential.client_id == "scanner")
+    )).scalar_one()
+    first = row.last_authenticated_at
+    assert first is not None                      # first push always stamps
+    await ic.resolve_ingest_client(db_session, ic.ROUTE_FOLDER, token)
+    await db_session.refresh(row)
+    assert row.last_authenticated_at == first     # second, immediately after, does not
+
+
+async def test_last_seen_stamps_again_once_stale(db_session):
+    from datetime import timedelta
+    token = await ic.mint_credential(
+        db_session, client_id="scanner", label="S", route=ic.ROUTE_FOLDER)
+    row = (await db_session.execute(
+        select(IngestCredential).where(IngestCredential.client_id == "scanner")
+    )).scalar_one()
+    row.last_authenticated_at = ic.datetime.utcnow() - timedelta(
+        seconds=ic._LAST_SEEN_THROTTLE_SECONDS + 5)
+    await db_session.commit()
+    stale = row.last_authenticated_at
+    await ic.resolve_ingest_client(db_session, ic.ROUTE_FOLDER, token)
+    await db_session.refresh(row)
+    assert row.last_authenticated_at > stale
+
+
+async def test_verify_does_not_block_the_event_loop(db_session):
+    # bcrypt takes ~150ms. Called inline it stalls every other request in this
+    # worker on EVERY push, so it must be offloaded to a thread.
+    import asyncio as _a
+    token = await ic.mint_credential(
+        db_session, client_id="scanner", label="S", route=ic.ROUTE_FOLDER)
+    ticks = 0
+
+    async def _ticker():
+        nonlocal ticks
+        while True:
+            await _a.sleep(0.005)
+            ticks += 1
+
+    t = _a.create_task(_ticker())
+    await ic.resolve_ingest_client(db_session, ic.ROUTE_FOLDER, token)
+    t.cancel()
+    # If bcrypt ran inline, the loop would be blocked and the ticker starved.
+    assert ticks > 0, "event loop was blocked during token verification"

--- a/tests/backend/test_ingest_credentials.py
+++ b/tests/backend/test_ingest_credentials.py
@@ -274,3 +274,30 @@ async def test_verify_does_not_block_the_event_loop(db_session):
     t.cancel()
     # If bcrypt ran inline, the loop would be blocked and the ticker starved.
     assert ticks > 0, "event loop was blocked during token verification"
+
+
+async def test_rotate_reenables_a_revoked_credential(db_session):
+    # Without this, revoking is a permanent dead end: the row keeps the
+    # client_id (unique), so mint refuses that name forever.
+    await ic.mint_credential(
+        db_session, client_id="scanner", label="S", route=ic.ROUTE_FOLDER)
+    await ic.revoke_credential(db_session, "scanner")
+    with pytest.raises(ValueError, match="already exists"):
+        await ic.mint_credential(
+            db_session, client_id="scanner", label="S", route=ic.ROUTE_FOLDER)
+
+    revived = await ic.rotate_credential(db_session, "scanner")
+    row = (await db_session.execute(
+        select(IngestCredential).where(IngestCredential.client_id == "scanner")
+    )).scalar_one()
+    assert row.is_enabled is True and row.revoked_at is None
+    assert await ic.resolve_ingest_client(db_session, ic.ROUTE_FOLDER, revived) is not None
+
+
+async def test_the_revoked_secret_stays_dead_after_reenable(db_session):
+    old = await ic.mint_credential(
+        db_session, client_id="scanner", label="S", route=ic.ROUTE_FOLDER)
+    await ic.revoke_credential(db_session, "scanner")
+    await ic.rotate_credential(db_session, "scanner")
+    # Re-enabling must not resurrect the secret that was revoked.
+    assert await ic.resolve_ingest_client(db_session, ic.ROUTE_FOLDER, old) is None

--- a/tests/backend/test_ingest_credentials_routes.py
+++ b/tests/backend/test_ingest_credentials_routes.py
@@ -1,0 +1,128 @@
+"""Admin CRUD for ingest credentials (#1218 Phase 2).
+
+The security-relevant assertions here are that a token value is returned exactly
+ONCE and never by the list route, and that the legacy shared token reports its
+SOURCE so the UI can refuse to offer a rotation the boot reconciler would
+silently revert.
+"""
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from api.routes import ingest_credentials as routes
+from models.permissions import Permission
+from services.auth_service import require_permission
+from services.database import get_db
+from services.ingest_credentials import ROUTE_EMAIL, ROUTE_FOLDER
+
+pytestmark = [pytest.mark.backend, pytest.mark.database]
+
+
+@pytest.fixture
+def app(db_session):
+    a = FastAPI()
+    a.include_router(routes.router, prefix="/api/ingest-credentials")
+    a.dependency_overrides[get_db] = lambda: db_session
+    a.dependency_overrides[require_permission(Permission.SETTINGS_MANAGE)] = (
+        lambda: type("U", (), {"id": 1, "username": "admin"})()
+    )
+    # slowapi needs request.app.state.limiter present
+    from services.api_rate_limiter import limiter
+    a.state.limiter = limiter
+    return a
+
+
+@pytest.fixture
+async def client(app):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        yield c
+
+
+async def test_mint_returns_the_token_once(client):
+    r = await client.post("/api/ingest-credentials",
+                          json={"client_id": "scanner", "label": "Scanner",
+                                "route": ROUTE_FOLDER})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["token"].startswith("rfi.scanner.")
+
+
+async def test_list_never_returns_a_token(client):
+    await client.post("/api/ingest-credentials",
+                      json={"client_id": "scanner", "label": "S", "route": ROUTE_FOLDER})
+    r = await client.get("/api/ingest-credentials")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["credentials"][0]["client_id"] == "scanner"
+    # The whole response, not just the obvious field — a token must not leak
+    # through any key.
+    assert "rfi." not in r.text
+    assert "token" not in body["credentials"][0]
+
+
+async def test_duplicate_client_id_is_409(client):
+    p = {"client_id": "scanner", "label": "S", "route": ROUTE_FOLDER}
+    assert (await client.post("/api/ingest-credentials", json=p)).status_code == 200
+    assert (await client.post("/api/ingest-credentials", json=p)).status_code == 409
+
+
+async def test_reserved_client_id_is_400(client):
+    r = await client.post("/api/ingest-credentials",
+                          json={"client_id": "legacy", "label": "x", "route": ROUTE_FOLDER})
+    assert r.status_code == 400
+
+
+async def test_unknown_route_is_400(client):
+    r = await client.post("/api/ingest-credentials",
+                          json={"client_id": "x", "label": "x", "route": "nope"})
+    assert r.status_code == 400
+
+
+async def test_rotate_returns_a_new_token(client):
+    first = (await client.post("/api/ingest-credentials",
+             json={"client_id": "scanner", "label": "S",
+                   "route": ROUTE_FOLDER})).json()["token"]
+    second = (await client.post("/api/ingest-credentials/scanner/rotate")).json()["token"]
+    assert second != first and second.startswith("rfi.scanner.")
+
+
+async def test_rotate_unknown_is_404(client):
+    assert (await client.post("/api/ingest-credentials/ghost/rotate")).status_code == 404
+
+
+async def test_revoke_then_listed_as_disabled(client):
+    await client.post("/api/ingest-credentials",
+                      json={"client_id": "scanner", "label": "S", "route": ROUTE_FOLDER})
+    assert (await client.delete("/api/ingest-credentials/scanner")).status_code == 200
+    row = (await client.get("/api/ingest-credentials")).json()["credentials"][0]
+    assert row["is_enabled"] is False and row["revoked_at"] is not None
+
+
+async def test_revoke_unknown_is_404(client):
+    assert (await client.delete("/api/ingest-credentials/ghost")).status_code == 404
+
+
+async def test_legacy_reports_env_source(client, monkeypatch):
+    # env-authoritative: the boot reconciler re-seeds the DB from this, so a UI
+    # rotation would silently revert at the next restart. The UI keys its
+    # read-only rendering off this field.
+    monkeypatch.setattr(routes.settings, "folder_ingest_token", "seeded-from-env",
+                        raising=False)
+    legacy = {x["route"]: x for x in (await client.get("/api/ingest-credentials")).json()["legacy"]}
+    assert legacy[ROUTE_FOLDER]["configured"] is True
+    assert legacy[ROUTE_FOLDER]["source"] == "env"
+
+
+async def test_legacy_reports_db_source_when_env_empty(client, monkeypatch):
+    monkeypatch.setattr(routes.settings, "folder_ingest_token", "", raising=False)
+    monkeypatch.setattr(routes.settings, "email_ingest_token", "", raising=False)
+    legacy = {x["route"]: x for x in (await client.get("/api/ingest-credentials")).json()["legacy"]}
+    assert legacy[ROUTE_FOLDER]["source"] == "db"
+    assert set(legacy) == {ROUTE_FOLDER, ROUTE_EMAIL}
+
+
+async def test_list_reports_the_feature_flag(client, monkeypatch):
+    # The UI must be able to say "these are configured but not yet in effect".
+    monkeypatch.setattr(routes.settings, "ingest_credentials_enabled", False, raising=False)
+    assert (await client.get("/api/ingest-credentials")).json()["enabled"] is False

--- a/tests/frontend/react/components/IngestCredentials.test.tsx
+++ b/tests/frontend/react/components/IngestCredentials.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Ingest credentials UI (#1218 Phase 2).
+ *
+ * The assertions that matter are the ones the single shared token could not
+ * express: a token is shown exactly once, rotation is gated behind a warning
+ * naming the client that breaks, and an env-managed legacy token offers no
+ * rotation at all — because the backend would silently revert it.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { I18nextProvider } from 'react-i18next';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import i18n from '../../../../src/frontend/src/i18n';
+
+const get = vi.fn();
+const post = vi.fn();
+const del = vi.fn();
+
+vi.mock('../../../../src/frontend/src/utils/axios', () => ({
+  default: {
+    get: (...a: unknown[]) => get(...a),
+    post: (...a: unknown[]) => post(...a),
+    delete: (...a: unknown[]) => del(...a),
+  },
+}));
+
+const { default: IngestCredentials } = await import(
+  '../../../../src/frontend/src/components/integrations/IngestCredentials'
+);
+
+const credential = {
+  client_id: 'scanner',
+  label: 'Scanner',
+  route: 'folder_ingest',
+  created_at: '2026-09-08T10:00:00Z',
+  rotated_at: null,
+  last_authenticated_at: '2026-09-08T11:00:00Z',
+  revoked_at: null,
+  is_enabled: true,
+};
+
+const body = (o: Record<string, unknown> = {}) => ({
+  data: { credentials: [credential], legacy: [], enabled: true, ...o },
+});
+
+function renderIt() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <I18nextProvider i18n={i18n}>
+      <QueryClientProvider client={qc}>
+        <IngestCredentials />
+      </QueryClientProvider>
+    </I18nextProvider>,
+  );
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  await i18n.changeLanguage('en');
+  get.mockResolvedValue(body());
+});
+
+describe('IngestCredentials', () => {
+  it('lists a credential with its client id', async () => {
+    renderIt();
+    expect(await screen.findByText('scanner')).toBeInTheDocument();
+  });
+
+  it('never renders a token value in the list', async () => {
+    const { container } = renderIt();
+    await screen.findByText('scanner');
+    // Only a hash is stored server-side; nothing token-shaped may reach the DOM.
+    expect(container.textContent).not.toContain('rfi.');
+  });
+
+  it('requires confirmation before rotating, naming the affected client', async () => {
+    const user = userEvent.setup();
+    renderIt();
+    await screen.findByText('scanner');
+    await user.click(screen.getByRole('button', { name: /^rotate$/i }));
+    // A bare rotate button is a footgun: the client keeps presenting the old
+    // token until its copy is updated, so the warning must name it.
+    expect(await screen.findByRole('button', { name: /confirm rotation/i })).toBeInTheDocument();
+    expect(document.body.textContent).toMatch(/keeps presenting the old token/i);
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('shows the token once after minting, with a not-retrievable warning', async () => {
+    post.mockResolvedValue({ data: { client_id: 'newone', token: 'rfi.newone.s3cr3t' } });
+    const user = userEvent.setup();
+    renderIt();
+    await screen.findByText('scanner');
+    await user.type(screen.getByPlaceholderText('scanner'), 'newone');
+    await user.click(screen.getByRole('button', { name: /create token/i }));
+    expect(await screen.findByText('rfi.newone.s3cr3t')).toBeInTheDocument();
+    expect(document.body.textContent).toMatch(/cannot be retrieved again/i);
+  });
+
+  it('warns when the feature flag is off', async () => {
+    get.mockResolvedValue(body({ enabled: false }));
+    renderIt();
+    await waitFor(() =>
+      expect(document.body.textContent).toMatch(/INGEST_CREDENTIALS_ENABLED/));
+  });
+
+  it('renders an env-managed legacy token read-only, with no rotate action', async () => {
+    // The backend re-seeds it from env on every boot, so a rotation offered
+    // here would silently revert at the next restart.
+    get.mockResolvedValue(body({
+      credentials: [],
+      legacy: [{ route: 'folder_ingest', configured: true, source: 'env' }],
+    }));
+    renderIt();
+    await waitFor(() =>
+      expect(document.body.textContent).toMatch(/managed by the backend environment/i));
+    expect(screen.queryByRole('button', { name: /^rotate$/i })).toBeNull();
+  });
+});

--- a/tests/frontend/react/components/IngestCredentials.test.tsx
+++ b/tests/frontend/react/components/IngestCredentials.test.tsx
@@ -98,6 +98,18 @@ describe('IngestCredentials', () => {
     expect(document.body.textContent).toMatch(/cannot be retrieved again/i);
   });
 
+  it('requires confirmation before revoking, which is the more destructive action', async () => {
+    const user = userEvent.setup();
+    renderIt();
+    await screen.findByText('scanner');
+    await user.click(screen.getByRole('button', { name: /^revoke$/i }));
+    expect(await screen.findByRole('button', { name: /confirm revocation/i })).toBeInTheDocument();
+    // The client id stays taken after revocation, so the warning must say how
+    // to get it back rather than implying the name is freed.
+    expect(document.body.textContent).toMatch(/stays taken/i);
+    expect(del).not.toHaveBeenCalled();
+  });
+
   it('warns when the feature flag is off', async () => {
     get.mockResolvedValue(body({ enabled: false }));
     renderIt();


### PR DESCRIPTION
Phase 1 of #1218. **Dark and inert**: the flag defaults off, the legacy shared
token still authenticates, and no behaviour changes until it is switched on.

## What lands

- Migration `pc20260908_ingest_credentials` — additive, chains off the single
  head `pc20260901_doc_content_emb` (verified: one head, no forks)
- `models.IngestCredential`, mirroring the **`satellites` table**, which already
  solves per-device machine credentials in this codebase: bcrypt `token_hash`
  only, `revoked_at` + `is_enabled` for independent revocation,
  `last_authenticated_at`
- `services/ingest_credentials.py` — mint / rotate / revoke / resolve
- `resolve_{folder,email}_ingest_client` wired into every call site
- Flag `ingest_credentials_enabled` (default `false`)

Two immediate improvements over the shared token it replaces: it was stored **in
the clear**, and every client of a route presented the **same string**, so none
could be revoked alone and the backend could not tell who pushed.

## Deliberate divergence from the design doc

The doc specified walking the stored credentials and bcrypt-ing each until one
matched. That costs **N bcrypt rounds for every _rejected_ token** (~250ms
each) — a cheap denial of service for anyone who can reach the push endpoint,
worsening with each integration added.

Tokens are now **self-identifying**: `rfi.<client_id>.<secret>`. Resolution is
one indexed lookup plus **one** bcrypt, regardless of how many credentials
exist. The client_id is not a secret — it names the client, it does not
authenticate it. The design doc is corrected in this PR to match.

Two consequences, both implemented and tested:

- **Timing equalisation on the miss path.** An unknown client_id would otherwise
  return without hashing (~0ms) while a real one spends a full round, which
  enumerates valid client_ids. A throwaway verify against a dummy hash equalises
  the branches — the same defence, for the same reason, as
  `auth_service._DUMMY_PASSWORD_HASH`.
- **Revocation and route checks run AFTER the hash**, so a revoked, disabled or
  wrong-route credential cannot be told apart from a wrong secret by timing.

## The design doc said two call sites. There are five.

`api/routes/mcp_health.py` is a third consumer that accepts **either** ingest
token, on top of the two routes each in folder-ingest and email-ingest. All five
are wired; the now-unused imports are removed.

## Why this matters beyond rotation

Once the backend knows **which client** pushed, it has exactly what
server-authoritative sphere routing needs (`client -> owner/tier/kb`). That is
why the scanner's `scan_profile_id` (#1215) is inert today — folder-ingest
cannot tell its clients apart, so it files into one configured destination.
Phase 4 closes that, and is nearly free once this lands.

## Test plan

- [x] **37 new tests**, asserting the security properties directly rather than by
      inference: plaintext never stored (only a `$2`-prefixed hash), credential
      bound to ONE route, revocation immediate and independent (one dies, the
      other lives), rotation invalidates the old secret,
      `last_authenticated_at` actually stamped, legacy fallback in both
      directions, flag-off inert, timing-safe parsing of malformed tokens
- [x] **Full backend suite on .159: 6128 passed / 2 failed**, against
      **6091 / 2 on clean `origin/main`** — exactly +37, the **same** two
      failures
- [x] Regression run over every touched area (folder-ingest x4, email-ingest,
      mcp-health): 172 passed, 0 failed

### The two failures are pre-existing, and verified so

Not assumed — the full suite was run on clean `origin/main` for comparison. They
have different root causes and neither is fixed here:

- `test_paperless_stanza_maps_tools` — fails on `main` **even in isolation**:
  genuine rot or a real bug
- `test_find_pairs_returns_empty_on_sqlite` — passes isolated and with its own
  file, fails in the full run on `main` too: **cross-test contamination**, i.e.
  a test-isolation defect

Both deserve fixing, in their own change rather than smuggled into this one.

## Deploy note

Migration only; no data migration, nothing dropped. The legacy SystemSetting
tokens are untouched and keep working. **Re-verify `alembic heads` against the
live DB before deploying** — the single-head check here was computed from the
migration files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iG4mG4bmRugn3xkJeJN8K
