### PR TITLE
feat(scanner): authenticate Renfield to the scanner MCP (#1215)

### DIFF
--- a/config/mcp_servers.yaml
+++ b/config/mcp_servers.yaml
@@ -447,6 +447,11 @@ servers:
     transport: streamable_http
     url: "${SCANNER_MCP_URL:-http://127.0.0.1:9093/mcp}"
     enabled: "${SCANNER_MCP_ENABLED:-false}"
+    # Authenticates RENFIELD TO THE SCANNER — the opposite direction from the
+    # scanner's folder-ingest push token, and a separate secret. Without it the
+    # server would be an unauthenticated device-control and document-ingest
+    # endpoint on the LAN; it refuses to bind a non-loopback address without one.
+    auth_token_env: SCANNER_MCP_TOKEN
     refresh_interval: 300
     example_intent: mcp.scanner.scanner_status
     examples:


### PR DESCRIPTION
Adds `auth_token_env: SCANNER_MCP_TOKEN` to the scanner stanza.

Registering the scanner forced a gap into the open: the backend runs in-cluster, so the MCP server has to listen on the network — and unauthenticated, that is a **device-control and document-ingest endpoint open to the whole LAN**. Anything on it could call `scan_document` (driving the hardware and filing documents into Renfield under the scanner's own push credential) or read `list_pending_scans`.

The design specified a Bearer-gated endpoint; Phase 1 had not built one. It now exists in `ebongard/renfield-mcp-scanner`, **fail-closed**: binding a non-loopback address without a token raises and refuses to start, rather than warning. Starting unauthenticated "just for now" is how an open endpoint becomes permanent.

**No Renfield-side code change was needed** — the MCP client already sends `Authorization: Bearer <token>` for any stanza carrying `auth_token_env` (the homeassistant stanza uses the same mechanism).

A **separate secret** from the scanner's folder-ingest push token, deliberately, because they protect opposite directions:

| secret | direction |
|---|---|
| `SCANNER_TOKEN_*` | scanner → Renfield (pushing documents) |
| `SCANNER_MCP_TOKEN` | Renfield → scanner (calling tools) |

`SCANNER_MCP_TOKEN` is in the `renfield-env-private` Secret; both sides verified to hold the same value by hash comparison.

## Test plan

- [x] 21 new tests in the scanner repo: loopback detection, the fail-closed refusal, and rejection of every malformed credential shape (missing, empty, bare token, wrong scheme, wrong case, trailing data) — each asserting the handler did **not** run
- [x] Fail-closed guard verified at real startup, not just in a unit test
- [ ] Post-apply: backend connects and lists the scanner's tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iG4mG4bmRugn3xkJeJN8K