### PR TITLE
fix(cnpg): iscsid-Neustart durch unattended-upgrades legte beide PG-Cluster lahm

### DIFF
--- a/docs/KUBERNETES_DEPLOYMENT.md
+++ b/docs/KUBERNETES_DEPLOYMENT.md
@@ -69,7 +69,7 @@ Cluster-wide Traefik changes (entrypoints, TLS, CRDs) are tracked in `../private
 |---------|-------|-------|
 | Backend | `your-registry.example/renfield/backend:latest` | CPU image (~3.5 GB). Includes wake-word models and renfield-mcp-dlna entrypoint |
 | Frontend | `your-registry.example/renfield/frontend:latest` | Nginx serving React SPA (vite-plugin-pwa PWA). `nginx.conf` serves `sw.js`/`registerSW.js`/`index.html`/manifest `no-cache` and content-hashed bundles `immutable` — required for new deploys to reach the browser; see deploy-production skill → "Frontend PWA cache propagation" |
-| PostgreSQL | `pgvector/pgvector:pg16` | pgvector for embedding search. Single-node StatefulSet; an HA CloudNativePG track for the app DB is in progress — see "Postgres HA (CloudNativePG)" below |
+| PostgreSQL | `pgvector/pgvector:pg16` | pgvector for embedding search. Single-node StatefulSet, now only for Paperless + the digital twin; the app DB runs on the HA CloudNativePG cluster — see "Postgres HA (CloudNativePG)" below |
 | Redis | `redis:7-alpine` | Message queue + cache (AOF enabled) |
 | Ollama | `ollama/ollama:latest` | LLM inference, requires GPU |
 | SearXNG | `searxng/searxng` (digest-pinned, == `2026.8.29`) | In-cluster metasearch. Engine set tuned for a datacenter egress IP (scraper engines CAPTCHA-block → backbone is Bing + Google-CSE, the rest best-effort; limiter stays OFF — it rejects the backend's `format=json`). **Per-instance — see note below.** |
@@ -138,32 +138,59 @@ A follow-up that consolidates all 41 migrations into a single clean baseline is 
 
 ## Postgres HA (CloudNativePG)
 
-The app database is being moved off the single-node `postgres` StatefulSet onto a
-3-instance **CloudNativePG (CNPG)** cluster (`renfield-pg`) with streaming
-replication + automatic failover + external S3 PITR backups. Manifests + the full
-phased runbook live in **`k8s/cnpg/`** (`README.md` there is the source of truth).
+The app database runs on a 3-instance **CloudNativePG (CNPG)** cluster with
+streaming replication, quorum-based synchronous commit, automatic failover, and
+external S3 PITR backups. Manifests + the full phased runbook live in
+**`k8s/cnpg/`** (`README.md` there is the source of truth).
 
 Scope + status:
 
 - **Scope is the renfield app DB only.** Paperless (`paperlessdb`) and the
   digital-twin DB stay on the legacy `postgres` StatefulSet, which keeps running
-  for them. The cutover is a pure host swap in `DATABASE_URL`:
-  `@postgres` → `@renfield-pg-rw` (services: `renfield-pg-rw`/`-ro`/`-r`).
-- **Rollout is household (`ns renfield`) first, then xidra** (Phase 6). Applied by
-  hand, phase by phase — the `k8s/cnpg/` files are deliberately **not** in
+  for them.
+- **LIVE on both instances.** Household (`ns renfield`) cut over 2026-08-25,
+  xidra (`ns renfield-xidra`) the same day (Phase 6). `DATABASE_URL` points at
+  `@renfield-pg-r1-rw` (services: `<cluster>-rw`/`-ro`/`-r`). Applied by hand,
+  phase by phase — the `k8s/cnpg/` files are deliberately **not** in
   `kustomization.yaml`.
-- **Live so far:** operator stack (cert-manager, CNPG operator 1.27.0, Barman
-  Cloud plugin v0.14.0), the `longhorn-pg` StorageClass, the Garage-S3
-  `ObjectStore`, and the CNPG NetworkPolicy are applied; the pgvector operand
-  image is built (`cnpg-pg16-pgvector:16.9-pgvector0.8.6`); a scratch dry-run
-  proved import + failover with no data loss. **The household cutover (Phase 4)
-  has not run yet** — the app still uses the single-node `postgres`.
+- **Cluster name carries an `-r1` suffix** on both instances since the
+  2026-09-12 recovery (below). Renaming back is deferred; a rename is a restore.
 - **pgvector image:** the stock CNPG operand has no pgvector, so a thin custom
   image (`k8s/cnpg/Dockerfile.pgvector`) adds `postgresql-16-pgvector`.
 - **Backups:** base backups + WAL archiving go to the Garage S3 server on the NAS
-  (`renfield-pg-backups`) for PITR, plus a nightly `pg_dump` → NFS fallback.
+  (`renfield-pg-backups` / `xidra-pg-backups`) for PITR, plus a nightly
+  `pg_dump` → NFS fallback. **Restore procedure:
+  `k8s/cnpg/90-recovery-cluster.yaml`** — a Cluster manifest with the runbook in
+  its header comment. Rehearsed 2026-08-25, used in anger 2026-09-12.
 - **Known ceiling:** the single control-plane node bounds real availability until
   the control plane is also HA (separate track).
+
+### Incident 2026-09-11 — `unattended-upgrades` restarting iscsid
+
+Both clusters went down for ~21.5 h. Worth reading before touching node packages
+or the WAL sizing:
+
+1. `apt-daily-upgrade` restarted `iscsid` on k8s-gpu-1 and k8s-gpu-2
+   (06:17:44 / 06:19:39 UTC). Longhorn attaches **every** volume through that
+   initiator, so the sessions tore down and replicas faulted seconds later.
+2. `longhorn-pg` runs `numberOfReplicas: 1` (PG replicates at its own layer), so
+   there was no second copy — instance `renfield-pg-3` died in BOTH namespaces.
+3. Its CNPG HA replication slot then pinned WAL on the primary, because
+   `max_slot_wal_keep_size` was unset (= unlimited).
+4. `archive_timeout: 5min` forces a WAL segment switch every 5 minutes, so the
+   cluster generates ~4.6 GB WAL/day **even while idle**. The dedicated 2Gi WAL
+   volume filled in ~10 hours and both primaries hit
+   `PANIC: could not write to file "pg_wal/xlogtemp": No space left on device`.
+
+Fixes applied: **`k8s/node-iscsi-update-guard.sh`** (run on every Longhorn
+storage node — holds `open-iscsi` and blacklists it in unattended-upgrades; it
+also documents how to upgrade that package deliberately), `max_slot_wal_keep_size:
+2GB` in both Cluster manifests, WAL volumes 2Gi → 8Gi, and the worker VM disks
+grown to 140G/140G/160G (they were 100% allocated, which is what left Longhorn
+unable to reschedule the faulted replica in the first place).
+
+Still open: **alerting**. Nothing noticed for 21.5 hours. That gap matters more
+than any of the above.
 
 > **Auth-on instances (`AUTH_ENABLED=true` / `RENFIELD_ENV=production`):** the v2.20.0 boot
 > guard (`fail_closed_on_insecure_jwt_key`) validates `SECRET_KEY` at `Settings()` init, which

--- a/k8s/alembic-upgrade-job.yaml
+++ b/k8s/alembic-upgrade-job.yaml
@@ -66,7 +66,7 @@ spec:
                   key: secret-key
                   optional: true
             - name: DATABASE_URL
-              value: postgresql+asyncpg://renfield:$(POSTGRES_PASSWORD)@renfield-pg-rw:5432/renfield
+              value: postgresql+asyncpg://renfield:$(POSTGRES_PASSWORD)@renfield-pg-r1-rw:5432/renfield
           resources:
             requests:
               cpu: 100m

--- a/k8s/backend.yaml
+++ b/k8s/backend.yaml
@@ -182,7 +182,7 @@ spec:
                   name: renfield-secrets
                   key: postgres-password
             - name: DATABASE_URL
-              value: postgresql+asyncpg://renfield:$(POSTGRES_PASSWORD)@renfield-pg-rw:5432/renfield
+              value: postgresql+asyncpg://renfield:$(POSTGRES_PASSWORD)@renfield-pg-r1-rw:5432/renfield
             - name: SECRET_KEY
               valueFrom:
                 secretKeyRef:

--- a/k8s/cnpg/20-cluster-renfield-pg.yaml
+++ b/k8s/cnpg/20-cluster-renfield-pg.yaml
@@ -53,6 +53,22 @@ spec:
       number: 1
       dataDurability: required
 
+    parameters:
+      # HARD CAP on how much WAL a replication slot may pin (incident 2026-09-11).
+      # `replicationSlots.highAvailability` creates a slot per standby. An offline
+      # standby's slot holds WAL FOREVER by default — and with `archive_timeout:
+      # 5min` forcing a segment switch every 5 minutes, this cluster generates
+      # ~4.6 GB WAL/day even while idle. A single dead standby therefore filled the
+      # 2Gi WAL volume in ~10 hours and PANICked the primary
+      # ("No space left on device"), taking the whole cluster down.
+      #
+      # With this cap a lagging slot is INVALIDATED instead: that standby must
+      # re-bootstrap from a base backup (cheap here — data volumes are ~500 MB),
+      # but the primary survives. Losing one standby is always preferable to
+      # losing the cluster. Tolerance at the current WAL rate: ~10 h of standby
+      # downtime before invalidation.
+      max_slot_wal_keep_size: 2GB
+
   # --- One instance per node --------------------------------------------------
   affinity:
     enablePodAntiAffinity: true
