### PR TITLE
feat(ingest): server-authoritative sphere routing on client identity, Phase 4 (#1218)

### DIFF
--- a/src/backend/alembic/versions/pc20260908b_ingest_credential_sphere.py
+++ b/src/backend/alembic/versions/pc20260908b_ingest_credential_sphere.py
@@ -1,0 +1,38 @@
+"""ingest_credentials: per-client sphere routing (owner / tier / kb).
+
+Revision ID: pc20260908b_cred_sphere
+Revises: pc20260908_ingest_credentials
+Create Date: 2026-09-08 01:00:00.000000
+
+Phase 4 of docs/design/ingest-credentials.md. Folder-ingest files everything into
+ONE globally configured destination because it could not tell its clients apart.
+Now that a push resolves to a credential, the destination can be a property of
+WHO pushed — which is what email-ingest already does per mailbox.
+
+All three columns are NULLABLE and NULL means "use the global
+folder_ingest_* configuration", so existing credentials keep behaving exactly as
+they do today. Nothing is backfilled.
+
+The client never SENDS these. They are read from the authenticated credential
+row, so a stolen token cannot pick an owner, raise a tier, or file into another
+knowledge base.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "pc20260908b_cred_sphere"
+down_revision = "pc20260908_ingest_credentials"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("ingest_credentials", sa.Column("owner", sa.String(length=100), nullable=True))
+    op.add_column("ingest_credentials", sa.Column("tier", sa.SmallInteger(), nullable=True))
+    op.add_column("ingest_credentials", sa.Column("kb_name", sa.String(length=200), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("ingest_credentials", "kb_name")
+    op.drop_column("ingest_credentials", "tier")
+    op.drop_column("ingest_credentials", "owner")

--- a/src/backend/api/routes/folder_ingest.py
+++ b/src/backend/api/routes/folder_ingest.py
@@ -179,15 +179,26 @@ async def ingest_pushed_document(
     # bridge already maps its own known errors to FAILED/RETRY; this guards the
     # residual transient ones so the 4-state transport contract never breaks.
     try:
-        kb = await resolve_target_kb(db)
-        owner_user_id = await resolve_owner_user_id(db)
+        # Sphere routing is SERVER-AUTHORITATIVE: owner/tier/kb come from the
+        # credential row this push authenticated as, never from the request. A
+        # stolen token can file a document; it cannot choose whose it is, raise
+        # its tier, or put it in another knowledge base. A client with no
+        # override configured falls back to the global folder_ingest_* settings,
+        # which is exactly what every client did before Phase 4.
+        kb = await resolve_target_kb(db, ingest_client.kb_name)
+        owner_user_id = await resolve_owner_user_id(db, ingest_client.owner)
+        tier = (
+            ingest_client.tier
+            if ingest_client.tier is not None
+            else settings.folder_ingest_default_tier
+        )
         result = await ingest_document(
             file_bytes,
             meta,
             db=db,
             kb_id=kb.id,
             owner_user_id=owner_user_id,
-            default_tier=settings.folder_ingest_default_tier,
+            default_tier=tier,
             file_to_paperless=_should_file_paperless(),
             source=FOLDER_INGEST_SOURCE,  # provenance for the Simba review flow
         )

--- a/src/backend/api/routes/ingest_credentials.py
+++ b/src/backend/api/routes/ingest_credentials.py
@@ -37,6 +37,7 @@ from services.ingest_credentials import (
     mint_credential,
     revoke_credential,
     rotate_credential,
+    set_client_sphere,
 )
 from utils.config import settings
 
@@ -54,6 +55,10 @@ class CredentialOut(BaseModel):
     client_id: str
     label: str
     route: str
+    # Where this client's documents land. null => the global default.
+    owner: str | None = None
+    tier: int | None = None
+    kb_name: str | None = None
     created_at: str | None = None
     rotated_at: str | None = None
     last_authenticated_at: str | None = None
@@ -81,6 +86,16 @@ class MintIn(BaseModel):
     client_id: str = Field(min_length=1, max_length=64)
     label: str = Field(min_length=1, max_length=200)
     route: str
+    # Optional sphere routing. Set by the ADMIN here, never by the client.
+    owner: str | None = None
+    tier: int | None = Field(default=None, ge=0, le=4)
+    kb_name: str | None = None
+
+
+class SphereIn(BaseModel):
+    owner: str | None = None
+    tier: int | None = Field(default=None, ge=0, le=4)
+    kb_name: str | None = None
 
 
 class TokenOut(BaseModel):
@@ -124,6 +139,7 @@ async def list_all(
         credentials=[
             CredentialOut(
                 client_id=r.client_id, label=r.label, route=r.route,
+                owner=r.owner, tier=r.tier, kb_name=r.kb_name,
                 created_at=_iso(r.created_at), rotated_at=_iso(r.rotated_at),
                 last_authenticated_at=_iso(r.last_authenticated_at),
                 revoked_at=_iso(r.revoked_at), is_enabled=bool(r.is_enabled),
@@ -150,6 +166,7 @@ async def mint(
         token = await mint_credential(
             db, client_id=body.client_id, label=body.label, route=body.route,
             created_by_user_id=getattr(user, "id", None),
+            owner=body.owner, tier=body.tier, kb_name=body.kb_name,
         )
     except InvalidClientId as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from None
@@ -194,3 +211,29 @@ async def revoke(
     if not ok:
         raise HTTPException(status_code=404, detail=f"unknown client_id: {client_id}")
     return {"revoked": True, "client_id": client_id.strip().lower()}
+
+
+@router.put("/{client_id}/sphere")
+@limiter.limit(settings.api_rate_limit_admin)
+async def set_sphere(
+    request: Request,
+    client_id: str,
+    body: SphereIn,
+    db: AsyncSession = Depends(get_db),
+    user=Depends(require_permission(Permission.SETTINGS_MANAGE)),
+):
+    """Set where this client's documents land (owner / tier / knowledge base).
+
+    Admin-only and server-side by design: the client never sends these, so a
+    stolen push token cannot choose an owner, raise a tier, or file elsewhere.
+    A null field clears the override back to the global default.
+    """
+    try:
+        ok = await set_client_sphere(
+            db, client_id, owner=body.owner, tier=body.tier, kb_name=body.kb_name
+        )
+    except InvalidClientId as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+    if not ok:
+        raise HTTPException(status_code=404, detail=f"unknown client_id: {client_id}")
+    return {"updated": True, "client_id": client_id.strip().lower()}

--- a/src/backend/api/routes/ingest_credentials.py
+++ b/src/backend/api/routes/ingest_credentials.py
@@ -29,6 +29,7 @@ from models.permissions import Permission
 from services.api_rate_limiter import limiter
 from services.auth_service import require_permission
 from services.database import get_db
+from services.ingest_common import resolve_user_id
 from services.ingest_credentials import (
     ROUTE_EMAIL,
     ROUTE_FOLDER,
@@ -109,6 +110,22 @@ def _iso(value) -> str | None:
     return value.isoformat() if value else None
 
 
+async def _validated_owner(db: AsyncSession, owner: str | None) -> str | None:
+    """Reject an owner that does not resolve to a real user.
+
+    resolve_user_id returns None for an unknown username, which the ingest path
+    treats as "ownerless" — so a typo would silently produce unowned documents
+    while the admin believed they had assigned an owner. Fail here, where a
+    human is present to read the message.
+    """
+    value = (owner or "").strip()
+    if not value:
+        return None
+    if await resolve_user_id(db, value) is None:
+        raise HTTPException(status_code=400, detail=f"unknown owner: {value!r}")
+    return value
+
+
 async def _legacy_state(db: AsyncSession) -> list[LegacyOut]:
     out: list[LegacyOut] = []
     for route, (settings_attr, setting_key) in _LEGACY_ENV.items():
@@ -166,7 +183,8 @@ async def mint(
         token = await mint_credential(
             db, client_id=body.client_id, label=body.label, route=body.route,
             created_by_user_id=getattr(user, "id", None),
-            owner=body.owner, tier=body.tier, kb_name=body.kb_name,
+            owner=await _validated_owner(db, body.owner),
+            tier=body.tier, kb_name=body.kb_name,
         )
     except InvalidClientId as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from None
@@ -230,7 +248,8 @@ async def set_sphere(
     """
     try:
         ok = await set_client_sphere(
-            db, client_id, owner=body.owner, tier=body.tier, kb_name=body.kb_name
+            db, client_id, owner=await _validated_owner(db, body.owner),
+            tier=body.tier, kb_name=body.kb_name,
         )
     except InvalidClientId as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from None

--- a/src/backend/models/database.py
+++ b/src/backend/models/database.py
@@ -3249,6 +3249,15 @@ class IngestCredential(Base):
     revoked_at = Column(DateTime, nullable=True)
     is_enabled = Column(Boolean, nullable=False, default=True, server_default="true")
 
+    # Server-authoritative sphere routing (Phase 4). NULL => use the global
+    # folder_ingest_* configuration, so existing credentials are unchanged.
+    # The client never SENDS these; they are read from the row it authenticated
+    # as, so a stolen token cannot pick an owner, raise a tier, or file
+    # elsewhere. Mirrors email-ingest's per-mailbox routing.
+    owner = Column(String(100), nullable=True)      # username or numeric id
+    tier = Column(SmallInteger, nullable=True)      # circle tier 0-4
+    kb_name = Column(String(200), nullable=True)
+
 
 class DocumentProcessingHistory(Base):
     """

--- a/src/backend/services/folder_ingest.py
+++ b/src/backend/services/folder_ingest.py
@@ -444,20 +444,24 @@ async def resolve_folder_ingest_client(db: AsyncSession, token: str):
 # (folder_ingest_kb_name, folder_ingest_target_user) destination.
 # ---------------------------------------------------------------------------
 
-async def resolve_target_kb(db: AsyncSession) -> KnowledgeBase:
-    """Get-or-create the configured folder-ingest target KB. Mirrors the
-    chat-upload default-KB pattern so a fresh install just works."""
+async def resolve_target_kb(db: AsyncSession, kb_name: str | None = None) -> KnowledgeBase:
+    """Get-or-create the target KB. Mirrors the chat-upload default-KB pattern
+    so a fresh install just works.
+
+    ``kb_name`` comes from the authenticated CLIENT's credential row when it has
+    one (Phase 4 sphere routing); None falls back to the global configuration,
+    which is what every client did before per-integration credentials existed.
+    """
+    target_name = (kb_name or "").strip() or settings.folder_ingest_kb_name
     kb = (
         await db.execute(
-            select(KnowledgeBase).where(
-                KnowledgeBase.name == settings.folder_ingest_kb_name
-            )
+            select(KnowledgeBase).where(KnowledgeBase.name == target_name)
         )
     ).scalar_one_or_none()
     if kb:
         return kb
     kb = KnowledgeBase(
-        name=settings.folder_ingest_kb_name,
+        name=target_name,
         description="Auto-ingested documents from watched folders",
     )
     db.add(kb)
@@ -480,8 +484,11 @@ async def target_kb_exists(db: AsyncSession) -> bool:
     return kb_id is not None
 
 
-async def resolve_owner_user_id(db: AsyncSession) -> int | None:
-    """Resolve ``folder_ingest_target_user`` (username or numeric id) to a user
-    id. Empty config → None (the bridge/worker handle an ownerless enqueue the
-    same way the upload route does for unauthenticated single-user mode)."""
-    return await resolve_user_id(db, settings.folder_ingest_target_user)
+async def resolve_owner_user_id(db: AsyncSession, owner: str | None = None) -> int | None:
+    """Resolve an owner (username or numeric id) to a user id.
+
+    ``owner`` comes from the authenticated CLIENT's credential row when it has
+    one; None falls back to ``folder_ingest_target_user``. Empty → None (the
+    bridge/worker handle an ownerless enqueue the same way the upload route does
+    for unauthenticated single-user mode)."""
+    return await resolve_user_id(db, (owner or "").strip() or settings.folder_ingest_target_user)

--- a/src/backend/services/ingest_credentials.py
+++ b/src/backend/services/ingest_credentials.py
@@ -69,12 +69,21 @@ class InvalidClientId(ValueError):
 @dataclass(frozen=True)
 class IngestClient:
     """Who pushed. ``legacy`` marks the shared SystemSetting token, which has no
-    identity — that is precisely the gap this module closes."""
+    identity — that is precisely the gap this module closes.
+
+    The sphere fields are read from the credential ROW, never from the request.
+    A client cannot name its own owner, tier or knowledge base; if it could, a
+    stolen token would be an escalation rather than a nuisance. ``None`` on any
+    of them means "use the global folder_ingest_* configuration".
+    """
 
     client_id: str
     label: str
     route: str
     legacy: bool = False
+    owner: str | None = None
+    tier: int | None = None
+    kb_name: str | None = None
 
 
 def _validate_client_id(client_id: str) -> str:
@@ -110,6 +119,9 @@ async def mint_credential(
     label: str,
     route: str,
     created_by_user_id: int | None = None,
+    owner: str | None = None,
+    tier: int | None = None,
+    kb_name: str | None = None,
 ) -> str:
     """Create a credential. Returns the plaintext ONCE; only the hash is stored."""
     cid = _validate_client_id(client_id)
@@ -130,6 +142,9 @@ async def mint_credential(
             token_hash=await asyncio.to_thread(pwd_context.hash, secret),
             created_by_user_id=created_by_user_id,
             created_at=datetime.utcnow(),
+            owner=(owner or None),
+            tier=(min(max(int(tier), 0), 4) if tier is not None else None),
+            kb_name=(kb_name or None),
         )
     )
     try:
