### PR TITLE
chore(k8s): enable per-integration ingest credentials on the household (#1218)

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -357,6 +357,11 @@ data:
   FOLDER_INGEST_RENAME_PROCESSED_ENABLED: "true"
   FOLLOWUP_CHIPS_ENABLED: "true"
   GRAPH_EXPANSION_ENABLED: "true"
+  # Per-integration ingest credentials (#1218). ADDITIVE: a token without the
+  # rfi. prefix still falls through to the legacy shared token, so the
+  # filesystem/email-ingest MCPs are unaffected. Enables minting per-client
+  # credentials in the Integrations UI, and per-client sphere routing.
+  INGEST_CREDENTIALS_ENABLED: "true"
   KG_CONFLATION_MONITOR_ENABLED: "true"
   KG_RECONCILER_ENABLED: "true"
   MEMORY_EXTRACTION_V2_SHADOW: "true"


### PR DESCRIPTION
Flips `INGEST_CREDENTIALS_ENABLED` to true for the household instance.

The code was deployed as `2026-09-08-ingest-credentials` and verified by the post-deploy smoke test: pods green with 0 restarts, migrations at head, browser E2E clean on the new bundle, and — the finding that mattered — the filesystem MCP rode through the rollout, self-recovered against the new backend, and has returned 200 every 30s since, with **zero 4xx/5xx on any ingest route**.

**Additive, not a switch.** `resolve_ingest_client` only consults the credentials table for a token carrying the `rfi.` prefix; anything else falls through to the legacy shared token whether the flag is on or off. So the filesystem and email-ingest MCPs cannot break, and the new branch stays dormant until a credential is actually minted.

In git rather than a `kubectl patch`, so the live ConfigMap does not drift from the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iG4mG4bmRugn3xkJeJN8K