@@ -64,13 +80,28 @@ spec:
     storageClass: longhorn-pg
     size: 10Gi
   # Separate WAL volume: if S3 WAL archiving stalls (Garage/NAS down) unarchived
-  # WAL accumulates — isolating it here means that pressure fills a dedicated 2Gi
+  # WAL accumulates — isolating it here means that pressure fills a dedicated
   # volume instead of PGDATA, and each is resizable independently
   # (allowVolumeExpansion). Monitor free space on both; a full WAL volume still
   # halts the primary (by design — never silently drop WAL).
+  #
+  # Sized 8Gi after the 2026-09-11 incident: at ~4.6 GB WAL/day (forced by
+  # `archive_timeout: 5min`) the old 2Gi absorbed barely 10 hours of an
+  # archiving stall — far too little to be the safety buffer this volume is
+  # meant to be. 8Gi buys ~40 hours, well clear of the steady state
+  # (max_slot_wal_keep_size 2GB + wal_keep_size 512MB + in-flight).
+  #
+  # NOTE for anyone resizing this again: Longhorn counts the REQUESTED size
+  # against a disk's free space — thin provisioning does not help its
+  # scheduler — and gpu-1/gpu-2 each host TWO of these WAL volumes (household
+  # + xidra). At the old 80G node disks there was no room for this at all; the
+  # worker VM disks were grown to 140G/160G on 2026-09-12 to make it fit.
+  # Check `kubectl -n longhorn-system get nodes.longhorn.io` headroom BEFORE
+  # raising this further. See also `max_slot_wal_keep_size` above, which closes
+  # the OTHER way this volume fills (a pinning replication slot).
   walStorage:
     storageClass: longhorn-pg
-    size: 2Gi
+    size: 8Gi
 
   # --- Bootstrap: MIGRATE from the live single-node DB via pg_dump/restore -----
   # `microservice` import copies exactly the `renfield` database and re-owns it

--- a/k8s/cnpg/30-scheduledbackup.yaml
+++ b/k8s/cnpg/30-scheduledbackup.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: renfield
 spec:
   cluster:
-    name: renfield-pg
+    name: renfield-pg-r1
   schedule: "0 30 2 * * *"        # 02:30 every night
   backupOwnerReference: self
   method: plugin

--- a/k8s/cnpg/50-pgdump-cronjob.yaml
+++ b/k8s/cnpg/50-pgdump-cronjob.yaml
@@ -4,7 +4,7 @@
 # any pgvector-capable Postgres, no operator/plugin required. Barman is the
 # primary (PITR); this is the "can always get the data back" belt.
 #
-# The dump runs against `renfield-pg-rw` (primary). Custom format (-Fc) preserves
+# The dump runs against `renfield-pg-r1-rw` (primary). Custom format (-Fc) preserves
 # the pgvector/halfvec column types + HNSW index definitions. Restore + verify
 # procedure is in README.md (Phase 0).
 apiVersion: v1
@@ -52,7 +52,7 @@ spec:
               imagePullPolicy: Always
               env:
                 - name: PGHOST
-                  value: renfield-pg-rw
+                  value: renfield-pg-r1-rw
                 - name: PGUSER
                   value: renfield
                 - name: PGDATABASE

--- a/k8s/cnpg/90-recovery-cluster.yaml
+++ b/k8s/cnpg/90-recovery-cluster.yaml
@@ -37,9 +37,19 @@
 #         kubectl -n renfield set env deploy/$d \
 #           'DATABASE_URL=postgresql+asyncpg://renfield:$(POSTGRES_PASSWORD)@renfield-pg-r1-rw:5432/renfield'
 #       done
-#  5. Only AFTER the app is healthy: re-add the synchronous block below and
+#  5. Update the COMMITTED manifests to the new cluster name — `set env` only
+#     changes the live object, and the files on disk still point at a service
+#     that now has ZERO endpoints. Missing this was the one real defect /review
+#     caught in the 2026-09-12 recovery; `bin/deploy-production.sh` applies
+#     `k8s/alembic-upgrade-job.yaml` on EVERY deploy, so a stale host there
+#     breaks the next migration run:
+#       grep -rln 'renfield-pg-rw' k8s/
+#     Covers alembic-upgrade-job, backend, document-worker, meeting-worker,
+#     pdf-split-worker, configmap, and the `cnpg.io/cluster` selector in
+#     redis-postgres-netpol.yaml.
+#  6. Only AFTER the app is healthy: re-add the synchronous block below and
 #     apply again (see the NOTE on synchronous replication).
-#  6. Only after a soak: delete the old cluster + its orphaned Longhorn volumes.
+#  7. Only after a soak: delete the old cluster + its orphaned Longhorn volumes.
 #
 # ── NOTE ON SYNCHRONOUS REPLICATION — READ BEFORE RE-USING THIS FILE ─────────
 # The production guarantee is `synchronous: {method: any, number: 1,