@@ -237,10 +252,45 @@ async def resolve_ingest_client(
             if last is None or (now - last).total_seconds() >= _LAST_SEEN_THROTTLE_SECONDS:
                 row.last_authenticated_at = now
                 await db.commit()
-            return IngestClient(client_id=row.client_id, label=row.label, route=row.route)
+            return IngestClient(
+                client_id=row.client_id, label=row.label, route=row.route,
+                owner=(row.owner or None),
+                # Clamp to the circle ladder. A row edited outside the API must
+                # not be able to express a tier that does not exist.
+                tier=(min(max(int(row.tier), 0), 4) if row.tier is not None else None),
+                kb_name=(row.kb_name or None),
+            )
         # Not one of ours → fall through to the legacy shared token.
 
     if legacy_verify is not None and await legacy_verify(db, token):
         return IngestClient(client_id="legacy", label="Legacy shared token",
                             route=route, legacy=True)
     return None
+
+
+async def set_client_sphere(
+    db: AsyncSession,
+    client_id: str,
+    *,
+    owner: str | None,
+    tier: int | None,
+    kb_name: str | None,
+) -> bool:
+    """Set where this client's documents land. Admin-only, server-side.
+
+    Passing ``None`` for a field clears it back to the global default rather
+    than leaving a stale value — an operator removing an owner must actually
+    remove it.
+    """
+    cid = _validate_client_id(client_id)
+    row = (
+        await db.execute(select(IngestCredential).where(IngestCredential.client_id == cid))
+    ).scalar_one_or_none()
+    if row is None:
+        return False
+    row.owner = owner or None
+    row.tier = min(max(int(tier), 0), 4) if tier is not None else None
+    row.kb_name = kb_name or None
+    await db.commit()
+    logger.info(f"ingest credential {cid} sphere set: owner={row.owner} tier={row.tier} kb={row.kb_name}")
+    return True

--- a/src/backend/services/ingest_credentials.py
+++ b/src/backend/services/ingest_credentials.py
@@ -26,7 +26,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from models.database import IngestCredential
+from models.database import TIER_PUBLIC, TIER_SELF, IngestCredential
 from utils.config import settings
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -86,6 +86,12 @@ class IngestClient:
     kb_name: str | None = None
 
 
+def _clamp_tier(value) -> int:
+    """Clamp to the circle ladder using its canonical bounds, not literals — a
+    hardcoded 0/4 would silently diverge if the ladder ever changed."""
+    return min(max(int(value), TIER_SELF), TIER_PUBLIC)
+
+
 def _validate_client_id(client_id: str) -> str:
     cid = (client_id or "").strip().lower()
     if not _CLIENT_ID_RE.match(cid):
@@ -143,7 +149,7 @@ async def mint_credential(
             created_by_user_id=created_by_user_id,
             created_at=datetime.utcnow(),
             owner=(owner or None),
-            tier=(min(max(int(tier), 0), 4) if tier is not None else None),
+            tier=(_clamp_tier(tier) if tier is not None else None),
             kb_name=(kb_name or None),
         )
     )
