### PR TITLE
feat(scanner): register the scanner MCP with the household (#1215)

### DIFF
--- a/config/agent_roles.yaml
+++ b/config/agent_roles.yaml
@@ -55,7 +55,9 @@ roles:
     description:
       de: "Dokumente und E-Mail: Suche in Wissensdatenbank und Paperless, Download, Versand; SOWIE Verwaltung & Status der Dokument-VERARBEITUNG selbst: Verarbeitungsstatus/Rückstau der Indexierung, wie viele Dokumente KEINE Chunks haben / leer oder unvollständig indexiert sind, Dokumente ohne Chunks NEU INDEXIEREN / neu einlesen / reparieren; SOWIE Paperless-Ablage-STATUS & -Pflege: ob ALLE Dokumente in Paperless (vollständig) abgelegt sind, ob Dokumente in Paperless FEHLEN, wie viele (noch nicht) in Paperless sind; SOWIE DUBLETTEN / doppelte Dokumente finden — sowohl in der WISSENSBASIS (gleiches Dokument doppelt eingelesen) als auch in Paperless aufräumen/löschen"
       en: "Documents and email: search knowledge base and Paperless, download, send; AND administration & status of the document PROCESSING itself: indexing status/backlog, how many documents have NO chunks / are empty or incompletely indexed, RE-INDEX documents without chunks; AND Paperless filing STATUS & upkeep: whether ALL documents are (fully) filed in Paperless, whether documents are MISSING from Paperless, how many are (not yet) in Paperless; AND find DUPLICATE documents — both in the KNOWLEDGE BASE (same document ingested twice) and cleaning up/deleting duplicates in Paperless"
-    mcp_servers: [paperless, email]
+    # scanner: "scanne das Dokument" — the USB scanner pushes into the same
+    # folder-ingest seam, so a scan is a document action, not a device action.
+    mcp_servers: [paperless, email, scanner]
     internal_tools: [internal.knowledge_search, internal.forward_attachment_to_paperless, internal.render_table, internal.render_list, internal.ingest_status, internal.reindex_documents, internal.list_chunkless_documents, internal.list_unfiled_documents, internal.refile_to_paperless, internal.system_health, internal.reextract_paperless_metadata, internal.paperless_dedupe, internal.find_duplicate_documents]
     max_steps: 8
     prompt_key: agent_prompt_documents

--- a/config/mcp_servers.yaml
+++ b/config/mcp_servers.yaml
@@ -427,6 +427,36 @@ servers:
         - "List the files in the inbox folder"
         - "Ingest the PDF from the documents folder"
 
+  # --- Scanner MCP Server ---
+  # Dedicated Python MCP server (renfield-mcp-scanner) driving a USB document
+  # scanner: it scans, corrects the image, and PUSHES the resulting PDF into the
+  # backend over REST (POST /api/folder-ingest/document) — the same seam the
+  # filesystem MCP uses, so dedup / tier / PDF-split / Paperless are unchanged.
+  # This streamable_http connection is the AGENT path (scan on request).
+  #
+  # Runs on the OPERATOR HOST, not in the cluster: the scanner is USB, and macOS
+  # cannot pass a USB device into a container (Docker Desktop runs a Linux VM
+  # with no host USB access). So the backend dials OUT to that host, and this
+  # server reads `down` whenever that machine is asleep or logged out — expected,
+  # not a fault. Moving the scanner to a Linux host makes the k8s packaging
+  # viable (hostPath /dev/bus/usb).
+  #
+  # GitHub: https://github.com/ebongard/renfield-mcp-scanner
+  # See docs/design/scanner-ingest.md.
+  - name: scanner
+    transport: streamable_http
+    url: "${SCANNER_MCP_URL:-http://127.0.0.1:9093/mcp}"
+    enabled: "${SCANNER_MCP_ENABLED:-false}"
+    refresh_interval: 300
+    example_intent: mcp.scanner.scanner_status
+    examples:
+      de:
+        - "Scanne die Dokumente im Einzug"
+        - "Ist der Scanner bereit?"
+      en:
+        - "Scan the documents in the feeder"
+        - "Is the scanner ready?"
+
   # --- Email MCP Server ---
   # Custom Python MCP server for multi-account email (IMAP/SMTP).
   # Requires: MAIL_ACCOUNTS_CONFIG env var pointing to YAML config file

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -58,6 +58,12 @@ data:
   DLNA_MCP_URL: "http://dlna-mcp:9091/mcp"
   # Samsung TV MCP — same hostNetwork pattern; the `samsung-mcp` Service routes to it.
   SAMSUNG_MCP_URL: "http://samsung-mcp:9092/mcp"
+  # Scanner MCP — runs on the OPERATOR HOST, not in-cluster: the scanner is USB
+  # and macOS cannot pass a USB device into a container, so the backend dials
+  # OUT to that machine. It reads `down` whenever the host is asleep or logged
+  # out; that is expected, not a fault. Needs a DHCP reservation for the host.
+  SCANNER_MCP_URL: "http://192.168.1.228:9093/mcp"
+  SCANNER_MCP_ENABLED: "true"
 
   # External integrations
   HOME_ASSISTANT_URL: "http://192.168.1.80:8123"


### PR DESCRIPTION
Registers `renfield-mcp-scanner` so it appears in Integrations and the agent can call it.

Both halves of the two-step registration — doing only the first makes the agent report *"no tool available"* while the server sits happily connected:

1. `config/mcp_servers.yaml` — `scanner` stanza, `streamable_http`
2. `config/agent_roles.yaml` — added to the `documents` role (a scan pushes into the same folder-ingest seam as the filesystem MCP, so it is a document action, not a device action)

Plus `SCANNER_MCP_URL` / `SCANNER_MCP_ENABLED` in the ConfigMap.

**Config apply + backend restart, not an image rebuild** — both files are ConfigMap-*mounted* (`/app/config/{mcp_servers,agent_roles}.yaml` ← `renfield-mcp-config`).

## Recorded in the stanza, because it will otherwise look like a fault

This server runs on the **operator host, not in the cluster**. The scanner is USB, and macOS cannot pass a USB device into a container — Docker Desktop runs a Linux VM with no host USB access, and there is no `usbipd` for macOS to bridge it. So the backend dials *out* to that machine, and the server will read `down` whenever it is asleep or logged out.

The `saned`-over-network workaround does exist (both `saned` and the SANE `net` backend are present on that host), but it keeps the host dependency while adding a daemon to babysit. Containerising only pays off on a **Linux** host, where `hostPath /dev/bus/usb` genuinely works — the Phase 4 k8s packaging already in `docs/design/scanner-ingest.md`.

Needs a DHCP reservation for the host address.

## Test plan

- [x] Both YAML files validated in-cluster
- [x] ConfigMap `--dry-run=client` clean
- [ ] Post-apply: server appears in Integrations and reports its tools
- [ ] Agent can reach it (the `agent_roles` half is what makes this work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iG4mG4bmRugn3xkJeJN8K