--- a/k8s/cnpg/90-recovery-cluster.yaml
+++ b/k8s/cnpg/90-recovery-cluster.yaml
@@ -1,0 +1,130 @@
+# DISASTER RECOVERY — rebuild the renfield app DB from the Garage S3 backup.
+#
+# "A backup you have not restored is not a backup." This file is the restore,
+# written down. It was first rehearsed in Phase 5 (2026-08-25, scratch cluster
+# `renfield-pg-restore`, verified identical to live) and first used in anger on
+# 2026-09-12.
+#
+# ── WHEN TO USE ──────────────────────────────────────────────────────────────
+# The `renfield-pg` cluster is unrecoverable in place: PGDATA lost, both
+# instances down with no healthy volume, or the storage layer is wedged. If the
+# cluster merely lost ONE instance, do NOT come here — let CNPG rebuild that
+# instance (delete its PVCs + pod).
+#
+# ── WHAT IT DOES ─────────────────────────────────────────────────────────────
+# Bootstraps a SEPARATE cluster (`renfield-pg-r1`) from the ObjectStore, reading
+# the base backup of `serverName: renfield-pg` plus every archived WAL segment
+# after it. No `recoveryTarget` = recover to the LATEST archived WAL, i.e. as
+# close to the moment the old primary died as the archive reaches.
+#
+# A separate NAME is deliberate: the broken cluster and its volumes stay
+# untouched as a second fallback until the restore is verified. The cost is that
+# the app must be repointed (`renfield-pg-rw` -> `renfield-pg-r1-rw`).
+#
+# ── RUNBOOK ──────────────────────────────────────────────────────────────────
+#  1. sed the registry placeholder and apply (household):
+#       sed 's|your-registry.example|<real-registry>|' k8s/cnpg/90-recovery-cluster.yaml \
+#         | kubectl apply -f -
+#       kubectl apply -f k8s/cnpg/91-netpol-recovery.yaml
+#  2. Watch: kubectl -n renfield get cluster renfield-pg-r1 -w
+#     Instance 1 restores from S3, then 2 and 3 pg_basebackup from it.
+#  3. VERIFY before repointing — alembic head, pgvector extension, row counts
+#     against what you expect, and that the recovery actually ended
+#     (`SELECT pg_is_in_recovery()` = false on the primary).
+#  4. Repoint the app with `kubectl set env`, NOT `apply` — the live deployments
+#     run pinned image tags the committed yamls do not carry:
+#       for d in backend document-worker meeting-worker pdf-split-worker; do
+#         kubectl -n renfield set env deploy/$d \
+#           'DATABASE_URL=postgresql+asyncpg://renfield:$(POSTGRES_PASSWORD)@renfield-pg-r1-rw:5432/renfield'
+#       done
+#  5. Only AFTER the app is healthy: re-add the synchronous block below and
+#     apply again (see the NOTE on synchronous replication).
+#  6. Only after a soak: delete the old cluster + its orphaned Longhorn volumes.
+#
+# ── NOTE ON SYNCHRONOUS REPLICATION — READ BEFORE RE-USING THIS FILE ─────────
+# The production guarantee is `synchronous: {method: any, number: 1,
+# dataDurability: required}` — at least one standby must confirm every commit,
+# so a primary loss never drops an acked write.
+#
+# During BOOTSTRAP only instance 1 exists, so that requirement has nobody to
+# confirm and risks stalling the restore itself. The block below is therefore
+# left COMMENTED OUT while recovering, and uncommented once the cluster reports
+# 3/3 healthy (runbook step 5).
+#
+# The block is currently UNCOMMENTED because this file also describes the live
+# `renfield-pg-r1` cluster created on 2026-09-12. If you are starting a NEW
+# restore from this template: COMMENT IT OUT AGAIN for the bootstrap, then
+# uncomment and re-apply at 3/3. Do not skip that — without it the cluster can
+# lose the last commits on a failover.
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: renfield-pg-r1
+  namespace: renfield
+  labels:
+    app.kubernetes.io/part-of: renfield
+spec:
+  instances: 3
+
+  imageName: your-registry.example/renfield/cnpg-pg16-pgvector:16.9-pgvector0.8.6
+  imagePullPolicy: Always
+  imagePullSecrets:
+    - name: harbor-pull-secret
+
+  # See the NOTE above before re-using this file for a fresh restore.
+  postgresql:
+    synchronous:
+      method: any
+      number: 1
+      dataDurability: required
+
+    parameters:
+      # Same hard cap as the production cluster. An offline standby's slot must
+      # never be able to fill the WAL volume again (incident 2026-09-11).
+      max_slot_wal_keep_size: 2GB
+
+  affinity:
+    enablePodAntiAffinity: true
+    topologyKey: kubernetes.io/hostname
+    podAntiAffinityType: required
+
+  storage:
+    storageClass: longhorn-pg
+    size: 10Gi
+  walStorage:
+    storageClass: longhorn-pg
+    size: 8Gi
+
+  # --- The restore itself ------------------------------------------------------
+  # No `recoveryTarget` => replay every archived WAL segment, i.e. latest.
+  # To restore to a point in time instead, add e.g.:
+  #   recoveryTarget: {targetTime: "2026-09-11 16:00:00.000000+00"}
+  bootstrap:
+    recovery:
+      source: renfield-pg-backup-source
+
+  externalClusters:
+    - name: renfield-pg-backup-source
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: renfield-pg-backup
+          # The SOURCE server's name in the bucket — the cluster that WROTE the
+          # backup, not this one. Getting this wrong yields an empty restore.
+          serverName: renfield-pg
+
+  # This cluster archives its OWN WAL under serverName `renfield-pg-r1`, so it
+  # cannot overwrite the source cluster's backup history in the same bucket.
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: renfield-pg-backup
+
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "2"
+      memory: 2Gi

--- a/k8s/cnpg/91-netpol-recovery.yaml
+++ b/k8s/cnpg/91-netpol-recovery.yaml
@@ -1,0 +1,51 @@
+# NetworkPolicy for the renfield-pg CNPG pods — same defense-in-depth posture as
+# the legacy `postgres-allow-app-only` (pentest F6): only the renfield app
+# workloads may reach the DB port, everything else in the namespace is denied.
+#
+# CNPG pods do NOT carry `app.kubernetes.io/name: postgres`, so the existing
+# policy does not select them — WITHOUT this file they would be unrestricted
+# (deny-by-default only applies to pods some policy selects). This policy also
+# MUST allow the traffic CNPG itself needs, or HA breaks:
+#   - 5432 between the cluster's own instances (streaming replication)
+#   - 5432 + 8000 from the operator namespace (management + instance status)
+#
+# NB: requires a NetworkPolicy-enforcing CNI (Calico here).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: renfield-pg-r1-allow
+  namespace: renfield
+  labels:
+    app.kubernetes.io/part-of: renfield
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: renfield-pg-r1
+  policyTypes: [Ingress]
+  ingress:
+    # --- App workloads: Postgres wire protocol only -------------------------
+    - from:
+        - podSelector: {matchLabels: {app.kubernetes.io/name: backend}}
+        - podSelector: {matchLabels: {app.kubernetes.io/name: document-worker}}
+        - podSelector: {matchLabels: {app.kubernetes.io/name: meeting-worker}}
+        - podSelector: {matchLabels: {app.kubernetes.io/name: pdf-split-worker}}
+        # alembic-upgrade Job + any backend-image job carry this shared label.
+        - podSelector: {matchLabels: {app.kubernetes.io/part-of: renfield, app.kubernetes.io/component: backend-job}}
+      ports:
+        - {protocol: TCP, port: 5432}
+    # --- Intra-cluster: streaming replication (5432) AND the instance-manager
+    # failsafe/liveness cross-check (8000). Instances probe each other's
+    # /failsafe on 8000; without it the split-brain self-fencing safety net is
+    # blocked (cluster still promotes via the operator, but the instance-to-
+    # instance failsafe degrades — silent HA weakening). ------------------------
+    - from:
+        - podSelector: {matchLabels: {cnpg.io/cluster: renfield-pg-r1}}
+      ports:
+        - {protocol: TCP, port: 5432}
+        - {protocol: TCP, port: 8000}
+    # --- The CNPG operator (management + instance-manager status on 8000) ----
+    - from:
+        - namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: cnpg-system}}
+      ports:
+        - {protocol: TCP, port: 5432}
+        - {protocol: TCP, port: 8000}

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -43,7 +43,7 @@ data:
   # ────────────────────────────────────────────────────────────────────────────
 
   # Infra endpoints (cluster-internal DNS)