@@ -257,7 +263,7 @@ async def resolve_ingest_client(
                 owner=(row.owner or None),
                 # Clamp to the circle ladder. A row edited outside the API must
                 # not be able to express a tier that does not exist.
-                tier=(min(max(int(row.tier), 0), 4) if row.tier is not None else None),
+                tier=(_clamp_tier(row.tier) if row.tier is not None else None),
                 kb_name=(row.kb_name or None),
             )
         # Not one of ours → fall through to the legacy shared token.
@@ -289,7 +295,7 @@ async def set_client_sphere(
     if row is None:
         return False
     row.owner = owner or None
-    row.tier = min(max(int(tier), 0), 4) if tier is not None else None
+    row.tier = _clamp_tier(tier) if tier is not None else None
     row.kb_name = kb_name or None
     await db.commit()
     logger.info(f"ingest credential {cid} sphere set: owner={row.owner} tier={row.tier} kb={row.kb_name}")

--- a/src/frontend/src/api/resources/ingestCredentials.ts
+++ b/src/frontend/src/api/resources/ingestCredentials.ts
@@ -17,6 +17,10 @@ export interface IngestCredential {
   client_id: string;
   label: string;
   route: IngestRoute;
+  /** Where this client's documents land. null => the instance default. */
+  owner: string | null;
+  tier: number | null;
+  kb_name: string | null;
   created_at: string | null;
   rotated_at: string | null;
   last_authenticated_at: string | null;
@@ -45,6 +49,9 @@ export interface MintPayload {
   client_id: string;
   label: string;
   route: IngestRoute;
+  /** Optional sphere routing, set by the ADMIN here — never by the client. */
+  kb_name?: string | null;
+  tier?: number | null;
 }
 
 /** Carries the plaintext. Shown once, never re-fetchable. */

--- a/src/frontend/src/components/integrations/IngestCredentials.tsx
+++ b/src/frontend/src/components/integrations/IngestCredentials.tsx
@@ -44,6 +44,7 @@ export default function IngestCredentials() {
   const [clientId, setClientId] = useState('');
   const [label, setLabel] = useState('');
   const [route, setRoute] = useState<IngestRoute>('folder_ingest');
+  const [kbName, setKbName] = useState('');
   const [minted, setMinted] = useState<(MintResult & { rotated: boolean }) | null>(null);
   const [copied, setCopied] = useState(false);
   const [copyFailed, setCopyFailed] = useState(false);
@@ -63,9 +64,15 @@ export default function IngestCredentials() {
 
   const doMint = async () => {
     try {
-      reveal(await mint.mutateAsync({ client_id: clientId.trim(), label: label.trim() || clientId.trim(), route }), false);
+      reveal(await mint.mutateAsync({
+        client_id: clientId.trim(),
+        label: label.trim() || clientId.trim(),
+        route,
+        kb_name: kbName.trim() || null,
+      }), false);
       setClientId('');
       setLabel('');
+      setKbName('');
     } catch {
       setError(t('integrations.credentials.mintFailed'));
     }
@@ -176,6 +183,12 @@ export default function IngestCredentials() {
             ))}
           </select>
         </label>
+        <label className="flex flex-col text-xs text-gray-500 dark:text-gray-400">
+          {t('integrations.credentials.kb')}
+          <input className="input mt-1 w-40" value={kbName}
+                 placeholder={t('integrations.credentials.kbDefault')}
+                 onChange={(e) => setKbName(e.target.value)} />
+        </label>
         <button className="btn-primary" disabled={!clientId.trim() || mint.isPending} onClick={doMint}>
           {t('integrations.credentials.mint')}
         </button>
@@ -207,6 +220,14 @@ export default function IngestCredentials() {
                   )}
                 </span>
               </div>
+              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                {/* Where this client's documents land. The client cannot choose
+                    this — it is read from the credential it authenticates as. */}
+                {t('integrations.credentials.filesInto')}:{' '}
+                {c.kb_name || t('integrations.credentials.kbDefault')}
+                {c.tier != null && ` · ${t('integrations.credentials.tier')} ${c.tier}`}
+                {c.owner && ` · ${c.owner}`}
+              </p>
               <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
                 {t('integrations.credentials.lastSeen')}: {fmt(c.last_authenticated_at)}
                 {' · '}

--- a/src/frontend/src/i18n/locales/de.json
+++ b/src/frontend/src/i18n/locales/de.json
@@ -1262,6 +1262,10 @@
       "revokeWarning": "„{{id}}“ kann sich danach nicht mehr anmelden. Die Kennung bleibt vergeben — reaktiviert wird sie über „Erneuern“, das ein neues Token ausgibt.",
       "revokeConfirm": "Widerruf bestätigen",
       "revokeFailed": "Widerruf fehlgeschlagen.",
+      "kb": "Wissensbasis",
+      "kbDefault": "Standard",
+      "filesInto": "Ablage",
+      "tier": "Stufe",
       "routes": {
         "folder_ingest": "Ordner-Ingest",
         "email_ingest": "E-Mail-Ingest"

--- a/src/frontend/src/i18n/locales/en.json
+++ b/src/frontend/src/i18n/locales/en.json
@@ -1262,6 +1262,10 @@
       "revokeWarning": "“{{id}}” can no longer authenticate. The client id stays taken — reactivate it with Rotate, which issues a new token.",
       "revokeConfirm": "Confirm revocation",
       "revokeFailed": "Could not revoke the credential.",
+      "kb": "Knowledge base",
+      "kbDefault": "default",
+      "filesInto": "Files into",
+      "tier": "Tier",
       "routes": {
         "folder_ingest": "Folder ingest",
         "email_ingest": "Email ingest"

--- a/tests/backend/test_ingest_credentials_routes.py
+++ b/tests/backend/test_ingest_credentials_routes.py
@@ -126,3 +126,41 @@ async def test_list_reports_the_feature_flag(client, monkeypatch):
     # The UI must be able to say "these are configured but not yet in effect".
     monkeypatch.setattr(routes.settings, "ingest_credentials_enabled", False, raising=False)
     assert (await client.get("/api/ingest-credentials")).json()["enabled"] is False
+
+
+# --- review findings (Phase 4) -----------------------------------------------
+
+async def test_unknown_owner_is_rejected_not_silently_dropped(client):
+    # resolve_user_id returns None for an unknown username, which the ingest
+    # path reads as "ownerless" — so a typo would silently produce unowned
+    # documents while the admin believed an owner was set.
+    r = await client.post("/api/ingest-credentials",
+                          json={"client_id": "scanner", "label": "S",
+                                "route": ROUTE_FOLDER, "owner": "nosuchuser"})
+    assert r.status_code == 400
+    assert "unknown owner" in r.text
+
+
+async def test_sphere_update_also_rejects_an_unknown_owner(client):
+    await client.post("/api/ingest-credentials",
+                      json={"client_id": "scanner", "label": "S", "route": ROUTE_FOLDER})
+    r = await client.put("/api/ingest-credentials/scanner/sphere",
+                         json={"owner": "nosuchuser", "tier": None, "kb_name": None})
+    assert r.status_code == 400
+
+
+async def test_sphere_can_be_set_and_read_back(client):
+    await client.post("/api/ingest-credentials",
+                      json={"client_id": "scanner", "label": "S", "route": ROUTE_FOLDER})
+    r = await client.put("/api/ingest-credentials/scanner/sphere",
+                         json={"owner": None, "tier": 2, "kb_name": "Scans"})
+    assert r.status_code == 200
+    row = (await client.get("/api/ingest-credentials")).json()["credentials"][0]
+    assert row["tier"] == 2 and row["kb_name"] == "Scans"
+
+
+async def test_out_of_range_tier_is_refused_by_the_schema(client):
+    r = await client.post("/api/ingest-credentials",
+                          json={"client_id": "x", "label": "x",
+                                "route": ROUTE_FOLDER, "tier": 9})
+    assert r.status_code == 422

--- a/tests/backend/test_ingest_sphere_routing.py
+++ b/tests/backend/test_ingest_sphere_routing.py
@@ -55,6 +55,13 @@ async def test_two_clients_route_to_different_spheres(db_session):
     assert (cb.kb_name, cb.tier) == ("Scans", 3)
 
 
+async def test_clamp_uses_the_canonical_ladder_bounds(db_session):
+    # Not hardcoded 0/4: a literal would silently diverge if the ladder changed.
+    from models.database import TIER_PUBLIC, TIER_SELF
+    assert ic._clamp_tier(99) == TIER_PUBLIC
+    assert ic._clamp_tier(-5) == TIER_SELF
+
+
 async def test_tier_is_clamped_to_the_circle_ladder(db_session):
     # A row edited outside the API must not express a tier that does not exist.
     await ic.mint_credential(db_session, client_id="scanner", label="S",

--- a/tests/backend/test_ingest_sphere_routing.py
+++ b/tests/backend/test_ingest_sphere_routing.py
@@ -1,0 +1,171 @@
+"""Server-authoritative sphere routing on client identity (#1218 Phase 4).
+
+The property under test is that the DESTINATION is a function of WHO
+authenticated, never of what the request said. A stolen push token must be able
+to file a document and nothing more: it cannot choose an owner, raise a tier, or
+put the document in another knowledge base.
+"""
+
+import pytest
+
+from services import ingest_credentials as ic
+from services.folder_ingest import resolve_owner_user_id, resolve_target_kb
+
+pytestmark = [pytest.mark.backend, pytest.mark.database]
+
+
+@pytest.fixture(autouse=True)
+def _enable(monkeypatch):
+    monkeypatch.setattr(ic.settings, "ingest_credentials_enabled", True, raising=False)
+
+
+async def test_client_without_an_override_uses_the_global_default(db_session, monkeypatch):
+    # Backward compatibility: this is exactly what every client did before
+    # per-integration credentials existed.
+    monkeypatch.setattr("services.folder_ingest.settings.folder_ingest_kb_name", "Eingang")
+    token = await ic.mint_credential(
+        db_session, client_id="files", label="Files", route=ic.ROUTE_FOLDER)
+    client = await ic.resolve_ingest_client(db_session, ic.ROUTE_FOLDER, token)
+    assert client.kb_name is None and client.owner is None and client.tier is None
+    kb = await resolve_target_kb(db_session, client.kb_name)
+    assert kb.name == "Eingang"
+
+
+async def test_client_override_routes_to_its_own_kb(db_session, monkeypatch):
+    monkeypatch.setattr("services.folder_ingest.settings.folder_ingest_kb_name", "Eingang")
+    token = await ic.mint_credential(
+        db_session, client_id="scanner", label="Scanner", route=ic.ROUTE_FOLDER,
+        kb_name="Scans", tier=2)
+    client = await ic.resolve_ingest_client(db_session, ic.ROUTE_FOLDER, token)
+    assert client.kb_name == "Scans" and client.tier == 2
+    kb = await resolve_target_kb(db_session, client.kb_name)
+    assert kb.name == "Scans"
+
+
+async def test_two_clients_route_to_different_spheres(db_session):
+    # The whole point: one endpoint, one route, two destinations decided by
+    # which credential authenticated.
+    a = await ic.mint_credential(db_session, client_id="files", label="F",
+                                 route=ic.ROUTE_FOLDER, kb_name="Eingang", tier=0)
+    b = await ic.mint_credential(db_session, client_id="scanner", label="S",
+                                 route=ic.ROUTE_FOLDER, kb_name="Scans", tier=3)
+    ca = await ic.resolve_ingest_client(db_session, ic.ROUTE_FOLDER, a)
+    cb = await ic.resolve_ingest_client(db_session, ic.ROUTE_FOLDER, b)
+    assert (ca.kb_name, ca.tier) == ("Eingang", 0)
+    assert (cb.kb_name, cb.tier) == ("Scans", 3)
+
+
+async def test_tier_is_clamped_to_the_circle_ladder(db_session):
+    # A row edited outside the API must not express a tier that does not exist.
+    await ic.mint_credential(db_session, client_id="scanner", label="S",
+                             route=ic.ROUTE_FOLDER, tier=99)
+    from sqlalchemy import select
+    from models.database import IngestCredential
+    row = (await db_session.execute(
+        select(IngestCredential).where(IngestCredential.client_id == "scanner")
+    )).scalar_one()
+    assert row.tier == 4
+
+
+async def test_sphere_can_be_changed_and_cleared(db_session):
+    await ic.mint_credential(db_session, client_id="scanner", label="S",
+                             route=ic.ROUTE_FOLDER, kb_name="Scans", tier=2, owner="alice")
+    assert await ic.set_client_sphere(
+        db_session, "scanner", owner=None, tier=None, kb_name=None) is True
+    token = await ic.rotate_credential(db_session, "scanner")
+    client = await ic.resolve_ingest_client(db_session, ic.ROUTE_FOLDER, token)
+    # Clearing must actually clear — an operator removing an owner must remove it.
+    assert client.owner is None and client.tier is None and client.kb_name is None
+
+
+async def test_set_sphere_on_unknown_client_is_false(db_session):
+    assert await ic.set_client_sphere(
+        db_session, "ghost", owner=None, tier=None, kb_name=None) is False
+
+
+async def test_legacy_client_has_no_sphere_override(db_session):
+    # The shared token has no identity, so it cannot carry a sphere — it must
+    # keep falling back to the global configuration.
+    async def legacy_ok(db, token):
+        return True
+
+    client = await ic.resolve_ingest_client(
+        db_session, ic.ROUTE_FOLDER, "shared", legacy_verify=legacy_ok)
+    assert client.legacy is True
+    assert client.owner is None and client.tier is None and client.kb_name is None
+
+
+async def test_owner_falls_back_to_global_when_unset(db_session, monkeypatch):
+    monkeypatch.setattr("services.folder_ingest.settings.folder_ingest_target_user", "")
+    assert await resolve_owner_user_id(db_session, None) is None
+
+
+# --- the property that matters: the request cannot choose the destination -----
+
+@pytest.fixture
+async def push_client(db_session):
+    """The folder-ingest push route, mounted alone against the test session."""
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+    from slowapi.errors import RateLimitExceeded
+    from unittest.mock import MagicMock
+
+    from api.routes import folder_ingest as route
+    from services.api_rate_limiter import limiter, rate_limit_exceeded_handler
+    from services.auth_service import get_current_user
+    from services.database import get_db
+
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
+    app.include_router(route.router, prefix="/api/folder-ingest")
+
+    async def _db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = lambda: MagicMock(id=1, username="admin")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        yield c
+
+
+async def test_a_push_cannot_choose_its_own_sphere(db_session, push_client, monkeypatch):
+    """A stolen token may file a document; it may NOT decide whose it is.
+
+    The push claims owner/tier/kb in its metadata. The backend must ignore all
+    three and use the credential row it authenticated as.
+    """
+    import json
+    from unittest.mock import AsyncMock
+    from api.routes import folder_ingest as route
+    from services.folder_ingest import IngestResult, IngestStatus
+
+    monkeypatch.setattr(route.settings, "folder_ingest_enabled", True, raising=False)
+    monkeypatch.setattr(route, "_worker_is_alive", AsyncMock(return_value=True))
+    monkeypatch.setattr(route.settings, "folder_ingest_default_tier", 0, raising=False)
+
+    token = await ic.mint_credential(
+        db_session, client_id="scanner", label="Scanner", route=ic.ROUTE_FOLDER,
+        kb_name="Scans", tier=1)
+
+    captured = {}
+
+    async def _capture(*args, **kwargs):
+        captured.update(kwargs)
+        return IngestResult(IngestStatus.INGESTED, document_id=1)
+
+    monkeypatch.setattr(route, "ingest_document", _capture)
+
+    resp = await push_client.post(
+        "/api/folder-ingest/document",
+        headers={"Authorization": f"Bearer {token}"},
+        files={"file": ("x.pdf", b"%PDF-1.4", "application/pdf")},
+        data={"metadata": json.dumps({
+            "filename": "x.pdf",
+            # All three are hostile: the client naming its own sphere.
+            "owner": "admin", "tier": 4, "kb": "Privat", "kb_name": "Privat",
+        })},
+    )
+    assert resp.status_code == 200, resp.text
+    # The tier came from the CREDENTIAL (1), not the request (4).
+    assert captured["default_tier"] == 1, "request-supplied tier was honoured"

--- a/tests/frontend/react/components/IngestCredentials.test.tsx
+++ b/tests/frontend/react/components/IngestCredentials.test.tsx
@@ -34,6 +34,9 @@ const credential = {
   client_id: 'scanner',
   label: 'Scanner',
   route: 'folder_ingest',
+  owner: null,
+  tier: 1,
+  kb_name: 'Scans',
   created_at: '2026-09-08T10:00:00Z',
   rotated_at: null,
   last_authenticated_at: '2026-09-08T11:00:00Z',
@@ -108,6 +111,24 @@ describe('IngestCredentials', () => {
     // to get it back rather than implying the name is freed.
     expect(document.body.textContent).toMatch(/stays taken/i);
     expect(del).not.toHaveBeenCalled();
+  });
+
+  it('shows where the client files, which the client itself cannot choose', async () => {
+    renderIt();
+    await screen.findByText('scanner');
+    expect(document.body.textContent).toMatch(/Files into/i);
+    expect(document.body.textContent).toMatch(/Scans/);
+    expect(document.body.textContent).toMatch(/Tier 1/);
+  });
+
+  it('does not render a tier when the field is absent, not just null', async () => {
+    // A response missing the field would otherwise render "Tier undefined".
+    get.mockResolvedValue(body({
+      credentials: [{ ...credential, tier: undefined, kb_name: undefined }],
+    }));
+    renderIt();
+    await screen.findByText('scanner');
+    expect(document.body.textContent).not.toMatch(/undefined/);
   });
 
   it('warns when the feature flag is off', async () => {


### PR DESCRIPTION
Phase 4 of #1218. Depends on the credentials table from #1220 (merged).

## What it fixes

Folder-ingest filed **everything** into one globally configured destination,
because it could not tell its clients apart. Now that a push resolves to a
credential, the destination becomes a property of **who pushed** — which is what
email-ingest has always done per mailbox.

Three nullable columns on the credential (`owner`, `tier`, `kb_name`), migration
`pc20260908b_cred_sphere`. **NULL means "use the global `folder_ingest_*`
configuration"**, so every existing client behaves exactly as before and nothing
is backfilled.

## The security property

**The client never sends these.** They are read from the row it authenticated
as. A stolen push token can file a document and nothing more — it cannot choose
whose the document is, raise its circle tier, or put it in another knowledge
base.

The test that proves it pushes metadata claiming `owner`, `tier` **and** `kb`,
then asserts the **credential's** tier reached `ingest_document`, not the
request's. That is the assertion worth reading in this PR.

Tiers are clamped to the 0-4 ladder on both write and read, so a row edited
outside the API cannot express a tier that does not exist.

## Why this was worth building beyond rotation

This is what makes the scanner's `scan_profile_id` (#1215) stop being inert. The
missing piece was never the scanner — it was the backend not knowing which
client pushed. Folder-ingest is now level with email-ingest.

## Deliberately left global

`target_kb_exists()` is the health-handshake probe reporting whether the
**instance's** default KB is provisioned. That is not a client's sphere, so it
keeps reading the global config.

## Caught while wiring the UI

`c.tier !== null` rendered **"Tier undefined"** for a response missing the field
rather than one carrying an explicit null. Now a loose `!= null`, with a test
that asserts nothing renders "undefined".

## Test plan

- [x] 10 sphere tests, incl. the request-cannot-choose-its-destination case, two
      clients routing to different spheres, tier clamping, clearing an override
      actually clearing, and the legacy client having no sphere (it has no
      identity, so it must keep falling back to the global config)
- [x] 9 frontend component tests
- [x] Full backend suite on .159: **6157 passed**, against **6091 on clean
      `origin/main`** — same 2 pre-existing failures, already verified against
      main in #1220
- [x] `tsc --noEmit` clean; production build green

## Deploy note

Additive migration, three nullable columns, no backfill. Flag-gated behind
`INGEST_CREDENTIALS_ENABLED` like the rest of #1218. **Re-verify `alembic heads`
against the live DB before deploying.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iG4mG4bmRugn3xkJeJN8K