-  DATABASE_URL: "postgresql+asyncpg://renfield:__PG_PASSWORD__@renfield-pg-rw:5432/renfield"
+  DATABASE_URL: "postgresql+asyncpg://renfield:__PG_PASSWORD__@renfield-pg-r1-rw:5432/renfield"
   REDIS_URL: "redis://redis:6379"
   OLLAMA_URL: "http://ollama:11434"
   OLLAMA_EMBED_URL: "http://ollama:11434"

--- a/k8s/document-worker.yaml
+++ b/k8s/document-worker.yaml
@@ -116,7 +116,7 @@ spec:
               valueFrom:
                 secretKeyRef: {name: renfield-secrets, key: secret-key, optional: true}
             - name: DATABASE_URL
-              value: postgresql+asyncpg://renfield:$(POSTGRES_PASSWORD)@renfield-pg-rw:5432/renfield
+              value: postgresql+asyncpg://renfield:$(POSTGRES_PASSWORD)@renfield-pg-r1-rw:5432/renfield
             # Integration secrets mirror the backend so Docling/RAG code paths
             # that eventually call out (e.g. contextual retrieval LLM) work.
             - name: HOME_ASSISTANT_TOKEN

--- a/k8s/meeting-worker.yaml
+++ b/k8s/meeting-worker.yaml
@@ -87,7 +87,7 @@ spec:
               valueFrom:
                 secretKeyRef: {name: renfield-secrets, key: secret-key, optional: true}
             - name: DATABASE_URL
-              value: postgresql+asyncpg://renfield:$(POSTGRES_PASSWORD)@renfield-pg-rw:5432/renfield
+              value: postgresql+asyncpg://renfield:$(POSTGRES_PASSWORD)@renfield-pg-r1-rw:5432/renfield
           volumeMounts:
             # Read the audio the backend streamed here; ingest_document also
             # persists the rendered transcript under this PVC.

--- a/k8s/node-iscsi-update-guard.sh
+++ b/k8s/node-iscsi-update-guard.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Keep `unattended-upgrades` from restarting iscsid under a running Longhorn.
+#
+# WHY (incident 2026-09-11): apt-daily-upgrade.service ran on k8s-gpu-1 and
+# k8s-gpu-2 and restarted iscsid.service (06:19:39 and 06:17:44 UTC). Longhorn
+# attaches EVERY volume through that iSCSI initiator, so the restart tore down
+# the sessions; Longhorn marked replicas faulted seconds later (06:20:15). With
+# `longhorn-pg` running numberOfReplicas=1 there was no second copy, so the
+# renfield-pg-3 instance died in BOTH namespaces. Its CNPG HA replication slot
+# then pinned WAL on the primary (max_slot_wal_keep_size was unset = unlimited),
+# the dedicated 2Gi WAL volume filled in ~10 hours, and both primaries hit
+# "PANIC: could not write to file pg_wal/xlogtemp: No space left on device".
+# One unattended package upgrade took down two production databases.
+#
+# It also leaves a SECOND booby trap: Longhorn's already-running engine
+# processes cache the iscsid PID namespace path (/host/proc/<pid>/ns/mnt). After
+# the restart that path is stale, so any later iSCSI operation on an engine that
+# predates the restart fails with
+#   nsenter: cannot open /host/proc/<pid>/ns/mnt: No such file or directory
+# — which is why the recovery's WAL volume expansion hung until the affected
+# engine was recreated.
+#
+# Longhorn's own docs call this out: the iSCSI daemon must not be restarted
+# while volumes are attached. Security updates stay on; only this one package is
+# held and pulled in deliberately during a maintenance window (see below).
+#
+# Run as root on every Longhorn storage node:
+#   ssh <node> 'sudo bash -s' < k8s/node-iscsi-update-guard.sh
+#
+# To update open-iscsi later, do it DELIBERATELY, one node at a time:
+#   1. kubectl cordon <node> && kubectl drain <node> --ignore-daemonsets --delete-emptydir-data
+#   2. apt-mark unhold open-iscsi && apt install -y open-iscsi && apt-mark hold open-iscsi
+#   3. reboot the node (cleanest way to get consistent iSCSI + Longhorn state)
+#   4. kubectl uncordon <node>, wait for Longhorn volumes healthy before the next node
+set -euo pipefail
+
+CONF=/etc/apt/apt.conf.d/52-longhorn-iscsi-hold
+
+echo "== $(hostname) =="
+
+# 1) dpkg-level hold: no automatic upgrade path can pull a new open-iscsi in.
+apt-mark hold open-iscsi >/dev/null
+echo "apt-mark hold: $(apt-mark showhold | tr '\n' ' ')"
+
+# 2) unattended-upgrades blacklist: belt and suspenders. The hold alone already
+#    stops it, but the blacklist makes the intent visible in the u-u config and
+#    survives someone clearing holds wholesale.
+cat > "$CONF" <<'CONFEOF'
+// See k8s/node-iscsi-update-guard.sh in the renfield repo.
+// Restarting iscsid tears down every attached Longhorn volume (incident
+// 2026-09-11: two production Postgres clusters lost). Upgrade this package
+// deliberately, with the node drained, never from the nightly job.
+Unattended-Upgrade::Package-Blacklist {
+    "open-iscsi";
+};
+CONFEOF
+echo "geschrieben: $CONF"
+
+# 3) Prove the config still parses — a broken apt.conf breaks ALL apt runs.
+apt-config dump >/dev/null && echo "apt-config: ok"
+echo -n "blacklist wirksam: "
+apt-config dump 2>/dev/null | grep -c 'Package-Blacklist::.*open-iscsi' || true
+
+echo "iscsid laeuft seit: $(systemctl show iscsid -p ActiveEnterTimestamp --value)"

--- a/k8s/pdf-split-worker.yaml
+++ b/k8s/pdf-split-worker.yaml
@@ -78,7 +78,7 @@ spec:
               valueFrom:
                 secretKeyRef: {name: renfield-secrets, key: secret-key, optional: true}
             - name: DATABASE_URL
-              value: postgresql+asyncpg://renfield:$(POSTGRES_PASSWORD)@renfield-pg-rw:5432/renfield
+              value: postgresql+asyncpg://renfield:$(POSTGRES_PASSWORD)@renfield-pg-r1-rw:5432/renfield
           volumeMounts:
             # Read the parent PDF; execute_split persists the child PDFs here
             # via ingest_document.

--- a/k8s/redis-postgres-netpol.yaml
+++ b/k8s/redis-postgres-netpol.yaml
@@ -61,6 +61,10 @@ spec:
         # this legacy DB during bootstrap.initdb.import. They carry the cnpg.io
         # cluster label, not the app labels, so without this they'd be blackholed
         # and the import would hang. Same-namespace (ns renfield). See k8s/cnpg/.
+        # BOTH names are listed: the live cluster is `renfield-pg-r1` since the
+        # 2026-09-12 restore, and `renfield-pg` is kept while the old cluster is
+        # still around for the post-incident soak. Drop the old one when it goes.
         - podSelector: {matchLabels: {cnpg.io/cluster: renfield-pg}}
+        - podSelector: {matchLabels: {cnpg.io/cluster: renfield-pg-r1}}
       ports:
         - {protocol: TCP, port: 5432}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,191 +1,155 @@
-# Proper document search on /wissen/dokumente (+ /knowledge)
+# renfield-pg Ausfall — Befund & Wiederherstellungsplan (2026-09-12)
 
-**Goal:** typing a query (omnisearch on `/wissen/dokumente`, or the search box on
-`/knowledge`) returns **ranked document ROWS** — reusing the existing row + all
-its actions ("An Simba senden", reindex, tier, delete) — via a **server-side
-hybrid (RRF) search** over name + Schicht-A facts + chunk content. Fixes the
->100-newest reachability cap (search runs over the whole KB, not the 100-window).
-Keep the semantic chunk snippets as a **secondary "Textstellen" section**.
+## Befund (gemessen, nicht vermutet)
 
-Decisions (agreed): **full hybrid up front**; **keep chunk search as a secondary section**.
+**Fehlerkette, beide Instanzen identisch:**
+1. `2026-09-11 06:20 UTC` — die Longhorn-Replica von `renfield-pg-3` (Daten + WAL,
+   beide Namespaces) auf **k8s-gpu-1** fällt aus → Volumes `faulted`.
+   `longhorn-pg` hat `numberOfReplicas: 1` → kein Ersatz vorhanden.
+2. Longhorn kann keine neue Replica anlegen: die Disks auf gpu-1/gpu-2 stehen auf
+   `Schedulable: False` (25-%-Mindestfreiraum unterschritten; VGs zu 100 % belegt).
+   → `renfield-pg-3` bleibt tot, seither ~290 Restarts.
+3. Der HA-Replication-Slot `_cnpg_renfield_pg_3` auf dem Primary hält damit WAL
+   dauerhaft fest. `max_slot_wal_keep_size` ist **nicht gesetzt** = unbegrenzt.
+4. `archive_timeout: 5min` erzwingt einen WAL-Switch alle 5 min → ~4,6 GB WAL/Tag,
+   auch im Leerlauf. Das 2-GiB-WAL-Volume ist damit in ~10 h voll.
+5. `2026-09-11 16:16/16:17 UTC` — beide Primaries: 
+   `PANIC: could not write to file "pg_wal/xlogtemp": No space left on device`,
+   `restart_after_crash=off` → Cluster-Status `Not enough disk space`.
 
-## Backend
+**Zeitachse:** Vollausfall seit ~29 h (nicht 8 Tage). Die Pods sind 9 Tage alt —
+das ist das letzte Rollout, nicht der Ausfallbeginn.
 
-- [ ] **Migration `pcXXXX_documents_fts`** — add GENERATED STORED `search_vector`
-      tsvector on `documents` over `generated_title + title + filename`
-      (multilingual union across `FTS_LANGUAGES`, mirror `notes`/`messages`) + a
-      GIN index. Idempotent (`IF NOT EXISTS`); existing rows populate at ALTER.
-      Model: add the column to `Document` (create_all parity, guarded like notes).
-- [ ] **`services/document_search.py::search_documents(db, query, asker_id,
-      knowledge_base_id, status, limit, offset) -> list[Document]`** — hybrid RRF:
-  - Name list: `documents.search_vector @@ websearch_to_tsquery` (`ts_rank`) +
-    ILIKE fallback on the 3 name columns (partial tokens like "Arkad").
-  - Facts list: `DocumentFactRetrieval.search(query, asker_id)` → document_ids
-    (already circle-filtered).
-  - Chunk list: `RAGRetrieval` semantic (circle-filtered) aggregated to the best
-    chunk per document_id (reuse the existing chunk search path).
-  - Fuse the three ranked id-lists with **RRF** (`k = rag_hybrid_rrf_k`), sum
-    scores, sort desc, take `limit`/`offset`.
-  - **Circle-correct visibility for ALL signals** (apply `circle_sql` document
-    filter to the name signal too, so search can't widen beyond what the user may
-    see; auth-off short-circuits). Note: the browse list's non-circle-filtering is
-    a separate pre-existing concern — out of scope.
-  - Fetch `Document` rows for the fused ids in order; `_doc_to_response_kwargs` +
-    `_augment_with_progress` → `DocumentResponse`.
-- [ ] **Route** `GET /api/knowledge/documents`: add `q: str | None` (keep
-      `limit`/`offset`). `q` present → `search_documents` (ranked); else the
-      existing recency list. Same `DocumentResponse` output. Same KB-ACL gate.
-- [ ] Optional: expose a `matched` hint or `rank` if useful for the UI (else omit).
+**Datenlage:** Die Datenvolumes von pg-1 und pg-2 sind in beiden Namespaces
+`attached / healthy`. Letztes vollständiges Backup in Garage-S3: 2026-09-11 02:30,
+`completed`, WAL-Archivierung lief bis zum PANIC. Datenverlustrisiko: nahe null.
+Nur pg-3 ist verloren (Einzel-Replica, kein Ersatz) — wird neu aufgebaut.
 
-## Frontend
+**Betroffen:** Haushalt (ns `renfield`) und xidra (ns `renfield-xidra`) vollständig
+— beide Backends zeigen `ConnectionRefused` gegen `renfield-pg-rw`.
 
-- [ ] `api/resources/knowledge.ts`: `DocsFilter` gains `q`; `fetchDocuments`
-      passes `params.q`; list query key includes `q`.
-- [ ] `KnowledgePage.tsx`: debounce `searchQuery` (standalone) + `omniQ`
-      (embedded, scope=lens) → feed the **document-list** `q`. The list becomes
-      the ranked result set of document rows (all actions intact). Warm empty
-      state on no match. At `scope=everything` defer to the omni overlay (unchanged).
-- [ ] Keep the semantic chunk search as a **secondary collapsible "Textstellen"**
-      section (the current snippet cards), below the ranked document rows —
-      driven by the same query, best-effort.
-- [ ] i18n (de/en/it) for the new labels/empty state.
+## Plan
 
-## Tests
+### Phase 0 — Kapazität (Voraussetzung für alles Weitere)
+- [ ] Ungenutzte Container-Images auf gpu-1/gpu-2 entfernen (`crictl rmi --prune`),
+      verwaiste Longhorn-Replicas gelöschter Volumes aufräumen
+- [ ] Ziel: Longhorn-Disks gpu-1/gpu-2 wieder `Schedulable: True`
+- [ ] Vorsicht: Harbor-WAN ist auf ~41 Mbit/s gedeckelt — nur wirklich
+      unreferenzierte Images entfernen
 
-- [ ] Backend (real-PG): FTS migration applies; name match ranks a title-term doc
-      to the top; facts + chunk signals contribute; RRF ordering; circle/ACL
-      (a non-owner can't surface a restricted doc); >100-doc reachability (a doc
-      outside the 100-newest window is found by name). Empty query → recency list.
-- [ ] Frontend: list re-queries on `q`; renders document rows (not just chunks);
-      the row actions still work; the secondary Textstellen section renders.
+### Phase 1 — WAL-Luft schaffen + Ursache beheben (Git, nicht kubectl patch)
+- [ ] `k8s/cnpg/20-cluster-renfield-pg.yaml` + xidra-Pendant:
+      `walStorage.size: 2Gi → 8Gi`
+- [ ] `max_slot_wal_keep_size: 2GB` ergänzen — ein verwaister Slot wird künftig
+      invalidiert, statt den Primary zu töten
+- [ ] `kubectl apply` → CNPG vergrößert die PVCs
 
-## Deploy / rollout
-- [ ] Branch → build+tests on .159 → review → docs sweep → deploy xidra
-      (migration via the alembic job, namespace-stripped) + browser E2E ("Arkadon"
-      → doc #34 top of list, "An Simba senden" clickable).
+### Phase 2 — Cluster hochfahren (erst Haushalt, dann xidra)
+- [ ] Tote pg-Pods löschen → Neustart auf vergrößertem WAL-Volume
+- [ ] Crash-Recovery + Checkpoint beobachten
+- [ ] ACHTUNG `synchronous: {number: 1, dataDurability: required}`: solange nur
+      EINE Instanz läuft, blockieren Schreibzugriffe. Erst weitermachen, wenn
+      pg-1 UND pg-2 stehen.
+- [ ] Verifizieren: `pg_replication_slots`, WAL-Verzeichnisgröße, Archivierung
 
-## Federated search across document MCP sources (point 1)
+### Phase 3 — pg-3 neu aufbauen
+- [ ] Faulted PVCs von pg-3 löschen → CNPG bootstrappt die Instanz neu
+- [ ] Warten auf 3/3
 
-The document search should also span **searchable document MCP servers**, not just
-the local KB. Audit of connected MCPs:
-- **Paperless** — `mcp.paperless.search_documents` (full-text archive search). PRIMARY external source.
-- **Simba** — `list_transfers(contains=…)` now does **server-side** search (MCP v1.0.8). Include as a
-  federation source (user-confirmed) — surfaces "already transferred to the tax accountant" hits.
-- **Filesystem** — only `mcp.files.read_file` (NO content-search tool) → not federatable for search.
-- **SearXNG** — `mcp.search.web_search` = WEB metasearch only; it has no index of / connector to
-  the internal document sources, so it is NOT the federation layer (point 2 answer). Federation is
-  renfield-side (fan-out + RRF), mirroring `PolymorphicAtomStore`. SearXNG stays web-search.
+### Phase 4 — Anwendung
+- [ ] Backend + Worker in beiden Namespaces neu starten
+- [ ] Browser-E2E beide Instanzen (Pflicht), PWA-Service-Worker vorher entladen
 
-Architecture:
-- [ ] **`services/federated_document_search.py`**: (a) run the local hybrid `search_documents`;
-      (b) fan out **in parallel** to each registered searchable doc MCP (Paperless
-      `search_documents`) via `mcp_manager`, with a per-call timeout (best-effort — a slow/down
-      MCP never blocks local results); (c) normalize each source to a common `DocSearchHit`
-      {source, source_id, title, snippet, date, ref/url, dedup_key}; (d) **dedup** across sources
-      (folder-ingest files KB docs INTO Paperless, so most KB docs are ALSO in Paperless — dedup by
-      checksum/title+date, prefer the local KB hit which has full row actions); (e) merge/rank.
-- [ ] **Result model:** local KB hits = full `DocumentResponse` rows (all actions). External hits =
-      a distinct shape with source-appropriate actions (Paperless: "In Paperless öffnen" /
-      "In die Wissensbasis importieren"). Decision needed (see below): unified-ranked-with-source-
-      badges vs primary-local-rows + secondary-per-source-sections.
-- [ ] **Registry:** which MCP+tool is a "searchable document source" should be config/registry-driven
-      (a small mapping), so a new document MCP = config, not code — consistent with the platform ethos.
+### Phase 5 — Vorbeugung (eigener PR)
+- [ ] Alarmierung: CNPG-Cluster nicht `Ready` / WAL-Volume-Füllstand.
+      Der eigentliche Mangel ist, dass 29 h Ausfall unbemerkt blieben.
+- [ ] Knotenkapazität: alle drei VGs sind zu 100 % belegt — dauerhafte Lösung
+      liegt auf der Proxmox-Ebene (Disk vergrößern)
+- [ ] `archive_timeout: 5min` bewerten: erzeugt 4,6 GB WAL/Tag im Leerlauf
 
-### Access-control note (must resolve in review)
-The local KB search is **circle-filtered**. Paperless has **no circle/tier concept** — its
-`search_documents` returns the whole shared archive. Surfacing Paperless hits could expose documents
-a user shouldn't see under circles (esp. xidra multi-user). Options: (i) gate external-source federation
-behind a permission/flag; (ii) only federate for admins/owners; (iii) accept archive-wide visibility as
-intended for the business instance. MUST be decided before shipping external federation.
 
-### Open design questions (for the eng review)
-1. Unified ranked list (source badges, heterogeneous actions) **vs** primary local rows + secondary
-   per-source sections. The row-actions divergence argues for sections; a single ranked list is nicer UX.
-2. Dedup key across KB↔Paperless (checksum? title+date? Paperless doc id stored on our `documents`?).
-3. External-source access control (the circle vs archive-wide tension above).
-4. Phasing: ship **local hybrid first** (solves the immediate "Arkadon" need), then add Paperless
-   federation as a second PR — or build both together?
-5. Latency/UX: external fan-out is async — stream local rows first, append external hits as they arrive?
+---
 
-## Out of scope (follow-ups)
-- A paginated / "Mehr laden" BROWSE (no-query) beyond 100 newest — search fixes the
-  immediate reachability; browse pagination is separate.
-- Making the browse list itself circle-filtered (pre-existing over-broad behavior).
+# Abschluss 2026-09-12 14:05 UTC
 
-## Eng review outcome (plan-eng-review)
+## Ursache (korrigiert gegenüber der Erstannahme)
 
-**Decisions locked:**
-- **D1 Scope split:** ship **PR1 = local hybrid** (name+facts+chunks RRF → document rows +
-  >100 reachability + Wissen integration). **PR2 = MCP federation** (Paperless + Simba), after
-  resolving access-control + dedup deliberately. Keeps the safe fix off the risky federation's
-  critical path (incremental / low blast radius).
-- **D2 Search ACL:** **circle-filter ALL search signals** (name signal too, via `circle_sql`) —
-  search is circle-correct, never widens visibility. Browse-list's non-circle-filtering stays a
-  separate pre-existing concern (out of scope). For the owner it's identical (sees own docs).
+Nicht die zu kleinen Platten, sondern **`unattended-upgrades`**:
 
-**Bake-in recommendations (no separate decision needed):**
-- **DRY:** reuse a shared RRF-fuse helper (don't reimplement the atom-store's RRF); factor the
-  multilingual `to_tsvector` union into one helper reused by the new documents FTS + notes/messages
-  (they currently repeat it). Explicit > clever.
-- **Perf:** the ILIKE name-fallback is a seq scan (no trigram index). Fine at ≤ a few-thousand
-  docs/KB (xidra = 401); if a KB grows large, add a `pg_trgm` GIN index on
-  generated_title/title/filename. Note in code, don't build now.
-
-### Test coverage (target 100% of new paths)
 ```
-BACKEND
-[+] migration pcXXXX_documents_fts
-  └── [★★★] search_vector populates existing rows; GIN present  (real-PG)
-[+] services/document_search.py :: search_documents()
-  ├── [★★★] name FTS ranks a title-term doc (e.g. "Arkadon") to TOP
-  ├── [★★★] >100-doc reachability: doc at recency-rank 368/401 IS found by name  ← the bug
-  ├── [★★★] facts signal contributes (query matches a Schicht-A fact, not the title)
-  ├── [★★★] chunk signal contributes (term only in body)
-  ├── [★★★] RRF ordering: name match outranks content-only match
-  ├── [★★★] circle-filter: a non-owner/circle-restricted doc is NOT returned  ← D2
-  ├── [★★ ] ILIKE partial token ("Arkad") still matches
-  └── [★★ ] empty/blank q → falls back to recency list (no search)
-[+] route GET /api/knowledge/documents?q=
-  ├── [★★★] q present → ranked; q absent → recency list (byte-identical to today)
-  └── [★★ ] KB-ACL gate unchanged (403 without kb.own / KB access)
-FRONTEND
-[+] KnowledgePage
-  ├── [★★  →E2E] typing "Arkadon" → doc row appears (not just chunk cards), "An Simba senden" clickable
-  ├── [★★ ] list re-queries on debounced q (standalone box + omni ?q= on the lens)
-  ├── [★★ ] scope=everything → defers to omni overlay (list not hijacked)
-  └── [★  ] secondary "Textstellen" section still renders the chunk hits
+11.09. 06:17:44  k8s-gpu-2  systemd: Stopping/Starting iscsid.service
+11.09. 06:19:39  k8s-gpu-1  systemd: Stopping/Starting iscsid.service
+11.09. 06:20:15  Longhorn:  Replicas von renfield-pg-3 faulted (beide Namespaces)
+11.09. 16:16:19  Postgres:  PANIC "No space left on device" (Haushalt)
+11.09. 16:17:30  Postgres:  dito (xidra)
 ```
 
-### Failure modes (new codepaths)
-- `websearch_to_tsquery` on odd input (operators, empty) → wrap/guard so a malformed query returns
-  no rows, never a 500. Test + guard.
-- A retrieval signal (facts/chunks) MCP/DB slow or throwing → the fuse must degrade to the signals
-  that returned (best-effort), never fail the whole search. Local signals are DB-only (no MCP) so
-  low risk; still guard each branch.
-- Circle-filter mis-wire → **silent over-exposure** (a restricted doc appears). Highest-stakes;
-  the D2 circle test is the guard. Flag CRITICAL if untested.
+`apt-daily-upgrade` startet den iSCSI-Initiator neu, über den Longhorn JEDES
+Volume anbindet. Die Sessions reißen; `numberOfReplicas: 1` lässt keine zweite
+Kopie zu → pg-3 tot in beiden Instanzen → dessen HA-Replikationsslot hält WAL
+fest (`max_slot_wal_keep_size` war ungesetzt = unbegrenzt) → bei ~4,6 GB WAL/Tag
+(erzwungen durch `archive_timeout: 5min`) lief das 2-GiB-WAL-Volume in ~10 h voll
+→ Primary PANIC. Die kleinen WAL-Volumes waren der **Verstärker**, nicht die
+Ursache. Ein nächtlicher Paket-Job hat zwei Produktionsdatenbanken abgeschaltet.
 
-### NOT in scope (deferred)
-- **MCP federation (Paperless + Simba)** → PR2 (own access-control + dedup + heterogeneous-result design).
-- **Paginated / "Mehr laden" BROWSE** beyond 100 newest (no query) → search fixes the reachability need.
-- **Circle-filtering the BROWSE list** (pre-existing over-broad behavior) → separate concern.
-- SearXNG as a document-search backend → rejected (web metasearch, no internal index/connectors).
+Vollausfall: 11.09. 16:16 bis 12.09. 13:51 UTC, rund **21,5 Stunden** (nicht
+8 Tage — das war das Alter der Pods seit dem letzten Rollout).
 
-### What already exists (reuse, don't rebuild)
-- `DocumentResponse`/`DocumentRow` + the row render + all actions (An Simba senden, tier, reindex,
-  delete) — reused as-is; a search result must return this shape.
-- `DocumentFactRetrieval.search()` — query→document_ids, already circle-filtered (facts signal).
-- `RAGRetrieval` — circle-filtered chunk semantic search (chunk signal; aggregate to best-per-doc).
-- The GENERATED `search_vector` + GIN + multilingual-union FTS pattern (notes/messages/facts/chunks).
-- The Wissen lens `consumesQueryInline` wiring already reads `?q=`/`?scope=` on this lens.
-- `rag.list_documents` (rag_service.py:888) — the seam to add `q`.
+## Ergebnis
 
-## GSTACK REVIEW REPORT
+Beide Instanzen laufen wieder, wiederhergestellt aus den Garage-S3-Sicherungen:
 
-| Review | Trigger | Why | Runs | Status | Findings |
-|--------|---------|-----|------|--------|----------|
-| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | CLEAR | Scope split to PR1/PR2; D2 circle-filter locked; DRY+perf baked in; 0 critical gaps |
+| | Haushalt | xidra |
+|---|---|---|
+| Cluster | `renfield-pg-r1` 3/3 gesund | `renfield-pg-r1` 3/3 gesund |
+| Wiederherstellungspunkt | 11.09. 16:15:56 | 11.09. 16:17:07 |
+| Absturz war | 16:16:19 | 16:17:30 |
+| **Lücke** | **23 Sekunden** | **23 Sekunden** |
+| Umfang | 380 Dok. / 2847 Chunks / 2677 Nachr. | 546 Dok. / 4368 Chunks |
+| Alembic | `pc20260908b_cred_sphere` | `pc20260908b_cred_sphere` |
 
-- **UNRESOLVED:** none.
-- **VERDICT:** ENG CLEARED — PR1 (local hybrid) ready to implement. Federation (Paperless + Simba) is PR2, gated on an access-control + dedup design.
+Browser-E2E Haushalt: Seite lädt, Verlauf rehydriert, WebSocket verbunden,
+neuer Chat-Zug geschrieben (2 Nachrichten um 14:00:56) und auf dem Standby
+angekommen, null Anwendungsfehler in der Konsole. xidra: Anmeldeseite und
+Backend sauber — der angemeldete Durchlauf bleibt beim Benutzer (auth-on).
 
+## Erledigt
+
+- [x] Ursache gefunden und **abgestellt**: `k8s/node-iscsi-update-guard.sh` auf
+      allen drei Knoten — `open-iscsi` auf hold + aus unattended-upgrades
+      ausgenommen (gpu-3 hatte es am 12.09. 06:57 ebenfalls erwischt)
+- [x] `max_slot_wal_keep_size: 2GB` in beiden Cluster-Manifesten — ein verwaister
+      Slot wird künftig invalidiert, statt den Primary zu töten. Live verifiziert.
+- [x] WAL-Volumes 2 GiB → 8 GiB
+- [x] Knoten-Platten vergrößert: gpu-1 80→140 GB, gpu-2 80→140 GB,
+      gpu-3 100→160 GB. Longhorn-Spielraum von ~6 GiB auf 75-82 GiB je Knoten.
+- [x] Aufgeräumt: 4 defekte pg-3-Volumes, speaches-Cache (seit 130 Tagen auf 0/0),
+      alte Container-Images
+- [x] `k8s/cnpg/90-recovery-cluster.yaml` + `91-netpol-recovery.yaml` — das
+      Wiederherstellungsverfahren als Manifest mit Runbook, nicht als Handgriff
+- [x] Anwendung + pg-dump-CronJob + ScheduledBackups auf `renfield-pg-r1-rw`
+      umgestellt (`set env`, nicht `apply` — Live-Deployments tragen gepinnte Tags)
+- [x] Frische Basissicherung beider Cluster, ContinuousArchiving=True
+
+## Was schiefging (für die Lessons)
+
+Ich habe die Engine-Ressource des WAL-Volumes gelöscht, um die veraltete
+iscsid-PID loszuwerden. Das erzeugte eine Verklemmung in Longhorns Steuerebene,
+aus der ich mit sechs Versuchen nicht herauskam. Richtig wäre gewesen, das
+Volume erst vollständig abzulösen ODER direkt den geprobten
+Wiederherstellungspfad zu nehmen. Die Wiederherstellung dauerte am Ende
+vier Minuten.
+
+## Offen
+
+- [ ] **Alarmierung** — 21,5 Stunden Ausfall blieben unbemerkt. Das ist der
+      wichtigste offene Punkt, wichtiger als alles technisch Reparierte:
+      CNPG-Cluster nicht `Ready`, WAL-Füllstand, Backend down.
+- [ ] Alte `renfield-pg`-Cluster + verwaiste Longhorn-Volumes löschen (nach Soak)
+- [ ] `numberOfReplicas: 1` auf `longhorn-pg` überdenken — machte den
+      iscsid-Neustart überhaupt erst tödlich
+- [ ] `kubeadm`/`kubectl`/`kubelet` nur auf gpu-3 auf hold, nicht auf gpu-1/gpu-2
+- [ ] `archive_timeout: 5min` erzeugt 4,6 GB WAL/Tag im Leerlauf — prüfen
+- [ ] Paperless unter 192.168.1.162 antwortet mit HTTP 500 (separates Problem,
+      fiel beim Neustart des geplanten Dedupe-Tasks auf)
+- [ ] Clusternamen tragen jetzt das `-r1`-Suffix — irgendwann zurückbenennen


### PR DESCRIPTION
## Was passiert ist

Am 11.09. startete `apt-daily-upgrade` den iSCSI-Initiator auf zwei Knoten neu. Longhorn bindet **jedes** Volume darüber an. Beide Produktions-Postgres-Cluster standen danach 21,5 Stunden still.

```
11.09. 06:17:44  k8s-gpu-2  systemd: Stopping/Starting iscsid.service
11.09. 06:19:39  k8s-gpu-1  systemd: Stopping/Starting iscsid.service
11.09. 06:20:15  Longhorn:  Replicas von renfield-pg-3 faulted (beide Namespaces)
11.09. 16:16:19  Postgres:  PANIC "No space left on device"  (Haushalt)
11.09. 16:17:30  Postgres:  dito                              (xidra)
```

Die Kette braucht jedes einzelne Glied:

1. `iscsid`-Neustart reißt die Sessions aller angebundenen Volumes.
2. `longhorn-pg` läuft mit `numberOfReplicas: 1` (Postgres repliziert auf seiner eigenen Ebene) → keine zweite Kopie → `renfield-pg-3` stirbt in **beiden** Namespaces gleichzeitig.
3. Die Longhorn-Platten waren überbucht und unter der 25-%-Schwelle → keine Replica konnte neu platziert werden → pg-3 blieb tot.
4. Der HA-Replikationsslot der toten Instanz hielt WAL auf dem Primary fest — `max_slot_wal_keep_size` war **ungesetzt, also unbegrenzt**.
5. `archive_timeout: 5min` erzwingt alle fünf Minuten einen Segmentwechsel, also **~4,6 GB WAL pro Tag auch im Leerlauf**. Das 2-GiB-WAL-Volume war in zehn Stunden voll.

Die kleinen WAL-Volumes waren der **Verstärker**, nicht die Ursache. Bemerkenswert: der Manifest-Kommentar beschrieb diesen Fehlermodus wörtlich („a full WAL volume still halts the primary — by design").

## Was dieser PR ändert

**Ursache abgestellt**
- `k8s/node-iscsi-update-guard.sh` — `open-iscsi` auf `hold` plus Eintrag in die `Unattended-Upgrade::Package-Blacklist`, auf jedem Longhorn-Speicherknoten. Sicherheitsupdates laufen weiter; dieses eine Paket wird bewusst mit geräumtem Knoten aktualisiert (Runbook steht im Skriptkopf). Auf allen drei Knoten bereits ausgeführt — gpu-3 hatte es am 12.09. um 06:57 ebenfalls erwischt.

**Verstärker entschärft**
- `max_slot_wal_keep_size: 2GB` in beiden Cluster-Manifesten. Ein verwaister Slot wird künftig invalidiert, statt den Primary zu töten. Eine Instanz zu verlieren ist immer besser, als den Cluster zu verlieren.
- `walStorage` 2Gi → 8Gi, also rund 40 statt 10 Stunden Puffer gegen eine Archivierungsstörung.

**Wiederherstellung aufgeschrieben**
- `k8s/cnpg/90-recovery-cluster.yaml` + `91-netpol-recovery.yaml` — der `bootstrap.recovery`-Restore als Manifest, Runbook im Kopfkommentar. Der Synchron-Block muss für den Bootstrap auskommentiert und bei 3/3 wieder aktiviert werden; das steht dort ausdrücklich.
- ScheduledBackup und pg-dump-CronJob ziehen auf die wiederhergestellten Cluster um (`-r1`-Suffix).

**Dokumentation**
- `docs/KUBERNETES_DEPLOYMENT.md`: Der Abschnitt behauptete noch, der Haushalt-Cutover stünde aus — tatsächlich lief er am 25.08. Jetzt auf dem Stand, samt Ursachenanalyse.

## Nicht im Diff, aber ausgeführt

Die Worker-VM-Platten wurden über Proxmox vergrößert (80→140 GB, 80→140 GB, 100→160 GB) und online per `growpart`/`pvresize`/`lvextend`/`resize2fs` nachgezogen. Die Volume-Groups waren zu 100 % belegt — deshalb konnte Longhorn die ausgefallene Replica überhaupt nicht neu platzieren. Longhorn-Spielraum jetzt 75–82 GiB je Knoten statt 6.

Aufgeräumt: vier zerstörte pg-3-Volumes, der `speaches`-Cache (Deployment seit 130 Tagen auf `0/0`), ungenutzte Container-Images.

## Verifikation

| | Haushalt | xidra |
|---|---|---|
| Cluster | `renfield-pg-r1` 3/3 gesund | `renfield-pg-r1` 3/3 gesund |
| Wiederhergestellt bis | 11.09. 16:15:56 | 11.09. 16:17:07 |
| Absturz war | 16:16:19 | 16:17:30 |
| **Datenlücke** | **23 s** | **23 s** |
| Umfang | 380 Dok. / 2847 Chunks / 2677 Nachr. | 546 Dok. / 4368 Chunks |
| Alembic | `pc20260908b_cred_sphere` | `pc20260908b_cred_sphere` |

Browser-E2E Haushalt: Seite lädt, Verlauf rehydriert, WebSocket verbunden, neuer Chat-Zug geschrieben (14:00:56) und auf dem Standby angekommen, null Anwendungsfehler in der Konsole. Schreibtest unter aktiver synchroner Replikation auf beiden Clustern bestanden, `max_slot_wal_keep_size=2048` live bestätigt, frische Basissicherung beider Cluster abgeschlossen.

xidra: Anmeldeseite und Backend sauber. Der angemeldete Durchlauf bleibt benutzergetrieben (auth-on, keine echten Zugangsdaten meinerseits).

## Offen

**Es hat 21,5 Stunden lang nichts alarmiert.** Das wiegt schwerer als alles, was dieser PR repariert, und gehört in einen eigenen Vorgang: CNPG-Cluster nicht `Ready`, WAL-Füllstand, Backend unten.

Daneben:
- Alte `renfield-pg`-Cluster samt verwaister Longhorn-Volumes nach einer Beobachtungszeit entfernen
- `numberOfReplicas: 1` auf `longhorn-pg` überdenken — machte den iscsid-Neustart überhaupt erst tödlich
- `kubeadm`/`kubectl`/`kubelet` sind nur auf gpu-3 gehalten, nicht auf gpu-1/gpu-2
- `archive_timeout: 5min` erzeugt 4,6 GB WAL/Tag im Leerlauf
- Clusternamen tragen jetzt `-r1`; Zurückbenennen wäre ein erneuter Restore
- Paperless unter 192.168.1.162 antwortet mit HTTP 500 (separates Thema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEBYQwXDyd9NuvV47gUzu4
